### PR TITLE
feat(demo-admin-dashboard): campaign bulk tag editor

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/bulkTagEditor.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkTagEditor.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import {
+  applyBulkTagEdit,
+  normalizeTag,
+  normalizeTags,
+  parseTagInput,
+  summarizeBulkTagEdit,
+} from "../bulkTagEditor";
+
+function makeCampaign(id: string, name: string, tags: string[]): CampaignSnapshot {
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    targetAudience: "Test Audience",
+    tags,
+    timestamp: "2026-06-16T12:00:00Z",
+    drafts: [],
+  };
+}
+
+function byId(campaigns: CampaignSnapshot[], id: string): CampaignSnapshot {
+  const found = campaigns.find((campaign) => campaign.id === id);
+  if (!found) {
+    throw new Error(`Campaign ${id} not found`);
+  }
+  return found;
+}
+
+function sample(): CampaignSnapshot[] {
+  return [
+    makeCampaign("c1", "Welcome Series", ["onboarding", "welcome"]),
+    makeCampaign("c2", "Security Notice", ["security", "alert"]),
+    makeCampaign("c3", "Monthly News", ["newsletter"]),
+  ];
+}
+
+describe("tag normalization", () => {
+  it("lower-cases and trims a single tag", () => {
+    expect(normalizeTag("  Onboarding  ")).toBe("onboarding");
+  });
+
+  it("normalizes, drops blanks, and de-duplicates a list", () => {
+    expect(normalizeTags(["Welcome", "welcome", "  ", "Stellar"])).toEqual(["welcome", "stellar"]);
+  });
+
+  it("parses comma or whitespace separated input", () => {
+    expect(parseTagInput("VIP, vip  promo")).toEqual(["vip", "promo"]);
+  });
+});
+
+describe("applyBulkTagEdit - add", () => {
+  it("adds new tags to selected campaigns without mutating input", () => {
+    const campaigns = sample();
+    const result = applyBulkTagEdit(campaigns, ["c1", "c3"], ["promo"], "add");
+
+    expect(campaigns[0].tags).toEqual(["onboarding", "welcome"]);
+    expect(byId(result.campaigns, "c1").tags).toEqual(["onboarding", "welcome", "promo"]);
+    expect(byId(result.campaigns, "c3").tags).toEqual(["newsletter", "promo"]);
+    expect(byId(result.campaigns, "c2").tags).toEqual(["security", "alert"]);
+  });
+
+  it("prevents duplicate tags", () => {
+    const result = applyBulkTagEdit(sample(), ["c1"], ["welcome", "promo"], "add");
+
+    expect(byId(result.campaigns, "c1").tags).toEqual(["onboarding", "welcome", "promo"]);
+    expect(result.changes[0].applied).toEqual(["promo"]);
+    expect(result.changes[0].skipped).toEqual(["welcome"]);
+    expect(result.summary.totalApplied).toBe(1);
+    expect(result.summary.totalSkipped).toBe(1);
+  });
+});
+
+describe("applyBulkTagEdit - remove", () => {
+  it("removes existing tags and skips ones not present", () => {
+    const result = applyBulkTagEdit(sample(), ["c1", "c2"], ["alert", "missing"], "remove");
+
+    expect(byId(result.campaigns, "c1").tags).toEqual(["onboarding", "welcome"]);
+    expect(byId(result.campaigns, "c2").tags).toEqual(["security"]);
+    expect(result.summary.totalApplied).toBe(1);
+    expect(result.summary.affectedCount).toBe(1);
+  });
+});
+
+describe("summarizeBulkTagEdit", () => {
+  it("summarizes an add across multiple campaigns", () => {
+    const result = applyBulkTagEdit(sample(), ["c1", "c2"], ["promo"], "add");
+    expect(summarizeBulkTagEdit(result)).toBe("Added 2 tags across 2 campaigns.");
+  });
+
+  it("reports when nothing changed", () => {
+    const result = applyBulkTagEdit(sample(), ["c1"], ["welcome"], "add");
+    expect(summarizeBulkTagEdit(result)).toBe("No changes - all were duplicates (1 skipped).");
+  });
+});

--- a/src/features/demo-admin-dashboard/bulkTagEditor.ts
+++ b/src/features/demo-admin-dashboard/bulkTagEditor.ts
@@ -1,0 +1,145 @@
+import type { CampaignSnapshot } from "./types/campaignSnapshot";
+
+/**
+ * Bulk tag editor logic for the demo admin dashboard.
+ *
+ * Pure, deterministic helpers that add or remove tags across many campaigns
+ * at once, prevent duplicate tags, and produce an audit summary describing
+ * exactly what changed. Inputs are never mutated.
+ */
+
+export type BulkTagOperation = "add" | "remove";
+
+export interface BulkTagCampaignChange {
+  id: string;
+  name: string;
+  applied: string[];
+  skipped: string[];
+}
+
+export interface BulkTagAuditSummary {
+  operation: BulkTagOperation;
+  selectedCount: number;
+  affectedCount: number;
+  totalApplied: number;
+  totalSkipped: number;
+}
+
+export interface BulkTagEditResult {
+  campaigns: CampaignSnapshot[];
+  operation: BulkTagOperation;
+  requestedTags: string[];
+  changes: BulkTagCampaignChange[];
+  summary: BulkTagAuditSummary;
+}
+
+export function normalizeTag(tag: string): string {
+  return tag.toLowerCase().trim();
+}
+
+export function normalizeTags(tags: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of tags) {
+    const tag = normalizeTag(raw);
+    if (tag.length === 0 || seen.has(tag)) {
+      continue;
+    }
+    seen.add(tag);
+    result.push(tag);
+  }
+  return result;
+}
+
+export function parseTagInput(input: string): string[] {
+  return normalizeTags(input.split(/[\s,]+/));
+}
+
+export function applyBulkTagEdit(
+  campaigns: CampaignSnapshot[],
+  selectedIds: string[],
+  tags: string[],
+  operation: BulkTagOperation,
+): BulkTagEditResult {
+  const requestedTags = normalizeTags(tags);
+  const selected = new Set(selectedIds);
+  const changes: BulkTagCampaignChange[] = [];
+
+  const nextCampaigns = campaigns.map((campaign) => {
+    if (!selected.has(campaign.id)) {
+      return campaign;
+    }
+
+    const existing = campaign.tags.map(normalizeTag);
+    const existingSet = new Set(existing);
+    const applied: string[] = [];
+    const skipped: string[] = [];
+
+    if (operation === "add") {
+      const nextTags = [...existing];
+      for (const tag of requestedTags) {
+        if (existingSet.has(tag)) {
+          skipped.push(tag);
+        } else {
+          existingSet.add(tag);
+          nextTags.push(tag);
+          applied.push(tag);
+        }
+      }
+      changes.push({ id: campaign.id, name: campaign.name, applied, skipped });
+      return applied.length === 0 ? campaign : { ...campaign, tags: nextTags };
+    }
+
+    const removeSet = new Set(requestedTags);
+    for (const tag of requestedTags) {
+      if (existingSet.has(tag)) {
+        applied.push(tag);
+      } else {
+        skipped.push(tag);
+      }
+    }
+    changes.push({ id: campaign.id, name: campaign.name, applied, skipped });
+    return applied.length === 0
+      ? campaign
+      : { ...campaign, tags: existing.filter((tag) => !removeSet.has(tag)) };
+  });
+
+  const affectedCount = changes.filter((change) => change.applied.length > 0).length;
+  const totalApplied = changes.reduce((sum, change) => sum + change.applied.length, 0);
+  const totalSkipped = changes.reduce((sum, change) => sum + change.skipped.length, 0);
+
+  return {
+    campaigns: nextCampaigns,
+    operation,
+    requestedTags,
+    changes,
+    summary: {
+      operation,
+      selectedCount: changes.length,
+      affectedCount,
+      totalApplied,
+      totalSkipped,
+    },
+  };
+}
+
+export function summarizeBulkTagEdit(result: BulkTagEditResult): string {
+  const { operation, summary } = result;
+
+  if (summary.totalApplied === 0) {
+    const reason = operation === "add" ? "all were duplicates" : "none were present";
+    return `No changes - ${reason} (${summary.totalSkipped} skipped).`;
+  }
+
+  const verb = operation === "add" ? "Added" : "Removed";
+  const tagWord = summary.totalApplied === 1 ? "tag" : "tags";
+  const campaignWord = summary.affectedCount === 1 ? "campaign" : "campaigns";
+  const base = `${verb} ${summary.totalApplied} ${tagWord} across ${summary.affectedCount} ${campaignWord}`;
+
+  if (summary.totalSkipped === 0) {
+    return `${base}.`;
+  }
+
+  const skipReason = operation === "add" ? "skipped as duplicates" : "skipped (not present)";
+  return `${base} (${summary.totalSkipped} ${skipReason}).`;
+}

--- a/src/features/demo-admin-dashboard/components/BulkTagEditor.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkTagEditor.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from "react";
+import { Check, Plus, Tag, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import { getTagToken } from "../constants/displayTokens";
+import {
+  applyBulkTagEdit,
+  parseTagInput,
+  summarizeBulkTagEdit,
+  type BulkTagEditResult,
+  type BulkTagOperation,
+} from "../bulkTagEditor";
+
+export interface BulkTagEditorProps {
+  campaigns: CampaignSnapshot[];
+  onApply?: (result: BulkTagEditResult) => void;
+  className?: string;
+}
+
+export function BulkTagEditor({ campaigns, onApply, className }: BulkTagEditorProps) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [tagsInput, setTagsInput] = useState("");
+  const [lastResult, setLastResult] = useState<BulkTagEditResult | null>(null);
+
+  const parsedTags = useMemo(() => parseTagInput(tagsInput), [tagsInput]);
+  const canApply = selectedIds.length > 0 && parsedTags.length > 0;
+
+  const toggleCampaign = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id],
+    );
+  };
+
+  const runEdit = (operation: BulkTagOperation) => {
+    if (!canApply) {
+      return;
+    }
+    const result = applyBulkTagEdit(campaigns, selectedIds, parsedTags, operation);
+    setLastResult(result);
+    onApply?.(result);
+  };
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-center gap-2">
+        <Tag className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Bulk tag editor</h3>
+      </header>
+
+      <ul className="flex flex-col gap-1">
+        {campaigns.map((campaign) => {
+          const checked = selectedIds.includes(campaign.id);
+          return (
+            <li key={campaign.id}>
+              <button
+                type="button"
+                onClick={() => toggleCampaign(campaign.id)}
+                className={cn(
+                  "flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition-colors",
+                  checked
+                    ? "border-sky-500/40 bg-sky-500/10"
+                    : "border-white/[0.06] hover:bg-white/[0.04]",
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 items-center justify-center rounded border",
+                      checked ? "border-sky-400 bg-sky-500/20" : "border-white/20",
+                    )}
+                  >
+                    {checked ? <Check className="h-3 w-3" /> : null}
+                  </span>
+                  {campaign.name}
+                </span>
+                <span className="flex flex-wrap gap-1">
+                  {campaign.tags.map((tag) => {
+                    const token = getTagToken(tag);
+                    return (
+                      <span
+                        key={tag}
+                        className={cn(
+                          "rounded-full border px-2 py-0.5 text-xs",
+                          token.bg,
+                          token.text,
+                          token.border,
+                        )}
+                      >
+                        {token.label}
+                      </span>
+                    );
+                  })}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="flex flex-col gap-2">
+        <input
+          type="text"
+          value={tagsInput}
+          onChange={(event) => setTagsInput(event.target.value)}
+          aria-label="Tags to add or remove"
+          placeholder="Tags (comma separated), e.g. promo, vip"
+          className="rounded-lg border border-white/[0.08] bg-transparent px-3 py-2 text-sm outline-none focus:border-sky-500/40"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={!canApply}
+            onClick={() => runEdit("add")}
+            className={cn(
+              "flex items-center gap-1 rounded-lg border px-3 py-2 text-sm transition-colors",
+              canApply
+                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20"
+                : "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60",
+            )}
+          >
+            <Plus className="h-4 w-4" />
+            Add tags
+          </button>
+          <button
+            type="button"
+            disabled={!canApply}
+            onClick={() => runEdit("remove")}
+            className={cn(
+              "flex items-center gap-1 rounded-lg border px-3 py-2 text-sm transition-colors",
+              canApply
+                ? "border-rose-500/30 bg-rose-500/10 text-rose-300 hover:bg-rose-500/20"
+                : "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60",
+            )}
+          >
+            <X className="h-4 w-4" />
+            Remove tags
+          </button>
+        </div>
+      </div>
+
+      {lastResult ? (
+        <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 text-sm">
+          <p className="font-medium">{summarizeBulkTagEdit(lastResult)}</p>
+          <ul className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
+            {lastResult.changes
+              .filter((change) => change.applied.length > 0)
+              .map((change) => (
+                <li key={change.id}>
+                  {change.name}: {lastResult.operation === "add" ? "+" : "-"}
+                  {change.applied.join(", ")}
+                  {change.skipped.length > 0 ? ` (skipped ${change.skipped.join(", ")})` : ""}
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/docs/BULK_TAG_EDITOR.md
+++ b/src/features/demo-admin-dashboard/docs/BULK_TAG_EDITOR.md
@@ -1,0 +1,38 @@
+# Bulk Tag Editor
+
+Lets an admin add or remove campaign tags across multiple selected campaigns at
+once, with duplicate prevention and an audit summary of what changed.
+
+All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on
+fake, deterministic demo data (`CampaignSnapshot[]`). Nothing here touches real
+mail flows, network calls, or data outside this folder.
+
+## Pieces
+
+- `bulkTagEditor.ts` — pure, immutable helpers:
+  - `normalizeTag` / `normalizeTags` / `parseTagInput` — normalize (lowercase +
+    trim), drop blanks, and de-duplicate tag input.
+  - `applyBulkTagEdit(campaigns, selectedIds, tags, operation)` — returns a new
+    campaign list plus a per-campaign change log and an audit summary. Inputs
+    are never mutated.
+  - `summarizeBulkTagEdit(result)` — a one-line human summary.
+- `components/BulkTagEditor.tsx` — selection list, tag input, Add/Remove
+  buttons, and a rendered audit summary using the existing tag color tokens.
+
+## Duplicate prevention
+
+- **Add:** a tag already present on a campaign is skipped (never duplicated).
+- **Remove:** a tag not present on a campaign is skipped.
+
+Skipped tags are reported per campaign and counted in the audit summary.
+
+## Audit summary
+
+`applyBulkTagEdit` returns a `summary` with the operation, number of selected
+and affected campaigns, and totals for applied vs skipped tags. Example line:
+`Added 2 tags across 3 campaigns (1 skipped as duplicates).`
+
+## Follow-up
+
+Wiring this component into the main dashboard view is intentionally left as a
+follow-up so this change stays scoped and independently reviewable.

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,3 +56,19 @@ export * from "./validation";
 export * from "./validationFixtures";
 export { ValidationResultsPanel } from "./ValidationResultsPanel";
 export type { ValidationResultsPanelProps } from "./ValidationResultsPanel";
+
+export {
+  applyBulkTagEdit,
+  normalizeTag,
+  normalizeTags,
+  parseTagInput,
+  summarizeBulkTagEdit,
+} from "./bulkTagEditor";
+export type {
+  BulkTagOperation,
+  BulkTagCampaignChange,
+  BulkTagAuditSummary,
+  BulkTagEditResult,
+} from "./bulkTagEditor";
+export { BulkTagEditor } from "./components/BulkTagEditor";
+export type { BulkTagEditorProps } from "./components/BulkTagEditor";


### PR DESCRIPTION
## What this does
Adds a bulk tag editor for campaigns in the demo admin dashboard. An admin can select multiple campaigns and add or remove tags across all of them in one action.

## Highlights
- **Duplicate prevention** — adding a tag a campaign already has is skipped; removing a tag it doesn't have is skipped.
- **Audit summary** — each action reports what changed per campaign and in total, e.g. `Added 2 tags across 3 campaigns (1 skipped as duplicates)`.
- Reuses the existing tag color tokens and `CampaignSnapshot` data so it stays consistent with the rest of the dashboard.

## Scope
All changes live under `src/features/demo-admin-dashboard/`. No files outside the folder are touched, and all campaign data stays fake and deterministic. Wiring the component into the main dashboard view is left as a follow-up to keep this PR focused and easy to review.

## Files
- `bulkTagEditor.ts` — pure add/remove/normalize/summary helpers
- `components/BulkTagEditor.tsx` — selection + tag input UI with the audit summary
- `__tests__/bulkTagEditor.test.ts` — 8 unit tests
- `docs/BULK_TAG_EDITOR.md` — short feature doc
- `index.ts` — exports

## Testing
- `vitest run src/features/demo-admin-dashboard` → 113 passing (8 new)
- ESLint clean, Prettier formatted, `tsc --noEmit` reports 0 errors

Closes #283
