### PR TITLE
Add team analytics dashboard test plan

### DIFF
--- a/tools/v2/team/team-analytics-dashboard/README.md
+++ b/tools/v2/team/team-analytics-dashboard/README.md
@@ -1,15 +1,66 @@
 # Team Analytics Dashboard
 
-This folder is the isolated workspace for the Team Analytics Dashboard tool.
+Team Analytics Dashboard is an isolated V2 team tool workspace for reviewing
+team-level email performance metrics before a future dashboard integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\team-analytics-dashboard\
-`
+```text
+tools/v2/team/team-analytics-dashboard/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node test.
+No app install is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
+```
+
+The test validates the sample analytics fixture against the local review
+contract described in `specs.md`.
+
+## Analytics Workflow
+
+1. Capture synthetic team metric snapshots.
+2. Normalize totals, response times, backlog, and alert state.
+3. Route each snapshot to `healthy`, `watch`, `needs-attention`, or `blocked`.
+4. Preserve a source report id for auditability.
+5. Keep live aggregation and dashboard wiring out of scope until a future issue
+   allows app integration.
+
+## Fixtures
+
+The folder-local fixture at `fixtures/sample-team-analytics.json` contains:
+
+- a healthy support team snapshot
+- a watch-state sales team snapshot with growing backlog
+- a needs-attention operations snapshot with slow response time
+- a blocked finance snapshot with missing source data
+
+The fixture intentionally uses synthetic teams, dates, and report ids so
+contributors can validate behavior without using real performance or mailbox
+data.
+
+## Documentation Map
+
+- `specs.md` defines the local analytics snapshot contract and scope.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` explains validation and known limits.
+- `tests/analytics-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or live metric aggregation.
+- Dashboard behavior is represented through fixture expectations only.
+- Data retention, privacy controls, live charts, and notification delivery remain
+  out of scope for this isolated V2 folder.

--- a/tools/v2/team/team-analytics-dashboard/docs/review-notes.md
+++ b/tools/v2/team/team-analytics-dashboard/docs/review-notes.md
@@ -1,0 +1,28 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces generated placeholder copy with a concrete team analytics review
+  contract.
+- Adds synthetic fixture data for analytics snapshot states.
+- Adds a zero-dependency Node test for the fixture and local rules.
+- Documents setup, review flow, limitations, and future integration needs.
+
+## Validation Performed
+
+- `node --test tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs`
+
+## Reviewer Focus
+
+- This issue is limited to testing and documentation assets.
+- The fixture should make future analytics behavior unambiguous.
+- No real mailbox metrics, employee performance data, or private reports are
+  used.
+- No production app behavior changes from this contribution.
+
+## Follow-Up Work
+
+- Add service code that normalizes team analytics snapshots.
+- Add UI and accessibility coverage for dashboard states.
+- Add privacy and retention rules before live analytics aggregation.
+- Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/team/team-analytics-dashboard/docs/test-plan.md
+++ b/tools/v2/team/team-analytics-dashboard/docs/test-plan.md
@@ -1,0 +1,44 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source report maps to one expected snapshot
+- all local analytics statuses are represented
+- metrics are non-negative when source data is available
+- blocked snapshots require human review
+- healthy snapshots do not require review
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-team-analytics.json`.
+2. Confirm all team reports are synthetic.
+3. Confirm each expected snapshot has a traceable `sourceReportId`.
+4. Confirm `docs/review-notes.md` documents out-of-scope live analytics
+   behavior.
+5. Confirm no files outside `tools/v2/team/team-analytics-dashboard/` changed.
+
+## Edge Cases Covered
+
+- healthy team with low backlog
+- watch state with growing backlog
+- needs-attention state with slow response time
+- blocked state with incomplete source data
+
+## Future Integration Tests
+
+When implementation code is added, add tests for:
+
+- configurable response-time thresholds
+- stale report detection
+- role-based dashboard access
+- anonymized aggregate metrics
+- notification throttling and audit log creation

--- a/tools/v2/team/team-analytics-dashboard/fixtures/sample-team-analytics.json
+++ b/tools/v2/team/team-analytics-dashboard/fixtures/sample-team-analytics.json
@@ -1,0 +1,93 @@
+{
+  "tool": "team-analytics-dashboard",
+  "version": 1,
+  "sourceReports": [
+    {
+      "id": "report-support-001",
+      "team": "Support",
+      "period": "2026-W25",
+      "totalThreads": 140,
+      "averageFirstResponseHours": 2.4,
+      "openBacklog": 8,
+      "hasCompleteSourceData": true
+    },
+    {
+      "id": "report-sales-002",
+      "team": "Sales",
+      "period": "2026-W25",
+      "totalThreads": 92,
+      "averageFirstResponseHours": 6.5,
+      "openBacklog": 24,
+      "hasCompleteSourceData": true
+    },
+    {
+      "id": "report-ops-003",
+      "team": "Operations",
+      "period": "2026-W25",
+      "totalThreads": 76,
+      "averageFirstResponseHours": 18.2,
+      "openBacklog": 31,
+      "hasCompleteSourceData": true
+    },
+    {
+      "id": "report-finance-004",
+      "team": "Finance",
+      "period": "2026-W25",
+      "totalThreads": 0,
+      "averageFirstResponseHours": null,
+      "openBacklog": 0,
+      "hasCompleteSourceData": false
+    }
+  ],
+  "expectedSnapshots": [
+    {
+      "id": "snapshot-support-001",
+      "team": "Support",
+      "period": "2026-W25",
+      "status": "healthy",
+      "totalThreads": 140,
+      "averageFirstResponseHours": 2.4,
+      "openBacklog": 8,
+      "sourceReportId": "report-support-001",
+      "reviewRequired": false
+    },
+    {
+      "id": "snapshot-sales-002",
+      "team": "Sales",
+      "period": "2026-W25",
+      "status": "watch",
+      "totalThreads": 92,
+      "averageFirstResponseHours": 6.5,
+      "openBacklog": 24,
+      "sourceReportId": "report-sales-002",
+      "reviewRequired": false
+    },
+    {
+      "id": "snapshot-ops-003",
+      "team": "Operations",
+      "period": "2026-W25",
+      "status": "needs-attention",
+      "totalThreads": 76,
+      "averageFirstResponseHours": 18.2,
+      "openBacklog": 31,
+      "sourceReportId": "report-ops-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "snapshot-finance-004",
+      "team": "Finance",
+      "period": "2026-W25",
+      "status": "blocked",
+      "totalThreads": 0,
+      "averageFirstResponseHours": null,
+      "openBacklog": 0,
+      "sourceReportId": "report-finance-004",
+      "reviewRequired": true
+    }
+  ],
+  "reviewNotes": [
+    "The fixture uses synthetic team reports only.",
+    "Backlog and response-time thresholds are local to this fixture and should be configurable later.",
+    "Live analytics aggregation and personal productivity scoring remain out of scope."
+  ]
+}

--- a/tools/v2/team/team-analytics-dashboard/specs.md
+++ b/tools/v2/team/team-analytics-dashboard/specs.md
@@ -1,41 +1,65 @@
-# Team Analytics Dashboard
-
-Performance analytics.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/team-analytics-dashboard/README.md"
-  @"
-
 # Team Analytics Dashboard Specs
 
 ## Purpose
 
-Performance analytics.
+Define a self-contained review contract for team email performance analytics
+before any future dashboard, inbox, or notification integration.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: team
+- Folder ownership: `tools/v2/team/team-analytics-dashboard/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model team metric snapshots with synthetic source metadata.
+- Distinguish healthy teams from watch, attention, and blocked states.
+- Represent missing source data without attempting live aggregation.
+- Provide fixture coverage for each local analytics status.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mail rendering, or metric collection changes
+- Database schema, chart rendering, or shared design system changes
+- Notification delivery or role-permission enforcement
+- Real user productivity scoring
+
+## Analytics Snapshot Contract
+
+Each expected analytics snapshot should include:
+
+- `id`: stable fixture-local snapshot identifier
+- `team`: team display name
+- `period`: reporting period label
+- `status`: one of `healthy`, `watch`, `needs-attention`, `blocked`
+- `totalThreads`: non-negative number of tracked threads
+- `averageFirstResponseHours`: non-negative number or null when blocked
+- `openBacklog`: non-negative number of unresolved threads
+- `sourceReportId`: source report identifier
+- `reviewRequired`: true when a person must investigate the snapshot
+
+## Review Rules
+
+- blocked snapshots must have missing or invalid source data
+- blocked and needs-attention snapshots must require review
+- high backlog snapshots should not be healthy
+- healthy snapshots need positive source data and no review requirement
+- every snapshot must map back to a source report
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. If a future issue adds live
+analytics, it should define privacy, retention, aggregation, and role-access
+constraints before connecting this tool to production data.

--- a/tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
+++ b/tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-team-analytics.json");
+
+const allowedStatuses = new Set(["healthy", "watch", "needs-attention", "blocked"]);
+const requiredStatuses = ["healthy", "watch", "needs-attention", "blocked"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample team analytics fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "team-analytics-dashboard");
+  assert.ok(Array.isArray(fixture.sourceReports), "sourceReports must be an array");
+  assert.ok(Array.isArray(fixture.expectedSnapshots), "expectedSnapshots must be an array");
+  assert.equal(fixture.sourceReports.length, fixture.expectedSnapshots.length);
+
+  const sourceIds = new Set(fixture.sourceReports.map((report) => report.id));
+  const sourceById = new Map(fixture.sourceReports.map((report) => [report.id, report]));
+  const seenStatuses = new Set();
+
+  for (const snapshot of fixture.expectedSnapshots) {
+    assert.ok(snapshot.id, "snapshot needs a stable id");
+    assert.ok(snapshot.team, `${snapshot.id} needs a team`);
+    assert.ok(snapshot.period, `${snapshot.id} needs a period`);
+    assert.ok(allowedStatuses.has(snapshot.status), `${snapshot.id} has invalid status`);
+    assert.equal(typeof snapshot.totalThreads, "number", `${snapshot.id} totalThreads must be numeric`);
+    assert.ok(snapshot.totalThreads >= 0, `${snapshot.id} totalThreads must be non-negative`);
+    assert.equal(typeof snapshot.openBacklog, "number", `${snapshot.id} openBacklog must be numeric`);
+    assert.ok(snapshot.openBacklog >= 0, `${snapshot.id} openBacklog must be non-negative`);
+    assert.ok(sourceIds.has(snapshot.sourceReportId), `${snapshot.id} source report is missing`);
+
+    if (snapshot.averageFirstResponseHours !== null) {
+      assert.equal(
+        typeof snapshot.averageFirstResponseHours,
+        "number",
+        `${snapshot.id} response time must be numeric or null`,
+      );
+      assert.ok(snapshot.averageFirstResponseHours >= 0, `${snapshot.id} response time must be non-negative`);
+    }
+
+    if (snapshot.status === "blocked" || snapshot.status === "needs-attention") {
+      assert.equal(snapshot.reviewRequired, true, `${snapshot.id} must require review`);
+    }
+
+    if (snapshot.status === "healthy") {
+      assert.equal(snapshot.reviewRequired, false, `${snapshot.id} healthy snapshots should not require review`);
+      assert.ok(snapshot.totalThreads > 0, `${snapshot.id} healthy snapshots need source volume`);
+      assert.ok(snapshot.openBacklog < 20, `${snapshot.id} healthy snapshots should have low backlog`);
+    }
+
+    const source = sourceById.get(snapshot.sourceReportId);
+    if (source?.hasCompleteSourceData === false) {
+      assert.equal(snapshot.status, "blocked", `${snapshot.id} incomplete source data must be blocked`);
+      assert.equal(snapshot.averageFirstResponseHours, null, `${snapshot.id} blocked data should not invent metrics`);
+    }
+
+    if (snapshot.openBacklog >= 30) {
+      assert.notEqual(snapshot.status, "healthy", `${snapshot.id} high backlog should not be healthy`);
+    }
+
+    seenStatuses.add(snapshot.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});

--- a/tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
+++ b/tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs
@@ -32,9 +32,17 @@ test("sample team analytics fixture follows the local review contract", async ()
     assert.ok(snapshot.team, `${snapshot.id} needs a team`);
     assert.ok(snapshot.period, `${snapshot.id} needs a period`);
     assert.ok(allowedStatuses.has(snapshot.status), `${snapshot.id} has invalid status`);
-    assert.equal(typeof snapshot.totalThreads, "number", `${snapshot.id} totalThreads must be numeric`);
+    assert.equal(
+      typeof snapshot.totalThreads,
+      "number",
+      `${snapshot.id} totalThreads must be numeric`,
+    );
     assert.ok(snapshot.totalThreads >= 0, `${snapshot.id} totalThreads must be non-negative`);
-    assert.equal(typeof snapshot.openBacklog, "number", `${snapshot.id} openBacklog must be numeric`);
+    assert.equal(
+      typeof snapshot.openBacklog,
+      "number",
+      `${snapshot.id} openBacklog must be numeric`,
+    );
     assert.ok(snapshot.openBacklog >= 0, `${snapshot.id} openBacklog must be non-negative`);
     assert.ok(sourceIds.has(snapshot.sourceReportId), `${snapshot.id} source report is missing`);
 
@@ -44,7 +52,10 @@ test("sample team analytics fixture follows the local review contract", async ()
         "number",
         `${snapshot.id} response time must be numeric or null`,
       );
-      assert.ok(snapshot.averageFirstResponseHours >= 0, `${snapshot.id} response time must be non-negative`);
+      assert.ok(
+        snapshot.averageFirstResponseHours >= 0,
+        `${snapshot.id} response time must be non-negative`,
+      );
     }
 
     if (snapshot.status === "blocked" || snapshot.status === "needs-attention") {
@@ -52,19 +63,38 @@ test("sample team analytics fixture follows the local review contract", async ()
     }
 
     if (snapshot.status === "healthy") {
-      assert.equal(snapshot.reviewRequired, false, `${snapshot.id} healthy snapshots should not require review`);
+      assert.equal(
+        snapshot.reviewRequired,
+        false,
+        `${snapshot.id} healthy snapshots should not require review`,
+      );
       assert.ok(snapshot.totalThreads > 0, `${snapshot.id} healthy snapshots need source volume`);
-      assert.ok(snapshot.openBacklog < 20, `${snapshot.id} healthy snapshots should have low backlog`);
+      assert.ok(
+        snapshot.openBacklog < 20,
+        `${snapshot.id} healthy snapshots should have low backlog`,
+      );
     }
 
     const source = sourceById.get(snapshot.sourceReportId);
     if (source?.hasCompleteSourceData === false) {
-      assert.equal(snapshot.status, "blocked", `${snapshot.id} incomplete source data must be blocked`);
-      assert.equal(snapshot.averageFirstResponseHours, null, `${snapshot.id} blocked data should not invent metrics`);
+      assert.equal(
+        snapshot.status,
+        "blocked",
+        `${snapshot.id} incomplete source data must be blocked`,
+      );
+      assert.equal(
+        snapshot.averageFirstResponseHours,
+        null,
+        `${snapshot.id} blocked data should not invent metrics`,
+      );
     }
 
     if (snapshot.openBacklog >= 30) {
-      assert.notEqual(snapshot.status, "healthy", `${snapshot.id} high backlog should not be healthy`);
+      assert.notEqual(
+        snapshot.status,
+        "healthy",
+        `${snapshot.id} high backlog should not be healthy`,
+      );
     }
 
     seenStatuses.add(snapshot.status);


### PR DESCRIPTION
## Summary
- replace generated placeholder copy with a concrete Team Analytics Dashboard review contract
- add synthetic analytics fixtures covering healthy, watch, needs-attention, and blocked states
- add folder-local test plan, review notes, and a zero-dependency Node fixture test

## Test
- node --test tools/v2/team/team-analytics-dashboard/tests/analytics-fixtures.test.mjs

Closes #678
