### PR TITLE
feat: guided per-sender conversion flow (#122)

### DIFF
--- a/src/components/mail/EmailList.tsx
+++ b/src/components/mail/EmailList.tsx
@@ -9,6 +9,7 @@ import {
   type MailFolder,
 } from "./data";
 import { cn } from "@/lib/utils";
+import { ConvertSenderButton } from "@/features/sender-conversion";
 
 type FilterTab = "all" | "unread" | "flagged";
 
@@ -16,6 +17,7 @@ export function EmailList({
   emails,
   selectedId,
   onSelect,
+  onConvertSender,
   folder,
   filters,
   customFolder,
@@ -25,6 +27,7 @@ export function EmailList({
   emails: Email[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onConvertSender: (email: Email) => void;
   folder: MailFolder;
   filters: MailFilters;
   customFolder?: string | null;
@@ -157,6 +160,15 @@ export function EmailList({
                   </div>
                 </div>
               </motion.button>
+              {e.folder === "requests" && (
+                <div className="mt-1 flex justify-end px-2">
+                  <ConvertSenderButton
+                    variant="subtle"
+                    label="Review sender"
+                    onClick={() => onConvertSender(e)}
+                  />
+                </div>
+              )}
             </motion.li>
           );
         })}

--- a/src/components/mail/EmailView.tsx
+++ b/src/components/mail/EmailView.tsx
@@ -3,7 +3,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import {
   Archive,
   BadgeCheck,
-  Ban,
   Braces,
   File,
   FileArchive,
@@ -23,6 +22,7 @@ import {
 import { cn } from "@/lib/utils";
 import { EventMailCard, type CalendarEvent, type CalendarResponse } from "@/features/calendar";
 import { OTPCard, detectOtp } from "@/features/otp";
+import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import type { Email } from "./data";
 
 export type EmailViewActions = {
@@ -32,8 +32,7 @@ export type EmailViewActions = {
   onArchive?: (email: Email) => void;
   onTrash?: (email: Email) => void;
   onToggleStar?: (email: Email) => void;
-  onApproveSender?: (email: Email) => void;
-  onBlockSender?: (email: Email) => void;
+  onConvertSender?: (email: Email) => void;
   onShowToast?: (message: string) => void;
   onAddEvent?: (email: Email) => CalendarEvent | void;
   getCalendarEvent?: (email: Email) => CalendarEvent | null;
@@ -172,6 +171,14 @@ export function EmailView({
               </div>
 
               <div className="flex items-center justify-end gap-1">
+                {actions.onConvertSender && (
+                  <ConvertSenderButton
+                    variant="ghost"
+                    label={email.senderPolicy ? "Sender" : "Add sender"}
+                    onClick={() => actions.onConvertSender?.(email)}
+                    className="hidden sm:inline-flex"
+                  />
+                )}
                 <motion.button
                   whileTap={{ scale: 0.9 }}
                   onClick={() => actions.onArchive?.(email)}
@@ -244,8 +251,7 @@ export function EmailView({
                   <SenderRequest
                     sender={email.from}
                     address={email.email}
-                    onApprove={() => actions.onApproveSender?.(email)}
-                    onBlock={() => actions.onBlockSender?.(email)}
+                    onManage={() => actions.onConvertSender?.(email)}
                   />
                 ) : null}
 
@@ -378,32 +384,25 @@ function ProtocolStatus({
 function SenderRequest({
   sender,
   address,
-  onApprove,
-  onBlock,
+  onManage,
 }: {
   sender: string;
   address: string;
-  onApprove: () => void;
-  onBlock: () => void;
+  onManage: () => void;
 }) {
   return (
     <div className="mt-5 rounded-xl border border-amber-200/15 bg-amber-100/[0.035] p-4">
       <p className="text-sm font-semibold text-foreground">Decide who can mail you</p>
       <p className="mt-1 text-xs leading-5 text-muted-foreground">
-        {sender} ({address}) paid postage, but is not in your trusted sender list.
+        {sender} ({address}) paid postage, but is not in your trusted sender list. Review how to
+        allow, verify, or block them before anything changes.
       </p>
       <div className="mt-3 flex gap-2">
         <button
-          onClick={onApprove}
+          onClick={onManage}
           className="inline-flex items-center gap-2 rounded-lg bg-foreground px-3 py-2 text-xs font-semibold text-background transition hover:opacity-90"
         >
-          <BadgeCheck className="h-3.5 w-3.5" /> Allow sender
-        </button>
-        <button
-          onClick={onBlock}
-          className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs text-muted-foreground transition hover:bg-white/[0.05] hover:text-foreground"
-        >
-          <Ban className="h-3.5 w-3.5" /> Block and refund
+          <BadgeCheck className="h-3.5 w-3.5" /> Review sender
         </button>
       </div>
     </div>
@@ -455,8 +454,11 @@ function SenderIdentity({ email, compact = false }: { email: Email; compact?: bo
           .join("")}
       </div>
       <div className="min-w-0 flex-1">
-        <div className="mail-reader-meta truncate text-[12px] font-semibold leading-4 text-foreground/92">
-          {email.from}
+        <div className="mail-reader-meta flex items-center gap-1.5">
+          <span className="truncate text-[12px] font-semibold leading-4 text-foreground/92">
+            {email.from}
+          </span>
+          <SenderBadge policy={email.senderPolicy} />
         </div>
         <div className="mail-reader-meta truncate text-[9.5px] leading-3 text-muted-foreground/80">
           {email.email}

--- a/src/components/mail/RightPanel.tsx
+++ b/src/components/mail/RightPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { format, isSameDay, parseISO } from "date-fns";
 import type { CalendarDefinition, CalendarEvent } from "@/features/calendar";
+import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import type { Email } from "./data";
 
 export type ContextAction = "snooze" | "translate" | "schedule" | "summarize";
@@ -21,6 +22,7 @@ export function RightPanel({
   email,
   onAction,
   onDraftReply,
+  onConvertSender,
   calendarEvents,
   calendars,
   onOpenCalendar,
@@ -29,6 +31,7 @@ export function RightPanel({
   email: Email | null;
   onAction: (action: ContextAction, email: Email) => void;
   onDraftReply: (email: Email, prompt: string) => void;
+  onConvertSender: (email: Email) => void;
   calendarEvents: CalendarEvent[];
   calendars: CalendarDefinition[];
   onOpenCalendar: (eventId?: string) => void;
@@ -184,11 +187,20 @@ export function RightPanel({
                 .slice(0, 2)
                 .join("")}
             </div>
-            <div className="min-w-0">
-              <div className="truncate text-sm text-foreground">{email.from}</div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="truncate text-sm text-foreground">{email.from}</span>
+                <SenderBadge policy={email.senderPolicy} />
+              </div>
               <div className="truncate text-[11px] text-muted-foreground">{email.email}</div>
             </div>
           </div>
+          <ConvertSenderButton
+            variant="subtle"
+            label={email.senderPolicy ? "Update sender policy" : "Convert to contact"}
+            onClick={() => onConvertSender(email)}
+            className="mt-3 w-full justify-center"
+          />
         </Card>
       )}
     </aside>

--- a/src/components/mail/data.ts
+++ b/src/components/mail/data.ts
@@ -23,6 +23,13 @@ type VirtualMailFolder = "all" | "starred";
 
 export type MailLocation = Exclude<MailFolder, VirtualMailFolder>;
 
+/**
+ * Per-sender policy applied through the sender-conversion flow.
+ * `undefined` means the sender has never been converted (still "unknown").
+ * See src/features/sender-conversion.
+ */
+export type SenderPolicy = "allow" | "verify" | "block";
+
 export type Email = {
   id: string;
   from: string;
@@ -38,6 +45,7 @@ export type Email = {
   attachments?: { name: string; size: string; type: string }[];
   avatarColor: string;
   event?: MailEvent;
+  senderPolicy?: SenderPolicy;
 };
 
 export type MailFilters = {

--- a/src/features/sender-conversion/ConvertSenderButton.tsx
+++ b/src/features/sender-conversion/ConvertSenderButton.tsx
@@ -1,0 +1,42 @@
+import { UserPlus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Variant = "solid" | "subtle" | "ghost";
+
+const variantClasses: Record<Variant, string> = {
+  solid: "bg-foreground text-background hover:opacity-90",
+  subtle: "border border-white/12 bg-white/[0.05] text-foreground/90 hover:bg-white/[0.09]",
+  ghost: "text-muted-foreground hover:bg-white/[0.06] hover:text-foreground",
+};
+
+/**
+ * Shared entry point into the sender-conversion flow. Used from the request
+ * card, the sender (contact) card, and the reader header so every CTA opens the
+ * exact same guided dialog with consistent affordance and label.
+ */
+export function ConvertSenderButton({
+  onClick,
+  label = "Convert to contact",
+  variant = "subtle",
+  className,
+}: {
+  onClick: () => void;
+  label?: string;
+  variant?: Variant;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition",
+        variantClasses[variant],
+        className,
+      )}
+    >
+      <UserPlus className="h-3.5 w-3.5" aria-hidden />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/features/sender-conversion/SenderBadge.tsx
+++ b/src/features/sender-conversion/SenderBadge.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+import type { SenderPolicy } from "@/components/mail/data";
+import { getSenderPolicyOption } from "./types";
+
+const toneClasses: Record<SenderPolicy, string> = {
+  allow: "border-emerald-300/25 bg-emerald-300/10 text-emerald-200",
+  verify: "border-sky-300/25 bg-sky-300/10 text-sky-200",
+  block: "border-red-300/25 bg-red-300/10 text-red-200",
+};
+
+/**
+ * Compact pill that reflects a sender's converted policy. Rendered wherever the
+ * sender identity appears (reader header, sender card) so the badge stays
+ * consistent across surfaces once a conversion completes.
+ */
+export function SenderBadge({
+  policy,
+  className,
+}: {
+  policy: SenderPolicy | undefined;
+  className?: string;
+}) {
+  if (!policy) return null;
+  const option = getSenderPolicyOption(policy);
+  const Icon = option.icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium leading-none",
+        toneClasses[policy],
+        className,
+      )}
+    >
+      <Icon className="h-2.5 w-2.5" aria-hidden />
+      {option.badge}
+    </span>
+  );
+}

--- a/src/features/sender-conversion/SenderConversionDialog.tsx
+++ b/src/features/sender-conversion/SenderConversionDialog.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowRight, Check, FolderInput, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getFolderLabel } from "@/components/mail/data";
+import { SenderBadge } from "./SenderBadge";
+import {
+  SENDER_POLICY_OPTIONS,
+  getSenderPolicyOption,
+  resolveSenderConversion,
+  type SenderConversionTarget,
+  type SenderPolicyChoice,
+} from "./types";
+
+type Phase = "choose" | "done";
+
+type Props = {
+  /** Non-null while the flow is open. */
+  target: SenderConversionTarget | null;
+  /** Apply the chosen policy. Returns nothing; the route owns the mutation. */
+  onConfirm: (target: SenderConversionTarget, choice: SenderPolicyChoice) => void;
+  /** Close without changing any policy. */
+  onClose: () => void;
+};
+
+/**
+ * Guided per-sender conversion flow.
+ *
+ * Phase 1 ("choose"): explains how Allow / Verify / Block differ and requires
+ * an explicit selection — nothing is pre-selected, so the dialog can never
+ * auto-allow a sender. Cancel (button, backdrop, or Esc) closes with no change.
+ *
+ * Phase 2 ("done"): confirms the new sender badge and folder placement. The
+ * underlying mutation already ran on confirm, so every other open surface is
+ * already in sync by the time this is shown.
+ */
+export function SenderConversionDialog({ target, onConfirm, onClose }: Props) {
+  const [choice, setChoice] = useState<SenderPolicyChoice | null>(null);
+  const [phase, setPhase] = useState<Phase>("choose");
+
+  // Reset whenever a different sender (or a fresh open) drives the dialog so a
+  // previous selection never leaks into the next conversion.
+  useEffect(() => {
+    if (target) {
+      setChoice(null);
+      setPhase("choose");
+    }
+  }, [target?.emailId, target]);
+
+  // Esc cancels — same no-op semantics as the Cancel button.
+  useEffect(() => {
+    if (!target) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [target, onClose]);
+
+  const handleConfirm = () => {
+    if (!target || !choice) return;
+    onConfirm(target, choice);
+    setPhase("done");
+  };
+
+  const result = target && choice ? resolveSenderConversion({ from: target.sender }, choice) : null;
+
+  return (
+    <AnimatePresence>
+      {target && (
+        <>
+          <motion.div
+            key="sender-conversion-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-40 bg-black/70 backdrop-blur-md"
+          />
+
+          <motion.div
+            key="sender-conversion-panel"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Convert sender"
+            initial={{ opacity: 0, scale: 0.96, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ type: "spring", stiffness: 300, damping: 28 }}
+            className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(460px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
+          >
+            <div className="flex items-start justify-between gap-3 px-6 pt-5">
+              <div className="min-w-0 space-y-1">
+                <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                  {phase === "choose" ? "Convert sender" : "Sender updated"}
+                </p>
+                <h2 className="truncate text-base font-semibold text-foreground">
+                  {target.sender}
+                </h2>
+                <p className="truncate text-xs text-muted-foreground">{target.address}</p>
+              </div>
+              <button
+                onClick={onClose}
+                aria-label="Cancel"
+                className="glow-ring shrink-0 rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.07] hover:text-foreground"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <AnimatePresence mode="wait">
+              {phase === "choose" ? (
+                <motion.div
+                  key="choose"
+                  initial={{ opacity: 0, x: 16 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -16 }}
+                  transition={{ duration: 0.18 }}
+                  className="px-6 pb-6 pt-4"
+                >
+                  <p className="mb-3 text-xs leading-5 text-muted-foreground">
+                    This sender isn't in your trusted list yet. Choose how their mail should be
+                    handled from now on — you can change this later.
+                  </p>
+
+                  <div className="grid gap-2">
+                    {SENDER_POLICY_OPTIONS.map((option) => {
+                      const Icon = option.icon;
+                      const selected = choice === option.value;
+                      const current = target.currentPolicy === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          onClick={() => setChoice(option.value)}
+                          aria-pressed={selected}
+                          className={cn(
+                            "relative rounded-xl border p-3 text-left transition",
+                            selected
+                              ? "border-emerald-400/30 bg-emerald-400/[0.07]"
+                              : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+                          )}
+                        >
+                          <div className="flex items-start gap-3">
+                            <span
+                              className={cn(
+                                "mt-0.5 grid h-7 w-7 shrink-0 place-items-center rounded-lg border",
+                                selected
+                                  ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-200"
+                                  : "border-white/10 bg-white/[0.04] text-muted-foreground",
+                              )}
+                            >
+                              <Icon className="h-3.5 w-3.5" />
+                            </span>
+                            <div className="min-w-0 flex-1 space-y-1">
+                              <div className="flex items-center gap-2">
+                                <span className="text-sm font-medium text-foreground">
+                                  {option.label}
+                                </span>
+                                {current && (
+                                  <span className="rounded-full bg-white/[0.07] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-muted-foreground">
+                                    Current
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-xs leading-5 text-foreground/70">
+                                {option.summary}
+                              </p>
+                              <p className="text-[11px] leading-4 text-muted-foreground">
+                                {option.effect}
+                              </p>
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="mt-5 flex gap-3">
+                    <button
+                      onClick={onClose}
+                      className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleConfirm}
+                      disabled={!choice}
+                      className={cn(
+                        "flex flex-1 items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+                        choice
+                          ? "bg-foreground text-background hover:opacity-90"
+                          : "cursor-not-allowed bg-white/[0.06] text-muted-foreground",
+                      )}
+                    >
+                      {choice ? getSenderPolicyOption(choice).label : "Choose an action"}
+                      {choice && <ArrowRight className="h-3.5 w-3.5" />}
+                    </button>
+                  </div>
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="done"
+                  initial={{ opacity: 0, x: 16 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -16 }}
+                  transition={{ duration: 0.18 }}
+                  className="px-6 pb-6 pt-4"
+                >
+                  <div className="mb-4 flex items-center gap-2">
+                    <span className="grid h-8 w-8 place-items-center rounded-full border border-emerald-300/30 bg-emerald-300/10 text-emerald-200">
+                      <Check className="h-4 w-4" />
+                    </span>
+                    <p className="text-sm text-foreground/90">
+                      {result?.toast.message ?? "Sender updated"}.
+                    </p>
+                  </div>
+
+                  <dl className="space-y-2 rounded-xl border border-white/10 bg-black/15 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <dt className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                        Sender badge
+                      </dt>
+                      <dd>
+                        <SenderBadge policy={choice ?? undefined} />
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3 border-t border-white/[0.06] pt-2">
+                      <dt className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                        Filed under
+                      </dt>
+                      <dd className="flex items-center gap-1.5 text-xs text-foreground">
+                        <FolderInput className="h-3.5 w-3.5 text-muted-foreground" />
+                        {result ? getFolderLabel(result.folder) : ""}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <button
+                    onClick={onClose}
+                    className="mt-5 w-full rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+                  >
+                    Done
+                  </button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/sender-conversion/index.ts
+++ b/src/features/sender-conversion/index.ts
@@ -1,0 +1,13 @@
+export { SenderConversionDialog } from "./SenderConversionDialog";
+export { ConvertSenderButton } from "./ConvertSenderButton";
+export { SenderBadge } from "./SenderBadge";
+export { useSenderConversion, type SenderConversionController } from "./useSenderConversion";
+export {
+  SENDER_POLICY_OPTIONS,
+  getSenderPolicyOption,
+  resolveSenderConversion,
+  type SenderConversionResult,
+  type SenderConversionTarget,
+  type SenderPolicyChoice,
+  type SenderPolicyOption,
+} from "./types";

--- a/src/features/sender-conversion/types.ts
+++ b/src/features/sender-conversion/types.ts
@@ -1,0 +1,130 @@
+import { BadgeCheck, Ban, ShieldCheck, type LucideIcon } from "lucide-react";
+import type { Email, MailLocation, SenderPolicy } from "@/components/mail/data";
+import type { FeedbackTone } from "@/features/design-system/feedback/use-feedback";
+
+/**
+ * The decision a user can make about a frequent unknown sender.
+ * Mirrors the protocol-level per-sender rule (`allow` / `block`) plus an
+ * intermediate `verify` step that keeps the sender but requires a verified
+ * Stellar identity before their mail is trusted.
+ */
+export type SenderPolicyChoice = SenderPolicy;
+
+/**
+ * Minimal description of the sender being converted. Decoupled from `Email`
+ * so any surface (request card, sender card, reader header) can open the flow
+ * with just the fields it has.
+ */
+export type SenderConversionTarget = {
+  emailId: string;
+  sender: string;
+  address: string;
+  /** Current policy, if the sender was converted before (enables re-decisions). */
+  currentPolicy?: SenderPolicyChoice;
+};
+
+/**
+ * Static, presentational metadata for each choice. Lives in one place so the
+ * dialog, the success state, and tests all read the same copy.
+ */
+export type SenderPolicyOption = {
+  value: SenderPolicyChoice;
+  label: string;
+  /** One-line summary shown on the option card. */
+  summary: string;
+  /** The concrete difference — what actually happens to their mail. */
+  effect: string;
+  badge: string;
+  icon: LucideIcon;
+  tone: FeedbackTone;
+};
+
+export const SENDER_POLICY_OPTIONS: SenderPolicyOption[] = [
+  {
+    value: "allow",
+    label: "Allow",
+    summary: "Treat this sender as a trusted contact.",
+    effect: "Future mail skips review and lands directly in your inbox. No postage required.",
+    badge: "Trusted",
+    icon: BadgeCheck,
+    tone: "success",
+  },
+  {
+    value: "verify",
+    label: "Verify",
+    summary: "Allow, but only with a verified Stellar identity.",
+    effect:
+      "Mail is accepted once the sender's cryptographic identity checks out, then filed under Verified.",
+    badge: "Verified",
+    icon: ShieldCheck,
+    tone: "neutral",
+  },
+  {
+    value: "block",
+    label: "Block",
+    summary: "Reject this sender and refund their postage.",
+    effect: "Their messages are quarantined to Spam and they can no longer reach you.",
+    badge: "Blocked",
+    icon: Ban,
+    tone: "danger",
+  },
+];
+
+export function getSenderPolicyOption(choice: SenderPolicyChoice): SenderPolicyOption {
+  const option = SENDER_POLICY_OPTIONS.find((item) => item.value === choice);
+  // Exhaustive by construction; the fallback keeps callers null-safe.
+  return option ?? SENDER_POLICY_OPTIONS[0];
+}
+
+/**
+ * The outcome of a conversion: the email patch that moves the sender to its new
+ * home plus a human-readable confirmation. Pure so it can be unit-tested and so
+ * the route layer stays a thin applicator.
+ */
+export type SenderConversionResult = {
+  choice: SenderPolicyChoice;
+  patch: Partial<Email>;
+  /** Destination folder, surfaced in the success state ("filed under …"). */
+  folder: MailLocation;
+  badge: string;
+  toast: { message: string; tone: FeedbackTone };
+};
+
+/** Where each choice files the sender's current message. */
+const CHOICE_FOLDER: Record<SenderPolicyChoice, MailLocation> = {
+  allow: "inbox",
+  verify: "verified",
+  block: "spam",
+};
+
+/**
+ * Resolve a choice into the concrete email mutation. Keeps the policy badge in
+ * sync with folder placement and replaces any prior conversion label so a
+ * sender re-decision doesn't accumulate stale badges.
+ */
+export function resolveSenderConversion(
+  email: Pick<Email, "from" | "labels">,
+  choice: SenderPolicyChoice,
+): SenderConversionResult {
+  const option = getSenderPolicyOption(choice);
+  const folder = CHOICE_FOLDER[choice];
+  const conversionLabels = new Set(SENDER_POLICY_OPTIONS.map((item) => item.badge));
+  const labels = [
+    ...(email.labels ?? []).filter((label) => !conversionLabels.has(label)),
+    option.badge,
+  ];
+
+  const toastByChoice: Record<SenderPolicyChoice, string> = {
+    allow: `${email.from} is now a trusted contact`,
+    verify: `${email.from} will be accepted once their identity is verified`,
+    block: `${email.from} blocked — postage marked for refund`,
+  };
+
+  return {
+    choice,
+    folder,
+    badge: option.badge,
+    patch: { folder, senderPolicy: choice, labels },
+    toast: { message: toastByChoice[choice], tone: option.tone },
+  };
+}

--- a/src/features/sender-conversion/useSenderConversion.ts
+++ b/src/features/sender-conversion/useSenderConversion.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from "react";
+import type { SenderConversionTarget } from "./types";
+
+/**
+ * Owns the open/closed state of the sender-conversion flow. A single instance
+ * lives at the route level so every entry point (request card, sender card,
+ * reader header) drives the same dialog and the same single source of truth.
+ *
+ * Opening the flow is inert: it only records which sender is in focus. No
+ * policy changes until the user explicitly confirms inside the dialog.
+ */
+export function useSenderConversion() {
+  const [target, setTarget] = useState<SenderConversionTarget | null>(null);
+
+  const open = useCallback((next: SenderConversionTarget) => setTarget(next), []);
+  const close = useCallback(() => setTarget(null), []);
+
+  return {
+    target,
+    isOpen: target !== null,
+    open,
+    close,
+  };
+}
+
+export type SenderConversionController = ReturnType<typeof useSenderConversion>;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,6 +23,13 @@ import { CalendarWorkspace, useCalendar } from "@/features/calendar";
 import { FeedbackViewport } from "@/features/design-system/feedback/feedback-viewport";
 import { useFeedback } from "@/features/design-system/feedback/use-feedback";
 import { OnboardingModal, draftToMailboxPolicy, type OnboardingDraft } from "@/features/onboarding";
+import {
+  SenderConversionDialog,
+  resolveSenderConversion,
+  useSenderConversion,
+  type SenderConversionTarget,
+  type SenderPolicyChoice,
+} from "@/features/sender-conversion";
 
 export const Route = createFileRoute("/")({
   head: () => ({
@@ -58,6 +65,7 @@ function MailApp() {
   const [calendarEventId, setCalendarEventId] = useState<string | null>(null);
   const [calendarCreateRequest, setCalendarCreateRequest] = useState(0);
   const { preferences, setPreferences, hydrated } = usePreferences();
+  const senderConversion = useSenderConversion();
 
   // Gate: show onboarding only after localStorage has been read (hydrated) and only
   // when it has not been completed in a previous session.
@@ -122,6 +130,26 @@ function MailApp() {
     setComposeOpen(true);
   };
 
+  // Opening the flow is inert — it only puts the sender in focus. No policy
+  // changes until the user explicitly confirms a choice in the dialog.
+  const openSenderConversion = (e: Email) =>
+    senderConversion.open({
+      emailId: e.id,
+      sender: e.from,
+      address: e.email,
+      currentPolicy: e.senderPolicy,
+    });
+
+  // Single applicator: mutating the shared `emails` array re-renders every open
+  // surface (list, reader, sender card, sidebar counts) from one source of truth.
+  const handleConvertSender = (target: SenderConversionTarget, choice: SenderPolicyChoice) => {
+    const email = emails.find((item) => item.id === target.emailId);
+    if (!email) return;
+    const result = resolveSenderConversion(email, choice);
+    updateEmail(email.id, result.patch);
+    showToast(result.toast.message, { tone: result.toast.tone });
+  };
+
   const quoteBody = (e: Email) =>
     `\n\n---\nOn ${e.time}, ${e.from} <${e.email}> wrote:\n${e.body
       .split("\n")
@@ -166,14 +194,7 @@ function MailApp() {
       updateEmail(e.id, { starred: !e.starred });
       showToast(e.starred ? "Removed star" : "Starred");
     },
-    onApproveSender: (e: Email) => {
-      updateEmail(e.id, { folder: "verified" });
-      showToast(`${e.from} can now mail you`);
-    },
-    onBlockSender: (e: Email) => {
-      updateEmail(e.id, { folder: "spam" });
-      showToast(`${e.from} blocked and postage marked for refund`);
-    },
+    onConvertSender: openSenderConversion,
     onShowToast: showToast,
     onAddEvent: (e: Email) => {
       if (!e.event) return;
@@ -324,6 +345,7 @@ function MailApp() {
               emails={emails}
               selectedId={selectedId}
               onSelect={setSelectedId}
+              onConvertSender={openSenderConversion}
               folder={folder}
               filters={filters}
               customFolder={customFolder}
@@ -334,6 +356,7 @@ function MailApp() {
             <RightPanel
               email={selected}
               onAction={handleContextAction}
+              onConvertSender={openSenderConversion}
               calendarEvents={calendar.visibleEvents}
               calendars={calendar.calendars}
               onOpenCalendar={(eventId) => {
@@ -418,6 +441,12 @@ function MailApp() {
       <FeedbackViewport items={feedbackItems} onDismiss={dismissFeedback} />
 
       <OnboardingModal open={showOnboarding} onComplete={handleOnboardingComplete} />
+
+      <SenderConversionDialog
+        target={senderConversion.target}
+        onConfirm={handleConvertSender}
+        onClose={senderConversion.close}
+      />
     </div>
   );
 }

--- a/tests/unit/sender-conversion/sender-conversion.test.ts
+++ b/tests/unit/sender-conversion/sender-conversion.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SENDER_POLICY_OPTIONS,
+  getSenderPolicyOption,
+  resolveSenderConversion,
+  type SenderPolicyChoice,
+} from "../../../src/features/sender-conversion/types";
+
+// ---------------------------------------------------------------------------
+// Option metadata
+// ---------------------------------------------------------------------------
+describe("SENDER_POLICY_OPTIONS", () => {
+  it("explains allow, verify, and block as distinct choices", () => {
+    expect(SENDER_POLICY_OPTIONS.map((option) => option.value)).toEqual([
+      "allow",
+      "verify",
+      "block",
+    ]);
+  });
+
+  it("gives every option an effect description so differences are explained", () => {
+    for (const option of SENDER_POLICY_OPTIONS) {
+      expect(option.summary.length).toBeGreaterThan(0);
+      expect(option.effect.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves an option for each choice", () => {
+    for (const choice of ["allow", "verify", "block"] as SenderPolicyChoice[]) {
+      expect(getSenderPolicyOption(choice).value).toBe(choice);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSenderConversion
+// ---------------------------------------------------------------------------
+describe("resolveSenderConversion", () => {
+  it("files an allowed sender in the inbox with a trusted badge", () => {
+    const result = resolveSenderConversion({ from: "Lina" }, "allow");
+    expect(result.folder).toBe("inbox");
+    expect(result.patch.folder).toBe("inbox");
+    expect(result.patch.senderPolicy).toBe("allow");
+    expect(result.patch.labels).toContain("Trusted");
+    expect(result.toast.tone).toBe("success");
+  });
+
+  it("files a verified sender under Verified", () => {
+    const result = resolveSenderConversion({ from: "Mina" }, "verify");
+    expect(result.folder).toBe("verified");
+    expect(result.patch.labels).toContain("Verified");
+  });
+
+  it("quarantines a blocked sender to spam with a danger tone", () => {
+    const result = resolveSenderConversion({ from: "Spammer" }, "block");
+    expect(result.folder).toBe("spam");
+    expect(result.patch.senderPolicy).toBe("block");
+    expect(result.toast.tone).toBe("danger");
+    expect(result.toast.message).toMatch(/refund/i);
+  });
+
+  it("keeps unrelated labels but never stacks stale conversion badges on re-decision", () => {
+    const result = resolveSenderConversion(
+      { from: "Lina", labels: ["Design", "Trusted"] },
+      "block",
+    );
+    expect(result.patch.labels).toContain("Design");
+    expect(result.patch.labels).toContain("Blocked");
+    expect(result.patch.labels).not.toContain("Trusted");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a guided, per-sender conversion flow that helps a user turn a frequent **unknown sender** into a **trusted**, **verified**, or **blocked** contact. This is distinct from first-run onboarding — it is per-sender conversion UX, reachable in context from wherever a sender appears.

Closes #122.

## What's included

A new feature module `src/features/sender-conversion/`:

- **`types.ts`** — `SenderPolicyChoice` (`allow` / `verify` / `block`), per-option metadata (label, summary, concrete effect, badge, icon, tone), and a **pure** `resolveSenderConversion()` that maps a choice to an email patch, destination folder, and confirmation toast. Keeping the policy logic pure makes it testable and keeps the route a thin applicator.
- **`useSenderConversion.ts`** — a small controller that owns the open/closed state. Opening is inert: it only records which sender is in focus.
- **`SenderConversionDialog.tsx`** — the guided modal.
- **`SenderBadge.tsx`** / **`ConvertSenderButton.tsx`** — shared, reused across every surface for consistent affordance and badging.

## Entry points (CTAs)

All three open the **same** dialog from a single controller in `src/routes/index.tsx`:

- **Request cards** — inline "Review sender" CTA (`EmailList.tsx`).
- **Sender card** — "Convert to contact" CTA + badge in the contact panel (`RightPanel.tsx`).
- **Reader header** — "Add sender" CTA + badge; the previous one-click "Allow sender" on the request card now routes through the explained flow (`EmailView.tsx`).

## Flow behavior

1. **Choose** — explains how allow / verify / block differ (summary + concrete effect for each). Nothing is pre-selected and Confirm stays disabled until the user picks an option.
2. **Done** — success state showing the updated sender badge and the folder the sender is now filed under.

## How acceptance criteria are met

- **Never auto-allows a sender without explicit action** — the dialog opens with no selection, Confirm is disabled until a choice is made, and the old instant "Allow" affordance now goes through the explained flow.
- **Users can cancel without changing policy** — Cancel, the backdrop, and Esc all close the dialog as no-ops; no mutation runs.
- **Completion updates all open surfaces consistently** — confirm performs a single mutation on the shared email state, so the list, reader, sender card, and sidebar counts all re-render from one source of truth; the success state mirrors the same result.

## Model change

- Added an optional `senderPolicy` field to the `Email` type so a converted sender's badge stays in sync with its folder placement across surfaces.

## Testing

- New unit tests for the pure resolver in `tests/unit/sender-conversion/` (allow → inbox/Trusted, verify → Verified, block → spam/refund, and label hygiene on re-decision).
- Full suite: **57 tests pass**. ESLint clean. Production build succeeds.

## Notes

- This change is purely additive UI/UX wiring on the existing mock mail state; it does not alter the protocol API.
