### PR TITLE
fix(receipts): fix #58 by binding receipts to payload commitments

### DIFF
--- a/contracts/soroban/receipts/README.md
+++ b/contracts/soroban/receipts/README.md
@@ -1,12 +1,16 @@
 # Receipts Contract
 
-Creates authenticated delivery and read-receipt state for a message hash.
+Creates authenticated delivery and read-receipt state for an encrypted payload
+commitment.
 
-The sender authorizes the delivery record. Only the recipient can add the
-read timestamp. Both transitions emit events for relays and clients.
+The sender authorizes the delivery record, which binds the message ID, payload
+hash, protocol version, sender, recipient, and delivery timestamp. The payload
+commitment is immutable: duplicate message IDs cannot overwrite existing state,
+and a duplicate ID with a different commitment fails. Only the recipient can add
+the read timestamp. Both transitions emit events for relays and clients.
 
 ## Interface
 
-- `delivered(message_id, sender, recipient)` creates a delivery receipt.
+- `delivered(message_id, payload_hash, protocol_version, sender, recipient)` creates a delivery receipt.
 - `read(message_id)` adds the recipient-authorized read timestamp.
 - `get(message_id)` reads the receipt.

--- a/contracts/soroban/receipts/src/lib.rs
+++ b/contracts/soroban/receipts/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    contract, contracterror, contractevent, contractimpl, contracttype, symbol_short, Address,
+    BytesN, Env,
 };
 
 #[contract]
@@ -10,10 +11,27 @@ pub struct ReceiptsContract;
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Receipt {
+    pub message_id: BytesN<32>,
+    pub payload_hash: BytesN<32>,
+    pub protocol_version: u32,
     pub sender: Address,
     pub recipient: Address,
     pub delivered_at: u64,
     pub read_at: Option<u64>,
+}
+
+#[contractevent(data_format = "single-value")]
+pub struct Delivered {
+    #[topic]
+    pub message_id: BytesN<32>,
+    pub receipt: Receipt,
+}
+
+#[contractevent(data_format = "single-value")]
+pub struct Read {
+    #[topic]
+    pub message_id: BytesN<32>,
+    pub receipt: Receipt,
 }
 
 #[contracttype]
@@ -28,6 +46,7 @@ pub enum Error {
     DuplicateReceipt = 1,
     ReceiptNotFound = 2,
     AlreadyRead = 3,
+    CommitmentMismatch = 4,
 }
 
 #[contractimpl]
@@ -35,24 +54,39 @@ impl ReceiptsContract {
     pub fn delivered(
         env: Env,
         message_id: BytesN<32>,
+        payload_hash: BytesN<32>,
+        protocol_version: u32,
         sender: Address,
         recipient: Address,
     ) -> Result<Receipt, Error> {
         sender.require_auth();
         let key = DataKey::Receipt(message_id.clone());
-        if env.storage().persistent().has(&key) {
+        if let Some(existing) = env.storage().persistent().get::<DataKey, Receipt>(&key) {
+            if existing.payload_hash != payload_hash
+                || existing.protocol_version != protocol_version
+                || existing.sender != sender
+                || existing.recipient != recipient
+            {
+                return Err(Error::CommitmentMismatch);
+            }
             return Err(Error::DuplicateReceipt);
         }
 
         let receipt = Receipt {
+            message_id: message_id.clone(),
+            payload_hash,
+            protocol_version,
             sender,
             recipient,
             delivered_at: env.ledger().timestamp(),
             read_at: None,
         };
         env.storage().persistent().set(&key, &receipt);
-        env.events()
-            .publish((symbol_short!("delivered"), message_id), receipt.clone());
+        Delivered {
+            message_id,
+            receipt: receipt.clone(),
+        }
+        .publish(&env);
         Ok(receipt)
     }
 
@@ -71,8 +105,11 @@ impl ReceiptsContract {
 
         receipt.read_at = Some(env.ledger().timestamp());
         env.storage().persistent().set(&key, &receipt);
-        env.events()
-            .publish((symbol_short!("read"), message_id), receipt.clone());
+        Read {
+            message_id,
+            receipt: receipt.clone(),
+        }
+        .publish(&env);
         Ok(receipt)
     }
 
@@ -87,7 +124,80 @@ impl ReceiptsContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
+        IntoVal,
+    };
+
+    fn hash(env: &Env, byte: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[byte; 32])
+    }
+
+    #[test]
+    fn delivery_receipt_commits_payload_and_protocol() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ReceiptsContract, ());
+        let client = ReceiptsContractClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let message_id = hash(&env, 7);
+        let payload_hash = hash(&env, 8);
+
+        env.ledger().set_timestamp(10);
+        let delivered = client.delivered(&message_id, &payload_hash, &1, &sender, &recipient);
+        assert_eq!(delivered.message_id, message_id);
+        assert_eq!(delivered.payload_hash, payload_hash);
+        assert_eq!(delivered.protocol_version, 1);
+        assert_eq!(delivered.sender, sender);
+        assert_eq!(delivered.recipient, recipient);
+        assert_eq!(delivered.delivered_at, 10);
+        assert_eq!(delivered.read_at, None);
+
+        let fetched = client.get(&message_id);
+        assert_eq!(fetched, delivered);
+    }
+
+    #[test]
+    fn duplicate_id_with_different_payload_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ReceiptsContract, ());
+        let client = ReceiptsContractClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let message_id = hash(&env, 7);
+
+        client.delivered(&message_id, &hash(&env, 8), &1, &sender, &recipient);
+        assert_eq!(
+            client
+                .try_delivered(&message_id, &hash(&env, 9), &1, &sender, &recipient)
+                .unwrap_err()
+                .unwrap(),
+            Error::CommitmentMismatch
+        );
+    }
+
+    #[test]
+    fn duplicate_id_with_same_commitment_still_cannot_overwrite() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ReceiptsContract, ());
+        let client = ReceiptsContractClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let message_id = hash(&env, 7);
+        let payload_hash = hash(&env, 8);
+
+        client.delivered(&message_id, &payload_hash, &1, &sender, &recipient);
+        assert_eq!(
+            client
+                .try_delivered(&message_id, &payload_hash, &1, &sender, &recipient)
+                .unwrap_err()
+                .unwrap(),
+            Error::DuplicateReceipt
+        );
+    }
 
     #[test]
     fn recipient_can_publish_read_receipt() {
@@ -97,15 +207,66 @@ mod test {
         let client = ReceiptsContractClient::new(&env, &contract_id);
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
-        let message_id = BytesN::from_array(&env, &[7; 32]);
+        let message_id = hash(&env, 7);
+        let payload_hash = hash(&env, 8);
 
         env.ledger().set_timestamp(10);
-        let delivered = client.delivered(&message_id, &sender, &recipient);
-        assert_eq!(delivered.delivered_at, 10);
-        assert_eq!(delivered.read_at, None);
+        client.delivered(&message_id, &payload_hash, &1, &sender, &recipient);
 
         env.ledger().set_timestamp(20);
         let read = client.read(&message_id);
+        assert_eq!(read.payload_hash, payload_hash);
         assert_eq!(read.read_at, Some(20));
+    }
+
+    #[test]
+    fn authorization_tree_binds_delivery_to_sender_and_read_to_recipient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ReceiptsContract, ());
+        let client = ReceiptsContractClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let message_id = hash(&env, 7);
+        let payload_hash = hash(&env, 8);
+
+        client.delivered(&message_id, &payload_hash, &1, &sender, &recipient);
+        assert_eq!(
+            env.auths(),
+            [(
+                sender.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        contract_id.clone(),
+                        symbol_short!("delivered"),
+                        (
+                            message_id.clone(),
+                            payload_hash.clone(),
+                            1_u32,
+                            sender.clone(),
+                            recipient.clone(),
+                        )
+                            .into_val(&env),
+                    )),
+                    sub_invocations: [].into(),
+                }
+            )]
+        );
+
+        client.read(&message_id);
+        assert_eq!(
+            env.auths(),
+            [(
+                recipient.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        contract_id,
+                        symbol_short!("read"),
+                        (message_id,).into_val(&env),
+                    )),
+                    sub_invocations: [].into(),
+                }
+            )]
+        );
     }
 }


### PR DESCRIPTION
Closes #58 

# PR Description

This PR fixes issue #58 by binding delivery receipts to encrypted payload commitments in the Soroban receipts contract.

Before this change, a receipt was keyed by `message_id` and stored sender, recipient, delivery time, and optional read time. That proved a message ID had a receipt, but it did not prove which encrypted payload the receipt referred to.

The delivery flow now records the message ID, payload hash, protocol version, sender, recipient, delivery timestamp, and optional read timestamp in the receipt state. The sender authorizes the delivery record with those commitment fields as part of the contract call. Once a receipt exists for a message ID, the contract rejects any attempt to reuse that ID with a different payload hash, protocol version, sender, or recipient. Reusing the same commitment also fails, so receipt state cannot be overwritten.

The read flow remains recipient-controlled. `read(message_id)` loads the existing receipt, requires authorization from the stored recipient, and only adds `read_at`; it does not change the payload commitment. A third party can call `get(message_id)` to verify receipt consistency against the known payload hash without seeing message content.

# Changes Made

- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by adding `message_id`, `payload_hash`, and `protocol_version` to `Receipt`.
- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by changing `delivered` to accept and persist the payload commitment fields.
- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by rejecting duplicate IDs with changed commitments using `CommitmentMismatch`.
- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by preserving recipient-only control over `read_at`.
- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by adding typed receipt events for delivery and read transitions.
- Fixed #58 in `contracts/soroban/receipts/src/lib.rs` by adding tests for commitment persistence, duplicate handling, sender delivery auth, and recipient read auth.
- Updated `contracts/soroban/receipts/README.md` to document the new receipt interface and immutability behavior.