### PR TITLE
test: add Playwright E2E coverage for core mailbox workflows (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,50 +2,6 @@ name: CI
 
 on:
   push:
-<<<<<<< feature/version-negotiation
-    branches: [main, develop, "feature/**"]
-  pull_request:
-    branches: [main, develop]
-
-jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      # 1️⃣ Checkout repository
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      # 2️⃣ Set up Node (use the version defined in `package.json` “engines”, fallback to 20)
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      # 3️⃣ Install dependencies (honors npm config, no script execution restrictions)
-      - name: Install dependencies
-        run: npm ci
-
-      # 4️⃣ Lint the codebase
-      - name: Run ESLint
-        run: npm run lint
-
-      # 5️⃣ Check Prettier formatting
-      - name: Check Prettier format
-        run: npm run format:check || npx prettier --check .
-
-      # 6️⃣ Run unit / integration tests
-      - name: Run tests
-        run: npm test
-
-      # 7️⃣ Build the app (optional but useful for PR checks)
-      - name: Build
-        run: npm run build
-=======
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
@@ -144,6 +100,45 @@ jobs:
           name: contract-wasm
           path: contracts/soroban/target/wasm32-unknown-unknown/release/*.wasm
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [client-checks]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.20
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7
+
   security:
     name: Security & Dependency Review
     runs-on: ubuntu-latest
@@ -174,7 +169,7 @@ jobs:
           echo "### Release Artifact Hashes" >> $GITHUB_STEP_SUMMARY
           echo "| Artifact | SHA-256 Hash |" >> $GITHUB_STEP_SUMMARY
           echo "| :--- | :--- |" >> $GITHUB_STEP_SUMMARY
-          
+
           # Collect and hash important artifacts
           find . -name "*.wasm" -o -name "index.html" -o -name "*.js" -o -name "*.css" | grep -v "node_modules" | while read file; do
             hash=$(sha256sum "$file" | awk '{print $1}')
@@ -188,4 +183,3 @@ jobs:
         with:
           name: release-hashes
           path: SHA256SUMS
->>>>>>> main

--- a/docs/deployment/RELEASE_GATES.md
+++ b/docs/deployment/RELEASE_GATES.md
@@ -10,13 +10,13 @@ A release reviewer must be able to make a defensible decision based on the evide
 
 ## 1. Pre-Flight Checklist (All Environments)
 
-| Gate | Requirement | Owner | Evidence/Link | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| **Audit** | Security audit of code changes completed and findings addressed. | | [Link] | ⬜ |
-| **Threat Model** | Threat model updated for new features/changes. | | [Link] | ⬜ |
-| **Lint & Format** | CI passing for linting, formatting, and typechecking. | | [CI Job] | ⬜ |
-| **Tests** | Unit and integration tests passing (100% success). | | [CI Job] | ⬜ |
-| **Wasm Size** | Soroban contract Wasm sizes within limits. | | [CI Job] | ⬜ |
+| Gate              | Requirement                                                      | Owner | Evidence/Link | Status |
+| :---------------- | :--------------------------------------------------------------- | :---- | :------------ | :----- |
+| **Audit**         | Security audit of code changes completed and findings addressed. |       | [Link]        | ⬜     |
+| **Threat Model**  | Threat model updated for new features/changes.                   |       | [Link]        | ⬜     |
+| **Lint & Format** | CI passing for linting, formatting, and typechecking.            |       | [CI Job]      | ⬜     |
+| **Tests**         | Unit and integration tests passing (100% success).               |       | [CI Job]      | ⬜     |
+| **Wasm Size**     | Soroban contract Wasm sizes within limits.                       |       | [CI Job]      | ⬜     |
 
 ---
 
@@ -24,12 +24,12 @@ A release reviewer must be able to make a defensible decision based on the evide
 
 Focus: Functional validation and integration testing in a live environment.
 
-| Gate | Requirement | Owner | Evidence/Link | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| **Migration** | Migration scripts tested and verified on Testnet. | | [Logs] | ⬜ |
-| **Rollback** | Rollback procedure verified for this version. | | [Runbook] | ⬜ |
-| **Monitoring** | Alerts and dashboards updated for new metrics. | | [Dashboard] | ⬜ |
-| **Artifacts** | SHA-256 hashes of build artifacts recorded. | | See [Artifacts](#artifacts) | ⬜ |
+| Gate           | Requirement                                       | Owner | Evidence/Link               | Status |
+| :------------- | :------------------------------------------------ | :---- | :-------------------------- | :----- |
+| **Migration**  | Migration scripts tested and verified on Testnet. |       | [Logs]                      | ⬜     |
+| **Rollback**   | Rollback procedure verified for this version.     |       | [Runbook]                   | ⬜     |
+| **Monitoring** | Alerts and dashboards updated for new metrics.    |       | [Dashboard]                 | ⬜     |
+| **Artifacts**  | SHA-256 hashes of build artifacts recorded.       |       | See [Artifacts](#artifacts) | ⬜     |
 
 ---
 
@@ -37,14 +37,14 @@ Focus: Functional validation and integration testing in a live environment.
 
 Focus: Security, compliance, and operational readiness.
 
-| Gate | Requirement | Owner | Evidence/Link | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| **Key Ceremony** | Key management ceremony completed for new signers/upgrades. | | [Protocol] | ⬜ |
-| **Legal Review** | Compliance and legal sign-off for release scope. | | [Sign-off] | ⬜ |
-| **Incident Response** | IR team briefed and on-call schedule confirmed. | | [Schedule] | ⬜ |
-| **User Warnings** | Public documentation and UI warnings updated. | | [Docs] | ⬜ |
-| **Support** | Support team trained on new features/changes. | | [Training] | ⬜ |
-| **Reliability** | Load testing/Stress testing completed. | | [Report] | ⬜ |
+| Gate                  | Requirement                                                 | Owner | Evidence/Link | Status |
+| :-------------------- | :---------------------------------------------------------- | :---- | :------------ | :----- |
+| **Key Ceremony**      | Key management ceremony completed for new signers/upgrades. |       | [Protocol]    | ⬜     |
+| **Legal Review**      | Compliance and legal sign-off for release scope.            |       | [Sign-off]    | ⬜     |
+| **Incident Response** | IR team briefed and on-call schedule confirmed.             |       | [Schedule]    | ⬜     |
+| **User Warnings**     | Public documentation and UI warnings updated.               |       | [Docs]        | ⬜     |
+| **Support**           | Support team trained on new features/changes.               |       | [Training]    | ⬜     |
+| **Reliability**       | Load testing/Stress testing completed.                      |       | [Report]      | ⬜     |
 
 ---
 
@@ -54,29 +54,29 @@ Every release must record the exact identifiers of the deployed components.
 
 ### Contract IDs (Soroban)
 
-| Component | Network | Contract ID | Artifact Hash (SHA-256) |
-| :--- | :--- | :--- | :--- |
-| `policies` | Testnet | | |
-| `policies` | Mainnet | | |
-| `postage` | Testnet | | |
-| `postage` | Mainnet | | |
-| `receipts` | Testnet | | |
-| `receipts` | Mainnet | | |
+| Component  | Network | Contract ID | Artifact Hash (SHA-256) |
+| :--------- | :------ | :---------- | :---------------------- |
+| `policies` | Testnet |             |                         |
+| `policies` | Mainnet |             |                         |
+| `postage`  | Testnet |             |                         |
+| `postage`  | Mainnet |             |                         |
+| `receipts` | Testnet |             |                         |
+| `receipts` | Mainnet |             |                         |
 
 ### Client Artifacts
 
-| Component | Version | Environment | Build Hash (SHA-256) |
-| :--- | :--- | :--- | :--- |
-| `stealth-mail` | | Testnet | |
-| `stealth-mail` | | Mainnet | |
+| Component      | Version | Environment | Build Hash (SHA-256) |
+| :------------- | :------ | :---------- | :------------------- |
+| `stealth-mail` |         | Testnet     |                      |
+| `stealth-mail` |         | Mainnet     |                      |
 
 ---
 
 ## 5. Promotion Sign-off
 
-| Role | Name | Signature | Date |
-| :--- | :--- | :--- | :--- |
-| **Security Reviewer** | | | |
-| **Engineering Lead** | | | |
-| **Product Owner** | | | |
-| **Release Manager** | | | |
+| Role                  | Name | Signature | Date |
+| :-------------------- | :--- | :-------- | :--- |
+| **Security Reviewer** |      |           |      |
+| **Engineering Lead**  |      |           |      |
+| **Product Owner**     |      |           |      |
+| **Release Manager**   |      |           |      |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,4 +25,11 @@ export default tseslint.config(
     },
   },
   eslintPluginPrettier,
+  {
+    files: ["tests/**/*.{ts,tsx}"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+      "react-hooks/exhaustive-deps": "off",
+    },
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@stellar/freighter-api": "^6.0.1",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.168.0",
@@ -63,6 +64,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.49.1",
         "@types/node": "^22.16.5",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -108,7 +110,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1372,6 +1373,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -3383,6 +3400,28 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tabby_ai/hijri-converter": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
@@ -4271,7 +4310,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4282,7 +4320,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4293,7 +4330,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4343,7 +4379,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4740,7 +4775,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4872,6 +4906,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -4950,7 +5004,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4963,6 +5016,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/callsites": {
@@ -5492,8 +5569,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5599,7 +5675,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5660,7 +5735,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6166,6 +6240,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7003,6 +7097,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -7046,7 +7187,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7102,7 +7242,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7134,7 +7273,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7147,7 +7285,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7436,7 +7573,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
       "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8268,7 +8404,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8328,7 +8463,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8480,7 +8614,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9207,7 +9340,6 @@
       "integrity": "sha512-T/GRD6Y5vN9g4CnGmOlfST1w7bj+1IjRFvX0K7CodZPJuPVPNPGhz8Wppah0WdT6A7I8Kad3zgZ2OkDdWtENrg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "format": "prettier --write .",
     "local:setup": "powershell -ExecutionPolicy Bypass -File scripts/setup-local-env/setup.ps1",
     "local:teardown": "powershell -ExecutionPolicy Bypass -File scripts/setup-local-env/teardown.ps1",
@@ -76,6 +78,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.49.1",
     "@types/node": "^22.16.5",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "on-failure" }]],
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/mail/Topbar.tsx
+++ b/src/components/mail/Topbar.tsx
@@ -447,7 +447,7 @@ function FilterToggle({
   checked,
   onChange,
 }: {
-  icon: any;
+  icon: LucideIcon;
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
@@ -474,7 +474,7 @@ function AccountMenuItem({
   label,
   onClick,
 }: {
-  icon: any;
+  icon: LucideIcon;
   label: string;
   onClick: () => void;
 }) {

--- a/src/features/onboarding/OnboardingModal.tsx
+++ b/src/features/onboarding/OnboardingModal.tsx
@@ -51,18 +51,10 @@ function renderStep(step: OnboardingStep, props: StepProps): React.ReactNode {
   switch (step) {
     case "identity":
       return (
-        <IdentityStep
-          freighter={props.freighter}
-          onAdvance={(patch) => props.onAdvance(patch)}
-        />
+        <IdentityStep freighter={props.freighter} onAdvance={(patch) => props.onAdvance(patch)} />
       );
     case "recovery":
-      return (
-        <RecoveryStep
-          onAdvance={props.onAdvance}
-          onRetreat={props.onRetreat}
-        />
-      );
+      return <RecoveryStep onAdvance={props.onAdvance} onRetreat={props.onRetreat} />;
     case "address":
       return (
         <AddressStep
@@ -174,10 +166,7 @@ export function OnboardingModal({ open, onComplete }: Props) {
             transition={{ type: "spring", stiffness: 300, damping: 28 }}
             className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(480px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
           >
-            <ProgressBar
-              stepIndex={onboarding.stepIndex}
-              totalSteps={onboarding.totalSteps}
-            />
+            <ProgressBar stepIndex={onboarding.stepIndex} totalSteps={onboarding.totalSteps} />
 
             {/* Step content area with direction-aware slide transition */}
             <div className="overflow-hidden px-6 pb-6 pt-4">

--- a/src/features/onboarding/steps/AddressStep.tsx
+++ b/src/features/onboarding/steps/AddressStep.tsx
@@ -31,8 +31,8 @@ export function AddressStep({ walletAddress, onAdvance, onRetreat }: Props) {
       <div className="space-y-1">
         <h2 className="text-base font-semibold text-foreground">Your mailbox address</h2>
         <p className="text-sm text-muted-foreground">
-          Your Stealth address is your Stellar public key. Share it with senders so they can
-          deliver mail to you on-chain.
+          Your Stealth address is your Stellar public key. Share it with senders so they can deliver
+          mail to you on-chain.
         </p>
       </div>
 

--- a/src/features/onboarding/steps/PolicyReviewStep.tsx
+++ b/src/features/onboarding/steps/PolicyReviewStep.tsx
@@ -32,13 +32,7 @@ function ReviewRow({ label, value }: { label: string; value: string }) {
  * PUT /api/v1/policies/$owner transaction to activate the mailbox.
  * Errors are surfaced inline so the user can retry without losing context.
  */
-export function PolicyReviewStep({
-  draft,
-  isSubmitting,
-  submitError,
-  onSubmit,
-  onRetreat,
-}: Props) {
+export function PolicyReviewStep({ draft, isSubmitting, submitError, onSubmit, onRetreat }: Props) {
   const address = draft.walletAddress ?? "";
   const short = address ? `${address.slice(0, 8)}…${address.slice(-6)}` : "—";
   const postageDisplay = draft.minimumPostage === "0" ? "None" : `${draft.minimumPostage} XLM`;
@@ -57,10 +51,7 @@ export function PolicyReviewStep({
         <ReviewRow label="Wallet address" value={short} />
         <ReviewRow label="Unknown senders" value={RULE_LABELS[draft.unknownSenderRule] ?? "—"} />
         <ReviewRow label="Minimum postage" value={postageDisplay} />
-        <ReviewRow
-          label="Read receipts"
-          value={draft.receiptOnDelivery ? "Enabled" : "Disabled"}
-        />
+        <ReviewRow label="Read receipts" value={draft.receiptOnDelivery ? "Enabled" : "Disabled"} />
       </div>
 
       {submitError && (

--- a/src/features/onboarding/steps/RecoveryStep.tsx
+++ b/src/features/onboarding/steps/RecoveryStep.tsx
@@ -40,8 +40,8 @@ export function RecoveryStep({ onAdvance, onRetreat }: Props) {
       <div className="flex items-start gap-3 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
         <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
         <p className="text-xs text-amber-200">
-          Stealth has no account recovery system. If you lose your seed phrase, your mailbox
-          address and all associated mail history become permanently inaccessible.
+          Stealth has no account recovery system. If you lose your seed phrase, your mailbox address
+          and all associated mail history become permanently inaccessible.
         </p>
       </div>
 

--- a/src/features/onboarding/useFreighter.ts
+++ b/src/features/onboarding/useFreighter.ts
@@ -1,11 +1,6 @@
 import { useState } from "react";
 
-export type FreighterStatus =
-  | "idle"
-  | "connecting"
-  | "connected"
-  | "unavailable"
-  | "error";
+export type FreighterStatus = "idle" | "connecting" | "connected" | "unavailable" | "error";
 
 export type FreighterState =
   | { status: "idle" }

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "./fixtures";
+
+test.describe("calendar linking", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "stealth-preferences",
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    });
+    await page.goto("/");
+  });
+
+  test("adds a calendar event from a mail with an event attachment", async ({ page }) => {
+    // The TOKEN2049 email (id=2) has an event – it lives in the 'verified' folder
+    await page.getByRole("button", { name: "Verified" }).click();
+    await page.getByText("TOKEN2049 Abu Dhabi - founder pass ready").click();
+
+    // The EventMailCard should render with the event title
+    await expect(page.getByText("TOKEN2049 Abu Dhabi")).toBeVisible();
+
+    // Add to calendar
+    await page.getByRole("button", { name: /Add to calendar/i }).click();
+
+    // Toast confirms the event was added
+    await expect(page.getByText(/added to your calendar/i)).toBeVisible();
+  });
+
+  test("opens the calendar workspace from the sidebar calendar button", async ({ page }) => {
+    // The right panel has an "Open calendar" or calendar section
+    // Alternatively open via the event mail card's "Open calendar" action
+    await page.getByRole("button", { name: "Verified" }).click();
+    await page.getByText("TOKEN2049 Abu Dhabi - founder pass ready").click();
+
+    // Add event first so it exists in calendar state
+    await page.getByRole("button", { name: /Add to calendar/i }).click();
+
+    // Then open the calendar workspace
+    await page.getByRole("button", { name: /Open calendar/i }).click();
+
+    // CalendarWorkspace dialog/modal should appear
+    await expect(page.getByText("TOKEN2049 Abu Dhabi")).toBeVisible();
+  });
+
+  test("calendar workspace closes on close button click", async ({ page }) => {
+    // Open via right panel create event button – requires an email selected first
+    await page.getByRole("button", { name: "Verified" }).click();
+    await page.getByText("TOKEN2049 Abu Dhabi - founder pass ready").click();
+    await page.getByRole("button", { name: /Add to calendar/i }).click();
+    await page.getByRole("button", { name: /Open calendar/i }).click();
+
+    // Dismiss the calendar workspace
+    await page.getByRole("button", { name: /close/i }).first().click();
+
+    // The CalendarWorkspace modal should no longer be visible
+    // Check that calendar-specific heading is gone
+    await expect(page.getByText("TOKEN2049 Abu Dhabi - founder pass ready")).toBeVisible();
+  });
+});

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -3,10 +3,7 @@ import { test, expect } from "./fixtures";
 test.describe("calendar linking", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "stealth-preferences",
-        JSON.stringify({ onboardingCompleted: true }),
-      );
+      localStorage.setItem("stealth-preferences", JSON.stringify({ onboardingCompleted: true }));
     });
     await page.goto("/");
   });

--- a/tests/e2e/compose.spec.ts
+++ b/tests/e2e/compose.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "./fixtures";
+
+test.describe("compose flow", () => {
+  test.beforeEach(async ({ page }) => {
+    // Skip onboarding by pre-setting localStorage
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "stealth-preferences",
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    });
+    await page.goto("/");
+  });
+
+  test("opens compose, fills fields, and sends message", async ({ page }) => {
+    // Open compose via keyboard shortcut
+    await page.keyboard.press("Control+n");
+
+    // Compose dialog becomes visible
+    await expect(page.getByText("New message")).toBeVisible();
+
+    // Fill recipient, subject, and body
+    await page.getByPlaceholder("recipients@…").fill("alice*stellar.org");
+    await page.getByPlaceholder("Subject").fill("E2E test subject");
+    await page.getByPlaceholder("Write your message…").fill("Hello from E2E test");
+
+    // Send
+    await page.getByRole("button", { name: "Send" }).click();
+
+    // Dialog closes and toast confirms delivery
+    await expect(page.getByText("New message")).not.toBeVisible();
+    await expect(page.getByText(/Encrypted message sent/i)).toBeVisible();
+  });
+
+  test("validates required fields before sending", async ({ page }) => {
+    await page.keyboard.press("Control+n");
+    await expect(page.getByText("New message")).toBeVisible();
+
+    // Attempt to send with empty recipient
+    await page.getByRole("button", { name: "Send" }).click();
+
+    // Dialog stays open; error toast shown
+    await expect(page.getByText("New message")).toBeVisible();
+    await expect(page.getByText(/Please enter a recipient/i)).toBeVisible();
+  });
+
+  test("schedules message instead of immediate send", async ({ page }) => {
+    await page.keyboard.press("Control+n");
+
+    await page.getByPlaceholder("recipients@…").fill("bob*stellar.org");
+    await page.getByPlaceholder("Subject").fill("Scheduled message");
+    await page.getByPlaceholder("Write your message…").fill("Sent later");
+
+    await page.getByRole("button", { name: "Schedule" }).click();
+
+    await expect(page.getByText("New message")).not.toBeVisible();
+    await expect(page.getByText(/scheduled/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/compose.spec.ts
+++ b/tests/e2e/compose.spec.ts
@@ -4,10 +4,7 @@ test.describe("compose flow", () => {
   test.beforeEach(async ({ page }) => {
     // Skip onboarding by pre-setting localStorage
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "stealth-preferences",
-        JSON.stringify({ onboardingCompleted: true }),
-      );
+      localStorage.setItem("stealth-preferences", JSON.stringify({ onboardingCompleted: true }));
     });
     await page.goto("/");
   });

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,87 @@
+import { test as base, type Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Deterministic Stellar addresses used across all tests
+// ---------------------------------------------------------------------------
+export const ACTOR = `G${"A".repeat(55)}`;
+export const SENDER = `G${"B".repeat(55)}`;
+
+// A deterministic 32-byte hex hash
+export const MSG_ID = "a".repeat(64);
+export const PAYMENT_HASH = "b".repeat(64);
+
+// ---------------------------------------------------------------------------
+// API helpers – thin wrappers around page.request so tests stay readable
+// ---------------------------------------------------------------------------
+export class ApiHelper {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  private headers(actor = ACTOR) {
+    return { "Content-Type": "application/json", "x-stealth-address": actor };
+  }
+
+  async putPolicy(actor = ACTOR, policy = { allowUnknown: true, minimumPostage: "0", requireVerified: false }) {
+    return this.page.request.put(`/api/v1/policies/${actor}`, {
+      headers: this.headers(actor),
+      data: policy,
+    });
+  }
+
+  async getPolicy(owner = ACTOR) {
+    return this.page.request.get(`/api/v1/policies/${owner}`, {
+      headers: this.headers(),
+    });
+  }
+
+  async setSenderRule(owner = ACTOR, sender = SENDER, rule: "allow" | "block" | "default") {
+    return this.page.request.put(`/api/v1/policies/${owner}/senders/${sender}`, {
+      headers: this.headers(owner),
+      data: { rule },
+    });
+  }
+
+  async quotePostage(recipient = ACTOR, sender = SENDER) {
+    return this.page.request.post("/api/v1/postage/quote", {
+      headers: this.headers(sender),
+      data: { recipient, sender },
+    });
+  }
+
+  async submitPostage(messageId = MSG_ID, paymentHash = PAYMENT_HASH, amount = "100") {
+    return this.page.request.post("/api/v1/postage/", {
+      headers: this.headers(SENDER),
+      data: { amount, messageId, paymentHash, recipient: ACTOR, sender: SENDER },
+    });
+  }
+
+  async settlePostage(messageId = MSG_ID) {
+    return this.page.request.patch(`/api/v1/postage/${messageId}`, {
+      headers: this.headers(ACTOR),
+      data: { status: "settled" },
+    });
+  }
+
+  async refundPostage(messageId = MSG_ID) {
+    return this.page.request.patch(`/api/v1/postage/${messageId}`, {
+      headers: this.headers(ACTOR),
+      data: { status: "refunded" },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extended test fixture that exposes the API helper and pre-loads the app
+// ---------------------------------------------------------------------------
+type Fixtures = { api: ApiHelper };
+
+export const test = base.extend<Fixtures>({
+  api: async ({ page }, use) => {
+    await use(new ApiHelper(page));
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -24,7 +24,10 @@ export class ApiHelper {
     return { "Content-Type": "application/json", "x-stealth-address": actor };
   }
 
-  async putPolicy(actor = ACTOR, policy = { allowUnknown: true, minimumPostage: "0", requireVerified: false }) {
+  async putPolicy(
+    actor = ACTOR,
+    policy = { allowUnknown: true, minimumPostage: "0", requireVerified: false },
+  ) {
     return this.page.request.put(`/api/v1/policies/${actor}`, {
       headers: this.headers(actor),
       data: policy,

--- a/tests/e2e/policy-editing.spec.ts
+++ b/tests/e2e/policy-editing.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "./fixtures";
+
+test.describe("policy editing", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "stealth-preferences",
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    });
+    await page.goto("/");
+  });
+
+  async function openSettings(page: Parameters<typeof test>[1]) {
+    // Settings button is an IconBtn labelled "Settings" in the topbar
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  }
+
+  test("switches to Inbox control tab and changes unknown-sender policy", async ({ page }) => {
+    await openSettings(page);
+
+    // Navigate to the Inbox control tab
+    await page.getByRole("button", { name: "Inbox control" }).click();
+
+    // Verify the section heading
+    await expect(page.getByText("Inbox control", { exact: true })).toBeVisible();
+
+    // Select "Verified only" policy
+    await page.getByRole("button", { name: "Verified only" }).click();
+
+    // Save
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    // Toast confirms save
+    await expect(page.getByText(/Settings saved/i)).toBeVisible();
+  });
+
+  test("updates minimum postage value and saves", async ({ page }) => {
+    await openSettings(page);
+    await page.getByRole("button", { name: "Inbox control" }).click();
+
+    // Minimum postage input
+    const postageInput = page.getByRole("textbox").filter({ hasText: /^0/ }).first();
+    // Use the input near the XLM label
+    await page.locator('input[inputmode="decimal"]').last().fill("0.001");
+
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText(/Settings saved/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/policy-editing.spec.ts
+++ b/tests/e2e/policy-editing.spec.ts
@@ -3,10 +3,7 @@ import { test, expect } from "./fixtures";
 test.describe("policy editing", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "stealth-preferences",
-        JSON.stringify({ onboardingCompleted: true }),
-      );
+      localStorage.setItem("stealth-preferences", JSON.stringify({ onboardingCompleted: true }));
     });
     await page.goto("/");
   });

--- a/tests/e2e/postage.spec.ts
+++ b/tests/e2e/postage.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, ACTOR, SENDER, MSG_ID, PAYMENT_HASH } from "./fixtures";
+
+// API-level tests – no UI navigation required. The dev server must be running
+// so that the TanStack Start API routes are reachable at /api/v1/…
+
+test.describe("postage API", () => {
+  test("quotes zero postage for an explicitly allowed sender", async ({ api }) => {
+    // Allow the sender first
+    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "100", requireVerified: false });
+    await api.setSenderRule(ACTOR, SENDER, "allow");
+
+    const res = await api.quotePostage(ACTOR, SENDER);
+    expect(res.status()).toBe(200);
+
+    const { data } = await res.json();
+    expect(data.amount).toBe("0");
+    expect(data.trusted).toBe(true);
+    expect(data.eligible).toBe(true);
+  });
+
+  test("quote marks blocked sender as ineligible", async ({ api }) => {
+    await api.setSenderRule(ACTOR, SENDER, "block");
+
+    const res = await api.quotePostage(ACTOR, SENDER);
+    expect(res.status()).toBe(200);
+
+    const { data } = await res.json();
+    expect(data.eligible).toBe(false);
+    expect(data.reason).toBe("sender_blocked");
+  });
+
+  test("submits postage and then settles it", async ({ page, api }) => {
+    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "100", requireVerified: false });
+
+    const submitRes = await api.submitPostage(MSG_ID, PAYMENT_HASH, "100");
+    expect(submitRes.status()).toBe(201);
+    const { data: pending } = await submitRes.json();
+    expect(pending.status).toBe("pending");
+
+    // Settle as recipient (ACTOR)
+    const settleRes = await page.request.post(`/api/v1/postage/${MSG_ID}/settle`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-stealth-address": ACTOR,
+      },
+    });
+    expect(settleRes.status()).toBe(200);
+    const { data: settled } = await settleRes.json();
+    expect(settled.status).toBe("settled");
+  });
+
+  test("submits postage and then refunds it", async ({ page, api }) => {
+    // Use different IDs to avoid collision with other tests
+    const msgId = "c".repeat(64);
+    const payHash = "d".repeat(64);
+
+    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "0", requireVerified: false });
+
+    const submitRes = await page.request.post("/api/v1/postage/", {
+      headers: { "Content-Type": "application/json", "x-stealth-address": SENDER },
+      data: { amount: "50", messageId: msgId, paymentHash: payHash, recipient: ACTOR, sender: SENDER },
+    });
+    expect(submitRes.status()).toBe(201);
+
+    const refundRes = await page.request.post(`/api/v1/postage/${msgId}/refund`, {
+      headers: { "Content-Type": "application/json", "x-stealth-address": ACTOR },
+    });
+    expect(refundRes.status()).toBe(200);
+    const { data } = await refundRes.json();
+    expect(data.status).toBe("refunded");
+  });
+
+  test("rejects duplicate postage submission with 409", async ({ api }) => {
+    const msgId = "e".repeat(64);
+    const payHash = "f".repeat(64);
+
+    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "0", requireVerified: false });
+
+    const first = await api.submitPostage(msgId, payHash, "0");
+    expect(first.status()).toBe(201);
+
+    const second = await api.submitPostage(msgId, payHash, "0");
+    expect(second.status()).toBe(409);
+  });
+
+  test("rejects postage below mailbox minimum with 422", async ({ api }) => {
+    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "1000", requireVerified: false });
+
+    const msgId = "9".repeat(64);
+    const payHash = "8".repeat(64);
+    const res = await api.submitPostage(msgId, payHash, "1");
+    expect(res.status()).toBe(422);
+  });
+});

--- a/tests/e2e/postage.spec.ts
+++ b/tests/e2e/postage.spec.ts
@@ -6,7 +6,11 @@ import { test, expect, ACTOR, SENDER, MSG_ID, PAYMENT_HASH } from "./fixtures";
 test.describe("postage API", () => {
   test("quotes zero postage for an explicitly allowed sender", async ({ api }) => {
     // Allow the sender first
-    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "100", requireVerified: false });
+    await api.putPolicy(ACTOR, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
     await api.setSenderRule(ACTOR, SENDER, "allow");
 
     const res = await api.quotePostage(ACTOR, SENDER);
@@ -30,7 +34,11 @@ test.describe("postage API", () => {
   });
 
   test("submits postage and then settles it", async ({ page, api }) => {
-    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "100", requireVerified: false });
+    await api.putPolicy(ACTOR, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
 
     const submitRes = await api.submitPostage(MSG_ID, PAYMENT_HASH, "100");
     expect(submitRes.status()).toBe(201);
@@ -58,7 +66,13 @@ test.describe("postage API", () => {
 
     const submitRes = await page.request.post("/api/v1/postage/", {
       headers: { "Content-Type": "application/json", "x-stealth-address": SENDER },
-      data: { amount: "50", messageId: msgId, paymentHash: payHash, recipient: ACTOR, sender: SENDER },
+      data: {
+        amount: "50",
+        messageId: msgId,
+        paymentHash: payHash,
+        recipient: ACTOR,
+        sender: SENDER,
+      },
     });
     expect(submitRes.status()).toBe(201);
 
@@ -84,7 +98,11 @@ test.describe("postage API", () => {
   });
 
   test("rejects postage below mailbox minimum with 422", async ({ api }) => {
-    await api.putPolicy(ACTOR, { allowUnknown: true, minimumPostage: "1000", requireVerified: false });
+    await api.putPolicy(ACTOR, {
+      allowUnknown: true,
+      minimumPostage: "1000",
+      requireVerified: false,
+    });
 
     const msgId = "9".repeat(64);
     const payHash = "8".repeat(64);

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "./fixtures";
+
+test.describe("search and filter", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "stealth-preferences",
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    });
+    await page.goto("/");
+  });
+
+  test("clicking the search bar opens the command palette", async ({ page }) => {
+    // The search input opens the command palette on click
+    await page.getByPlaceholder("Search messages, people, proofs, attachments...").click();
+
+    // Command palette should appear
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("keyboard shortcut Ctrl+K opens the command palette", async ({ page }) => {
+    await page.keyboard.press("Control+k");
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  test("filter dropdown toggles unread-only filter", async ({ page }) => {
+    // Open filter panel
+    await page.getByRole("button", { name: "Filter" }).click();
+
+    // Filter overlay appears
+    await expect(page.getByText("Unread only")).toBeVisible();
+
+    // Toggle unread filter on
+    await page.getByText("Unread only").click();
+
+    // Close the filter overlay by pressing Escape
+    await page.keyboard.press("Escape");
+
+    // The Filter button should now appear active (highlighted)
+    // We verify by re-opening and confirming state
+    await page.getByRole("button", { name: "Filter" }).click();
+    const unreadToggle = page.getByText("Unread only");
+    await expect(unreadToggle).toBeVisible();
+  });
+
+  test("filter dropdown allows selecting a date range", async ({ page }) => {
+    await page.getByRole("button", { name: "Filter" }).click();
+    await expect(page.getByText("This week")).toBeVisible();
+
+    await page.getByText("This week").click();
+
+    // Filter panel should still be visible and show the active state
+    await expect(page.getByText("This week")).toBeVisible();
+  });
+
+  test("navigating to Pending Proof folder via Quick action shows proof items", async ({
+    page,
+  }) => {
+    // 'Proofs' quick action navigates to pending proof folder
+    await page.getByRole("button", { name: "Proofs" }).click();
+
+    // The email list heading (or an email) from pending folder should appear
+    await expect(page.getByText("Your relay verification code")).toBeVisible();
+  });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -3,10 +3,7 @@ import { test, expect } from "./fixtures";
 test.describe("search and filter", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "stealth-preferences",
-        JSON.stringify({ onboardingCompleted: true }),
-      );
+      localStorage.setItem("stealth-preferences", JSON.stringify({ onboardingCompleted: true }));
     });
     await page.goto("/");
   });

--- a/tests/e2e/sender-approval.spec.ts
+++ b/tests/e2e/sender-approval.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "./fixtures";
+
+test.describe("sender approval", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "stealth-preferences",
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    });
+    await page.goto("/");
+  });
+
+  test("approves an unknown sender from the requests folder", async ({ page }) => {
+    // Navigate to Requests folder in sidebar
+    await page.getByRole("button", { name: "Requests" }).click();
+
+    // Select the 'Message request awaiting approval' email (id=5 in seed data)
+    await page.getByText("Message request awaiting approval").click();
+
+    // The SenderRequest widget should be visible
+    await expect(page.getByText("Decide who can mail you")).toBeVisible();
+
+    // Approve the sender
+    await page.getByRole("button", { name: "Allow sender" }).click();
+
+    // Toast confirms approval
+    await expect(page.getByText(/can now mail you/i)).toBeVisible();
+  });
+
+  test("blocks an unknown sender and queues postage refund", async ({ page }) => {
+    await page.getByRole("button", { name: "Requests" }).click();
+    await page.getByText("Message request awaiting approval").click();
+
+    await expect(page.getByText("Decide who can mail you")).toBeVisible();
+
+    await page.getByRole("button", { name: "Block and refund" }).click();
+
+    await expect(page.getByText(/blocked and postage marked for refund/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/sender-approval.spec.ts
+++ b/tests/e2e/sender-approval.spec.ts
@@ -3,10 +3,7 @@ import { test, expect } from "./fixtures";
 test.describe("sender approval", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem(
-        "stealth-preferences",
-        JSON.stringify({ onboardingCompleted: true }),
-      );
+      localStorage.setItem("stealth-preferences", JSON.stringify({ onboardingCompleted: true }));
     });
     await page.goto("/");
   });


### PR DESCRIPTION
## Summary

Closes #140

Adds a complete Playwright E2E test suite for the core mailbox workflows identified in the issue.

## What's included

**Setup**
- `playwright.config.ts` — headless Chromium, CI-friendly (workers=1, retries=2 in CI), screenshots/traces/video retained on failure, `webServer` auto-starts the dev server
- `tests/e2e/fixtures.ts` — shared `ApiHelper` with deterministic Stellar addresses and wrappers for all protocol API endpoints
- `package.json` — `test:e2e` and `test:e2e:ui` scripts

**21 tests across 6 spec files**

| File | Tests |
|---|---|
| `compose.spec.ts` | Open/fill/send, field validation, schedule |
| `sender-approval.spec.ts` | Allow sender, block and refund |
| `policy-editing.spec.ts` | Inbox policy switch, minimum postage update |
| `postage.spec.ts` | Quote trusted/blocked, submit→settle, submit→refund, duplicate 409, below-minimum 422 |
| `search.spec.ts` | Command palette (click + Ctrl+K), filter panel, date range, quick actions |
| `calendar.spec.ts` | Add event from mail, open workspace, close workspace |

**CI**
- New `e2e` job in `.github/workflows/ci.yml` (depends on `client-checks`)
- Uploads HTML report on every run; traces uploaded on failure (7-day retention)
- Also resolves the pre-existing merge conflict in `ci.yml`

## Acceptance criteria

- [x] Core workflows validated without manual clicking
- [x] Tests assert visible user outcomes (toasts, headings, folder state, API response shapes)
- [x] Failures capture screenshots, traces, and video for debugging