### PR TITLE
Build campaign validation results view (#279)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.49.1",
         "@types/node": "^22.16.5",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -109,7 +110,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1373,6 +1373,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -4292,7 +4307,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4303,7 +4317,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4314,7 +4327,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4364,7 +4376,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4761,7 +4772,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4990,7 +5000,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5555,8 +5564,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5662,7 +5670,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5723,7 +5730,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7085,6 +7091,50 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -7128,7 +7178,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7184,7 +7233,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7216,7 +7264,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7229,7 +7276,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7518,7 +7564,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
       "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8350,7 +8395,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8410,7 +8454,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8562,7 +8605,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9289,7 +9331,6 @@
       "integrity": "sha512-T/GRD6Y5vN9g4CnGmOlfST1w7bj+1IjRFvX0K7CodZPJuPVPNPGhz8Wppah0WdT6A7I8Kad3zgZ2OkDdWtENrg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -35,7 +35,6 @@ import { validateCampaignDrafts } from "./validation";
 import type { Draft } from "./types/draft";
 import type { ValidationNavigation } from "./validation-types";
 
-
 // ─── Default Deterministic fake data ──────────────────────────────────────────
 
 const NAV_ITEMS: DashboardNavItem[] = [
@@ -686,7 +685,6 @@ function CampaignsContent({
   );
 }
 
-
 // ─── Dashboard Shell ──────────────────────────────────────────────────────────
 
 export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
@@ -695,7 +693,6 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
   const [selectedAccountAddress, setSelectedAccountAddress] = useState<string | null>(null);
   const [selectedMailSubject, setSelectedMailSubject] = useState<string | null>(null);
   const [draftDataset, setDraftDataset] = useState<Draft[]>([]);
-
 
   const activePreset = PRESET_SCENARIOS.find((p) => p.id === activePresetId);
 

--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -29,6 +29,12 @@ import type {
 import { TemplatePicker } from "./templates";
 import { PRESET_SCENARIOS } from "./fixtures/presets";
 import { AdminDataTable, type Column } from "./components/AdminDataTable";
+import { CampaignSnapshots } from "./components/CampaignSnapshots";
+import { ValidationResultsPanel } from "./ValidationResultsPanel";
+import { validateCampaignDrafts } from "./validation";
+import type { Draft } from "./types/draft";
+import type { ValidationNavigation } from "./validation-types";
+
 
 // ─── Default Deterministic fake data ──────────────────────────────────────────
 
@@ -643,9 +649,43 @@ function AuditContent({ auditEvents }: { auditEvents: PresetAuditEvent[] }) {
   );
 }
 
-function TemplatesContent() {
-  return <TemplatePicker />;
+function TemplatesContent({
+  dataset,
+  onDatasetChange,
+}: {
+  dataset: Draft[];
+  onDatasetChange: (dataset: Draft[]) => void;
+}) {
+  return <TemplatePicker dataset={dataset} onDatasetChange={onDatasetChange} />;
 }
+
+function CampaignsContent({
+  dataset,
+  onDatasetChange,
+  onSelectIssue,
+}: {
+  dataset: Draft[];
+  onDatasetChange: (dataset: Draft[]) => void;
+  onSelectIssue: (nav: ValidationNavigation) => void;
+}) {
+  const issues = validateCampaignDrafts(dataset);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_350px] items-start">
+      <div className="space-y-6">
+        <CampaignSnapshots currentDataset={dataset} onRestoreDataset={onDatasetChange} />
+      </div>
+      <div className="space-y-6 lg:sticky lg:top-4">
+        <ValidationResultsPanel
+          issues={issues}
+          onSelectIssue={onSelectIssue}
+          title="Campaign Validation"
+        />
+      </div>
+    </div>
+  );
+}
+
 
 // ─── Dashboard Shell ──────────────────────────────────────────────────────────
 
@@ -654,6 +694,8 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
   const [activePresetId, setActivePresetId] = useState<PresetId>("none");
   const [selectedAccountAddress, setSelectedAccountAddress] = useState<string | null>(null);
   const [selectedMailSubject, setSelectedMailSubject] = useState<string | null>(null);
+  const [draftDataset, setDraftDataset] = useState<Draft[]>([]);
+
 
   const activePreset = PRESET_SCENARIOS.find((p) => p.id === activePresetId);
 
@@ -789,7 +831,17 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
 
           {activeSection === "events" && <EventsContent events={events} />}
 
-          {activeSection === "templates" && <TemplatesContent />}
+          {activeSection === "templates" && (
+            <TemplatesContent dataset={draftDataset} onDatasetChange={setDraftDataset} />
+          )}
+
+          {activeSection === "campaigns" && (
+            <CampaignsContent
+              dataset={draftDataset}
+              onDatasetChange={setDraftDataset}
+              onSelectIssue={() => handleSectionChange("templates")}
+            />
+          )}
 
           {activeSection === "audit" && <AuditContent auditEvents={auditEvents} />}
         </div>

--- a/src/features/demo-admin-dashboard/validation.test.ts
+++ b/src/features/demo-admin-dashboard/validation.test.ts
@@ -181,4 +181,3 @@ describe("validateCampaignDrafts", () => {
     expect(results).toHaveLength(0);
   });
 });
-

--- a/src/features/demo-admin-dashboard/validation.test.ts
+++ b/src/features/demo-admin-dashboard/validation.test.ts
@@ -6,6 +6,7 @@ import {
   isDatasetValid,
   sortIssues,
   summarizeValidation,
+  validateCampaignDrafts,
 } from "./validation";
 import type { ValidationIssue } from "./validation-types";
 
@@ -107,3 +108,77 @@ describe("isDatasetValid", () => {
     expect(isDatasetValid(issues.filter((issue) => issue.severity !== "error"))).toBe(true);
   });
 });
+
+describe("validateCampaignDrafts", () => {
+  it("returns an info issue if drafts list is empty", () => {
+    const results = validateCampaignDrafts([]);
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe("info");
+    expect(results[0].fieldPath).toBe("drafts");
+    expect(results[0].message).toContain("no message drafts");
+  });
+
+  it("detects empty subject, empty body, and empty recipients", () => {
+    const results = validateCampaignDrafts([
+      {
+        id: "draft-bad",
+        subject: "",
+        body: "   ",
+        recipients: [],
+      },
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(results.filter((i) => i.severity === "error")).toHaveLength(3);
+    expect(results[0].fieldPath).toBe("drafts[0].subject");
+    expect(results[1].fieldPath).toBe("drafts[0].body");
+    expect(results[2].fieldPath).toBe("drafts[0].recipients");
+  });
+
+  it("detects invalid recipient formatting (no @ and no *)", () => {
+    const results = validateCampaignDrafts([
+      {
+        id: "draft-bad-recipient",
+        subject: "Sub",
+        body: "Body",
+        recipients: ["invalidformat"],
+      },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe("error");
+    expect(results[0].fieldPath).toBe("drafts[0].recipients[0]");
+    expect(results[0].message).toContain("format is invalid");
+  });
+
+  it("warns about unsafe/external domains", () => {
+    const results = validateCampaignDrafts([
+      {
+        id: "draft-unsafe-recipient",
+        subject: "Sub",
+        body: "Body",
+        recipients: ["user@untrusted.com", "user*untrusted.com"],
+      },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((i) => i.severity === "warning")).toBe(true);
+    expect(results[0].fieldPath).toBe("drafts[0].recipients[0]");
+    expect(results[1].fieldPath).toBe("drafts[0].recipients[1]");
+    expect(results[0].message).toContain("external or unverified domain");
+  });
+
+  it("passes with correct example domains and federation handles", () => {
+    const results = validateCampaignDrafts([
+      {
+        id: "draft-good",
+        subject: "Sub",
+        body: "Body",
+        recipients: ["alice@example.com", "bob@example.org", "new.user*stealth.demo"],
+      },
+    ]);
+
+    expect(results).toHaveLength(0);
+  });
+});
+

--- a/src/features/demo-admin-dashboard/validation.ts
+++ b/src/features/demo-admin-dashboard/validation.ts
@@ -7,7 +7,6 @@ import type {
 } from "./validation-types";
 import type { Draft } from "./types/draft";
 
-
 /** Display order for severities (errors first). */
 export const SEVERITY_ORDER: ValidationSeverity[] = ["error", "warning", "info"];
 
@@ -165,4 +164,3 @@ export function validateCampaignDrafts(drafts: Draft[]): ValidationIssue[] {
 
   return issues;
 }
-

--- a/src/features/demo-admin-dashboard/validation.ts
+++ b/src/features/demo-admin-dashboard/validation.ts
@@ -5,6 +5,8 @@ import type {
   ValidationSeverity,
   ValidationSeveritySummary,
 } from "./validation-types";
+import type { Draft } from "./types/draft";
+
 
 /** Display order for severities (errors first). */
 export const SEVERITY_ORDER: ValidationSeverity[] = ["error", "warning", "info"];
@@ -66,3 +68,101 @@ export function getIssueNavigation(issue: ValidationIssue): ValidationNavigation
 export function isDatasetValid(issues: ValidationIssue[]): boolean {
   return issues.every((issue) => issue.severity !== "error");
 }
+
+const SAFE_DOMAIN_PATTERN = /(@example\.(com|org)|@([\w.-]+\.)?stealth\.demo)$/i;
+
+/** Validate campaign drafts and return any validation issues. */
+export function validateCampaignDrafts(drafts: Draft[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (drafts.length === 0) {
+    issues.push({
+      id: "campaign-empty",
+      severity: "info",
+      fieldPath: "drafts",
+      message: "The campaign currently contains no message drafts.",
+      datasetId: "campaign-drafts",
+      hint: "Go to the Templates tab to insert draft templates.",
+    });
+    return issues;
+  }
+
+  drafts.forEach((draft, index) => {
+    const draftId = draft.id;
+
+    // Subject validation
+    if (!draft.subject || draft.subject.trim() === "") {
+      issues.push({
+        id: `draft-${draftId}-subject-empty`,
+        severity: "error",
+        fieldPath: `drafts[${index}].subject`,
+        message: "Subject is required for draft message.",
+        datasetId: "campaign-drafts",
+        recordId: draftId,
+        hint: "Enter a subject line for this draft.",
+      });
+    }
+
+    // Body validation
+    if (!draft.body || draft.body.trim() === "") {
+      issues.push({
+        id: `draft-${draftId}-body-empty`,
+        severity: "error",
+        fieldPath: `drafts[${index}].body`,
+        message: "Message body is empty.",
+        datasetId: "campaign-drafts",
+        recordId: draftId,
+        hint: "Enter a body text for this draft.",
+      });
+    }
+
+    // Recipients validation
+    if (!draft.recipients || draft.recipients.length === 0) {
+      issues.push({
+        id: `draft-${draftId}-recipients-empty`,
+        severity: "error",
+        fieldPath: `drafts[${index}].recipients`,
+        message: "Recipient list is empty.",
+        datasetId: "campaign-drafts",
+        recordId: draftId,
+        hint: "Add at least one recipient federated address or email.",
+      });
+    } else {
+      draft.recipients.forEach((recipient, rIdx) => {
+        const hasAt = recipient.includes("@");
+        const hasAsterisk = recipient.includes("*");
+
+        if (!hasAt && !hasAsterisk) {
+          issues.push({
+            id: `draft-${draftId}-recipient-${rIdx}-invalid-format`,
+            severity: "error",
+            fieldPath: `drafts[${index}].recipients[${rIdx}]`,
+            message: `Recipient "${recipient}" format is invalid. Must be an email address or federated handle.`,
+            datasetId: "campaign-drafts",
+            recordId: draftId,
+            hint: "Use a format like name@domain.com or name*federation.",
+          });
+          return;
+        }
+
+        // Check for safe domain
+        const normalized = recipient.replace("*", "@");
+        const isSafe = SAFE_DOMAIN_PATTERN.test(normalized);
+        if (!isSafe) {
+          issues.push({
+            id: `draft-${draftId}-recipient-${rIdx}-unsafe-domain`,
+            severity: "warning",
+            fieldPath: `drafts[${index}].recipients[${rIdx}]`,
+            message: `Recipient "${recipient}" uses an external or unverified domain for a demo campaign.`,
+            datasetId: "campaign-drafts",
+            recordId: draftId,
+            hint: "For safety, stick to example.com, example.org, or *.stealth.demo.",
+          });
+        }
+      });
+    }
+  });
+
+  return issues;
+}
+


### PR DESCRIPTION
# Pull Request Description

## Build campaign validation results view
Closes #279

### Goal
Implement a focused campaign validation panel displaying errors, warnings, and info issues for the campaign draft dataset under the Demo Admin Dashboard workspace.

### Proposed Changes

#### Campaign validation helpers
- Added `validateCampaignDrafts` helper in `src/features/demo-admin-dashboard/validation.ts` to perform validation on subjects, bodies, recipient formats, and demo domain safety constraints.

#### Dashboard Integration
- Updated `src/features/demo-admin-dashboard/DemoAdminDashboard.tsx` to lift draft dataset state, sharing it between the Templates and Campaigns tabs.
- Added campaigns tab rendering which shows the saved campaigns list side-by-side with the campaign validation panel in a responsive two-column grid.
- Click-to-fix interaction: Selecting a validation issue from the panel navigates the user back to the Templates tab.

#### Unit Tests
- Created unit tests for the campaign validation logic in `src/features/demo-admin-dashboard/validation.test.ts`.

### Verification Results

All tests pass:
```bash
npx vitest run src/features/demo-admin-dashboard/
```
Output:
```
 Test Files  15 passed (15)
      Tests  110 passed (110)
```
