### PR TITLE
feat(demo-admin): define adapter contract for demo dataset publishing

### DIFF
--- a/src/features/demo-admin-dashboard/adapter.test.ts
+++ b/src/features/demo-admin-dashboard/adapter.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { InMemoryPublishingAdapter, type DemoDataset } from "./adapter";
+
+describe("InMemoryPublishingAdapter", () => {
+  let adapter: InMemoryPublishingAdapter;
+
+  const mockDataset: DemoDataset = {
+    id: "test-dataset",
+    name: "Test Dataset",
+    version: 1,
+    updatedAt: "",
+    emails: [
+      {
+        id: "1",
+        from: "Sender",
+        email: "sender*stealth.xyz",
+        subject: "Subject",
+        preview: "Preview",
+        body: "Body",
+        time: "Now",
+        unread: false,
+        starred: false,
+        folder: "inbox",
+        avatarColor: "#5b6470",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    adapter = new InMemoryPublishingAdapter();
+    if (typeof window !== "undefined") {
+      localStorage.clear();
+    } else {
+      // Mock localStorage for node environment if needed, but vitest runs in jsdom/node
+      // with standard global mocks if configured.
+      const store: Record<string, string> = {};
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) => store[key] || null,
+        setItem: (key: string, value: string) => {
+          store[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+        clear: () => {
+          for (const k in store) delete store[k];
+        },
+      });
+    }
+  });
+
+  it("should publish and retrieve a dataset", async () => {
+    const publishRes = await adapter.publishDataset(mockDataset);
+    expect(publishRes.success).toBe(true);
+    expect(publishRes.datasetId).toBe(mockDataset.id);
+
+    const retrieved = await adapter.getDataset(mockDataset.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.name).toBe(mockDataset.name);
+    expect(retrieved?.emails.length).toBe(1);
+  });
+
+  it("should list published datasets", async () => {
+    await adapter.publishDataset(mockDataset);
+    const list = await adapter.listDatasets();
+    expect(list.length).toBe(1);
+    expect(list[0].id).toBe(mockDataset.id);
+  });
+
+  it("should delete a dataset", async () => {
+    await adapter.publishDataset(mockDataset);
+    const deleted = await adapter.deleteDataset(mockDataset.id);
+    expect(deleted).toBe(true);
+
+    const list = await adapter.listDatasets();
+    expect(list.length).toBe(0);
+  });
+
+  it("should handle network mock failure", async () => {
+    adapter.setMockFailure("network");
+    await expect(adapter.listDatasets()).rejects.toThrow("Failed to fetch");
+  });
+
+  it("should handle auth mock failure", async () => {
+    adapter.setMockFailure("auth");
+    await expect(adapter.getDataset("some-id")).rejects.toThrow("Unauthorized");
+  });
+
+  it("should handle validation mock failure", async () => {
+    adapter.setMockFailure("validation");
+    const res = await adapter.publishDataset(mockDataset);
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("Validation failed");
+  });
+});

--- a/src/features/demo-admin-dashboard/adapter.ts
+++ b/src/features/demo-admin-dashboard/adapter.ts
@@ -1,0 +1,121 @@
+import type { Email } from "@/components/mail/data";
+
+export interface DemoDataset {
+  id: string;
+  name: string;
+  version: number;
+  updatedAt: string;
+  emails: Email[];
+}
+
+export interface PublishResult {
+  success: boolean;
+  datasetId: string;
+  version: number;
+  message?: string;
+  error?: string;
+}
+
+export type MockFailureType = "none" | "network" | "auth" | "validation";
+
+export interface DemoPublishingAdapter {
+  listDatasets(): Promise<DemoDataset[]>;
+  getDataset(id: string): Promise<DemoDataset | null>;
+  publishDataset(dataset: DemoDataset): Promise<PublishResult>;
+  deleteDataset(id: string): Promise<boolean>;
+  setMockFailure(type: MockFailureType): void;
+}
+
+const STORAGE_KEY = "stealth-demo-datasets";
+const LATENCY_MS = 300;
+
+export class InMemoryPublishingAdapter implements DemoPublishingAdapter {
+  private mockFailure: MockFailureType = "none";
+
+  private async simulateLatencyAndCheckFailure(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, LATENCY_MS));
+
+    if (this.mockFailure === "network") {
+      throw new TypeError("Failed to fetch");
+    }
+    if (this.mockFailure === "auth") {
+      throw new Error("Unauthorized: Invalid API key or expired session");
+    }
+  }
+
+  setMockFailure(type: MockFailureType): void {
+    this.mockFailure = type;
+  }
+
+  private loadFromStorage(): DemoDataset[] {
+    if (typeof localStorage === "undefined") return [];
+    try {
+      const data = localStorage.getItem(STORAGE_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveToStorage(datasets: DemoDataset[]): void {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(datasets));
+  }
+
+  async listDatasets(): Promise<DemoDataset[]> {
+    await this.simulateLatencyAndCheckFailure();
+    return this.loadFromStorage();
+  }
+
+  async getDataset(id: string): Promise<DemoDataset | null> {
+    await this.simulateLatencyAndCheckFailure();
+    const datasets = this.loadFromStorage();
+    return datasets.find((d) => d.id === id) ?? null;
+  }
+
+  async publishDataset(dataset: DemoDataset): Promise<PublishResult> {
+    await this.simulateLatencyAndCheckFailure();
+
+    if (this.mockFailure === "validation") {
+      return {
+        success: false,
+        datasetId: dataset.id,
+        version: dataset.version,
+        error: "Validation failed: Dataset contains invalid email addresses",
+      };
+    }
+
+    const datasets = this.loadFromStorage();
+    const existingIndex = datasets.findIndex((d) => d.id === dataset.id);
+    const updatedDataset = {
+      ...dataset,
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (existingIndex >= 0) {
+      datasets[existingIndex] = updatedDataset;
+    } else {
+      datasets.push(updatedDataset);
+    }
+
+    this.saveToStorage(datasets);
+
+    return {
+      success: true,
+      datasetId: dataset.id,
+      version: dataset.version,
+      message: `Successfully published dataset "${dataset.name}"`,
+    };
+  }
+
+  async deleteDataset(id: string): Promise<boolean> {
+    await this.simulateLatencyAndCheckFailure();
+    const datasets = this.loadFromStorage();
+    const newDatasets = datasets.filter((d) => d.id !== id);
+    if (newDatasets.length === datasets.length) {
+      return false;
+    }
+    this.saveToStorage(newDatasets);
+    return true;
+  }
+}


### PR DESCRIPTION
This pr closes #225 

Created DemoDataset and DemoPublishingAdapter interfaces in 
adapter.ts
.
Implemented InMemoryPublishingAdapter using localStorage for state persistence, introducing a mock latency of 300ms, and supporting mock failure configurations (none, network, auth, validation).
Added unit tests in 
adapter.test.ts
 to verify datasets can be published, read, deleted, and that simulated failure types throw correct errors.