### PR TITLE
feat(issue-222): add dataset versioning utilities

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/datasetVersion.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/datasetVersion.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  versionToNumber,
+  compareVersions,
+  parseVersion,
+  formatVersion,
+  calculateChecksum,
+  MigrationRegistry,
+  globalMigrationRegistry,
+  type DatasetVersion,
+} from "../types/datasetVersion";
+
+describe("Dataset Versioning", () => {
+  describe("versionToNumber", () => {
+    it("converts semantic version to comparable number", () => {
+      const v = { major: 1, minor: 2, patch: 3, timestamp: "2026-06-16T00:00:00Z" };
+      expect(versionToNumber(v)).toBe(10203);
+    });
+
+    it("accepts string format", () => {
+      expect(versionToNumber("1.2.3")).toBe(10203);
+      expect(versionToNumber("v2.0.0")).toBe(20000);
+    });
+
+    it("handles major-only changes", () => {
+      expect(versionToNumber("2.0.0")).toBeGreaterThan(versionToNumber("1.99.99"));
+    });
+  });
+
+  describe("compareVersions", () => {
+    it("returns -1 when v1 < v2", () => {
+      expect(compareVersions("1.0.0", "1.0.1")).toBe(-1);
+      expect(compareVersions("1.0.0", "2.0.0")).toBe(-1);
+    });
+
+    it("returns 0 when versions are equal", () => {
+      expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    });
+
+    it("returns 1 when v1 > v2", () => {
+      expect(compareVersions("1.0.1", "1.0.0")).toBe(1);
+      expect(compareVersions("2.0.0", "1.99.99")).toBe(1);
+    });
+
+    it("accepts version objects", () => {
+      const v1 = { major: 1, minor: 0, patch: 0, timestamp: "2026-06-16T00:00:00Z" };
+      const v2 = { major: 1, minor: 0, patch: 1, timestamp: "2026-06-16T00:00:00Z" };
+      expect(compareVersions(v1, v2)).toBe(-1);
+    });
+  });
+
+  describe("parseVersion", () => {
+    it("parses semantic version string", () => {
+      const v = parseVersion("1.2.3");
+      expect(v.major).toBe(1);
+      expect(v.minor).toBe(2);
+      expect(v.patch).toBe(3);
+    });
+
+    it("handles 'v' prefix", () => {
+      const v = parseVersion("v2.0.1");
+      expect(v.major).toBe(2);
+      expect(v.minor).toBe(0);
+      expect(v.patch).toBe(1);
+    });
+
+    it("sets timestamp on parse", () => {
+      const before = new Date();
+      const v = parseVersion("1.0.0");
+      const after = new Date();
+
+      expect(v.timestamp).toBeDefined();
+      const ts = new Date(v.timestamp);
+      expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(ts.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it("throws on invalid format", () => {
+      expect(() => parseVersion("invalid")).toThrow();
+      expect(() => parseVersion("1.2")).toThrow();
+      expect(() => parseVersion("1.2.a")).toThrow();
+    });
+  });
+
+  describe("formatVersion", () => {
+    it("formats version object as string", () => {
+      const v: DatasetVersion = {
+        major: 2,
+        minor: 1,
+        patch: 0,
+        timestamp: "2026-06-16T00:00:00Z",
+      };
+      expect(formatVersion(v)).toBe("2.1.0");
+    });
+  });
+
+  describe("calculateChecksum", () => {
+    it("produces consistent checksum for same data", () => {
+      const data = { name: "test", value: 123 };
+      const c1 = calculateChecksum(data);
+      const c2 = calculateChecksum(data);
+      expect(c1).toBe(c2);
+    });
+
+    it("produces different checksums for different data", () => {
+      const c1 = calculateChecksum({ value: 1 });
+      const c2 = calculateChecksum({ value: 2 });
+      expect(c1).not.toBe(c2);
+    });
+
+    it("returns hex string", () => {
+      const c = calculateChecksum({ test: true });
+      expect(/^[0-9a-f]+$/.test(c)).toBe(true);
+    });
+  });
+
+  describe("MigrationRegistry", () => {
+    let registry: MigrationRegistry;
+
+    beforeEach(() => {
+      registry = new MigrationRegistry();
+    });
+
+    it("registers and retrieves migrations", () => {
+      const entry = {
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Add new field",
+        migrate: (data: any) => ({ ...data, newField: true }),
+      };
+
+      registry.register(entry);
+      const found = registry.findMigration("1.0.0", "1.1.0");
+      expect(found).toBe(entry);
+    });
+
+    it("executes registered migration", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Transform data",
+        migrate: (data: any) => ({ ...data, migrated: true }),
+      });
+
+      const migration = registry.findMigration("1.0.0", "1.1.0");
+      const result = migration!.migrate({ original: true });
+      expect(result).toEqual({ original: true, migrated: true });
+    });
+
+    it("detects missing migrations", () => {
+      const found = registry.findMigration("1.0.0", "2.0.0");
+      expect(found).toBeUndefined();
+    });
+
+    it("returns all registered migrations", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "M1",
+        migrate: (d) => d,
+      });
+      registry.register({
+        fromVersion: "1.1.0",
+        toVersion: "2.0.0",
+        description: "M2",
+        migrate: (d) => d,
+      });
+
+      expect(registry.getAll()).toHaveLength(2);
+    });
+
+    it("clears registry", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Test",
+        migrate: (d) => d,
+      });
+      registry.clear();
+      expect(registry.getAll()).toHaveLength(0);
+    });
+
+    it("detects direct migration path", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Direct",
+        migrate: (d) => d,
+      });
+
+      expect(registry.canMigrate("1.0.0", "1.1.0")).toBe(true);
+      expect(registry.canMigrate("1.0.0", "2.0.0")).toBe(false);
+      expect(registry.canMigrate("1.0.0", "1.0.0")).toBe(true); // Identity
+    });
+
+    it("detects chained migration path", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Step 1",
+        migrate: (d) => d,
+      });
+      registry.register({
+        fromVersion: "1.1.0",
+        toVersion: "2.0.0",
+        description: "Step 2",
+        migrate: (d) => d,
+      });
+
+      expect(registry.canMigrate("1.0.0", "2.0.0")).toBe(true);
+    });
+
+    it("finds migration path via chain", () => {
+      registry.register({
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        description: "Step 1",
+        migrate: (d) => d,
+      });
+      registry.register({
+        fromVersion: "1.1.0",
+        toVersion: "2.0.0",
+        description: "Step 2",
+        migrate: (d) => d,
+      });
+
+      const path = registry.findMigrationPath("1.0.0", "2.0.0");
+      expect(path).toHaveLength(2);
+      expect(path[0].toVersion).toBe("1.1.0");
+      expect(path[1].toVersion).toBe("2.0.0");
+    });
+
+    it("returns empty path for same version", () => {
+      const path = registry.findMigrationPath("1.0.0", "1.0.0");
+      expect(path).toHaveLength(0);
+    });
+  });
+
+  describe("globalMigrationRegistry", () => {
+    it("is a shared registry instance", () => {
+      expect(globalMigrationRegistry).toBeDefined();
+      expect(globalMigrationRegistry.getAll).toBeDefined();
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/types/datasetVersion.ts
+++ b/src/features/demo-admin-dashboard/types/datasetVersion.ts
@@ -31,10 +31,7 @@ export function versionToNumber(version: DatasetVersion | string): number {
  * Compares two versions.
  * Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
  */
-export function compareVersions(
-  v1: DatasetVersion | string,
-  v2: DatasetVersion | string,
-): number {
+export function compareVersions(v1: DatasetVersion | string, v2: DatasetVersion | string): number {
   const n1 = versionToNumber(v1);
   const n2 = versionToNumber(v2);
   if (n1 < n2) return -1;
@@ -138,11 +135,7 @@ export class MigrationRegistry {
   /**
    * Check if a migration path exists from source to target version.
    */
-  canMigrate(
-    fromVersion: string,
-    toVersion: string,
-    chain: Set<string> = new Set(),
-  ): boolean {
+  canMigrate(fromVersion: string, toVersion: string, chain: Set<string> = new Set()): boolean {
     if (fromVersion === toVersion) return true;
 
     const key = `${fromVersion}->${toVersion}`;

--- a/src/features/demo-admin-dashboard/types/datasetVersion.ts
+++ b/src/features/demo-admin-dashboard/types/datasetVersion.ts
@@ -1,0 +1,206 @@
+/**
+ * Dataset versioning and migration support for demo admin dashboard.
+ * Enables tracking of dataset structure changes and automatic migrations
+ * between versions.
+ */
+
+/**
+ * Represents the version metadata for a dataset.
+ * Used to track structural changes and enable safe migrations.
+ */
+export interface DatasetVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  timestamp: string;
+  description?: string;
+  checksum?: string;
+}
+
+/**
+ * Converts a DatasetVersion to a comparable numeric version.
+ * Format: major * 10000 + minor * 100 + patch
+ * Example: v1.2.3 => 10203
+ */
+export function versionToNumber(version: DatasetVersion | string): number {
+  const parsed = typeof version === "string" ? parseVersion(version) : version;
+  return parsed.major * 10000 + parsed.minor * 100 + parsed.patch;
+}
+
+/**
+ * Compares two versions.
+ * Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
+ */
+export function compareVersions(
+  v1: DatasetVersion | string,
+  v2: DatasetVersion | string,
+): number {
+  const n1 = versionToNumber(v1);
+  const n2 = versionToNumber(v2);
+  if (n1 < n2) return -1;
+  if (n1 > n2) return 1;
+  return 0;
+}
+
+/**
+ * Parses a version string in semantic versioning format.
+ * Supports formats: "1.2.3", "v1.2.3"
+ */
+export function parseVersion(versionString: string): DatasetVersion {
+  const cleaned = versionString.replace(/^v/, "").trim();
+  const parts = cleaned.split(".").map((p) => parseInt(p, 10));
+
+  if (parts.length < 3 || parts.some(isNaN)) {
+    throw new Error(
+      `Invalid version format: "${versionString}". Expected semantic versioning (e.g., "1.2.3" or "v1.2.3")`,
+    );
+  }
+
+  return {
+    major: parts[0],
+    minor: parts[1],
+    patch: parts[2],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Formats a DatasetVersion as a semantic version string.
+ */
+export function formatVersion(version: DatasetVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+/**
+ * Calculates a simple checksum for version data.
+ * Used to detect changes in dataset structure or content.
+ */
+export function calculateChecksum(data: any): string {
+  const str = JSON.stringify(data);
+  let hash = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32-bit integer
+  }
+
+  return Math.abs(hash).toString(16);
+}
+
+/**
+ * Migration registry entry for tracking available migrations.
+ */
+export interface MigrationEntry {
+  fromVersion: string;
+  toVersion: string;
+  description: string;
+  migrate(data: any): any;
+}
+
+/**
+ * Registry for managing dataset migrations.
+ * Provides lookup and execution of version-specific migrations.
+ */
+export class MigrationRegistry {
+  private migrations: Map<string, MigrationEntry> = new Map();
+
+  /**
+   * Register a migration step from one version to another.
+   */
+  register(entry: MigrationEntry): void {
+    const key = `${entry.fromVersion}->${entry.toVersion}`;
+    this.migrations.set(key, entry);
+  }
+
+  /**
+   * Find a migration from source to target version.
+   */
+  findMigration(fromVersion: string, toVersion: string): MigrationEntry | undefined {
+    const key = `${fromVersion}->${toVersion}`;
+    return this.migrations.get(key);
+  }
+
+  /**
+   * Get all registered migrations.
+   */
+  getAll(): MigrationEntry[] {
+    return Array.from(this.migrations.values());
+  }
+
+  /**
+   * Clear all registered migrations.
+   */
+  clear(): void {
+    this.migrations.clear();
+  }
+
+  /**
+   * Check if a migration path exists from source to target version.
+   */
+  canMigrate(
+    fromVersion: string,
+    toVersion: string,
+    chain: Set<string> = new Set(),
+  ): boolean {
+    if (fromVersion === toVersion) return true;
+
+    const key = `${fromVersion}->${toVersion}`;
+    if (this.migrations.has(key)) return true;
+
+    // Check for chained migrations
+    if (chain.has(fromVersion)) return false;
+    chain.add(fromVersion);
+
+    for (const [, migration] of this.migrations) {
+      if (migration.fromVersion === fromVersion) {
+        if (this.canMigrate(migration.toVersion, toVersion, new Set(chain))) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Find a migration path (chain) from source to target version.
+   */
+  findMigrationPath(fromVersion: string, toVersion: string): MigrationEntry[] {
+    if (fromVersion === toVersion) return [];
+
+    const direct = this.findMigration(fromVersion, toVersion);
+    if (direct) return [direct];
+
+    // BFS to find shortest path
+    const queue: Array<{ version: string; path: MigrationEntry[] }> = [
+      { version: fromVersion, path: [] },
+    ];
+    const visited = new Set<string>();
+
+    while (queue.length > 0) {
+      const { version, path } = queue.shift()!;
+
+      if (visited.has(version)) continue;
+      visited.add(version);
+
+      if (version === toVersion) return path;
+
+      for (const [, migration] of this.migrations) {
+        if (migration.fromVersion === version && !visited.has(migration.toVersion)) {
+          queue.push({
+            version: migration.toVersion,
+            path: [...path, migration],
+          });
+        }
+      }
+    }
+
+    return [];
+  }
+}
+
+/**
+ * Default global migration registry instance.
+ */
+export const globalMigrationRegistry = new MigrationRegistry();


### PR DESCRIPTION
- Add DatasetVersion interface for metadata tracking
- Implement semantic version parsing, formatting, comparison
- Add checksum calculation for data integrity verification
- Create MigrationRegistry for tracking and executing migrations
- Support chained migration path detection and execution
- Add comprehensive tests for all versioning utilities (25 tests)

closes #222 