### PR TITLE
added loading and skeleton state to admin dashboard

### DIFF
--- a/src/features/demo-admin-dashboard/loading/LoadingGuide.tsx
+++ b/src/features/demo-admin-dashboard/loading/LoadingGuide.tsx
@@ -1,0 +1,87 @@
+/**
+ * LoadingGuide — visual fixture for all four loading-state views.
+ *
+ * Use this component during development to inspect skeletons, progress bars,
+ * and status labels without running any real flows. All state is fake and
+ * deterministic — safe for public repository review.
+ *
+ * Render in isolation (Storybook, a dev route, or a quick test page) by
+ * mounting <LoadingGuide /> with no props.
+ */
+
+import { ImportLoadingView } from "./states";
+import { ValidationLoadingView } from "./states";
+import { PreviewLoadingView } from "./states";
+import { PublishLoadingView } from "./states";
+
+// ---------------------------------------------------------------------------
+// Fake fixture states — deterministic, no live data
+// ---------------------------------------------------------------------------
+
+const IMPORT_FIXTURE = {
+  status: "loading" as const,
+  totalRecords: 40,
+  processedRecords: 14,
+};
+
+const VALIDATION_FIXTURE = {
+  status: "loading" as const,
+  totalRecords: 40,
+  passCount: 12,
+  failCount: 2,
+};
+
+const PREVIEW_FIXTURE = {
+  status: "loading" as const,
+  section: "inbox" as const,
+  progress: 60,
+};
+
+const PUBLISH_FIXTURE = {
+  status: "loading" as const,
+  progress: 30,
+  label: "Writing demo records…",
+  mockTxId: "mock-tx-0000dead0000beef",
+};
+
+// ---------------------------------------------------------------------------
+// Guide component
+// ---------------------------------------------------------------------------
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border p-4 space-y-2">
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export function LoadingGuide() {
+  return (
+    <div className="max-w-xl mx-auto space-y-6 p-6">
+      <h1 className="text-lg font-semibold">Demo Admin Dashboard — Loading States</h1>
+      <p className="text-sm text-muted-foreground">
+        Fixture preview of all four flow skeletons. No real data or network calls.
+      </p>
+
+      <Section title="Import">
+        <ImportLoadingView state={IMPORT_FIXTURE} />
+      </Section>
+
+      <Section title="Validation">
+        <ValidationLoadingView state={VALIDATION_FIXTURE} />
+      </Section>
+
+      <Section title="Preview">
+        <PreviewLoadingView state={PREVIEW_FIXTURE} />
+      </Section>
+
+      <Section title="Publish (mock)">
+        <PublishLoadingView state={PUBLISH_FIXTURE} />
+      </Section>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/loading/index.ts
+++ b/src/features/demo-admin-dashboard/loading/index.ts
@@ -1,0 +1,19 @@
+export type {
+  LoadingStatus,
+  FlowLoadingState,
+  ImportLoadingState,
+  ValidationLoadingState,
+  PreviewLoadingState,
+  PublishLoadingState,
+} from "./types";
+
+export { ImportSkeleton, ValidationSkeleton, PreviewSkeleton, PublishSkeleton } from "./skeletons";
+
+export {
+  ImportLoadingView,
+  ValidationLoadingView,
+  PreviewLoadingView,
+  PublishLoadingView,
+} from "./states";
+
+export { LoadingGuide } from "./LoadingGuide";

--- a/src/features/demo-admin-dashboard/loading/skeletons.tsx
+++ b/src/features/demo-admin-dashboard/loading/skeletons.tsx
@@ -1,0 +1,77 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Skeleton for the import file-drop / record list while data loads. */
+export function ImportSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-24 w-full rounded-lg" /> {/* drop zone */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 flex-1" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for the validation results table. */
+export function ValidationSkeleton() {
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-4">
+        <Skeleton className="h-6 w-20" />
+        <Skeleton className="h-6 w-20" />
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 flex-1" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for the demo inbox preview panel. */
+export function PreviewSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 rounded-md border p-3">
+          <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-16" />
+            </div>
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-3 w-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for the publish confirmation / receipt view. */
+export function PublishSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-10 w-full rounded-md" /> {/* action bar */}
+      <div className="rounded-md border p-4 space-y-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Skeleton className="h-9 w-20" />
+        <Skeleton className="h-9 w-24" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/loading/states.tsx
+++ b/src/features/demo-admin-dashboard/loading/states.tsx
@@ -1,0 +1,128 @@
+import { Progress } from "@/components/ui/progress";
+import type {
+  ImportLoadingState,
+  ValidationLoadingState,
+  PreviewLoadingState,
+  PublishLoadingState,
+} from "./types";
+import {
+  ImportSkeleton,
+  ValidationSkeleton,
+  PreviewSkeleton,
+  PublishSkeleton,
+} from "./skeletons";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function StatusLabel({ label, error }: { label?: string; error?: string }) {
+  if (error) return <p className="text-sm text-destructive">{error}</p>;
+  if (label) return <p className="text-sm text-muted-foreground">{label}</p>;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+export function ImportLoadingView({ state }: { state: ImportLoadingState }) {
+  if (state.status !== "loading") return null;
+
+  const pct =
+    state.progress ??
+    (state.totalRecords && state.processedRecords != null
+      ? Math.round((state.processedRecords / state.totalRecords) * 100)
+      : undefined);
+
+  return (
+    <div className="space-y-3">
+      <ImportSkeleton />
+      {pct != null && <Progress value={pct} />}
+      <StatusLabel
+        label={
+          state.label ??
+          (state.processedRecords != null && state.totalRecords != null
+            ? `Importing ${state.processedRecords} / ${state.totalRecords} records…`
+            : "Preparing import…")
+        }
+        error={state.error}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function ValidationLoadingView({ state }: { state: ValidationLoadingState }) {
+  if (state.status !== "loading") return null;
+
+  const pct =
+    state.progress ??
+    (state.totalRecords && (state.passCount ?? 0) + (state.failCount ?? 0) > 0
+      ? Math.round((((state.passCount ?? 0) + (state.failCount ?? 0)) / state.totalRecords) * 100)
+      : undefined);
+
+  return (
+    <div className="space-y-3">
+      <ValidationSkeleton />
+      {pct != null && <Progress value={pct} />}
+      <StatusLabel
+        label={state.label ?? "Validating records…"}
+        error={state.error}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+const SECTION_LABELS: Record<NonNullable<PreviewLoadingState["section"]>, string> = {
+  inbox: "Rendering inbox preview…",
+  thread: "Rendering thread preview…",
+  calendar: "Rendering calendar preview…",
+  contacts: "Rendering contacts preview…",
+};
+
+export function PreviewLoadingView({ state }: { state: PreviewLoadingState }) {
+  if (state.status !== "loading") return null;
+
+  return (
+    <div className="space-y-3">
+      <PreviewSkeleton />
+      {state.progress != null && <Progress value={state.progress} />}
+      <StatusLabel
+        label={state.label ?? (state.section ? SECTION_LABELS[state.section] : "Loading preview…")}
+        error={state.error}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Publish (mock — no real Stellar tx)
+// ---------------------------------------------------------------------------
+
+export function PublishLoadingView({ state }: { state: PublishLoadingState }) {
+  if (state.status !== "loading") return null;
+
+  return (
+    <div className="space-y-3">
+      <PublishSkeleton />
+      {state.progress != null && <Progress value={state.progress} />}
+      <StatusLabel
+        label={state.label ?? "Publishing demo data…"}
+        error={state.error}
+      />
+      {state.mockTxId && (
+        <p className="font-mono text-xs text-muted-foreground">
+          mock tx: {state.mockTxId}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/loading/types.ts
+++ b/src/features/demo-admin-dashboard/loading/types.ts
@@ -1,0 +1,36 @@
+/** Shared loading state types for all demo-admin-dashboard flows. */
+
+export type LoadingStatus = "idle" | "loading" | "success" | "error";
+
+export interface FlowLoadingState {
+  status: LoadingStatus;
+  /** 0–100, used for flows with deterministic steps */
+  progress?: number;
+  /** Human-readable label shown below a progress bar or spinner */
+  label?: string;
+  error?: string;
+}
+
+export interface ImportLoadingState extends FlowLoadingState {
+  /** Total records expected from the source fixture */
+  totalRecords?: number;
+  /** Records processed so far */
+  processedRecords?: number;
+}
+
+export interface ValidationLoadingState extends FlowLoadingState {
+  /** Number of records being validated */
+  totalRecords?: number;
+  passCount?: number;
+  failCount?: number;
+}
+
+export interface PreviewLoadingState extends FlowLoadingState {
+  /** Which preview section is rendering */
+  section?: "inbox" | "thread" | "calendar" | "contacts";
+}
+
+export interface PublishLoadingState extends FlowLoadingState {
+  /** Fake transaction ID for UI display only — no real Stellar tx */
+  mockTxId?: string;
+}


### PR DESCRIPTION
Loading & Skeleton States for Demo Admin Dashboard
  
  Five files created under src/features/demo-admin-dashboard/loading/, nothing
  else touched.
  
  types.ts
  
  Defines LoadingStatus (idle | loading | success | error) and per-flow state
  interfaces — ImportLoadingState, ValidationLoadingState, PreviewLoadingState,
  PublishLoadingState — each extending a shared FlowLoadingState with progress,
  label, and error.
  
  skeletons.tsx
  
  Four skeleton components shaped to each flow's layout, built on the existing
  Skeleton UI primitive:
  
  - ImportSkeleton — drop zone + record rows
  - ValidationSkeleton — pass/fail summary + result rows
  - PreviewSkeleton — inbox email card list
  - PublishSkeleton — action bar + receipt block + buttons
  
  states.tsx
  
  Four *LoadingView components that wrap each skeleton with a Progress bar
  (auto-derived from record counts when an explicit progress value isn't
  provided) and a status label. Each renders nothing unless status === "loading",
  so they're safe to drop into any panel unconditionally.
  
  LoadingGuide.tsx
  
  A standalone fixture component with hardcoded deterministic state for all four
  flows. Mount <LoadingGuide /> in a dev route to visually inspect every skeleton
  and progress state — no network calls or real data.
  
  index.ts
  
  Barrel export for all types, skeletons, views, and the guide.

closes #200 