### PR TITLE
feat: publish protocol interoperability vectors

### DIFF
--- a/contracts/soroban/policies/Cargo.toml
+++ b/contracts/soroban/policies/Cargo.toml
@@ -13,3 +13,5 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -94,6 +94,216 @@ impl PoliciesContract {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Canonical interoperability vector tests
+//
+// Reads the language-neutral fixture at protocol/vectors/vectors.json and
+// drives every primitive-validation case and every policy-decision case
+// through the live Rust helpers and contract functions.  This ensures that
+// CI catches any divergence between the fixture and this implementation.
+//
+// Space/time: O(n) — each vector case is exercised exactly once.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod vectors {
+    extern crate std;
+
+    use serde_json::Value;
+    use soroban_sdk::testutils::Address as _;
+
+    use super::*;
+
+    const VECTORS_JSON: &str = include_str!("../../../../protocol/vectors/vectors.json");
+
+    // -----------------------------------------------------------------------
+    // Primitive-validation helpers (mirror the TypeScript Zod schemas)
+    // -----------------------------------------------------------------------
+
+    fn is_valid_stellar_address(s: &str) -> bool {
+        let s = s.trim();
+        s.len() == 56
+            && s.starts_with('G')
+            && s[1..].chars().all(|c| matches!(c, 'A'..='Z' | '2'..='7'))
+    }
+
+    fn validate_hash32(s: &str) -> Result<std::string::String, ()> {
+        let normalised = s.trim().to_lowercase();
+        if normalised.len() == 64
+            && normalised.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+        {
+            Ok(normalised)
+        } else {
+            Err(())
+        }
+    }
+
+    fn validate_stroop_amount(s: &str) -> Result<i128, ()> {
+        let s = s.trim();
+        if s.is_empty() || (!s.chars().all(|c| c.is_ascii_digit())) {
+            return Err(());
+        }
+        if s != "0" && s.starts_with('0') {
+            return Err(());
+        }
+        let val: u128 = s.parse().map_err(|_| ())?;
+        if val > i128::MAX as u128 {
+            return Err(());
+        }
+        Ok(val as i128)
+    }
+
+    // -----------------------------------------------------------------------
+    // primitives/address
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn primitives_address() {
+        let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
+        let cases = root["categories"]["primitives"]["address"]["cases"]
+            .as_array()
+            .unwrap();
+        for c in cases {
+            let id = c["id"].as_str().unwrap();
+            let input = c["input"].as_str().unwrap_or("");
+            let expected = c["expected"]["valid"].as_bool().unwrap();
+            assert_eq!(
+                is_valid_stellar_address(input),
+                expected,
+                "vectors: {}",
+                id
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // primitives/hash
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn primitives_hash() {
+        let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
+        let cases = root["categories"]["primitives"]["hash"]["cases"]
+            .as_array()
+            .unwrap();
+        for c in cases {
+            let id = c["id"].as_str().unwrap();
+            let input = c["input"].as_str().unwrap_or("");
+            let expected = c["expected"]["valid"].as_bool().unwrap();
+            let got = validate_hash32(input);
+            assert_eq!(got.is_ok(), expected, "vectors: {}", id);
+            if got.is_ok() {
+                if let Some(exp_norm) = c["expected"]["normalized"].as_str() {
+                    assert_eq!(got.unwrap(), exp_norm, "vectors: {} normalised", id);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // primitives/amount
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn primitives_amount() {
+        let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
+        let cases = root["categories"]["primitives"]["amount"]["cases"]
+            .as_array()
+            .unwrap();
+        for c in cases {
+            let id = c["id"].as_str().unwrap();
+            let input = c["input"].as_str().unwrap_or("");
+            let expected = c["expected"]["valid"].as_bool().unwrap();
+            assert_eq!(
+                validate_stroop_amount(input).is_ok(),
+                expected,
+                "vectors: {}",
+                id
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // policy_decisions — exercises the live can_mail contract function
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn policy_decisions() {
+        let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
+        let cases = root["categories"]["policy_decisions"]["cases"]
+            .as_array()
+            .unwrap();
+
+        for c in cases {
+            let id = c["id"].as_str().unwrap();
+            let env = Env::default();
+            env.mock_all_auths();
+            let contract_id = env.register(PoliciesContract, ());
+            let client = PoliciesContractClient::new(&env, &contract_id);
+            let owner = soroban_sdk::Address::generate(&env);
+            let sender = soroban_sdk::Address::generate(&env);
+
+            // Apply sender rule from fixture
+            match c["setup"]["senderRule"].as_str().unwrap_or("default") {
+                "allow" => client.set_sender_rule(&owner, &sender, &SenderRule::Allow),
+                "block" => client.set_sender_rule(&owner, &sender, &SenderRule::Block),
+                _ => {}
+            }
+
+            // Apply mailbox policy from fixture (if present)
+            if let Some(policy_obj) = c["setup"]["policy"].as_object() {
+                let min: i128 = policy_obj["minimumPostage"]
+                    .as_str()
+                    .unwrap_or("0")
+                    .parse()
+                    .unwrap();
+                client.set_policy(
+                    &owner,
+                    &MailboxPolicy {
+                        allow_unknown: policy_obj["allowUnknown"].as_bool().unwrap(),
+                        require_verified: policy_obj["requireVerified"].as_bool().unwrap(),
+                        minimum_postage: min,
+                    },
+                );
+            }
+
+            let postage: i128 = c["input"]["postage"].as_str().unwrap().parse().unwrap();
+            let verified = c["input"]["verified"].as_bool().unwrap();
+            let expected = c["expected"]["allowed"].as_bool().unwrap();
+
+            assert_eq!(
+                client.can_mail(&owner, &sender, &verified, &postage),
+                expected,
+                "vectors: {}",
+                id
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // tampered — all cases must be rejected by the relevant validator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tampered() {
+        let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
+        let cases = root["categories"]["tampered"]["cases"]
+            .as_array()
+            .unwrap();
+        for c in cases {
+            let id = c["id"].as_str().unwrap();
+            let schema = c["schema"].as_str().unwrap();
+            let input = c["input"].as_str().unwrap_or("");
+            let valid = match schema {
+                "stellarAddress" => is_valid_stellar_address(input),
+                "hash32" => validate_hash32(input).is_ok(),
+                "stroopAmount" => validate_stroop_amount(input).is_ok(),
+                _ => panic!("unknown schema: {schema}"),
+            };
+            assert!(!valid, "vectors: {id} should be invalid");
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/protocol/vectors/vectors.json
+++ b/protocol/vectors/vectors.json
@@ -1,0 +1,532 @@
+{
+  "$schema": "stealth-protocol-vectors@1",
+  "description": "Canonical interoperability test vectors for the Stealth protocol. No production secrets are included — all addresses and hashes are placeholder values.",
+  "version": "1",
+  "notes": {
+    "addresses": "Placeholder Stellar G-addresses use repeated characters (GAAA…, GBBB…, GCCC…). They satisfy the format regex G[A-Z2-7]{55} but are not derived from real keys.",
+    "hashes": "Placeholder 32-byte hashes use repeated hex digits (aaa…, bbb…, ccc…). They satisfy the format regex [a-f0-9]{64}.",
+    "amounts": "All amounts are Soroban i128 values serialised as decimal strings. The maximum valid value is 2^127-1 = 170141183460469231731687303715884105727.",
+    "hash_normalisation": "hash32 inputs are lowercased before validation. ABCDEF… and abcdef… refer to the same hash. Implementations must normalise to lowercase before storage and comparison."
+  },
+  "categories": {
+    "primitives": {
+      "address": {
+        "description": "Stellar G-address format validation. Pattern: G followed by exactly 55 characters from the base32 alphabet A-Z and 2-7.",
+        "cases": [
+          {
+            "id": "primitives/address/valid/all-A",
+            "description": "Minimum base32 character (A = 0). 56 characters total.",
+            "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/address/valid/all-Z",
+            "description": "Maximum base32 character (Z = 25). 56 characters total.",
+            "input": "GZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/address/valid/mixed-base32",
+            "description": "Mix of letters and digits 2-7 — all valid base32 characters.",
+            "input": "GABCDEFG2345672ABCDEFG2345672ABCDEFG2345672ABCDEFG234567",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/address/invalid/too-short",
+            "description": "55 characters total — one character short of the required 56.",
+            "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/too-long",
+            "description": "57 characters total — one character over the required 56.",
+            "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/wrong-prefix",
+            "description": "Starts with X instead of G.",
+            "input": "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/digit-zero",
+            "description": "Contains digit 0, which is not in the base32 alphabet (valid digits are 2-7).",
+            "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/digit-one",
+            "description": "Contains digit 1, which is not in the base32 alphabet (valid digits are 2-7).",
+            "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/lowercase",
+            "description": "Lowercase g is not accepted — the prefix must be uppercase G.",
+            "input": "gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          },
+          {
+            "id": "primitives/address/invalid/empty",
+            "description": "Empty string.",
+            "input": "",
+            "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+          }
+        ]
+      },
+      "hash": {
+        "description": "32-byte hash encoded as 64 lowercase hexadecimal characters. Implementations must normalise input to lowercase before validation and storage.",
+        "cases": [
+          {
+            "id": "primitives/hash/valid/all-zeros",
+            "description": "All-zero hash — the minimum representable 32-byte value.",
+            "input": "0000000000000000000000000000000000000000000000000000000000000000",
+            "expected": { "valid": true, "normalized": "0000000000000000000000000000000000000000000000000000000000000000" }
+          },
+          {
+            "id": "primitives/hash/valid/all-f",
+            "description": "All-0xff hash — the maximum representable 32-byte value.",
+            "input": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "expected": { "valid": true, "normalized": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" }
+          },
+          {
+            "id": "primitives/hash/valid/mixed",
+            "description": "Mixed lowercase hex characters — typical SHA-256 output pattern.",
+            "input": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            "expected": { "valid": true, "normalized": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" }
+          },
+          {
+            "id": "primitives/hash/valid/uppercase-normalised",
+            "description": "Uppercase hex characters are normalised to lowercase. Implementations must store the normalised form.",
+            "input": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+            "expected": { "valid": true, "normalized": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" }
+          },
+          {
+            "id": "primitives/hash/invalid/too-short",
+            "description": "63 hex characters — one short of the required 64.",
+            "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+          },
+          {
+            "id": "primitives/hash/invalid/too-long",
+            "description": "65 hex characters — one over the required 64.",
+            "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0",
+            "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+          },
+          {
+            "id": "primitives/hash/invalid/non-hex-char",
+            "description": "64 characters but the last is 'g', which is outside the hex alphabet [a-f0-9].",
+            "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaag",
+            "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+          },
+          {
+            "id": "primitives/hash/invalid/empty",
+            "description": "Empty string.",
+            "input": "",
+            "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+          }
+        ]
+      },
+      "amount": {
+        "description": "Soroban i128 amount encoded as a non-negative decimal integer string. No leading zeros (except the literal '0'). Range: 0 to 2^127-1.",
+        "cases": [
+          {
+            "id": "primitives/amount/valid/zero",
+            "description": "Zero — the minimum valid amount.",
+            "input": "0",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/amount/valid/one-xlm-in-stroops",
+            "description": "10 000 000 stroops = 1 XLM.",
+            "input": "10000000",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/amount/valid/arbitrary",
+            "description": "Arbitrary mid-range value.",
+            "input": "1000",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/amount/valid/max-i128",
+            "description": "Maximum Soroban i128 value: 2^127 - 1.",
+            "input": "170141183460469231731687303715884105727",
+            "expected": { "valid": true }
+          },
+          {
+            "id": "primitives/amount/invalid/negative",
+            "description": "Negative amount — stroops cannot be negative.",
+            "input": "-1",
+            "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+          },
+          {
+            "id": "primitives/amount/invalid/decimal",
+            "description": "Decimal value — amounts must be integers.",
+            "input": "1.5",
+            "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+          },
+          {
+            "id": "primitives/amount/invalid/leading-zero",
+            "description": "Leading zero — not a canonical integer representation.",
+            "input": "01",
+            "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+          },
+          {
+            "id": "primitives/amount/invalid/non-numeric",
+            "description": "Non-numeric string.",
+            "input": "abc",
+            "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+          },
+          {
+            "id": "primitives/amount/invalid/empty",
+            "description": "Empty string.",
+            "input": "",
+            "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+          },
+          {
+            "id": "primitives/amount/invalid/overflow",
+            "description": "2^127 — one over the maximum Soroban i128 value.",
+            "input": "170141183460469231731687303715884105728",
+            "expected": { "valid": false, "error": "Amount exceeds Soroban i128" }
+          }
+        ]
+      }
+    },
+    "policy_decisions": {
+      "description": "Decision tree for can_mail (Rust contract) and evaluateMailboxPolicy (TypeScript service). All 6 branches are covered. Addresses used: owner=GAAA…, sender=GBBB….",
+      "owner": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      "cases": [
+        {
+          "id": "policy/explicit-allow",
+          "description": "Explicit allow rule bypasses all policy checks regardless of postage or verification.",
+          "setup": { "senderRule": "allow", "policy": null },
+          "input": { "postage": "0", "verified": false },
+          "expected": { "allowed": true, "reason": "sender_allowed" }
+        },
+        {
+          "id": "policy/explicit-block",
+          "description": "Explicit block rule rejects the sender regardless of postage or verification.",
+          "setup": { "senderRule": "block", "policy": null },
+          "input": { "postage": "1000", "verified": true },
+          "expected": { "allowed": false, "reason": "sender_blocked" }
+        },
+        {
+          "id": "policy/unknown-senders-disabled",
+          "description": "No explicit rule; mailbox policy has allowUnknown=false — all unknown senders are rejected.",
+          "setup": {
+            "senderRule": "default",
+            "policy": { "allowUnknown": false, "requireVerified": false, "minimumPostage": "0" }
+          },
+          "input": { "postage": "1000", "verified": true },
+          "expected": { "allowed": false, "reason": "unknown_senders_disabled" }
+        },
+        {
+          "id": "policy/verification-required",
+          "description": "No explicit rule; mailbox requires verified senders; sender is unverified.",
+          "setup": {
+            "senderRule": "default",
+            "policy": { "allowUnknown": true, "requireVerified": true, "minimumPostage": "0" }
+          },
+          "input": { "postage": "1000", "verified": false },
+          "expected": { "allowed": false, "reason": "verification_required" }
+        },
+        {
+          "id": "policy/insufficient-postage",
+          "description": "No explicit rule; mailbox minimum is 500 stroops; sender attaches only 499.",
+          "setup": {
+            "senderRule": "default",
+            "policy": { "allowUnknown": true, "requireVerified": false, "minimumPostage": "500" }
+          },
+          "input": { "postage": "499", "verified": false },
+          "expected": { "allowed": false, "reason": "insufficient_postage" }
+        },
+        {
+          "id": "policy/satisfied",
+          "description": "No explicit rule; all policy conditions are met — sender is allowed.",
+          "setup": {
+            "senderRule": "default",
+            "policy": { "allowUnknown": true, "requireVerified": false, "minimumPostage": "0" }
+          },
+          "input": { "postage": "0", "verified": false },
+          "expected": { "allowed": true, "reason": "policy_satisfied" }
+        },
+        {
+          "id": "policy/default-policy",
+          "description": "No sender rule and no configured policy. The protocol default is allowUnknown=false, requireVerified=true, minimumPostage=0 — so unknown senders are rejected.",
+          "setup": { "senderRule": "default", "policy": null },
+          "input": { "postage": "0", "verified": true },
+          "expected": { "allowed": false, "reason": "unknown_senders_disabled" }
+        }
+      ]
+    },
+    "postage_states": {
+      "description": "Postage lifecycle state machine. Each case describes a sequence of operations and the expected terminal state or error. Shared fixture fields are listed per case.",
+      "cases": [
+        {
+          "id": "postage/submit-pending",
+          "description": "Submitting postage creates a record with status 'pending'.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["submit"],
+          "expected": {
+            "status": "pending",
+            "createdAt": "2026-01-01T00:00:00.000Z"
+          }
+        },
+        {
+          "id": "postage/submit-and-settle",
+          "description": "Postage transitions from pending to settled on recipient action.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["submit", "settle"],
+          "expected": { "status": "settled" }
+        },
+        {
+          "id": "postage/submit-and-refund",
+          "description": "Postage transitions from pending to refunded on recipient action.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["submit", "refund"],
+          "expected": { "status": "refunded" }
+        },
+        {
+          "id": "postage/duplicate-submit",
+          "description": "Submitting postage for the same messageId twice is rejected.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["submit", "submit"],
+          "expected": {
+            "error": {
+              "code": "conflict",
+              "status": 409,
+              "message": "Postage already exists for this message"
+            }
+          }
+        },
+        {
+          "id": "postage/resolve-already-resolved",
+          "description": "Attempting to settle already-settled postage is rejected.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["submit", "settle", "settle"],
+          "expected": {
+            "error": {
+              "code": "conflict",
+              "status": 409,
+              "message": "Postage has already been resolved"
+            }
+          }
+        },
+        {
+          "id": "postage/blocked-sender",
+          "description": "A sender the recipient has blocked cannot submit postage.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "1000",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "preconditions": [
+            { "op": "setSenderRule", "rule": "block" }
+          ],
+          "operations": ["submit"],
+          "expected": {
+            "error": {
+              "code": "forbidden",
+              "status": 403,
+              "message": "The recipient has blocked this sender"
+            }
+          }
+        },
+        {
+          "id": "postage/below-minimum",
+          "description": "Amount below the mailbox minimum postage is rejected.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "paymentHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "amount": "999",
+            "submitAt": "2026-01-01T00:00:00.000Z"
+          },
+          "preconditions": [
+            {
+              "op": "setPolicy",
+              "policy": { "allowUnknown": true, "requireVerified": false, "minimumPostage": "1000" }
+            }
+          ],
+          "operations": ["submit"],
+          "expected": {
+            "error": {
+              "code": "validation_error",
+              "status": 422,
+              "message": "Postage is below the mailbox minimum"
+            }
+          }
+        }
+      ]
+    },
+    "receipts": {
+      "description": "Delivery and read receipt lifecycle. Each case describes a sequence of operations on a single messageId.",
+      "cases": [
+        {
+          "id": "receipts/deliver",
+          "description": "Creating a delivery receipt sets deliveredAt and leaves readAt null.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "deliverAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["deliver"],
+          "expected": {
+            "readAt": null,
+            "deliveredAt": "2026-01-01T00:00:00.000Z"
+          }
+        },
+        {
+          "id": "receipts/deliver-and-read",
+          "description": "Marking a delivered receipt as read sets readAt to a non-null timestamp.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "deliverAt": "2026-01-01T00:00:00.000Z",
+            "readAt": "2026-01-02T00:00:00.000Z"
+          },
+          "operations": ["deliver", "read"],
+          "expected": {
+            "readAt": "2026-01-02T00:00:00.000Z",
+            "deliveredAt": "2026-01-01T00:00:00.000Z"
+          }
+        },
+        {
+          "id": "receipts/duplicate-deliver",
+          "description": "Creating a second delivery receipt for the same messageId is rejected.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "deliverAt": "2026-01-01T00:00:00.000Z"
+          },
+          "operations": ["deliver", "deliver"],
+          "expected": {
+            "error": {
+              "code": "conflict",
+              "status": 409,
+              "message": "A delivery receipt already exists for this message"
+            }
+          }
+        },
+        {
+          "id": "receipts/read-already-read",
+          "description": "Marking an already-read receipt as read again is rejected.",
+          "fixture": {
+            "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "messageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "deliverAt": "2026-01-01T00:00:00.000Z",
+            "readAt": "2026-01-02T00:00:00.000Z"
+          },
+          "operations": ["deliver", "read", "read"],
+          "expected": {
+            "error": {
+              "code": "conflict",
+              "status": 409,
+              "message": "The receipt has already been marked as read"
+            }
+          }
+        }
+      ]
+    },
+    "tampered": {
+      "description": "Cases where field values have been corrupted or forged. Each case specifies the schema being validated and the exact error the implementation must return.",
+      "cases": [
+        {
+          "id": "tampered/address/wrong-prefix",
+          "description": "Address starts with X instead of G.",
+          "schema": "stellarAddress",
+          "input": "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+        },
+        {
+          "id": "tampered/address/digit-eight",
+          "description": "Address contains 8 which is outside the base32 alphabet (valid digits are 2-7).",
+          "schema": "stellarAddress",
+          "input": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8",
+          "expected": { "valid": false, "error": "Expected a Stellar G-address" }
+        },
+        {
+          "id": "tampered/hash/truncated",
+          "description": "Hash is only 32 hex characters — half the required 64.",
+          "schema": "hash32",
+          "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+        },
+        {
+          "id": "tampered/hash/non-hex",
+          "description": "Hash contains 'z', which is outside the hex alphabet.",
+          "schema": "hash32",
+          "input": "zaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "expected": { "valid": false, "error": "Expected a 32-byte lowercase hexadecimal hash" }
+        },
+        {
+          "id": "tampered/amount/negative",
+          "description": "Negative stroop amount — rejected by pattern before i128 range check.",
+          "schema": "stroopAmount",
+          "input": "-1",
+          "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+        },
+        {
+          "id": "tampered/amount/overflow",
+          "description": "Amount is 2^127 — one above the Soroban i128 maximum.",
+          "schema": "stroopAmount",
+          "input": "170141183460469231731687303715884105728",
+          "expected": { "valid": false, "error": "Amount exceeds Soroban i128" }
+        },
+        {
+          "id": "tampered/amount/floating-point",
+          "description": "Floating-point string is not a canonical integer — rejected even if representable.",
+          "schema": "stroopAmount",
+          "input": "100.0",
+          "expected": { "valid": false, "error": "Expected a non-negative integer string" }
+        }
+      ]
+    }
+  }
+}

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -15,7 +15,13 @@ export const stroopAmountSchema = z
   .string()
   .trim()
   .regex(/^(0|[1-9]\d*)$/, "Expected a non-negative integer string")
-  .refine((value) => BigInt(value) <= 2n ** 127n - 1n, "Amount exceeds Soroban i128");
+  .refine((value) => {
+    try {
+      return BigInt(value) <= 2n ** 127n - 1n;
+    } catch {
+      return false;
+    }
+  }, "Amount exceeds Soroban i128");
 
 export const senderRuleSchema = z.enum(["default", "allow", "block"]);
 export const postageStatusSchema = z.enum(["pending", "settled", "refunded"]);

--- a/tests/unit/protocol/vectors.test.ts
+++ b/tests/unit/protocol/vectors.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Canonical interoperability vector tests — TypeScript implementation.
+ *
+ * Reads protocol/vectors/vectors.json and drives every case through the
+ * live TypeScript services and Zod schemas so that CI gates divergence
+ * between the fixture and the implementation.
+ *
+ * Space/time: O(n) over the number of vector cases — each case is exercised
+ * exactly once with an isolated MemoryApiRepository, so no shared state leaks.
+ */
+import { describe, expect, it } from "vitest";
+
+import { stellarAddressSchema, hash32Schema, stroopAmountSchema } from "../../../src/server/api/domain";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  evaluateMailboxPolicy,
+  setMailboxPolicy,
+  setSenderRule,
+} from "../../../src/server/api/policy-service";
+import {
+  submitPostage,
+  resolvePostage,
+} from "../../../src/server/api/postage-service";
+import {
+  createDeliveryReceipt,
+  markReceiptRead,
+} from "../../../src/server/api/receipt-service";
+import { ApiError } from "../../../src/server/api/errors";
+import type { MailboxPolicy, SenderRule } from "../../../src/server/api/domain";
+
+import vectors from "../../../protocol/vectors/vectors.json";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assertApiError(
+  err: unknown,
+  expected: { code: string; status: number; message: string },
+) {
+  expect(err).toBeInstanceOf(ApiError);
+  const apiErr = err as ApiError;
+  expect(apiErr.code, "error code").toBe(expected.code);
+  expect(apiErr.status, "http status").toBe(expected.status);
+  expect(apiErr.message, "error message").toBe(expected.message);
+}
+
+// ---------------------------------------------------------------------------
+// Primitive: Stellar address
+// ---------------------------------------------------------------------------
+
+describe("primitives/address", () => {
+  for (const c of vectors.categories.primitives.address.cases) {
+    it(c.id, () => {
+      const result = stellarAddressSchema.safeParse(c.input);
+      expect(result.success, c.description).toBe(c.expected.valid);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(c.expected.error);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Primitive: 32-byte hash
+// ---------------------------------------------------------------------------
+
+describe("primitives/hash", () => {
+  for (const c of vectors.categories.primitives.hash.cases) {
+    it(c.id, () => {
+      const result = hash32Schema.safeParse(c.input);
+      expect(result.success, c.description).toBe(c.expected.valid);
+      if (result.success && "normalized" in c.expected) {
+        // Verify the normalised (lowercased) output matches the vector
+        expect(result.data).toBe(c.expected.normalized);
+      }
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(c.expected.error);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Primitive: Stroop amount (Soroban i128)
+// ---------------------------------------------------------------------------
+
+describe("primitives/amount", () => {
+  for (const c of vectors.categories.primitives.amount.cases) {
+    it(c.id, () => {
+      const result = stroopAmountSchema.safeParse(c.input);
+      expect(result.success, c.description).toBe(c.expected.valid);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(c.expected.error);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Policy decisions
+// ---------------------------------------------------------------------------
+
+describe("policy_decisions", () => {
+  const { owner, sender } = vectors.categories.policy_decisions;
+
+  for (const c of vectors.categories.policy_decisions.cases) {
+    it(c.id, async () => {
+      const repo = new MemoryApiRepository();
+
+      // Apply the optional sender rule
+      const rule = c.setup.senderRule as SenderRule;
+      if (rule === "allow" || rule === "block") {
+        await setSenderRule(repo, owner, sender, rule);
+      }
+
+      // Apply the optional mailbox policy
+      if (c.setup.policy) {
+        const p = c.setup.policy as MailboxPolicy;
+        await setMailboxPolicy(repo, owner, p);
+      }
+
+      const result = await evaluateMailboxPolicy(repo, {
+        owner,
+        sender,
+        postage: c.input.postage,
+        verified: c.input.verified,
+      });
+
+      expect(result.allowed, `${c.id}: allowed`).toBe(c.expected.allowed);
+      expect(result.reason, `${c.id}: reason`).toBe(c.expected.reason);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Postage states
+// ---------------------------------------------------------------------------
+
+describe("postage_states", () => {
+  for (const c of vectors.categories.postage_states.cases) {
+    it(c.id, async () => {
+      const repo = new MemoryApiRepository();
+      const f = c.fixture;
+
+      // Apply preconditions (sender rules, mailbox policy)
+      for (const pre of (c as { preconditions?: Array<{ op: string; rule?: string; policy?: MailboxPolicy }> }).preconditions ?? []) {
+        if (pre.op === "setSenderRule" && pre.rule) {
+          await setSenderRule(repo, f.recipient, f.sender, pre.rule as SenderRule);
+        }
+        if (pre.op === "setPolicy" && pre.policy) {
+          await setMailboxPolicy(repo, f.recipient, pre.policy as MailboxPolicy);
+        }
+      }
+
+      const postageInput = {
+        messageId: f.messageId,
+        sender: f.sender,
+        recipient: f.recipient,
+        amount: f.amount,
+        paymentHash: f.paymentHash,
+      };
+
+      const submitAt = new Date(f.submitAt);
+      let lastResult: Awaited<ReturnType<typeof submitPostage>> | undefined;
+      let caughtError: unknown;
+
+      for (const op of c.operations) {
+        try {
+          if (op === "submit") {
+            lastResult = await submitPostage(repo, postageInput, submitAt);
+          } else if (op === "settle") {
+            lastResult = await resolvePostage(repo, f.messageId, "settled");
+          } else if (op === "refund") {
+            lastResult = await resolvePostage(repo, f.messageId, "refunded");
+          }
+        } catch (err) {
+          caughtError = err;
+          break;
+        }
+      }
+
+      const exp = c.expected as {
+        status?: string;
+        createdAt?: string;
+        error?: { code: string; status: number; message: string };
+      };
+
+      if (exp.error) {
+        assertApiError(caughtError, exp.error);
+      } else {
+        expect(caughtError, `${c.id}: unexpected error`).toBeUndefined();
+        expect(lastResult?.status, `${c.id}: status`).toBe(exp.status);
+        if (exp.createdAt) {
+          expect(lastResult?.createdAt, `${c.id}: createdAt`).toBe(exp.createdAt);
+        }
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Receipts
+// ---------------------------------------------------------------------------
+
+describe("receipts", () => {
+  for (const c of vectors.categories.receipts.cases) {
+    it(c.id, async () => {
+      const repo = new MemoryApiRepository();
+      const f = c.fixture as {
+        sender: string;
+        recipient: string;
+        messageId: string;
+        deliverAt: string;
+        readAt?: string;
+      };
+
+      const receiptInput = {
+        messageId: f.messageId,
+        sender: f.sender,
+        recipient: f.recipient,
+      };
+
+      const deliverAt = new Date(f.deliverAt);
+      const readAt = f.readAt ? new Date(f.readAt) : new Date();
+
+      let lastResult: Awaited<ReturnType<typeof createDeliveryReceipt>> | undefined;
+      let caughtError: unknown;
+
+      for (const op of c.operations) {
+        try {
+          if (op === "deliver") {
+            lastResult = await createDeliveryReceipt(repo, receiptInput, deliverAt);
+          } else if (op === "read") {
+            lastResult = await markReceiptRead(repo, f.messageId, readAt);
+          }
+        } catch (err) {
+          caughtError = err;
+          break;
+        }
+      }
+
+      const exp = c.expected as {
+        readAt?: string | null;
+        deliveredAt?: string;
+        error?: { code: string; status: number; message: string };
+      };
+
+      if (exp.error) {
+        assertApiError(caughtError, exp.error);
+      } else {
+        expect(caughtError, `${c.id}: unexpected error`).toBeUndefined();
+        if ("readAt" in exp) {
+          expect(lastResult?.readAt, `${c.id}: readAt`).toBe(exp.readAt);
+        }
+        if (exp.deliveredAt) {
+          expect(lastResult?.deliveredAt, `${c.id}: deliveredAt`).toBe(exp.deliveredAt);
+        }
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tampered cases
+// ---------------------------------------------------------------------------
+
+describe("tampered", () => {
+  const schemaMap = {
+    stellarAddress: stellarAddressSchema,
+    hash32: hash32Schema,
+    stroopAmount: stroopAmountSchema,
+  } as const;
+
+  for (const c of vectors.categories.tampered.cases) {
+    it(c.id, () => {
+      const schema = schemaMap[c.schema as keyof typeof schemaMap];
+      const result = schema.safeParse(c.input);
+      expect(result.success, c.description).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(c.expected.error);
+      }
+    });
+  }
+});


### PR DESCRIPTION
- Add protocol/vectors/vectors.json with 53 canonical test cases across primitives (address, hash, amount), policy decisions, postage states, receipts, and tampered inputs. All values are placeholder — no production secrets included.

- Add tests/unit/protocol/vectors.test.ts driving every case through live Zod schemas and TypeScript service functions (all 53 pass).

- Fix stroopAmountSchema: wrap BigInt() in try-catch so .refine() never throws a SyntaxError when the regex already rejected a non-integer input.

- Add serde + serde_json dev-deps to the policies crate and a Rust vectors module (primitives, policy_decisions, tampered) that reads the same JSON fixture via include_str!().

Closes  #63 