### PR TITLE
feat(postage): fixed #57 by adding expiry, reclaim, and dispute states

### DIFF
--- a/contracts/soroban/postage/README.md
+++ b/contracts/soroban/postage/README.md
@@ -1,28 +1,37 @@
 # Postage Contract
 
 Records sender-authorized token escrow for Stealth messages and tracks whether
-the recipient settled or refunded each escrow.
+each escrow is pending, expired, disputed, settled, refunded, or reclaimed.
 
 The contract is initialized with one accepted SEP-41/Stellar Asset Contract
 asset, a minimum postage amount, a treasury address, and an explicit fee in
-basis points. `submit` transfers the full postage amount from the sender into
-the contract address. `settle` transfers net postage to the recipient and fee
-to treasury. `refund` returns the full escrow to the sender.
+basis points, a fixed expiry duration, and an optional dispute duration.
+`submit` transfers the full postage amount from the sender into the contract
+address and fixes the absolute expiry timestamps on the record. `settle`
+transfers net postage to the recipient and fee to treasury. `refund` returns
+the full escrow to the sender. `reclaim` lets the sender recover unresolved
+escrow after expiry and any dispute window.
 
 ## Interface
 
-- `initialize(asset, treasury, minimum, fee_bps)` sets accepted asset and fee policy once.
+- `initialize(asset, treasury, minimum, fee_bps, expiry_seconds, dispute_seconds)` sets accepted asset, fee, expiry, and dispute policy once.
 - `config()` reads the accepted asset, treasury, minimum, and fee policy.
 - `minimum()` reads the configured minimum postage.
 - `quote(sender_trusted)` returns zero for trusted senders or the minimum.
 - `submit(...)` escrows sender-authorized postage for a message.
+- `expire(message_id)` marks unresolved postage expired at its fixed expiry boundary.
 - `settle(message_id)` lets the recipient accept the postage and releases escrow.
 - `refund(message_id)` lets the recipient return escrow to the sender.
+- `dispute(message_id)` lets the recipient move expired pending postage into the bounded dispute state when dispute seconds are configured.
+- `reclaim(message_id)` lets the sender reclaim unresolved postage at the fixed reclaim boundary.
 - `get(message_id)` reads the current record.
 
 ## Settlement Invariants
 
 - Only the configured asset is accepted.
 - Fee policy is explicit and bounded to `0..=10000` basis points.
-- A message can move from pending to settled or refunded exactly once.
+- Expiry and dispute deadlines are fixed at submission.
+- Reclaim fails before the fixed reclaim boundary.
+- A message can move from pending, expired, or disputed to exactly one terminal state: settled, refunded, or reclaimed.
+- Terminal states cannot transition.
 - Balance conservation is tested across sender, recipient, treasury, and contract escrow balances.

--- a/contracts/soroban/postage/src/lib.rs
+++ b/contracts/soroban/postage/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
-    MuxedAddress,
+    contract, contracterror, contractevent, contractimpl, contracttype, symbol_short, token,
+    Address, BytesN, Env, MuxedAddress, Symbol,
 };
 
 #[contract]
@@ -16,7 +16,19 @@ pub struct Postage {
     pub amount: i128,
     pub fee: i128,
     pub created_at: u64,
+    pub expires_at: u64,
+    pub dispute_until: u64,
     pub status: PostageStatus,
+}
+
+#[contractevent(topics = ["postage"])]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PostageEvent {
+    #[topic]
+    pub action: Symbol,
+    #[topic]
+    pub message_id: BytesN<32>,
+    pub postage: Postage,
 }
 
 #[contracttype]
@@ -26,14 +38,19 @@ pub struct EscrowConfig {
     pub minimum: i128,
     pub treasury: Address,
     pub fee_bps: u32,
+    pub expiry_seconds: u64,
+    pub dispute_seconds: u64,
 }
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PostageStatus {
     Pending,
+    Expired,
+    Disputed,
     Settled,
     Refunded,
+    Reclaimed,
 }
 
 #[contracttype]
@@ -53,6 +70,9 @@ pub enum Error {
     PostageNotFound = 5,
     AlreadyResolved = 6,
     InvalidFee = 7,
+    InvalidWindow = 8,
+    NotExpired = 9,
+    DisputeUnavailable = 10,
 }
 
 #[contractimpl]
@@ -63,6 +83,8 @@ impl PostageContract {
         treasury: Address,
         minimum: i128,
         fee_bps: u32,
+        expiry_seconds: u64,
+        dispute_seconds: u64,
     ) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Config) {
             return Err(Error::AlreadyInitialized);
@@ -73,6 +95,9 @@ impl PostageContract {
         if fee_bps > 10_000 {
             return Err(Error::InvalidFee);
         }
+        if expiry_seconds == 0 {
+            return Err(Error::InvalidWindow);
+        }
 
         env.storage().instance().set(
             &DataKey::Config,
@@ -81,6 +106,8 @@ impl PostageContract {
                 minimum,
                 treasury,
                 fee_bps,
+                expiry_seconds,
+                dispute_seconds,
             },
         );
         Ok(())
@@ -121,6 +148,10 @@ impl PostageContract {
         }
 
         let fee = Self::fee_for(amount, config.fee_bps)?;
+        let created_at = env.ledger().timestamp();
+        let expires_at = Self::checked_deadline(created_at, config.expiry_seconds)?;
+        let dispute_until = Self::checked_deadline(expires_at, config.dispute_seconds)?;
+
         token::TokenClient::new(&env, &config.asset).transfer(
             &sender,
             &MuxedAddress::from(env.current_contract_address()),
@@ -132,12 +163,37 @@ impl PostageContract {
             recipient,
             amount,
             fee,
-            created_at: env.ledger().timestamp(),
+            created_at,
+            expires_at,
+            dispute_until,
             status: PostageStatus::Pending,
         };
         env.storage().persistent().set(&key, &postage);
-        env.events()
-            .publish((symbol_short!("postage"), message_id), postage.clone());
+        Self::publish_event(&env, symbol_short!("submit"), message_id, postage.clone());
+        Ok(postage)
+    }
+
+    pub fn expire(env: Env, message_id: BytesN<32>) -> Result<Postage, Error> {
+        let key = DataKey::Postage(message_id.clone());
+        let mut postage: Postage = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PostageNotFound)?;
+
+        if Self::is_terminal(postage.status) {
+            return Err(Error::AlreadyResolved);
+        }
+        if postage.status != PostageStatus::Pending {
+            return Err(Error::DisputeUnavailable);
+        }
+        if env.ledger().timestamp() < postage.expires_at {
+            return Err(Error::NotExpired);
+        }
+
+        postage.status = PostageStatus::Expired;
+        env.storage().persistent().set(&key, &postage);
+        Self::publish_event(&env, symbol_short!("expire"), message_id, postage.clone());
         Ok(postage)
     }
 
@@ -147,6 +203,68 @@ impl PostageContract {
 
     pub fn refund(env: Env, message_id: BytesN<32>) -> Result<Postage, Error> {
         Self::resolve(env, message_id, PostageStatus::Refunded)
+    }
+
+    pub fn dispute(env: Env, message_id: BytesN<32>) -> Result<Postage, Error> {
+        let key = DataKey::Postage(message_id.clone());
+        let mut postage: Postage = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PostageNotFound)?;
+
+        postage.recipient.require_auth();
+        if Self::is_terminal(postage.status) {
+            return Err(Error::AlreadyResolved);
+        }
+        if !matches!(
+            postage.status,
+            PostageStatus::Pending | PostageStatus::Expired
+        ) || postage.dispute_until == postage.expires_at
+        {
+            return Err(Error::DisputeUnavailable);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < postage.expires_at || now >= postage.dispute_until {
+            return Err(Error::DisputeUnavailable);
+        }
+
+        postage.status = PostageStatus::Disputed;
+        env.storage().persistent().set(&key, &postage);
+        Self::publish_event(&env, symbol_short!("dispute"), message_id, postage.clone());
+        Ok(postage)
+    }
+
+    pub fn reclaim(env: Env, message_id: BytesN<32>) -> Result<Postage, Error> {
+        let key = DataKey::Postage(message_id.clone());
+        let mut postage: Postage = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PostageNotFound)?;
+
+        postage.sender.require_auth();
+        if Self::is_terminal(postage.status) {
+            return Err(Error::AlreadyResolved);
+        }
+
+        let reclaimable_at = Self::reclaimable_at(&postage);
+        if env.ledger().timestamp() < reclaimable_at {
+            return Err(Error::NotExpired);
+        }
+
+        let config = Self::read_config(&env)?;
+        token::TokenClient::new(&env, &config.asset).transfer(
+            &env.current_contract_address(),
+            &MuxedAddress::from(postage.sender.clone()),
+            &postage.amount,
+        );
+
+        postage.status = PostageStatus::Reclaimed;
+        env.storage().persistent().set(&key, &postage);
+        Self::publish_event(&env, symbol_short!("reclaim"), message_id, postage.clone());
+        Ok(postage)
     }
 
     pub fn get(env: Env, message_id: BytesN<32>) -> Result<Postage, Error> {
@@ -165,7 +283,10 @@ impl PostageContract {
             .ok_or(Error::PostageNotFound)?;
 
         postage.recipient.require_auth();
-        if postage.status != PostageStatus::Pending {
+        if Self::is_terminal(postage.status) {
+            return Err(Error::AlreadyResolved);
+        }
+        if env.ledger().timestamp() >= Self::reclaimable_at(&postage) {
             return Err(Error::AlreadyResolved);
         }
 
@@ -193,13 +314,20 @@ impl PostageContract {
                     &postage.amount,
                 );
             }
-            PostageStatus::Pending => return Err(Error::AlreadyResolved),
+            PostageStatus::Pending
+            | PostageStatus::Expired
+            | PostageStatus::Disputed
+            | PostageStatus::Reclaimed => return Err(Error::AlreadyResolved),
         }
 
         postage.status = status;
         env.storage().persistent().set(&key, &postage);
-        env.events()
-            .publish((symbol_short!("resolved"), message_id), postage.clone());
+        Self::publish_event(
+            &env,
+            Self::status_symbol(status),
+            message_id,
+            postage.clone(),
+        );
         Ok(postage)
     }
 
@@ -208,6 +336,45 @@ impl PostageContract {
             .instance()
             .get(&DataKey::Config)
             .ok_or(Error::NotInitialized)
+    }
+
+    fn checked_deadline(timestamp: u64, seconds: u64) -> Result<u64, Error> {
+        timestamp.checked_add(seconds).ok_or(Error::InvalidWindow)
+    }
+
+    fn is_terminal(status: PostageStatus) -> bool {
+        matches!(
+            status,
+            PostageStatus::Settled | PostageStatus::Refunded | PostageStatus::Reclaimed
+        )
+    }
+
+    fn reclaimable_at(postage: &Postage) -> u64 {
+        if postage.dispute_until > postage.expires_at {
+            postage.dispute_until
+        } else {
+            postage.expires_at
+        }
+    }
+
+    fn publish_event(env: &Env, action: Symbol, message_id: BytesN<32>, postage: Postage) {
+        PostageEvent {
+            action,
+            message_id,
+            postage,
+        }
+        .publish(env);
+    }
+
+    fn status_symbol(status: PostageStatus) -> Symbol {
+        match status {
+            PostageStatus::Settled => symbol_short!("settle"),
+            PostageStatus::Refunded => symbol_short!("refund"),
+            PostageStatus::Reclaimed => symbol_short!("reclaim"),
+            PostageStatus::Expired => symbol_short!("expire"),
+            PostageStatus::Disputed => symbol_short!("dispute"),
+            PostageStatus::Pending => symbol_short!("pending"),
+        }
     }
 
     fn fee_for(amount: i128, fee_bps: u32) -> Result<i128, Error> {
@@ -223,10 +390,12 @@ impl PostageContract {
 
 #[cfg(test)]
 mod test {
+    extern crate std;
+
     use super::*;
     use soroban_sdk::{
-        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
-        IntoVal,
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events, Ledger},
+        Event, IntoVal,
     };
 
     fn id(env: &Env, byte: u8) -> BytesN<32> {
@@ -258,7 +427,7 @@ mod test {
         let treasury = Address::generate(&env);
 
         token_admin.mint(&sender, &1_000);
-        client.initialize(&asset, &treasury, &100, &fee_bps);
+        client.initialize(&asset, &treasury, &100, &fee_bps, &86_400, &3_600);
 
         Setup {
             env,
@@ -279,6 +448,8 @@ mod test {
         let postage = client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &200);
         assert_eq!(postage.status, PostageStatus::Pending);
         assert_eq!(postage.created_at, 42);
+        assert_eq!(postage.expires_at, 86_442);
+        assert_eq!(postage.dispute_until, 90_042);
         assert_eq!(postage.fee, 10);
         assert_eq!(token.balance(&setup.sender), 800);
         assert_eq!(token.balance(&setup.contract_id), 200);
@@ -336,6 +507,8 @@ mod test {
                 minimum: 100,
                 treasury: setup.treasury,
                 fee_bps: 125,
+                expiry_seconds: 86_400,
+                dispute_seconds: 3_600,
             }
         );
     }
@@ -348,7 +521,7 @@ mod test {
         let treasury = Address::generate(&env);
         let contract_id = env.register(PostageContract, ());
         let client = PostageContractClient::new(&env, &contract_id);
-        client.initialize(&asset, &treasury, &100, &0);
+        client.initialize(&asset, &treasury, &100, &0, &86_400, &0);
 
         assert_eq!(client.quote(&true), 0);
         assert_eq!(client.quote(&false), 100);
@@ -408,6 +581,248 @@ mod test {
                     sub_invocations: [].into(),
                 }
             )]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #9)")]
+    fn reclaim_fails_before_expiry() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(86_441);
+        client.reclaim(&id(&setup.env, 1));
+    }
+
+    #[test]
+    fn reclaim_succeeds_at_expiry_when_dispute_window_is_disabled() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(10);
+        let admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let asset = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &asset);
+        let contract_id = env.register(PostageContract, ());
+        let client = PostageContractClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let token = token::TokenClient::new(&env, &asset);
+
+        token_admin.mint(&sender, &1_000);
+        client.initialize(&asset, &treasury, &100, &0, &30, &0);
+        let postage = client.submit(&id(&env, 1), &sender, &recipient, &125);
+        assert_eq!(postage.expires_at, 40);
+        assert_eq!(postage.dispute_until, 40);
+
+        env.ledger().set_timestamp(40);
+        let reclaimed = client.reclaim(&id(&env, 1));
+
+        assert_eq!(reclaimed.status, PostageStatus::Reclaimed);
+        assert_eq!(token.balance(&sender), 1_000);
+        assert_eq!(token.balance(&contract_id), 0);
+    }
+
+    #[test]
+    fn expiry_state_is_fixed_and_callable_at_boundary() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        let postage = client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        assert_eq!(postage.expires_at, 86_442);
+
+        setup.env.ledger().set_timestamp(86_441);
+        assert_eq!(
+            client.try_expire(&id(&setup.env, 1)),
+            Err(Ok(Error::NotExpired))
+        );
+
+        setup.env.ledger().set_timestamp(86_442);
+        let expired = client.expire(&id(&setup.env, 1));
+        assert_eq!(expired.status, PostageStatus::Expired);
+        assert_eq!(expired.expires_at, 86_442);
+        assert_eq!(expired.dispute_until, 90_042);
+    }
+
+    #[test]
+    fn dispute_window_blocks_reclaim_until_boundary() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(86_442);
+        let disputed = client.dispute(&id(&setup.env, 1));
+        assert_eq!(disputed.status, PostageStatus::Disputed);
+
+        setup.env.ledger().set_timestamp(90_041);
+        assert_eq!(
+            client.try_reclaim(&id(&setup.env, 1)),
+            Err(Ok(Error::NotExpired))
+        );
+
+        setup.env.ledger().set_timestamp(90_042);
+        let reclaimed = client.reclaim(&id(&setup.env, 1));
+        assert_eq!(reclaimed.status, PostageStatus::Reclaimed);
+        assert_eq!(token.balance(&setup.sender), 1_000);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+    }
+
+    #[test]
+    fn expired_postage_can_be_disputed_or_reclaimed() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        client.submit(&id(&setup.env, 2), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(86_442);
+        client.expire(&id(&setup.env, 1));
+        let disputed = client.dispute(&id(&setup.env, 1));
+        assert_eq!(disputed.status, PostageStatus::Disputed);
+
+        setup.env.ledger().set_timestamp(90_042);
+        client.expire(&id(&setup.env, 2));
+        let reclaimed = client.reclaim(&id(&setup.env, 2));
+        assert_eq!(reclaimed.status, PostageStatus::Reclaimed);
+        assert_eq!(token.balance(&setup.contract_id), 125);
+    }
+
+    #[test]
+    fn expiry_and_reclaim_emit_typed_events() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let message_id = id(&setup.env, 1);
+
+        client.submit(&message_id, &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(90_042);
+
+        let expired = client.expire(&message_id);
+        assert_eq!(
+            setup
+                .env
+                .events()
+                .all()
+                .filter_by_contract(&setup.contract_id),
+            std::vec![PostageEvent {
+                action: symbol_short!("expire"),
+                message_id: message_id.clone(),
+                postage: expired,
+            }
+            .to_xdr(&setup.env, &setup.contract_id)]
+        );
+
+        let reclaimed = client.reclaim(&message_id);
+        assert_eq!(
+            setup
+                .env
+                .events()
+                .all()
+                .filter_by_contract(&setup.contract_id),
+            std::vec![PostageEvent {
+                action: symbol_short!("reclaim"),
+                message_id,
+                postage: reclaimed,
+            }
+            .to_xdr(&setup.env, &setup.contract_id)]
+        );
+    }
+
+    #[test]
+    fn dispute_fails_at_dispute_deadline() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(90_042);
+
+        assert_eq!(
+            client.try_dispute(&id(&setup.env, 1)),
+            Err(Ok(Error::DisputeUnavailable))
+        );
+    }
+
+    #[test]
+    fn disputed_postage_can_be_refunded_before_deadline() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+        let token = token::TokenClient::new(&setup.env, &setup.asset);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(86_442);
+        client.dispute(&id(&setup.env, 1));
+        setup.env.ledger().set_timestamp(90_041);
+        let refunded = client.refund(&id(&setup.env, 1));
+
+        assert_eq!(refunded.status, PostageStatus::Refunded);
+        assert_eq!(token.balance(&setup.sender), 1_000);
+        assert_eq!(token.balance(&setup.contract_id), 0);
+    }
+
+    #[test]
+    fn recipient_resolution_fails_at_reclaim_boundary() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        client.submit(&id(&setup.env, 2), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(90_041);
+        assert_eq!(
+            client.settle(&id(&setup.env, 1)).status,
+            PostageStatus::Settled
+        );
+
+        setup.env.ledger().set_timestamp(90_042);
+        assert_eq!(
+            client.try_refund(&id(&setup.env, 2)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+        assert_eq!(
+            client.try_settle(&id(&setup.env, 2)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+    }
+
+    #[test]
+    fn terminal_states_cannot_transition() {
+        let setup = setup(0);
+        let client = PostageContractClient::new(&setup.env, &setup.contract_id);
+
+        client.submit(&id(&setup.env, 1), &setup.sender, &setup.recipient, &125);
+        setup.env.ledger().set_timestamp(90_042);
+        client.reclaim(&id(&setup.env, 1));
+
+        assert_eq!(
+            client.try_settle(&id(&setup.env, 1)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+        assert_eq!(
+            client.try_refund(&id(&setup.env, 1)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+        assert_eq!(
+            client.try_dispute(&id(&setup.env, 1)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+        assert_eq!(
+            client.try_expire(&id(&setup.env, 1)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+
+        client.submit(&id(&setup.env, 2), &setup.sender, &setup.recipient, &125);
+        client.refund(&id(&setup.env, 2));
+        assert_eq!(
+            client.try_reclaim(&id(&setup.env, 2)),
+            Err(Ok(Error::AlreadyResolved))
+        );
+
+        client.submit(&id(&setup.env, 3), &setup.sender, &setup.recipient, &125);
+        client.settle(&id(&setup.env, 3));
+        assert_eq!(
+            client.try_dispute(&id(&setup.env, 3)),
+            Err(Ok(Error::AlreadyResolved))
         );
     }
 }


### PR DESCRIPTION
Closes #57 

# PR Description

This PR closes issue #57 by adding bounded lifecycle handling to the Soroban postage escrow contract. Pending postage now records fixed `expires_at` and `dispute_until` timestamps at submission, so the reclaim timeline cannot move after funds are escrowed.

The flow now supports explicit expiry, recipient dispute, sender reclaim, and terminal-state enforcement. Recipients can still settle or refund before the reclaim boundary. After the fixed boundary, the sender can reclaim unresolved escrow so funds do not remain inaccessible forever. The contract also emits typed postage events for submit, expire, settle, refund, dispute, and reclaim transitions.

This matters because unresolved postage should not trap escrow indefinitely. The new state machine gives both parties a bounded path while preserving the existing recipient settlement and refund flow.

# Changes Made

- Fixed #57 in `contracts/soroban/postage/src/lib.rs` by adding `expires_at`, `dispute_until`, `Expired`, `Disputed`, and `Reclaimed` lifecycle support.
- Fixed #57 in `contracts/soroban/postage/src/lib.rs` by adding `expire(message_id)`, `dispute(message_id)`, and `reclaim(message_id)` transitions.
- Fixed #57 in `contracts/soroban/postage/src/lib.rs` by blocking terminal-state transitions after settlement, refund, or reclaim.
- Fixed #57 in `contracts/soroban/postage/src/lib.rs` by publishing typed `PostageEvent` events for postage lifecycle transitions.
- Fixed #57 in `contracts/soroban/postage/src/lib.rs` by adding boundary tests for expiry, dispute, reclaim, recipient resolution, typed events, and terminal states.
- Updated `contracts/soroban/postage/README.md` with the new interface and settlement invariants.

# Testing

```bash
cd contracts/soroban
cargo fmt
cargo test -p stealth-postage
cargo test --workspace
```

Result: all tests passed. The workspace still reports existing deprecated raw event warnings in untouched `policies` and `receipts` contracts.