### PR TITLE
Add vendor mail tracker test plan

### DIFF
--- a/tools/v2/team/vendor-mail-tracker/README.md
+++ b/tools/v2/team/vendor-mail-tracker/README.md
@@ -1,15 +1,66 @@
 # Vendor Mail Tracker
 
-This folder is the isolated workspace for the Vendor Mail Tracker tool.
+Vendor Mail Tracker is an isolated V2 team tool workspace for tracking vendor
+communications, outstanding replies, blockers, and follow-up ownership before a
+future mail-app integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\vendor-mail-tracker\
-`
+```text
+tools/v2/team/vendor-mail-tracker/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node test.
+No app install is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
+```
+
+The test validates the sample vendor-mail fixture against the local review
+contract described in `specs.md`.
+
+## Tracking Workflow
+
+1. Capture vendor messages from synthetic email records.
+2. Normalize each thread into vendor, owner, status, last contact, and due date.
+3. Route each thread to `open`, `waiting-on-vendor`, `blocked`, or `resolved`.
+4. Preserve a source message id for traceability.
+5. Flag stale, blocked, or high-priority vendor threads for human review.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-vendor-mails.json` contains:
+
+- an open onboarding thread that needs an internal owner response
+- a waiting-on-vendor thread with a pending security questionnaire
+- a blocked invoice thread missing required documentation
+- a resolved renewal thread with complete owner evidence
+
+The fixture intentionally uses `example.test` addresses, synthetic vendor names,
+and fake thread ids so contributors can validate behavior without using real
+vendor, invoice, customer, or mailbox data.
+
+## Documentation Map
+
+- `specs.md` defines the local vendor-mail tracking contract and scope.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` explains validation and known limits.
+- `tests/vendor-mail-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or live mailbox ingestion.
+- Tracking behavior is represented through fixture expectations only.
+- Vendor authentication, attachment storage, billing workflows, and
+  notifications remain out of scope for this isolated V2 folder.

--- a/tools/v2/team/vendor-mail-tracker/docs/review-notes.md
+++ b/tools/v2/team/vendor-mail-tracker/docs/review-notes.md
@@ -1,0 +1,27 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete vendor-mail review
+  contract.
+- Adds synthetic fixture data for vendor thread tracking states.
+- Adds a zero-dependency Node test for the fixture and local rules.
+- Documents setup, review flow, limitations, and future integration needs.
+
+## Validation Performed
+
+- `node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- This issue is limited to testing and documentation assets.
+- The fixture should make future implementation behavior unambiguous.
+- No real vendor names, invoice data, mailbox content, or credentials are used.
+- No production app behavior changes from this contribution.
+
+## Follow-Up Work
+
+- Add service code that normalizes vendor email thread records.
+- Add UI and accessibility coverage for vendor status review.
+- Add security and retention rules before any live mailbox integration.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/team/vendor-mail-tracker/docs/test-plan.md
+++ b/tools/v2/team/vendor-mail-tracker/docs/test-plan.md
@@ -1,0 +1,43 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source message maps to one expected vendor thread
+- all local vendor thread statuses are represented
+- thread priorities are limited to the local priority set
+- blocked threads require human review
+- resolved threads do not require a next action due date
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-vendor-mails.json`.
+2. Confirm all source messages use synthetic data.
+3. Confirm each expected thread has a traceable `sourceMessageId`.
+4. Confirm `docs/review-notes.md` documents out-of-scope live mailbox behavior.
+5. Confirm no files outside `tools/v2/team/vendor-mail-tracker/` changed.
+
+## Edge Cases Covered
+
+- active vendor onboarding thread
+- high-priority waiting-on-vendor thread
+- blocked invoice thread with missing supporting documentation
+- resolved procurement thread without future due date
+
+## Future Integration Tests
+
+When implementation code is added, add tests for:
+
+- stale thread threshold configuration
+- duplicate vendor thread detection
+- attachment and document presence checks
+- owner assignment and reassignment
+- notification throttling and audit log creation

--- a/tools/v2/team/vendor-mail-tracker/fixtures/sample-vendor-mails.json
+++ b/tools/v2/team/vendor-mail-tracker/fixtures/sample-vendor-mails.json
@@ -1,0 +1,97 @@
+{
+  "tool": "vendor-mail-tracker",
+  "version": 1,
+  "sourceMessages": [
+    {
+      "id": "message-onboarding-001",
+      "type": "email",
+      "from": "implementation@example.test",
+      "subject": "Vendor onboarding steps",
+      "receivedAt": "2026-06-15T08:40:00Z",
+      "body": "Please confirm the data-processing checklist before kickoff.",
+      "hasRequiredDocument": true,
+      "vendorResponded": true
+    },
+    {
+      "id": "message-security-002",
+      "type": "email",
+      "from": "security-review@example.test",
+      "subject": "Security questionnaire pending",
+      "receivedAt": "2026-06-15T13:25:00Z",
+      "body": "We sent the security questionnaire to the vendor and are waiting for their answers.",
+      "hasRequiredDocument": true,
+      "vendorResponded": false
+    },
+    {
+      "id": "message-invoice-003",
+      "type": "email",
+      "from": "billing@example.test",
+      "subject": "Invoice dispute needs supporting document",
+      "receivedAt": "2026-06-16T09:10:00Z",
+      "body": "The vendor invoice total changed, but the revised purchase order is missing.",
+      "hasRequiredDocument": false,
+      "vendorResponded": true
+    },
+    {
+      "id": "message-renewal-004",
+      "type": "email",
+      "from": "procurement@example.test",
+      "subject": "Renewal complete",
+      "receivedAt": "2026-06-16T16:50:00Z",
+      "body": "The vendor renewal has been reviewed and marked complete by procurement.",
+      "hasRequiredDocument": true,
+      "vendorResponded": true
+    }
+  ],
+  "expectedThreads": [
+    {
+      "id": "thread-onboarding-001",
+      "vendor": "Atlas Implementation",
+      "owner": "implementation",
+      "priority": "medium",
+      "status": "open",
+      "lastContactAt": "2026-06-15T08:40:00Z",
+      "nextActionDueAt": "2026-06-17T17:00:00Z",
+      "sourceMessageId": "message-onboarding-001",
+      "reviewRequired": true
+    },
+    {
+      "id": "thread-security-002",
+      "vendor": "Northstar Security",
+      "owner": "security",
+      "priority": "high",
+      "status": "waiting-on-vendor",
+      "lastContactAt": "2026-06-15T13:25:00Z",
+      "nextActionDueAt": "2026-06-18T12:00:00Z",
+      "sourceMessageId": "message-security-002",
+      "reviewRequired": true
+    },
+    {
+      "id": "thread-invoice-003",
+      "vendor": "Blue River Billing",
+      "owner": "finance",
+      "priority": "high",
+      "status": "blocked",
+      "lastContactAt": "2026-06-16T09:10:00Z",
+      "nextActionDueAt": "2026-06-17T09:00:00Z",
+      "sourceMessageId": "message-invoice-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "thread-renewal-004",
+      "vendor": "Evergreen Procurement",
+      "owner": "procurement",
+      "priority": "low",
+      "status": "resolved",
+      "lastContactAt": "2026-06-16T16:50:00Z",
+      "nextActionDueAt": null,
+      "sourceMessageId": "message-renewal-004",
+      "reviewRequired": false
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses synthetic example.test messages only.",
+    "Staleness thresholds are local to this fixture and should be configurable later.",
+    "Live mailbox ingestion, vendor notifications, and attachment storage stay out of scope."
+  ]
+}

--- a/tools/v2/team/vendor-mail-tracker/specs.md
+++ b/tools/v2/team/vendor-mail-tracker/specs.md
@@ -1,41 +1,65 @@
-# Vendor Mail Tracker
-
-Vendor communication tracking.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/vendor-mail-tracker/README.md"
-  @"
-
 # Vendor Mail Tracker Specs
 
 ## Purpose
 
-Vendor communication tracking.
+Define a self-contained review contract for tracking vendor email threads before
+any future app, inbox, or notification integration.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: team
+- Folder ownership: `tools/v2/team/vendor-mail-tracker/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model vendor email threads with audit-friendly source metadata.
+- Distinguish routine follow-ups from stale, blocked, or high-priority threads.
+- Represent blocked threads without attempting vendor communication side effects.
+- Provide fixture coverage for each local tracking status.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mail rendering, or attachment storage changes
+- Vendor portal authentication or external API calls
+- Database schema or shared design system changes
+- Notification delivery or role-permission enforcement
+
+## Vendor Thread Contract
+
+Each expected tracking record should include:
+
+- `id`: stable fixture-local tracking identifier
+- `vendor`: vendor display name
+- `owner`: internal owner responsible for the next action
+- `priority`: one of `low`, `medium`, `high`
+- `status`: one of `open`, `waiting-on-vendor`, `blocked`, `resolved`
+- `lastContactAt`: ISO timestamp for the last vendor-related message
+- `nextActionDueAt`: ISO timestamp or null when the thread is resolved
+- `sourceMessageId`: source email identifier
+- `reviewRequired`: true when a person must resolve missing or risky details
+
+## Review Rules
+
+- high-priority threads require human review unless already resolved
+- missing required documents must be blocked
+- stale open threads require review
+- blocked threads must set `reviewRequired` to true
+- resolved threads must not require a next action due date
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. If a future issue adds live
+mailbox ingestion or vendor notifications, it should define security, privacy,
+and retention constraints before connecting this tool to production data.

--- a/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
+++ b/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-vendor-mails.json");
+
+const allowedPriorities = new Set(["low", "medium", "high"]);
+const allowedStatuses = new Set(["open", "waiting-on-vendor", "blocked", "resolved"]);
+const requiredStatuses = ["open", "waiting-on-vendor", "blocked", "resolved"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample vendor mail fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "vendor-mail-tracker");
+  assert.ok(Array.isArray(fixture.sourceMessages), "sourceMessages must be an array");
+  assert.ok(Array.isArray(fixture.expectedThreads), "expectedThreads must be an array");
+  assert.equal(fixture.sourceMessages.length, fixture.expectedThreads.length);
+
+  const sourceIds = new Set(fixture.sourceMessages.map((message) => message.id));
+  const sourceById = new Map(fixture.sourceMessages.map((message) => [message.id, message]));
+  const seenStatuses = new Set();
+
+  for (const thread of fixture.expectedThreads) {
+    assert.ok(thread.id, "thread needs a stable id");
+    assert.ok(thread.vendor, `${thread.id} needs a vendor`);
+    assert.ok(thread.owner, `${thread.id} needs an owner`);
+    assert.ok(allowedPriorities.has(thread.priority), `${thread.id} has invalid priority`);
+    assert.ok(allowedStatuses.has(thread.status), `${thread.id} has invalid status`);
+    assert.ok(sourceIds.has(thread.sourceMessageId), `${thread.id} source message is missing`);
+    assert.match(thread.lastContactAt, /^\d{4}-\d{2}-\d{2}T/, `${thread.id} needs an ISO last contact`);
+
+    if (thread.status === "resolved") {
+      assert.equal(thread.nextActionDueAt, null, `${thread.id} resolved threads should not have due dates`);
+      assert.equal(thread.reviewRequired, false, `${thread.id} resolved threads should not require review`);
+    } else {
+      assert.match(thread.nextActionDueAt, /^\d{4}-\d{2}-\d{2}T/, `${thread.id} needs an ISO due date`);
+    }
+
+    if (thread.priority === "high" && thread.status !== "resolved") {
+      assert.equal(thread.reviewRequired, true, `${thread.id} high-priority open threads require review`);
+    }
+
+    if (thread.status === "blocked") {
+      assert.equal(thread.reviewRequired, true, `${thread.id} blocked threads must require review`);
+    }
+
+    const source = sourceById.get(thread.sourceMessageId);
+    if (source && source.hasRequiredDocument === false) {
+      assert.equal(thread.status, "blocked", `${thread.id} missing documents must be blocked`);
+    }
+
+    if (source && source.vendorResponded === false) {
+      assert.equal(
+        thread.status,
+        "waiting-on-vendor",
+        `${thread.id} unanswered vendor threads should wait on vendor`,
+      );
+    }
+
+    seenStatuses.add(thread.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});

--- a/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
+++ b/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
@@ -35,17 +35,37 @@ test("sample vendor mail fixture follows the local review contract", async () =>
     assert.ok(allowedPriorities.has(thread.priority), `${thread.id} has invalid priority`);
     assert.ok(allowedStatuses.has(thread.status), `${thread.id} has invalid status`);
     assert.ok(sourceIds.has(thread.sourceMessageId), `${thread.id} source message is missing`);
-    assert.match(thread.lastContactAt, /^\d{4}-\d{2}-\d{2}T/, `${thread.id} needs an ISO last contact`);
+    assert.match(
+      thread.lastContactAt,
+      /^\d{4}-\d{2}-\d{2}T/,
+      `${thread.id} needs an ISO last contact`,
+    );
 
     if (thread.status === "resolved") {
-      assert.equal(thread.nextActionDueAt, null, `${thread.id} resolved threads should not have due dates`);
-      assert.equal(thread.reviewRequired, false, `${thread.id} resolved threads should not require review`);
+      assert.equal(
+        thread.nextActionDueAt,
+        null,
+        `${thread.id} resolved threads should not have due dates`,
+      );
+      assert.equal(
+        thread.reviewRequired,
+        false,
+        `${thread.id} resolved threads should not require review`,
+      );
     } else {
-      assert.match(thread.nextActionDueAt, /^\d{4}-\d{2}-\d{2}T/, `${thread.id} needs an ISO due date`);
+      assert.match(
+        thread.nextActionDueAt,
+        /^\d{4}-\d{2}-\d{2}T/,
+        `${thread.id} needs an ISO due date`,
+      );
     }
 
     if (thread.priority === "high" && thread.status !== "resolved") {
-      assert.equal(thread.reviewRequired, true, `${thread.id} high-priority open threads require review`);
+      assert.equal(
+        thread.reviewRequired,
+        true,
+        `${thread.id} high-priority open threads require review`,
+      );
     }
 
     if (thread.status === "blocked") {


### PR DESCRIPTION
## Summary
- replace generated placeholder copy with a concrete Vendor Mail Tracker review contract
- add synthetic vendor-mail fixture data covering open, waiting-on-vendor, blocked, and resolved states
- add folder-local test plan, review notes, and a zero-dependency Node fixture test

## Test
- node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs

Closes #718
