### PR TITLE
feat(settings): add mailbox policy template gallery with preview and …

### DIFF
--- a/src/components/mail/SettingsModal.tsx
+++ b/src/components/mail/SettingsModal.tsx
@@ -22,6 +22,16 @@ import { useState, type CSSProperties } from "react";
 import { Surface } from "@/features/design-system";
 import { cn } from "@/lib/utils";
 import type { ReceiptPreference, UiPreferences } from "@/features/preferences";
+import {
+  MAILBOX_POLICY_TEMPLATES,
+  buildCustomMailboxPolicyTemplate,
+  findMailboxPolicyTemplate,
+  mailboxPolicyTemplateMatchesPreferences,
+  savedCustomTemplateToPreferences,
+  templateToPreferences,
+  type MailboxPolicyTemplateId,
+  type SavedMailboxPolicyTemplate,
+} from "@/features/settings/mailbox-policy-templates";
 import { AuditLog } from "@/features/audit-log";
 
 const tabs = [
@@ -124,7 +134,7 @@ export function SettingsModal({
                   <NotificationSettings preferences={preferences} onChange={onChange} />
                 )}
                 {activeTab === "inbox" && (
-                  <InboxSettings preferences={preferences} onChange={onChange} />
+                  <InboxSettings open={open} preferences={preferences} onChange={onChange} />
                 )}
                 {activeTab === "receipts" && (
                   <ReceiptSettings preferences={preferences} onChange={onChange} />
@@ -136,7 +146,8 @@ export function SettingsModal({
             </div>
             <div className="flex items-center justify-between border-t border-white/5 px-5 py-3">
               <span className="text-[11px] text-muted-foreground">
-                Preview applies immediately. Save to keep changes or cancel to restore.
+                Manual edits apply immediately. Template selections preview before apply. Save to
+                keep changes or cancel to restore.
               </span>
               <div className="flex items-center gap-2">
                 <button
@@ -416,68 +427,418 @@ function NotificationSettings({
 }
 
 function InboxSettings({
+  open,
   preferences,
   onChange,
 }: {
+  open: boolean;
   preferences: UiPreferences;
   onChange: (preferences: UiPreferences) => void;
 }) {
+  const [previewTemplateId, setPreviewTemplateId] = useState<MailboxPolicyTemplateId | "custom">(
+    () => findMailboxPolicyTemplate(preferences)?.id ?? "custom",
+  );
+  const [savedCustomTemplate, setSavedCustomTemplate] = useState<SavedMailboxPolicyTemplate | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setPreviewTemplateId(findMailboxPolicyTemplate(preferences)?.id ?? "custom");
+  }, [open, preferences]);
+
+  const currentDraft = {
+    unknownSenders: preferences.unknownSenders,
+    minimumPostage: preferences.minimumPostage,
+  } as const;
+
+  const liveTemplate = findMailboxPolicyTemplate(currentDraft);
+
+  const selectedPreview =
+    previewTemplateId === "custom"
+      ? (savedCustomTemplate ??
+        buildCustomMailboxPolicyTemplate(currentDraft, liveTemplate?.id ?? null))
+      : (MAILBOX_POLICY_TEMPLATES.find((template) => template.id === previewTemplateId) ?? null);
+
+  const selectedPreferences =
+    previewTemplateId === "custom"
+      ? savedCustomTemplate
+        ? savedCustomTemplateToPreferences(savedCustomTemplate)
+        : currentDraft
+      : selectedPreview
+        ? templateToPreferences(selectedPreview)
+        : currentDraft;
+
+  const previewMatchesCurrent =
+    previewTemplateId === "custom"
+      ? savedCustomTemplate
+        ? savedCustomTemplate.policy.unknownSenders === preferences.unknownSenders &&
+          savedCustomTemplate.policy.minimumPostage === preferences.minimumPostage
+        : true
+      : selectedPreview
+        ? mailboxPolicyTemplateMatchesPreferences(selectedPreview, currentDraft)
+        : false;
+
+  const applyingWillReplaceCurrent =
+    previewTemplateId === "custom"
+      ? !!savedCustomTemplate && !previewMatchesCurrent
+      : !previewMatchesCurrent;
+
+  const handleTemplateChange = (id: MailboxPolicyTemplateId) => {
+    setPreviewTemplateId(id);
+  };
+
+  const handleApply = () => {
+    if (!selectedPreview) return;
+
+    if (previewTemplateId === "custom") {
+      if (!savedCustomTemplate) {
+        setSavedCustomTemplate(
+          buildCustomMailboxPolicyTemplate(currentDraft, liveTemplate?.id ?? null),
+        );
+        return;
+      }
+
+      onChange({
+        ...preferences,
+        ...savedCustomTemplateToPreferences(savedCustomTemplate),
+      });
+      return;
+    }
+
+    onChange({
+      ...preferences,
+      ...templateToPreferences(selectedPreview),
+    });
+  };
+
+  const handleSaveCustom = () => {
+    setSavedCustomTemplate(
+      buildCustomMailboxPolicyTemplate(currentDraft, liveTemplate?.id ?? null),
+    );
+    setPreviewTemplateId("custom");
+  };
+
+  const updateUnknownSenders = (unknownSenders: UiPreferences["unknownSenders"]) => {
+    setPreviewTemplateId("custom");
+    onChange({
+      ...preferences,
+      unknownSenders,
+    });
+  };
+
+  const updateMinimumPostage = (minimumPostage: string) => {
+    setPreviewTemplateId("custom");
+    onChange({
+      ...preferences,
+      minimumPostage,
+    });
+  };
+
   return (
     <div className="space-y-6">
       <div>
         <h3 className="text-sm font-medium text-foreground">Inbox control</h3>
-        <p className="mt-1 text-xs text-muted-foreground">Choose how unknown senders reach you.</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Choose how unknown senders reach you, or preview a common inbox policy template.
+        </p>
       </div>
-      <div className="grid gap-2">
-        {[
-          {
-            value: "request",
-            label: "Request approval",
-            description: "Hold unknown senders for review.",
-          },
-          {
-            value: "verified",
-            label: "Verified only",
-            description: "Accept verified identities with postage.",
-          },
-          {
-            value: "block",
-            label: "Trusted contacts only",
-            description: "Reject every unknown sender.",
-          },
-        ].map((policy) => (
-          <button
-            key={policy.value}
-            onClick={() =>
-              onChange({
-                ...preferences,
-                unknownSenders: policy.value as UiPreferences["unknownSenders"],
-              })
-            }
-            className={cn(
-              "rounded-xl border p-3 text-left transition",
-              preferences.unknownSenders === policy.value
-                ? "border-emerald-200/20 bg-emerald-200/[0.06]"
-                : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
-            )}
-          >
-            <span className="block text-sm font-medium text-foreground">{policy.label}</span>
-            <span className="mt-1 block text-xs text-muted-foreground">{policy.description}</span>
-          </button>
-        ))}
-      </div>
-      <label className="block">
-        <span className="text-xs text-muted-foreground">Minimum postage</span>
-        <div className="mt-1 flex items-center rounded-lg border border-white/10 bg-white/[0.04] px-3">
-          <input
-            value={preferences.minimumPostage}
-            onChange={(event) => onChange({ ...preferences, minimumPostage: event.target.value })}
-            inputMode="decimal"
-            className="w-full bg-transparent py-2 text-sm text-foreground outline-none"
-          />
-          <span className="text-xs text-muted-foreground">XLM</span>
+
+      <div className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs font-medium text-foreground">Template gallery</p>
+              <p className="text-[11px] text-muted-foreground">
+                Comparison cards show each template’s tradeoff and sender experience before you
+                apply it.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            {MAILBOX_POLICY_TEMPLATES.map((template) => {
+              const selected = previewTemplateId === template.id;
+              return (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => handleTemplateChange(template.id)}
+                  className={cn(
+                    "rounded-2xl border p-4 text-left transition",
+                    selected
+                      ? "border-emerald-300/30 bg-emerald-300/[0.08] shadow-[0_0_0_1px_rgba(110,231,183,0.12)]"
+                      : "border-white/10 bg-white/[0.025] hover:border-white/15 hover:bg-white/[0.05]",
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-foreground">{template.label}</p>
+                      <p className="text-[11px] text-muted-foreground">{template.summary}</p>
+                    </div>
+                    <span
+                      className={cn(
+                        "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                        selected
+                          ? "bg-emerald-400/20 text-emerald-300"
+                          : "bg-white/[0.06] text-muted-foreground",
+                      )}
+                    >
+                      {selected ? "Previewing" : "View"}
+                    </span>
+                  </div>
+
+                  <div className="mt-3 grid gap-2 text-[11px] text-muted-foreground sm:grid-cols-2">
+                    <div className="rounded-xl border border-white/5 bg-black/15 px-3 py-2">
+                      <span className="block text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                        Tradeoff
+                      </span>
+                      <span className="mt-1 block text-foreground">{template.tradeoff}</span>
+                    </div>
+                    <div className="rounded-xl border border-white/5 bg-black/15 px-3 py-2">
+                      <span className="block text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                        Sender experience
+                      </span>
+                      <span className="mt-1 block text-foreground">
+                        {template.senderExperience}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+
+            <button
+              type="button"
+              onClick={() => handleTemplateChange("custom")}
+              className={cn(
+                "rounded-2xl border p-4 text-left transition",
+                previewTemplateId === "custom"
+                  ? "border-sky-300/30 bg-sky-300/[0.08] shadow-[0_0_0_1px_rgba(103,232,249,0.12)]"
+                  : "border-dashed border-white/10 bg-white/[0.02] hover:border-white/15 hover:bg-white/[0.04]",
+              )}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">
+                    {savedCustomTemplate?.label ?? "Custom draft"}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {savedCustomTemplate?.summary ??
+                      "Your unsaved policy edits stay separate from the built-in templates."}
+                  </p>
+                </div>
+                <span
+                  className={cn(
+                    "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                    previewTemplateId === "custom"
+                      ? "bg-sky-400/20 text-sky-300"
+                      : "bg-white/[0.06] text-muted-foreground",
+                  )}
+                >
+                  {savedCustomTemplate ? "Saved" : "Local"}
+                </span>
+              </div>
+              {savedCustomTemplate ? (
+                <div className="mt-3 grid gap-2 sm:grid-cols-2 text-[11px] text-muted-foreground">
+                  <div className="rounded-xl border border-white/5 bg-black/15 px-3 py-2">
+                    <span className="block text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                      Source
+                    </span>
+                    <span className="mt-1 block text-foreground">
+                      {savedCustomTemplate.sourceTemplateId ?? "Manual draft"}
+                    </span>
+                  </div>
+                  <div className="rounded-xl border border-white/5 bg-black/15 px-3 py-2">
+                    <span className="block text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                      Exact values
+                    </span>
+                    <span className="mt-1 block text-foreground">
+                      {selectedPreferences.unknownSenders === "request"
+                        ? "Request approval"
+                        : selectedPreferences.unknownSenders === "verified"
+                          ? "Verified only"
+                          : "Allowlist only"}
+                      {" | "}
+                      {selectedPreferences.minimumPostage} XLM
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-3 text-[11px] text-muted-foreground">
+                  Click Save as custom after you tune the live policy fields.
+                </div>
+              )}
+            </button>
+          </div>
         </div>
-      </label>
+
+        <Surface variant="strong" padding="md" className="space-y-4 border border-white/10">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                Policy preview
+              </p>
+              <h4 className="mt-1 text-sm font-semibold text-foreground">
+                {previewTemplateId === "custom"
+                  ? "Custom draft"
+                  : (selectedPreview?.label ?? "Mailbox policy")}
+              </h4>
+              <p className="mt-1 text-xs text-muted-foreground">{selectedPreview?.summary}</p>
+            </div>
+            <span
+              className={cn(
+                "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                previewTemplateId === "custom"
+                  ? "bg-sky-400/15 text-sky-300"
+                  : "bg-emerald-400/15 text-emerald-300",
+              )}
+            >
+              {previewTemplateId === "custom" ? "Custom" : "Template"}
+            </span>
+          </div>
+
+          <div className="grid gap-3">
+            <PreviewStat
+              label="Unknown sender handling"
+              value={
+                selectedPreferences.unknownSenders === "request"
+                  ? "Request approval"
+                  : selectedPreferences.unknownSenders === "verified"
+                    ? "Verified only"
+                    : "Allowlist only"
+              }
+              meta={
+                previewTemplateId === "custom"
+                  ? "Reflects the current live policy values."
+                  : "Matches the selected template before apply."
+              }
+            />
+            <PreviewStat
+              label="Minimum postage"
+              value={`${selectedPreferences.minimumPostage} XLM`}
+              meta={
+                previewTemplateId === "custom"
+                  ? "Current draft postage value."
+                  : "Template postage used when applied."
+              }
+            />
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-black/15 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              Sender experience
+            </p>
+            <p className="mt-1 text-sm text-foreground">{selectedPreview?.senderExperience}</p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-black/15 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              Tradeoff
+            </p>
+            <p className="mt-1 text-sm text-foreground">{selectedPreview?.tradeoff}</p>
+          </div>
+
+          {applyingWillReplaceCurrent && (
+            <div className="rounded-2xl border border-amber-300/20 bg-amber-300/[0.08] p-3">
+              <p className="text-sm font-medium text-amber-200">Explicit overwrite required</p>
+              <p className="mt-1 text-xs text-amber-100/80">
+                Applying this preview will replace the current unsaved policy draft. Your live draft
+                stays unchanged until you click Apply.
+              </p>
+            </div>
+          )}
+
+          <div className="flex gap-2 pt-1">
+            {previewTemplateId === "custom" && !savedCustomTemplate ? (
+              <button
+                type="button"
+                onClick={handleSaveCustom}
+                className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+              >
+                Save as custom
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleApply}
+                className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+              >
+                {previewTemplateId === "custom" ? "Apply custom template" : "Apply template"}
+              </button>
+            )}
+          </div>
+        </Surface>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <p className="text-sm font-medium text-foreground">Policy editor</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Manual edits update the live policy draft. Template selection previews values until you
+            apply.
+          </p>
+        </div>
+
+        <div className="grid gap-2">
+          {[
+            {
+              value: "request",
+              label: "Request approval",
+              description: "Hold unknown senders for review.",
+            },
+            {
+              value: "verified",
+              label: "Verified only",
+              description: "Accept verified identities with postage.",
+            },
+            {
+              value: "block",
+              label: "Trusted contacts only",
+              description: "Reject every unknown sender.",
+            },
+          ].map((policy) => (
+            <button
+              key={policy.value}
+              onClick={() => updateUnknownSenders(policy.value as UiPreferences["unknownSenders"])}
+              className={cn(
+                "rounded-xl border p-3 text-left transition",
+                preferences.unknownSenders === policy.value
+                  ? "border-emerald-200/20 bg-emerald-200/[0.06]"
+                  : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
+              )}
+            >
+              <span className="block text-sm font-medium text-foreground">{policy.label}</span>
+              <span className="mt-1 block text-xs text-muted-foreground">{policy.description}</span>
+            </button>
+          ))}
+        </div>
+
+        <label className="block">
+          <span className="text-xs text-muted-foreground">Minimum postage</span>
+          <div className="mt-1 flex items-center rounded-lg border border-white/10 bg-white/[0.04] px-3">
+            <input
+              value={preferences.minimumPostage}
+              onChange={(event) => updateMinimumPostage(event.target.value)}
+              inputMode="decimal"
+              className="w-full bg-transparent py-2 text-sm text-foreground outline-none"
+            />
+            <span className="text-xs text-muted-foreground">XLM</span>
+          </div>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function PreviewStat({ label, value, meta }: { label: string; value: string; meta: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/15 px-3 py-2.5">
+      <span className="block text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        {label}
+      </span>
+      <span className="mt-1 block text-sm font-medium text-foreground">{value}</span>
+      <span className="mt-1 block text-[11px] text-muted-foreground">{meta}</span>
     </div>
   );
 }

--- a/src/features/settings/mailbox-policy-templates.ts
+++ b/src/features/settings/mailbox-policy-templates.ts
@@ -1,0 +1,155 @@
+import type { UiPreferences, UnknownSenderPolicy } from "@/features/preferences";
+
+export type MailboxPolicyTemplateId =
+  | "private"
+  | "public-paid-inbox"
+  | "investor-inbox"
+  | "recruiting-inbox"
+  | "allowlist-only";
+
+export type MailboxPolicyTemplate = {
+  id: MailboxPolicyTemplateId;
+  label: string;
+  summary: string;
+  tradeoff: string;
+  senderExperience: string;
+  policy: {
+    unknownSenders: UnknownSenderPolicy;
+    minimumPostage: string;
+  };
+};
+
+export type SavedMailboxPolicyTemplate = {
+  id: "custom";
+  label: string;
+  summary: string;
+  tradeoff: string;
+  senderExperience: string;
+  policy: {
+    unknownSenders: UnknownSenderPolicy;
+    minimumPostage: string;
+  };
+  sourceTemplateId: MailboxPolicyTemplateId | null;
+};
+
+export function templateToPreferences(
+  template: MailboxPolicyTemplate,
+): Pick<UiPreferences, "unknownSenders" | "minimumPostage"> {
+  return {
+    unknownSenders: template.policy.unknownSenders,
+    minimumPostage: template.policy.minimumPostage,
+  };
+}
+
+export function buildCustomMailboxPolicyTemplate(
+  preferences: Pick<UiPreferences, "unknownSenders" | "minimumPostage">,
+  sourceTemplateId: MailboxPolicyTemplateId | null,
+): SavedMailboxPolicyTemplate {
+  return {
+    id: "custom",
+    label: "Custom draft",
+    summary: "Your current inbox policy draft, saved as a reusable custom template.",
+    tradeoff:
+      "This custom policy is a local draft snapshot and won’t overwrite your current settings until applied.",
+    senderExperience:
+      "Your current mailbox policy keeps unknown senders and postage values exactly as you set them.",
+    policy: {
+      unknownSenders: preferences.unknownSenders,
+      minimumPostage: preferences.minimumPostage,
+    },
+    sourceTemplateId,
+  };
+}
+
+export function savedCustomTemplateToPreferences(
+  template: SavedMailboxPolicyTemplate,
+): Pick<UiPreferences, "unknownSenders" | "minimumPostage"> {
+  return {
+    unknownSenders: template.policy.unknownSenders,
+    minimumPostage: template.policy.minimumPostage,
+  };
+}
+
+export function mailboxPolicyTemplateMatchesPreferences(
+  template: MailboxPolicyTemplate,
+  preferences: Pick<UiPreferences, "unknownSenders" | "minimumPostage">,
+) {
+  return (
+    template.policy.unknownSenders === preferences.unknownSenders &&
+    template.policy.minimumPostage === preferences.minimumPostage
+  );
+}
+
+export function findMailboxPolicyTemplate(
+  preferences: Pick<UiPreferences, "unknownSenders" | "minimumPostage">,
+): MailboxPolicyTemplate | null {
+  return (
+    MAILBOX_POLICY_TEMPLATES.find((template) =>
+      mailboxPolicyTemplateMatchesPreferences(template, preferences),
+    ) ?? null
+  );
+}
+
+export const MAILBOX_POLICY_TEMPLATES: MailboxPolicyTemplate[] = [
+  {
+    id: "private",
+    label: "Private",
+    summary: "Low-friction inbox for personal mail and trusted contacts.",
+    tradeoff: "Unknown senders can ask for review, while your inbox stays quiet by default.",
+    senderExperience:
+      "Trusted contacts arrive normally. Everyone else lands in a review queue unless you approve them.",
+    policy: {
+      unknownSenders: "request",
+      minimumPostage: "0.0001",
+    },
+  },
+  {
+    id: "public-paid-inbox",
+    label: "Public paid inbox",
+    summary: "Open inbox for newsletters, communities, and inbound outreach.",
+    tradeoff: "More messages get through, so postage makes noise expensive and discourages spam.",
+    senderExperience:
+      "Unknown senders can reach you if they pay postage. This is the easiest path for broad inbound mail.",
+    policy: {
+      unknownSenders: "request",
+      minimumPostage: "0.01",
+    },
+  },
+  {
+    id: "investor-inbox",
+    label: "Investor inbox",
+    summary: "Tighter inbox for inbound opportunities and high-signal introductions.",
+    tradeoff: "It raises outreach cost and expects verified senders before review.",
+    senderExperience:
+      "Senders must be verified and pay a meaningful postage amount before their message is worth your time.",
+    policy: {
+      unknownSenders: "verified",
+      minimumPostage: "0.1",
+    },
+  },
+  {
+    id: "recruiting-inbox",
+    label: "Recruiting inbox",
+    summary: "Structured inbox for hiring, introductions, and candidate screening.",
+    tradeoff:
+      "Forwarding and outreach stay open, but postage keeps casual spam from dominating the queue.",
+    senderExperience:
+      "Potential candidates can still reach you, but low-effort senders are discouraged by the postage floor.",
+    policy: {
+      unknownSenders: "request",
+      minimumPostage: "0.001",
+    },
+  },
+  {
+    id: "allowlist-only",
+    label: "Allowlist only",
+    summary: "Strict inbox for maximum control and minimal surface area.",
+    tradeoff: "Only approved contacts get through, so you trade discoverability for certainty.",
+    senderExperience:
+      "Unknown senders are rejected up front. Only contacts you already trust can deliver mail.",
+    policy: {
+      unknownSenders: "block",
+      minimumPostage: "0",
+    },
+  },
+];

--- a/tests/unit/settings/mailbox-policy-templates.test.ts
+++ b/tests/unit/settings/mailbox-policy-templates.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAILBOX_POLICY_TEMPLATES,
+  buildCustomMailboxPolicyTemplate,
+  findMailboxPolicyTemplate,
+  mailboxPolicyTemplateMatchesPreferences,
+  savedCustomTemplateToPreferences,
+  templateToPreferences,
+  type MailboxPolicyTemplateId,
+} from "../../../src/features/settings/mailbox-policy-templates";
+
+describe("mailbox policy templates", () => {
+  it("finds the matching template for a standard request policy", () => {
+    const preferences = { unknownSenders: "request", minimumPostage: "0.0001" };
+    expect(findMailboxPolicyTemplate(preferences)?.id).toBe("private");
+  });
+
+  it("finds the allowlist-only template when unknown senders are blocked", () => {
+    const preferences = { unknownSenders: "block", minimumPostage: "0" };
+    expect(findMailboxPolicyTemplate(preferences)?.id).toBe("allowlist-only");
+  });
+
+  it("maps a template to the correct preference values", () => {
+    const template = MAILBOX_POLICY_TEMPLATES.find((item) => item.id === "investor-inbox") as {
+      policy: { unknownSenders: string; minimumPostage: string };
+    };
+
+    expect(templateToPreferences(template)).toEqual({
+      unknownSenders: "verified",
+      minimumPostage: "0.1",
+    });
+  });
+
+  it("builds a reusable saved custom template from preferences", () => {
+    const preferences = { unknownSenders: "verified", minimumPostage: "0.25" };
+    const saved = buildCustomMailboxPolicyTemplate(preferences, "investor-inbox");
+
+    expect(saved.id).toBe("custom");
+    expect(saved.sourceTemplateId).toBe("investor-inbox");
+    expect(saved.policy).toEqual({ unknownSenders: "verified", minimumPostage: "0.25" });
+  });
+
+  it("rehydrates a saved custom template back into preferences", () => {
+    const saved = buildCustomMailboxPolicyTemplate(
+      { unknownSenders: "request", minimumPostage: "0.01" },
+      null,
+    );
+    expect(savedCustomTemplateToPreferences(saved)).toEqual({
+      unknownSenders: "request",
+      minimumPostage: "0.01",
+    });
+  });
+
+  it("recognizes matching and non-matching template preferences", () => {
+    const template = MAILBOX_POLICY_TEMPLATES.find((item) => item.id === "public-paid-inbox") as {
+      policy: { unknownSenders: string; minimumPostage: string };
+    };
+
+    expect(
+      mailboxPolicyTemplateMatchesPreferences(template, {
+        unknownSenders: "request",
+        minimumPostage: "0.01",
+      }),
+    ).toBe(true);
+
+    expect(
+      mailboxPolicyTemplateMatchesPreferences(template, {
+        unknownSenders: "request",
+        minimumPostage: "0.001",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION

closes #121 

## Summary

Implemented **Mailbox Policy Templates** to streamline mailbox configuration with predefined policy presets and a guided selection experience.

## Changes

### Added Mailbox Policy Template Helpers

* Created `mailbox-policy-templates.ts`
* Added 5 predefined mailbox policy templates
* Added template-to-policy conversion helpers
* Added policy-to-template matching utilities

### Updated Mailbox Settings UI

* Replaced manual inbox policy configuration with a template gallery
* Added template preview functionality
* Integrated template application into the existing mailbox settings workflow

### Added Tests

* Created `mailbox-policy-templates.test.ts`
* Added unit tests for template definitions
* Added coverage for conversion and matching helper functions

## Validation

* Fixed syntax and formatting issues discovered during implementation
* Verified ESLint passes on all modified files
* Confirmed test coverage for new mailbox policy template functionality
closes #52 