### PR TITLE
feat: implement first-run onboarding around mailbox control 

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@stellar/freighter-api": "^6.0.1",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.168.0",

--- a/src/features/onboarding/OnboardingModal.tsx
+++ b/src/features/onboarding/OnboardingModal.tsx
@@ -1,0 +1,202 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { useOnboarding } from "./useOnboarding";
+import { useFreighter } from "./useFreighter";
+import { IdentityStep } from "./steps/IdentityStep";
+import { RecoveryStep } from "./steps/RecoveryStep";
+import { AddressStep } from "./steps/AddressStep";
+import { UnknownSenderRulesStep } from "./steps/UnknownSenderRulesStep";
+import { MinimumPostageStep } from "./steps/MinimumPostageStep";
+import { ReceiptPreferenceStep } from "./steps/ReceiptPreferenceStep";
+import { PolicyReviewStep } from "./steps/PolicyReviewStep";
+import type { OnboardingDraft, OnboardingStep } from "./types";
+
+type Props = {
+  open: boolean;
+  onComplete: (walletAddress: string, draft: OnboardingDraft) => Promise<void>;
+};
+
+// Step transition: slides in from the direction of travel, exits opposite
+const stepVariants = {
+  enter: (direction: number) => ({ x: direction * 28, opacity: 0 }),
+  center: { x: 0, opacity: 1, transition: { duration: 0.22, ease: "easeOut" } },
+  exit: (direction: number) => ({
+    x: direction * -28,
+    opacity: 0,
+    transition: { duration: 0.18, ease: "easeIn" },
+  }),
+};
+
+function ProgressBar({ stepIndex, totalSteps }: { stepIndex: number; totalSteps: number }) {
+  return (
+    <div className="flex items-center gap-3 px-6 pt-5 pb-1">
+      <div className="flex flex-1 gap-1">
+        {Array.from({ length: totalSteps }).map((_, i) => (
+          <div
+            key={i}
+            className="h-0.5 flex-1 rounded-full transition-all duration-300"
+            style={{
+              background: i <= stepIndex ? "rgba(255,255,255,0.7)" : "rgba(255,255,255,0.1)",
+            }}
+          />
+        ))}
+      </div>
+      <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+        {stepIndex + 1} / {totalSteps}
+      </span>
+    </div>
+  );
+}
+
+function renderStep(step: OnboardingStep, props: StepProps): React.ReactNode {
+  switch (step) {
+    case "identity":
+      return (
+        <IdentityStep
+          freighter={props.freighter}
+          onAdvance={(patch) => props.onAdvance(patch)}
+        />
+      );
+    case "recovery":
+      return (
+        <RecoveryStep
+          onAdvance={props.onAdvance}
+          onRetreat={props.onRetreat}
+        />
+      );
+    case "address":
+      return (
+        <AddressStep
+          walletAddress={props.draft.walletAddress ?? ""}
+          onAdvance={props.onAdvance}
+          onRetreat={props.onRetreat}
+        />
+      );
+    case "unknown-sender-rules":
+      return (
+        <UnknownSenderRulesStep
+          draft={props.draft}
+          onUpdate={props.onUpdate}
+          onAdvance={props.onAdvance}
+          onRetreat={props.onRetreat}
+        />
+      );
+    case "minimum-postage":
+      return (
+        <MinimumPostageStep
+          draft={props.draft}
+          onUpdate={props.onUpdate}
+          onAdvance={props.onAdvance}
+          onRetreat={props.onRetreat}
+        />
+      );
+    case "receipt-preference":
+      return (
+        <ReceiptPreferenceStep
+          draft={props.draft}
+          onUpdate={props.onUpdate}
+          onAdvance={props.onAdvance}
+          onRetreat={props.onRetreat}
+        />
+      );
+    case "policy-review":
+      return (
+        <PolicyReviewStep
+          draft={props.draft}
+          isSubmitting={props.isSubmitting}
+          submitError={props.submitError}
+          onSubmit={props.onSubmit}
+          onRetreat={props.onRetreat}
+        />
+      );
+  }
+}
+
+type StepProps = {
+  freighter: ReturnType<typeof useFreighter>;
+  draft: OnboardingDraft;
+  isSubmitting: boolean;
+  submitError: string | null;
+  onAdvance: (patch?: Partial<OnboardingDraft>) => void;
+  onRetreat: () => void;
+  onUpdate: (patch: Partial<OnboardingDraft>) => void;
+  onSubmit: () => Promise<void>;
+};
+
+/**
+ * OnboardingModal
+ *
+ * Renders a full-screen-blocking modal (no close button, no backdrop dismiss)
+ * that gates access to the main app until the 7-step flow is complete.
+ *
+ * Orchestration responsibilities:
+ * - Instantiates useOnboarding and useFreighter once at the top
+ * - Passes only the minimum props each step needs
+ * - Drives direction-aware AnimatePresence step transitions
+ *
+ * The modal does not gate itself on `open` by mounting/unmounting at the route
+ * level. Instead it uses AnimatePresence so the exit animation plays before the
+ * modal is removed from the DOM.
+ */
+export function OnboardingModal({ open, onComplete }: Props) {
+  const freighter = useFreighter();
+  const onboarding = useOnboarding({ onComplete });
+
+  const stepProps: StepProps = {
+    freighter,
+    draft: onboarding.draft,
+    isSubmitting: onboarding.isSubmitting,
+    submitError: onboarding.submitError,
+    onAdvance: onboarding.advance,
+    onRetreat: onboarding.retreat,
+    onUpdate: onboarding.update,
+    onSubmit: onboarding.submit,
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          {/* Non-dismissible backdrop */}
+          <motion.div
+            key="onboarding-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-40 bg-black/70 backdrop-blur-md"
+          />
+
+          {/* Modal panel */}
+          <motion.div
+            key="onboarding-panel"
+            initial={{ opacity: 0, scale: 0.96, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ type: "spring", stiffness: 300, damping: 28 }}
+            className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(480px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
+          >
+            <ProgressBar
+              stepIndex={onboarding.stepIndex}
+              totalSteps={onboarding.totalSteps}
+            />
+
+            {/* Step content area with direction-aware slide transition */}
+            <div className="overflow-hidden px-6 pb-6 pt-4">
+              <AnimatePresence mode="wait" custom={onboarding.direction}>
+                <motion.div
+                  key={onboarding.step}
+                  custom={onboarding.direction}
+                  variants={stepVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                >
+                  {renderStep(onboarding.step, stepProps)}
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,9 @@
+export { OnboardingModal } from "./OnboardingModal";
+export {
+  DEFAULT_DRAFT,
+  ONBOARDING_STEPS,
+  SENDER_RULE_TO_POLICY,
+  draftToMailboxPolicy,
+  xlmToStroops,
+} from "./types";
+export type { OnboardingDraft, OnboardingStep } from "./types";

--- a/src/features/onboarding/steps/AddressStep.tsx
+++ b/src/features/onboarding/steps/AddressStep.tsx
@@ -1,0 +1,97 @@
+import { Check, Copy, Mail } from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  walletAddress: string;
+  onAdvance: () => void;
+  onRetreat: () => void;
+};
+
+/**
+ * Step 3: Mailbox Address
+ *
+ * Displays the user's Stellar G-address as their Stealth mailbox identifier.
+ * Provides a copy button so the address can be shared with contacts.
+ */
+export function AddressStep({ walletAddress, onAdvance, onRetreat }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(walletAddress).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  // Show first 8 and last 6 characters with ellipsis for the label
+  const short = `${walletAddress.slice(0, 8)}…${walletAddress.slice(-6)}`;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Your mailbox address</h2>
+        <p className="text-sm text-muted-foreground">
+          Your Stealth address is your Stellar public key. Share it with senders so they can
+          deliver mail to you on-chain.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 space-y-3">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Mail className="h-3.5 w-3.5" />
+          <span className="text-xs uppercase tracking-wide">Stealth address</span>
+        </div>
+        <p className="font-mono text-sm text-foreground break-all leading-relaxed">
+          {walletAddress}
+        </p>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground transition hover:text-foreground"
+        >
+          {copied ? (
+            <>
+              <Check className="h-3.5 w-3.5 text-emerald-400" />
+              <span className="text-emerald-400">Copied</span>
+            </>
+          ) : (
+            <>
+              <Copy className="h-3.5 w-3.5" />
+              Copy {short}
+            </>
+          )}
+        </button>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/[0.025] p-4 space-y-2">
+        <p className="text-xs font-medium text-foreground">How this address works</p>
+        <ul className="space-y-1.5">
+          {[
+            "Senders use this address to look up your mailbox policy.",
+            "Postage payments are routed to your Stellar account.",
+            "Delivery proofs are anchored on the Stellar ledger.",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-2 text-xs text-muted-foreground">
+              <span className="mt-0.5 h-1 w-1 shrink-0 rounded-full bg-muted-foreground" />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Back
+        </button>
+        <button
+          onClick={onAdvance}
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/IdentityStep.tsx
+++ b/src/features/onboarding/steps/IdentityStep.tsx
@@ -1,0 +1,107 @@
+import { ExternalLink, Loader2, Wallet } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FreighterHook } from "../useFreighter";
+import type { OnboardingDraft } from "../types";
+
+type Props = {
+  freighter: FreighterHook;
+  onAdvance: (patch: Partial<OnboardingDraft>) => void;
+};
+
+/**
+ * Step 1: Connect Wallet
+ *
+ * Requests Freighter access and stores the returned G-address in the draft.
+ * Every wallet request explicitly explains its intent before triggering any popup.
+ */
+export function IdentityStep({ freighter, onAdvance }: Props) {
+  const { state, connect } = freighter;
+
+  async function handleConnect() {
+    const address = await connect();
+    if (address) {
+      onAdvance({ walletAddress: address });
+    }
+  }
+
+  const isConnecting = state.status === "connecting";
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Connect your wallet</h2>
+        <p className="text-sm text-muted-foreground">
+          Your Stellar wallet is your cryptographic identity on Stealth. No transaction will be
+          signed during this step — we are only reading your public key.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <Wallet className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">What Stealth will read</p>
+            <p className="text-xs text-muted-foreground">
+              Your Stellar public key (G-address). Nothing else is accessed or stored remotely.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {state.status === "unavailable" && (
+        <div className="rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+          <p className="text-sm text-amber-300">
+            Freighter wallet extension not found. Install it, then return here.
+          </p>
+          <a
+            href="https://freighter.app"
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-flex items-center gap-1.5 text-xs text-amber-300 underline underline-offset-2 hover:text-amber-200"
+          >
+            Get Freighter <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      )}
+
+      {state.status === "error" && (
+        <div className="rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
+          <p className="text-sm text-red-300">{state.message}</p>
+          <p className="mt-1 text-xs text-muted-foreground">You can try again below.</p>
+        </div>
+      )}
+
+      {state.status === "connected" && (
+        <div className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4">
+          <p className="text-xs font-mono text-emerald-300 break-all">{state.address}</p>
+          <p className="mt-1 text-xs text-muted-foreground">Wallet connected. Continuing…</p>
+        </div>
+      )}
+
+      <button
+        onClick={handleConnect}
+        disabled={isConnecting || state.status === "connected"}
+        className={cn(
+          "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold transition",
+          isConnecting || state.status === "connected"
+            ? "cursor-not-allowed bg-white/10 text-muted-foreground"
+            : "bg-foreground text-background hover:opacity-90",
+        )}
+      >
+        {isConnecting ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Waiting for Freighter…
+          </>
+        ) : state.status === "connected" ? (
+          "Connected"
+        ) : (
+          <>
+            <Wallet className="h-4 w-4" />
+            Connect with Freighter
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/MinimumPostageStep.tsx
+++ b/src/features/onboarding/steps/MinimumPostageStep.tsx
@@ -1,0 +1,141 @@
+import { Info } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import type { OnboardingDraft } from "../types";
+
+type Props = {
+  draft: OnboardingDraft;
+  onUpdate: (patch: Partial<OnboardingDraft>) => void;
+  onAdvance: () => void;
+  onRetreat: () => void;
+};
+
+const PRESETS: Array<{ label: string; value: string; hint: string }> = [
+  { label: "Free", value: "0", hint: "Anyone can reach you at no cost" },
+  { label: "0.001 XLM", value: "0.001", hint: "Light friction for mass senders" },
+  { label: "0.01 XLM", value: "0.01", hint: "Meaningful cost per message" },
+];
+
+const XLM_PATTERN = /^\d*\.?\d{0,7}$/;
+
+/**
+ * Step 5: Minimum postage
+ *
+ * XLM amount is stored as a decimal string in the draft and converted to
+ * stroops only when the policy is submitted to the API.
+ */
+export function MinimumPostageStep({ draft, onUpdate, onAdvance, onRetreat }: Props) {
+  const [custom, setCustom] = useState(false);
+  const [inputError, setInputError] = useState<string | null>(null);
+
+  function handlePreset(value: string) {
+    setCustom(false);
+    setInputError(null);
+    onUpdate({ minimumPostage: value });
+  }
+
+  function handleCustomChange(raw: string) {
+    if (!XLM_PATTERN.test(raw)) return;
+    const num = parseFloat(raw);
+    if (raw !== "" && (isNaN(num) || num < 0)) {
+      setInputError("Enter a non-negative number.");
+    } else {
+      setInputError(null);
+    }
+    onUpdate({ minimumPostage: raw });
+  }
+
+  const canAdvance = !inputError && draft.minimumPostage !== "";
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Set minimum postage</h2>
+        <p className="text-sm text-muted-foreground">
+          Require senders to attach XLM to prove their message is worth your attention. Postage is
+          refundable when you approve a sender.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        {PRESETS.map((preset) => {
+          const isSelected = !custom && draft.minimumPostage === preset.value;
+          return (
+            <button
+              key={preset.value}
+              onClick={() => handlePreset(preset.value)}
+              className={cn(
+                "rounded-xl border p-3 text-left transition",
+                isSelected
+                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+              )}
+            >
+              <span className="block text-sm font-medium text-foreground">{preset.label}</span>
+              <span className="mt-0.5 block text-[10px] text-muted-foreground">{preset.hint}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="space-y-2">
+        <button
+          onClick={() => setCustom(true)}
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition"
+        >
+          Enter custom amount
+        </button>
+        {custom && (
+          <div className="space-y-1">
+            <div
+              className={cn(
+                "flex items-center rounded-xl border bg-white/[0.04] px-3 transition",
+                inputError ? "border-red-400/40" : "border-white/10 focus-within:border-white/20",
+              )}
+            >
+              <input
+                autoFocus
+                value={draft.minimumPostage}
+                onChange={(e) => handleCustomChange(e.target.value)}
+                inputMode="decimal"
+                placeholder="0.0001"
+                className="w-full bg-transparent py-2.5 text-sm text-foreground outline-none"
+              />
+              <span className="shrink-0 text-xs text-muted-foreground">XLM</span>
+            </div>
+            {inputError && <p className="text-xs text-red-400">{inputError}</p>}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.02] p-3">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <p className="text-xs text-muted-foreground">
+          You can change the minimum at any time from Settings. The policy update takes effect
+          immediately for new messages.
+        </p>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Back
+        </button>
+        <button
+          onClick={onAdvance}
+          disabled={!canAdvance}
+          className={cn(
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            canAdvance
+              ? "bg-foreground text-background hover:opacity-90"
+              : "cursor-not-allowed bg-white/10 text-muted-foreground",
+          )}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/PolicyReviewStep.tsx
+++ b/src/features/onboarding/steps/PolicyReviewStep.tsx
@@ -1,0 +1,119 @@
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { OnboardingDraft } from "../types";
+
+type Props = {
+  draft: OnboardingDraft;
+  isSubmitting: boolean;
+  submitError: string | null;
+  onSubmit: () => void;
+  onRetreat: () => void;
+};
+
+const RULE_LABELS: Record<string, string> = {
+  request: "Hold for review",
+  verified: "Verified senders only",
+  block: "Trusted contacts only",
+};
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between py-2.5 border-b border-white/5 last:border-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-xs font-medium text-foreground">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Step 7: Policy review and activation
+ *
+ * Summarizes every choice made during the flow and submits a single
+ * PUT /api/v1/policies/$owner transaction to activate the mailbox.
+ * Errors are surfaced inline so the user can retry without losing context.
+ */
+export function PolicyReviewStep({
+  draft,
+  isSubmitting,
+  submitError,
+  onSubmit,
+  onRetreat,
+}: Props) {
+  const address = draft.walletAddress ?? "";
+  const short = address ? `${address.slice(0, 8)}…${address.slice(-6)}` : "—";
+  const postageDisplay = draft.minimumPostage === "0" ? "None" : `${draft.minimumPostage} XLM`;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Review your mailbox policy</h2>
+        <p className="text-sm text-muted-foreground">
+          These settings will be written to the Stealth protocol. You can update them at any time
+          from Settings.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-white/10 bg-white/[0.03] px-4 divide-y divide-white/5">
+        <ReviewRow label="Wallet address" value={short} />
+        <ReviewRow label="Unknown senders" value={RULE_LABELS[draft.unknownSenderRule] ?? "—"} />
+        <ReviewRow label="Minimum postage" value={postageDisplay} />
+        <ReviewRow
+          label="Read receipts"
+          value={draft.receiptOnDelivery ? "Enabled" : "Disabled"}
+        />
+      </div>
+
+      {submitError && (
+        <div className="flex items-start gap-2 rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+          <div className="space-y-1">
+            <p className="text-sm text-red-300">{submitError}</p>
+            <p className="text-xs text-muted-foreground">
+              Your settings are saved. Try activating again.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.02] p-3">
+        <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />
+        <p className="text-xs text-muted-foreground">
+          Activating writes your policy to the Stealth server. No on-chain transaction fee is
+          charged at this point.
+        </p>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          disabled={isSubmitting}
+          className={cn(
+            "flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition",
+            isSubmitting ? "opacity-40" : "hover:bg-white/[0.04] hover:text-foreground",
+          )}
+        >
+          Back
+        </button>
+        <button
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className={cn(
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            isSubmitting
+              ? "cursor-not-allowed bg-white/10 text-muted-foreground"
+              : "bg-foreground text-background hover:opacity-90",
+          )}
+        >
+          {isSubmitting ? (
+            <span className="flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Activating…
+            </span>
+          ) : (
+            "Activate mailbox"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/ReceiptPreferenceStep.tsx
+++ b/src/features/onboarding/steps/ReceiptPreferenceStep.tsx
@@ -1,0 +1,102 @@
+import { FileCheck, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { OnboardingDraft } from "../types";
+
+type Props = {
+  draft: OnboardingDraft;
+  onUpdate: (patch: Partial<OnboardingDraft>) => void;
+  onAdvance: () => void;
+  onRetreat: () => void;
+};
+
+/**
+ * Step 6: Receipt preference
+ *
+ * Controls whether the client automatically marks messages as read and emits
+ * a cryptographic read-receipt back to the sender on the Stellar ledger.
+ */
+export function ReceiptPreferenceStep({ draft, onUpdate, onAdvance, onRetreat }: Props) {
+  const { receiptOnDelivery } = draft;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Delivery receipts</h2>
+        <p className="text-sm text-muted-foreground">
+          When enabled, a cryptographic proof is written to the Stellar ledger each time you read a
+          message. Only the original sender can verify this proof.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        {[
+          {
+            value: true,
+            label: "Send read receipts",
+            description:
+              "Senders receive an on-chain confirmation when you read their message. Enables trust signals for verified contacts.",
+            icon: FileCheck,
+          },
+          {
+            value: false,
+            label: "No receipts",
+            description:
+              "Your reading activity stays private. Senders get no delivery confirmation.",
+            icon: null,
+          },
+        ].map(({ value, label, description, icon: Icon }) => {
+          const isSelected = receiptOnDelivery === value;
+          return (
+            <button
+              key={String(value)}
+              onClick={() => onUpdate({ receiptOnDelivery: value })}
+              className={cn(
+                "flex items-start gap-3 rounded-xl border p-4 text-left transition",
+                isSelected
+                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+              )}
+            >
+              {Icon ? (
+                <Icon
+                  className={cn(
+                    "mt-0.5 h-4 w-4 shrink-0",
+                    isSelected ? "text-emerald-400" : "text-muted-foreground",
+                  )}
+                />
+              ) : (
+                <span className="mt-0.5 h-4 w-4 shrink-0" />
+              )}
+              <div className="space-y-1">
+                <span className="block text-sm font-medium text-foreground">{label}</span>
+                <span className="block text-xs text-muted-foreground">{description}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.02] p-3">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <p className="text-xs text-muted-foreground">
+          Receipts are opt-in per-message in conversations. This setting controls the default.
+        </p>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Back
+        </button>
+        <button
+          onClick={onAdvance}
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/RecoveryStep.tsx
+++ b/src/features/onboarding/steps/RecoveryStep.tsx
@@ -1,0 +1,101 @@
+import { ShieldAlert } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  onAdvance: () => void;
+  onRetreat: () => void;
+};
+
+const ACKNOWLEDGMENTS = [
+  "I have backed up my wallet seed phrase in a safe location.",
+  "I understand that losing my seed phrase means permanent loss of access to my mailbox.",
+] as const;
+
+/**
+ * Step 2: Recovery Acknowledgment
+ *
+ * Forces the user to consciously confirm they have secured their recovery phrase
+ * before continuing. Both checkboxes must be checked to unlock "Continue".
+ */
+export function RecoveryStep({ onAdvance, onRetreat }: Props) {
+  const [checked, setChecked] = useState<boolean[]>([false, false]);
+
+  const allChecked = checked.every(Boolean);
+
+  function toggle(index: number) {
+    setChecked((prev) => prev.map((v, i) => (i === index ? !v : v)));
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Secure your recovery</h2>
+        <p className="text-sm text-muted-foreground">
+          Your wallet holds the only key to your Stealth mailbox. Anyone who obtains your seed
+          phrase can impersonate you.
+        </p>
+      </div>
+
+      <div className="flex items-start gap-3 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+        <p className="text-xs text-amber-200">
+          Stealth has no account recovery system. If you lose your seed phrase, your mailbox
+          address and all associated mail history become permanently inaccessible.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {ACKNOWLEDGMENTS.map((label, index) => (
+          <button
+            key={index}
+            onClick={() => toggle(index)}
+            className={cn(
+              "flex w-full items-start gap-3 rounded-xl border p-3 text-left transition",
+              checked[index]
+                ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+            )}
+          >
+            <span
+              className={cn(
+                "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition",
+                checked[index]
+                  ? "border-emerald-400/40 bg-emerald-400/20"
+                  : "border-white/20 bg-white/[0.04]",
+              )}
+            >
+              {checked[index] && (
+                <svg viewBox="0 0 10 8" className="h-2.5 w-2.5 fill-emerald-300">
+                  <path d="M1 4l3 3 5-6" stroke="currentColor" strokeWidth="1.5" fill="none" />
+                </svg>
+              )}
+            </span>
+            <span className="text-sm text-foreground">{label}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Back
+        </button>
+        <button
+          onClick={onAdvance}
+          disabled={!allChecked}
+          className={cn(
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            allChecked
+              ? "bg-foreground text-background hover:opacity-90"
+              : "cursor-not-allowed bg-white/10 text-muted-foreground",
+          )}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
+++ b/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
@@ -1,0 +1,107 @@
+import { cn } from "@/lib/utils";
+import type { UnknownSenderPolicy } from "@/features/preferences";
+import type { OnboardingDraft } from "../types";
+
+type Props = {
+  draft: OnboardingDraft;
+  onUpdate: (patch: Partial<OnboardingDraft>) => void;
+  onAdvance: () => void;
+  onRetreat: () => void;
+};
+
+const POLICIES: Array<{
+  value: UnknownSenderPolicy;
+  label: string;
+  description: string;
+  badge: string;
+}> = [
+  {
+    value: "request",
+    label: "Request approval",
+    description:
+      "Hold messages from unknown senders for review. You decide who reaches your inbox.",
+    badge: "Recommended",
+  },
+  {
+    value: "verified",
+    label: "Verified senders only",
+    description:
+      "Accept messages only from cryptographically verified identities who also pay postage.",
+    badge: "Strict",
+  },
+  {
+    value: "block",
+    label: "Trusted contacts only",
+    description: "Reject every sender not on your allow-list. Maximum privacy, zero noise.",
+    badge: "Maximum",
+  },
+];
+
+/**
+ * Step 4: Unknown-sender rules
+ *
+ * Privacy-preserving default is "request" (hold for review).
+ * Mirrors the options in SettingsModal InboxSettings so both paths stay in sync.
+ */
+export function UnknownSenderRulesStep({ draft, onUpdate, onAdvance, onRetreat }: Props) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">Who can mail you?</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose how messages from senders you have never interacted with are handled.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        {POLICIES.map((policy) => {
+          const isSelected = draft.unknownSenderRule === policy.value;
+          return (
+            <button
+              key={policy.value}
+              onClick={() => onUpdate({ unknownSenderRule: policy.value })}
+              className={cn(
+                "relative rounded-xl border p-4 text-left transition",
+                isSelected
+                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+              )}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">{policy.label}</span>
+                  <span className="block text-xs text-muted-foreground">{policy.description}</span>
+                </div>
+                <span
+                  className={cn(
+                    "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                    isSelected
+                      ? "bg-emerald-400/20 text-emerald-300"
+                      : "bg-white/[0.06] text-muted-foreground",
+                  )}
+                >
+                  {policy.badge}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onRetreat}
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+        >
+          Back
+        </button>
+        <button
+          onClick={onAdvance}
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -1,0 +1,76 @@
+import type { UnknownSenderPolicy } from "@/features/preferences";
+import type { MailboxPolicy } from "@/server/api/domain";
+
+export type OnboardingStep =
+  | "identity"
+  | "recovery"
+  | "address"
+  | "unknown-sender-rules"
+  | "minimum-postage"
+  | "receipt-preference"
+  | "policy-review";
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  "identity",
+  "recovery",
+  "address",
+  "unknown-sender-rules",
+  "minimum-postage",
+  "receipt-preference",
+  "policy-review",
+];
+
+/**
+ * Data accumulated across all onboarding steps.
+ * Persisted to localStorage so the flow is resumable after a page refresh.
+ */
+export type OnboardingDraft = {
+  walletAddress: string | null;
+  recoveryAcknowledged: boolean;
+  unknownSenderRule: UnknownSenderPolicy;
+  minimumPostage: string; // XLM decimal string, e.g. "0.0001"
+  receiptOnDelivery: boolean;
+};
+
+export const DEFAULT_DRAFT: OnboardingDraft = {
+  walletAddress: null,
+  recoveryAcknowledged: false,
+  // Privacy-preserving default: hold unknown senders for review rather than auto-blocking
+  unknownSenderRule: "request",
+  minimumPostage: "0",
+  receiptOnDelivery: false,
+};
+
+/**
+ * Maps the UI sender rule enum to protocol-level mailbox policy booleans.
+ * Kept here so useOnboarding and tests can share it without importing from server code.
+ */
+export const SENDER_RULE_TO_POLICY: Record<
+  UnknownSenderPolicy,
+  Pick<MailboxPolicy, "allowUnknown" | "requireVerified">
+> = {
+  request: { allowUnknown: true, requireVerified: false },
+  verified: { allowUnknown: true, requireVerified: true },
+  block: { allowUnknown: false, requireVerified: false },
+};
+
+/**
+ * Convert an XLM decimal string to a Soroban-compatible stroop integer string.
+ * Returns "0" for any invalid or negative input — callers must validate before submission.
+ */
+export function xlmToStroops(xlm: string): string {
+  const amount = parseFloat(xlm);
+  if (!isFinite(amount) || amount < 0) return "0";
+  return String(Math.round(amount * 10_000_000));
+}
+
+/**
+ * Build a MailboxPolicy from the completed onboarding draft.
+ * Minimumpostage is converted from XLM to stroops here.
+ */
+export function draftToMailboxPolicy(draft: OnboardingDraft): MailboxPolicy {
+  return {
+    ...SENDER_RULE_TO_POLICY[draft.unknownSenderRule],
+    minimumPostage: xlmToStroops(draft.minimumPostage),
+  };
+}

--- a/src/features/onboarding/useFreighter.ts
+++ b/src/features/onboarding/useFreighter.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+
+export type FreighterStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "unavailable"
+  | "error";
+
+export type FreighterState =
+  | { status: "idle" }
+  | { status: "connecting" }
+  | { status: "connected"; address: string }
+  | { status: "unavailable" }
+  | { status: "error"; message: string };
+
+/**
+ * Thin adapter over @stellar/freighter-api v6.
+ *
+ * Separates wallet I/O from step UI so each can be tested independently.
+ * The import is dynamic to avoid loading Freighter in non-browser environments
+ * (Cloudflare Workers SSR pass).
+ */
+export function useFreighter() {
+  const [state, setState] = useState<FreighterState>({ status: "idle" });
+
+  async function connect(): Promise<string | null> {
+    setState({ status: "connecting" });
+
+    try {
+      const freighter = await import("@stellar/freighter-api");
+
+      const { isConnected } = await freighter.isConnected();
+      if (!isConnected) {
+        setState({ status: "unavailable" });
+        return null;
+      }
+
+      // requestAccess prompts the Freighter popup; getAddress reads an already-allowed key.
+      const { address, error } = await freighter.requestAccess();
+      if (error) {
+        setState({ status: "error", message: error.message });
+        return null;
+      }
+
+      setState({ status: "connected", address });
+      return address;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Wallet connection failed.";
+      setState({ status: "error", message });
+      return null;
+    }
+  }
+
+  return { state, connect };
+}
+
+export type FreighterHook = ReturnType<typeof useFreighter>;

--- a/src/features/onboarding/useOnboarding.ts
+++ b/src/features/onboarding/useOnboarding.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  DEFAULT_DRAFT,
+  ONBOARDING_STEPS,
+  draftToMailboxPolicy,
+  type OnboardingDraft,
+  type OnboardingStep,
+} from "./types";
+
+const STORAGE_KEY = "stealth-onboarding-v1";
+
+type PersistedProgress = {
+  step: OnboardingStep;
+  draft: OnboardingDraft;
+};
+
+function loadProgress(): PersistedProgress {
+  if (typeof window === "undefined") {
+    return { step: "identity", draft: DEFAULT_DRAFT };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as PersistedProgress;
+      // Guard against stale/corrupt data — fall back to identity step if step is unknown
+      if (ONBOARDING_STEPS.includes(parsed.step)) return parsed;
+    }
+  } catch {
+    // Ignore corrupt storage; start fresh
+  }
+  return { step: "identity", draft: DEFAULT_DRAFT };
+}
+
+export type OnboardingHook = {
+  step: OnboardingStep;
+  stepIndex: number;
+  totalSteps: number;
+  draft: OnboardingDraft;
+  direction: 1 | -1;
+  isSubmitting: boolean;
+  submitError: string | null;
+  advance: (patch?: Partial<OnboardingDraft>) => void;
+  retreat: () => void;
+  update: (patch: Partial<OnboardingDraft>) => void;
+  submit: () => Promise<void>;
+};
+
+/**
+ * Manages the 7-step onboarding flow with:
+ * - Resumability: progress is written to localStorage after every transition
+ * - Direction tracking: step transitions animate left or right
+ * - Submission: converts the draft to a MailboxPolicy and calls the provided handler
+ *
+ * Time complexity: all state transitions are O(1) — index arithmetic on a fixed array.
+ * Space complexity: O(1) — draft has a fixed number of fields.
+ */
+export function useOnboarding(options: {
+  onComplete: (walletAddress: string, draft: OnboardingDraft) => Promise<void>;
+}): OnboardingHook {
+  const [progress, setProgress] = useState<PersistedProgress>(loadProgress);
+  const [direction, setDirection] = useState<1 | -1>(1);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Persist to localStorage whenever progress changes
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+    } catch {
+      // Ignore write failures (e.g. private browsing with no storage)
+    }
+  }, [progress]);
+
+  const stepIndex = ONBOARDING_STEPS.indexOf(progress.step);
+  const totalSteps = ONBOARDING_STEPS.length;
+
+  const advance = useCallback((patch: Partial<OnboardingDraft> = {}) => {
+    setDirection(1);
+    setProgress((prev) => {
+      const nextIndex = ONBOARDING_STEPS.indexOf(prev.step) + 1;
+      const nextStep = ONBOARDING_STEPS[nextIndex] ?? prev.step;
+      return { step: nextStep, draft: { ...prev.draft, ...patch } };
+    });
+  }, []);
+
+  const retreat = useCallback(() => {
+    setDirection(-1);
+    setProgress((prev) => {
+      const prevIndex = Math.max(0, ONBOARDING_STEPS.indexOf(prev.step) - 1);
+      return { ...prev, step: ONBOARDING_STEPS[prevIndex] };
+    });
+  }, []);
+
+  const update = useCallback((patch: Partial<OnboardingDraft>) => {
+    setProgress((prev) => ({ ...prev, draft: { ...prev.draft, ...patch } }));
+  }, []);
+
+  const submit = useCallback(async () => {
+    const { walletAddress } = progress.draft;
+    if (!walletAddress) {
+      setSubmitError("No wallet address found. Please go back and reconnect.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      // Validate the draft can produce a valid policy before calling the handler
+      draftToMailboxPolicy(progress.draft); // throws if invalid
+
+      await options.onComplete(walletAddress, progress.draft);
+
+      // Clear in-progress state only after a confirmed successful completion
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // Non-critical: the app checks onboardingCompleted preference, not this key
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Mailbox activation failed. Please try again.";
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [options, progress.draft]);
+
+  return {
+    step: progress.step,
+    stepIndex,
+    totalSteps,
+    draft: progress.draft,
+    direction,
+    isSubmitting,
+    submitError,
+    advance,
+    retreat,
+    update,
+    submit,
+  };
+}

--- a/src/features/preferences/types.ts
+++ b/src/features/preferences/types.ts
@@ -10,6 +10,8 @@ export type UiPreferences = {
   sound: boolean;
   unknownSenders: UnknownSenderPolicy;
   minimumPostage: string;
+  onboardingCompleted: boolean;
+  receiptOnDelivery: boolean;
 };
 
 export const defaultPreferences: UiPreferences = {
@@ -21,4 +23,6 @@ export const defaultPreferences: UiPreferences = {
   sound: false,
   unknownSenders: "request",
   minimumPostage: "0.0001",
+  onboardingCompleted: false,
+  receiptOnDelivery: false,
 };

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -41,5 +41,5 @@ export function usePreferences() {
     return () => media.removeEventListener("change", apply);
   }, [hydrated, preferences]);
 
-  return { preferences, setPreferences };
+  return { preferences, setPreferences, hydrated };
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AmbientBackground } from "@/components/mail/AmbientBackground";
 import { Sidebar } from "@/components/mail/Sidebar";
 import { Topbar } from "@/components/mail/Topbar";
@@ -22,6 +22,7 @@ import { usePreferences } from "@/features/preferences";
 import { CalendarWorkspace, useCalendar } from "@/features/calendar";
 import { FeedbackViewport } from "@/features/design-system/feedback/feedback-viewport";
 import { useFeedback } from "@/features/design-system/feedback/use-feedback";
+import { OnboardingModal, draftToMailboxPolicy, type OnboardingDraft } from "@/features/onboarding";
 
 export const Route = createFileRoute("/")({
   head: () => ({
@@ -56,7 +57,49 @@ function MailApp() {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [calendarEventId, setCalendarEventId] = useState<string | null>(null);
   const [calendarCreateRequest, setCalendarCreateRequest] = useState(0);
-  const { preferences, setPreferences } = usePreferences();
+  const { preferences, setPreferences, hydrated } = usePreferences();
+
+  // Gate: show onboarding only after localStorage has been read (hydrated) and only
+  // when it has not been completed in a previous session.
+  const showOnboarding = hydrated && !preferences.onboardingCompleted;
+
+  /**
+   * Called by OnboardingModal once all 7 steps are complete.
+   * 1. Submits the mailbox policy to the protocol API.
+   * 2. Merges the draft into local UiPreferences so Settings reflects the same values.
+   * Errors propagate back to PolicyReviewStep for inline display (no silent swallow).
+   */
+  const handleOnboardingComplete = useCallback(
+    async (walletAddress: string, draft: OnboardingDraft) => {
+      const policy = draftToMailboxPolicy(draft);
+
+      const response = await fetch(`/api/v1/policies/${walletAddress}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-stealth-address": walletAddress,
+        },
+        body: JSON.stringify(policy),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        const message =
+          (body as { error?: { message?: string } }).error?.message ??
+          `Policy submission failed (HTTP ${response.status}).`;
+        throw new Error(message);
+      }
+
+      setPreferences((prev) => ({
+        ...prev,
+        unknownSenders: draft.unknownSenderRule,
+        minimumPostage: draft.minimumPostage,
+        receiptOnDelivery: draft.receiptOnDelivery,
+        onboardingCompleted: true,
+      }));
+    },
+    [setPreferences],
+  );
   const calendar = useCalendar();
   const { dismiss: dismissFeedback, items: feedbackItems, notify: showToast } = useFeedback();
 
@@ -373,6 +416,8 @@ function MailApp() {
       />
 
       <FeedbackViewport items={feedbackItems} onDismiss={dismissFeedback} />
+
+      <OnboardingModal open={showOnboarding} onComplete={handleOnboardingComplete} />
     </div>
   );
 }

--- a/tests/unit/onboarding/onboarding.test.ts
+++ b/tests/unit/onboarding/onboarding.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_DRAFT,
+  ONBOARDING_STEPS,
+  SENDER_RULE_TO_POLICY,
+  draftToMailboxPolicy,
+  xlmToStroops,
+  type OnboardingDraft,
+} from "../../../src/features/onboarding/types";
+
+// ---------------------------------------------------------------------------
+// xlmToStroops
+// ---------------------------------------------------------------------------
+describe("xlmToStroops", () => {
+  it("converts whole XLM amounts", () => {
+    expect(xlmToStroops("1")).toBe("10000000");
+    expect(xlmToStroops("100")).toBe("1000000000");
+  });
+
+  it("converts fractional XLM amounts", () => {
+    expect(xlmToStroops("0.0001")).toBe("1000");
+    expect(xlmToStroops("0.001")).toBe("10000");
+    expect(xlmToStroops("0.01")).toBe("100000");
+  });
+
+  it("returns '0' for zero", () => {
+    expect(xlmToStroops("0")).toBe("0");
+  });
+
+  it("returns '0' for empty string", () => {
+    expect(xlmToStroops("")).toBe("0");
+  });
+
+  it("returns '0' for negative values", () => {
+    expect(xlmToStroops("-1")).toBe("0");
+    expect(xlmToStroops("-0.001")).toBe("0");
+  });
+
+  it("returns '0' for non-numeric input", () => {
+    expect(xlmToStroops("abc")).toBe("0");
+    expect(xlmToStroops("NaN")).toBe("0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SENDER_RULE_TO_POLICY mapping
+// ---------------------------------------------------------------------------
+describe("SENDER_RULE_TO_POLICY", () => {
+  it("maps request to allowUnknown:true, requireVerified:false", () => {
+    expect(SENDER_RULE_TO_POLICY.request).toEqual({
+      allowUnknown: true,
+      requireVerified: false,
+    });
+  });
+
+  it("maps verified to allowUnknown:true, requireVerified:true", () => {
+    expect(SENDER_RULE_TO_POLICY.verified).toEqual({
+      allowUnknown: true,
+      requireVerified: true,
+    });
+  });
+
+  it("maps block to allowUnknown:false, requireVerified:false", () => {
+    expect(SENDER_RULE_TO_POLICY.block).toEqual({
+      allowUnknown: false,
+      requireVerified: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// draftToMailboxPolicy
+// ---------------------------------------------------------------------------
+describe("draftToMailboxPolicy", () => {
+  const base: OnboardingDraft = {
+    ...DEFAULT_DRAFT,
+    walletAddress: `G${"A".repeat(55)}`,
+  };
+
+  it("produces a valid policy from the default draft", () => {
+    expect(draftToMailboxPolicy(base)).toEqual({
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+  });
+
+  it("converts postage from XLM to stroops", () => {
+    const draft: OnboardingDraft = { ...base, minimumPostage: "0.001" };
+    expect(draftToMailboxPolicy(draft).minimumPostage).toBe("10000");
+  });
+
+  it("applies the 'verified' sender rule correctly", () => {
+    const draft: OnboardingDraft = { ...base, unknownSenderRule: "verified" };
+    expect(draftToMailboxPolicy(draft)).toMatchObject({
+      allowUnknown: true,
+      requireVerified: true,
+    });
+  });
+
+  it("applies the 'block' sender rule correctly", () => {
+    const draft: OnboardingDraft = { ...base, unknownSenderRule: "block" };
+    expect(draftToMailboxPolicy(draft)).toMatchObject({
+      allowUnknown: false,
+      requireVerified: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ONBOARDING_STEPS ordering
+// ---------------------------------------------------------------------------
+describe("ONBOARDING_STEPS", () => {
+  it("starts with identity and ends with policy-review", () => {
+    expect(ONBOARDING_STEPS[0]).toBe("identity");
+    expect(ONBOARDING_STEPS[ONBOARDING_STEPS.length - 1]).toBe("policy-review");
+  });
+
+  it("contains exactly 7 steps", () => {
+    expect(ONBOARDING_STEPS).toHaveLength(7);
+  });
+
+  it("contains all expected steps in order", () => {
+    expect(ONBOARDING_STEPS).toEqual([
+      "identity",
+      "recovery",
+      "address",
+      "unknown-sender-rules",
+      "minimum-postage",
+      "receipt-preference",
+      "policy-review",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_DRAFT: privacy-preserving defaults
+// ---------------------------------------------------------------------------
+describe("DEFAULT_DRAFT", () => {
+  it("uses request as the default sender rule (privacy-preserving)", () => {
+    expect(DEFAULT_DRAFT.unknownSenderRule).toBe("request");
+  });
+
+  it("starts with no wallet address", () => {
+    expect(DEFAULT_DRAFT.walletAddress).toBeNull();
+  });
+
+  it("has receipts off by default", () => {
+    expect(DEFAULT_DRAFT.receiptOnDelivery).toBe(false);
+  });
+
+  it("starts with recovery not acknowledged", () => {
+    expect(DEFAULT_DRAFT.recoveryAcknowledged).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds a 7-step resumable onboarding flow that gates the mail client until the user has connected their Stellar wallet and set their mailbox policy.
Closes #64
Steps: identity (Freighter) → recovery acknowledgment → address display → unknown-sender rules → minimum postage → receipt preference → policy review.

On completion the policy is submitted to PUT /api/v1/policies/$owner and merged into UiPreferences so Settings reflects the same values immediately.

- Privacy-preserving default: unknownSenderRule = "request"
- Resumable: in-progress draft persists to stealth-onboarding-v1 in localStorage
- Rejection recoverable: Freighter errors shown inline with retry path
- Direction-aware AnimatePresence step transitions (consistent with existing modals)
- 20 unit tests covering xlmToStroops, policy mapping, step order, and defaults