### PR TITLE
feat(contracts): fix #56 token escrow settlement

### DIFF
--- a/contracts/soroban/postage/README.md
+++ b/contracts/soroban/postage/README.md
@@ -1,18 +1,28 @@
 # Postage Contract
 
-Records authenticated postage proofs for Stealth messages and tracks whether
-the recipient settled or refunded each proof.
+Records sender-authorized token escrow for Stealth messages and tracks whether
+the recipient settled or refunded each escrow.
 
-This first version is intentionally non-custodial. The relay must verify that
-`payment_hash` points to a valid Stellar payment before accepting `submit`.
-Token custody, transfer authorization, expiry, and dispute handling remain
-separate audited milestones.
+The contract is initialized with one accepted SEP-41/Stellar Asset Contract
+asset, a minimum postage amount, a treasury address, and an explicit fee in
+basis points. `submit` transfers the full postage amount from the sender into
+the contract address. `settle` transfers net postage to the recipient and fee
+to treasury. `refund` returns the full escrow to the sender.
 
 ## Interface
 
-- `initialize(minimum)` sets the global minimum postage once.
+- `initialize(asset, treasury, minimum, fee_bps)` sets accepted asset and fee policy once.
+- `config()` reads the accepted asset, treasury, minimum, and fee policy.
+- `minimum()` reads the configured minimum postage.
 - `quote(sender_trusted)` returns zero for trusted senders or the minimum.
-- `submit(...)` records a sender-authorized payment proof.
-- `settle(message_id)` lets the recipient accept the postage.
-- `refund(message_id)` lets the recipient mark it for refund.
+- `submit(...)` escrows sender-authorized postage for a message.
+- `settle(message_id)` lets the recipient accept the postage and releases escrow.
+- `refund(message_id)` lets the recipient return escrow to the sender.
 - `get(message_id)` reads the current record.
+
+## Settlement Invariants
+
+- Only the configured asset is accepted.
+- Fee policy is explicit and bounded to `0..=10000` basis points.
+- A message can move from pending to settled or refunded exactly once.
+- Balance conservation is tested across sender, recipient, treasury, and contract escrow balances.

--- a/contracts/soroban/postage/src/lib.rs
+++ b/contracts/soroban/postage/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+    MuxedAddress,
 };
 
 #[contract]
@@ -13,9 +14,18 @@ pub struct Postage {
     pub sender: Address,
     pub recipient: Address,
     pub amount: i128,
-    pub payment_hash: BytesN<32>,
+    pub fee: i128,
     pub created_at: u64,
     pub status: PostageStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowConfig {
+    pub asset: Address,
+    pub minimum: i128,
+    pub treasury: Address,
+    pub fee_bps: u32,
 }
 
 #[contracttype]
@@ -28,7 +38,7 @@ pub enum PostageStatus {
 
 #[contracttype]
 enum DataKey {
-    Minimum,
+    Config,
     Postage(BytesN<32>),
 }
 
@@ -42,27 +52,46 @@ pub enum Error {
     DuplicateMessage = 4,
     PostageNotFound = 5,
     AlreadyResolved = 6,
+    InvalidFee = 7,
 }
 
 #[contractimpl]
 impl PostageContract {
-    pub fn initialize(env: Env, minimum: i128) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Minimum) {
+    pub fn initialize(
+        env: Env,
+        asset: Address,
+        treasury: Address,
+        minimum: i128,
+        fee_bps: u32,
+    ) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Config) {
             return Err(Error::AlreadyInitialized);
         }
         if minimum < 0 {
             return Err(Error::InvalidAmount);
         }
+        if fee_bps > 10_000 {
+            return Err(Error::InvalidFee);
+        }
 
-        env.storage().instance().set(&DataKey::Minimum, &minimum);
+        env.storage().instance().set(
+            &DataKey::Config,
+            &EscrowConfig {
+                asset,
+                minimum,
+                treasury,
+                fee_bps,
+            },
+        );
         Ok(())
     }
 
+    pub fn config(env: Env) -> Result<EscrowConfig, Error> {
+        Self::read_config(&env)
+    }
+
     pub fn minimum(env: Env) -> Result<i128, Error> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Minimum)
-            .ok_or(Error::NotInitialized)
+        Ok(Self::read_config(&env)?.minimum)
     }
 
     pub fn quote(env: Env, sender_trusted: bool) -> Result<i128, Error> {
@@ -78,12 +107,11 @@ impl PostageContract {
         sender: Address,
         recipient: Address,
         amount: i128,
-        payment_hash: BytesN<32>,
     ) -> Result<Postage, Error> {
         sender.require_auth();
 
-        let minimum = Self::minimum(env.clone())?;
-        if amount < minimum {
+        let config = Self::read_config(&env)?;
+        if amount < config.minimum {
             return Err(Error::InvalidAmount);
         }
 
@@ -92,11 +120,18 @@ impl PostageContract {
             return Err(Error::DuplicateMessage);
         }
 
+        let fee = Self::fee_for(amount, config.fee_bps)?;
+        token::TokenClient::new(&env, &config.asset).transfer(
+            &sender,
+            &MuxedAddress::from(env.current_contract_address()),
+            &amount,
+        );
+
         let postage = Postage {
             sender,
             recipient,
             amount,
-            payment_hash,
+            fee,
             created_at: env.ledger().timestamp(),
             status: PostageStatus::Pending,
         };
@@ -134,50 +169,245 @@ impl PostageContract {
             return Err(Error::AlreadyResolved);
         }
 
+        let config = Self::read_config(&env)?;
+        let escrow = env.current_contract_address();
+        let token = token::TokenClient::new(&env, &config.asset);
+        match status {
+            PostageStatus::Settled => {
+                let recipient_amount = postage.amount - postage.fee;
+                if recipient_amount > 0 {
+                    token.transfer(
+                        &escrow,
+                        &MuxedAddress::from(postage.recipient.clone()),
+                        &recipient_amount,
+                    );
+                }
+                if postage.fee > 0 {
+                    token.transfer(&escrow, &MuxedAddress::from(config.treasury), &postage.fee);
+                }
+            }
+            PostageStatus::Refunded => {
+                token.transfer(
+                    &escrow,
+                    &MuxedAddress::from(postage.sender.clone()),
+                    &postage.amount,
+                );
+            }
+            PostageStatus::Pending => return Err(Error::AlreadyResolved),
+        }
+
         postage.status = status;
         env.storage().persistent().set(&key, &postage);
         env.events()
             .publish((symbol_short!("resolved"), message_id), postage.clone());
         Ok(postage)
     }
+
+    fn read_config(env: &Env) -> Result<EscrowConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(Error::NotInitialized)
+    }
+
+    fn fee_for(amount: i128, fee_bps: u32) -> Result<i128, Error> {
+        if amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+        amount
+            .checked_mul(fee_bps as i128)
+            .and_then(|gross| gross.checked_div(10_000))
+            .ok_or(Error::InvalidAmount)
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
+        IntoVal,
+    };
 
     fn id(env: &Env, byte: u8) -> BytesN<32> {
         BytesN::from_array(env, &[byte; 32])
     }
 
-    #[test]
-    fn records_and_settles_postage() {
+    struct Setup {
+        env: Env,
+        contract_id: Address,
+        asset: Address,
+        sender: Address,
+        recipient: Address,
+        treasury: Address,
+    }
+
+    fn setup(fee_bps: u32) -> Setup {
         let env = Env::default();
         env.mock_all_auths();
         env.ledger().set_timestamp(42);
+        env.ledger().set_sequence_number(10);
+        let admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let asset = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &asset);
         let contract_id = env.register(PostageContract, ());
         let client = PostageContractClient::new(&env, &contract_id);
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
+        let treasury = Address::generate(&env);
 
-        client.initialize(&100);
-        let postage = client.submit(&id(&env, 1), &sender, &recipient, &125, &id(&env, 2));
+        token_admin.mint(&sender, &1_000);
+        client.initialize(&asset, &treasury, &100, &fee_bps);
+
+        Setup {
+            env,
+            contract_id,
+            asset,
+            sender,
+            recipient,
+            treasury,
+        }
+    }
+
+    #[test]
+    fn records_escrows_and_settles_postage() {
+        let setup = setup(500);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        let postage = client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &200);
         assert_eq!(postage.status, PostageStatus::Pending);
         assert_eq!(postage.created_at, 42);
+        assert_eq!(postage.fee, 10);
+        assert_eq!(token.balance(&setup.sender), 800);
+        assert_eq!(token.balance(&setup.contract_id), 200);
 
-        let settled = client.settle(&id(&env, 1));
+        let settled = client.settle(&id(&setup.env, 1));
         assert_eq!(settled.status, PostageStatus::Settled);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+        assert_eq!(token.balance(&setup.recipient), 190);
+        assert_eq!(token.balance(&setup.treasury), 10);
+        assert_eq!(
+            token.balance(&setup.sender)
+                + token.balance(&setup.recipient)
+                + token.balance(&setup.treasury)
+                + token.balance(&setup.contract_id),
+            1_000
+        );
+    }
+
+    #[test]
+    fn refund_returns_full_escrow_to_sender() {
+        let setup = setup(250);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &200);
+        let refunded = client.refund(&id(&setup.env, 1));
+
+        assert_eq!(refunded.status, PostageStatus::Refunded);
+        assert_eq!(token.balance(&setup.sender), 1_000);
+        assert_eq!(token.balance(&setup.recipient), 0);
+        assert_eq!(token.balance(&setup.treasury), 0);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn double_settlement_and_refund_are_impossible() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        client.settle(&id(&setup.env, 1));
+        client.refund(&id(&setup.env, 1));
+    }
+
+    #[test]
+    fn accepted_asset_and_fee_policy_are_explicit() {
+        let setup = setup(125);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        assert_eq!(
+            client.config(),
+            EscrowConfig {
+                asset: setup.asset,
+                minimum: 100,
+                treasury: setup.treasury,
+                fee_bps: 125,
+            }
+        );
     }
 
     #[test]
     fn trusted_sender_has_zero_quote() {
         let env = Env::default();
+        let admin = Address::generate(&env);
+        let asset = env.register_stellar_asset_contract_v2(admin).address();
+        let treasury = Address::generate(&env);
         let contract_id = env.register(PostageContract, ());
         let client = PostageContractClient::new(&env, &contract_id);
-        client.initialize(&100);
+        client.initialize(&asset, &treasury, &100, &0);
 
         assert_eq!(client.quote(&true), 0);
         assert_eq!(client.quote(&false), 100);
+    }
+
+    #[test]
+    fn authorization_tree_captures_sender_deposit_and_recipient_resolution() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        assert_eq!(
+            setup.env.auths(),
+            [(
+                setup.sender.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        setup.contract_id.clone(),
+                        symbol_short!("submit"),
+                        (
+                            id(&setup.env, 1),
+                            setup.sender.clone(),
+                            setup.recipient.clone(),
+                            125_i128,
+                        )
+                            .into_val(&setup.env),
+                    )),
+                    sub_invocations: [AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            setup.asset.clone(),
+                            symbol_short!("transfer"),
+                            (
+                                setup.sender.clone(),
+                                MuxedAddress::from(setup.contract_id.clone()),
+                                125_i128,
+                            )
+                                .into_val(&setup.env),
+                        )),
+                        sub_invocations: [].into(),
+                    }]
+                    .into(),
+                }
+            )]
+        );
+
+        client.settle(&id(&setup.env, 1));
+        assert_eq!(
+            setup.env.auths(),
+            [(
+                setup.recipient.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        setup.contract_id.clone(),
+                        symbol_short!("settle"),
+                        (id(&setup.env, 1),).into_val(&setup.env),
+                    )),
+                    sub_invocations: [].into(),
+                }
+            )]
+        );
     }
 }


### PR DESCRIPTION
Closes #56 


# PR Description

This PR fixes #56 by replacing the postage contract's non-custodial payment-hash record with an on-chain token escrow flow. The postage contract is now initialized with one accepted SEP-41/Stellar Asset Contract token, a treasury address, a minimum postage amount, and an explicit fee policy in basis points.

When a sender submits postage, the contract requires sender authorization and transfers the full postage amount into the contract escrow address. When the recipient settles the message, the contract releases net postage to the recipient and transfers the configured fee to treasury. When the recipient refunds the message, the full escrowed amount is returned to the sender. The message state can resolve only once, so double settlement, refund after settlement, and settlement after refund are rejected.

The change matters because a recorded payment hash alone is not enforceable settlement. This PR gives reviewers a contract-level custody flow that can be reconciled from message state to token balances.

# Changes Made

- Added `EscrowConfig` with accepted asset, treasury, minimum postage, and fee basis points.
- Updated `submit` to require sender authorization and escrow tokens into the contract address.
- Updated `settle` to release net postage to recipient and fee to treasury.
- Updated `refund` to return full escrow to sender.
- Preserved single-resolution state so pending postage can become settled or refunded exactly once.
- Added tests for balance conservation, accepted asset/fee config, refund behavior, double-resolution rejection, and authorization assertions.
- Updated the postage contract README with the new interface and invariants.