### PR TITLE
Add dataset validation results panel to demo admin dashboard

### DIFF
--- a/src/features/demo-admin-dashboard/ValidationResultsPanel.md
+++ b/src/features/demo-admin-dashboard/ValidationResultsPanel.md
@@ -1,0 +1,25 @@
+# ValidationResultsPanel
+
+Displays dataset validation errors and warnings with their field paths for the
+demo admin dashboard. All data is fake and deterministic; nothing here touches
+production mail flows.
+
+## Pieces
+
+- `validation-types.ts` — `ValidationIssue`, `ValidationSeverity`,
+  `ValidationNavigation`, and summary/group types.
+- `validation.ts` — helpers: `summarizeValidation`, `sortIssues`,
+  `groupBySeverity`, `getIssueNavigation`, `isDatasetValid`.
+- `validationFixtures.ts` — `demoValidationIssues` (and an empty variant).
+- `ValidationResultsPanel.tsx` — the panel UI.
+
+## Behavior
+
+- Issues are grouped by severity (errors, then warnings, then info); empty
+  groups are hidden.
+- A summary row shows counts per severity.
+- Each issue shows its message, field path, and an optional fix hint.
+- When `onSelectIssue` is provided, issues become clickable and report
+  `ValidationNavigation` metadata (datasetId, recordId, fieldPath) so a parent
+  can navigate to the source field.
+- With no issues, a friendly empty state is shown.

--- a/src/features/demo-admin-dashboard/ValidationResultsPanel.tsx
+++ b/src/features/demo-admin-dashboard/ValidationResultsPanel.tsx
@@ -1,0 +1,119 @@
+import { AlertCircle, AlertTriangle, CheckCircle2, Info } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  getIssueNavigation,
+  groupBySeverity,
+  SEVERITY_LABEL,
+  summarizeValidation,
+} from "./validation";
+import type { ValidationIssue, ValidationNavigation, ValidationSeverity } from "./validation-types";
+
+const SEVERITY_ICON: Record<ValidationSeverity, LucideIcon> = {
+  error: AlertCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const SEVERITY_STYLES: Record<ValidationSeverity, string> = {
+  error: "border-red-500/30 bg-red-500/10 text-red-300",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-300",
+  info: "border-sky-500/30 bg-sky-500/10 text-sky-300",
+};
+
+export type ValidationResultsPanelProps = {
+  issues: ValidationIssue[];
+  onSelectIssue?: (navigation: ValidationNavigation, issue: ValidationIssue) => void;
+  title?: string;
+  className?: string;
+};
+
+export function ValidationResultsPanel({
+  issues,
+  onSelectIssue,
+  title = "Validation results",
+  className,
+}: ValidationResultsPanelProps) {
+  const summary = summarizeValidation(issues);
+  const groups = groupBySeverity(issues);
+  const interactive = Boolean(onSelectIssue);
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border border-white/10 bg-white/[0.02] p-4",
+        className,
+      )}
+      aria-label={title}
+    >
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        <div className="flex items-center gap-1.5 text-[11px] font-medium">
+          <span className="rounded-full border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-red-300">
+            {summary.error} errors
+          </span>
+          <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-amber-300">
+            {summary.warning} warnings
+          </span>
+          <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-0.5 text-sky-300">
+            {summary.info} info
+          </span>
+        </div>
+      </header>
+
+      {groups.length === 0 ? (
+        <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-4 text-sm text-emerald-300">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span>No validation issues found. This dataset looks good.</span>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map((group) => {
+            const Icon = SEVERITY_ICON[group.severity];
+            return (
+              <div key={group.severity} className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <Icon className="h-3.5 w-3.5" />
+                  <span>
+                    {SEVERITY_LABEL[group.severity]} ({group.issues.length})
+                  </span>
+                </div>
+                <ul className="flex flex-col gap-1.5">
+                  {group.issues.map((issue) => (
+                    <li key={issue.id}>
+                      <button
+                        type="button"
+                        disabled={!interactive}
+                        onClick={
+                          interactive
+                            ? () => onSelectIssue?.(getIssueNavigation(issue), issue)
+                            : undefined
+                        }
+                        className={cn(
+                          "w-full rounded-md border px-3 py-2 text-left transition-colors",
+                          SEVERITY_STYLES[issue.severity],
+                          interactive ? "cursor-pointer hover:brightness-110" : "cursor-default",
+                        )}
+                      >
+                        <span className="block text-[13px] font-medium text-foreground">
+                          {issue.message}
+                        </span>
+                        <code className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                          {issue.fieldPath}
+                        </code>
+                        {issue.hint ? (
+                          <p className="mt-1 text-[11px] text-muted-foreground/80">{issue.hint}</p>
+                        ) : null}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -39,3 +39,8 @@ export {
   type MessageTemplate,
   type TemplateCategory,
 } from "./templates";
+export * from "./validation-types";
+export * from "./validation";
+export * from "./validationFixtures";
+export { ValidationResultsPanel } from "./ValidationResultsPanel";
+export type { ValidationResultsPanelProps } from "./ValidationResultsPanel";

--- a/src/features/demo-admin-dashboard/validation-types.ts
+++ b/src/features/demo-admin-dashboard/validation-types.ts
@@ -1,0 +1,34 @@
+export type ValidationSeverity = "error" | "warning" | "info";
+
+export type ValidationIssue = {
+  id: string;
+  severity: ValidationSeverity;
+  /** Dot/bracket path to the offending field, e.g. "records[3].email". */
+  fieldPath: string;
+  message: string;
+  /** Identifier of the dataset the issue belongs to. */
+  datasetId: string;
+  /** Optional record identifier within the dataset. */
+  recordId?: string;
+  /** Optional short, non-technical hint on how to fix it. */
+  hint?: string;
+};
+
+/** Metadata used to navigate from an issue to its source field. */
+export type ValidationNavigation = {
+  datasetId: string;
+  recordId?: string;
+  fieldPath: string;
+};
+
+export type ValidationSeveritySummary = {
+  error: number;
+  warning: number;
+  info: number;
+  total: number;
+};
+
+export type ValidationGroup = {
+  severity: ValidationSeverity;
+  issues: ValidationIssue[];
+};

--- a/src/features/demo-admin-dashboard/validation.test.ts
+++ b/src/features/demo-admin-dashboard/validation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getIssueNavigation,
+  groupBySeverity,
+  isDatasetValid,
+  sortIssues,
+  summarizeValidation,
+} from "./validation";
+import type { ValidationIssue } from "./validation-types";
+
+const issues: ValidationIssue[] = [
+  {
+    id: "1",
+    severity: "warning",
+    fieldPath: "records[1].labels",
+    message: "w1",
+    datasetId: "d",
+    recordId: "r1",
+  },
+  {
+    id: "2",
+    severity: "error",
+    fieldPath: "records[0].email",
+    message: "e1",
+    datasetId: "d",
+    recordId: "r0",
+  },
+  {
+    id: "3",
+    severity: "info",
+    fieldPath: "meta.generatedAt",
+    message: "i1",
+    datasetId: "d",
+  },
+  {
+    id: "4",
+    severity: "error",
+    fieldPath: "records[2].postageAmount",
+    message: "e2",
+    datasetId: "d",
+    recordId: "r2",
+  },
+];
+
+describe("summarizeValidation", () => {
+  it("counts issues by severity", () => {
+    const summary = summarizeValidation(issues);
+    expect(summary.error).toBe(2);
+    expect(summary.warning).toBe(1);
+    expect(summary.info).toBe(1);
+    expect(summary.total).toBe(4);
+  });
+
+  it("returns zeroes for an empty list", () => {
+    expect(summarizeValidation([])).toEqual({
+      error: 0,
+      warning: 0,
+      info: 0,
+      total: 0,
+    });
+  });
+});
+
+describe("sortIssues", () => {
+  it("orders errors first, then by field path", () => {
+    expect(sortIssues(issues).map((issue) => issue.id)).toEqual(["2", "4", "1", "3"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const copy = [...issues];
+    sortIssues(issues);
+    expect(issues).toEqual(copy);
+  });
+});
+
+describe("groupBySeverity", () => {
+  it("groups in severity order and omits empty groups", () => {
+    const groups = groupBySeverity(issues);
+    expect(groups.map((group) => group.severity)).toEqual(["error", "warning", "info"]);
+    expect(groups[0].issues).toHaveLength(2);
+  });
+
+  it("omits a severity with no issues", () => {
+    const groups = groupBySeverity(issues.filter((issue) => issue.severity === "warning"));
+    expect(groups).toHaveLength(1);
+    expect(groups[0].severity).toBe("warning");
+  });
+});
+
+describe("getIssueNavigation", () => {
+  it("extracts dataset, record, and field path", () => {
+    expect(getIssueNavigation(issues[1])).toEqual({
+      datasetId: "d",
+      recordId: "r0",
+      fieldPath: "records[0].email",
+    });
+  });
+});
+
+describe("isDatasetValid", () => {
+  it("is false when errors exist", () => {
+    expect(isDatasetValid(issues)).toBe(false);
+  });
+
+  it("is true with only warnings and info", () => {
+    expect(isDatasetValid(issues.filter((issue) => issue.severity !== "error"))).toBe(true);
+  });
+});

--- a/src/features/demo-admin-dashboard/validation.ts
+++ b/src/features/demo-admin-dashboard/validation.ts
@@ -1,0 +1,68 @@
+import type {
+  ValidationGroup,
+  ValidationIssue,
+  ValidationNavigation,
+  ValidationSeverity,
+  ValidationSeveritySummary,
+} from "./validation-types";
+
+/** Display order for severities (errors first). */
+export const SEVERITY_ORDER: ValidationSeverity[] = ["error", "warning", "info"];
+
+const SEVERITY_RANK: Record<ValidationSeverity, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+export const SEVERITY_LABEL: Record<ValidationSeverity, string> = {
+  error: "Errors",
+  warning: "Warnings",
+  info: "Info",
+};
+
+/** Count issues per severity (plus total). */
+export function summarizeValidation(issues: ValidationIssue[]): ValidationSeveritySummary {
+  const summary: ValidationSeveritySummary = {
+    error: 0,
+    warning: 0,
+    info: 0,
+    total: 0,
+  };
+  for (const issue of issues) {
+    summary[issue.severity] += 1;
+    summary.total += 1;
+  }
+  return summary;
+}
+
+/** Sort by severity (errors first), then field path for stable ordering. */
+export function sortIssues(issues: ValidationIssue[]): ValidationIssue[] {
+  return [...issues].sort((a, b) => {
+    const bySeverity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (bySeverity !== 0) return bySeverity;
+    return a.fieldPath.localeCompare(b.fieldPath);
+  });
+}
+
+/** Group issues by severity in display order; empty groups are omitted. */
+export function groupBySeverity(issues: ValidationIssue[]): ValidationGroup[] {
+  return SEVERITY_ORDER.map((severity) => ({
+    severity,
+    issues: sortIssues(issues.filter((issue) => issue.severity === severity)),
+  })).filter((group) => group.issues.length > 0);
+}
+
+/** Extract the navigation metadata needed to jump to an issue's field. */
+export function getIssueNavigation(issue: ValidationIssue): ValidationNavigation {
+  return {
+    datasetId: issue.datasetId,
+    recordId: issue.recordId,
+    fieldPath: issue.fieldPath,
+  };
+}
+
+/** True when there are no blocking errors (warnings/info are allowed). */
+export function isDatasetValid(issues: ValidationIssue[]): boolean {
+  return issues.every((issue) => issue.severity !== "error");
+}

--- a/src/features/demo-admin-dashboard/validationFixtures.ts
+++ b/src/features/demo-admin-dashboard/validationFixtures.ts
@@ -1,0 +1,54 @@
+import type { ValidationIssue } from "./validation-types";
+
+/**
+ * Deterministic, fake validation issues for the demo admin dashboard.
+ * Safe for public review: no real user data, secrets, or network calls.
+ */
+export const demoValidationIssues: ValidationIssue[] = [
+  {
+    id: "v-001",
+    severity: "error",
+    fieldPath: "records[0].email",
+    message: "Email address is missing the domain.",
+    datasetId: "demo-contacts",
+    recordId: "rec-0",
+    hint: "Use a full address like name@example.com.",
+  },
+  {
+    id: "v-002",
+    severity: "error",
+    fieldPath: "records[2].postageAmount",
+    message: "Postage amount must be a positive number.",
+    datasetId: "demo-contacts",
+    recordId: "rec-2",
+    hint: "Enter an amount greater than 0.",
+  },
+  {
+    id: "v-003",
+    severity: "warning",
+    fieldPath: "records[1].labels",
+    message: "Unknown label will be ignored on import.",
+    datasetId: "demo-contacts",
+    recordId: "rec-1",
+    hint: "Pick a label from the existing set.",
+  },
+  {
+    id: "v-004",
+    severity: "warning",
+    fieldPath: "records[4].avatarColor",
+    message: "Avatar color is not a recognized token.",
+    datasetId: "demo-contacts",
+    recordId: "rec-4",
+  },
+  {
+    id: "v-005",
+    severity: "info",
+    fieldPath: "meta.generatedAt",
+    message: "Dataset was generated more than 7 days ago.",
+    datasetId: "demo-contacts",
+    hint: "Regenerate to refresh the preview.",
+  },
+];
+
+/** A clean dataset (no issues) for demoing the empty state. */
+export const demoValidationIssuesEmpty: ValidationIssue[] = [];


### PR DESCRIPTION
Closes #220

## Summary
Adds a `ValidationResultsPanel` to the demo admin dashboard that surfaces dataset validation errors and warnings, each with its field path, so demo data issues are easy to scan and fix.

All work is contained within `src/features/demo-admin-dashboard/`. No files outside that folder are touched.

## What's included
- **Component:** `ValidationResultsPanel.tsx` — groups issues by severity (errors → warnings → info), shows per-severity counts, field paths, and optional fix hints, with a clean empty state when there are no issues.
- **Types:** `validation-types.ts` — `ValidationIssue`, `ValidationSeverity`, and `ValidationNavigation` (datasetId / recordId / fieldPath) for jumping to a source field.
- **Helpers:** `validation.ts` — `summarizeValidation`, `sortIssues`, `groupBySeverity`, `getIssueNavigation`, `isDatasetValid`.
- **Demo data:** `validationFixtures.ts` — deterministic, fake sample issues (no real data, secrets, or network calls).
- **Docs:** `ValidationResultsPanel.md`.
- **Tests:** `validation.test.ts` — covers counts, sorting, grouping, navigation metadata, and validity checks.

## Navigation metadata
Passing `onSelectIssue` makes each issue clickable and reports `{ datasetId, recordId, fieldPath }` so a parent view can navigate to the offending field.

## Testing
- `npx vitest run src/features/demo-admin-dashboard/validation.test.ts` — all passing
- Type-check clean for the new files

