### PR TITLE
Add unsubscribe finder test plan

### DIFF
--- a/tools/v2/individual/unsubscribe-finder/README.md
+++ b/tools/v2/individual/unsubscribe-finder/README.md
@@ -1,15 +1,68 @@
 # Unsubscribe Finder
 
-This folder is the isolated workspace for the Unsubscribe Finder tool.
+Unsubscribe Finder is an isolated V2 individual tool workspace for detecting
+newsletter, marketing, and notification emails that expose safe unsubscribe
+options before a future inbox integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\unsubscribe-finder\
-`
+```text
+tools/v2/individual/unsubscribe-finder/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node test.
+No app install is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+```
+
+The test validates the sample unsubscribe fixture against the local review
+contract described in `specs.md`.
+
+## Detection Workflow
+
+1. Capture synthetic email records with headers, sender metadata, and body hints.
+2. Normalize unsubscribe signals into method, confidence, safety, and source.
+3. Route each candidate to `detected`, `needs-review`, `unsafe`, or `ignored`.
+4. Preserve source message ids for reviewability.
+5. Keep all unsubscribe actions manual until a future safety issue defines live
+   behavior.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-unsubscribe-candidates.json`
+contains:
+
+- a newsletter with a standards-based `List-Unsubscribe` header
+- a promotional email with an unsubscribe link that needs review
+- a phishing-like message whose unsubscribe target is unsafe
+- a transactional message that should be ignored
+
+The fixture intentionally uses `example.test` addresses, synthetic URLs, and fake
+message ids so contributors can validate behavior without using real mailbox
+content or personal subscription data.
+
+## Documentation Map
+
+- `specs.md` defines the local unsubscribe candidate contract and scope.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` explains validation and known limits.
+- `tests/unsubscribe-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or live email scanning.
+- Detection behavior is represented through fixture expectations only.
+- One-click unsubscribe, sender reputation checks, and mailbox mutations remain
+  out of scope for this isolated V2 folder.

--- a/tools/v2/individual/unsubscribe-finder/docs/review-notes.md
+++ b/tools/v2/individual/unsubscribe-finder/docs/review-notes.md
@@ -1,0 +1,27 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete unsubscribe candidate
+  review contract.
+- Adds synthetic fixture data for unsubscribe detection states.
+- Adds a zero-dependency Node test for the fixture and local rules.
+- Documents setup, review flow, limitations, and future integration needs.
+
+## Validation Performed
+
+- `node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- This issue is limited to testing and documentation assets.
+- The fixture should make future detection behavior unambiguous.
+- No real mailbox content, personal subscription data, or credentials are used.
+- No production app behavior changes from this contribution.
+
+## Follow-Up Work
+
+- Add service code that normalizes unsubscribe candidate records.
+- Add UI and accessibility coverage for user consent before any action.
+- Add security and link-safety rules before live unsubscribe execution.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/individual/unsubscribe-finder/docs/test-plan.md
+++ b/tools/v2/individual/unsubscribe-finder/docs/test-plan.md
@@ -1,0 +1,44 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source message maps to one expected candidate
+- all local unsubscribe statuses are represented
+- confidence scores stay between 0 and 1
+- unsafe and ignored candidates are not offered as actions
+- body-link-only candidates require review
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-unsubscribe-candidates.json`.
+2. Confirm all source messages use synthetic data.
+3. Confirm each expected candidate has a traceable `sourceMessageId`.
+4. Confirm `docs/review-notes.md` documents out-of-scope live unsubscribe
+   execution.
+5. Confirm no files outside `tools/v2/individual/unsubscribe-finder/` changed.
+
+## Edge Cases Covered
+
+- high-confidence `List-Unsubscribe` header
+- body-only unsubscribe link requiring review
+- suspicious unsubscribe target marked unsafe
+- transactional message ignored
+
+## Future Integration Tests
+
+When implementation code is added, add tests for:
+
+- URL allowlist and denylist handling
+- same-domain and cross-domain unsubscribe targets
+- one-click unsubscribe consent prompts
+- duplicate sender grouping
+- rollback or audit behavior after a user action

--- a/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-candidates.json
+++ b/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-candidates.json
@@ -1,0 +1,97 @@
+{
+  "tool": "unsubscribe-finder",
+  "version": 1,
+  "sourceMessages": [
+    {
+      "id": "message-newsletter-001",
+      "type": "email",
+      "from": "weekly@example.test",
+      "subject": "Weekly product newsletter",
+      "receivedAt": "2026-06-15T07:45:00Z",
+      "hasListUnsubscribeHeader": true,
+      "bodyContainsUnsubscribeLink": true,
+      "isTransactional": false,
+      "linkHost": "unsubscribe.example.test"
+    },
+    {
+      "id": "message-promo-002",
+      "type": "email",
+      "from": "offers@example.test",
+      "subject": "Limited promotion",
+      "receivedAt": "2026-06-15T11:30:00Z",
+      "hasListUnsubscribeHeader": false,
+      "bodyContainsUnsubscribeLink": true,
+      "isTransactional": false,
+      "linkHost": "offers.example.test"
+    },
+    {
+      "id": "message-suspicious-003",
+      "type": "email",
+      "from": "security-alert@example.test",
+      "subject": "Unusual login detected",
+      "receivedAt": "2026-06-16T09:20:00Z",
+      "hasListUnsubscribeHeader": false,
+      "bodyContainsUnsubscribeLink": true,
+      "isTransactional": false,
+      "linkHost": "unknown-example.test"
+    },
+    {
+      "id": "message-receipt-004",
+      "type": "email",
+      "from": "billing@example.test",
+      "subject": "Your receipt",
+      "receivedAt": "2026-06-16T16:15:00Z",
+      "hasListUnsubscribeHeader": false,
+      "bodyContainsUnsubscribeLink": false,
+      "isTransactional": true,
+      "linkHost": null
+    }
+  ],
+  "expectedCandidates": [
+    {
+      "id": "candidate-newsletter-001",
+      "sender": "weekly.example.test",
+      "method": "header",
+      "status": "detected",
+      "confidence": 0.96,
+      "safeToOffer": true,
+      "sourceMessageId": "message-newsletter-001",
+      "reason": "List-Unsubscribe header is available on a non-transactional newsletter."
+    },
+    {
+      "id": "candidate-promo-002",
+      "sender": "offers.example.test",
+      "method": "body-link",
+      "status": "needs-review",
+      "confidence": 0.74,
+      "safeToOffer": false,
+      "sourceMessageId": "message-promo-002",
+      "reason": "Body-only unsubscribe link should be reviewed before action."
+    },
+    {
+      "id": "candidate-suspicious-003",
+      "sender": "security-alert.example.test",
+      "method": "body-link",
+      "status": "unsafe",
+      "confidence": 0.2,
+      "safeToOffer": false,
+      "sourceMessageId": "message-suspicious-003",
+      "reason": "Suspicious sender context and unknown link host make the action unsafe."
+    },
+    {
+      "id": "candidate-receipt-004",
+      "sender": "billing.example.test",
+      "method": "none",
+      "status": "ignored",
+      "confidence": 0,
+      "safeToOffer": false,
+      "sourceMessageId": "message-receipt-004",
+      "reason": "Transactional receipt has no unsubscribe signal."
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses synthetic example.test messages only.",
+    "Unsafe and body-link-only candidates are intentionally not offered as actions.",
+    "Live unsubscribe execution must remain out of scope until a future safety issue defines it."
+  ]
+}

--- a/tools/v2/individual/unsubscribe-finder/specs.md
+++ b/tools/v2/individual/unsubscribe-finder/specs.md
@@ -1,41 +1,65 @@
-# Unsubscribe Finder
-
-Detect unsubscribe opportunities.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/unsubscribe-finder/README.md"
-  @"
-
 # Unsubscribe Finder Specs
 
 ## Purpose
 
-Detect unsubscribe opportunities.
+Define a self-contained review contract for detecting unsubscribe opportunities
+before any future inbox, link-following, or mailbox mutation integration.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: individual
+- Folder ownership: `tools/v2/individual/unsubscribe-finder/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model email records with synthetic unsubscribe signals.
+- Distinguish safe unsubscribe candidates from suspicious links.
+- Represent ignored transactional emails without side effects.
+- Provide fixture coverage for each local candidate status.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mail rendering, or mailbox mutation changes
+- Automatic link following or one-click unsubscribe execution
+- Sender reputation services or external API calls
+- Database schema or shared design system changes
+
+## Unsubscribe Candidate Contract
+
+Each expected candidate should include:
+
+- `id`: stable fixture-local candidate identifier
+- `sender`: sender display name or domain
+- `method`: one of `header`, `body-link`, `none`
+- `status`: one of `detected`, `needs-review`, `unsafe`, `ignored`
+- `confidence`: number from 0 to 1
+- `safeToOffer`: boolean that controls whether the UI can offer this action
+- `sourceMessageId`: source email identifier
+- `reason`: short review note for the status choice
+
+## Review Rules
+
+- standards-based header candidates may be detected when confidence is high
+- body-link candidates require review unless a future security issue says
+  otherwise
+- unsafe links must never be offered as an action
+- transactional messages without unsubscribe signals should be ignored
+- every candidate must map back to a source message
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. If a future issue adds live
+unsubscribe actions, it should define link safety, consent, audit, and rollback
+constraints before connecting this tool to production mailboxes.

--- a/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+++ b/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-unsubscribe-candidates.json");
+
+const allowedMethods = new Set(["header", "body-link", "none"]);
+const allowedStatuses = new Set(["detected", "needs-review", "unsafe", "ignored"]);
+const requiredStatuses = ["detected", "needs-review", "unsafe", "ignored"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample unsubscribe fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "unsubscribe-finder");
+  assert.ok(Array.isArray(fixture.sourceMessages), "sourceMessages must be an array");
+  assert.ok(Array.isArray(fixture.expectedCandidates), "expectedCandidates must be an array");
+  assert.equal(fixture.sourceMessages.length, fixture.expectedCandidates.length);
+
+  const sourceIds = new Set(fixture.sourceMessages.map((message) => message.id));
+  const sourceById = new Map(fixture.sourceMessages.map((message) => [message.id, message]));
+  const seenStatuses = new Set();
+
+  for (const candidate of fixture.expectedCandidates) {
+    assert.ok(candidate.id, "candidate needs a stable id");
+    assert.ok(candidate.sender, `${candidate.id} needs a sender`);
+    assert.ok(allowedMethods.has(candidate.method), `${candidate.id} has invalid method`);
+    assert.ok(allowedStatuses.has(candidate.status), `${candidate.id} has invalid status`);
+    assert.equal(typeof candidate.confidence, "number", `${candidate.id} confidence must be numeric`);
+    assert.ok(candidate.confidence >= 0 && candidate.confidence <= 1, `${candidate.id} confidence is out of range`);
+    assert.equal(typeof candidate.safeToOffer, "boolean", `${candidate.id} safeToOffer must be boolean`);
+    assert.ok(sourceIds.has(candidate.sourceMessageId), `${candidate.id} source message is missing`);
+    assert.ok(candidate.reason, `${candidate.id} needs a review reason`);
+
+    if (candidate.status === "detected") {
+      assert.equal(candidate.safeToOffer, true, `${candidate.id} detected candidates should be offerable`);
+      assert.ok(candidate.confidence >= 0.9, `${candidate.id} detected candidates need high confidence`);
+    }
+
+    if (candidate.status === "needs-review" || candidate.status === "unsafe" || candidate.status === "ignored") {
+      assert.equal(candidate.safeToOffer, false, `${candidate.id} must not be offered automatically`);
+    }
+
+    const source = sourceById.get(candidate.sourceMessageId);
+    if (source?.hasListUnsubscribeHeader) {
+      assert.equal(candidate.method, "header", `${candidate.id} should use header method`);
+    }
+
+    if (source?.bodyContainsUnsubscribeLink && !source.hasListUnsubscribeHeader) {
+      assert.notEqual(candidate.status, "detected", `${candidate.id} body-only links should not auto-detect`);
+    }
+
+    if (source?.isTransactional) {
+      assert.equal(candidate.status, "ignored", `${candidate.id} transactional messages should be ignored`);
+      assert.equal(candidate.method, "none", `${candidate.id} ignored transactional messages should not have a method`);
+    }
+
+    seenStatuses.add(candidate.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});

--- a/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+++ b/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
@@ -33,19 +33,48 @@ test("sample unsubscribe fixture follows the local review contract", async () =>
     assert.ok(candidate.sender, `${candidate.id} needs a sender`);
     assert.ok(allowedMethods.has(candidate.method), `${candidate.id} has invalid method`);
     assert.ok(allowedStatuses.has(candidate.status), `${candidate.id} has invalid status`);
-    assert.equal(typeof candidate.confidence, "number", `${candidate.id} confidence must be numeric`);
-    assert.ok(candidate.confidence >= 0 && candidate.confidence <= 1, `${candidate.id} confidence is out of range`);
-    assert.equal(typeof candidate.safeToOffer, "boolean", `${candidate.id} safeToOffer must be boolean`);
-    assert.ok(sourceIds.has(candidate.sourceMessageId), `${candidate.id} source message is missing`);
+    assert.equal(
+      typeof candidate.confidence,
+      "number",
+      `${candidate.id} confidence must be numeric`,
+    );
+    assert.ok(
+      candidate.confidence >= 0 && candidate.confidence <= 1,
+      `${candidate.id} confidence is out of range`,
+    );
+    assert.equal(
+      typeof candidate.safeToOffer,
+      "boolean",
+      `${candidate.id} safeToOffer must be boolean`,
+    );
+    assert.ok(
+      sourceIds.has(candidate.sourceMessageId),
+      `${candidate.id} source message is missing`,
+    );
     assert.ok(candidate.reason, `${candidate.id} needs a review reason`);
 
     if (candidate.status === "detected") {
-      assert.equal(candidate.safeToOffer, true, `${candidate.id} detected candidates should be offerable`);
-      assert.ok(candidate.confidence >= 0.9, `${candidate.id} detected candidates need high confidence`);
+      assert.equal(
+        candidate.safeToOffer,
+        true,
+        `${candidate.id} detected candidates should be offerable`,
+      );
+      assert.ok(
+        candidate.confidence >= 0.9,
+        `${candidate.id} detected candidates need high confidence`,
+      );
     }
 
-    if (candidate.status === "needs-review" || candidate.status === "unsafe" || candidate.status === "ignored") {
-      assert.equal(candidate.safeToOffer, false, `${candidate.id} must not be offered automatically`);
+    if (
+      candidate.status === "needs-review" ||
+      candidate.status === "unsafe" ||
+      candidate.status === "ignored"
+    ) {
+      assert.equal(
+        candidate.safeToOffer,
+        false,
+        `${candidate.id} must not be offered automatically`,
+      );
     }
 
     const source = sourceById.get(candidate.sourceMessageId);
@@ -54,12 +83,24 @@ test("sample unsubscribe fixture follows the local review contract", async () =>
     }
 
     if (source?.bodyContainsUnsubscribeLink && !source.hasListUnsubscribeHeader) {
-      assert.notEqual(candidate.status, "detected", `${candidate.id} body-only links should not auto-detect`);
+      assert.notEqual(
+        candidate.status,
+        "detected",
+        `${candidate.id} body-only links should not auto-detect`,
+      );
     }
 
     if (source?.isTransactional) {
-      assert.equal(candidate.status, "ignored", `${candidate.id} transactional messages should be ignored`);
-      assert.equal(candidate.method, "none", `${candidate.id} ignored transactional messages should not have a method`);
+      assert.equal(
+        candidate.status,
+        "ignored",
+        `${candidate.id} transactional messages should be ignored`,
+      );
+      assert.equal(
+        candidate.method,
+        "none",
+        `${candidate.id} ignored transactional messages should not have a method`,
+      );
     }
 
     seenStatuses.add(candidate.status);


### PR DESCRIPTION
## Summary
- replace generated placeholder copy with a concrete Unsubscribe Finder review contract
- add synthetic unsubscribe candidate fixtures covering detected, needs-review, unsafe, and ignored states
- add folder-local test plan, review notes, and a zero-dependency Node fixture test

## Test
- node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs

Closes #568
