### PR TITLE
feat(mail): add proof timeline to message provenance panel

### DIFF
--- a/src/components/mail/ProvenancePanel.tsx
+++ b/src/components/mail/ProvenancePanel.tsx
@@ -20,10 +20,7 @@ import {
   getEmailProvenance,
   type ProvenanceDetails,
   type ProvenanceItemDetails,
-<<<<<<< HEAD
-=======
   type ProvenanceTimelineItem,
->>>>>>> 4223141 (feat(mail): add proof timeline to message provenance panel)
 } from "./provenance";
 import { ProvenanceInspector } from "./ProvenanceInspector";
 import type { Email } from "./data";

--- a/src/components/mail/ProvenancePanel.tsx
+++ b/src/components/mail/ProvenancePanel.tsx
@@ -14,11 +14,16 @@ import {
   Coins,
   Receipt,
   Check,
+  type LucideIcon,
 } from "lucide-react";
 import {
   getEmailProvenance,
   type ProvenanceDetails,
   type ProvenanceItemDetails,
+<<<<<<< HEAD
+=======
+  type ProvenanceTimelineItem,
+>>>>>>> 4223141 (feat(mail): add proof timeline to message provenance panel)
 } from "./provenance";
 import { ProvenanceInspector } from "./ProvenanceInspector";
 import type { Email } from "./data";
@@ -46,6 +51,25 @@ export function ProvenancePanel({
 
   const provenance = getEmailProvenance(email);
 
+  const getTimelineIcon = (step: ProvenanceTimelineItem["key"]) => {
+    switch (step) {
+      case "senderIdentity":
+        return Fingerprint;
+      case "relaySource":
+        return Server;
+      case "messageHash":
+        return Database;
+      case "payloadCommitment":
+        return Lock;
+      case "postageRecord":
+        return Coins;
+      case "receiptRecord":
+        return Receipt;
+      default:
+        return Shield;
+    }
+  };
+
   const handleCopy = async (key: string, value: string, label: string) => {
     try {
       await navigator.clipboard.writeText(value);
@@ -71,7 +95,7 @@ export function ProvenancePanel({
   }: {
     fieldKey: string;
     label: string;
-    icon: any;
+    icon: LucideIcon;
     displayValue: string;
     rawValue: string;
     details?: string;
@@ -153,6 +177,55 @@ export function ProvenancePanel({
                 ? "Bridged message without Stellar cryptographic signatures."
                 : "Message processed but security verification is currently in progress."}
           </p>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-white/[0.06] bg-black/10 p-3">
+        <div className="flex items-center justify-between gap-3 text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+          <span>Proof Timeline</span>
+          <span>
+            {provenance.timeline.filter((item) => item.status === "complete").length}/
+            {provenance.timeline.length} complete
+          </span>
+        </div>
+        <div className="mt-3 space-y-3">
+          {provenance.timeline.map((item, index) => {
+            const Icon = getTimelineIcon(item.key);
+            const statusStyles =
+              item.status === "complete"
+                ? "border-emerald-500 bg-emerald-500 text-black"
+                : item.status === "pending"
+                  ? "border-amber-300 bg-amber-300 text-black"
+                  : "border-white/10 bg-white/10 text-muted-foreground";
+
+            return (
+              <div key={item.key} className="grid grid-cols-[auto_1fr] gap-3">
+                <div className="relative flex flex-col items-center">
+                  <span
+                    className={`grid h-9 w-9 place-items-center rounded-full border ${statusStyles}`}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  {index < provenance.timeline.length - 1 && (
+                    <span className="absolute top-10 left-1/2 h-full w-px -translate-x-1/2 bg-white/[0.08]" />
+                  )}
+                </div>
+                <div className="border-b border-white/[0.04] pb-3 last:border-none last:pb-0">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-semibold text-foreground">{item.title}</div>
+                      <p className="mt-1 text-[10.5px] leading-relaxed text-muted-foreground">
+                        {item.description}
+                      </p>
+                    </div>
+                    <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                      {item.timestamp}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/src/components/mail/provenance.ts
+++ b/src/components/mail/provenance.ts
@@ -7,7 +7,16 @@ export interface ProvenanceItemDetails {
   rawJson: string;
 }
 
+export type ProvenanceTimelineItem = {
+  key: string;
+  title: string;
+  description: string;
+  status: "complete" | "pending" | "skipped";
+  timestamp: string;
+};
+
 export interface ProvenanceDetails {
+  timeline: ProvenanceTimelineItem[];
   senderIdentity: {
     raw: string;
     resolved: string;
@@ -365,7 +374,63 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
     ),
   };
 
+  const receiptTimestamp = isSmtpBridge ? "Not requested" : "2026-06-16 14:58:22 UTC";
+  const postageTimestamp = isSmtpBridge ? "Not requested" : "2026-06-16 14:34:18 UTC";
+
+  const timelineItems: ProvenanceTimelineItem[] = [
+    {
+      key: "senderIdentity",
+      title: "Sender identity resolved",
+      description: isVerified
+        ? "Verified sender identity through Stellar federation and signature validation."
+        : "Sender domain was bridged via SMTP without an on-chain cryptographic signature.",
+      status: "complete",
+      timestamp: relayTimestamp,
+    },
+    {
+      key: "messageHash",
+      title: "Message integrity hashed",
+      description:
+        "A deterministic integrity hash was generated for the message body to prevent tampering.",
+      status: "complete",
+      timestamp: relayTimestamp,
+    },
+    {
+      key: "payloadCommitment",
+      title: "Payload envelope committed",
+      description:
+        "A cryptographic commitment for the encrypted payload was prepared for ledger anchoring.",
+      status: "complete",
+      timestamp: relayTimestamp,
+    },
+    {
+      key: "postageRecord",
+      title: "Postage payment recorded",
+      description: isSmtpBridge
+        ? "Bridged messages skip on-chain postage settlement."
+        : "Postage was settled on the Stellar ledger to secure delivery priority.",
+      status: isSmtpBridge ? "skipped" : "complete",
+      timestamp: postageTimestamp,
+    },
+    {
+      key: "receiptRecord",
+      title: "Delivery proof recorded",
+      description: isSmtpBridge
+        ? "No receipt proof is available for bridged delivery."
+        : receiptStatus === "Confirmed / Proof Written"
+          ? "A Soroban delivery receipt was written when the recipient read the message."
+          : "Receipt proof is pending until delivery is confirmed.",
+      status: isSmtpBridge
+        ? "skipped"
+        : receiptStatus === "Confirmed / Proof Written"
+          ? "complete"
+          : "pending",
+      timestamp: receiptTimestamp,
+    },
+  ];
+
   return {
+    timeline: timelineItems,
     senderIdentity: {
       raw: rawIdentity,
       resolved: resolvedKey,

--- a/tests/unit/mail/provenance.test.ts
+++ b/tests/unit/mail/provenance.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getEmailProvenance } from "../../../src/components/mail/provenance";
+import type { Email } from "../../../src/components/mail/data";
+
+describe("mail/provenance timeline", () => {
+  const baseEmail: Email = {
+    id: "123",
+    from: "Alice Example",
+    email: "alice@example.com",
+    subject: "Test proof timeline",
+    preview: "This is a preview",
+    body: "Hello world",
+    time: "10:00 AM",
+    unread: true,
+    starred: false,
+    folder: "verified",
+    avatarColor: "#6d28d9",
+  };
+
+  it("includes a complete timeline for verified messages", () => {
+    const provenance = getEmailProvenance(baseEmail);
+    expect(provenance.timeline).toHaveLength(5);
+    expect(provenance.timeline.map((item) => item.status)).toEqual([
+      "complete",
+      "complete",
+      "complete",
+      "complete",
+      "complete",
+    ]);
+  });
+
+  it("marks bridged messages as skipped for postage and receipt", () => {
+    const bridgedEmail: Email = { ...baseEmail, folder: "spam", from: "Relay Bridge" };
+    const provenance = getEmailProvenance(bridgedEmail);
+    expect(provenance.timeline).toHaveLength(5);
+    expect(provenance.timeline[3]).toMatchObject({ status: "skipped" });
+    expect(provenance.timeline[4]).toMatchObject({ status: "skipped" });
+  });
+});


### PR DESCRIPTION
## Summary
closes #95 
Adds a proof timeline to the message detail view, making message verification states easier to inspect and understand.

## Changes

### Added Proof Timeline

* Added a chronological proof timeline to the message provenance panel
* Displays proof steps with status indicators, descriptions, and timestamp slots
* Supports clear visual representation of verification progress

### Extended Provenance Model

* Added `ProvenanceTimelineItem` type
* Added timeline data generation for provenance records
* Included timeline states for sender identity, message hash, payload commitment, postage, and receipt verification

### Improved Message Verification UX

* Added status badges and step metadata
* Handles incomplete or unavailable proof data gracefully
* Provides a structured view of message verification history

### Added Tests

* Added unit tests for proof timeline generation
* Verified complete timelines for verified messages
* Verified conditional handling for bridged messages and skipped proof steps

## Validation

* Verified with ESLint
* Verified with Vitest unit tests

## Commit

`feat(mail): add proof timeline to message provenance panel`
