### PR TITLE
Add docs and fixture tests for Team Payment Approval

### DIFF
--- a/tools/v2/team/team-payment-approval/README.md
+++ b/tools/v2/team/team-payment-approval/README.md
@@ -1,15 +1,64 @@
 # Team Payment Approval
 
-This folder is the isolated workspace for the Team Payment Approval tool.
+Team Payment Approval is an isolated V2 team tool workspace for reviewing
+payment requests before they move to a future Stellar or finance integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-``text
-.\tools\v2\team\team-payment-approval\
-``
+```text
+tools/v2/team/team-payment-approval/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node test.
+No app install is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs
+```
+
+The test validates the sample payment approval fixture against the local review
+contract described in `specs.md`.
+
+## Approval Workflow
+
+1. Capture payment requests from team communication or mailbox records.
+2. Normalize amount, currency, requester, vendor, and required approvers.
+3. Route each request to `submitted`, `needs-review`, `blocked`, or `approved`.
+4. Preserve a source record link for auditability.
+5. Flag incomplete or policy-sensitive requests for human review.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-payment-approvals.json` contains:
+
+- a standard vendor reimbursement that is ready for first approval
+- a high-value vendor payment requiring finance review
+- a blocked request missing required documentation
+- an approved contractor payment with complete approval evidence
+
+The fixture intentionally uses `example.test` data and synthetic request ids so
+contributors can validate behavior without using real financial information.
+
+## Documentation Map
+
+- `specs.md` defines the local approval request contract and scope.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` explains validation and known limits.
+- `tests/payment-approval-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or payment execution code.
+- Approval logic is represented through fixture expectations only.
+- Wallet, Stellar, bank, tax, invoice storage, and notification behavior remain
+  out of scope for this isolated V2 folder.

--- a/tools/v2/team/team-payment-approval/docs/review-notes.md
+++ b/tools/v2/team/team-payment-approval/docs/review-notes.md
@@ -1,0 +1,26 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete approval review contract.
+- Adds synthetic fixture data for payment approval states.
+- Adds a zero-dependency Node test for the fixture and local rules.
+- Documents setup, review flow, limitations, and future integration needs.
+
+## Validation Performed
+
+- `node --test tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- This issue is limited to testing and documentation assets.
+- The fixture should make future implementation behavior unambiguous.
+- No real financial data, wallet instructions, or payment credentials are used.
+- No production app behavior changes from this contribution.
+
+## Follow-Up Work
+
+- Add service code that normalizes payment request records.
+- Add UI and accessibility coverage for reviewer decisions.
+- Add permission and audit log rules before any live payment integration.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/team/team-payment-approval/docs/test-plan.md
+++ b/tools/v2/team/team-payment-approval/docs/test-plan.md
@@ -1,0 +1,43 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source record maps to one expected approval
+- all local approval statuses are represented
+- payment amounts are positive numbers
+- high-value payments require finance review
+- blocked requests require human review
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-payment-approvals.json`.
+2. Confirm all source records use synthetic data.
+3. Confirm each expected approval has a traceable `sourceRecordId`.
+4. Confirm `docs/review-notes.md` documents out-of-scope payment execution.
+5. Confirm no files outside `tools/v2/team/team-payment-approval/` changed.
+
+## Edge Cases Covered
+
+- standard request ready for approval
+- high-value request routed to finance review
+- missing documentation routed to blocked
+- completed approval with complete evidence
+
+## Future Integration Tests
+
+When implementation code is added, add tests for:
+
+- duplicate request detection
+- invoice attachment presence checks
+- role-based approval permissions
+- audit log creation
+- offline-safe reviewer decisions

--- a/tools/v2/team/team-payment-approval/fixtures/sample-payment-approvals.json
+++ b/tools/v2/team/team-payment-approval/fixtures/sample-payment-approvals.json
@@ -1,0 +1,93 @@
+{
+  "tool": "team-payment-approval",
+  "version": 1,
+  "sourceRecords": [
+    {
+      "id": "record-vendor-001",
+      "type": "email",
+      "from": "ops@example.test",
+      "subject": "Approve vendor reimbursement",
+      "receivedAt": "2026-06-15T08:30:00Z",
+      "body": "Please approve 240 USD for the courier reimbursement. Receipt is attached.",
+      "hasSupportingDocument": true
+    },
+    {
+      "id": "record-high-value-002",
+      "type": "email",
+      "from": "procurement@example.test",
+      "subject": "Large vendor invoice approval",
+      "receivedAt": "2026-06-15T12:20:00Z",
+      "body": "The Atlas vendor invoice is 7200 USD and needs finance approval before payout.",
+      "hasSupportingDocument": true
+    },
+    {
+      "id": "record-missing-doc-003",
+      "type": "email",
+      "from": "sales@example.test",
+      "subject": "Customer event reimbursement",
+      "receivedAt": "2026-06-16T10:45:00Z",
+      "body": "Please reimburse 380 USD for the customer event. I will send the receipt later.",
+      "hasSupportingDocument": false
+    },
+    {
+      "id": "record-contractor-004",
+      "type": "internal-request",
+      "from": "engineering@example.test",
+      "subject": "Contractor milestone payment approved",
+      "receivedAt": "2026-06-16T15:05:00Z",
+      "body": "Engineering lead approved the 1500 USD contractor milestone payment.",
+      "hasSupportingDocument": true
+    }
+  ],
+  "expectedApprovals": [
+    {
+      "id": "approval-vendor-001",
+      "vendor": "Courier Vendor",
+      "amount": 240,
+      "currency": "USD",
+      "requester": "Ops",
+      "status": "submitted",
+      "requiredApprovers": ["team-lead"],
+      "sourceRecordId": "record-vendor-001",
+      "reviewRequired": false
+    },
+    {
+      "id": "approval-high-value-002",
+      "vendor": "Atlas Vendor",
+      "amount": 7200,
+      "currency": "USD",
+      "requester": "Procurement",
+      "status": "needs-review",
+      "requiredApprovers": ["finance", "team-lead"],
+      "sourceRecordId": "record-high-value-002",
+      "reviewRequired": true
+    },
+    {
+      "id": "approval-missing-doc-003",
+      "vendor": "Customer Event Reimbursement",
+      "amount": 380,
+      "currency": "USD",
+      "requester": "Sales",
+      "status": "blocked",
+      "requiredApprovers": ["team-lead"],
+      "sourceRecordId": "record-missing-doc-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "approval-contractor-004",
+      "vendor": "Contractor Milestone",
+      "amount": 1500,
+      "currency": "USD",
+      "requester": "Engineering",
+      "status": "approved",
+      "requiredApprovers": ["engineering-lead"],
+      "sourceRecordId": "record-contractor-004",
+      "reviewRequired": false
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses synthetic example.test records only.",
+    "The high-value threshold is local to this fixture and should be configurable later.",
+    "Payment execution must remain blocked until a future security issue defines live constraints."
+  ]
+}

--- a/tools/v2/team/team-payment-approval/specs.md
+++ b/tools/v2/team/team-payment-approval/specs.md
@@ -1,40 +1,64 @@
-# Team Payment Approval
-
-Payment approval workflows.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- 	ests/
-- docs/
-"@ | Set-Content -Path "tools/v2/team/team-payment-approval/README.md"
-  @"
 # Team Payment Approval Specs
 
 ## Purpose
 
-Payment approval workflows.
+Define a self-contained review contract for team payment approvals before any
+future app, wallet, or finance-system integration.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: team
+- Folder ownership: `tools/v2/team/team-payment-approval/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model payment requests with audit-friendly source metadata.
+- Distinguish low-risk approvals from requests that need finance review.
+- Represent blocked requests without attempting payment side effects.
+- Provide fixture coverage for each local approval status.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mail rendering, or attachment storage changes
+- Wallet, Stellar, bank transfer, tax, or invoice execution
+- Database schema or shared design system changes
+- Notification delivery or role-permission enforcement
+
+## Approval Request Contract
+
+Each expected approval record should include:
+
+- `id`: stable fixture-local request identifier
+- `vendor`: payee or vendor display name
+- `amount`: positive numeric payment amount
+- `currency`: ISO-style currency code
+- `requester`: team member requesting payment
+- `status`: one of `submitted`, `needs-review`, `blocked`, `approved`
+- `requiredApprovers`: list of roles or people required before execution
+- `sourceRecordId`: source email or internal request identifier
+- `reviewRequired`: true when a person must resolve missing or risky details
+
+## Review Rules
+
+- amounts at or above 5000 require finance review
+- missing supporting documents must be blocked
+- approved requests must include at least one required approver
+- blocked and needs-review requests must set `reviewRequired` to true
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. If a future issue adds actual
+payment execution, it should define security, audit, and wallet constraints
+before connecting this tool to live data.

--- a/tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs
+++ b/tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-payment-approvals.json");
+
+const allowedStatuses = new Set(["submitted", "needs-review", "blocked", "approved"]);
+const requiredStatuses = ["submitted", "needs-review", "blocked", "approved"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample payment approval fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "team-payment-approval");
+  assert.ok(Array.isArray(fixture.sourceRecords), "sourceRecords must be an array");
+  assert.ok(Array.isArray(fixture.expectedApprovals), "expectedApprovals must be an array");
+  assert.equal(fixture.sourceRecords.length, fixture.expectedApprovals.length);
+
+  const sourceIds = new Set(fixture.sourceRecords.map((record) => record.id));
+  const sourceById = new Map(fixture.sourceRecords.map((record) => [record.id, record]));
+  const seenStatuses = new Set();
+
+  for (const approval of fixture.expectedApprovals) {
+    assert.ok(approval.id, "approval needs a stable id");
+    assert.ok(approval.vendor, `${approval.id} needs a vendor`);
+    assert.ok(approval.requester, `${approval.id} needs a requester`);
+    assert.equal(typeof approval.amount, "number", `${approval.id} amount must be numeric`);
+    assert.ok(approval.amount > 0, `${approval.id} amount must be positive`);
+    assert.match(approval.currency, /^[A-Z]{3}$/, `${approval.id} currency must be uppercase code`);
+    assert.ok(allowedStatuses.has(approval.status), `${approval.id} has invalid status`);
+    assert.ok(sourceIds.has(approval.sourceRecordId), `${approval.id} source record is missing`);
+    assert.ok(Array.isArray(approval.requiredApprovers), `${approval.id} approvers must be an array`);
+    assert.ok(approval.requiredApprovers.length > 0, `${approval.id} needs at least one approver`);
+
+    if (approval.amount >= 5000) {
+      assert.ok(
+        approval.requiredApprovers.includes("finance"),
+        `${approval.id} high-value approvals must include finance`,
+      );
+      assert.equal(approval.reviewRequired, true, `${approval.id} high-value approvals require review`);
+    }
+
+    if (approval.status === "blocked" || approval.status === "needs-review") {
+      assert.equal(approval.reviewRequired, true, `${approval.id} must require review`);
+    }
+
+    const source = sourceById.get(approval.sourceRecordId);
+    if (source && source.hasSupportingDocument === false) {
+      assert.equal(approval.status, "blocked", `${approval.id} missing documents must be blocked`);
+    }
+
+    seenStatuses.add(approval.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});


### PR DESCRIPTION
## Summary
- replaces placeholder specs for the isolated Team Payment Approval tool
- documents the local approval workflow, review rules, fixtures, and limitations
- adds synthetic payment approval fixtures plus a zero-dependency Node test

## Scope
All changes stay inside `tools/v2/team/team-payment-approval/`.

## Test
`node --test tools/v2/team/team-payment-approval/tests/payment-approval-fixtures.test.mjs`

Closes #698