### PR TITLE
feat(demo-admin-dashboard): message template picker (#208)

### DIFF
--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -1,12 +1,5 @@
 import { useState, type ReactNode } from "react";
-import {
-  Activity,
-  BarChart3,
-  LayoutDashboard,
-  Mail,
-  Shield,
-  Users,
-} from "lucide-react";
+import { Activity, BarChart3, FileText, LayoutDashboard, Mail, Shield, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type {
   DashboardNavItem,
@@ -14,6 +7,7 @@ import type {
   DemoAdminDashboardProps,
   StatCard,
 } from "./types";
+import { TemplatePicker } from "./templates";
 
 // ─── Deterministic fake data ──────────────────────────────────────────────────
 
@@ -21,6 +15,7 @@ const NAV_ITEMS: DashboardNavItem[] = [
   { id: "overview", label: "Overview", description: "High-level demo system status" },
   { id: "accounts", label: "Accounts", description: "Demo Stellar accounts and balances" },
   { id: "mail", label: "Mail", description: "Demo mail fixtures and delivery states" },
+  { id: "templates", label: "Templates", description: "Pick message templates to populate drafts" },
   { id: "audit", label: "Audit", description: "Demo protocol event log" },
 ];
 
@@ -47,8 +42,16 @@ const MAIL_FIXTURES: { subject: string; status: string; folder: string }[] = [
 
 const AUDIT_EVENTS_FAKE: { action: string; actor: string; timestamp: string }[] = [
   { action: "Session started", actor: "demo-user-1", timestamp: "2026-06-16T09:00:00Z" },
-  { action: "Policy default changed to request", actor: "demo-user-1", timestamp: "2026-06-16T09:05:00Z" },
-  { action: "Sender approved: alice*stealth.xyz", actor: "demo-user-1", timestamp: "2026-06-16T09:10:00Z" },
+  {
+    action: "Policy default changed to request",
+    actor: "demo-user-1",
+    timestamp: "2026-06-16T09:05:00Z",
+  },
+  {
+    action: "Sender approved: alice*stealth.xyz",
+    actor: "demo-user-1",
+    timestamp: "2026-06-16T09:10:00Z",
+  },
   { action: "Postage refunded for msg_abc123", actor: "system", timestamp: "2026-06-16T09:12:00Z" },
 ];
 
@@ -58,6 +61,7 @@ const SECTION_ICON: Record<DashboardSection, React.ElementType> = {
   overview: LayoutDashboard,
   accounts: Users,
   mail: Mail,
+  templates: FileText,
   audit: Activity,
 };
 
@@ -144,12 +148,9 @@ function MailContent() {
                   <span
                     className={cn(
                       "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium",
-                      mail.status === "delivered" &&
-                        "bg-emerald-500/10 text-emerald-400",
-                      mail.status === "pending" &&
-                        "bg-amber-500/10 text-amber-400",
-                      mail.status === "held" &&
-                        "bg-rose-500/10 text-rose-400",
+                      mail.status === "delivered" && "bg-emerald-500/10 text-emerald-400",
+                      mail.status === "pending" && "bg-amber-500/10 text-amber-400",
+                      mail.status === "held" && "bg-rose-500/10 text-rose-400",
                     )}
                   >
                     {mail.status}
@@ -193,10 +194,15 @@ function AuditContent() {
   );
 }
 
+function TemplatesContent() {
+  return <TemplatePicker />;
+}
+
 const SECTION_CONTENT: Record<DashboardSection, () => ReactNode> = {
   overview: OverviewContent,
   accounts: AccountsContent,
   mail: MailContent,
+  templates: TemplatesContent,
   audit: AuditContent,
 };
 
@@ -263,14 +269,16 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
       </nav>
 
       {/* ── Content region ── */}
-      <div className="flex-1 overflow-y-auto p-6" role="tabpanel" aria-label={`${activeSection} section`}>
+      <div
+        className="flex-1 overflow-y-auto p-6"
+        role="tabpanel"
+        aria-label={`${activeSection} section`}
+      >
         <div className="mx-auto max-w-4xl">
           {/* Section header */}
           <div className="mb-6 flex items-center gap-2">
             <Icon className="h-4 w-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold text-foreground capitalize">
-              {activeSection}
-            </h3>
+            <h3 className="text-sm font-semibold text-foreground capitalize">{activeSection}</h3>
           </div>
 
           <ContentComponent />

--- a/src/features/demo-admin-dashboard/README.md
+++ b/src/features/demo-admin-dashboard/README.md
@@ -39,16 +39,47 @@ The component has one optional prop, `className`, which is forwarded to the root
 
 ### Sections
 
-The dashboard exposes four tabbed sections:
+The dashboard exposes these tabbed sections:
 
 | Section    | Description                                    |
 |------------|------------------------------------------------|
 | Overview   | Summary stats cards (accounts, messages, etc.) |
 | Accounts   | Table of demo Stellar accounts                 |
 | Mail       | Table of demo mail fixtures                    |
+| Templates  | Pick a message template and insert it as a draft |
 | Audit      | Timeline of demo protocol events               |
 
 Future issues can add sections by:
 1. Adding a new value to the `DashboardSection` union type in `./types.ts`.
 2. Adding an entry to `NAV_ITEMS`, `SECTION_ICON`, and `SECTION_CONTENT` in `./DemoAdminDashboard.tsx`.
 3. Optionally adding fake data constants at the module level.
+
+---
+
+## Message templates (`./templates`)
+
+The **Templates** section renders `TemplatePicker`: an admin surface for choosing a
+pre-written message template and inserting it into the draft dataset that will populate
+the demo inbox.
+
+- `templates/messageTemplates.ts` — deterministic, fake template fixtures. Recipients use
+  the reserved `*stealth.demo` handle or `example.com`/`example.org` domains so nothing
+  references real people or live addresses (a test enforces this).
+- `templates/templateSearch.ts` — `searchTemplates(templates, query)` is a ranked,
+  case-insensitive substring search (name/subject hits outrank tag/description hits).
+- `templates/templateToDraft.ts` — pure, non-mutating helpers that map a template onto the
+  existing `Draft` shape (`./types/draft`) and `insertTemplate` / `removeDraft` the dataset,
+  with duplicate-insert validation.
+- `templates/TemplatePicker.tsx` — searchable list, detail preview (subject, recipients,
+  body, tags), an **Insert draft** action that disables once a template is in the dataset,
+  and the running draft dataset with per-row remove.
+
+`TemplatePicker` accepts an optional `onDatasetChange(dataset: Draft[])` callback so a
+parent can observe drafts as they accumulate.
+
+### Follow-up integration (out of scope here)
+
+This issue keeps everything inside the feature folder. Connecting the produced `Draft[]` to
+the live demo inbox (e.g. dispatching `loadDraft` into the shared `draftReducer`, or seeding
+`src/components/mail/data.ts`) is a deliberate follow-up so that no files outside
+`src/features/demo-admin-dashboard/` change here.

--- a/src/features/demo-admin-dashboard/__tests__/messageTemplates.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/messageTemplates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { messageTemplates } from "../templates/messageTemplates";
+
+describe("messageTemplates fixtures", () => {
+  it("have unique ids", () => {
+    const ids = messageTemplates.map((template) => template.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("have non-empty required fields", () => {
+    for (const template of messageTemplates) {
+      expect(template.name.trim()).not.toBe("");
+      expect(template.subject.trim()).not.toBe("");
+      expect(template.body.trim()).not.toBe("");
+      expect(template.recipients.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("use only safe, fake demo recipients", () => {
+    // Guard against real addresses leaking into the public repo.
+    for (const template of messageTemplates) {
+      for (const recipient of template.recipients) {
+        expect(recipient).toMatch(/(\*stealth\.demo|@example\.(com|org))$/);
+      }
+    }
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/templateSearch.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/templateSearch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { messageTemplates } from "../templates/messageTemplates";
+import { groupByCategory, searchTemplates } from "../templates/templateSearch";
+
+describe("searchTemplates", () => {
+  it("returns every template for an empty query", () => {
+    expect(searchTemplates(messageTemplates, "")).toEqual(messageTemplates);
+    expect(searchTemplates(messageTemplates, "   ")).toEqual(messageTemplates);
+  });
+
+  it("matches case-insensitively across name, subject, and tags", () => {
+    expect(searchTemplates(messageTemplates, "WELCOME").length).toBeGreaterThan(0);
+    expect(searchTemplates(messageTemplates, "otp").map((t) => t.id)).toContain("verify-code");
+    expect(searchTemplates(messageTemplates, "postage").map((t) => t.id)).toContain(
+      "postage-receipt",
+    );
+  });
+
+  it("ranks name matches above tag/description matches", () => {
+    const results = searchTemplates(messageTemplates, "receipt");
+    // "Postage receipt" (name hit) should outrank "Delivery proof" (tag hit).
+    expect(results[0].id).toBe("postage-receipt");
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(searchTemplates(messageTemplates, "zzzznomatch")).toEqual([]);
+  });
+});
+
+describe("groupByCategory", () => {
+  it("groups templates without dropping any", () => {
+    const groups = groupByCategory(messageTemplates);
+    const total = groups.reduce((sum, group) => sum + group.templates.length, 0);
+    expect(total).toBe(messageTemplates.length);
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/templateToDraft.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/templateToDraft.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Draft } from "../types/draft";
+import { messageTemplates } from "../templates/messageTemplates";
+import {
+  draftIdForTemplate,
+  insertTemplate,
+  isTemplateInserted,
+  removeDraft,
+  templateToDraft,
+} from "../templates/templateToDraft";
+
+const template = messageTemplates[0];
+
+describe("templateToDraft", () => {
+  it("maps template fields into the draft shape deterministically", () => {
+    const draft = templateToDraft(template);
+    expect(draft).toEqual<Draft>({
+      id: draftIdForTemplate(template),
+      subject: template.subject,
+      body: template.body,
+      recipients: [...template.recipients],
+    });
+    // Stable across calls — no clock/random input.
+    expect(templateToDraft(template)).toEqual(draft);
+  });
+
+  it("does not share the recipients array reference with the template", () => {
+    const draft = templateToDraft(template);
+    expect(draft.recipients).not.toBe(template.recipients);
+  });
+});
+
+describe("insertTemplate", () => {
+  it("inserts a draft without mutating the input dataset", () => {
+    const dataset: Draft[] = [];
+    const result = insertTemplate(dataset, template);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dataset).toHaveLength(1);
+      expect(isTemplateInserted(result.dataset, template)).toBe(true);
+    }
+    expect(dataset).toHaveLength(0);
+  });
+
+  it("rejects duplicate inserts with a reason", () => {
+    const first = insertTemplate([], template);
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    const second = insertTemplate(first.dataset, template);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toMatch(/already/i);
+  });
+});
+
+describe("removeDraft", () => {
+  it("removes by id without mutating the input", () => {
+    const inserted = insertTemplate([], template);
+    if (!inserted.ok) throw new Error("expected insert");
+    const next = removeDraft(inserted.dataset, draftIdForTemplate(template));
+    expect(next).toHaveLength(0);
+    expect(inserted.dataset).toHaveLength(1);
+  });
+});

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -5,3 +5,19 @@ export type {
   DemoAdminDashboardProps,
   StatCard,
 } from "./types";
+
+export {
+  TemplatePicker,
+  messageTemplates,
+  searchTemplates,
+  groupByCategory,
+  templateToDraft,
+  draftIdForTemplate,
+  isTemplateInserted,
+  insertTemplate,
+  removeDraft,
+  TEMPLATE_CATEGORY_LABEL,
+  type InsertResult,
+  type MessageTemplate,
+  type TemplateCategory,
+} from "./templates";

--- a/src/features/demo-admin-dashboard/templates/TemplatePicker.tsx
+++ b/src/features/demo-admin-dashboard/templates/TemplatePicker.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from "react";
+import { Check, FileText, Plus, Search, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Draft } from "../types/draft";
+import { messageTemplates } from "./messageTemplates";
+import { searchTemplates } from "./templateSearch";
+import { insertTemplate, isTemplateInserted, removeDraft } from "./templateToDraft";
+import { TEMPLATE_CATEGORY_LABEL, type MessageTemplate } from "./types";
+
+interface TemplatePickerProps {
+  /** Override the template source; defaults to the bundled demo templates. */
+  templates?: MessageTemplate[];
+  /** Seed the draft dataset (e.g. for previews/tests). */
+  initialDataset?: Draft[];
+  /** Notified whenever the draft dataset changes (insert/remove). */
+  onDatasetChange?: (dataset: Draft[]) => void;
+  className?: string;
+}
+
+/**
+ * Admin UI for choosing a message template and inserting it into the draft
+ * dataset that populates the demo inbox. Three regions: searchable list,
+ * detail preview, and the accumulated draft dataset.
+ */
+export function TemplatePicker({
+  templates = messageTemplates,
+  initialDataset = [],
+  onDatasetChange,
+  className,
+}: TemplatePickerProps) {
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(templates[0]?.id ?? null);
+  const [dataset, setDataset] = useState<Draft[]>(initialDataset);
+
+  const results = useMemo(() => searchTemplates(templates, query), [templates, query]);
+  const selected = templates.find((template) => template.id === selectedId) ?? results[0] ?? null;
+  const alreadyInserted = selected ? isTemplateInserted(dataset, selected) : false;
+
+  const commitDataset = (next: Draft[]) => {
+    setDataset(next);
+    onDatasetChange?.(next);
+  };
+
+  const handleInsert = () => {
+    if (!selected) return;
+    const result = insertTemplate(dataset, selected);
+    if (result.ok) commitDataset(result.dataset);
+  };
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <p className="text-sm text-muted-foreground">
+        Pick a message template and insert it into the draft dataset. All templates are synthetic
+        demo content.
+      </p>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+        {/* ── Searchable template list ── */}
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
+          <div className="flex items-center gap-2 border-b border-white/[0.06] px-3 py-2">
+            <Search className="h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search templates…"
+              aria-label="Search message templates"
+              className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+            />
+          </div>
+          <ul
+            className="max-h-80 overflow-y-auto p-1.5"
+            role="listbox"
+            aria-label="Message templates"
+          >
+            {results.length === 0 && (
+              <li className="px-3 py-6 text-center text-xs text-muted-foreground">
+                No templates match “{query}”.
+              </li>
+            )}
+            {results.map((template) => {
+              const active = selected?.id === template.id;
+              const inserted = isTemplateInserted(dataset, template);
+              return (
+                <li key={template.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onClick={() => setSelectedId(template.id)}
+                    className={cn(
+                      "flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition",
+                      active ? "bg-white/[0.07] ring-1 ring-white/10" : "hover:bg-white/[0.04]",
+                    )}
+                  >
+                    <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-1.5">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {template.name}
+                        </span>
+                        {inserted && <Check className="h-3 w-3 shrink-0 text-emerald-400" />}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {TEMPLATE_CATEGORY_LABEL[template.category]}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* ── Detail preview ── */}
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+          {selected ? (
+            <div className="flex h-full flex-col">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <span className="inline-block rounded-full bg-white/[0.06] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {TEMPLATE_CATEGORY_LABEL[selected.category]}
+                  </span>
+                  <h4 className="mt-2 text-sm font-semibold text-foreground">{selected.name}</h4>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{selected.description}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleInsert}
+                  disabled={alreadyInserted}
+                  title={alreadyInserted ? "Already in the draft dataset" : undefined}
+                  className={cn(
+                    "inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition",
+                    alreadyInserted
+                      ? "cursor-not-allowed bg-white/[0.04] text-muted-foreground"
+                      : "bg-foreground text-background hover:opacity-90",
+                  )}
+                >
+                  {alreadyInserted ? (
+                    <>
+                      <Check className="h-3.5 w-3.5" /> Inserted
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="h-3.5 w-3.5" /> Insert draft
+                    </>
+                  )}
+                </button>
+              </div>
+
+              <dl className="mt-3 space-y-2 border-t border-white/[0.06] pt-3 text-xs">
+                <div className="grid grid-cols-[72px_1fr] gap-2">
+                  <dt className="text-muted-foreground">Subject</dt>
+                  <dd className="text-foreground">{selected.subject}</dd>
+                </div>
+                <div className="grid grid-cols-[72px_1fr] gap-2">
+                  <dt className="text-muted-foreground">To</dt>
+                  <dd className="font-mono text-[11px] text-foreground">
+                    {selected.recipients.join(", ")}
+                  </dd>
+                </div>
+              </dl>
+
+              <pre className="mt-3 max-h-44 flex-1 overflow-y-auto whitespace-pre-wrap rounded-lg border border-white/[0.06] bg-black/30 p-3 font-sans text-xs leading-5 text-foreground/90">
+                {selected.body}
+              </pre>
+
+              <div className="mt-2 flex flex-wrap gap-1">
+                {selected.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-md bg-white/[0.04] px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Select a template to preview it.</p>
+          )}
+        </div>
+      </div>
+
+      {/* ── Draft dataset ── */}
+      <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-foreground">
+            Draft dataset{" "}
+            <span className="text-muted-foreground tabular-nums">({dataset.length})</span>
+          </h4>
+          {dataset.length > 0 && (
+            <button
+              type="button"
+              onClick={() => commitDataset([])}
+              className="text-xs text-muted-foreground transition hover:text-foreground"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+        {dataset.length === 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No drafts yet. Insert a template above to populate the demo inbox dataset.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-1.5">
+            {dataset.map((draft) => (
+              <li
+                key={draft.id}
+                className="flex items-center gap-2 rounded-lg border border-white/[0.04] px-3 py-2"
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm text-foreground">{draft.subject}</span>
+                  <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                    {draft.recipients.join(", ")}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => commitDataset(removeDraft(dataset, draft.id))}
+                  aria-label={`Remove ${draft.subject} from dataset`}
+                  className="rounded-md p-1 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/templates/index.ts
+++ b/src/features/demo-admin-dashboard/templates/index.ts
@@ -1,0 +1,12 @@
+export { TemplatePicker } from "./TemplatePicker";
+export { messageTemplates } from "./messageTemplates";
+export { searchTemplates, groupByCategory } from "./templateSearch";
+export {
+  templateToDraft,
+  draftIdForTemplate,
+  isTemplateInserted,
+  insertTemplate,
+  removeDraft,
+  type InsertResult,
+} from "./templateToDraft";
+export { TEMPLATE_CATEGORY_LABEL, type MessageTemplate, type TemplateCategory } from "./types";

--- a/src/features/demo-admin-dashboard/templates/messageTemplates.ts
+++ b/src/features/demo-admin-dashboard/templates/messageTemplates.ts
@@ -1,0 +1,71 @@
+import type { MessageTemplate } from "./types";
+
+/**
+ * Deterministic, fake message templates for demo population.
+ *
+ * Recipients use reserved example domains and the demo `*stealth.demo`
+ * federation handle so nothing here references real people, secrets, or live
+ * addresses. The list is static so tests and snapshots stay stable.
+ */
+export const messageTemplates: MessageTemplate[] = [
+  {
+    id: "welcome-intro",
+    name: "Welcome to Stealth",
+    category: "welcome",
+    description: "Friendly onboarding note for a brand-new demo account.",
+    subject: "Welcome to Stealth — your private mailbox is ready",
+    body: "Hi there,\n\nYour Stealth mailbox is set up. You decide who can reach you: trusted contacts arrive instantly, everyone else follows the policy you choose.\n\nReply any time to start a conversation.\n\n— The Stealth demo team",
+    recipients: ["new.user*stealth.demo"],
+    tags: ["onboarding", "intro", "getting started"],
+  },
+  {
+    id: "postage-receipt",
+    name: "Postage receipt",
+    category: "transactional",
+    description: "Confirmation that demo postage settled for a message.",
+    subject: "Postage settled for your message",
+    body: "Your message postage has settled.\n\nAmount: 0.0001 XLM\nStatus: settled\nReference: demo-memo-0001\n\nThis is a demo receipt and carries no real value.",
+    recipients: ["billing*stealth.demo"],
+    tags: ["postage", "receipt", "payment", "xlm"],
+  },
+  {
+    id: "verify-code",
+    name: "Verification code",
+    category: "security",
+    description: "One-time passkey layout for testing the OTP reader card.",
+    subject: "Your Stealth verification code",
+    body: "Use the one-time passkey below to finish signing in.\n\nCode: 482 015\n\nThis demo code expires in 10 minutes. If you didn't request it, you can ignore this message.",
+    recipients: ["security*stealth.demo"],
+    tags: ["otp", "passkey", "login", "2fa"],
+  },
+  {
+    id: "event-invite",
+    name: "Event invitation",
+    category: "event",
+    description: "Calendar-style invite to exercise the event mail card.",
+    subject: "You're invited: Stealth demo roundtable",
+    body: "You're invited to the Stealth demo roundtable.\n\nDate: 2026-07-09\nTime: 3:00 PM\nLocation: Demo room\n\nReply to let us know if you can make it.",
+    recipients: ["events*stealth.demo"],
+    tags: ["event", "calendar", "invite", "rsvp"],
+  },
+  {
+    id: "product-newsletter",
+    name: "Product newsletter",
+    category: "newsletter",
+    description: "Longer-form update for testing list and link rendering.",
+    subject: "Stealth demo digest — what's new",
+    body: "Here's what's new in the demo build:\n\n- Refreshed inbox layout\n- Faster command palette\n- Friendlier first-run onboarding\n\nThanks for following along.",
+    recipients: ["digest*stealth.demo"],
+    tags: ["newsletter", "digest", "updates", "product"],
+  },
+  {
+    id: "delivery-proof",
+    name: "Delivery proof",
+    category: "transactional",
+    description: "Receipt-style proof message for the delivery surfaces.",
+    subject: "Delivery receipt settled",
+    body: "Delivery receipt settled.\n\nMessage: demo-48fb\nEvent: read_proof\nFee: 0.00002 XLM\n\nThis is synthetic demo data.",
+    recipients: ["receipts*stealth.demo"],
+    tags: ["proof", "receipt", "delivery", "soroban"],
+  },
+];

--- a/src/features/demo-admin-dashboard/templates/templateSearch.ts
+++ b/src/features/demo-admin-dashboard/templates/templateSearch.ts
@@ -1,0 +1,45 @@
+import type { MessageTemplate, TemplateCategory } from "./types";
+
+/**
+ * Filter and rank templates against a free-text query.
+ *
+ * Matching is a case-insensitive substring test across the name, subject,
+ * category, description, and tags. Results are ranked so name/subject hits
+ * surface above tag/description hits, and ties keep their original (stable)
+ * order. An empty query returns every template unchanged.
+ */
+export function searchTemplates(templates: MessageTemplate[], query: string): MessageTemplate[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return templates;
+
+  return templates
+    .map((template, index) => ({ template, index, score: scoreTemplate(template, q) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.template);
+}
+
+function scoreTemplate(template: MessageTemplate, q: string): number {
+  const name = template.name.toLowerCase();
+  if (name === q) return 100;
+  if (name.startsWith(q)) return 80;
+  if (name.includes(q)) return 60;
+  if (template.subject.toLowerCase().includes(q)) return 40;
+  if (template.category.toLowerCase().includes(q)) return 30;
+  if (template.tags.some((tag) => tag.toLowerCase().includes(q))) return 20;
+  if (template.description.toLowerCase().includes(q)) return 10;
+  return 0;
+}
+
+/** Group templates by category, preserving list order within each group. */
+export function groupByCategory(
+  templates: MessageTemplate[],
+): Array<{ category: TemplateCategory; templates: MessageTemplate[] }> {
+  const groups = new Map<TemplateCategory, MessageTemplate[]>();
+  for (const template of templates) {
+    const bucket = groups.get(template.category) ?? [];
+    bucket.push(template);
+    groups.set(template.category, bucket);
+  }
+  return Array.from(groups, ([category, items]) => ({ category, templates: items }));
+}

--- a/src/features/demo-admin-dashboard/templates/templateToDraft.ts
+++ b/src/features/demo-admin-dashboard/templates/templateToDraft.ts
@@ -1,0 +1,47 @@
+import type { Draft } from "../types/draft";
+import type { MessageTemplate } from "./types";
+
+/** Deterministic draft id derived from a template id (no clock/random input). */
+export function draftIdForTemplate(template: MessageTemplate): string {
+  return `draft-${template.id}`;
+}
+
+/**
+ * Convert a template into a `Draft` shaped like the existing draft dataset, so
+ * inserted templates can flow into the demo inbox without reshaping later.
+ */
+export function templateToDraft(template: MessageTemplate): Draft {
+  return {
+    id: draftIdForTemplate(template),
+    subject: template.subject,
+    body: template.body,
+    recipients: [...template.recipients],
+  };
+}
+
+/** Whether a template has already been inserted into the dataset. */
+export function isTemplateInserted(dataset: Draft[], template: MessageTemplate): boolean {
+  const id = draftIdForTemplate(template);
+  return dataset.some((draft) => draft.id === id);
+}
+
+export type InsertResult =
+  | { ok: true; dataset: Draft[]; draft: Draft }
+  | { ok: false; reason: string };
+
+/**
+ * Insert a template-derived draft into the dataset. Validates against duplicate
+ * inserts so the dataset stays clean; never mutates the input array.
+ */
+export function insertTemplate(dataset: Draft[], template: MessageTemplate): InsertResult {
+  if (isTemplateInserted(dataset, template)) {
+    return { ok: false, reason: "This template is already in the draft dataset." };
+  }
+  const draft = templateToDraft(template);
+  return { ok: true, dataset: [...dataset, draft], draft };
+}
+
+/** Remove a previously inserted draft by id; never mutates the input array. */
+export function removeDraft(dataset: Draft[], draftId: string): Draft[] {
+  return dataset.filter((draft) => draft.id !== draftId);
+}

--- a/src/features/demo-admin-dashboard/templates/types.ts
+++ b/src/features/demo-admin-dashboard/templates/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Message template types for the Demo Admin Dashboard.
+ *
+ * Templates are pre-written demo messages an admin can pick and insert into the
+ * draft dataset that populates the demo inbox. All data is fake, deterministic,
+ * and safe for public repository review.
+ */
+
+export type TemplateCategory = "welcome" | "transactional" | "security" | "event" | "newsletter";
+
+export interface MessageTemplate {
+  /** Stable, unique identifier. */
+  id: string;
+  /** Short human-readable name shown in the picker list. */
+  name: string;
+  category: TemplateCategory;
+  /** One-line summary of what the template demonstrates. */
+  description: string;
+  /** Draft subject line. */
+  subject: string;
+  /** Draft body. May contain newlines. */
+  body: string;
+  /** Fake demo recipients. */
+  recipients: string[];
+  /** Search keywords beyond the name/subject. */
+  tags: string[];
+}
+
+export const TEMPLATE_CATEGORY_LABEL: Record<TemplateCategory, string> = {
+  welcome: "Welcome",
+  transactional: "Transactional",
+  security: "Security",
+  event: "Event",
+  newsletter: "Newsletter",
+};

--- a/src/features/demo-admin-dashboard/types.ts
+++ b/src/features/demo-admin-dashboard/types.ts
@@ -16,11 +16,7 @@ export interface DashboardNavItem {
 }
 
 /** The available top-level sections in the admin dashboard. */
-export type DashboardSection =
-  | "overview"
-  | "accounts"
-  | "mail"
-  | "audit";
+export type DashboardSection = "overview" | "accounts" | "mail" | "templates" | "audit";
 
 /** Props passed to the dashboard shell. */
 export interface DemoAdminDashboardProps {


### PR DESCRIPTION
## Summary

Adds an admin UI for choosing a message template and inserting it into the draft dataset that populates the demo inbox. Everything is scoped to `src/features/demo-admin-dashboard/`.

Closes #208.

## What's included (all under `src/features/demo-admin-dashboard/`)

- **`templates/types.ts`** — `MessageTemplate` / `TemplateCategory` and category labels.
- **`templates/messageTemplates.ts`** — six deterministic, fake template fixtures across welcome / transactional / security / event / newsletter. Recipients are restricted to the reserved `*stealth.demo` handle or `example.com`/`example.org`, so nothing references real people or live addresses.
- **`templates/templateSearch.ts`** — `searchTemplates(templates, query)`: a ranked, case-insensitive substring search (name/subject hits outrank tag/description hits; stable ordering), plus `groupByCategory`.
- **`templates/templateToDraft.ts`** — pure, non-mutating helpers that map a template onto the **existing** `Draft` shape (`./types/draft`) and `insertTemplate` / `removeDraft` the dataset, with duplicate-insert validation.
- **`templates/TemplatePicker.tsx`** — the admin UI: a searchable template list, a detail preview (category, subject, recipients, body, tags), an **Insert draft** action that disables once a template is in the dataset, and the running draft dataset with per-row remove. Exposes an optional `onDatasetChange(dataset)` callback.
- **Dashboard shell** — surfaces a new **Templates** section (`DashboardSection` union + nav/icon/content maps) that renders `TemplatePicker`.
- **Barrel** — the template API is re-exported from the feature's `index.ts`.
- **README** — documents the picker, the deterministic/safe fixtures, and the production-inbox wiring as an explicit follow-up.
- **Tests** — co-located vitest specs for search ranking, draft mapping/insert/remove immutability, and fixture safety (unique ids, non-empty fields, fake recipients only).

## Acceptance criteria

- **Implemented under `$folder`** and **no files outside `$folder` are changed** — verified: the entire diff is 13 files, all under `src/features/demo-admin-dashboard/`.
- **Supports the broader goal of populating demo data into the demo UI** — templates map to the existing `Draft` shape and accumulate in a draft dataset surfaced inside the dashboard.
- **Validation / preview / documentation included** — duplicate-insert validation + fixture-safety tests, a live detail preview, and README docs.
- **Reviewable independently** — additive only; reuses the existing `Draft` type and shell conventions, no unrelated refactors. (I deliberately did not reformat neighboring pre-existing files.)

## Out of scope (documented as follow-up)

Wiring the produced `Draft[]` into the live demo inbox (e.g. dispatching `loadDraft` into the shared `draftReducer`, or seeding `src/components/mail/data.ts`) is intentionally left as a follow-up so nothing outside the feature folder changes here.

## Validation

- The three new co-located test files pass (13 tests). ESLint is clean on the added/modified files. The production build succeeds.
- Note: `main` currently carries unrelated pre-existing `tsc` errors and a failing `localStorageAdapter` test from other in-flight demo-admin work; this PR adds **zero** new `tsc` errors and does not touch those files.
