### PR TITLE
Implemented safe multi-select bulk actions for mail conversations.

### DIFF
--- a/src/components/mail/BulkActionBar.tsx
+++ b/src/components/mail/BulkActionBar.tsx
@@ -1,0 +1,272 @@
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+import {
+  Archive,
+  BadgeCheck,
+  Ban,
+  CheckCheck,
+  Clock3,
+  FolderInput,
+  Star,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import { SNOOZE_PRESETS, type SnoozeChoice } from "@/features/snooze";
+import {
+  canApplyBulkActionToEmail,
+  getBulkActionIdsForContext,
+  MOVE_FOLDERS,
+  type BulkActionId,
+  type BulkActionRequest,
+  type BulkFailure,
+  type BulkProgressState,
+  type BulkSnoozeChoice,
+} from "./bulk-actions";
+import { getFolderLabel, type Email, type MailFolder, type MailLocation } from "./data";
+
+type BulkActionBarProps = {
+  selectedEmails: Email[];
+  folder: MailFolder;
+  customFolder?: string | null;
+  onAction: (request: BulkActionRequest) => void;
+  onClearSelection: () => void;
+  bulkProgress: BulkProgressState | null;
+  bulkFailures: BulkFailure[];
+};
+
+export function BulkActionBar({
+  selectedEmails,
+  folder,
+  customFolder,
+  onAction,
+  onClearSelection,
+  bulkProgress,
+  bulkFailures,
+}: BulkActionBarProps) {
+  const actions = useMemo(
+    () => getBulkActionIdsForContext(selectedEmails, folder, customFolder),
+    [selectedEmails, folder, customFolder],
+  );
+  const starValue = selectedEmails.some((email) => !email.starred);
+  const moveTargets = useMemo(
+    () =>
+      MOVE_FOLDERS.filter((target) =>
+        selectedEmails.some((email) =>
+          canApplyBulkActionToEmail({ action: "move", folder: target }, email),
+        ),
+      ),
+    [selectedEmails],
+  );
+  const snoozeChoices = useMemo(
+    () =>
+      SNOOZE_PRESETS.filter((preset) =>
+        selectedEmails.some((email) =>
+          canApplyBulkActionToEmail(
+            { action: "snooze", snoozeChoice: preset.id as BulkSnoozeChoice },
+            email,
+          ),
+        ),
+      ),
+    [selectedEmails],
+  );
+  const progressValue = bulkProgress
+    ? Math.round((bulkProgress.completed / Math.max(bulkProgress.total, 1)) * 100)
+    : 0;
+
+  if (selectedEmails.length === 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      className="relative z-20 mx-3 rounded-t-[8px] border-x border-t border-white/10 bg-white/[0.045] p-2 backdrop-blur-md"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-md border border-white/10 bg-black/20 px-2 py-1 text-[11px] font-medium text-foreground">
+          {selectedEmails.length} selected
+        </span>
+
+        {actions.includes("archive") && (
+          <ActionButton
+            icon={Archive}
+            label="Archive"
+            onClick={() => onAction({ action: "archive" })}
+            disabled={!!bulkProgress}
+          />
+        )}
+
+        {actions.includes("star") && (
+          <ActionButton
+            icon={Star}
+            label={starValue ? "Star" : "Unstar"}
+            onClick={() => onAction({ action: "star", value: starValue })}
+            disabled={!!bulkProgress}
+          />
+        )}
+
+        {actions.includes("mark-read") && (
+          <ActionButton
+            icon={CheckCheck}
+            label="Mark read"
+            onClick={() => onAction({ action: "mark-read" })}
+            disabled={!!bulkProgress}
+          />
+        )}
+
+        {snoozeChoices.length > 0 && (
+          <ActionDropdown
+            icon={Clock3}
+            label="Snooze"
+            disabled={!!bulkProgress}
+            items={snoozeChoices.map((preset) => ({
+              id: preset.id as BulkSnoozeChoice,
+              label: preset.label,
+              onClick: () =>
+                onAction({ action: "snooze", snoozeChoice: preset.id as BulkSnoozeChoice }),
+            }))}
+          />
+        )}
+
+        {actions.includes("approve") && (
+          <ActionButton
+            icon={BadgeCheck}
+            label="Approve"
+            onClick={() => onAction({ action: "approve" })}
+            disabled={!!bulkProgress}
+          />
+        )}
+
+        {actions.includes("block") && (
+          <ActionButton
+            icon={Ban}
+            label="Block"
+            tone="danger"
+            onClick={() => onAction({ action: "block" })}
+            disabled={!!bulkProgress}
+          />
+        )}
+
+        {actions.includes("move") && (
+          <ActionDropdown
+            icon={FolderInput}
+            label="Move"
+            disabled={!!bulkProgress}
+            items={moveTargets.map((target) => ({
+              id: target,
+              label: getFolderLabel(target),
+              onClick: () => onAction({ action: "move", folder: target }),
+            }))}
+          />
+        )}
+
+        <button
+          type="button"
+          onClick={onClearSelection}
+          disabled={!!bulkProgress}
+          className="ml-auto inline-flex h-8 items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.035] px-2.5 text-[11px] font-medium text-muted-foreground transition hover:bg-white/[0.08] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear
+        </button>
+      </div>
+
+      {bulkProgress && (
+        <div className="mt-2 space-y-1.5">
+          <div className="flex items-center justify-between gap-3 text-[10px] text-muted-foreground">
+            <span className="truncate">{bulkProgress.label}</span>
+            <span className="shrink-0 tabular-nums">
+              {bulkProgress.completed}/{bulkProgress.total}
+            </span>
+          </div>
+          <Progress value={progressValue} className="h-1.5" />
+        </div>
+      )}
+
+      {bulkFailures.length > 0 && (
+        <div className="mt-2 rounded-lg border border-red-300/20 bg-red-300/[0.06] p-2 text-[11px] text-red-100">
+          <p className="font-medium">
+            {bulkFailures.length} message{bulkFailures.length === 1 ? "" : "s"} skipped
+          </p>
+          <ul className="mt-1 space-y-0.5 text-red-100/75">
+            {bulkFailures.slice(0, 3).map((failure) => (
+              <li key={failure.id} className="truncate">
+                {failure.subject}: {failure.reason}
+              </li>
+            ))}
+            {bulkFailures.length > 3 && (
+              <li className="text-muted-foreground">+{bulkFailures.length - 3} more</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function ActionButton({
+  icon: Icon,
+  label,
+  onClick,
+  disabled,
+  tone = "default",
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  tone?: "default" | "danger";
+}) {
+  return (
+    <motion.button
+      whileTap={{ scale: 0.96 }}
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-[11px] font-medium transition disabled:cursor-not-allowed disabled:opacity-40",
+        tone === "danger"
+          ? "border-red-300/20 bg-red-300/[0.08] text-red-100 hover:bg-red-300/[0.14]"
+          : "border-white/10 bg-white/[0.04] text-foreground/90 hover:bg-white/[0.08]",
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span className="hidden sm:inline">{label}</span>
+    </motion.button>
+  );
+}
+
+function ActionDropdown({
+  icon: Icon,
+  label,
+  disabled,
+  items,
+}: {
+  icon: LucideIcon;
+  label: string;
+  disabled?: boolean;
+  items: { id: BulkActionId | MailLocation | SnoozeChoice; label: string; onClick: () => void }[];
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <ActionButton icon={Icon} label={label} onClick={() => undefined} disabled={disabled} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" className="z-[120]">
+        {items.map((item) => (
+          <DropdownMenuItem key={`${item.id}`} onClick={item.onClick} className="text-xs">
+            {item.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/mail/BulkConfirmDialog.tsx
+++ b/src/components/mail/BulkConfirmDialog.tsx
@@ -1,0 +1,38 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { BulkActionConfirmation } from "./bulk-actions";
+
+type BulkConfirmDialogProps = {
+  confirmation: BulkActionConfirmation | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function BulkConfirmDialog({ confirmation, onCancel, onConfirm }: BulkConfirmDialogProps) {
+  return (
+    <AlertDialog open={!!confirmation} onOpenChange={(open) => !open && onCancel()}>
+      <AlertDialogContent>
+        {confirmation && (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{confirmation.title}</AlertDialogTitle>
+              <AlertDialogDescription>{confirmation.description}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={onConfirm}>{confirmation.confirmLabel}</AlertDialogAction>
+            </AlertDialogFooter>
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/mail/EmailList.tsx
+++ b/src/components/mail/EmailList.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   applyMailFilters,
   getEmailsForFolder,
@@ -11,13 +12,20 @@ import {
 import { cn } from "@/lib/utils";
 import { ConvertSenderButton } from "@/features/sender-conversion";
 import { MobileMailCard } from "./MobileMailCard";
+import { BulkActionBar } from "./BulkActionBar";
+import type { BulkActionRequest, BulkFailure, BulkProgressState } from "./bulk-actions";
 
 type FilterTab = "all" | "unread" | "flagged";
 
 export function EmailList({
   emails,
   selectedId,
+  selectedIds,
   onSelect,
+  onSelectionChange,
+  onBulkAction,
+  bulkProgress,
+  bulkFailures,
   onConvertSender,
   folder,
   filters,
@@ -31,7 +39,12 @@ export function EmailList({
 }: {
   emails: Email[];
   selectedId: string | null;
+  selectedIds: string[];
   onSelect: (id: string) => void;
+  onSelectionChange: (ids: string[]) => void;
+  onBulkAction: (request: BulkActionRequest) => void;
+  bulkProgress: BulkProgressState | null;
+  bulkFailures: BulkFailure[];
   onConvertSender: (email: Email) => void;
   folder: MailFolder;
   filters: MailFilters;
@@ -57,6 +70,88 @@ export function EmailList({
     if (activeTab === "flagged") return e.starred;
     return true;
   });
+  const visibleIds = filtered.map((email) => email.id);
+  const selectedVisibleIds = visibleIds.filter((id) => selectedIds.includes(id));
+  const selectedEmails = selectedIds
+    .map((id) => emails.find((email) => email.id === id))
+    .filter((email): email is Email => Boolean(email));
+  const allSelected = visibleIds.length > 0 && selectedVisibleIds.length === visibleIds.length;
+  const someSelected = selectedVisibleIds.length > 0;
+  const listRef = useRef<HTMLUListElement>(null);
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  const [lastAnchorId, setLastAnchorId] = useState<string | null>(null);
+
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  });
+
+  useEffect(() => {
+    const visible = new Set(visibleIds);
+    const next = selectedIds.filter((id) => visible.has(id));
+    if (next.length !== selectedIds.length) onSelectionChangeRef.current(next);
+  });
+
+  useEffect(() => {
+    const node = listRef.current;
+    if (!node) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName)) return;
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a") {
+        event.preventDefault();
+        onSelectionChangeRef.current(visibleIds);
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onSelectionChangeRef.current([]);
+      }
+    };
+
+    node.addEventListener("keydown", onKeyDown);
+    return () => node.removeEventListener("keydown", onKeyDown);
+  });
+
+  const toggleSelection = (id: string) => {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onSelectionChangeRef.current(visibleIds.filter((visibleId) => next.has(visibleId)));
+    setLastAnchorId(id);
+  };
+
+  const selectRange = (id: string) => {
+    const anchor = lastAnchorId ?? id;
+    const startIndex = visibleIds.indexOf(anchor);
+    const endIndex = visibleIds.indexOf(id);
+
+    if (startIndex === -1 || endIndex === -1) {
+      toggleSelection(id);
+      return;
+    }
+
+    const range = new Set(
+      visibleIds.slice(Math.min(startIndex, endIndex), Math.max(startIndex, endIndex) + 1),
+    );
+    const next = new Set(selectedIds);
+    range.forEach((rangeId) => {
+      if (next.has(rangeId)) {
+        next.delete(rangeId);
+      } else {
+        next.add(rangeId);
+      }
+    });
+    onSelectionChangeRef.current(visibleIds.filter((visibleId) => next.has(visibleId)));
+    setLastAnchorId(id);
+  };
+
+  const toggleAllSelection = () => {
+    onSelectionChangeRef.current(allSelected ? [] : visibleIds);
+  };
 
   return (
     <section className="mail-list-atmosphere relative m-3 flex h-[calc(100vh-3.5rem-1.5rem)] w-full flex-col overflow-hidden rounded-[8px] md:w-[328px] md:shrink-0 lg:w-[336px]">
@@ -88,18 +183,63 @@ export function EmailList({
         </div>
       </div>
 
-      <ul className={cn(
-        "scrollbar-thin relative z-10 flex-1 overflow-y-auto",
-        useMobile ? "space-y-2 p-2" : "space-y-2 p-2.5"
-      )}>
+      <BulkActionBar
+        selectedEmails={selectedEmails}
+        folder={folder}
+        customFolder={customFolder}
+        onAction={onBulkAction}
+        onClearSelection={() => onSelectionChange([])}
+        bulkProgress={bulkProgress}
+        bulkFailures={bulkFailures}
+      />
+
+      <ul
+        ref={listRef}
+        role="listbox"
+        aria-multiselectable="true"
+        tabIndex={0}
+        className={cn(
+          "scrollbar-thin relative z-10 flex-1 overflow-y-auto",
+          useMobile ? "space-y-2 p-2" : "space-y-2 p-2.5 outline-none",
+        )}
+      >
         {filtered.length === 0 && (
           <li className="px-3 py-10 text-center text-xs text-muted-foreground">
             No conversations in {folderLabel.toLowerCase()} yet.
           </li>
         )}
+        {filtered.length > 0 && (
+          <li className="sticky top-0 z-10 -mx-1 px-1 py-1">
+            <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.035] px-2 py-1.5 text-[11px] text-muted-foreground">
+              <Checkbox
+                checked={allSelected}
+                aria-label={
+                  allSelected ? "Clear all visible messages" : "Select all visible messages"
+                }
+                onCheckedChange={toggleAllSelection}
+              />
+              <button
+                type="button"
+                onClick={toggleAllSelection}
+                className="flex-1 truncate text-left text-foreground/88 transition hover:text-foreground"
+              >
+                {allSelected ? "Clear all" : "Select all"}
+              </button>
+              <span className="shrink-0 tabular-nums">
+                {someSelected
+                  ? `${selectedVisibleIds.length} selected`
+                  : `${filtered.length} conversations`}
+              </span>
+              <span className="hidden xl:inline text-[10px] text-muted-foreground/70">
+                Ctrl/⌘+A · Esc
+              </span>
+            </div>
+          </li>
+        )}
         {filtered.map((e, idx) => {
-          const active = selectedId === e.id;
-          
+          const active = selectedId === e.id || selectedIds.includes(e.id);
+          const selected = selectedIds.includes(e.id);
+
           if (useMobile) {
             return (
               <motion.li
@@ -108,14 +248,27 @@ export function EmailList({
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: idx * 0.03, duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
               >
-                <MobileMailCard
-                  email={e}
-                  selected={active}
-                  onSelect={() => onSelect(e.id)}
-                  onArchive={() => onArchive?.(e)}
-                  onStar={() => onStar?.(e)}
-                  onSnooze={() => onSnooze?.(e)}
-                />
+                <div className="flex items-start gap-2 px-1">
+                  <Checkbox
+                    checked={selected}
+                    aria-label={`Select ${e.from}: ${e.subject}`}
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onKeyDown={(event) => event.stopPropagation()}
+                    onCheckedChange={() => toggleSelection(e.id)}
+                    className="mt-3 border-white/15 bg-white/[0.035] data-[state=checked]:border-white/30"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <MobileMailCard
+                      email={e}
+                      selected={active}
+                      onSelect={() => onSelect(e.id)}
+                      onArchive={() => onArchive?.(e)}
+                      onStar={() => onStar?.(e)}
+                      onSnooze={() => onSnooze?.(e)}
+                    />
+                  </div>
+                </div>
                 {e.folder === "requests" && (
                   <div className="mt-1 flex justify-end px-2">
                     <ConvertSenderButton
@@ -136,72 +289,90 @@ export function EmailList({
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: idx * 0.02, duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
             >
-              <motion.button
-                onClick={() => onSelect(e.id)}
-                whileTap={{ scale: 0.975 }}
-                transition={{ type: "spring", stiffness: 520, damping: 30 }}
-                className={cn(
-                  "mail-preview-card group relative flex w-full items-start gap-3 px-3 text-left transition-[background,border-color,box-shadow,transform] duration-300",
-                  active
-                    ? "-translate-y-px border-white/15 bg-[oklch(0.38_0.007_270/0.55)] py-2 shadow-[0_18px_42px_oklch(0_0_0/0.35),0_0_0_1px_oklch(1_0_0/0.07),inset_0_1px_0_oklch(1_0_0/0.14)]"
-                    : compact
-                      ? "py-2"
-                      : "py-2.5",
-                )}
-              >
-                {active && (
-                  <motion.span
-                    layoutId="email-active"
-                    className="pointer-events-none absolute inset-0 rounded-[14px] ring-1 ring-white/12"
-                    style={{
-                      background:
-                        "radial-gradient(circle at 18% 22%, oklch(1 0 0 / 0.12), transparent 36%), linear-gradient(135deg, oklch(1 0 0 / 0.08), oklch(1 0 0 / 0.025) 44%, oklch(1 0 0 / 0.01))",
-                    }}
-                    transition={{ type: "spring", stiffness: 400, damping: 32 }}
-                  />
-                )}
-                {showAvatars && (
-                  <div
-                    className={cn(
-                      "relative shrink-0 overflow-hidden rounded-full ring-1 ring-white/15 shadow-[0_8px_18px_-12px_rgba(0,0,0,0.9)]",
-                      active ? "h-[30px] w-[30px]" : "h-7 w-7",
-                    )}
-                  >
-                    <img
-                      src={`https://api.dicebear.com/7.x/identicon/svg?seed=${encodeURIComponent(e.from)}&backgroundColor=1a1a1d`}
-                      alt={e.from}
-                      loading="lazy"
-                      className="h-full w-full object-cover"
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  checked={selected}
+                  aria-label={`Select ${e.from}: ${e.subject}`}
+                  onClick={(event) => event.stopPropagation()}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  onCheckedChange={() => toggleSelection(e.id)}
+                  className="mt-2.5 border-white/15 bg-white/[0.035] data-[state=checked]:border-white/30"
+                />
+                <motion.button
+                  onClick={(event) => {
+                    if (event.shiftKey && lastAnchorId) {
+                      selectRange(e.id);
+                    } else {
+                      onSelect(e.id);
+                    }
+                  }}
+                  whileTap={{ scale: 0.975 }}
+                  transition={{ type: "spring", stiffness: 520, damping: 30 }}
+                  aria-selected={active}
+                  className={cn(
+                    "mail-preview-card group relative flex w-full items-start gap-3 px-3 text-left transition-[background,border-color,box-shadow,transform] duration-300",
+                    active
+                      ? "-translate-y-px border-white/15 bg-[oklch(0.38_0.007_270/0.55)] py-2 shadow-[0_18px_42px_oklch(0_0_0/0.35),0_0_0_1px_oklch(1_0_0/0.07),inset_0_1px_0_oklch(1_0_0/0.14)]"
+                      : compact
+                        ? "py-2"
+                        : "py-2.5",
+                  )}
+                >
+                  {active && (
+                    <motion.span
+                      layoutId="email-active"
+                      className="pointer-events-none absolute inset-0 rounded-[14px] ring-1 ring-white/12"
+                      style={{
+                        background:
+                          "radial-gradient(circle at 18% 22%, oklch(1 0 0 / 0.12), transparent 36%), linear-gradient(135deg, oklch(1 0 0 / 0.08), oklch(1 0 0 / 0.025) 44%, oklch(1 0 0 / 0.01))",
+                      }}
+                      transition={{ type: "spring", stiffness: 400, damping: 32 }}
                     />
-                    {e.unread && (
-                      <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[oklch(0.9_0.005_270)] ring-2 ring-[oklch(0.18_0.005_270)]" />
-                    )}
-                  </div>
-                )}
-                <div className="relative min-w-0 flex-1">
-                  <div className="flex items-start justify-between gap-2">
-                    <span
+                  )}
+                  {showAvatars && (
+                    <div
                       className={cn(
-                        "mail-preview-heading truncate text-[13.5px] font-semibold leading-5 text-foreground/88",
-                        e.unread && "text-foreground/94",
+                        "relative shrink-0 overflow-hidden rounded-full ring-1 ring-white/15 shadow-[0_8px_18px_-12px_rgba(0,0,0,0.9)]",
+                        active ? "h-[30px] w-[30px]" : "h-7 w-7",
                       )}
                     >
-                      {e.from}
-                    </span>
-                    <span className="shrink-0 pt-0.5 text-[10.5px] font-medium leading-4 tabular-nums text-muted-foreground/85">
-                      {e.time}
-                    </span>
+                      <img
+                        src={`https://api.dicebear.com/7.x/identicon/svg?seed=${encodeURIComponent(e.from)}&backgroundColor=1a1a1d`}
+                        alt={e.from}
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                      {e.unread && (
+                        <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[oklch(0.9_0.005_270)] ring-2 ring-[oklch(0.18_0.005_270)]" />
+                      )}
+                    </div>
+                  )}
+                  <div className="relative min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-2">
+                      <span
+                        className={cn(
+                          "mail-preview-heading truncate text-[13.5px] font-semibold leading-5 text-foreground/88",
+                          e.unread && "text-foreground/94",
+                        )}
+                      >
+                        {e.from}
+                      </span>
+                      <span className="shrink-0 pt-0.5 text-[10.5px] font-medium leading-4 tabular-nums text-muted-foreground/85">
+                        {e.time}
+                      </span>
+                    </div>
+                    <div
+                      className={cn(
+                        "mail-preview-subheading mt-0.5 truncate text-[12.25px] font-semibold leading-4 text-foreground/68",
+                        e.unread && "text-foreground/78",
+                      )}
+                    >
+                      {e.subject}
+                    </div>
                   </div>
-                  <div
-                    className={cn(
-                      "mail-preview-subheading mt-0.5 truncate text-[12.25px] font-semibold leading-4 text-foreground/68",
-                      e.unread && "text-foreground/78",
-                    )}
-                  >
-                    {e.subject}
-                  </div>
-                </div>
-              </motion.button>
+                </motion.button>
+              </div>
               {e.folder === "requests" && (
                 <div className="mt-1 flex justify-end px-2">
                   <ConvertSenderButton

--- a/src/components/mail/bulk-actions.ts
+++ b/src/components/mail/bulk-actions.ts
@@ -1,0 +1,341 @@
+import {
+  addDays,
+  addHours,
+  nextMonday,
+  setHours,
+  setMinutes,
+  setSeconds,
+  startOfDay,
+} from "date-fns";
+import { getFolderLabel, type Email, type MailFolder, type MailLocation } from "./data";
+import {
+  resolveSenderConversion,
+  type SenderPolicyChoice,
+} from "@/features/sender-conversion/types";
+
+export type BulkActionId =
+  | "archive"
+  | "star"
+  | "snooze"
+  | "mark-read"
+  | "approve"
+  | "block"
+  | "move";
+
+export type BulkSnoozeChoice = "later-today" | "tomorrow" | "next-week";
+
+export type BulkActionRequest =
+  | { action: "archive" }
+  | { action: "star"; value: boolean }
+  | { action: "snooze"; snoozeChoice: BulkSnoozeChoice }
+  | { action: "mark-read" }
+  | { action: "approve" }
+  | { action: "block" }
+  | { action: "move"; folder: MailLocation };
+
+export type BulkFailure = {
+  id: string;
+  subject: string;
+  reason: string;
+};
+
+export type BulkProgressState = {
+  action: BulkActionId;
+  label: string;
+  total: number;
+  completed: number;
+  failures: BulkFailure[];
+};
+
+export type BulkActionConfirmation = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+};
+
+export const PROTOCOL_FOLDERS = new Set<MailLocation>([
+  "verified",
+  "pending",
+  "requests",
+  "encrypted",
+]);
+
+export const MOVE_FOLDERS: MailLocation[] = ["inbox", "priority", "archive", "spam", "trash"];
+
+const NON_MOVABLE_FOLDERS = new Set<MailLocation>([
+  "sent",
+  "outbox",
+  "scheduled",
+  "drafts",
+  "trash",
+]);
+
+const NON_SNOOZABLE_FOLDERS = new Set<MailLocation>([
+  "sent",
+  "outbox",
+  "scheduled",
+  "drafts",
+  "trash",
+  "spam",
+  "snoozed",
+]);
+
+const BULK_ACTIONS: BulkActionId[] = [
+  "archive",
+  "star",
+  "snooze",
+  "mark-read",
+  "approve",
+  "block",
+  "move",
+];
+
+const SNOOZE_LABELS: Record<BulkSnoozeChoice, string> = {
+  "later-today": "Later today",
+  tomorrow: "Tomorrow",
+  "next-week": "Next week",
+};
+
+function resolveBulkSnoozePreset(choice: BulkSnoozeChoice, now: Date) {
+  const at = (day: Date, hour: number, minute = 0) =>
+    setSeconds(setMinutes(setHours(startOfDay(day), hour), minute), 0);
+
+  if (choice === "later-today") {
+    const evening = at(now, 18);
+    const threeHours = addHours(now, 3);
+    return threeHours.getTime() > evening.getTime() ? evening : threeHours;
+  }
+  if (choice === "tomorrow") return at(addDays(now, 1), 9);
+  return at(nextMonday(now), 9);
+}
+
+function buildBulkSnoozeState(choice: BulkSnoozeChoice, remindAt: Date, now: Date) {
+  return {
+    remindAt: remindAt.toISOString(),
+    choice,
+    label: SNOOZE_LABELS[choice],
+    createdAt: now.toISOString(),
+  };
+}
+
+export function isProtocolFolder(folder: MailFolder | MailLocation) {
+  return PROTOCOL_FOLDERS.has(folder as MailLocation);
+}
+
+export function getBulkActionIdsForContext(
+  emails: Email[],
+  folder: MailFolder,
+  customFolder?: string | null,
+) {
+  const currentFolderIsProtocol = !customFolder && isProtocolFolder(folder);
+
+  return BULK_ACTIONS.filter((action) => {
+    if (
+      currentFolderIsProtocol &&
+      (action === "archive" || action === "snooze" || action === "move")
+    ) {
+      return false;
+    }
+
+    return emails.some((email) => {
+      if (action === "move") {
+        return MOVE_FOLDERS.some((target) =>
+          canApplyBulkActionToEmail({ action, folder: target }, email),
+        );
+      }
+      return canApplyBulkActionToEmail(actionRequest(action), email);
+    });
+  });
+}
+
+export function canApplyBulkActionToEmail(request: BulkActionRequest, email: Email) {
+  switch (request.action) {
+    case "archive":
+      return canArchiveEmail(email);
+    case "star":
+      return true;
+    case "snooze":
+      return canSnoozeEmail(email);
+    case "mark-read":
+      return email.unread;
+    case "approve":
+      return canApproveEmail(email);
+    case "block":
+      return canBlockEmail(email);
+    case "move":
+      return canMoveEmail(email) && request.folder !== email.folder;
+  }
+}
+
+export function buildBulkActionPatch(
+  request: BulkActionRequest,
+  email: Email,
+  now = new Date(),
+): { ok: true; patch: Partial<Email> } | { ok: false; reason: string } {
+  if (!canApplyBulkActionToEmail(request, email)) {
+    return { ok: false, reason: getBulkActionFailureReason(request, email) };
+  }
+
+  switch (request.action) {
+    case "archive":
+      return { ok: true, patch: { folder: "archive" } };
+    case "star":
+      return { ok: true, patch: { starred: request.value } };
+    case "snooze": {
+      const remindAt = resolveBulkSnoozePreset(request.snoozeChoice, now);
+      const state = buildBulkSnoozeState(request.snoozeChoice, remindAt, now);
+      return { ok: true, patch: { folder: "snoozed", time: state.label, snooze: state } };
+    }
+    case "mark-read":
+      return { ok: true, patch: { unread: false } };
+    case "approve":
+      return { ok: true, patch: resolveSenderConversion(email, "allow").patch };
+    case "block":
+      return { ok: true, patch: resolveSenderConversion(email, "block").patch };
+    case "move":
+      return { ok: true, patch: { folder: request.folder } };
+  }
+}
+
+export function getBulkActionConfirmation(
+  request: BulkActionRequest,
+  emails: Email[],
+): BulkActionConfirmation | null {
+  const count = emails.length;
+  const subject = count === 1 ? "conversation" : "conversations";
+
+  switch (request.action) {
+    case "archive":
+      return {
+        title: `Archive ${count} ${subject}?`,
+        description: "They will move to Archive and disappear from this view.",
+        confirmLabel: "Archive",
+      };
+    case "block":
+      return {
+        title: `Block ${count} sender${count === 1 ? "" : "s"}?`,
+        description: "Their mail moves to Spam and any postage is marked for refund.",
+        confirmLabel: "Block senders",
+      };
+    case "approve":
+      return {
+        title: `Approve ${count} sender${count === 1 ? "" : "s"}?`,
+        description: "Future mail from these senders will skip request review and land in Inbox.",
+        confirmLabel: "Approve senders",
+      };
+    case "move":
+      return {
+        title: `Move ${count} ${subject} to ${getFolderLabel(request.folder)}?`,
+        description:
+          request.folder === "trash" || request.folder === "spam"
+            ? "This is a destructive protocol change and may affect delivery state."
+            : "These conversations will be filed under the selected folder.",
+        confirmLabel: "Move",
+      };
+    case "snooze": {
+      return {
+        title: `Snooze ${count} ${subject} until ${SNOOZE_LABELS[request.snoozeChoice]}?`,
+        description: "They will return to Inbox at the selected time.",
+        confirmLabel: "Snooze",
+      };
+    }
+    case "star":
+    case "mark-read":
+      return null;
+  }
+}
+
+export function getBulkActionLabel(request: BulkActionRequest) {
+  switch (request.action) {
+    case "archive":
+      return "Archive";
+    case "star":
+      return request.value ? "Star" : "Unstar";
+    case "snooze":
+      return `Snooze until ${SNOOZE_LABELS[request.snoozeChoice]}`;
+    case "mark-read":
+      return "Mark read";
+    case "approve":
+      return "Approve senders";
+    case "block":
+      return "Block senders";
+    case "move":
+      return `Move to ${getFolderLabel(request.folder)}`;
+  }
+}
+
+export function getBulkActionProgressLabel(request: BulkActionRequest, total: number) {
+  return `${getBulkActionLabel(request)} · ${total} selected`;
+}
+
+function actionRequest(action: Exclude<BulkActionId, "move">): BulkActionRequest {
+  switch (action) {
+    case "archive":
+      return { action };
+    case "star":
+      return { action, value: true };
+    case "snooze":
+      return { action, snoozeChoice: "tomorrow" };
+    case "mark-read":
+      return { action };
+    case "approve":
+      return { action };
+    case "block":
+      return { action };
+  }
+}
+
+function canArchiveEmail(email: Email) {
+  return (
+    email.folder !== "archive" && email.folder !== "trash" && !PROTOCOL_FOLDERS.has(email.folder)
+  );
+}
+
+function canSnoozeEmail(email: Email) {
+  return !NON_SNOOZABLE_FOLDERS.has(email.folder) && !PROTOCOL_FOLDERS.has(email.folder);
+}
+
+function canMoveEmail(email: Email) {
+  return !NON_MOVABLE_FOLDERS.has(email.folder) && !PROTOCOL_FOLDERS.has(email.folder);
+}
+
+function canApproveEmail(email: Email) {
+  return (
+    email.folder === "requests" && email.senderPolicy !== "allow" && email.senderPolicy !== "block"
+  );
+}
+
+function canBlockEmail(email: Email) {
+  return (
+    email.senderPolicy !== "block" &&
+    !["sent", "outbox", "scheduled", "drafts"].includes(email.folder)
+  );
+}
+
+function getBulkActionFailureReason(request: BulkActionRequest, email: Email) {
+  switch (request.action) {
+    case "archive":
+      if (email.folder === "archive") return "Already archived.";
+      if (email.folder === "trash") return "Trash messages cannot be archived.";
+      return "Protocol messages cannot be archived in bulk.";
+    case "star":
+      return "This message cannot be starred.";
+    case "snooze":
+      if (email.folder === "snoozed") return "Already snoozed.";
+      if (PROTOCOL_FOLDERS.has(email.folder)) return "Protocol messages cannot be snoozed in bulk.";
+      return "This message cannot be snoozed.";
+    case "mark-read":
+      return "Already read.";
+    case "approve":
+      if (email.senderPolicy === "allow") return "Sender is already approved.";
+      if (email.senderPolicy === "block") return "Sender is already blocked.";
+      return "Approval applies to request messages.";
+    case "block":
+      if (email.senderPolicy === "block") return "Sender is already blocked.";
+      return "This message cannot be blocked.";
+    case "move":
+      if (request.folder === email.folder) return "Already in this folder.";
+      if (PROTOCOL_FOLDERS.has(email.folder)) return "Protocol messages cannot be moved in bulk.";
+      return "This message cannot be moved.";
+  }
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AmbientBackground } from "@/components/mail/AmbientBackground";
+import { BulkConfirmDialog } from "@/components/mail/BulkConfirmDialog";
 import { Sidebar } from "@/components/mail/Sidebar";
 import { Topbar } from "@/components/mail/Topbar";
 import { EmailList } from "@/components/mail/EmailList";
@@ -10,6 +11,15 @@ import type { ComposeSubmission } from "@/components/mail/composeValidation";
 import { RightPanel, type ContextAction } from "@/components/mail/RightPanel";
 import { SettingsModal } from "@/components/mail/SettingsModal";
 import { AttachmentPreviewDrawer } from "@/components/mail/AttachmentPreviewDrawer";
+import {
+  buildBulkActionPatch,
+  getBulkActionConfirmation,
+  getBulkActionProgressLabel,
+  type BulkActionConfirmation,
+  type BulkActionRequest,
+  type BulkFailure,
+  type BulkProgressState,
+} from "@/components/mail/bulk-actions";
 import {
   defaultMailFilters,
   deriveProof,
@@ -86,10 +96,21 @@ function IndexPage() {
   return <MailApp isDemoMode={authMode === "demo"} onSignOut={() => setAuthMode("logged-out")} />;
 }
 
+function delay(ms: number) {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}
+
 function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: () => void }) {
   const [folder, setFolder] = useState<MailFolder>("inbox");
   const [emails, setEmails] = useState<Email[]>(initialEmails);
   const [selectedId, setSelectedId] = useState<string | null>(initialEmails[0].id);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [bulkProgress, setBulkProgress] = useState<BulkProgressState | null>(null);
+  const [bulkFailures, setBulkFailures] = useState<BulkFailure[]>([]);
+  const [bulkConfirmation, setBulkConfirmation] = useState<{
+    request: BulkActionRequest;
+    confirmation: BulkActionConfirmation;
+  } | null>(null);
   const [collapsed, setCollapsed] = useState(false);
   const [composeOpen, setComposeOpen] = useState(false);
   const [composeInitial, setComposeInitial] = useState<{
@@ -170,6 +191,13 @@ function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: 
   );
   const visibleEmails = useMemo(() => getEmailsForFolder(emails, folder), [emails, folder]);
   const selected = emails.find((e) => e.id === selectedId) ?? null;
+  const selectedEmails = useMemo(
+    () =>
+      selectedIds
+        .map((id) => emails.find((email) => email.id === id))
+        .filter((email): email is Email => Boolean(email)),
+    [emails, selectedIds],
+  );
 
   const updateEmail = (id: string, patch: Partial<Email>) => {
     setEmails((prev) => prev.map((e) => (e.id === id ? { ...e, ...patch } : e)));
@@ -292,6 +320,82 @@ function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: 
     onCalendarReminderChange: calendar.updateReminder,
     onPreviewAttachment: (attachment: { name: string; size: string; type: string }) =>
       setPreviewAttachment(attachment),
+  };
+
+  const runBulkAction = async (request: BulkActionRequest) => {
+    if (!selectedEmails.length) return;
+
+    const targets = selectedEmails;
+    let failures: BulkFailure[] = [];
+    setBulkFailures([]);
+    setBulkProgress({
+      action: request.action,
+      label: getBulkActionProgressLabel(request, targets.length),
+      total: targets.length,
+      completed: 0,
+      failures: [],
+    });
+
+    for (const email of targets) {
+      const result = buildBulkActionPatch(request, email);
+      if (!result.ok) {
+        failures = [...failures, { id: email.id, subject: email.subject, reason: result.reason }];
+        setBulkProgress((current) =>
+          current
+            ? {
+                ...current,
+                completed: current.completed + 1,
+                failures,
+              }
+            : current,
+        );
+        continue;
+      }
+
+      updateEmail(email.id, result.patch);
+      await delay(90);
+      setBulkProgress((current) =>
+        current
+          ? {
+              ...current,
+              completed: current.completed + 1,
+              failures,
+            }
+          : current,
+      );
+    }
+
+    const successCount = targets.length - failures.length;
+    setBulkFailures(failures);
+    setBulkProgress((current) =>
+      current
+        ? {
+            ...current,
+            completed: current.total,
+            failures,
+          }
+        : current,
+    );
+    setSelectedIds([]);
+
+    if (failures.length > 0) {
+      showToast(
+        `${failures.length} selected message${failures.length === 1 ? "" : "s"} could not be updated`,
+        { tone: "danger" },
+      );
+    } else if (successCount > 0) {
+      showToast(`${getBulkActionProgressLabel(request, successCount)} complete`);
+    }
+  };
+
+  const handleBulkActionRequest = (request: BulkActionRequest) => {
+    if (!selectedEmails.length) return;
+    const confirmation = getBulkActionConfirmation(request, selectedEmails);
+    if (confirmation) {
+      setBulkConfirmation({ request, confirmation });
+      return;
+    }
+    void runBulkAction(request);
   };
 
   const handleContextAction = (action: ContextAction, email: Email) => {
@@ -432,7 +536,12 @@ function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: 
             <EmailList
               emails={emails}
               selectedId={selectedId}
+              selectedIds={selectedIds}
               onSelect={setSelectedId}
+              onSelectionChange={setSelectedIds}
+              onBulkAction={handleBulkActionRequest}
+              bulkProgress={bulkProgress}
+              bulkFailures={bulkFailures}
               onConvertSender={openSenderConversion}
               folder={folder}
               filters={filters}
@@ -476,6 +585,16 @@ function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: 
           </div>
         </div>
       </div>
+
+      <BulkConfirmDialog
+        confirmation={bulkConfirmation?.confirmation ?? null}
+        onCancel={() => setBulkConfirmation(null)}
+        onConfirm={() => {
+          const request = bulkConfirmation?.request;
+          setBulkConfirmation(null);
+          if (request) void runBulkAction(request);
+        }}
+      />
 
       <Compose
         open={composeOpen}
@@ -521,6 +640,7 @@ function MailApp({ isDemoMode, onSignOut }: { isDemoMode?: boolean; onSignOut?: 
           setFilters(defaultMailFilters);
           setFolder(email.folder);
           setSelectedId(email.id);
+          setSelectedIds([]);
         }}
         onOpenSettings={() => {
           setSettingsSnapshot(preferences);

--- a/tests/unit/bulk-actions/bulk-actions.test.ts
+++ b/tests/unit/bulk-actions/bulk-actions.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { type Email, type MailFolder } from "@/components/mail/data";
+import {
+  buildBulkActionPatch,
+  canApplyBulkActionToEmail,
+  getBulkActionConfirmation,
+  getBulkActionIdsForContext,
+  isProtocolFolder,
+  MOVE_FOLDERS,
+  type BulkActionRequest,
+} from "@/components/mail/bulk-actions";
+
+const baseEmail: Email = {
+  id: "bulk-1",
+  from: "Request Sender",
+  email: "sender*example",
+  subject: "Request",
+  preview: "Preview",
+  body: "Body",
+  time: "Now",
+  unread: true,
+  starred: false,
+  folder: "requests",
+  labels: ["Request"],
+  avatarColor: "#5b6470",
+};
+
+function email(folder: MailFolder, overrides: Partial<Email> = {}): Email {
+  return { ...baseEmail, id: `bulk-${folder}`, folder, ...overrides };
+}
+
+describe("bulk action availability", () => {
+  it("exposes only valid protocol-folder operations", () => {
+    const protocolFolders: MailFolder[] = ["verified", "pending", "requests", "encrypted"];
+
+    for (const folder of protocolFolders) {
+      expect(isProtocolFolder(folder)).toBe(true);
+      const actions = getBulkActionIdsForContext([email(folder)], folder);
+
+      expect(actions).toContain("star");
+      expect(actions).toContain("mark-read");
+      expect(actions).toContain("block");
+      expect(actions).not.toContain("archive");
+      expect(actions).not.toContain("snooze");
+      expect(actions).not.toContain("move");
+      expect(MOVE_FOLDERS.some((folder) => isProtocolFolder(folder))).toBe(false);
+    }
+
+    expect(getBulkActionIdsForContext([email("requests")], "requests")).toContain("approve");
+    expect(getBulkActionIdsForContext([email("verified")], "verified")).not.toContain("approve");
+  });
+
+  it("keeps non-protocol folders able to archive, snooze, star, mark read, and move", () => {
+    const inboxEmail = email("inbox");
+    const actions = getBulkActionIdsForContext([inboxEmail], "inbox");
+
+    expect(actions).toEqual(
+      expect.arrayContaining(["archive", "star", "snooze", "mark-read", "block", "move"]),
+    );
+    expect(actions).not.toContain("approve");
+  });
+
+  it("reports per-message applicability for mixed selections", () => {
+    const archived = email("archive");
+    const inbox = email("inbox");
+
+    expect(canApplyBulkActionToEmail({ action: "archive" }, archived)).toBe(false);
+    expect(canApplyBulkActionToEmail({ action: "archive" }, inbox)).toBe(true);
+    expect(canApplyBulkActionToEmail({ action: "approve" }, archived)).toBe(false);
+    expect(canApplyBulkActionToEmail({ action: "approve" }, email("requests"))).toBe(true);
+  });
+});
+
+describe("bulk action patches and confirmations", () => {
+  it("builds safe patches for archive, star, mark read, approve, block, move, and snooze", () => {
+    const request = email("requests");
+    const inbox = email("inbox");
+
+    expect(buildBulkActionPatch({ action: "archive" }, inbox)).toMatchObject({
+      ok: true,
+      patch: { folder: "archive" },
+    });
+    expect(buildBulkActionPatch({ action: "star", value: true }, request)).toMatchObject({
+      ok: true,
+      patch: { starred: true },
+    });
+    expect(buildBulkActionPatch({ action: "mark-read" }, request)).toMatchObject({
+      ok: true,
+      patch: { unread: false },
+    });
+    expect(buildBulkActionPatch({ action: "approve" }, request)).toMatchObject({
+      ok: true,
+      patch: { folder: "inbox", senderPolicy: "allow" },
+    });
+    expect(buildBulkActionPatch({ action: "block" }, request)).toMatchObject({
+      ok: true,
+      patch: { folder: "spam", senderPolicy: "block" },
+    });
+    expect(buildBulkActionPatch({ action: "move", folder: "spam" }, inbox)).toMatchObject({
+      ok: true,
+      patch: { folder: "spam" },
+    });
+    expect(
+      buildBulkActionPatch({ action: "snooze", snoozeChoice: "tomorrow" }, inbox),
+    ).toMatchObject({
+      ok: true,
+      patch: { folder: "snoozed" },
+    });
+  });
+
+  it("requires confirmation for destructive or protocol-affecting bulk changes", () => {
+    const requests = [email("requests"), { ...email("requests"), id: "bulk-2" }];
+
+    expect(getBulkActionConfirmation({ action: "archive" }, requests)?.confirmLabel).toBe(
+      "Archive",
+    );
+    expect(getBulkActionConfirmation({ action: "block" }, requests)?.confirmLabel).toBe(
+      "Block senders",
+    );
+    expect(getBulkActionConfirmation({ action: "approve" }, requests)?.confirmLabel).toBe(
+      "Approve senders",
+    );
+    expect(
+      getBulkActionConfirmation({ action: "move", folder: "trash" }, requests)?.confirmLabel,
+    ).toBe("Move");
+    expect(getBulkActionConfirmation({ action: "star", value: true }, requests)).toBeNull();
+    expect(getBulkActionConfirmation({ action: "mark-read" }, requests)).toBeNull();
+  });
+
+  it("rejects invalid actions with reasons", () => {
+    const archived: Email = { ...baseEmail, folder: "archive" };
+    const blocked: Email = { ...baseEmail, folder: "requests", senderPolicy: "block" };
+    const requests: BulkActionRequest[] = [
+      { action: "archive" },
+      { action: "approve" },
+      { action: "block" },
+    ];
+
+    expect(buildBulkActionPatch(requests[0], archived)).toMatchObject({
+      ok: false,
+      reason: "Already archived.",
+    });
+    expect(buildBulkActionPatch(requests[1], blocked)).toMatchObject({
+      ok: false,
+      reason: "Sender is already blocked.",
+    });
+    expect(buildBulkActionPatch(requests[2], blocked)).toMatchObject({
+      ok: false,
+      reason: "Sender is already blocked.",
+    });
+  });
+});


### PR DESCRIPTION

Closes #130 
## What changed
- Added multi-select support to the mail list:
  - Mouse/touch checkbox selection
  - Shift-click range selection
  - Select all visible conversations
  - `Ctrl/⌘+A` and `Esc` keyboard shortcuts
- Added a bulk action bar with:
  - Archive
  - Star / unstar
  - Mark read
  - Snooze presets
  - Approve sender
  - Block sender
  - Move to safe folders
- Added confirmation prompts for destructive or protocol-affecting bulk changes.
- Added progress tracking and per-message failure reporting.
- Restricted protocol folders to safe bulk operations only.
- Prevented generic move actions from targeting protocol/delivery folders.
- Added unit coverage for bulk action availability, patch generation, confirmations, and failure cases.

## Validation
- `npx vitest run tests/unit` passed: 16 files, 157 tests.
- Changed-file ESLint passed.
- Full lint still reports existing repo-wide CRLF/prettier issues.
- Full test script still includes e2e tests that fail under Vitest due existing Playwright config/test-type issues.
- Build client succeeded; SSR build is blocked by an existing Cloudflare/unenv dependency resolution issue.