### PR TITLE
feat(demo-admin): build migration runner to upgrade older dataset ver…

### DIFF
--- a/src/features/demo-admin-dashboard/migrations.test.ts
+++ b/src/features/demo-admin-dashboard/migrations.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { runMigrations } from "./migrations";
+
+describe("Migration Runner", () => {
+  it("should return successfully if already at target version", () => {
+    const data = { version: 3, emails: [] };
+    const result = runMigrations(data, 3);
+    expect(result.success).toBe(true);
+    expect(result.originalVersion).toBe(3);
+    expect(result.targetVersion).toBe(3);
+    expect(result.stepsApplied.length).toBe(0);
+  });
+
+  it("should fail on downgrade requests", () => {
+    const data = { version: 3, emails: [] };
+    const result = runMigrations(data, 2);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Downgrades are not supported");
+  });
+
+  it("should migrate V1 data to V2", () => {
+    const v1Data = {
+      version: 1,
+      emails: [
+        { id: "1", from: "Alice", email: "alice*stealth.xyz", trusted: true },
+        { id: "2", from: "Bob", email: "bob*stealth.xyz", trusted: false },
+        { id: "3", from: "Charlie", email: "charlie*stealth.xyz" },
+      ],
+    };
+
+    const result = runMigrations(v1Data, 2);
+    expect(result.success).toBe(true);
+    expect(result.data.version).toBe(2);
+    expect(result.data.emails[0].senderPolicy).toBe("allow");
+    expect(result.data.emails[0].trusted).toBeUndefined();
+    expect(result.data.emails[1].senderPolicy).toBe("block");
+    expect(result.data.emails[1].trusted).toBeUndefined();
+    expect(result.data.emails[2].senderPolicy).toBe("allow");
+  });
+
+  it("should migrate V2 data to V3 by standardizing event details", () => {
+    const v2Data = {
+      version: 2,
+      emails: [
+        {
+          id: "1",
+          from: "Lina",
+          email: "lina*stealth.xyz",
+          event: {
+            title: "Design Review",
+            time: "10:00 AM",
+            location: "Studio",
+            note: "review",
+            days: [],
+          },
+        },
+        {
+          id: "2",
+          from: "Marcus",
+          email: "marcus*stealth.xyz",
+        },
+      ],
+    };
+
+    const result = runMigrations(v2Data, 3);
+    expect(result.success).toBe(true);
+    expect(result.data.version).toBe(3);
+    expect(result.data.emails[0].event.endTime).toBe("11:00");
+    expect(result.data.emails[0].event.date).toBe("2026-06-13");
+    expect(result.data.emails[0].event.calendar).toBe("personal");
+    expect(result.data.emails[1].event).toBeUndefined();
+  });
+
+  it("should run full V1 to V3 migration path", () => {
+    const v1Data = {
+      version: 1,
+      emails: [
+        {
+          id: "1",
+          from: "Alice",
+          email: "alice*stealth.xyz",
+          trusted: true,
+          event: {
+            title: "Meeting",
+            time: "03:30 PM",
+            location: "Room 1",
+            note: "sync",
+            days: [],
+          },
+        },
+      ],
+    };
+
+    const result = runMigrations(v1Data, 3);
+    expect(result.success).toBe(true);
+    expect(result.data.version).toBe(3);
+    expect(result.data.emails[0].senderPolicy).toBe("allow");
+    expect(result.data.emails[0].event.endTime).toBe("16:30");
+    expect(result.data.emails[0].event.date).toBe("2026-06-13");
+    expect(result.data.emails[0].event.calendar).toBe("personal");
+    expect(result.stepsApplied).toEqual([
+      "Migrated V1 to V2",
+      "Migrated V2 to V3",
+    ]);
+  });
+});

--- a/src/features/demo-admin-dashboard/migrations.ts
+++ b/src/features/demo-admin-dashboard/migrations.ts
@@ -1,0 +1,160 @@
+export interface Migration {
+  fromVersion: number;
+  toVersion: number;
+  migrate(data: any): any;
+}
+
+export interface MigrationResult {
+  success: boolean;
+  originalVersion: number;
+  targetVersion: number;
+  data: any;
+  stepsApplied: string[];
+  error?: string;
+}
+
+/**
+ * Migration from V1 to V2:
+ * Converts old `trusted` boolean on emails to `senderPolicy` ("allow" | "block").
+ */
+export const migrationV1toV2: Migration = {
+  fromVersion: 1,
+  toVersion: 2,
+  migrate(data: any): any {
+    if (!data || !Array.isArray(data.emails)) return data;
+
+    const migratedEmails = data.emails.map((email: any) => {
+      if (email.senderPolicy !== undefined) return email;
+
+      const newEmail = { ...email };
+      if (typeof email.trusted === "boolean") {
+        newEmail.senderPolicy = email.trusted ? "allow" : "block";
+        delete newEmail.trusted;
+      } else {
+        newEmail.senderPolicy = "allow"; // Default policy
+      }
+      return newEmail;
+    });
+
+    return {
+      ...data,
+      version: 2,
+      emails: migratedEmails,
+    };
+  },
+};
+
+/**
+ * Migration from V2 to V3:
+ * Ensures all email events have an `endTime` and a valid `date`.
+ */
+export const migrationV2toV3: Migration = {
+  fromVersion: 2,
+  toVersion: 3,
+  migrate(data: any): any {
+    if (!data || !Array.isArray(data.emails)) return data;
+
+    const migratedEmails = data.emails.map((email: any) => {
+      if (!email.event) return email;
+
+      const updatedEvent = { ...email.event };
+
+      // Ensure date exists on the event, fallback to a default if missing
+      if (!updatedEvent.date) {
+        updatedEvent.date = "2026-06-13";
+      }
+
+      // Ensure endTime exists, otherwise calculate 1 hour after time
+      if (!updatedEvent.endTime) {
+        const timeStr = updatedEvent.time || "09:00 AM";
+        const match = timeStr.match(/(\d{1,2}):(\d{2})\s*(AM|PM)?/i);
+        if (match) {
+          let hour = Number(match[1]);
+          const minutes = match[2];
+          if (match[3]?.toUpperCase() === "PM" && hour < 12) hour += 12;
+          if (match[3]?.toUpperCase() === "AM" && hour === 12) hour = 0;
+          const endHour = (hour + 1) % 24;
+          updatedEvent.endTime = `${String(endHour).padStart(2, "0")}:${minutes}`;
+        } else {
+          updatedEvent.endTime = "10:00";
+        }
+      }
+
+      // Ensure calendar field exists
+      if (!updatedEvent.calendar) {
+        updatedEvent.calendar = "personal";
+      }
+
+      return {
+        ...email,
+        event: updatedEvent,
+      };
+    });
+
+    return {
+      ...data,
+      version: 3,
+      emails: migratedEmails,
+    };
+  },
+};
+
+const registeredMigrations: Migration[] = [migrationV1toV2, migrationV2toV3];
+
+export function runMigrations(data: any, targetVersion: number): MigrationResult {
+  const originalVersion = typeof data?.version === "number" ? data.version : 1;
+  let currentVersion = originalVersion;
+  let currentData = JSON.parse(JSON.stringify(data)); // deep clone
+  const stepsApplied: string[] = [];
+
+  if (currentVersion > targetVersion) {
+    return {
+      success: false,
+      originalVersion,
+      targetVersion,
+      data,
+      stepsApplied,
+      error: `Downgrades are not supported (source version ${originalVersion} is greater than target version ${targetVersion})`,
+    };
+  }
+
+  while (currentVersion < targetVersion) {
+    const migration = registeredMigrations.find(
+      (m) => m.fromVersion === currentVersion && m.toVersion === currentVersion + 1,
+    );
+
+    if (!migration) {
+      return {
+        success: false,
+        originalVersion,
+        targetVersion,
+        data: currentData,
+        stepsApplied,
+        error: `Missing migration path from version ${currentVersion} to ${currentVersion + 1}`,
+      };
+    }
+
+    try {
+      currentData = migration.migrate(currentData);
+      currentVersion = migration.toVersion;
+      stepsApplied.push(`Migrated V${migration.fromVersion} to V${migration.toVersion}`);
+    } catch (err: any) {
+      return {
+        success: false,
+        originalVersion,
+        targetVersion,
+        data: currentData,
+        stepsApplied,
+        error: `Failed to migrate from version ${migration.fromVersion} to ${migration.toVersion}: ${err?.message || err}`,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    originalVersion,
+    targetVersion,
+    data: currentData,
+    stepsApplied,
+  };
+}


### PR DESCRIPTION
This pr closes #223 

Created a schema migration runner (runMigrations) in 
migrations.ts
.
Implemented example migrations:
V1 to V2: Standardizes legacy trusted boolean values on email items into the modern senderPolicy ("allow" | "block") format.
V2 to V3: Validates and standardizes calendar events nested in emails, ensuring they have an endTime, a valid date, and a designated calendar.
Added unit tests in 
migrations.test.ts
 verifying correct forward migration progression and safe rejection of downgrade requests.