### PR TITLE
Close #135 create logged-out zero-data landing screen  #135

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@stellar/freighter-api": "^6.0.1",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.168.0",
@@ -3383,6 +3384,28 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tabby_ai/hijri-converter": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
@@ -4872,6 +4895,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
@@ -4963,6 +5006,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/callsites": {
@@ -6166,6 +6233,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/src/components/landing/LandingScreen.tsx
+++ b/src/components/landing/LandingScreen.tsx
@@ -1,0 +1,93 @@
+import { Shield, Mail, Zap, Key } from "lucide-react";
+import { AmbientBackground } from "@/components/mail/AmbientBackground";
+
+interface LandingScreenProps {
+  onConnectWallet: () => void;
+  onExploreDemo: () => void;
+}
+
+export function LandingScreen({ onConnectWallet, onExploreDemo }: LandingScreenProps) {
+  return (
+    <div className="relative min-h-screen text-foreground flex flex-col items-center justify-center p-6 overflow-hidden">
+      <AmbientBackground />
+      <div className="relative z-10 max-w-4xl w-full flex flex-col items-center text-center space-y-12">
+        {/* Hero Section */}
+        <div className="space-y-6">
+          <div className="inline-flex items-center justify-center p-3 mb-4 rounded-2xl bg-glass-strong border border-border shadow-lg">
+            <Mail className="w-10 h-10 text-primary" />
+          </div>
+          <h1 className="text-5xl md:text-7xl font-bold tracking-tight text-foreground">
+            Stealth Mail
+          </h1>
+          <p className="text-xl md:text-2xl text-muted-foreground max-w-2xl mx-auto">
+            A cryptographic mail client built on Stellar. Send messages with mathematical certainty.
+          </p>
+        </div>
+
+        {/* Feature Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-3xl">
+          <FeatureCard
+            icon={<Shield className="w-6 h-6 text-primary" />}
+            title="End-to-End Encrypted"
+            description="Your messages are secured by cryptography. Only you and the recipient can read them."
+          />
+          <FeatureCard
+            icon={<Key className="w-6 h-6 text-primary" />}
+            title="Cryptographic Identity"
+            description="No passwords to steal. Your Stellar wallet acts as your unforgeable mail identity."
+          />
+          <FeatureCard
+            icon={<Zap className="w-6 h-6 text-primary" />}
+            title="Delivery Proofs"
+            description="Every message sent provides cryptographic proof of delivery through the network."
+          />
+        </div>
+
+        {/* Call to Actions */}
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-8 w-full max-w-md mx-auto">
+          <button
+            onClick={onConnectWallet}
+            className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-lg transition-transform hover:scale-105 hover:bg-primary/90"
+          >
+            Connect Wallet
+          </button>
+          <button
+            onClick={onExploreDemo}
+            className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl bg-glass px-8 py-4 text-base font-medium text-foreground border border-border shadow-sm transition-colors hover:bg-muted"
+          >
+            Explore Demo Inbox
+          </button>
+        </div>
+
+        <div className="pt-12">
+          <a
+            href="/docs"
+            className="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Read Protocol Docs <span className="ml-1">→</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center p-6 text-center rounded-2xl bg-glass border border-border">
+      <div className="mb-4 p-3 rounded-full bg-background border border-border shadow-sm">
+        {icon}
+      </div>
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+    </div>
+  );
+}

--- a/src/components/mail/Topbar.tsx
+++ b/src/components/mail/Topbar.tsx
@@ -29,6 +29,7 @@ type TopbarProps = {
   onFiltersChange: (filters: MailFilters) => void;
   onQuickAction: (action: "proofs" | "later" | "files") => void;
   onViewNotifications: () => void;
+  onSignOut?: () => void;
 };
 
 const quickActions: {
@@ -50,6 +51,7 @@ export function Topbar({
   onFiltersChange,
   onQuickAction,
   onViewNotifications,
+  onSignOut,
 }: TopbarProps) {
   const [focused, setFocused] = useState(false);
   const [filterOpen, setFilterOpen] = useState(false);
@@ -360,6 +362,7 @@ export function Topbar({
                         onClick={() => {
                           setAccountOpen(false);
                           onShowToast("Signed out successfully");
+                          onSignOut?.();
                         }}
                       />
                     </div>
@@ -447,7 +450,7 @@ function FilterToggle({
   checked,
   onChange,
 }: {
-  icon: any;
+  icon: LucideIcon;
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
@@ -474,7 +477,7 @@ function AccountMenuItem({
   label,
   onClick,
 }: {
-  icon: any;
+  icon: LucideIcon;
   label: string;
   onClick: () => void;
 }) {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,8 @@ import { Compose, type ComposeSubmission } from "@/components/mail/Compose";
 import { RightPanel, type ContextAction } from "@/components/mail/RightPanel";
 import { CommandPalette } from "@/components/mail/CommandPalette";
 import { SettingsModal } from "@/components/mail/SettingsModal";
+import { LandingScreen } from "@/components/landing/LandingScreen";
+import { useFreighter } from "@/features/onboarding/useFreighter";
 import {
   defaultMailFilters,
   emails as initialEmails,
@@ -36,10 +38,37 @@ export const Route = createFileRoute("/")({
       },
     ],
   }),
-  component: MailApp,
+  component: IndexPage,
 });
 
-function MailApp() {
+function IndexPage() {
+  const [authMode, setAuthMode] = useState<"logged-out" | "demo" | "authenticated">("logged-out");
+  const { state: freighterState, connect } = useFreighter();
+
+  const handleConnectWallet = async () => {
+    const address = await connect();
+    if (address) {
+      setAuthMode("authenticated");
+    } else if (freighterState.status === "error" || freighterState.status === "unavailable") {
+      // Fallback for demo purposes if wallet isn't available
+      // In a real app we might show a toast, but here we can just alert or force auth
+      alert("Wallet connection failed or unavailable. Please use demo mode for now.");
+    }
+  };
+
+  if (authMode === "logged-out") {
+    return (
+      <LandingScreen
+        onConnectWallet={handleConnectWallet}
+        onExploreDemo={() => setAuthMode("demo")}
+      />
+    );
+  }
+
+  return <MailApp isDemoMode={authMode === "demo"} onSignOut={() => setAuthMode("logged-out")} />;
+}
+
+function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: () => void }) {
   const [folder, setFolder] = useState<MailFolder>("inbox");
   const [emails, setEmails] = useState<Email[]>(initialEmails);
   const [selectedId, setSelectedId] = useState<string | null>(initialEmails[0].id);
@@ -61,14 +90,9 @@ function MailApp() {
 
   // Gate: show onboarding only after localStorage has been read (hydrated) and only
   // when it has not been completed in a previous session.
-  const showOnboarding = hydrated && !preferences.onboardingCompleted;
+  // In demo mode, we might want to skip onboarding or mock it.
+  const showOnboarding = hydrated && !preferences.onboardingCompleted && !isDemoMode;
 
-  /**
-   * Called by OnboardingModal once all 7 steps are complete.
-   * 1. Submits the mailbox policy to the protocol API.
-   * 2. Merges the draft into local UiPreferences so Settings reflects the same values.
-   * Errors propagate back to PolicyReviewStep for inline display (no silent swallow).
-   */
   const handleOnboardingComplete = useCallback(
     async (walletAddress: string, draft: OnboardingDraft) => {
       const policy = draftToMailboxPolicy(draft);
@@ -281,6 +305,11 @@ function MailApp() {
   return (
     <div className="relative min-h-screen text-foreground">
       <AmbientBackground />
+      {isDemoMode && (
+        <div className="absolute top-0 inset-x-0 z-50 bg-primary/20 backdrop-blur-md border-b border-primary/30 py-1 text-center text-xs font-medium text-primary shadow-sm pointer-events-none">
+          Demo Mode: Showing placeholder data.
+        </div>
+      )}
 
       <div className="flex min-h-screen">
         <Sidebar
@@ -302,6 +331,7 @@ function MailApp() {
             onOpenPalette={() => setPaletteOpen(true)}
             onOpenSettings={() => setSettingsOpen(true)}
             onShowToast={showToast}
+            onSignOut={onSignOut}
             filters={filters}
             onFiltersChange={setFilters}
             onQuickAction={(action) => {


### PR DESCRIPTION
Adds a polished landing screen for unauthenticated users that 
communicates Stealth's value proposition and routes them to the 
right next action — without loading private mailbox data.

## What Changed
- Built a dedicated logged-out landing screen with product 
  value messaging and safety claims
- Added three primary CTAs: connect wallet, explore demo 
  inbox, and read protocol docs
- Demo mode is clearly labelled so users know they are 
  viewing sample data, not real mailbox content
- Separated product storytelling from the authenticated 
  mailbox UI so unauthenticated users never see private 
  mailbox fixtures

## Testing
1. Open the app without connecting a wallet
2. Confirm the landing screen renders correctly
3. Confirm connect wallet CTA works
4. Confirm demo inbox is labelled and loads sample data only
5. Confirm docs link routes correctly
6. Test on mobile and desktop viewports