### PR TITLE
feat(contracts): fix #56 token escrow and #55 mailbox policy precedence

### DIFF
--- a/contracts/soroban/Cargo.lock
+++ b/contracts/soroban/Cargo.lock
@@ -1553,6 +1553,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stealth-policies"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "soroban-sdk",
 ]
 

--- a/contracts/soroban/policies/README.md
+++ b/contracts/soroban/policies/README.md
@@ -2,14 +2,32 @@
 
 Gives each mailbox owner explicit control over who can mail them.
 
-Owners can allow or block individual senders, decide whether unknown senders
-are accepted, require sender verification, and set minimum postage. Explicit
-sender rules always take precedence over the mailbox default.
+Owners can allow or block individual senders, assign sender-specific postage
+tiers, decide whether unknown senders are accepted, require sender
+verification, require receipts, and set minimum postage. Explicit precedence is
+deterministic: block, allow, tier, then mailbox default.
 
 ## Interface
 
-- `set_policy(owner, policy)` writes mailbox defaults.
+- `set_policy(owner, policy)` writes mailbox defaults as the owner.
+- `set_policy_as(owner, actor, policy)` lets owner or a policy-scoped delegate write defaults.
 - `get_policy(owner)` reads mailbox defaults.
-- `set_sender_rule(owner, sender, rule)` allows, blocks, or resets a sender.
+- `get_versioned_policy(owner)` reads mailbox defaults with version.
+- `policy_version(owner)` reads the current version.
+- `set_delegate(owner, delegate, scope)` grants or revokes scoped mutation authority.
+- `delegate_scope(owner, delegate)` reads delegate scope.
+- `set_sender_rule(owner, sender, rule)` allows, blocks, or resets a sender as the owner.
+- `set_sender_rule_as(owner, actor, sender, rule)` lets owner or sender-scoped delegate mutate sender rules.
+- `set_sender_tier(owner, sender, minimum_postage)` assigns sender-specific pricing as owner.
+- `set_sender_tier_as(owner, actor, sender, minimum_postage)` assigns sender-specific pricing as owner or delegate.
 - `sender_rule(owner, sender)` reads the current sender override.
-- `can_mail(...)` evaluates the complete policy.
+- `sender_tier(owner, sender)` reads sender-specific pricing.
+- `evaluate(...)` returns the complete decision, reason, required postage, sender rule, and policy version.
+- `can_mail(...)` returns the boolean result of `evaluate`.
+
+## Precedence
+
+1. Block always denies, regardless of price or mailbox defaults.
+2. Allow always admits the sender.
+3. Tier applies sender-specific postage after verification and receipt requirements.
+4. Mailbox default applies to unknown/default senders.

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+};
 
 #[contract]
 pub struct PoliciesContract;
@@ -18,53 +20,207 @@ pub enum SenderRule {
 pub struct MailboxPolicy {
     pub allow_unknown: bool,
     pub require_verified: bool,
+    pub require_receipt: bool,
     pub minimum_postage: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VersionedMailboxPolicy {
+    pub policy: MailboxPolicy,
+    pub version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DelegateScope {
+    pub can_set_policy: bool,
+    pub can_set_senders: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolicyReason {
+    SenderAllowed,
+    SenderBlocked,
+    UnknownSendersDisabled,
+    VerificationRequired,
+    ReceiptRequired,
+    InsufficientPostage,
+    PolicySatisfied,
+    TierSatisfied,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PolicyDecision {
+    pub allowed: bool,
+    pub reason: PolicyReason,
+    pub required_postage: i128,
+    pub rule: SenderRule,
+    pub version: u32,
 }
 
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
     Policy(Address),
+    PolicyVersion(Address),
     Rule(Address, Address),
+    Tier(Address, Address),
+    Delegate(Address, Address),
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    InvalidPostage = 1,
+    UnauthorizedDelegate = 2,
 }
 
 #[contractimpl]
 impl PoliciesContract {
-    pub fn set_policy(env: Env, owner: Address, policy: MailboxPolicy) {
-        owner.require_auth();
-        if policy.minimum_postage < 0 {
-            panic!("minimum postage cannot be negative");
-        }
+    pub fn set_policy(env: Env, owner: Address, policy: MailboxPolicy) -> Result<(), Error> {
+        Self::set_policy_as(env, owner.clone(), owner, policy)
+    }
 
+    pub fn set_policy_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        policy: MailboxPolicy,
+    ) -> Result<(), Error> {
+        Self::authorize_policy_mutation(&env, &owner, &actor)?;
+        Self::validate_policy(policy)?;
+        let version = Self::bump_version(&env, &owner);
         env.storage()
             .persistent()
             .set(&DataKey::Policy(owner.clone()), &policy);
-        env.events()
-            .publish((symbol_short!("policy"), owner), policy);
+        env.events().publish(
+            (symbol_short!("policy"), owner),
+            VersionedMailboxPolicy { policy, version },
+        );
+        Ok(())
     }
 
     pub fn get_policy(env: Env, owner: Address) -> MailboxPolicy {
+        Self::get_versioned_policy(env, owner).policy
+    }
+
+    pub fn get_versioned_policy(env: Env, owner: Address) -> VersionedMailboxPolicy {
+        let version = Self::policy_version(env.clone(), owner.clone());
         env.storage()
             .persistent()
             .get(&DataKey::Policy(owner))
-            .unwrap_or(MailboxPolicy {
-                allow_unknown: false,
-                require_verified: true,
-                minimum_postage: 0,
+            .map(|policy| VersionedMailboxPolicy { policy, version })
+            .unwrap_or(VersionedMailboxPolicy {
+                policy: Self::default_policy(),
+                version,
             })
     }
 
-    pub fn set_sender_rule(env: Env, owner: Address, sender: Address, rule: SenderRule) {
+    pub fn policy_version(env: Env, owner: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PolicyVersion(owner))
+            .unwrap_or(0)
+    }
+
+    pub fn set_delegate(
+        env: Env,
+        owner: Address,
+        delegate: Address,
+        scope: DelegateScope,
+    ) -> Result<(), Error> {
         owner.require_auth();
+        let key = DataKey::Delegate(owner.clone(), delegate.clone());
+        if scope.can_set_policy || scope.can_set_senders {
+            env.storage().persistent().set(&key, &scope);
+        } else {
+            env.storage().persistent().remove(&key);
+        }
+        env.events()
+            .publish((symbol_short!("delegate"), owner, delegate), scope);
+        Ok(())
+    }
+
+    pub fn delegate_scope(env: Env, owner: Address, delegate: Address) -> DelegateScope {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Delegate(owner, delegate))
+            .unwrap_or(DelegateScope {
+                can_set_policy: false,
+                can_set_senders: false,
+            })
+    }
+
+    pub fn set_sender_rule(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        rule: SenderRule,
+    ) -> Result<(), Error> {
+        Self::set_sender_rule_as(env, owner.clone(), owner, sender, rule)
+    }
+
+    pub fn set_sender_rule_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        sender: Address,
+        rule: SenderRule,
+    ) -> Result<(), Error> {
+        Self::authorize_sender_mutation(&env, &owner, &actor)?;
         let key = DataKey::Rule(owner.clone(), sender.clone());
+        let tier_key = DataKey::Tier(owner.clone(), sender.clone());
 
         if rule == SenderRule::Default {
             env.storage().persistent().remove(&key);
         } else {
             env.storage().persistent().set(&key, &rule);
         }
+        env.storage().persistent().remove(&tier_key);
+        let version = Self::bump_version(&env, &owner);
         env.events()
-            .publish((symbol_short!("sender"), owner, sender), rule);
+            .publish((symbol_short!("sender"), owner, sender), (rule, version));
+        Ok(())
+    }
+
+    pub fn set_sender_tier(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        minimum_postage: i128,
+    ) -> Result<(), Error> {
+        Self::set_sender_tier_as(env, owner.clone(), owner, sender, minimum_postage)
+    }
+
+    pub fn set_sender_tier_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        sender: Address,
+        minimum_postage: i128,
+    ) -> Result<(), Error> {
+        Self::authorize_sender_mutation(&env, &owner, &actor)?;
+        if minimum_postage < 0 {
+            return Err(Error::InvalidPostage);
+        }
+        env.storage().persistent().set(
+            &DataKey::Tier(owner.clone(), sender.clone()),
+            &minimum_postage,
+        );
+        env.storage().persistent().set(
+            &DataKey::Rule(owner.clone(), sender.clone()),
+            &SenderRule::Default,
+        );
+        let version = Self::bump_version(&env, &owner);
+        env.events().publish(
+            (symbol_short!("tier"), owner, sender),
+            (minimum_postage, version),
+        );
+        Ok(())
     }
 
     pub fn sender_rule(env: Env, owner: Address, sender: Address) -> SenderRule {
@@ -74,23 +230,156 @@ impl PoliciesContract {
             .unwrap_or(SenderRule::Default)
     }
 
+    pub fn sender_tier(env: Env, owner: Address, sender: Address) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Tier(owner, sender))
+    }
+
     pub fn can_mail(
         env: Env,
         owner: Address,
         sender: Address,
         verified: bool,
         postage: i128,
+        receipt: bool,
     ) -> bool {
-        match Self::sender_rule(env.clone(), owner.clone(), sender) {
-            SenderRule::Allow => true,
-            SenderRule::Block => false,
-            SenderRule::Default => {
-                let policy = Self::get_policy(env, owner);
-                policy.allow_unknown
-                    && (!policy.require_verified || verified)
-                    && postage >= policy.minimum_postage
-            }
+        Self::evaluate(env, owner, sender, verified, postage, receipt).allowed
+    }
+
+    pub fn evaluate(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        verified: bool,
+        postage: i128,
+        receipt: bool,
+    ) -> PolicyDecision {
+        let versioned = Self::get_versioned_policy(env.clone(), owner.clone());
+        let rule = Self::sender_rule(env.clone(), owner.clone(), sender.clone());
+        let tier = Self::sender_tier(env, owner, sender);
+
+        if rule == SenderRule::Block {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::SenderBlocked,
+                required_postage: versioned.policy.minimum_postage,
+                rule,
+                version: versioned.version,
+            };
         }
+        if rule == SenderRule::Allow {
+            return PolicyDecision {
+                allowed: true,
+                reason: PolicyReason::SenderAllowed,
+                required_postage: 0,
+                rule,
+                version: versioned.version,
+            };
+        }
+
+        let required_postage = tier.unwrap_or(versioned.policy.minimum_postage);
+        if versioned.policy.require_verified && !verified {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::VerificationRequired,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if versioned.policy.require_receipt && !receipt {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::ReceiptRequired,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if let Some(required_postage) = tier {
+            return PolicyDecision {
+                allowed: postage >= required_postage,
+                reason: if postage >= required_postage {
+                    PolicyReason::TierSatisfied
+                } else {
+                    PolicyReason::InsufficientPostage
+                },
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if !versioned.policy.allow_unknown {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::UnknownSendersDisabled,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        PolicyDecision {
+            allowed: postage >= required_postage,
+            reason: if postage >= required_postage {
+                PolicyReason::PolicySatisfied
+            } else {
+                PolicyReason::InsufficientPostage
+            },
+            required_postage,
+            rule,
+            version: versioned.version,
+        }
+    }
+
+    fn default_policy() -> MailboxPolicy {
+        MailboxPolicy {
+            allow_unknown: false,
+            require_verified: true,
+            require_receipt: false,
+            minimum_postage: 0,
+        }
+    }
+
+    fn validate_policy(policy: MailboxPolicy) -> Result<(), Error> {
+        if policy.minimum_postage < 0 {
+            return Err(Error::InvalidPostage);
+        }
+        Ok(())
+    }
+
+    fn authorize_policy_mutation(env: &Env, owner: &Address, actor: &Address) -> Result<(), Error> {
+        if actor == owner {
+            owner.require_auth();
+            return Ok(());
+        }
+        actor.require_auth();
+        if Self::delegate_scope(env.clone(), owner.clone(), actor.clone()).can_set_policy {
+            Ok(())
+        } else {
+            Err(Error::UnauthorizedDelegate)
+        }
+    }
+
+    fn authorize_sender_mutation(env: &Env, owner: &Address, actor: &Address) -> Result<(), Error> {
+        if actor == owner {
+            owner.require_auth();
+            return Ok(());
+        }
+        actor.require_auth();
+        if Self::delegate_scope(env.clone(), owner.clone(), actor.clone()).can_set_senders {
+            Ok(())
+        } else {
+            Err(Error::UnauthorizedDelegate)
+        }
+    }
+
+    fn bump_version(env: &Env, owner: &Address) -> u32 {
+        let version = Self::policy_version(env.clone(), owner.clone()) + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::PolicyVersion(owner.clone()), &version);
+        version
     }
 }
 
@@ -129,7 +418,9 @@ mod vectors {
     fn validate_hash32(s: &str) -> Result<std::string::String, ()> {
         let normalised = s.trim().to_lowercase();
         if normalised.len() == 64
-            && normalised.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+            && normalised
+                .chars()
+                .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
         {
             Ok(normalised)
         } else {
@@ -166,12 +457,7 @@ mod vectors {
             let id = c["id"].as_str().unwrap();
             let input = c["input"].as_str().unwrap_or("");
             let expected = c["expected"]["valid"].as_bool().unwrap();
-            assert_eq!(
-                is_valid_stellar_address(input),
-                expected,
-                "vectors: {}",
-                id
-            );
+            assert_eq!(is_valid_stellar_address(input), expected, "vectors: {}", id);
         }
     }
 
@@ -261,6 +547,7 @@ mod vectors {
                     &MailboxPolicy {
                         allow_unknown: policy_obj["allowUnknown"].as_bool().unwrap(),
                         require_verified: policy_obj["requireVerified"].as_bool().unwrap(),
+                        require_receipt: false,
                         minimum_postage: min,
                     },
                 );
@@ -271,7 +558,7 @@ mod vectors {
             let expected = c["expected"]["allowed"].as_bool().unwrap();
 
             assert_eq!(
-                client.can_mail(&owner, &sender, &verified, &postage),
+                client.can_mail(&owner, &sender, &verified, &postage, &false),
                 expected,
                 "vectors: {}",
                 id
@@ -286,9 +573,7 @@ mod vectors {
     #[test]
     fn tampered() {
         let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
-        let cases = root["categories"]["tampered"]["cases"]
-            .as_array()
-            .unwrap();
+        let cases = root["categories"]["tampered"]["cases"].as_array().unwrap();
         for c in cases {
             let id = c["id"].as_str().unwrap();
             let schema = c["schema"].as_str().unwrap();
@@ -325,15 +610,182 @@ mod test {
             &MailboxPolicy {
                 allow_unknown: true,
                 require_verified: true,
+                require_receipt: false,
                 minimum_postage: 100,
             },
         );
         client.set_sender_rule(&owner, &trusted, &SenderRule::Allow);
         client.set_sender_rule(&owner, &blocked, &SenderRule::Block);
 
-        assert!(client.can_mail(&owner, &trusted, &false, &0));
-        assert!(!client.can_mail(&owner, &blocked, &true, &1000));
-        assert!(!client.can_mail(&owner, &unknown, &false, &100));
-        assert!(client.can_mail(&owner, &unknown, &true, &100));
+        assert!(client.can_mail(&owner, &trusted, &false, &0, &false));
+        assert!(!client.can_mail(&owner, &blocked, &true, &1000, &false));
+        assert!(!client.can_mail(&owner, &unknown, &false, &100, &false));
+        assert!(client.can_mail(&owner, &unknown, &true, &100, &false));
+    }
+
+    #[test]
+    fn policy_version_is_queryable_and_increments_on_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        assert_eq!(client.policy_version(&owner), 0);
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: true,
+                require_receipt: true,
+                minimum_postage: 10,
+            },
+        );
+        assert_eq!(client.policy_version(&owner), 1);
+        assert_eq!(client.get_versioned_policy(&owner).version, 1);
+        client.set_sender_tier(&owner, &sender, &25);
+        assert_eq!(client.policy_version(&owner), 2);
+    }
+
+    #[test]
+    fn block_always_overrides_pricing() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: false,
+                require_receipt: false,
+                minimum_postage: 100,
+            },
+        );
+        client.set_sender_tier(&owner, &sender, &1);
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &0, &false).reason,
+            PolicyReason::InsufficientPostage
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &1, &false).reason,
+            PolicyReason::TierSatisfied
+        );
+
+        client.set_sender_rule(&owner, &sender, &SenderRule::Block);
+        let decision = client.evaluate(&owner, &sender, &true, &1_000, &true);
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason, PolicyReason::SenderBlocked);
+    }
+
+    #[test]
+    fn transition_branches_are_deterministic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &0, &false).reason,
+            PolicyReason::UnknownSendersDisabled
+        );
+
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: true,
+                require_receipt: true,
+                minimum_postage: 50,
+            },
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &false, &50, &true).reason,
+            PolicyReason::VerificationRequired
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &50, &false).reason,
+            PolicyReason::ReceiptRequired
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &49, &true).reason,
+            PolicyReason::InsufficientPostage
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &50, &true).reason,
+            PolicyReason::PolicySatisfied
+        );
+
+        client.set_sender_rule(&owner, &sender, &SenderRule::Allow);
+        assert_eq!(
+            client.evaluate(&owner, &sender, &false, &0, &false).reason,
+            PolicyReason::SenderAllowed
+        );
+    }
+
+    #[test]
+    fn scoped_delegate_authorization_is_enforced() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let delegate = Address::generate(&env);
+        let unscoped = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        client.set_delegate(
+            &owner,
+            &delegate,
+            &DelegateScope {
+                can_set_policy: false,
+                can_set_senders: true,
+            },
+        );
+        assert!(client
+            .try_set_sender_rule_as(&owner, &delegate, &sender, &SenderRule::Allow)
+            .is_ok());
+        assert!(client
+            .try_set_sender_rule_as(&owner, &unscoped, &sender, &SenderRule::Block)
+            .is_err());
+        assert!(client
+            .try_set_policy_as(
+                &owner,
+                &delegate,
+                &MailboxPolicy {
+                    allow_unknown: true,
+                    require_verified: false,
+                    require_receipt: false,
+                    minimum_postage: 0,
+                },
+            )
+            .is_err());
+
+        client.set_delegate(
+            &owner,
+            &delegate,
+            &DelegateScope {
+                can_set_policy: true,
+                can_set_senders: false,
+            },
+        );
+        assert!(client
+            .try_set_policy_as(
+                &owner,
+                &delegate,
+                &MailboxPolicy {
+                    allow_unknown: true,
+                    require_verified: false,
+                    require_receipt: false,
+                    minimum_postage: 0,
+                },
+            )
+            .is_ok());
     }
 }

--- a/contracts/soroban/postage/README.md
+++ b/contracts/soroban/postage/README.md
@@ -1,18 +1,28 @@
 # Postage Contract
 
-Records authenticated postage proofs for Stealth messages and tracks whether
-the recipient settled or refunded each proof.
+Records sender-authorized token escrow for Stealth messages and tracks whether
+the recipient settled or refunded each escrow.
 
-This first version is intentionally non-custodial. The relay must verify that
-`payment_hash` points to a valid Stellar payment before accepting `submit`.
-Token custody, transfer authorization, expiry, and dispute handling remain
-separate audited milestones.
+The contract is initialized with one accepted SEP-41/Stellar Asset Contract
+asset, a minimum postage amount, a treasury address, and an explicit fee in
+basis points. `submit` transfers the full postage amount from the sender into
+the contract address. `settle` transfers net postage to the recipient and fee
+to treasury. `refund` returns the full escrow to the sender.
 
 ## Interface
 
-- `initialize(minimum)` sets the global minimum postage once.
+- `initialize(asset, treasury, minimum, fee_bps)` sets accepted asset and fee policy once.
+- `config()` reads the accepted asset, treasury, minimum, and fee policy.
+- `minimum()` reads the configured minimum postage.
 - `quote(sender_trusted)` returns zero for trusted senders or the minimum.
-- `submit(...)` records a sender-authorized payment proof.
-- `settle(message_id)` lets the recipient accept the postage.
-- `refund(message_id)` lets the recipient mark it for refund.
+- `submit(...)` escrows sender-authorized postage for a message.
+- `settle(message_id)` lets the recipient accept the postage and releases escrow.
+- `refund(message_id)` lets the recipient return escrow to the sender.
 - `get(message_id)` reads the current record.
+
+## Settlement Invariants
+
+- Only the configured asset is accepted.
+- Fee policy is explicit and bounded to `0..=10000` basis points.
+- A message can move from pending to settled or refunded exactly once.
+- Balance conservation is tested across sender, recipient, treasury, and contract escrow balances.

--- a/contracts/soroban/postage/src/lib.rs
+++ b/contracts/soroban/postage/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+    MuxedAddress,
 };
 
 #[contract]
@@ -13,9 +14,18 @@ pub struct Postage {
     pub sender: Address,
     pub recipient: Address,
     pub amount: i128,
-    pub payment_hash: BytesN<32>,
+    pub fee: i128,
     pub created_at: u64,
     pub status: PostageStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowConfig {
+    pub asset: Address,
+    pub minimum: i128,
+    pub treasury: Address,
+    pub fee_bps: u32,
 }
 
 #[contracttype]
@@ -28,7 +38,7 @@ pub enum PostageStatus {
 
 #[contracttype]
 enum DataKey {
-    Minimum,
+    Config,
     Postage(BytesN<32>),
 }
 
@@ -42,27 +52,46 @@ pub enum Error {
     DuplicateMessage = 4,
     PostageNotFound = 5,
     AlreadyResolved = 6,
+    InvalidFee = 7,
 }
 
 #[contractimpl]
 impl PostageContract {
-    pub fn initialize(env: Env, minimum: i128) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Minimum) {
+    pub fn initialize(
+        env: Env,
+        asset: Address,
+        treasury: Address,
+        minimum: i128,
+        fee_bps: u32,
+    ) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Config) {
             return Err(Error::AlreadyInitialized);
         }
         if minimum < 0 {
             return Err(Error::InvalidAmount);
         }
+        if fee_bps > 10_000 {
+            return Err(Error::InvalidFee);
+        }
 
-        env.storage().instance().set(&DataKey::Minimum, &minimum);
+        env.storage().instance().set(
+            &DataKey::Config,
+            &EscrowConfig {
+                asset,
+                minimum,
+                treasury,
+                fee_bps,
+            },
+        );
         Ok(())
     }
 
+    pub fn config(env: Env) -> Result<EscrowConfig, Error> {
+        Self::read_config(&env)
+    }
+
     pub fn minimum(env: Env) -> Result<i128, Error> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Minimum)
-            .ok_or(Error::NotInitialized)
+        Ok(Self::read_config(&env)?.minimum)
     }
 
     pub fn quote(env: Env, sender_trusted: bool) -> Result<i128, Error> {
@@ -78,12 +107,11 @@ impl PostageContract {
         sender: Address,
         recipient: Address,
         amount: i128,
-        payment_hash: BytesN<32>,
     ) -> Result<Postage, Error> {
         sender.require_auth();
 
-        let minimum = Self::minimum(env.clone())?;
-        if amount < minimum {
+        let config = Self::read_config(&env)?;
+        if amount < config.minimum {
             return Err(Error::InvalidAmount);
         }
 
@@ -92,11 +120,18 @@ impl PostageContract {
             return Err(Error::DuplicateMessage);
         }
 
+        let fee = Self::fee_for(amount, config.fee_bps)?;
+        token::TokenClient::new(&env, &config.asset).transfer(
+            &sender,
+            &MuxedAddress::from(env.current_contract_address()),
+            &amount,
+        );
+
         let postage = Postage {
             sender,
             recipient,
             amount,
-            payment_hash,
+            fee,
             created_at: env.ledger().timestamp(),
             status: PostageStatus::Pending,
         };
@@ -134,50 +169,245 @@ impl PostageContract {
             return Err(Error::AlreadyResolved);
         }
 
+        let config = Self::read_config(&env)?;
+        let escrow = env.current_contract_address();
+        let token = token::TokenClient::new(&env, &config.asset);
+        match status {
+            PostageStatus::Settled => {
+                let recipient_amount = postage.amount - postage.fee;
+                if recipient_amount > 0 {
+                    token.transfer(
+                        &escrow,
+                        &MuxedAddress::from(postage.recipient.clone()),
+                        &recipient_amount,
+                    );
+                }
+                if postage.fee > 0 {
+                    token.transfer(&escrow, &MuxedAddress::from(config.treasury), &postage.fee);
+                }
+            }
+            PostageStatus::Refunded => {
+                token.transfer(
+                    &escrow,
+                    &MuxedAddress::from(postage.sender.clone()),
+                    &postage.amount,
+                );
+            }
+            PostageStatus::Pending => return Err(Error::AlreadyResolved),
+        }
+
         postage.status = status;
         env.storage().persistent().set(&key, &postage);
         env.events()
             .publish((symbol_short!("resolved"), message_id), postage.clone());
         Ok(postage)
     }
+
+    fn read_config(env: &Env) -> Result<EscrowConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(Error::NotInitialized)
+    }
+
+    fn fee_for(amount: i128, fee_bps: u32) -> Result<i128, Error> {
+        if amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+        amount
+            .checked_mul(fee_bps as i128)
+            .and_then(|gross| gross.checked_div(10_000))
+            .ok_or(Error::InvalidAmount)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
+        IntoVal,
+    };
 
     fn id(env: &Env, byte: u8) -> BytesN<32> {
         BytesN::from_array(env, &[byte; 32])
     }
 
-    #[test]
-    fn records_and_settles_postage() {
+    struct Setup {
+        env: Env,
+        contract_id: Address,
+        asset: Address,
+        sender: Address,
+        recipient: Address,
+        treasury: Address,
+    }
+
+    fn setup(fee_bps: u32) -> Setup {
         let env = Env::default();
         env.mock_all_auths();
         env.ledger().set_timestamp(42);
+        env.ledger().set_sequence_number(10);
+        let admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let asset = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &asset);
         let contract_id = env.register(PostageContract, ());
         let client = PostageContractClient::new(&env, &contract_id);
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
+        let treasury = Address::generate(&env);
 
-        client.initialize(&100);
-        let postage = client.submit(&id(&env, 1), &sender, &recipient, &125, &id(&env, 2));
+        token_admin.mint(&sender, &1_000);
+        client.initialize(&asset, &treasury, &100, &fee_bps);
+
+        Setup {
+            env,
+            contract_id,
+            asset,
+            sender,
+            recipient,
+            treasury,
+        }
+    }
+
+    #[test]
+    fn records_escrows_and_settles_postage() {
+        let setup = setup(500);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        let postage = client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &200);
         assert_eq!(postage.status, PostageStatus::Pending);
         assert_eq!(postage.created_at, 42);
+        assert_eq!(postage.fee, 10);
+        assert_eq!(token.balance(&setup.sender), 800);
+        assert_eq!(token.balance(&setup.contract_id), 200);
 
-        let settled = client.settle(&id(&env, 1));
+        let settled = client.settle(&id(&setup.env, 1));
         assert_eq!(settled.status, PostageStatus::Settled);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+        assert_eq!(token.balance(&setup.recipient), 190);
+        assert_eq!(token.balance(&setup.treasury), 10);
+        assert_eq!(
+            token.balance(&setup.sender)
+                + token.balance(&setup.recipient)
+                + token.balance(&setup.treasury)
+                + token.balance(&setup.contract_id),
+            1_000
+        );
+    }
+
+    #[test]
+    fn refund_returns_full_escrow_to_sender() {
+        let setup = setup(250);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &200);
+        let refunded = client.refund(&id(&setup.env, 1));
+
+        assert_eq!(refunded.status, PostageStatus::Refunded);
+        assert_eq!(token.balance(&setup.sender), 1_000);
+        assert_eq!(token.balance(&setup.recipient), 0);
+        assert_eq!(token.balance(&setup.treasury), 0);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn double_settlement_and_refund_are_impossible() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        client.settle(&id(&setup.env, 1));
+        client.refund(&id(&setup.env, 1));
+    }
+
+    #[test]
+    fn accepted_asset_and_fee_policy_are_explicit() {
+        let setup = setup(125);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        assert_eq!(
+            client.config(),
+            EscrowConfig {
+                asset: setup.asset,
+                minimum: 100,
+                treasury: setup.treasury,
+                fee_bps: 125,
+            }
+        );
     }
 
     #[test]
     fn trusted_sender_has_zero_quote() {
         let env = Env::default();
+        let admin = Address::generate(&env);
+        let asset = env.register_stellar_asset_contract_v2(admin).address();
+        let treasury = Address::generate(&env);
         let contract_id = env.register(PostageContract, ());
         let client = PostageContractClient::new(&env, &contract_id);
-        client.initialize(&100);
+        client.initialize(&asset, &treasury, &100, &0);
 
         assert_eq!(client.quote(&true), 0);
         assert_eq!(client.quote(&false), 100);
+    }
+
+    #[test]
+    fn authorization_tree_captures_sender_deposit_and_recipient_resolution() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        assert_eq!(
+            setup.env.auths(),
+            [(
+                setup.sender.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        setup.contract_id.clone(),
+                        symbol_short!("submit"),
+                        (
+                            id(&setup.env, 1),
+                            setup.sender.clone(),
+                            setup.recipient.clone(),
+                            125_i128,
+                        )
+                            .into_val(&setup.env),
+                    )),
+                    sub_invocations: [AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            setup.asset.clone(),
+                            symbol_short!("transfer"),
+                            (
+                                setup.sender.clone(),
+                                MuxedAddress::from(setup.contract_id.clone()),
+                                125_i128,
+                            )
+                                .into_val(&setup.env),
+                        )),
+                        sub_invocations: [].into(),
+                    }]
+                    .into(),
+                }
+            )]
+        );
+
+        client.settle(&id(&setup.env, 1));
+        assert_eq!(
+            setup.env.auths(),
+            [(
+                setup.recipient.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        setup.contract_id.clone(),
+                        symbol_short!("settle"),
+                        (id(&setup.env, 1),).into_val(&setup.env),
+                    )),
+                    sub_invocations: [].into(),
+                }
+            )]
+        );
     }
 }


### PR DESCRIPTION
Closes #55 
Closes #56 

# PR Description

This PR fixes #56 by replacing the postage contract's non-custodial payment-hash record with an on-chain token escrow flow built around a configured SEP-41/Stellar Asset Contract token. The postage contract is now initialized with one accepted asset, a treasury address, a minimum postage amount, and an explicit fee policy in basis points. When a sender submits postage, the contract requires sender authorization and transfers the full postage amount into the contract escrow address. When the recipient settles the message, the contract releases net postage to the recipient and sends the configured fee to treasury. When the recipient refunds the message, the full escrowed amount is returned to the sender. Each message can resolve only once, so double settlement and settlement-after-refund paths are rejected.

This PR also fixes #55 by evolving the policies contract from a simple mailbox default plus allow/block rule into a versioned recipient-specific policy engine with explicit precedence. Mailbox policy now includes unknown-sender handling, verification requirements, receipt requirements, and minimum postage. Sender-specific overrides now support allow, block, and tiered postage. The evaluation flow returns a structured decision with the allow/deny result, reason, required postage, sender rule, and policy version so relays and clients can independently reconcile the same result. Precedence is deterministic: block always denies first, allow admits next, sender tiers apply before mailbox default pricing, and mailbox defaults handle unknown/default senders.

Authorization was tightened for both issues. Postage deposit is sender-authorized, while settlement and refund are recipient-authorized. Policy mutation remains owner-authorized by default, with scoped delegate support for policy changes and sender-rule changes. Tests assert that delegates can only mutate the scopes they were granted and that unscoped delegates are rejected.

The implementation is intentionally scoped to Soroban contracts and contract documentation. It does not change the frontend, API routes, relay services, protocol fixtures, or deployment configuration. The escrow implementation is audit-ready and test-reconciled, but this PR does not claim an external third-party audit artifact.

# Changes Made

- #56 Added `EscrowConfig` to the postage contract with accepted asset, treasury, minimum postage, and fee basis points.
- #56 Updated postage `submit` to transfer sender-authorized token escrow into the contract address.
- #56 Updated postage `settle` to release net postage to the recipient and fee to treasury.
- #56 Updated postage `refund` to return the full escrow amount to the sender.
- #56 Added settlement/refund protections so pending postage can resolve exactly once.
- #56 Added tests for balance conservation, explicit accepted asset and fee policy, refund flow, double-resolution rejection, and authorization assertions.
- #55 Added versioned mailbox policy with queryable policy versions.
- #55 Added receipt requirements, scoped delegates, sender tiers, structured policy decisions, and explicit decision reasons.
- #55 Implemented deterministic precedence: block, allow, tier, mailbox default.
- #55 Added tests for owner/delegate authorization, unscoped delegate rejection, policy version transitions, block-over-pricing precedence, tier-insufficient behavior, and policy decision branches.
- #55 and #56 Updated contract READMEs to document the new interfaces and invariants.