### PR TITLE
Add standardized trust status badges across mail surfaces

### DIFF
--- a/src/components/mail/Compose.tsx
+++ b/src/components/mail/Compose.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { EmojiPicker } from "./EmojiPicker";
+import { TrustBadge, type TrustState } from "@/features/design-system";
 import { cn } from "@/lib/utils";
 
 import {
@@ -398,6 +399,12 @@ export function Compose({
   );
 }
 
+function recipientTrustState(policy: RecipientReadiness["policy"]): TrustState {
+  if (policy === "blocked") return "blocked";
+  if (policy === "verify") return "verified";
+  return "allowed";
+}
+
 function RecipientReadinessChips({ recipients }: { recipients: RecipientReadiness[] }) {
   if (!recipients.length) return null;
 
@@ -416,6 +423,12 @@ function RecipientReadinessChips({ recipients }: { recipients: RecipientReadines
                 : "border-amber-200/20 bg-amber-200/[0.06] text-amber-100",
           )}
         >
+          <TrustBadge
+            state={recipientTrustState(recipient.policy)}
+            showLabel={false}
+            size="sm"
+            className="mr-1 align-middle"
+          />
           {recipient.address} · {recipient.policy} · postage {recipient.postage}
         </span>
       ))}

--- a/src/components/mail/EmailList.tsx
+++ b/src/components/mail/EmailList.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ConvertSenderButton } from "@/features/sender-conversion";
 import { MobileMailCard } from "./MobileMailCard";
+import { EmailTrustBadges } from "./EmailTrustBadges";
 import { BulkActionBar } from "./BulkActionBar";
 import type { BulkActionRequest, BulkFailure, BulkProgressState } from "./bulk-actions";
 
@@ -350,14 +351,23 @@ export function EmailList({
                   )}
                   <div className="relative min-w-0 flex-1">
                     <div className="flex items-start justify-between gap-2">
-                      <span
-                        className={cn(
-                          "mail-preview-heading truncate text-[13.5px] font-semibold leading-5 text-foreground/88",
-                          e.unread && "text-foreground/94",
-                        )}
-                      >
-                        {e.from}
-                      </span>
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span
+                          className={cn(
+                            "mail-preview-heading truncate text-[13.5px] font-semibold leading-5 text-foreground/88",
+                            e.unread && "text-foreground/94",
+                          )}
+                        >
+                          {e.from}
+                        </span>
+                        <EmailTrustBadges
+                          email={e}
+                          max={1}
+                          size="sm"
+                          showLabels={false}
+                          className="shrink-0"
+                        />
+                      </div>
                       <span className="shrink-0 pt-0.5 text-[10.5px] font-medium leading-4 tabular-nums text-muted-foreground/85">
                         {e.time}
                       </span>

--- a/src/components/mail/EmailTrustBadges.tsx
+++ b/src/components/mail/EmailTrustBadges.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+import type { Email } from "./data";
+import { getTrustStates } from "./trust-state";
+import { TrustBadge, type TrustBadgeSize } from "@/features/design-system/components/trust-badge";
+
+export interface EmailTrustBadgesProps {
+  email: Email;
+  /** Limit how many badges render (compact surfaces use 1). */
+  max?: number;
+  size?: TrustBadgeSize;
+  /** Hide visible labels (tooltip + screen-reader text remain). */
+  showLabels?: boolean;
+  className?: string;
+}
+
+/**
+ * Renders the trust badges for an email using the shared resolver + badge,
+ * so list rows, the reader header, compose chips, and sender cards stay
+ * perfectly consistent.
+ */
+export function EmailTrustBadges({
+  email,
+  max,
+  size = "sm",
+  showLabels = true,
+  className,
+}: EmailTrustBadgesProps) {
+  const states = getTrustStates(email);
+  const shown = typeof max === "number" ? states.slice(0, max) : states;
+
+  if (shown.length === 0) return null;
+
+  return (
+    <span className={cn("inline-flex items-center gap-1", className)}>
+      {shown.map((state) => (
+        <TrustBadge key={state} state={state} size={size} showLabel={showLabels} />
+      ))}
+    </span>
+  );
+}

--- a/src/components/mail/EmailView.tsx
+++ b/src/components/mail/EmailView.tsx
@@ -30,6 +30,7 @@ import { EventMailCard, type CalendarEvent, type CalendarResponse } from "@/feat
 import { OTPCard, detectOtp } from "@/features/otp";
 import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import { ProvenancePanel } from "./ProvenancePanel";
+import { EmailTrustBadges } from "./EmailTrustBadges";
 import type { Email } from "./data";
 import {
   getRecipientReadiness,
@@ -321,7 +322,8 @@ export function EmailView({
                           whileTap={{ scale: 0.98 }}
                           className={cn(
                             "glass-tile flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 transition-all duration-150",
-                            actions.onPreviewAttachment && "cursor-pointer hover:bg-white/[0.08] hover:border-white/15"
+                            actions.onPreviewAttachment &&
+                              "cursor-pointer hover:bg-white/[0.08] hover:border-white/15",
                           )}
                         >
                           <AttachmentIcon type={attachment.type} />
@@ -756,6 +758,7 @@ function SenderIdentity({ email, compact = false }: { email: Email; compact?: bo
             {email.from}
           </span>
           <SenderBadge policy={email.senderPolicy} />
+          <EmailTrustBadges email={email} max={3} size="sm" className="ml-1" />
         </div>
         <div className="mail-reader-meta truncate text-[9.5px] leading-3 text-muted-foreground/80">
           {email.email}

--- a/src/components/mail/MobileMailCard.tsx
+++ b/src/components/mail/MobileMailCard.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import type { Email } from "./data";
 import { isVerified, mailFolders } from "./data";
+import { EmailTrustBadges } from "./EmailTrustBadges";
 
 type MobileMailCardProps = {
   email: Email;
@@ -76,14 +77,23 @@ export function MobileMailCard({
           {/* Sender and time */}
           <div className="min-w-0 flex-1">
             <div className="flex items-start justify-between gap-2">
-              <span
-                className={cn(
-                  "truncate text-[13px] font-semibold leading-tight text-foreground/88",
-                  email.unread && "text-foreground/94",
-                )}
-              >
-                {email.from}
-              </span>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span
+                  className={cn(
+                    "truncate text-[13px] font-semibold leading-tight text-foreground/88",
+                    email.unread && "text-foreground/94",
+                  )}
+                >
+                  {email.from}
+                </span>
+                <EmailTrustBadges
+                  email={email}
+                  max={1}
+                  size="sm"
+                  showLabels={false}
+                  className="shrink-0"
+                />
+              </div>
               <span className="shrink-0 text-[10.5px] font-medium leading-none tabular-nums text-muted-foreground/85">
                 {email.time}
               </span>
@@ -109,11 +119,7 @@ export function MobileMailCard({
                   </Badge>
                 )}
                 {email.labels?.slice(0, 2).map((label) => (
-                  <Badge
-                    key={label}
-                    variant="secondary"
-                    className="h-4.5 px-1.5 text-[9px]"
-                  >
+                  <Badge key={label} variant="secondary" className="h-4.5 px-1.5 text-[9px]">
                     {label}
                   </Badge>
                 ))}
@@ -181,9 +187,7 @@ export function MobileMailCard({
               email.starred && "fill-amber-400 text-amber-400",
             )}
           />
-          <span className="text-[11px] font-medium">
-            {email.starred ? "Starred" : "Star"}
-          </span>
+          <span className="text-[11px] font-medium">{email.starred ? "Starred" : "Star"}</span>
         </motion.button>
 
         <motion.button

--- a/src/components/mail/RightPanel.tsx
+++ b/src/components/mail/RightPanel.tsx
@@ -17,6 +17,7 @@ import { format, isSameDay, parseISO } from "date-fns";
 import { getAppToday, type CalendarDefinition, type CalendarEvent } from "@/features/calendar";
 import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import { ProvenancePanel } from "./ProvenancePanel";
+import { EmailTrustBadges } from "./EmailTrustBadges";
 import type { Email } from "./data";
 
 export type ContextAction = "snooze" | "translate" | "schedule" | "summarize";
@@ -175,7 +176,7 @@ export function RightPanel({
                 onClick={() => onPreviewAttachment?.(attachment)}
                 className={cn(
                   "flex items-center gap-2 rounded-lg px-2 py-1.5 transition duration-150",
-                  onPreviewAttachment && "cursor-pointer hover:bg-white/[0.06]"
+                  onPreviewAttachment && "cursor-pointer hover:bg-white/[0.06]",
                 )}
               >
                 <div className="grid h-7 w-7 place-items-center rounded-md bg-white/[0.05] text-[9px] font-bold uppercase text-muted-foreground">
@@ -218,6 +219,7 @@ export function RightPanel({
               <div className="flex items-center gap-1.5">
                 <span className="truncate text-sm text-foreground">{email.from}</span>
                 <SenderBadge policy={email.senderPolicy} />
+                <EmailTrustBadges email={email} max={3} size="sm" className="ml-1" />
               </div>
               <div className="truncate text-[11px] text-muted-foreground">{email.email}</div>
             </div>

--- a/src/components/mail/trust-state.test.ts
+++ b/src/components/mail/trust-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getTrustStates, getPrimaryTrustState } from "./trust-state";
+import type { Email } from "./data";
+
+function makeEmail(overrides: Partial<Email>): Email {
+  return {
+    id: "1",
+    from: "Ada",
+    email: "ada@demo.stealth",
+    subject: "Subject",
+    preview: "Preview",
+    body: "Body",
+    time: "Now",
+    unread: false,
+    starred: false,
+    folder: "inbox",
+    avatarColor: "#ffffff",
+    ...overrides,
+  };
+}
+
+describe("getTrustStates", () => {
+  it("returns unknown for a plain inbox message", () => {
+    expect(getTrustStates(makeEmail({}))).toEqual(["unknown"]);
+  });
+
+  it("returns blocked for a blocked sender policy", () => {
+    expect(getTrustStates(makeEmail({ senderPolicy: "block" }))).toEqual(["blocked"]);
+  });
+
+  it("returns allowed for an allowed sender policy", () => {
+    expect(getTrustStates(makeEmail({ senderPolicy: "allow" }))).toEqual(["allowed"]);
+  });
+
+  it("marks verified senders", () => {
+    expect(getTrustStates(makeEmail({ verifiedSender: true }))).toContain("verified");
+  });
+
+  it("derives verified from a verified folder", () => {
+    expect(getTrustStates(makeEmail({ folder: "verified" }))).toContain("verified");
+  });
+
+  it("derives encrypted from the encrypted folder", () => {
+    const states = getTrustStates(makeEmail({ folder: "encrypted" }));
+    expect(states).toContain("encrypted");
+    expect(states).toContain("verified");
+  });
+
+  it("detects bridged and paid from labels", () => {
+    const states = getTrustStates(makeEmail({ labels: ["Bridge", "Paid"] }));
+    expect(states).toContain("bridged");
+    expect(states).toContain("paid");
+  });
+
+  it("detects paid from a postage amount", () => {
+    expect(getTrustStates(makeEmail({ postageAmount: "0.5 XLM" }))).toContain("paid");
+  });
+
+  it("does not produce duplicate states", () => {
+    const states = getTrustStates(makeEmail({ folder: "verified", verifiedSender: true }));
+    expect(new Set(states).size).toBe(states.length);
+  });
+
+  it("prioritizes the explicit policy as the primary state", () => {
+    expect(getPrimaryTrustState(makeEmail({ senderPolicy: "allow", folder: "verified" }))).toBe(
+      "allowed",
+    );
+  });
+});

--- a/src/components/mail/trust-state.ts
+++ b/src/components/mail/trust-state.ts
@@ -1,0 +1,41 @@
+import type { Email } from "./data";
+import { isVerified } from "./data";
+import type { TrustState } from "@/features/design-system/components/trust-badge";
+
+/**
+ * Derive the sender-trust states for a message from its protocol metadata.
+ * Centralizing this guarantees the same sender renders the same badges on
+ * every surface. States are ordered by priority so compact surfaces can show
+ * the most important one first.
+ */
+export function getTrustStates(email: Email): TrustState[] {
+  const states: TrustState[] = [];
+  const labels = new Set(email.labels ?? []);
+
+  // Explicit user decision takes precedence.
+  if (email.senderPolicy === "block") states.push("blocked");
+  else if (email.senderPolicy === "allow") states.push("allowed");
+
+  // Identity verification (folder-, flag-, or policy-derived).
+  if (email.verifiedSender || isVerified(email) || email.senderPolicy === "verify") {
+    states.push("verified");
+  }
+
+  // Protocol attributes can stack on top of the above.
+  if (email.folder === "encrypted" || labels.has("Encrypted")) {
+    states.push("encrypted");
+  }
+  if (labels.has("Bridge") || labels.has("Bridged")) states.push("bridged");
+  if (labels.has("Paid") || Boolean(email.postageAmount)) states.push("paid");
+
+  // Fallback when nothing else applies.
+  if (states.length === 0) states.push("unknown");
+
+  // De-duplicate while preserving priority order.
+  return [...new Set(states)];
+}
+
+/** The single most important trust state, for compact surfaces. */
+export function getPrimaryTrustState(email: Email): TrustState {
+  return getTrustStates(email)[0];
+}

--- a/src/features/design-system/components/trust-badge.md
+++ b/src/features/design-system/components/trust-badge.md
@@ -1,0 +1,22 @@
+# Trust Badge
+
+A single, canonical sender-trust badge shared across every mail surface so the
+same sender state always reads the same way.
+
+## States
+
+verified, allowed, unknown, paid, blocked, bridged, encrypted — each has one
+fixed label, color token, icon, and tooltip.
+
+## Parts
+
+- TrustBadge (design-system) — presentational pill. Always renders text (or a
+  screen-reader label), never color-only meaning. Tooltip on by default.
+- getTrustStates(email) (components/mail/trust-state) — derives the applicable
+  states from folder, labels, senderPolicy, and verifiedSender.
+- EmailTrustBadges (components/mail) — drop-in renderer for any surface.
+
+## Usage
+
+- List rows / compose chips: render EmailTrustBadges with max=1 for the primary state.
+- Reader header / sender cards: render EmailTrustBadges with no max to show all states.

--- a/src/features/design-system/components/trust-badge.tsx
+++ b/src/features/design-system/components/trust-badge.tsx
@@ -1,0 +1,130 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  BadgeCheck,
+  Ban,
+  Cable,
+  CircleDollarSign,
+  CircleHelp,
+  Lock,
+  ShieldCheck,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+/**
+ * Canonical sender-trust states shared across every mail surface.
+ * Standardizing these here keeps labels and colors identical everywhere.
+ */
+export type TrustState =
+  | "verified"
+  | "allowed"
+  | "unknown"
+  | "paid"
+  | "blocked"
+  | "bridged"
+  | "encrypted";
+
+export type TrustStateMeta = {
+  label: string;
+  tooltip: string;
+  icon: LucideIcon;
+  /** Border/background/text tokens — text is always present, never color-only. */
+  className: string;
+};
+
+export const TRUST_STATE_META: Record<TrustState, TrustStateMeta> = {
+  verified: {
+    label: "Verified",
+    tooltip: "This sender's Stellar identity has been cryptographically verified.",
+    icon: ShieldCheck,
+    className: "border-sky-300/25 bg-sky-300/10 text-sky-200",
+  },
+  allowed: {
+    label: "Allowed",
+    tooltip: "You've marked this sender as a trusted contact.",
+    icon: BadgeCheck,
+    className: "border-emerald-300/25 bg-emerald-300/10 text-emerald-200",
+  },
+  unknown: {
+    label: "Unknown",
+    tooltip: "This sender hasn't been verified or added to your contacts yet.",
+    icon: CircleHelp,
+    className: "border-zinc-300/20 bg-zinc-300/10 text-zinc-200",
+  },
+  paid: {
+    label: "Paid",
+    tooltip: "This sender attached postage to reach your inbox.",
+    icon: CircleDollarSign,
+    className: "border-amber-300/25 bg-amber-300/10 text-amber-200",
+  },
+  blocked: {
+    label: "Blocked",
+    tooltip: "Mail from this sender is rejected and moved to spam.",
+    icon: Ban,
+    className: "border-red-300/25 bg-red-300/10 text-red-200",
+  },
+  bridged: {
+    label: "Bridged",
+    tooltip: "Delivered over an email bridge, so it can't be fully verified.",
+    icon: Cable,
+    className: "border-violet-300/25 bg-violet-300/10 text-violet-200",
+  },
+  encrypted: {
+    label: "Encrypted",
+    tooltip: "This message's contents are end-to-end encrypted.",
+    icon: Lock,
+    className: "border-teal-300/25 bg-teal-300/10 text-teal-200",
+  },
+};
+
+export type TrustBadgeSize = "sm" | "md";
+
+export interface TrustBadgeProps {
+  state: TrustState;
+  /** Hide the visible text (icon + tooltip + screen-reader label remain). */
+  showLabel?: boolean;
+  /** Wrap in a tooltip explaining the state. Defaults to true. */
+  showTooltip?: boolean;
+  size?: TrustBadgeSize;
+  className?: string;
+}
+
+/**
+ * A single, consistent sender-trust pill. Presentational only so it can be
+ * reused in list rows, the reader header, compose chips, and sender cards.
+ */
+export function TrustBadge({
+  state,
+  showLabel = true,
+  showTooltip = true,
+  size = "sm",
+  className,
+}: TrustBadgeProps) {
+  const meta = TRUST_STATE_META[state];
+  const Icon = meta.icon;
+
+  const pill = (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-medium leading-none",
+        size === "sm" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs",
+        meta.className,
+        className,
+      )}
+    >
+      <Icon className={size === "sm" ? "h-2.5 w-2.5" : "h-3 w-3"} aria-hidden />
+      {showLabel ? meta.label : <span className="sr-only">{meta.label}</span>}
+    </span>
+  );
+
+  if (!showTooltip) return pill;
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>{pill}</TooltipTrigger>
+        <TooltipContent>{meta.tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/features/design-system/index.ts
+++ b/src/features/design-system/index.ts
@@ -10,3 +10,11 @@ export type { EmptyStateProps } from "./components/empty-state";
 export type { SurfacePadding, SurfaceProps, SurfaceVariant } from "./components/surface";
 export type { FeedbackViewportProps } from "./feedback/feedback-viewport";
 export type { FeedbackItem, FeedbackTone, NotifyOptions } from "./feedback/use-feedback";
+
+export { TrustBadge, TRUST_STATE_META } from "./components/trust-badge";
+export type {
+  TrustState,
+  TrustStateMeta,
+  TrustBadgeProps,
+  TrustBadgeSize,
+} from "./components/trust-badge";


### PR DESCRIPTION
Closes #104.

Standardizes the sender trust badges so the same state reads consistently across every mail surface.

What's included:
- A shared TrustBadge in the design system plus a getTrustStates resolver, so all surfaces derive state the same way.
- Badges wired into list rows, the reader header, compose recipient chips, and the sender card.
- Each badge uses an icon + label (not color alone) with a short tooltip explaining the protocol term.

States covered: verified, allowed, unknown, paid, blocked, bridged, encrypted.

Notes:
- Added unit tests for the resolver (10 cases, all passing).
- Typecheck only surfaces errors that already exist on main (RequestCard, OnboardingModal, routes/index, motion-gallery, EmailView) — nothing new from this change.