### PR TITLE
Add response time tracker core engine

### DIFF
--- a/tools/v2/team/response-time-tracker/README.md
+++ b/tools/v2/team/response-time-tracker/README.md
@@ -2,14 +2,32 @@
 
 This folder is the isolated workspace for the Response Time Tracker tool.
 
+The current core engine is a pure TypeScript service that converts supplied
+message events into response-time metrics. It does not fetch live mail, call
+production APIs, read secrets, or wire itself into the main app.
+
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-``text
+```text
 .\tools\v2\team\response-time-tracker\
-``
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder-Local API
+
+- `services/responseTimeTracker.ts` exposes `summarizeResponseTimes`,
+  `safeSummarizeResponseTimes`, and loading/error state helpers.
+- `tests/responseTimeTracker.test.ts` covers deterministic fixture behavior.
+- `docs/api.md` documents inputs, outputs, loading states, error states, and the
+  no-network boundary.
+
+## Verification
+
+```bash
+npx vitest run tools/v2/team/response-time-tracker/tests/responseTimeTracker.test.ts
+```
+
+See `specs.md` for the issue categories and contributor expectations.

--- a/tools/v2/team/response-time-tracker/docs/api.md
+++ b/tools/v2/team/response-time-tracker/docs/api.md
@@ -1,0 +1,41 @@
+# Response Time Tracker API
+
+## Purpose
+
+The core engine turns folder-local message events into response-time metrics for a future UI surface. It is pure TypeScript and does not fetch email, call production APIs, read secrets, or mutate app state.
+
+## Input
+
+Use `summarizeResponseTimes(events, options)` with an array of `ResponseTimeEvent` objects:
+
+```ts
+{
+  id: "in-1",
+  conversationId: "thread-a",
+  direction: "inbound",
+  sentAt: "2026-06-17T08:00:00.000Z",
+  customerId: "customer-a",
+  subject: "Invoice question"
+}
+```
+
+`direction` must be `inbound` or `outbound`. `sentAt` must be an ISO-compatible timestamp. `options.slaMinutes` defaults to `120`.
+
+## Output
+
+The ready state contains:
+
+- `totals`: aggregate conversation count, response count, pending count, median/average/longest response time, and SLA breach count.
+- `conversations`: per-conversation summaries with paired responses and pending inbound messages.
+- `slaMinutes`: the threshold used for `withinSla` calculations.
+
+## States
+
+- `createResponseTimeLoadingState()` returns `{ status: "loading" }` for a future UI to show a local loading state.
+- `summarizeResponseTimes()` throws on malformed input.
+- `safeSummarizeResponseTimes()` wraps failures as `{ status: "error" }` with details.
+- Successful summaries return `{ status: "ready" }`.
+
+## Boundary
+
+All behavior lives under `tools/v2/team/response-time-tracker/`. This folder-local API is intentionally not mounted into routing, inbox storage, wallet logic, Stellar integration, authentication, or the shared design system.

--- a/tools/v2/team/response-time-tracker/services/responseTimeTracker.ts
+++ b/tools/v2/team/response-time-tracker/services/responseTimeTracker.ts
@@ -1,0 +1,338 @@
+export type ResponseDirection = "inbound" | "outbound";
+
+export interface ResponseTimeEvent {
+  id: string;
+  conversationId: string;
+  direction: ResponseDirection;
+  sentAt: string;
+  actorId?: string;
+  actorName?: string;
+  customerId?: string;
+  subject?: string;
+}
+
+export interface ResponseTimeTrackerOptions {
+  now?: string;
+  slaMinutes?: number;
+}
+
+export interface ResponsePair {
+  conversationId: string;
+  inboundEventId: string;
+  responseEventId: string;
+  inboundAt: string;
+  responseAt: string;
+  responseMinutes: number;
+  withinSla: boolean;
+  responderId?: string;
+  responderName?: string;
+}
+
+export interface PendingInbound {
+  conversationId: string;
+  inboundEventId: string;
+  inboundAt: string;
+  ageMinutes: number;
+  customerId?: string;
+  subject?: string;
+}
+
+export interface ConversationResponseSummary {
+  conversationId: string;
+  inboundCount: number;
+  responseCount: number;
+  pendingCount: number;
+  averageResponseMinutes: number | null;
+  medianResponseMinutes: number | null;
+  longestResponseMinutes: number | null;
+  slaBreachCount: number;
+  pending: PendingInbound[];
+  responses: ResponsePair[];
+}
+
+export interface ResponseTimeTotals {
+  conversationCount: number;
+  inboundCount: number;
+  responseCount: number;
+  pendingCount: number;
+  averageResponseMinutes: number | null;
+  medianResponseMinutes: number | null;
+  longestResponseMinutes: number | null;
+  slaBreachCount: number;
+}
+
+export interface ResponseTimeReadyState {
+  status: "ready";
+  generatedAt: string;
+  slaMinutes: number;
+  totals: ResponseTimeTotals;
+  conversations: ConversationResponseSummary[];
+}
+
+export interface ResponseTimeLoadingState {
+  status: "loading";
+  message: string;
+}
+
+export interface ResponseTimeErrorState {
+  status: "error";
+  message: string;
+  details?: string[];
+}
+
+export type ResponseTimeTrackerState =
+  | ResponseTimeLoadingState
+  | ResponseTimeErrorState
+  | ResponseTimeReadyState;
+
+const DEFAULT_SLA_MINUTES = 120;
+
+export function createResponseTimeLoadingState(
+  message = "Preparing response-time metrics.",
+): ResponseTimeLoadingState {
+  return {
+    status: "loading",
+    message,
+  };
+}
+
+export function createResponseTimeErrorState(
+  message: string,
+  details: string[] = [],
+): ResponseTimeErrorState {
+  return {
+    status: "error",
+    message,
+    details,
+  };
+}
+
+export function summarizeResponseTimes(
+  events: ResponseTimeEvent[],
+  options: ResponseTimeTrackerOptions = {},
+): ResponseTimeReadyState {
+  const slaMinutes = options.slaMinutes ?? DEFAULT_SLA_MINUTES;
+  const now = parseTimestamp(options.now ?? new Date().toISOString(), "options.now");
+  const validatedEvents = events.map((event) => ({
+    event,
+    sentAt: parseTimestamp(event.sentAt, `event ${event.id}`),
+  }));
+
+  validateEvents(
+    validatedEvents.map(({ event }) => event),
+    slaMinutes,
+  );
+
+  const sortedEvents = validatedEvents.sort((left, right) => {
+    const timeDelta = left.sentAt.getTime() - right.sentAt.getTime();
+    if (timeDelta !== 0) {
+      return timeDelta;
+    }
+
+    return left.event.id.localeCompare(right.event.id);
+  });
+
+  const conversations = new Map<
+    string,
+    {
+      inbound: ResponseTimeEvent[];
+      pending: ResponseTimeEvent[];
+      responses: ResponsePair[];
+    }
+  >();
+
+  for (const { event } of sortedEvents) {
+    const bucket = getConversationBucket(conversations, event.conversationId);
+
+    if (event.direction === "inbound") {
+      bucket.inbound.push(event);
+      bucket.pending.push(event);
+      continue;
+    }
+
+    const nextPending = bucket.pending.shift();
+    if (!nextPending) {
+      continue;
+    }
+
+    const responseMinutes = minutesBetween(nextPending.sentAt, event.sentAt);
+    bucket.responses.push({
+      conversationId: event.conversationId,
+      inboundEventId: nextPending.id,
+      responseEventId: event.id,
+      inboundAt: nextPending.sentAt,
+      responseAt: event.sentAt,
+      responseMinutes,
+      withinSla: responseMinutes <= slaMinutes,
+      responderId: event.actorId,
+      responderName: event.actorName,
+    });
+  }
+
+  const summaries = [...conversations.entries()]
+    .map(([conversationId, bucket]) =>
+      buildConversationSummary(
+        conversationId,
+        bucket.inbound,
+        bucket.pending,
+        bucket.responses,
+        now,
+        slaMinutes,
+      ),
+    )
+    .sort((left, right) => left.conversationId.localeCompare(right.conversationId));
+
+  const allResponses = summaries.flatMap((summary) => summary.responses);
+  const responseDurations = allResponses.map((response) => response.responseMinutes);
+
+  return {
+    status: "ready",
+    generatedAt: now.toISOString(),
+    slaMinutes,
+    totals: {
+      conversationCount: summaries.length,
+      inboundCount: summaries.reduce((total, summary) => total + summary.inboundCount, 0),
+      responseCount: allResponses.length,
+      pendingCount: summaries.reduce((total, summary) => total + summary.pendingCount, 0),
+      averageResponseMinutes: average(responseDurations),
+      medianResponseMinutes: median(responseDurations),
+      longestResponseMinutes: max(responseDurations),
+      slaBreachCount: allResponses.filter((response) => !response.withinSla).length,
+    },
+    conversations: summaries,
+  };
+}
+
+export function safeSummarizeResponseTimes(
+  events: ResponseTimeEvent[],
+  options: ResponseTimeTrackerOptions = {},
+): ResponseTimeTrackerState {
+  try {
+    return summarizeResponseTimes(events, options);
+  } catch (error) {
+    return createResponseTimeErrorState("Response-time tracker could not build metrics.", [
+      error instanceof Error ? error.message : String(error),
+    ]);
+  }
+}
+
+function validateEvents(events: ResponseTimeEvent[], slaMinutes: number): void {
+  if (!Number.isFinite(slaMinutes) || slaMinutes <= 0) {
+    throw new Error("slaMinutes must be a positive number.");
+  }
+
+  for (const event of events) {
+    if (!event.id.trim()) {
+      throw new Error("Every event requires an id.");
+    }
+
+    if (!event.conversationId.trim()) {
+      throw new Error(`Event ${event.id} requires a conversationId.`);
+    }
+  }
+}
+
+function getConversationBucket(
+  conversations: Map<
+    string,
+    {
+      inbound: ResponseTimeEvent[];
+      pending: ResponseTimeEvent[];
+      responses: ResponsePair[];
+    }
+  >,
+  conversationId: string,
+) {
+  const existingBucket = conversations.get(conversationId);
+  if (existingBucket) {
+    return existingBucket;
+  }
+
+  const bucket = {
+    inbound: [],
+    pending: [],
+    responses: [],
+  };
+  conversations.set(conversationId, bucket);
+  return bucket;
+}
+
+function buildConversationSummary(
+  conversationId: string,
+  inbound: ResponseTimeEvent[],
+  pending: ResponseTimeEvent[],
+  responses: ResponsePair[],
+  now: Date,
+  slaMinutes: number,
+): ConversationResponseSummary {
+  const responseDurations = responses.map((response) => response.responseMinutes);
+
+  return {
+    conversationId,
+    inboundCount: inbound.length,
+    responseCount: responses.length,
+    pendingCount: pending.length,
+    averageResponseMinutes: average(responseDurations),
+    medianResponseMinutes: median(responseDurations),
+    longestResponseMinutes: max(responseDurations),
+    slaBreachCount: responses.filter((response) => !response.withinSla).length,
+    pending: pending.map((event) => ({
+      conversationId,
+      inboundEventId: event.id,
+      inboundAt: event.sentAt,
+      ageMinutes: minutesBetween(event.sentAt, now.toISOString()),
+      customerId: event.customerId,
+      subject: event.subject,
+    })),
+    responses: responses.map((response) => ({
+      ...response,
+      withinSla: response.responseMinutes <= slaMinutes,
+    })),
+  };
+}
+
+function parseTimestamp(value: string, context: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${context} has an invalid timestamp.`);
+  }
+
+  return parsed;
+}
+
+function minutesBetween(start: string, end: string): number {
+  const startDate = parseTimestamp(start, "start");
+  const endDate = parseTimestamp(end, "end");
+  return Math.max(0, Math.round((endDate.getTime() - startDate.getTime()) / 60000));
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return Math.round(values.reduce((total, value) => total + value, 0) / values.length);
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 1) {
+    return sorted[midpoint];
+  }
+
+  return Math.round((sorted[midpoint - 1] + sorted[midpoint]) / 2);
+}
+
+function max(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return Math.max(...values);
+}

--- a/tools/v2/team/response-time-tracker/specs.md
+++ b/tools/v2/team/response-time-tracker/specs.md
@@ -4,9 +4,9 @@ Track response speed.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: tools/v2/team/response-time-tracker/
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,21 +15,34 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
-- 	ests/
+- tests/
 - docs/
-"@ | Set-Content -Path "tools/v2/team/response-time-tracker/README.md"
-  @"
-# Response Time Tracker Specs
 
-## Purpose
+## Core feature engine
 
-Track response speed.
+The core service pairs inbound team messages with the next outbound reply in
+the same conversation, then reports aggregate and per-conversation response-time
+metrics.
 
-## Contributor boundary
+## Inputs
 
-All work for this tool should stay in:
+- Folder-local `ResponseTimeEvent` arrays.
+- Deterministic ISO timestamps.
+- Optional local SLA threshold in minutes.
 
-$dir/
+## Outputs
+
+- Loading state helper for future UI work.
+- Ready state with totals, per-conversation response pairs, pending inbound
+  messages, and SLA breach counts.
+- Error state wrapper for malformed inputs.
+
+## Non-goals
+
+- No live network calls.
+- No production email data.
+- No secrets.
+- No main app routing or shared design-system changes.
 
 ## Required issue categories
 

--- a/tools/v2/team/response-time-tracker/tests/responseTimeTracker.test.ts
+++ b/tools/v2/team/response-time-tracker/tests/responseTimeTracker.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createResponseTimeLoadingState,
+  safeSummarizeResponseTimes,
+  summarizeResponseTimes,
+  type ResponseTimeEvent,
+} from "../services/responseTimeTracker";
+
+const fixtures: ResponseTimeEvent[] = [
+  {
+    id: "in-1",
+    conversationId: "thread-a",
+    direction: "inbound",
+    sentAt: "2026-06-17T08:00:00.000Z",
+    customerId: "customer-a",
+    subject: "Invoice question",
+  },
+  {
+    id: "out-1",
+    conversationId: "thread-a",
+    direction: "outbound",
+    sentAt: "2026-06-17T08:42:00.000Z",
+    actorId: "agent-1",
+    actorName: "Avery",
+  },
+  {
+    id: "in-2",
+    conversationId: "thread-a",
+    direction: "inbound",
+    sentAt: "2026-06-17T09:00:00.000Z",
+    customerId: "customer-a",
+    subject: "Invoice follow-up",
+  },
+  {
+    id: "in-3",
+    conversationId: "thread-b",
+    direction: "inbound",
+    sentAt: "2026-06-17T07:10:00.000Z",
+    customerId: "customer-b",
+    subject: "SLA request",
+  },
+  {
+    id: "out-2",
+    conversationId: "thread-b",
+    direction: "outbound",
+    sentAt: "2026-06-17T10:20:00.000Z",
+    actorId: "agent-2",
+    actorName: "Blair",
+  },
+];
+
+describe("response time tracker core engine", () => {
+  it("pairs inbound messages with the next outbound response per conversation", () => {
+    const snapshot = summarizeResponseTimes(fixtures, {
+      now: "2026-06-17T10:30:00.000Z",
+      slaMinutes: 120,
+    });
+
+    expect(snapshot.status).toBe("ready");
+    expect(snapshot.totals.conversationCount).toBe(2);
+    expect(snapshot.totals.inboundCount).toBe(3);
+    expect(snapshot.totals.responseCount).toBe(2);
+    expect(snapshot.totals.pendingCount).toBe(1);
+    expect(snapshot.totals.averageResponseMinutes).toBe(116);
+    expect(snapshot.totals.medianResponseMinutes).toBe(116);
+    expect(snapshot.totals.longestResponseMinutes).toBe(190);
+    expect(snapshot.totals.slaBreachCount).toBe(1);
+  });
+
+  it("reports pending inbound age without calling any external service", () => {
+    const snapshot = summarizeResponseTimes(fixtures, {
+      now: "2026-06-17T10:30:00.000Z",
+      slaMinutes: 120,
+    });
+
+    const threadA = snapshot.conversations.find(
+      (conversation) => conversation.conversationId === "thread-a",
+    );
+
+    expect(threadA?.pending).toEqual([
+      {
+        conversationId: "thread-a",
+        inboundEventId: "in-2",
+        inboundAt: "2026-06-17T09:00:00.000Z",
+        ageMinutes: 90,
+        customerId: "customer-a",
+        subject: "Invoice follow-up",
+      },
+    ]);
+  });
+
+  it("exposes a deterministic loading state for future UI work", () => {
+    expect(createResponseTimeLoadingState()).toEqual({
+      status: "loading",
+      message: "Preparing response-time metrics.",
+    });
+  });
+
+  it("returns an error state for malformed event data", () => {
+    const state = safeSummarizeResponseTimes(
+      [
+        {
+          id: "bad",
+          conversationId: "thread-c",
+          direction: "inbound",
+          sentAt: "not-a-date",
+        },
+      ],
+      {
+        now: "2026-06-17T10:30:00.000Z",
+      },
+    );
+
+    expect(state.status).toBe("error");
+    expect(state.message).toBe("Response-time tracker could not build metrics.");
+    expect(state.details?.[0]).toContain("invalid timestamp");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #645.

Adds a folder-local core engine for the V2 team Response Time Tracker tool:

- pure TypeScript response-time metric service under `tools/v2/team/response-time-tracker/services/`
- deterministic Vitest coverage under the tool folder
- local API docs for inputs, outputs, loading/error/ready states, and no-network boundaries
- README/spec cleanup while preserving the issue's ownership boundary

## Boundary

All changed files stay inside `tools/v2/team/response-time-tracker/`.

No main app routing, inbox storage, wallet logic, Stellar integration, shared design system, production data, secrets, or live network calls are introduced.

## Validation

- `npx vitest run tools/v2/team/response-time-tracker/tests/responseTimeTracker.test.ts`
- `npx eslint tools/v2/team/response-time-tracker --max-warnings=0`
- `git diff --check`
- `npm run build`

Note: `npm ci` currently fails before this change because `package.json` and `package-lock.json` are out of sync around Playwright versions. I did not update lockfiles because this issue requires changes to remain inside the tool folder. Validation used `npm install --package-lock=false --ignore-scripts --no-audit --no-fund` before the checks above.
