### PR TITLE
feat(contracts): fix #55 mailbox policy precedence

### DIFF
--- a/contracts/soroban/Cargo.lock
+++ b/contracts/soroban/Cargo.lock
@@ -1553,6 +1553,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stealth-policies"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "soroban-sdk",
 ]
 

--- a/contracts/soroban/policies/README.md
+++ b/contracts/soroban/policies/README.md
@@ -2,14 +2,32 @@
 
 Gives each mailbox owner explicit control over who can mail them.
 
-Owners can allow or block individual senders, decide whether unknown senders
-are accepted, require sender verification, and set minimum postage. Explicit
-sender rules always take precedence over the mailbox default.
+Owners can allow or block individual senders, assign sender-specific postage
+tiers, decide whether unknown senders are accepted, require sender
+verification, require receipts, and set minimum postage. Explicit precedence is
+deterministic: block, allow, tier, then mailbox default.
 
 ## Interface
 
-- `set_policy(owner, policy)` writes mailbox defaults.
+- `set_policy(owner, policy)` writes mailbox defaults as the owner.
+- `set_policy_as(owner, actor, policy)` lets owner or a policy-scoped delegate write defaults.
 - `get_policy(owner)` reads mailbox defaults.
-- `set_sender_rule(owner, sender, rule)` allows, blocks, or resets a sender.
+- `get_versioned_policy(owner)` reads mailbox defaults with version.
+- `policy_version(owner)` reads the current version.
+- `set_delegate(owner, delegate, scope)` grants or revokes scoped mutation authority.
+- `delegate_scope(owner, delegate)` reads delegate scope.
+- `set_sender_rule(owner, sender, rule)` allows, blocks, or resets a sender as the owner.
+- `set_sender_rule_as(owner, actor, sender, rule)` lets owner or sender-scoped delegate mutate sender rules.
+- `set_sender_tier(owner, sender, minimum_postage)` assigns sender-specific pricing as owner.
+- `set_sender_tier_as(owner, actor, sender, minimum_postage)` assigns sender-specific pricing as owner or delegate.
 - `sender_rule(owner, sender)` reads the current sender override.
-- `can_mail(...)` evaluates the complete policy.
+- `sender_tier(owner, sender)` reads sender-specific pricing.
+- `evaluate(...)` returns the complete decision, reason, required postage, sender rule, and policy version.
+- `can_mail(...)` returns the boolean result of `evaluate`.
+
+## Precedence
+
+1. Block always denies, regardless of price or mailbox defaults.
+2. Allow always admits the sender.
+3. Tier applies sender-specific postage after verification and receipt requirements.
+4. Mailbox default applies to unknown/default senders.

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+};
 
 #[contract]
 pub struct PoliciesContract;
@@ -18,53 +20,207 @@ pub enum SenderRule {
 pub struct MailboxPolicy {
     pub allow_unknown: bool,
     pub require_verified: bool,
+    pub require_receipt: bool,
     pub minimum_postage: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VersionedMailboxPolicy {
+    pub policy: MailboxPolicy,
+    pub version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DelegateScope {
+    pub can_set_policy: bool,
+    pub can_set_senders: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolicyReason {
+    SenderAllowed,
+    SenderBlocked,
+    UnknownSendersDisabled,
+    VerificationRequired,
+    ReceiptRequired,
+    InsufficientPostage,
+    PolicySatisfied,
+    TierSatisfied,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PolicyDecision {
+    pub allowed: bool,
+    pub reason: PolicyReason,
+    pub required_postage: i128,
+    pub rule: SenderRule,
+    pub version: u32,
 }
 
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
     Policy(Address),
+    PolicyVersion(Address),
     Rule(Address, Address),
+    Tier(Address, Address),
+    Delegate(Address, Address),
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    InvalidPostage = 1,
+    UnauthorizedDelegate = 2,
 }
 
 #[contractimpl]
 impl PoliciesContract {
-    pub fn set_policy(env: Env, owner: Address, policy: MailboxPolicy) {
-        owner.require_auth();
-        if policy.minimum_postage < 0 {
-            panic!("minimum postage cannot be negative");
-        }
+    pub fn set_policy(env: Env, owner: Address, policy: MailboxPolicy) -> Result<(), Error> {
+        Self::set_policy_as(env, owner.clone(), owner, policy)
+    }
 
+    pub fn set_policy_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        policy: MailboxPolicy,
+    ) -> Result<(), Error> {
+        Self::authorize_policy_mutation(&env, &owner, &actor)?;
+        Self::validate_policy(policy)?;
+        let version = Self::bump_version(&env, &owner);
         env.storage()
             .persistent()
             .set(&DataKey::Policy(owner.clone()), &policy);
-        env.events()
-            .publish((symbol_short!("policy"), owner), policy);
+        env.events().publish(
+            (symbol_short!("policy"), owner),
+            VersionedMailboxPolicy { policy, version },
+        );
+        Ok(())
     }
 
     pub fn get_policy(env: Env, owner: Address) -> MailboxPolicy {
+        Self::get_versioned_policy(env, owner).policy
+    }
+
+    pub fn get_versioned_policy(env: Env, owner: Address) -> VersionedMailboxPolicy {
+        let version = Self::policy_version(env.clone(), owner.clone());
         env.storage()
             .persistent()
             .get(&DataKey::Policy(owner))
-            .unwrap_or(MailboxPolicy {
-                allow_unknown: false,
-                require_verified: true,
-                minimum_postage: 0,
+            .map(|policy| VersionedMailboxPolicy { policy, version })
+            .unwrap_or(VersionedMailboxPolicy {
+                policy: Self::default_policy(),
+                version,
             })
     }
 
-    pub fn set_sender_rule(env: Env, owner: Address, sender: Address, rule: SenderRule) {
+    pub fn policy_version(env: Env, owner: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PolicyVersion(owner))
+            .unwrap_or(0)
+    }
+
+    pub fn set_delegate(
+        env: Env,
+        owner: Address,
+        delegate: Address,
+        scope: DelegateScope,
+    ) -> Result<(), Error> {
         owner.require_auth();
+        let key = DataKey::Delegate(owner.clone(), delegate.clone());
+        if scope.can_set_policy || scope.can_set_senders {
+            env.storage().persistent().set(&key, &scope);
+        } else {
+            env.storage().persistent().remove(&key);
+        }
+        env.events()
+            .publish((symbol_short!("delegate"), owner, delegate), scope);
+        Ok(())
+    }
+
+    pub fn delegate_scope(env: Env, owner: Address, delegate: Address) -> DelegateScope {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Delegate(owner, delegate))
+            .unwrap_or(DelegateScope {
+                can_set_policy: false,
+                can_set_senders: false,
+            })
+    }
+
+    pub fn set_sender_rule(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        rule: SenderRule,
+    ) -> Result<(), Error> {
+        Self::set_sender_rule_as(env, owner.clone(), owner, sender, rule)
+    }
+
+    pub fn set_sender_rule_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        sender: Address,
+        rule: SenderRule,
+    ) -> Result<(), Error> {
+        Self::authorize_sender_mutation(&env, &owner, &actor)?;
         let key = DataKey::Rule(owner.clone(), sender.clone());
+        let tier_key = DataKey::Tier(owner.clone(), sender.clone());
 
         if rule == SenderRule::Default {
             env.storage().persistent().remove(&key);
         } else {
             env.storage().persistent().set(&key, &rule);
         }
+        env.storage().persistent().remove(&tier_key);
+        let version = Self::bump_version(&env, &owner);
         env.events()
-            .publish((symbol_short!("sender"), owner, sender), rule);
+            .publish((symbol_short!("sender"), owner, sender), (rule, version));
+        Ok(())
+    }
+
+    pub fn set_sender_tier(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        minimum_postage: i128,
+    ) -> Result<(), Error> {
+        Self::set_sender_tier_as(env, owner.clone(), owner, sender, minimum_postage)
+    }
+
+    pub fn set_sender_tier_as(
+        env: Env,
+        owner: Address,
+        actor: Address,
+        sender: Address,
+        minimum_postage: i128,
+    ) -> Result<(), Error> {
+        Self::authorize_sender_mutation(&env, &owner, &actor)?;
+        if minimum_postage < 0 {
+            return Err(Error::InvalidPostage);
+        }
+        env.storage().persistent().set(
+            &DataKey::Tier(owner.clone(), sender.clone()),
+            &minimum_postage,
+        );
+        env.storage().persistent().set(
+            &DataKey::Rule(owner.clone(), sender.clone()),
+            &SenderRule::Default,
+        );
+        let version = Self::bump_version(&env, &owner);
+        env.events().publish(
+            (symbol_short!("tier"), owner, sender),
+            (minimum_postage, version),
+        );
+        Ok(())
     }
 
     pub fn sender_rule(env: Env, owner: Address, sender: Address) -> SenderRule {
@@ -74,23 +230,156 @@ impl PoliciesContract {
             .unwrap_or(SenderRule::Default)
     }
 
+    pub fn sender_tier(env: Env, owner: Address, sender: Address) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Tier(owner, sender))
+    }
+
     pub fn can_mail(
         env: Env,
         owner: Address,
         sender: Address,
         verified: bool,
         postage: i128,
+        receipt: bool,
     ) -> bool {
-        match Self::sender_rule(env.clone(), owner.clone(), sender) {
-            SenderRule::Allow => true,
-            SenderRule::Block => false,
-            SenderRule::Default => {
-                let policy = Self::get_policy(env, owner);
-                policy.allow_unknown
-                    && (!policy.require_verified || verified)
-                    && postage >= policy.minimum_postage
-            }
+        Self::evaluate(env, owner, sender, verified, postage, receipt).allowed
+    }
+
+    pub fn evaluate(
+        env: Env,
+        owner: Address,
+        sender: Address,
+        verified: bool,
+        postage: i128,
+        receipt: bool,
+    ) -> PolicyDecision {
+        let versioned = Self::get_versioned_policy(env.clone(), owner.clone());
+        let rule = Self::sender_rule(env.clone(), owner.clone(), sender.clone());
+        let tier = Self::sender_tier(env, owner, sender);
+
+        if rule == SenderRule::Block {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::SenderBlocked,
+                required_postage: versioned.policy.minimum_postage,
+                rule,
+                version: versioned.version,
+            };
         }
+        if rule == SenderRule::Allow {
+            return PolicyDecision {
+                allowed: true,
+                reason: PolicyReason::SenderAllowed,
+                required_postage: 0,
+                rule,
+                version: versioned.version,
+            };
+        }
+
+        let required_postage = tier.unwrap_or(versioned.policy.minimum_postage);
+        if versioned.policy.require_verified && !verified {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::VerificationRequired,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if versioned.policy.require_receipt && !receipt {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::ReceiptRequired,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if let Some(required_postage) = tier {
+            return PolicyDecision {
+                allowed: postage >= required_postage,
+                reason: if postage >= required_postage {
+                    PolicyReason::TierSatisfied
+                } else {
+                    PolicyReason::InsufficientPostage
+                },
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        if !versioned.policy.allow_unknown {
+            return PolicyDecision {
+                allowed: false,
+                reason: PolicyReason::UnknownSendersDisabled,
+                required_postage,
+                rule,
+                version: versioned.version,
+            };
+        }
+        PolicyDecision {
+            allowed: postage >= required_postage,
+            reason: if postage >= required_postage {
+                PolicyReason::PolicySatisfied
+            } else {
+                PolicyReason::InsufficientPostage
+            },
+            required_postage,
+            rule,
+            version: versioned.version,
+        }
+    }
+
+    fn default_policy() -> MailboxPolicy {
+        MailboxPolicy {
+            allow_unknown: false,
+            require_verified: true,
+            require_receipt: false,
+            minimum_postage: 0,
+        }
+    }
+
+    fn validate_policy(policy: MailboxPolicy) -> Result<(), Error> {
+        if policy.minimum_postage < 0 {
+            return Err(Error::InvalidPostage);
+        }
+        Ok(())
+    }
+
+    fn authorize_policy_mutation(env: &Env, owner: &Address, actor: &Address) -> Result<(), Error> {
+        if actor == owner {
+            owner.require_auth();
+            return Ok(());
+        }
+        actor.require_auth();
+        if Self::delegate_scope(env.clone(), owner.clone(), actor.clone()).can_set_policy {
+            Ok(())
+        } else {
+            Err(Error::UnauthorizedDelegate)
+        }
+    }
+
+    fn authorize_sender_mutation(env: &Env, owner: &Address, actor: &Address) -> Result<(), Error> {
+        if actor == owner {
+            owner.require_auth();
+            return Ok(());
+        }
+        actor.require_auth();
+        if Self::delegate_scope(env.clone(), owner.clone(), actor.clone()).can_set_senders {
+            Ok(())
+        } else {
+            Err(Error::UnauthorizedDelegate)
+        }
+    }
+
+    fn bump_version(env: &Env, owner: &Address) -> u32 {
+        let version = Self::policy_version(env.clone(), owner.clone()) + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::PolicyVersion(owner.clone()), &version);
+        version
     }
 }
 
@@ -129,7 +418,9 @@ mod vectors {
     fn validate_hash32(s: &str) -> Result<std::string::String, ()> {
         let normalised = s.trim().to_lowercase();
         if normalised.len() == 64
-            && normalised.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+            && normalised
+                .chars()
+                .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
         {
             Ok(normalised)
         } else {
@@ -166,12 +457,7 @@ mod vectors {
             let id = c["id"].as_str().unwrap();
             let input = c["input"].as_str().unwrap_or("");
             let expected = c["expected"]["valid"].as_bool().unwrap();
-            assert_eq!(
-                is_valid_stellar_address(input),
-                expected,
-                "vectors: {}",
-                id
-            );
+            assert_eq!(is_valid_stellar_address(input), expected, "vectors: {}", id);
         }
     }
 
@@ -261,6 +547,7 @@ mod vectors {
                     &MailboxPolicy {
                         allow_unknown: policy_obj["allowUnknown"].as_bool().unwrap(),
                         require_verified: policy_obj["requireVerified"].as_bool().unwrap(),
+                        require_receipt: false,
                         minimum_postage: min,
                     },
                 );
@@ -271,7 +558,7 @@ mod vectors {
             let expected = c["expected"]["allowed"].as_bool().unwrap();
 
             assert_eq!(
-                client.can_mail(&owner, &sender, &verified, &postage),
+                client.can_mail(&owner, &sender, &verified, &postage, &false),
                 expected,
                 "vectors: {}",
                 id
@@ -286,9 +573,7 @@ mod vectors {
     #[test]
     fn tampered() {
         let root: Value = serde_json::from_str(VECTORS_JSON).unwrap();
-        let cases = root["categories"]["tampered"]["cases"]
-            .as_array()
-            .unwrap();
+        let cases = root["categories"]["tampered"]["cases"].as_array().unwrap();
         for c in cases {
             let id = c["id"].as_str().unwrap();
             let schema = c["schema"].as_str().unwrap();
@@ -325,15 +610,182 @@ mod test {
             &MailboxPolicy {
                 allow_unknown: true,
                 require_verified: true,
+                require_receipt: false,
                 minimum_postage: 100,
             },
         );
         client.set_sender_rule(&owner, &trusted, &SenderRule::Allow);
         client.set_sender_rule(&owner, &blocked, &SenderRule::Block);
 
-        assert!(client.can_mail(&owner, &trusted, &false, &0));
-        assert!(!client.can_mail(&owner, &blocked, &true, &1000));
-        assert!(!client.can_mail(&owner, &unknown, &false, &100));
-        assert!(client.can_mail(&owner, &unknown, &true, &100));
+        assert!(client.can_mail(&owner, &trusted, &false, &0, &false));
+        assert!(!client.can_mail(&owner, &blocked, &true, &1000, &false));
+        assert!(!client.can_mail(&owner, &unknown, &false, &100, &false));
+        assert!(client.can_mail(&owner, &unknown, &true, &100, &false));
+    }
+
+    #[test]
+    fn policy_version_is_queryable_and_increments_on_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        assert_eq!(client.policy_version(&owner), 0);
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: true,
+                require_receipt: true,
+                minimum_postage: 10,
+            },
+        );
+        assert_eq!(client.policy_version(&owner), 1);
+        assert_eq!(client.get_versioned_policy(&owner).version, 1);
+        client.set_sender_tier(&owner, &sender, &25);
+        assert_eq!(client.policy_version(&owner), 2);
+    }
+
+    #[test]
+    fn block_always_overrides_pricing() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: false,
+                require_receipt: false,
+                minimum_postage: 100,
+            },
+        );
+        client.set_sender_tier(&owner, &sender, &1);
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &0, &false).reason,
+            PolicyReason::InsufficientPostage
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &1, &false).reason,
+            PolicyReason::TierSatisfied
+        );
+
+        client.set_sender_rule(&owner, &sender, &SenderRule::Block);
+        let decision = client.evaluate(&owner, &sender, &true, &1_000, &true);
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason, PolicyReason::SenderBlocked);
+    }
+
+    #[test]
+    fn transition_branches_are_deterministic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &0, &false).reason,
+            PolicyReason::UnknownSendersDisabled
+        );
+
+        client.set_policy(
+            &owner,
+            &MailboxPolicy {
+                allow_unknown: true,
+                require_verified: true,
+                require_receipt: true,
+                minimum_postage: 50,
+            },
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &false, &50, &true).reason,
+            PolicyReason::VerificationRequired
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &50, &false).reason,
+            PolicyReason::ReceiptRequired
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &49, &true).reason,
+            PolicyReason::InsufficientPostage
+        );
+        assert_eq!(
+            client.evaluate(&owner, &sender, &true, &50, &true).reason,
+            PolicyReason::PolicySatisfied
+        );
+
+        client.set_sender_rule(&owner, &sender, &SenderRule::Allow);
+        assert_eq!(
+            client.evaluate(&owner, &sender, &false, &0, &false).reason,
+            PolicyReason::SenderAllowed
+        );
+    }
+
+    #[test]
+    fn scoped_delegate_authorization_is_enforced() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let delegate = Address::generate(&env);
+        let unscoped = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        client.set_delegate(
+            &owner,
+            &delegate,
+            &DelegateScope {
+                can_set_policy: false,
+                can_set_senders: true,
+            },
+        );
+        assert!(client
+            .try_set_sender_rule_as(&owner, &delegate, &sender, &SenderRule::Allow)
+            .is_ok());
+        assert!(client
+            .try_set_sender_rule_as(&owner, &unscoped, &sender, &SenderRule::Block)
+            .is_err());
+        assert!(client
+            .try_set_policy_as(
+                &owner,
+                &delegate,
+                &MailboxPolicy {
+                    allow_unknown: true,
+                    require_verified: false,
+                    require_receipt: false,
+                    minimum_postage: 0,
+                },
+            )
+            .is_err());
+
+        client.set_delegate(
+            &owner,
+            &delegate,
+            &DelegateScope {
+                can_set_policy: true,
+                can_set_senders: false,
+            },
+        );
+        assert!(client
+            .try_set_policy_as(
+                &owner,
+                &delegate,
+                &MailboxPolicy {
+                    allow_unknown: true,
+                    require_verified: false,
+                    require_receipt: false,
+                    minimum_postage: 0,
+                },
+            )
+            .is_ok());
     }
 }


### PR DESCRIPTION
Closes #55 

# PR Description

This PR fixes #55 by evolving the policies contract into a versioned recipient-specific mailbox policy engine with explicit precedence. Mailbox policy now includes unknown-sender handling, verification requirements, receipt requirements, and minimum postage. Sender-specific overrides now support allow, block, and tiered postage.

The evaluation flow now returns a structured decision containing whether mail is allowed, the decision reason, required postage, sender rule, and policy version. This makes the result deterministic and easier for relays and clients to independently reconcile. Precedence is explicit: block always denies first, allow admits next, sender tiers apply before mailbox default pricing, and mailbox defaults handle unknown/default senders.

Authorization was tightened through scoped delegates. Owners can still mutate their own policy and sender rules directly, while delegates can only mutate the scopes they were granted. Tests cover policy version transitions, block-over-pricing precedence, tier pricing behavior, policy decision branches, scoped delegate authorization, and unscoped delegate rejection.

# Changes Made

- Added `VersionedMailboxPolicy` and queryable policy versions.
- Added `require_receipt` to mailbox policy.
- Added `DelegateScope` plus delegate-aware mutation functions.
- Added sender-specific postage tiers.
- Added structured `PolicyDecision` and `PolicyReason` outputs.
- Implemented deterministic precedence: block, allow, tier, mailbox default.
- Added tests for policy version transitions, all major decision branches, tier-insufficient behavior, block-over-pricing precedence, scoped delegate mutation, and unscoped delegate rejection.
- Updated the policies contract README with the new interface and precedence rules.
- Updated `Cargo.lock` to include the existing policy test dev-dependencies resolved by the contract test workspace.