### PR TITLE
feat: layered abuse prevention for postage submission 

### DIFF
--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema, stellarAddressSchema, stroopAmountSchema } from "@/server/api/domain";
+import { buildDeviceFingerprint } from "@/server/api/abuse-service";
 import { submitPostage } from "@/server/api/postage-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
@@ -27,12 +28,27 @@ export const Route = createFileRoute("/api/v1/postage/")({
             request.headers.get("cf-connecting-ip") ??
             request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
             "unknown";
+          const userAgent = request.headers.get("user-agent") ?? undefined;
+          const acceptLanguage = request.headers.get("accept-language") ?? undefined;
+          const acceptEncoding = request.headers.get("accept-encoding") ?? undefined;
           const relayId = request.headers.get("x-stealth-relay-id") ?? undefined;
+          const ipPrefix =
+            ip === "unknown"
+              ? "unknown"
+              : ip.includes(":")
+                ? ip.split(":").slice(0, 4).join(":")
+                : ip.split(".").slice(0, 3).join(".");
+          const fingerprint = buildDeviceFingerprint({
+            userAgent,
+            acceptLanguage,
+            acceptEncoding,
+            ipPrefix,
+          });
           const postage = await submitPostage(
             getApiContext().repository,
             input,
             new Date(),
-            { ip, relayId },
+            { ip, relayId, fingerprint },
           );
           return apiSuccess(request, postage, { status: 201 });
         }),

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -5,7 +5,7 @@ import { requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema, stellarAddressSchema, stroopAmountSchema } from "@/server/api/domain";
 import { buildDeviceFingerprint } from "@/server/api/abuse-service";
-import { submitPostage } from "@/server/api/postage-service";
+import { submitPostage, type SubmitPostageContext } from "@/server/api/postage-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
 
@@ -44,18 +44,12 @@ export const Route = createFileRoute("/api/v1/postage/")({
             acceptEncoding,
             ipPrefix,
           });
-          const context = {
-            accountId: input.sender,
+          const context: SubmitPostageContext = {
+            actorId: input.sender,
             fingerprint,
             ip,
             relayId,
             sender: input.sender,
-          } as {
-            accountId?: string;
-            fingerprint?: string;
-            ip?: string;
-            relayId?: string;
-            sender?: string;
           };
           const postage = await submitPostage(
             getApiContext().repository,

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -23,7 +23,17 @@ export const Route = createFileRoute("/api/v1/postage/")({
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, submissionSchema);
           requireActorMatches(request, input.sender);
-          const postage = await submitPostage(getApiContext().repository, input);
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+          const relayId = request.headers.get("x-stealth-relay-id") ?? undefined;
+          const postage = await submitPostage(
+            getApiContext().repository,
+            input,
+            new Date(),
+            { ip, relayId },
+          );
           return apiSuccess(request, postage, { status: 201 });
         }),
     },

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -44,11 +44,24 @@ export const Route = createFileRoute("/api/v1/postage/")({
             acceptEncoding,
             ipPrefix,
           });
+          const context = {
+            accountId: input.sender,
+            fingerprint,
+            ip,
+            relayId,
+            sender: input.sender,
+          } as {
+            accountId?: string;
+            fingerprint?: string;
+            ip?: string;
+            relayId?: string;
+            sender?: string;
+          };
           const postage = await submitPostage(
             getApiContext().repository,
             input,
             new Date(),
-            { ip, relayId, fingerprint },
+            context,
           );
           return apiSuccess(request, postage, { status: 201 });
         }),

--- a/src/server/api/abuse-service.ts
+++ b/src/server/api/abuse-service.ts
@@ -1,0 +1,71 @@
+import type { ApiRepository } from "./repository";
+
+function rateLimited(retryAfterSeconds: number) {
+  return { allowed: false, retryAfterSeconds };
+}
+
+async function checkIncrementedLimit(
+  repository: ApiRepository,
+  key: string,
+  max: number,
+  windowSeconds: number,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  const count = await repository.incrementCounter(key, windowSeconds);
+  if (count > max) return rateLimited(windowSeconds);
+  return { allowed: true };
+}
+
+async function checkStoredLimit(
+  repository: ApiRepository,
+  key: string,
+  max: number,
+  retryAfterSeconds: number,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  const count = await repository.getCounter(key);
+  if (count >= max) return rateLimited(retryAfterSeconds);
+  return { allowed: true };
+}
+
+export async function checkAccountLimit(
+  repository: ApiRepository,
+  sender: string,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  return checkIncrementedLimit(repository, `abuse:account:${sender}`, 50, 3600);
+}
+
+export async function checkIpLimit(
+  repository: ApiRepository,
+  ip: string,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number; flagged?: boolean }> {
+  if (ip === "" || ip === "unknown") {
+    return { allowed: true, flagged: true };
+  }
+
+  return checkIncrementedLimit(repository, `abuse:ip:${ip}`, 100, 3600);
+}
+
+export async function checkSenderRecipientLimit(
+  repository: ApiRepository,
+  sender: string,
+  recipient: string,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  return checkIncrementedLimit(repository, `abuse:pair:${sender}:${recipient}`, 10, 3600);
+}
+
+export async function checkProofFailureLimit(
+  repository: ApiRepository,
+  sender: string,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  return checkStoredLimit(repository, `abuse:proof:${sender}`, 5, 900);
+}
+
+export async function recordProofFailure(repository: ApiRepository, sender: string): Promise<void> {
+  await repository.incrementCounter(`abuse:proof:${sender}`, 900);
+}
+
+export async function checkRelayLimit(
+  repository: ApiRepository,
+  relayId: string,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  return checkIncrementedLimit(repository, `abuse:relay:${relayId}`, 500, 3600);
+}

--- a/src/server/api/abuse-service.ts
+++ b/src/server/api/abuse-service.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { ApiRepository } from "./repository";
 
 function rateLimited(retryAfterSeconds: number) {
@@ -24,6 +26,26 @@ async function checkStoredLimit(
   const count = await repository.getCounter(key);
   if (count >= max) return rateLimited(retryAfterSeconds);
   return { allowed: true };
+}
+
+function normalizeFingerprintField(value?: string) {
+  return value?.trim().toLowerCase().replace(/\s+/g, " ") ?? "";
+}
+
+export function buildDeviceFingerprint(headers: {
+  userAgent?: string;
+  acceptLanguage?: string;
+  acceptEncoding?: string;
+  ipPrefix?: string;
+}): string {
+  const payload = [
+    normalizeFingerprintField(headers.userAgent),
+    normalizeFingerprintField(headers.acceptLanguage),
+    normalizeFingerprintField(headers.acceptEncoding),
+    normalizeFingerprintField(headers.ipPrefix),
+  ].join("|");
+
+  return createHash("sha256").update(payload).digest("hex").slice(0, 16);
 }
 
 export async function checkAccountLimit(
@@ -68,4 +90,16 @@ export async function checkRelayLimit(
   relayId: string,
 ): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
   return checkIncrementedLimit(repository, `abuse:relay:${relayId}`, 500, 3600);
+}
+
+export async function checkDeviceLimit(
+  repository: ApiRepository,
+  fingerprint: string,
+  opts?: { windowMs?: number; max?: number },
+): Promise<{ allowed: boolean; retryAfterMs?: number }> {
+  const windowMs = opts?.windowMs ?? 60_000;
+  const max = opts?.max ?? 30;
+  const count = await repository.incrementCounter(`device:${fingerprint}`, windowMs / 1000);
+  if (count > max) return { allowed: false, retryAfterMs: windowMs };
+  return { allowed: true };
 }

--- a/src/server/api/abuse-service.ts
+++ b/src/server/api/abuse-service.ts
@@ -96,10 +96,10 @@ export async function checkDeviceLimit(
   repository: ApiRepository,
   fingerprint: string,
   opts?: { windowMs?: number; max?: number },
-): Promise<{ allowed: boolean; retryAfterMs?: number }> {
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
   const windowMs = opts?.windowMs ?? 60_000;
   const max = opts?.max ?? 30;
   const count = await repository.incrementCounter(`device:${fingerprint}`, windowMs / 1000);
-  if (count > max) return { allowed: false, retryAfterMs: windowMs };
+  if (count > max) return { allowed: false, retryAfterSeconds: windowMs / 1000 };
   return { allowed: true };
 }

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -8,7 +8,8 @@ export type ApiErrorCode =
   | "method_not_allowed"
   | "not_found"
   | "unauthorized"
-  | "validation_error";
+  | "validation_error"
+  | "too_many_requests";
 
 export class ApiError extends Error {
   readonly code: ApiErrorCode;

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -10,6 +10,7 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly postage = new Map<string, Postage>();
   private readonly receipts = new Map<string, Receipt>();
   private readonly senderRules = new Map<string, SenderRule>();
+  private readonly counters = new Map<string, number[]>();
 
   async getPolicy(owner: string) {
     return structuredClone(this.policies.get(owner) ?? null);
@@ -49,10 +50,24 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(receipt);
   }
 
+  async getCounter(key: string) {
+    return this.counters.get(key)?.length ?? 0;
+  }
+
+  async incrementCounter(key: string, windowSeconds: number) {
+    const now = Date.now();
+    const windowMilliseconds = windowSeconds * 1000;
+    const timestamps = this.counters.get(key) ?? [];
+    const filtered = [...timestamps, now].filter((timestamp) => now - timestamp <= windowMilliseconds);
+    this.counters.set(key, filtered);
+    return filtered.length;
+  }
+
   reset() {
     this.policies.clear();
     this.postage.clear();
     this.receipts.clear();
     this.senderRules.clear();
+    this.counters.clear();
   }
 }

--- a/src/server/api/metrics.ts
+++ b/src/server/api/metrics.ts
@@ -1,4 +1,1 @@
-export function incrementCounter(metric: string, labels: Record<string, string>): void {
-  void metric;
-  void labels;
-}
+export function incrementCounter(_metric: string, _labels: Record<string, string>): void {}

--- a/src/server/api/metrics.ts
+++ b/src/server/api/metrics.ts
@@ -1,0 +1,4 @@
+export function incrementCounter(metric: string, labels: Record<string, string>): void {
+  void metric;
+  void labels;
+}

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -2,6 +2,7 @@ import type { Postage } from "./domain";
 import { ApiError } from "./errors";
 import {
   checkAccountLimit,
+  checkDeviceLimit,
   checkIpLimit,
   checkRelayLimit,
   checkSenderRecipientLimit,
@@ -38,7 +39,7 @@ export async function submitPostage(
   repository: ApiRepository,
   input: Omit<Postage, "createdAt" | "status">,
   now = new Date(),
-  context: { ip?: string; relayId?: string } = {},
+  context: { ip?: string; relayId?: string; fingerprint?: string } = {},
 ) {
   const accountLimit = await checkAccountLimit(repository, input.sender);
   if (!accountLimit.allowed) {
@@ -51,6 +52,13 @@ export async function submitPostage(
   if (!ipLimit.allowed) {
     throw new ApiError(429, "rate_limited", "IP limit exceeded", {
       retryAfterSeconds: ipLimit.retryAfterSeconds,
+    });
+  }
+
+  const deviceLimit = await checkDeviceLimit(repository, context.fingerprint ?? "");
+  if (!deviceLimit.allowed) {
+    throw new ApiError(429, "rate_limited", "Device limit exceeded", {
+      retryAfterMs: deviceLimit.retryAfterMs,
     });
   }
 

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -11,6 +11,14 @@ import { getMailboxPolicy } from "./policy-service";
 import * as metrics from "./metrics";
 import type { ApiRepository } from "./repository";
 
+export type SubmitPostageContext = {
+  actorId?: string;
+  fingerprint?: string;
+  ip?: string;
+  relayId?: string;
+  sender?: string;
+};
+
 export async function quotePostage(
   repository: ApiRepository,
   input: { recipient: string; sender: string },
@@ -28,6 +36,7 @@ export async function quotePostage(
   }
 
   const trusted = rule === "allow";
+
   return {
     amount: trusted ? "0" : policy.minimumPostage,
     eligible: true,
@@ -40,44 +49,44 @@ export async function submitPostage(
   repository: ApiRepository,
   input: Omit<Postage, "createdAt" | "status">,
   now = new Date(),
-  context: {
-    accountId?: string;
-    fingerprint?: string;
-    ip?: string;
-    relayId?: string;
-    sender?: string;
-  } = {},
+  context: SubmitPostageContext = {},
 ) {
-  const accountId = context.accountId ?? "unknown";
+  const actorId = context.actorId ?? "unknown";
+
   const accountLimit = await checkAccountLimit(repository, input.sender);
   if (!accountLimit.allowed) {
     metrics.incrementCounter("postage_limit_rejected", {
-      accountId,
+      actorId,
       limit: "account",
     });
-    throw new ApiError(429, "rate_limited", "Account limit exceeded", {
+
+    throw new ApiError(429, "too_many_requests", "Account limit exceeded", {
       retryAfterSeconds: accountLimit.retryAfterSeconds,
     });
   }
 
-  const ipLimit = await checkIpLimit(repository, context.ip ?? "unknown");
+  const ip = context.ip ?? "unknown";
+  const ipLimit = await checkIpLimit(repository, ip);
   if (!ipLimit.allowed) {
     metrics.incrementCounter("postage_limit_rejected", {
-      ip: context.ip ?? "unknown",
+      ip,
       limit: "ip",
     });
-    throw new ApiError(429, "rate_limited", "IP limit exceeded", {
+
+    throw new ApiError(429, "too_many_requests", "IP limit exceeded", {
       retryAfterSeconds: ipLimit.retryAfterSeconds,
     });
   }
 
-  const deviceLimit = await checkDeviceLimit(repository, context.fingerprint ?? "");
+  const fingerprint = context.fingerprint ?? "";
+  const deviceLimit = await checkDeviceLimit(repository, fingerprint);
   if (!deviceLimit.allowed) {
     metrics.incrementCounter("postage_limit_rejected", {
-      fingerprint: context.fingerprint ?? "unknown",
+      fingerprint: fingerprint || "unknown",
       limit: "device",
     });
-    throw new ApiError(429, "rate_limited", "Device limit exceeded", {
+
+    throw new ApiError(429, "too_many_requests", "Device limit exceeded", {
       retryAfterSeconds: deviceLimit.retryAfterSeconds,
     });
   }
@@ -87,25 +96,30 @@ export async function submitPostage(
     input.sender,
     input.recipient,
   );
+
   if (!senderRecipientLimit.allowed) {
     const sender = context.sender ?? input.sender;
+
     metrics.incrementCounter("postage_limit_rejected", {
       limit: "sender_recipient",
       sender,
     });
-    throw new ApiError(429, "rate_limited", "Sender-recipient limit exceeded", {
+
+    throw new ApiError(429, "too_many_requests", "Sender-recipient limit exceeded", {
       retryAfterSeconds: senderRecipientLimit.retryAfterSeconds,
     });
   }
 
   const relayId = context.relayId?.trim() || "unknown";
   const relayLimit = await checkRelayLimit(repository, relayId);
+
   if (!relayLimit.allowed) {
     metrics.incrementCounter("postage_limit_rejected", {
       limit: "relay",
-      relayId: context.relayId ?? "unknown",
+      relayId,
     });
-    throw new ApiError(429, "rate_limited", "Relay limit exceeded", {
+
+    throw new ApiError(429, "too_many_requests", "Relay limit exceeded", {
       retryAfterSeconds: relayLimit.retryAfterSeconds,
     });
   }
@@ -115,11 +129,13 @@ export async function submitPostage(
   }
 
   const rule = await repository.getSenderRule(input.recipient, input.sender);
+
   if (rule === "block") {
     throw new ApiError(403, "forbidden", "The recipient has blocked this sender");
   }
 
   const { policy } = await getMailboxPolicy(repository, input.recipient);
+
   if (BigInt(input.amount) < BigInt(policy.minimumPostage)) {
     throw new ApiError(422, "validation_error", "Postage is below the mailbox minimum", {
       minimumPostage: policy.minimumPostage,
@@ -135,9 +151,11 @@ export async function submitPostage(
 
 export async function getPostage(repository: ApiRepository, messageId: string) {
   const postage = await repository.getPostage(messageId);
+
   if (!postage) {
     throw new ApiError(404, "not_found", "Postage was not found");
   }
+
   return postage;
 }
 
@@ -153,6 +171,7 @@ export async function resolvePostage(
   status: "refunded" | "settled",
 ) {
   const postage = await getPostage(repository, messageId);
+
   if (postage.status !== "pending") {
     throw new ApiError(409, "conflict", "Postage has already been resolved", {
       status: postage.status,

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -40,9 +40,15 @@ export async function submitPostage(
   repository: ApiRepository,
   input: Omit<Postage, "createdAt" | "status">,
   now = new Date(),
-  context: { fingerprint?: string; ip?: string; relayId?: string } = {},
+  context: {
+    accountId?: string;
+    fingerprint?: string;
+    ip?: string;
+    relayId?: string;
+    sender?: string;
+  } = {},
 ) {
-  const accountId = (context as { accountId?: string }).accountId ?? "unknown";
+  const accountId = context.accountId ?? "unknown";
   const accountLimit = await checkAccountLimit(repository, input.sender);
   if (!accountLimit.allowed) {
     metrics.incrementCounter("postage_limit_rejected", {
@@ -72,7 +78,7 @@ export async function submitPostage(
       limit: "device",
     });
     throw new ApiError(429, "rate_limited", "Device limit exceeded", {
-      retryAfterMs: deviceLimit.retryAfterMs,
+      retryAfterSeconds: deviceLimit.retryAfterSeconds,
     });
   }
 
@@ -82,7 +88,7 @@ export async function submitPostage(
     input.recipient,
   );
   if (!senderRecipientLimit.allowed) {
-    const sender = (context as { sender?: string }).sender ?? input.sender;
+    const sender = context.sender ?? input.sender;
     metrics.incrementCounter("postage_limit_rejected", {
       limit: "sender_recipient",
       sender,

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -1,5 +1,11 @@
 import type { Postage } from "./domain";
 import { ApiError } from "./errors";
+import {
+  checkAccountLimit,
+  checkIpLimit,
+  checkRelayLimit,
+  checkSenderRecipientLimit,
+} from "./abuse-service";
 import { getMailboxPolicy } from "./policy-service";
 import type { ApiRepository } from "./repository";
 
@@ -32,7 +38,42 @@ export async function submitPostage(
   repository: ApiRepository,
   input: Omit<Postage, "createdAt" | "status">,
   now = new Date(),
+  context: { ip?: string; relayId?: string } = {},
 ) {
+  const accountLimit = await checkAccountLimit(repository, input.sender);
+  if (!accountLimit.allowed) {
+    throw new ApiError(429, "rate_limited", "Account limit exceeded", {
+      retryAfterSeconds: accountLimit.retryAfterSeconds,
+    });
+  }
+
+  const ipLimit = await checkIpLimit(repository, context.ip ?? "unknown");
+  if (!ipLimit.allowed) {
+    throw new ApiError(429, "rate_limited", "IP limit exceeded", {
+      retryAfterSeconds: ipLimit.retryAfterSeconds,
+    });
+  }
+
+  const senderRecipientLimit = await checkSenderRecipientLimit(
+    repository,
+    input.sender,
+    input.recipient,
+  );
+  if (!senderRecipientLimit.allowed) {
+    throw new ApiError(429, "rate_limited", "Sender-recipient limit exceeded", {
+      retryAfterSeconds: senderRecipientLimit.retryAfterSeconds,
+    });
+  }
+
+  if (context.relayId && context.relayId !== "") {
+    const relayLimit = await checkRelayLimit(repository, context.relayId);
+    if (!relayLimit.allowed) {
+      throw new ApiError(429, "rate_limited", "Relay limit exceeded", {
+        retryAfterSeconds: relayLimit.retryAfterSeconds,
+      });
+    }
+  }
+
   if (await repository.getPostage(input.messageId)) {
     throw new ApiError(409, "conflict", "Postage already exists for this message");
   }

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -8,6 +8,7 @@ import {
   checkSenderRecipientLimit,
 } from "./abuse-service";
 import { getMailboxPolicy } from "./policy-service";
+import * as metrics from "./metrics";
 import type { ApiRepository } from "./repository";
 
 export async function quotePostage(
@@ -39,10 +40,15 @@ export async function submitPostage(
   repository: ApiRepository,
   input: Omit<Postage, "createdAt" | "status">,
   now = new Date(),
-  context: { ip?: string; relayId?: string; fingerprint?: string } = {},
+  context: { fingerprint?: string; ip?: string; relayId?: string } = {},
 ) {
+  const accountId = (context as { accountId?: string }).accountId ?? "unknown";
   const accountLimit = await checkAccountLimit(repository, input.sender);
   if (!accountLimit.allowed) {
+    metrics.incrementCounter("postage_limit_rejected", {
+      accountId,
+      limit: "account",
+    });
     throw new ApiError(429, "rate_limited", "Account limit exceeded", {
       retryAfterSeconds: accountLimit.retryAfterSeconds,
     });
@@ -50,6 +56,10 @@ export async function submitPostage(
 
   const ipLimit = await checkIpLimit(repository, context.ip ?? "unknown");
   if (!ipLimit.allowed) {
+    metrics.incrementCounter("postage_limit_rejected", {
+      ip: context.ip ?? "unknown",
+      limit: "ip",
+    });
     throw new ApiError(429, "rate_limited", "IP limit exceeded", {
       retryAfterSeconds: ipLimit.retryAfterSeconds,
     });
@@ -57,6 +67,10 @@ export async function submitPostage(
 
   const deviceLimit = await checkDeviceLimit(repository, context.fingerprint ?? "");
   if (!deviceLimit.allowed) {
+    metrics.incrementCounter("postage_limit_rejected", {
+      fingerprint: context.fingerprint ?? "unknown",
+      limit: "device",
+    });
     throw new ApiError(429, "rate_limited", "Device limit exceeded", {
       retryAfterMs: deviceLimit.retryAfterMs,
     });
@@ -68,6 +82,11 @@ export async function submitPostage(
     input.recipient,
   );
   if (!senderRecipientLimit.allowed) {
+    const sender = (context as { sender?: string }).sender ?? input.sender;
+    metrics.incrementCounter("postage_limit_rejected", {
+      limit: "sender_recipient",
+      sender,
+    });
     throw new ApiError(429, "rate_limited", "Sender-recipient limit exceeded", {
       retryAfterSeconds: senderRecipientLimit.retryAfterSeconds,
     });
@@ -76,6 +95,10 @@ export async function submitPostage(
   const relayId = context.relayId?.trim() || "unknown";
   const relayLimit = await checkRelayLimit(repository, relayId);
   if (!relayLimit.allowed) {
+    metrics.incrementCounter("postage_limit_rejected", {
+      limit: "relay",
+      relayId: context.relayId ?? "unknown",
+    });
     throw new ApiError(429, "rate_limited", "Relay limit exceeded", {
       retryAfterSeconds: relayLimit.retryAfterSeconds,
     });

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -65,13 +65,12 @@ export async function submitPostage(
     });
   }
 
-  if (context.relayId && context.relayId !== "") {
-    const relayLimit = await checkRelayLimit(repository, context.relayId);
-    if (!relayLimit.allowed) {
-      throw new ApiError(429, "rate_limited", "Relay limit exceeded", {
-        retryAfterSeconds: relayLimit.retryAfterSeconds,
-      });
-    }
+  const relayId = context.relayId?.trim() || "unknown";
+  const relayLimit = await checkRelayLimit(repository, relayId);
+  if (!relayLimit.allowed) {
+    throw new ApiError(429, "rate_limited", "Relay limit exceeded", {
+      retryAfterSeconds: relayLimit.retryAfterSeconds,
+    });
   }
 
   if (await repository.getPostage(input.messageId)) {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -9,6 +9,8 @@ export interface ApiRepository {
   setPostage(postage: Postage): Promise<Postage>;
   getReceipt(messageId: string): Promise<Receipt | null>;
   setReceipt(receipt: Receipt): Promise<Receipt>;
+  getCounter(key: string): Promise<number>;
+  incrementCounter(key: string, windowSeconds: number): Promise<number>;
 }
 
 export const defaultMailboxPolicy: MailboxPolicy = {

--- a/tests/unit/api/abuse-service.test.ts
+++ b/tests/unit/api/abuse-service.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
 import {
+  buildDeviceFingerprint,
   checkAccountLimit,
+  checkDeviceLimit,
   checkIpLimit,
   checkProofFailureLimit,
   checkRelayLimit,
@@ -82,5 +84,86 @@ describe("abuse service", () => {
     const result = await checkRelayLimit(repository, relayId);
     expect(result).toMatchObject({ allowed: false });
     expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+
+  it("builds deterministic device fingerprints", () => {
+    const headers = {
+      userAgent: "  Mozilla/5.0  ",
+      acceptLanguage: "en-US,en;q=0.9",
+      acceptEncoding: "gzip, br",
+      ipPrefix: "203.0.113",
+    };
+    expect(buildDeviceFingerprint(headers)).toBe(buildDeviceFingerprint(headers));
+  });
+
+  it("changes fingerprint when the user agent changes", () => {
+    const base = {
+      acceptLanguage: "en-US,en;q=0.9",
+      acceptEncoding: "gzip, br",
+      ipPrefix: "203.0.113",
+    };
+    expect(
+      buildDeviceFingerprint({
+        ...base,
+        userAgent: "Mozilla/5.0",
+      }),
+    ).not.toBe(
+      buildDeviceFingerprint({
+        ...base,
+        userAgent: "curl/8.0.1",
+      }),
+    );
+  });
+
+  it("returns a valid fingerprint when all fields are missing", () => {
+    const fingerprint = buildDeviceFingerprint({});
+    expect(fingerprint).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("blocks a fingerprint after exceeding the device window max", async () => {
+    const repository = new MemoryApiRepository();
+    const fingerprint = buildDeviceFingerprint({
+      userAgent: "Mozilla/5.0",
+      acceptLanguage: "en-US",
+      acceptEncoding: "gzip",
+      ipPrefix: "203.0.113",
+    });
+
+    for (let i = 0; i < 30; i++) {
+      const result = await checkDeviceLimit(repository, fingerprint);
+      expect(result).toMatchObject({ allowed: true });
+    }
+
+    const blocked = await checkDeviceLimit(repository, fingerprint);
+    expect(blocked).toMatchObject({ allowed: false });
+    expect(blocked.retryAfterMs).toBe(60_000);
+  });
+
+  it("allows a fingerprint again after the device window resets", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-16T00:00:00.000Z"));
+
+    try {
+      const repository = new MemoryApiRepository();
+      const fingerprint = buildDeviceFingerprint({
+        userAgent: "Mozilla/5.0",
+        acceptLanguage: "en-US",
+        acceptEncoding: "gzip",
+        ipPrefix: "203.0.113",
+      });
+
+      for (let i = 0; i < 30; i++) {
+        const result = await checkDeviceLimit(repository, fingerprint);
+        expect(result).toMatchObject({ allowed: true });
+      }
+
+      vi.setSystemTime(new Date("2026-06-16T00:01:01.000Z"));
+
+      await expect(checkDeviceLimit(repository, fingerprint)).resolves.toMatchObject({
+        allowed: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/api/abuse-service.test.ts
+++ b/tests/unit/api/abuse-service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  checkAccountLimit,
+  checkIpLimit,
+  checkProofFailureLimit,
+  checkRelayLimit,
+  checkSenderRecipientLimit,
+  recordProofFailure,
+} from "../../../src/server/api/abuse-service";
+
+const sender = `G${"B".repeat(55)}`;
+const recipient = `G${"A".repeat(55)}`;
+const relayId = "relay-001";
+
+describe("abuse service", () => {
+  it("allows sender under account limit", async () => {
+    const repository = new MemoryApiRepository();
+    const result = await checkAccountLimit(repository, sender);
+    expect(result).toMatchObject({ allowed: true });
+  });
+
+  it("blocks sender over account limit", async () => {
+    const repository = new MemoryApiRepository();
+    for (let i = 0; i < 50; i++) {
+      await repository.incrementCounter(`abuse:account:${sender}`, 3600);
+    }
+    const result = await checkAccountLimit(repository, sender);
+    expect(result).toMatchObject({ allowed: false });
+    expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+
+  it("flags unknown ip but allows through", async () => {
+    const repository = new MemoryApiRepository();
+    const result = await checkIpLimit(repository, "unknown");
+    expect(result).toMatchObject({ allowed: true, flagged: true });
+  });
+
+  it("blocks ip over limit", async () => {
+    const repository = new MemoryApiRepository();
+    for (let i = 0; i < 100; i++) {
+      await repository.incrementCounter(`abuse:ip:1.2.3.4`, 3600);
+    }
+    const result = await checkIpLimit(repository, "1.2.3.4");
+    expect(result).toMatchObject({ allowed: false });
+    expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+
+  it("blocks targeted harassment over sender-recipient limit", async () => {
+    const repository = new MemoryApiRepository();
+    for (let i = 0; i < 10; i++) {
+      await repository.incrementCounter(`abuse:pair:${sender}:${recipient}`, 3600);
+    }
+    const result = await checkSenderRecipientLimit(repository, sender, recipient);
+    expect(result).toMatchObject({ allowed: false });
+    expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+
+  it("blocks sender after proof failures", async () => {
+    const repository = new MemoryApiRepository();
+    for (let i = 0; i < 5; i++) {
+      await recordProofFailure(repository, sender);
+    }
+    const result = await checkProofFailureLimit(repository, sender);
+    expect(result).toMatchObject({ allowed: false });
+    expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+
+  it("allows sender under proof failure limit", async () => {
+    const repository = new MemoryApiRepository();
+    await recordProofFailure(repository, sender);
+    const result = await checkProofFailureLimit(repository, sender);
+    expect(result).toMatchObject({ allowed: true });
+  });
+
+  it("blocks relay over limit", async () => {
+    const repository = new MemoryApiRepository();
+    for (let i = 0; i < 500; i++) {
+      await repository.incrementCounter(`abuse:relay:${relayId}`, 3600);
+    }
+    const result = await checkRelayLimit(repository, relayId);
+    expect(result).toMatchObject({ allowed: false });
+    expect(result.retryAfterSeconds).toBeTypeOf("number");
+  });
+});

--- a/tests/unit/api/abuse-service.test.ts
+++ b/tests/unit/api/abuse-service.test.ts
@@ -136,7 +136,7 @@ describe("abuse service", () => {
 
     const blocked = await checkDeviceLimit(repository, fingerprint);
     expect(blocked).toMatchObject({ allowed: false });
-    expect(blocked.retryAfterMs).toBe(60_000);
+    expect(blocked.retryAfterSeconds).toBe(60);
   });
 
   it("allows a fingerprint again after the device window resets", async () => {

--- a/tests/unit/api/postage-service.test.ts
+++ b/tests/unit/api/postage-service.test.ts
@@ -171,7 +171,7 @@ describe("postage service", () => {
       }),
     ).rejects.toMatchObject({
       status: 429,
-      code: "rate_limited",
+      code: "too_many_requests",
       message: "Relay limit exceeded",
     });
   });

--- a/tests/unit/api/postage-service.test.ts
+++ b/tests/unit/api/postage-service.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import * as metrics from "../../../src/server/api/metrics";
 import {
   assertPostageParticipant,
   getPostage,
@@ -80,6 +81,73 @@ describe("postage service", () => {
         sender,
       }),
     ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("emits a metric when the account limit is exceeded", async () => {
+    const repository = new MemoryApiRepository();
+    await repository.setPolicy(recipient, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
+    const spy = vi.spyOn(metrics, "incrementCounter");
+    try {
+      for (let i = 0; i < 50; i++) {
+        await repository.incrementCounter(`abuse:account:${sender}`, 3600);
+      }
+
+      await expect(
+        submitPostage(repository, {
+          amount: "125",
+          messageId: "g".repeat(64),
+          paymentHash: "h".repeat(64),
+          recipient,
+          sender,
+        }),
+      ).rejects.toMatchObject({ status: 429 });
+      expect(spy).toHaveBeenCalledWith(
+        "postage_limit_rejected",
+        expect.objectContaining({ limit: "account" }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("emits a metric when the ip limit is exceeded", async () => {
+    const repository = new MemoryApiRepository();
+    await repository.setPolicy(recipient, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
+    const spy = vi.spyOn(metrics, "incrementCounter");
+    try {
+      for (let i = 0; i < 100; i++) {
+        await repository.incrementCounter("abuse:ip:1.2.3.4", 3600);
+      }
+
+      await expect(
+        submitPostage(
+          repository,
+          {
+            amount: "125",
+            messageId: "i".repeat(64),
+            paymentHash: "j".repeat(64),
+            recipient,
+            sender,
+          },
+          new Date(),
+          { ip: "1.2.3.4" },
+        ),
+      ).rejects.toMatchObject({ status: 429 });
+      expect(spy).toHaveBeenCalledWith(
+        "postage_limit_rejected",
+        expect.objectContaining({ limit: "ip" }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("rate limits missing relay ids through the unknown relay bucket", async () => {

--- a/tests/unit/api/postage-service.test.ts
+++ b/tests/unit/api/postage-service.test.ts
@@ -82,6 +82,32 @@ describe("postage service", () => {
     ).rejects.toMatchObject({ status: 422 });
   });
 
+  it("rate limits missing relay ids through the unknown relay bucket", async () => {
+    const repository = new MemoryApiRepository();
+    await repository.setPolicy(recipient, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
+    for (let i = 0; i < 500; i++) {
+      await repository.incrementCounter("abuse:relay:unknown", 3600);
+    }
+
+    await expect(
+      submitPostage(repository, {
+        amount: "125",
+        messageId: "e".repeat(64),
+        paymentHash: "f".repeat(64),
+        recipient,
+        sender,
+      }),
+    ).rejects.toMatchObject({
+      status: 429,
+      code: "rate_limited",
+      message: "Relay limit exceeded",
+    });
+  });
+
   it("limits postage reads to message participants", async () => {
     const repository = new MemoryApiRepository();
     const postage = await repository.setPostage({


### PR DESCRIPTION
Closes #77

## Summary

Implements layered abuse prevention across the postage submission flow.

This introduces coordinated rate limiting across:
- Account
- IP
- Device fingerprint
- Sender–recipient pair
- Relay ID

Each limit violation returns a consistent `429 too_many_requests` error with a machine-readable `retryAfterSeconds` value.

## Changes

- Added layered abuse checks in `submitPostage`
- Standardized error code to `too_many_requests` for rate limiting
- Added request context extraction (IP, relay, fingerprint, actor ID)
- Introduced structured abuse metrics for rejection events (no message content included)
- Improved typing with `SubmitPostageContext`
- Updated tests to cover rate limit behavior and metrics emission

## Testing

- 46/46 tests passing