### PR TITLE
Add docs and fixture test plan for Team Task Board from Emails

### DIFF
--- a/tools/v2/team/team-task-board-from-emails/README.md
+++ b/tools/v2/team/team-task-board-from-emails/README.md
@@ -1,15 +1,68 @@
 # Team Task Board from Emails
 
-This folder is the isolated workspace for the Team Task Board from Emails tool.
+Team Task Board from Emails is an isolated V2 team tool workspace. It converts
+action-oriented email threads into a reviewable task board plan without wiring
+anything into the production app yet.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-``text
-.\tools\v2\team\team-task-board-from-emails\
-``
+```text
+tools/v2/team/team-task-board-from-emails/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue only adds folder-local documentation and test assets. No app install
+is required to review the contribution.
+
+Run the local fixture test from the repository root:
+
+```bash
+node --test tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs
+```
+
+The test uses Node's built-in test runner and validates the sample email fixture
+against the expected task board contract.
+
+## Tool Workflow
+
+1. Collect task-oriented emails from a shared team mailbox.
+2. Extract candidate task title, owner, due date, priority, and source thread.
+3. Group related emails into board columns: `new`, `triage`, `blocked`, `done`.
+4. Preserve a source trail so reviewers can trace each task back to the email.
+5. Show unresolved extraction gaps as review notes instead of silently guessing.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-task-emails.json` contains:
+
+- an onboarding task that should enter `new`
+- an invoice task that should enter `triage`
+- a vendor contract task that should enter `blocked`
+- a completed follow-up task that should enter `done`
+
+Each fixture item includes a source email, expected board card, and explicit
+review notes. The fixture is intentionally small so OSS contributors can reason
+about the expected behavior without running the main app.
+
+## Documentation Map
+
+- `specs.md` defines the local product contract and boundaries.
+- `docs/test-plan.md` lists manual and automated review steps.
+- `docs/review-notes.md` explains what was validated and what remains out of
+  scope until a future implementation issue.
+- `tests/task-board-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add UI components or app integration.
+- Extraction logic is described through the fixture contract, not connected to
+  live inbox data.
+- Authorization, routing, database writes, and notification side effects remain
+  out of scope for this isolated V2 folder.

--- a/tools/v2/team/team-task-board-from-emails/docs/review-notes.md
+++ b/tools/v2/team/team-task-board-from-emails/docs/review-notes.md
@@ -1,0 +1,26 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete local product contract.
+- Adds a folder-local fixture that models task extraction from email threads.
+- Adds a zero-dependency Node test for the fixture and expected board states.
+- Documents setup, usage, review steps, and limitations in the tool folder.
+
+## Validation Performed
+
+- `node --test tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- The issue is intentionally limited to testing and documentation assets.
+- The fixture should be easy to extend when implementation code arrives.
+- The expected cards should stay traceable to source emails.
+- No production app behavior should change from this contribution.
+
+## Follow-Up Work
+
+- Add service code that turns inbox messages into the card contract.
+- Add UI and accessibility coverage for the board surface.
+- Add security checks for shared mailbox permissions.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/team/team-task-board-from-emails/docs/test-plan.md
+++ b/tools/v2/team/team-task-board-from-emails/docs/test-plan.md
@@ -1,0 +1,44 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- every source email has a matching expected board card
+- all four board statuses are represented
+- blocked cards require human review
+- due dates, priorities, and source links follow the local card contract
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-task-emails.json`.
+2. Confirm every task can be traced back to a source email by `sourceEmailId`.
+3. Confirm the fixture includes a realistic mix of assignment, due date,
+   priority, and blocked-context examples.
+4. Confirm `docs/review-notes.md` lists what is intentionally out of scope.
+5. Confirm no files outside `tools/v2/team/team-task-board-from-emails/` changed.
+
+## Edge Cases Covered
+
+- unassigned task routed to `new`
+- task needing owner confirmation routed to `triage`
+- vendor dependency routed to `blocked`
+- completed follow-up routed to `done`
+- null due date allowed only when review is required
+
+## Future Integration Tests
+
+When a later issue adds implementation code, add tests for:
+
+- extraction from actual inbox message objects
+- duplicate task detection across the same thread
+- keyboard-accessible board interactions
+- offline-safe draft state
+- permission checks for shared team mailboxes

--- a/tools/v2/team/team-task-board-from-emails/fixtures/sample-task-emails.json
+++ b/tools/v2/team/team-task-board-from-emails/fixtures/sample-task-emails.json
@@ -1,0 +1,93 @@
+{
+  "tool": "team-task-board-from-emails",
+  "version": 1,
+  "emails": [
+    {
+      "id": "email-onboarding-001",
+      "threadId": "thread-onboarding",
+      "from": "people@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "New contractor setup needed by Friday",
+      "receivedAt": "2026-06-15T09:15:00Z",
+      "body": "Please create access for Mira before Friday. This should be handled by Ops.",
+      "signals": ["create access", "before Friday", "handled by Ops"]
+    },
+    {
+      "id": "email-invoice-002",
+      "threadId": "thread-invoice",
+      "from": "finance@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Invoice needs approval",
+      "receivedAt": "2026-06-15T11:30:00Z",
+      "body": "Can someone confirm who owns the June vendor invoice approval? It is due 2026-06-20.",
+      "signals": ["confirm owner", "invoice approval", "due 2026-06-20"]
+    },
+    {
+      "id": "email-vendor-003",
+      "threadId": "thread-vendor-contract",
+      "from": "legal@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Vendor contract blocked on security review",
+      "receivedAt": "2026-06-16T14:05:00Z",
+      "body": "Do not send the contract yet. Security needs to finish review first.",
+      "signals": ["blocked", "security review", "do not send"]
+    },
+    {
+      "id": "email-followup-004",
+      "threadId": "thread-followup",
+      "from": "support@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Follow-up sent to ACME",
+      "receivedAt": "2026-06-16T16:40:00Z",
+      "body": "The customer follow-up was sent and the action item is complete.",
+      "signals": ["sent", "complete"]
+    }
+  ],
+  "expectedCards": [
+    {
+      "id": "task-onboarding-001",
+      "title": "Create contractor access for Mira",
+      "owner": "Ops",
+      "dueDate": "2026-06-19",
+      "priority": "medium",
+      "status": "new",
+      "sourceEmailId": "email-onboarding-001",
+      "reviewRequired": false
+    },
+    {
+      "id": "task-invoice-002",
+      "title": "Confirm owner for June vendor invoice approval",
+      "owner": "unassigned",
+      "dueDate": "2026-06-20",
+      "priority": "high",
+      "status": "triage",
+      "sourceEmailId": "email-invoice-002",
+      "reviewRequired": true
+    },
+    {
+      "id": "task-vendor-003",
+      "title": "Wait for security review before sending vendor contract",
+      "owner": "Legal",
+      "dueDate": null,
+      "priority": "high",
+      "status": "blocked",
+      "sourceEmailId": "email-vendor-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "task-followup-004",
+      "title": "Customer follow-up sent to ACME",
+      "owner": "Support",
+      "dueDate": null,
+      "priority": "low",
+      "status": "done",
+      "sourceEmailId": "email-followup-004",
+      "reviewRequired": false
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses example.test addresses to avoid real customer data.",
+    "Relative dates should be normalized before implementation code ships.",
+    "Blocked tasks must preserve the blocking reason in future UI work."
+  ]
+}

--- a/tools/v2/team/team-task-board-from-emails/specs.md
+++ b/tools/v2/team/team-task-board-from-emails/specs.md
@@ -1,40 +1,56 @@
-# Team Task Board from Emails
-
-Generate team tasks.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- 	ests/
-- docs/
-"@ | Set-Content -Path "tools/v2/team/team-task-board-from-emails/README.md"
-  @"
 # Team Task Board from Emails Specs
 
 ## Purpose
 
-Generate team tasks.
+Create a team task board model from action-oriented emails while keeping the
+tool isolated from the main Stealth Mail application.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: team
+- Folder ownership: `tools/v2/team/team-task-board-from-emails/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Represent email-derived tasks as board cards.
+- Preserve each card's source email metadata for reviewer traceability.
+- Capture extraction confidence and review notes for ambiguous fields.
+- Define fixtures that cover each board state.
+- Provide a folder-local validation path for OSS reviewers.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion or mail rendering engine changes
+- Authentication, wallet, Stellar, or database changes
+- Shared design system changes
+- Notification delivery or collaboration side effects
+
+## Task Card Contract
+
+Each expected board card should include:
+
+- `id`: stable fixture-local task identifier
+- `title`: short action label
+- `owner`: assigned team member or `unassigned`
+- `dueDate`: ISO date string or `null`
+- `priority`: one of `low`, `medium`, `high`
+- `status`: one of `new`, `triage`, `blocked`, `done`
+- `sourceEmailId`: source email identifier
+- `reviewRequired`: true when extraction needs human confirmation
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Contributors should keep all changes for this issue in this folder. If the tool
+needs a future connection to shared inbox data, routing, or production UI, open a
+follow-up issue instead of adding integration here.

--- a/tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs
+++ b/tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-task-emails.json");
+
+const allowedPriorities = new Set(["low", "medium", "high"]);
+const allowedStatuses = new Set(["new", "triage", "blocked", "done"]);
+const requiredStatuses = ["new", "triage", "blocked", "done"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample task email fixture follows the local board contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "team-task-board-from-emails");
+  assert.ok(Array.isArray(fixture.emails), "emails must be an array");
+  assert.ok(Array.isArray(fixture.expectedCards), "expectedCards must be an array");
+  assert.equal(fixture.emails.length, fixture.expectedCards.length);
+
+  const emailIds = new Set(fixture.emails.map((email) => email.id));
+  const seenStatuses = new Set();
+
+  for (const card of fixture.expectedCards) {
+    assert.ok(card.id, "card needs a stable id");
+    assert.ok(card.title, `${card.id} needs a title`);
+    assert.ok(card.owner, `${card.id} needs an owner or unassigned`);
+    assert.ok(allowedPriorities.has(card.priority), `${card.id} has invalid priority`);
+    assert.ok(allowedStatuses.has(card.status), `${card.id} has invalid status`);
+    assert.ok(emailIds.has(card.sourceEmailId), `${card.id} source email is missing`);
+
+    if (card.dueDate !== null) {
+      assert.match(card.dueDate, /^\d{4}-\d{2}-\d{2}$/, `${card.id} dueDate must be ISO date`);
+    }
+
+    if (card.status === "blocked") {
+      assert.equal(card.reviewRequired, true, "blocked cards must require review");
+    }
+
+    if (card.owner === "unassigned") {
+      assert.equal(card.reviewRequired, true, "unassigned cards must require review");
+    }
+
+    seenStatuses.add(card.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});


### PR DESCRIPTION
## Summary
- replaces placeholder specs for the isolated Team Task Board from Emails tool
- documents the local review workflow, fixture coverage, and known limitations
- adds a folder-local sample email fixture and zero-dependency Node test

## Scope
All changes stay inside `tools/v2/team/team-task-board-from-emails/`.

## Test
`node --test tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.test.mjs`

Closes #708