### PR TITLE
Add job application helper test plan

### DIFF
--- a/tools/v2/individual/job-application-email-helper/README.md
+++ b/tools/v2/individual/job-application-email-helper/README.md
@@ -1,15 +1,67 @@
 # Job Application Email Helper
 
-This folder is the isolated workspace for the Job Application Email Helper tool.
+Job Application Email Helper is an isolated V2 individual tool workspace for
+drafting and reviewing job-application outreach emails before a future mail-app
+integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\job-application-email-helper\
-`
+```text
+tools/v2/individual/job-application-email-helper/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node test.
+No app install is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs
+```
+
+The test validates the sample application-email fixture against the local review
+contract described in `specs.md`.
+
+## Drafting Workflow
+
+1. Capture synthetic job target, candidate profile, and recruiter context.
+2. Normalize each draft into purpose, tone, required fields, and risk flags.
+3. Route each draft to `ready`, `needs-review`, `blocked`, or `sent-sample`.
+4. Preserve a source request id for traceability.
+5. Keep sending and recruiter contact discovery out of scope until a future
+   integration issue allows it.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-application-emails.json` contains:
+
+- a ready referral outreach draft with complete candidate and role context
+- a cold application draft that needs review for missing portfolio details
+- a blocked draft missing consent to contact the recruiter
+- a sent-sample follow-up draft with complete review evidence
+
+The fixture intentionally uses `example.test` addresses, synthetic people, and
+fake role ids so contributors can validate behavior without using real job
+applications or personal contact data.
+
+## Documentation Map
+
+- `specs.md` defines the local application-email draft contract and scope.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` explains validation and known limits.
+- `tests/application-email-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or live email sending.
+- Draft behavior is represented through fixture expectations only.
+- Recruiter scraping, resume parsing, attachment handling, and mailbox mutation
+  remain out of scope for this isolated V2 folder.

--- a/tools/v2/individual/job-application-email-helper/docs/review-notes.md
+++ b/tools/v2/individual/job-application-email-helper/docs/review-notes.md
@@ -1,0 +1,27 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete job-application email
+  review contract.
+- Adds synthetic fixture data for application draft states.
+- Adds a zero-dependency Node test for the fixture and local rules.
+- Documents setup, review flow, limitations, and future integration needs.
+
+## Validation Performed
+
+- `node --test tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- This issue is limited to testing and documentation assets.
+- The fixture should make future draft behavior unambiguous.
+- No real applicant, recruiter, resume, or mailbox data is used.
+- No production app behavior changes from this contribution.
+
+## Follow-Up Work
+
+- Add service code that normalizes application draft requests.
+- Add UI and accessibility coverage for draft review.
+- Add consent checks before any live email sending.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/individual/job-application-email-helper/docs/test-plan.md
+++ b/tools/v2/individual/job-application-email-helper/docs/test-plan.md
@@ -1,0 +1,44 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source request maps to one expected draft
+- all local draft statuses are represented
+- draft purpose and tone values stay in the local allowed sets
+- missing portfolio context requires review
+- missing contact consent blocks the draft
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-application-emails.json`.
+2. Confirm all candidates, companies, and requests are synthetic.
+3. Confirm each expected draft has a traceable `sourceRequestId`.
+4. Confirm `docs/review-notes.md` documents out-of-scope sending behavior.
+5. Confirm no files outside
+   `tools/v2/individual/job-application-email-helper/` changed.
+
+## Edge Cases Covered
+
+- complete referral outreach draft
+- cold application draft missing portfolio context
+- blocked draft missing contact consent
+- sent-sample follow-up with complete evidence
+
+## Future Integration Tests
+
+When implementation code is added, add tests for:
+
+- resume and portfolio field extraction
+- consent prompts before sending
+- attachment presence validation
+- duplicate application detection
+- follow-up scheduling and audit logging

--- a/tools/v2/individual/job-application-email-helper/fixtures/sample-application-emails.json
+++ b/tools/v2/individual/job-application-email-helper/fixtures/sample-application-emails.json
@@ -1,0 +1,101 @@
+{
+  "tool": "job-application-email-helper",
+  "version": 1,
+  "sourceRequests": [
+    {
+      "id": "request-referral-001",
+      "type": "application-draft",
+      "candidate": "Alex Example",
+      "role": "Frontend Engineer",
+      "company": "Northstar Labs",
+      "hasResume": true,
+      "hasPortfolio": true,
+      "hasContactConsent": true,
+      "requestedAt": "2026-06-15T08:35:00Z"
+    },
+    {
+      "id": "request-cold-002",
+      "type": "application-draft",
+      "candidate": "Riley Example",
+      "role": "Product Engineer",
+      "company": "Atlas Systems",
+      "hasResume": true,
+      "hasPortfolio": false,
+      "hasContactConsent": true,
+      "requestedAt": "2026-06-15T14:10:00Z"
+    },
+    {
+      "id": "request-consent-003",
+      "type": "application-draft",
+      "candidate": "Morgan Example",
+      "role": "Support Engineer",
+      "company": "Blue River Apps",
+      "hasResume": true,
+      "hasPortfolio": true,
+      "hasContactConsent": false,
+      "requestedAt": "2026-06-16T10:20:00Z"
+    },
+    {
+      "id": "request-follow-up-004",
+      "type": "application-draft",
+      "candidate": "Jamie Example",
+      "role": "QA Automation Engineer",
+      "company": "Evergreen Tools",
+      "hasResume": true,
+      "hasPortfolio": true,
+      "hasContactConsent": true,
+      "requestedAt": "2026-06-16T15:55:00Z"
+    }
+  ],
+  "expectedDrafts": [
+    {
+      "id": "draft-referral-001",
+      "role": "Frontend Engineer",
+      "company": "Northstar Labs",
+      "purpose": "referral",
+      "status": "ready",
+      "tone": "warm",
+      "requiredFields": ["candidate", "role", "company", "resume", "portfolio", "consent"],
+      "sourceRequestId": "request-referral-001",
+      "reviewRequired": false
+    },
+    {
+      "id": "draft-cold-002",
+      "role": "Product Engineer",
+      "company": "Atlas Systems",
+      "purpose": "cold-application",
+      "status": "needs-review",
+      "tone": "concise",
+      "requiredFields": ["candidate", "role", "company", "resume", "portfolio", "consent"],
+      "sourceRequestId": "request-cold-002",
+      "reviewRequired": true
+    },
+    {
+      "id": "draft-consent-003",
+      "role": "Support Engineer",
+      "company": "Blue River Apps",
+      "purpose": "cold-application",
+      "status": "blocked",
+      "tone": "formal",
+      "requiredFields": ["candidate", "role", "company", "resume", "consent"],
+      "sourceRequestId": "request-consent-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "draft-follow-up-004",
+      "role": "QA Automation Engineer",
+      "company": "Evergreen Tools",
+      "purpose": "follow-up",
+      "status": "sent-sample",
+      "tone": "concise",
+      "requiredFields": ["candidate", "role", "company", "resume", "portfolio", "consent"],
+      "sourceRequestId": "request-follow-up-004",
+      "reviewRequired": false
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses synthetic candidates, companies, and requests only.",
+    "Blocked drafts model missing consent and must not trigger sending behavior.",
+    "Live sending, attachments, recruiter discovery, and resume parsing remain out of scope."
+  ]
+}

--- a/tools/v2/individual/job-application-email-helper/specs.md
+++ b/tools/v2/individual/job-application-email-helper/specs.md
@@ -1,41 +1,65 @@
-# Job Application Email Helper
-
-Assist with job applications.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/job-application-email-helper/README.md"
-  @"
-
 # Job Application Email Helper Specs
 
 ## Purpose
 
-Assist with job applications.
+Define a self-contained review contract for job-application email drafts before
+any future inbox, resume, attachment, or sending integration.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: individual
+- Folder ownership: `tools/v2/individual/job-application-email-helper/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model application draft requests with synthetic role and candidate metadata.
+- Distinguish complete drafts from drafts needing review or consent.
+- Represent blocked drafts without attempting email sending side effects.
+- Provide fixture coverage for each local draft status.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mail rendering, or attachment storage changes
+- Resume parsing or recruiter contact discovery
+- Automatic sending, scheduling, or follow-up delivery
+- Database schema or shared design system changes
+
+## Application Draft Contract
+
+Each expected draft should include:
+
+- `id`: stable fixture-local draft identifier
+- `role`: target role or job title
+- `company`: target company display name
+- `purpose`: one of `referral`, `cold-application`, `follow-up`
+- `status`: one of `ready`, `needs-review`, `blocked`, `sent-sample`
+- `tone`: one of `concise`, `warm`, `formal`
+- `requiredFields`: fields that must be present before sending
+- `sourceRequestId`: source job-application request identifier
+- `reviewRequired`: true when a person must resolve missing or risky details
+
+## Review Rules
+
+- drafts missing required candidate or role context must need review
+- drafts without consent to contact must be blocked
+- sent-sample drafts must include complete review evidence
+- blocked and needs-review drafts must set `reviewRequired` to true
+- ready drafts should not include live sending side effects
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. If a future issue adds live
+email sending, it should define consent, rate limits, privacy, and audit
+constraints before connecting this tool to production mailboxes.

--- a/tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs
+++ b/tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-application-emails.json");
+
+const allowedPurposes = new Set(["referral", "cold-application", "follow-up"]);
+const allowedStatuses = new Set(["ready", "needs-review", "blocked", "sent-sample"]);
+const allowedTones = new Set(["concise", "warm", "formal"]);
+const requiredStatuses = ["ready", "needs-review", "blocked", "sent-sample"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample application email fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "job-application-email-helper");
+  assert.ok(Array.isArray(fixture.sourceRequests), "sourceRequests must be an array");
+  assert.ok(Array.isArray(fixture.expectedDrafts), "expectedDrafts must be an array");
+  assert.equal(fixture.sourceRequests.length, fixture.expectedDrafts.length);
+
+  const sourceIds = new Set(fixture.sourceRequests.map((request) => request.id));
+  const sourceById = new Map(fixture.sourceRequests.map((request) => [request.id, request]));
+  const seenStatuses = new Set();
+
+  for (const draft of fixture.expectedDrafts) {
+    assert.ok(draft.id, "draft needs a stable id");
+    assert.ok(draft.role, `${draft.id} needs a target role`);
+    assert.ok(draft.company, `${draft.id} needs a target company`);
+    assert.ok(allowedPurposes.has(draft.purpose), `${draft.id} has invalid purpose`);
+    assert.ok(allowedStatuses.has(draft.status), `${draft.id} has invalid status`);
+    assert.ok(allowedTones.has(draft.tone), `${draft.id} has invalid tone`);
+    assert.ok(Array.isArray(draft.requiredFields), `${draft.id} requiredFields must be an array`);
+    assert.ok(sourceIds.has(draft.sourceRequestId), `${draft.id} source request is missing`);
+
+    if (draft.status === "blocked" || draft.status === "needs-review") {
+      assert.equal(draft.reviewRequired, true, `${draft.id} must require review`);
+    }
+
+    if (draft.status === "ready" || draft.status === "sent-sample") {
+      assert.equal(draft.reviewRequired, false, `${draft.id} should not require review`);
+    }
+
+    const source = sourceById.get(draft.sourceRequestId);
+    if (source?.hasPortfolio === false) {
+      assert.equal(draft.status, "needs-review", `${draft.id} missing portfolio must need review`);
+    }
+
+    if (source?.hasContactConsent === false) {
+      assert.equal(draft.status, "blocked", `${draft.id} missing consent must be blocked`);
+      assert.ok(draft.requiredFields.includes("consent"), `${draft.id} must require consent`);
+    }
+
+    if (source?.hasResume === true) {
+      assert.ok(draft.requiredFields.includes("resume"), `${draft.id} should track resume context`);
+    }
+
+    seenStatuses.add(draft.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});


### PR DESCRIPTION
## Summary
- replace generated placeholder copy with a concrete Job Application Email Helper review contract
- add synthetic application draft fixtures covering ready, needs-review, blocked, and sent-sample states
- add folder-local test plan, review notes, and a zero-dependency Node fixture test

## Test
- node --test tools/v2/individual/job-application-email-helper/tests/application-email-fixtures.test.mjs

Closes #513
