### PR TITLE
Add email template library UI surface

### DIFF
--- a/tools/v2/individual/email-template-library/README.md
+++ b/tools/v2/individual/email-template-library/README.md
@@ -6,10 +6,21 @@ This folder is the isolated workspace for the Email Template Library tool.
 
 All work for this tool must stay inside:
 
-``text
-.\tools\v2\individual\email-template-library\
-``
+```text
+tools/v2/individual/email-template-library/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Local UI Surface
+
+This folder now includes a self-contained template browser and preview workflow:
+
+- `components/EmailTemplateLibrary.tsx` renders the folder-local UI.
+- `fixtures/templates.ts` provides deterministic sample templates.
+- `docs/review-guide.md` documents loading, error, empty, and success states plus accessibility behavior.
+- `index.ts` exports the component and fixtures for a future integration issue.
+
+The UI is not mounted in the main application. Reviewers can inspect or import it locally without changing app routing, navigation, authentication, wallet flows, Stellar integration, database schema, or the shared design system.
+
+See `specs.md` for the issue categories and contributor expectations.

--- a/tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx
+++ b/tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx
@@ -1,0 +1,329 @@
+import * as React from "react";
+
+import {
+  emailTemplateCategoryLabels,
+  emailTemplateFixtures,
+  type EmailTemplate,
+  type EmailTemplateCategory,
+} from "../fixtures/templates";
+
+type EmailTemplateLibraryProps = {
+  templates?: EmailTemplate[];
+  isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  onTemplateSelect?: (templateId: string) => void;
+  onUseTemplate?: (template: EmailTemplate) => void;
+};
+
+const categoryOptions: Array<EmailTemplateCategory | "all"> = [
+  "all",
+  "follow-up",
+  "intro",
+  "billing",
+  "support",
+];
+
+export function EmailTemplateLibrary({
+  templates = emailTemplateFixtures,
+  isLoading = false,
+  error = null,
+  onRetry,
+  onTemplateSelect,
+  onUseTemplate,
+}: EmailTemplateLibraryProps) {
+  const [query, setQuery] = React.useState("");
+  const [category, setCategory] = React.useState<EmailTemplateCategory | "all">("all");
+  const [selectedId, setSelectedId] = React.useState<string | null>(templates[0]?.id ?? null);
+  const [statusMessage, setStatusMessage] = React.useState("");
+  const [successMessage, setSuccessMessage] = React.useState("");
+  const searchId = React.useId();
+  const categoryHeadingId = React.useId();
+  const statusId = React.useId();
+
+  React.useEffect(() => {
+    if (templates.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+
+    if (!selectedId || !templates.some((template) => template.id === selectedId)) {
+      setSelectedId(templates[0].id);
+    }
+  }, [selectedId, templates]);
+
+  const filteredTemplates = React.useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return templates.filter((template) => {
+      const matchesCategory = category === "all" || template.category === category;
+      const matchesQuery =
+        normalizedQuery.length === 0 ||
+        [template.name, template.subject, template.body, ...template.tags]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedQuery);
+
+      return matchesCategory && matchesQuery;
+    });
+  }, [category, query, templates]);
+
+  const selectedTemplate =
+    filteredTemplates.find((template) => template.id === selectedId) ??
+    filteredTemplates[0] ??
+    null;
+
+  function selectTemplate(template: EmailTemplate) {
+    setSelectedId(template.id);
+    setSuccessMessage("");
+    setStatusMessage(`${template.name} selected`);
+    onTemplateSelect?.(template.id);
+  }
+
+  function useSelectedTemplate() {
+    if (!selectedTemplate) {
+      return;
+    }
+
+    setStatusMessage(`${selectedTemplate.name} is ready to use`);
+    setSuccessMessage(`${selectedTemplate.name} is ready to insert into a draft.`);
+    onUseTemplate?.(selectedTemplate);
+  }
+
+  return (
+    <section
+      aria-busy={isLoading}
+      aria-describedby={statusId}
+      className="grid gap-4 rounded-lg border border-slate-200 bg-white p-4 text-slate-950 shadow-sm"
+    >
+      <div className="flex flex-col gap-3 border-b border-slate-200 pb-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-normal text-indigo-700">
+            Email Template Library
+          </p>
+          <h2 className="text-xl font-semibold tracking-normal">Reusable personal replies</h2>
+          <p className="mt-1 max-w-2xl text-sm text-slate-600">
+            Search, preview, and select local email templates without connecting this V2 tool to the
+            production mail app.
+          </p>
+        </div>
+
+        <div className="w-full md:max-w-sm">
+          <label htmlFor={searchId} className="mb-1 block text-sm font-medium text-slate-800">
+            Search templates
+          </label>
+          <input
+            id={searchId}
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by subject, tag, or body"
+            onInput={() => setSuccessMessage("")}
+            className="h-10 w-full rounded-md border border-slate-300 px-3 text-sm outline-none transition focus:border-indigo-600 focus:ring-2 focus:ring-indigo-100"
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <ErrorState message={error} onRetry={onRetry} />
+      ) : isLoading ? (
+        <LoadingState />
+      ) : templates.length === 0 || filteredTemplates.length === 0 ? (
+        <EmptyState
+          hasFilters={templates.length > 0}
+          onClearFilters={() => {
+            setQuery("");
+            setCategory("all");
+          }}
+        />
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
+          <nav aria-labelledby={categoryHeadingId} className="grid content-start gap-3">
+            <h3 id={categoryHeadingId} className="text-sm font-semibold text-slate-800">
+              Categories
+            </h3>
+            <div className="grid gap-2" aria-label="Template categories">
+              {categoryOptions.map((option) => {
+                const isSelected = category === option;
+                const label =
+                  option === "all" ? "All templates" : emailTemplateCategoryLabels[option];
+
+                return (
+                  <button
+                    key={option}
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => {
+                      setCategory(option);
+                      setSuccessMessage("");
+                    }}
+                    className={`rounded-md border px-3 py-2 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-indigo-200 ${
+                      isSelected
+                        ? "border-indigo-600 bg-indigo-50 text-indigo-900"
+                        : "border-slate-200 bg-white text-slate-700 hover:border-slate-300"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </nav>
+
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,360px)_1fr]">
+            <div className="grid content-start gap-2" aria-label="Email templates">
+              {filteredTemplates.map((template) => {
+                const isSelected = selectedTemplate?.id === template.id;
+
+                return (
+                  <button
+                    key={template.id}
+                    type="button"
+                    aria-current={isSelected}
+                    onClick={() => selectTemplate(template)}
+                    className={`rounded-md border p-3 text-left transition focus:outline-none focus:ring-2 focus:ring-indigo-200 ${
+                      isSelected
+                        ? "border-indigo-600 bg-indigo-50"
+                        : "border-slate-200 bg-white hover:border-slate-300"
+                    }`}
+                  >
+                    <span className="block text-sm font-semibold text-slate-950">
+                      {template.name}
+                    </span>
+                    <span className="mt-1 block text-xs text-slate-600">{template.subject}</span>
+                    <span className="mt-3 flex flex-wrap gap-1">
+                      {template.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-700"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {selectedTemplate ? (
+              <article className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                <div className="flex flex-col gap-3 border-b border-slate-200 pb-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-normal text-slate-500">
+                      Preview
+                    </p>
+                    <h3 className="mt-1 text-lg font-semibold text-slate-950">
+                      {selectedTemplate.name}
+                    </h3>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={useSelectedTemplate}
+                    className="h-9 rounded-md bg-slate-950 px-3 text-sm font-medium text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300"
+                  >
+                    Use template
+                  </button>
+                </div>
+
+                <dl className="mt-4 grid gap-4">
+                  <div>
+                    <dt className="text-xs font-semibold uppercase tracking-normal text-slate-500">
+                      Subject
+                    </dt>
+                    <dd className="mt-1 rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-900">
+                      {selectedTemplate.subject}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs font-semibold uppercase tracking-normal text-slate-500">
+                      Body
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-line rounded-md border border-slate-200 bg-white p-3 text-sm leading-6 text-slate-900">
+                      {selectedTemplate.body}
+                    </dd>
+                  </div>
+                  <div className="text-xs text-slate-500">
+                    Last updated{" "}
+                    <time dateTime={selectedTemplate.lastUpdated}>
+                      {selectedTemplate.lastUpdated}
+                    </time>
+                  </div>
+                </dl>
+              </article>
+            ) : null}
+          </div>
+        </div>
+      )}
+
+      {successMessage && !isLoading && !error ? (
+        <div role="status" className="rounded-md border border-emerald-200 bg-emerald-50 p-3">
+          <p className="text-sm font-medium text-emerald-900">{successMessage}</p>
+        </div>
+      ) : null}
+
+      <p id={statusId} aria-live="polite" className="sr-only">
+        {statusMessage}
+      </p>
+    </section>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="grid gap-3" role="status" aria-label="Loading templates">
+      <span className="sr-only">Loading templates</span>
+      {[0, 1, 2].map((item) => (
+        <div key={item} className="h-20 animate-pulse rounded-md bg-slate-100" />
+      ))}
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm">
+      <p className="font-semibold text-red-900">Templates could not be loaded.</p>
+      <p className="mt-1 text-red-800">{message}</p>
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 h-9 rounded-md bg-red-700 px-3 text-sm font-medium text-white transition hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-red-200"
+        >
+          Retry
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyState({
+  hasFilters,
+  onClearFilters,
+}: {
+  hasFilters: boolean;
+  onClearFilters: () => void;
+}) {
+  return (
+    <div role="status" className="rounded-md border border-slate-200 bg-slate-50 p-6 text-sm">
+      <p className="font-semibold text-slate-950">
+        {hasFilters ? "No templates match the current filters." : "No templates yet."}
+      </p>
+      <p className="mt-1 text-slate-600">
+        {hasFilters
+          ? "Clear filters or search for a different subject, tag, or template body."
+          : "Add a local fixture or connect a future template service inside this tool folder."}
+      </p>
+      {hasFilters ? (
+        <button
+          type="button"
+          onClick={onClearFilters}
+          className="mt-3 h-9 rounded-md border border-slate-300 bg-white px-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          Clear filters
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/tools/v2/individual/email-template-library/docs/review-guide.md
+++ b/tools/v2/individual/email-template-library/docs/review-guide.md
@@ -1,0 +1,28 @@
+# Email Template Library Review Guide
+
+This tool is intentionally isolated from the main Stealth Mail application. Reviewers can inspect the local component and fixtures without mounting it in production routes.
+
+## Local UI Surface
+
+- `components/EmailTemplateLibrary.tsx` contains the folder-local React surface.
+- `fixtures/templates.ts` provides deterministic sample templates and category metadata.
+- `index.ts` exports the component and fixtures for a future integration issue.
+
+## States Covered
+
+- Loading: pass `isLoading` to the component. The root sets `aria-busy` and the skeleton area exposes a screen-reader status.
+- Error: pass `error` and optionally `onRetry`. The error panel uses `role="alert"` and exposes a keyboard-focusable retry button.
+- Empty: pass an empty `templates` array, or filter the fixtures until no results remain. The panel uses `role="status"`.
+- Success: using a template shows a visible success panel and updates a polite live region so screen readers announce the action.
+
+## Accessibility Notes
+
+- Search uses a native `<input type="search">` with an explicit label.
+- Category filters are native buttons with `aria-pressed`.
+- Template cards are native buttons, which keeps pointer, keyboard, and focus behavior consistent.
+- Preview content uses a definition list so subject, body, and update metadata remain structured.
+- The workflow does not require custom keyboard shortcuts; Tab, Shift+Tab, Enter, and Space cover all controls.
+
+## Visual Style
+
+The component uses neutral Tailwind utility classes and local markup only. It does not modify the shared design system, global CSS, app shell, navigation, authentication, wallet core, Stellar integration, database schema, or mail rendering engine.

--- a/tools/v2/individual/email-template-library/fixtures/templates.ts
+++ b/tools/v2/individual/email-template-library/fixtures/templates.ts
@@ -1,0 +1,57 @@
+export type EmailTemplateCategory = "follow-up" | "intro" | "billing" | "support";
+
+export type EmailTemplate = {
+  id: string;
+  name: string;
+  category: EmailTemplateCategory;
+  subject: string;
+  body: string;
+  tags: string[];
+  lastUpdated: string;
+};
+
+export const emailTemplateCategoryLabels: Record<EmailTemplateCategory, string> = {
+  "follow-up": "Follow-up",
+  intro: "Intro",
+  billing: "Billing",
+  support: "Support",
+};
+
+export const emailTemplateFixtures: EmailTemplate[] = [
+  {
+    id: "follow-up-gentle-nudge",
+    name: "Gentle follow-up",
+    category: "follow-up",
+    subject: "Following up on {{topic}}",
+    body: "Hi {{first_name}},\n\nI wanted to follow up on {{topic}} and see if there is anything I can clarify. Happy to adjust the timing if another date works better.\n\nBest,\n{{sender_name}}",
+    tags: ["low pressure", "pending reply"],
+    lastUpdated: "2026-06-15",
+  },
+  {
+    id: "intro-new-contact",
+    name: "New contact intro",
+    category: "intro",
+    subject: "Introduction from {{sender_name}}",
+    body: "Hi {{first_name}},\n\nIt was good connecting with you. I am sharing a short note here so we have a clear thread for {{shared_context}}.\n\nBest,\n{{sender_name}}",
+    tags: ["first touch", "relationship"],
+    lastUpdated: "2026-06-12",
+  },
+  {
+    id: "billing-payment-reminder",
+    name: "Payment reminder",
+    category: "billing",
+    subject: "Reminder: invoice {{invoice_number}}",
+    body: "Hi {{first_name}},\n\nThis is a quick reminder that invoice {{invoice_number}} is due on {{due_date}}. Let me know if you need the payment link sent again.\n\nThanks,\n{{sender_name}}",
+    tags: ["invoice", "due date"],
+    lastUpdated: "2026-06-10",
+  },
+  {
+    id: "support-resolution",
+    name: "Support resolution",
+    category: "support",
+    subject: "Resolution for {{ticket_topic}}",
+    body: "Hi {{first_name}},\n\nWe resolved {{ticket_topic}} and confirmed the account is working as expected. Reply here if you see the issue again.\n\nRegards,\n{{sender_name}}",
+    tags: ["ticket", "resolved"],
+    lastUpdated: "2026-06-08",
+  },
+];

--- a/tools/v2/individual/email-template-library/index.ts
+++ b/tools/v2/individual/email-template-library/index.ts
@@ -1,0 +1,7 @@
+export { EmailTemplateLibrary } from "./components/EmailTemplateLibrary";
+export {
+  emailTemplateCategoryLabels,
+  emailTemplateFixtures,
+  type EmailTemplate,
+  type EmailTemplateCategory,
+} from "./fixtures/templates";

--- a/tools/v2/individual/email-template-library/specs.md
+++ b/tools/v2/individual/email-template-library/specs.md
@@ -1,40 +1,37 @@
-# Email Template Library
-
-Personal template system.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- 	ests/
-- docs/
-"@ | Set-Content -Path "tools/v2/individual/email-template-library/README.md"
-  @"
 # Email Template Library Specs
 
 ## Purpose
 
 Personal template system.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V2
+- Audience: individual
+- Folder ownership: `tools/v2/individual/email-template-library/`
 
-$dir/
+This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, mail rendering engine, or shared design system unless a future integration issue explicitly allows it.
 
-## Required issue categories
+Recommended internal structure:
+
+- components/
+- services/
+- hooks/
+- tests/
+- docs/
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Implemented UI Scope
+
+- Folder-local React component for browsing, filtering, previewing, and selecting templates.
+- Deterministic local fixtures for individual email template categories.
+- Loading, error, empty, and successful selection states.
+- Native keyboard and focus behavior through labeled inputs and buttons.
+- Local review documentation for accessibility and visual style decisions.


### PR DESCRIPTION
## Summary
- Add a folder-local EmailTemplateLibrary React surface for searching, filtering, previewing, and selecting personal templates.
- Add deterministic local fixtures plus export entry points for a future integration issue.
- Document loading, error, empty, success, keyboard, focus, labeling, and screen-reader review notes without mounting the tool in the main app.
- Clean up the local README/specs placeholders inside the tool boundary.

## Validation
- ./node_modules/.bin/tsc --noEmit --jsx react-jsx --module ESNext --moduleResolution Bundler --target ES2022 --lib ES2022,DOM,DOM.Iterable --strict --skipLibCheck tools/v2/individual/email-template-library/index.ts
- ./node_modules/.bin/eslint tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx tools/v2/individual/email-template-library/fixtures/templates.ts tools/v2/individual/email-template-library/index.ts
- ./node_modules/.bin/prettier --check tools/v2/individual/email-template-library/README.md tools/v2/individual/email-template-library/specs.md tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx tools/v2/individual/email-template-library/fixtures/templates.ts tools/v2/individual/email-template-library/index.ts tools/v2/individual/email-template-library/docs/review-guide.md
- git diff --check

Closes