### PR TITLE
test: add scenario registry with registration, merge, and conflict tests

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/scenarioRegistry.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/scenarioRegistry.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  ScenarioConflictError,
+  ScenarioRegistry,
+  createScenarioRegistry,
+  type RegistrableScenario,
+} from "../scenarioRegistry";
+
+const scenario = (id: string, name = id): RegistrableScenario => ({
+  id,
+  name,
+  description: `Demo scenario ${name}`,
+});
+
+describe("ScenarioRegistry", () => {
+  describe("registration", () => {
+    it("registers scenarios and keeps insertion order", () => {
+      const registry = new ScenarioRegistry();
+      registry.register(scenario("relay-verification"));
+      registry.register(scenario("proof-pending"));
+
+      expect(registry.size).toBe(2);
+      expect(registry.ids()).toEqual(["relay-verification", "proof-pending"]);
+    });
+
+    it("throws on a duplicate id and stays unchanged", () => {
+      const registry = new ScenarioRegistry([scenario("relay-verification")]);
+
+      expect(() => registry.register(scenario("relay-verification"))).toThrow(
+        ScenarioConflictError,
+      );
+      expect(registry.size).toBe(1);
+    });
+
+    it("registers many at once and rejects internal duplicates", () => {
+      const registry = createScenarioRegistry();
+
+      registry.registerAll([scenario("a"), scenario("b")]);
+      expect(registry.ids()).toEqual(["a", "b"]);
+
+      expect(() =>
+        registry.registerAll([scenario("c"), scenario("c")]),
+      ).toThrow(ScenarioConflictError);
+      expect(registry.has("c")).toBe(false);
+    });
+  });
+
+  describe("loading", () => {
+    it("loads a scenario by id", () => {
+      const relay = scenario("relay-verification", "Relay Verification");
+      const registry = new ScenarioRegistry([relay]);
+
+      expect(registry.get("relay-verification")).toBe(relay);
+      expect(registry.has("relay-verification")).toBe(true);
+    });
+
+    it("returns undefined for an unknown id", () => {
+      const registry = new ScenarioRegistry();
+
+      expect(registry.get("missing")).toBeUndefined();
+      expect(registry.has("missing")).toBe(false);
+    });
+  });
+
+  describe("conflict detection", () => {
+    it("detects ids that clash with existing scenarios", () => {
+      const registry = new ScenarioRegistry([scenario("a"), scenario("b")]);
+
+      expect(registry.detectConflicts([scenario("b"), scenario("c")])).toEqual([
+        "b",
+      ]);
+    });
+
+    it("detects duplicates within the incoming batch", () => {
+      const registry = new ScenarioRegistry();
+
+      expect(
+        registry.detectConflicts([scenario("x"), scenario("x"), scenario("y")]),
+      ).toEqual(["x"]);
+    });
+
+    it("returns an empty array when there are no conflicts", () => {
+      const registry = new ScenarioRegistry([scenario("a")]);
+
+      expect(registry.detectConflicts([scenario("b"), scenario("c")])).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("merging", () => {
+    it("merges non-conflicting scenarios", () => {
+      const registry = new ScenarioRegistry([scenario("a")]);
+
+      const conflicts = registry.merge([scenario("b"), scenario("c")]);
+
+      expect(conflicts).toEqual([]);
+      expect(registry.ids()).toEqual(["a", "b", "c"]);
+    });
+
+    it("throws on conflict by default and changes nothing", () => {
+      const registry = new ScenarioRegistry([scenario("a", "Original")]);
+
+      expect(() => registry.merge([scenario("a", "Replacement")])).toThrow(
+        ScenarioConflictError,
+      );
+      expect(registry.get("a")?.name).toBe("Original");
+    });
+
+    it("keeps existing entries with the 'skip' strategy", () => {
+      const registry = new ScenarioRegistry([scenario("a", "Original")]);
+
+      const conflicts = registry.merge(
+        [scenario("a", "Replacement"), scenario("b", "New")],
+        "skip",
+      );
+
+      expect(conflicts).toEqual(["a"]);
+      expect(registry.get("a")?.name).toBe("Original");
+      expect(registry.get("b")?.name).toBe("New");
+    });
+
+    it("replaces entries with the 'overwrite' strategy", () => {
+      const registry = new ScenarioRegistry([scenario("a", "Original")]);
+
+      const conflicts = registry.merge(
+        [scenario("a", "Replacement")],
+        "overwrite",
+      );
+
+      expect(conflicts).toEqual(["a"]);
+      expect(registry.get("a")?.name).toBe("Replacement");
+      expect(registry.size).toBe(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("removes all scenarios", () => {
+      const registry = new ScenarioRegistry([scenario("a"), scenario("b")]);
+
+      registry.clear();
+
+      expect(registry.size).toBe(0);
+      expect(registry.list()).toEqual([]);
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/scenarioRegistry.ts
+++ b/src/features/demo-admin-dashboard/scenarioRegistry.ts
@@ -1,0 +1,165 @@
+/**
+ * Scenario registry for the demo admin dashboard.
+ *
+ * A small, dependency-free registry used to register, load, and merge demo
+ * "scenarios" while detecting duplicate-id conflicts.
+ *
+ * All data is fake, deterministic, and safe for public repository review.
+ * No real user data, secrets, private keys, or live network calls are used.
+ */
+
+/** Minimal shape a registrable scenario must satisfy. */
+export interface RegistrableScenario {
+  /** Unique identifier for the scenario. */
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /** Optional longer description. */
+  description?: string;
+}
+
+/** How {@link ScenarioRegistry.merge} resolves duplicate ids. */
+export type MergeStrategy = "error" | "skip" | "overwrite";
+
+/** Raised when a scenario is registered with an id that already exists. */
+export class ScenarioConflictError extends Error {
+  constructor(public readonly id: string) {
+    super(`Scenario with id "${id}" is already registered`);
+    this.name = "ScenarioConflictError";
+  }
+}
+
+/**
+ * In-memory registry of demo scenarios keyed by their unique id.
+ *
+ * Insertion order is preserved so that {@link ScenarioRegistry.list} output is
+ * deterministic.
+ */
+export class ScenarioRegistry<
+  T extends RegistrableScenario = RegistrableScenario,
+> {
+  private readonly scenarios = new Map<string, T>();
+
+  constructor(initial: readonly T[] = []) {
+    this.registerAll(initial);
+  }
+
+  /** Number of registered scenarios. */
+  get size(): number {
+    return this.scenarios.size;
+  }
+
+  /** Returns true when a scenario with the given id is registered. */
+  has(id: string): boolean {
+    return this.scenarios.has(id);
+  }
+
+  /** Loads a scenario by id, or undefined when it is not registered. */
+  get(id: string): T | undefined {
+    return this.scenarios.get(id);
+  }
+
+  /** Returns all scenarios in registration order. */
+  list(): T[] {
+    return [...this.scenarios.values()];
+  }
+
+  /** Returns all registered ids in registration order. */
+  ids(): string[] {
+    return [...this.scenarios.keys()];
+  }
+
+  /**
+   * Registers a single scenario.
+   *
+   * @throws {ScenarioConflictError} when the id is already registered.
+   */
+  register(scenario: T): this {
+    if (this.scenarios.has(scenario.id)) {
+      throw new ScenarioConflictError(scenario.id);
+    }
+    this.scenarios.set(scenario.id, scenario);
+    return this;
+  }
+
+  /**
+   * Registers many scenarios. Conflicts within the input or against existing
+   * entries throw before anything is added, leaving the registry unchanged.
+   */
+  registerAll(scenarios: readonly T[]): this {
+    const conflicts = this.detectConflicts(scenarios);
+    if (conflicts.length > 0) {
+      throw new ScenarioConflictError(conflicts[0]);
+    }
+    for (const scenario of scenarios) {
+      this.scenarios.set(scenario.id, scenario);
+    }
+    return this;
+  }
+
+  /**
+   * Returns the ids in `scenarios` that conflict either with each other or
+   * with already-registered scenarios. The result is de-duplicated and in
+   * order of first appearance.
+   */
+  detectConflicts(scenarios: readonly T[]): string[] {
+    const seen = new Set<string>();
+    const conflicts: string[] = [];
+    for (const scenario of scenarios) {
+      const duplicate =
+        seen.has(scenario.id) || this.scenarios.has(scenario.id);
+      if (duplicate && !conflicts.includes(scenario.id)) {
+        conflicts.push(scenario.id);
+      }
+      seen.add(scenario.id);
+    }
+    return conflicts;
+  }
+
+  /**
+   * Merges scenarios into this registry using the given strategy:
+   * - "error": throw on the first conflicting id, changing nothing (default)
+   * - "skip": keep the existing scenario, ignore the incoming one
+   * - "overwrite": replace the existing scenario with the incoming one
+   *
+   * Returns the ids that conflicted (useful for "skip"/"overwrite").
+   */
+  merge(scenarios: readonly T[], strategy: MergeStrategy = "error"): string[] {
+    if (strategy === "error") {
+      const conflicts = this.detectConflicts(scenarios);
+      if (conflicts.length > 0) {
+        throw new ScenarioConflictError(conflicts[0]);
+      }
+      for (const scenario of scenarios) {
+        this.scenarios.set(scenario.id, scenario);
+      }
+      return [];
+    }
+
+    const conflicts: string[] = [];
+    for (const scenario of scenarios) {
+      if (this.scenarios.has(scenario.id)) {
+        if (!conflicts.includes(scenario.id)) {
+          conflicts.push(scenario.id);
+        }
+        if (strategy === "skip") {
+          continue;
+        }
+      }
+      this.scenarios.set(scenario.id, scenario);
+    }
+    return conflicts;
+  }
+
+  /** Removes all registered scenarios. */
+  clear(): void {
+    this.scenarios.clear();
+  }
+}
+
+/** Convenience factory mirroring the class constructor. */
+export function createScenarioRegistry<
+  T extends RegistrableScenario = RegistrableScenario,
+>(initial: readonly T[] = []): ScenarioRegistry<T> {
+  return new ScenarioRegistry<T>(initial);
+}


### PR DESCRIPTION
Adds a small, dependency-free ScenarioRegistry for the demo admin dashboard that supports registering, loading, and merging demo scenarios while detecting duplicate-id conflicts. Includes unit tests covering registration, unique-id enforcement, loading, conflict detection, and the error/skip/overwrite merge strategies.

Closes #231