### PR TITLE
feat(app-ui): add encrypted payload reveal and verification states (#96)

### DIFF
--- a/src/components/mail/EmailView.tsx
+++ b/src/components/mail/EmailView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { useMediaQuery } from "@/lib/use-media-query";
 import {
   Archive,
   BadgeCheck,
@@ -32,6 +33,7 @@ import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import { SnoozeBanner } from "@/features/snooze";
 import { ProvenancePanel } from "./ProvenancePanel";
 import { EmailTrustBadges } from "./EmailTrustBadges";
+import { EncryptedPayloadBanner } from "./EncryptedPayloadBanner";
 import type { Email } from "./data";
 import {
   getRecipientReadiness,
@@ -61,6 +63,10 @@ export type EmailViewActions = {
   onCalendarResponseChange?: (eventId: string, response: CalendarResponse) => void;
   onCalendarReminderChange?: (eventId: string, reminder: string) => void;
   onPreviewAttachment?: (attachment: { name: string; size: string; type: string }) => void;
+  /** Attempt to load the decryption key and unlock the payload. */
+  onUnlockPayload?: (email: Email) => void;
+  /** Retry a failed decryption attempt. */
+  onRetryDecrypt?: (email: Email) => void;
 };
 
 export function EmailView({
@@ -72,6 +78,7 @@ export function EmailView({
 }) {
   const [replyMenuOpen, setReplyMenuOpen] = useState(false);
   const [inlineMode, setInlineMode] = useState<ComposeMode | null>(null);
+  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   useEffect(() => {
     setReplyMenuOpen(false);
@@ -307,7 +314,31 @@ export function EmailView({
                   return otp ? <OTPCard code={otp} /> : null;
                 })()}
 
-                <ReaderBody body={email.body} />
+                {email.encryptedPayload && (
+                  <EncryptedPayloadBanner
+                    payload={email.encryptedPayload}
+                    reducedMotion={reducedMotion}
+                    actions={{
+                      onUnlock: actions.onUnlockPayload
+                        ? () => actions.onUnlockPayload!(email)
+                        : undefined,
+                      onRetry: actions.onRetryDecrypt
+                        ? () => actions.onRetryDecrypt!(email)
+                        : undefined,
+                      onCopyDiagnosticId: async (id) => {
+                        await navigator.clipboard?.writeText(id);
+                        actions.onShowToast?.(`Diagnostic ID ${id} copied`);
+                      },
+                      onReportCorruption: (id) => {
+                        actions.onShowToast?.(`Corruption report submitted for ${id}`);
+                      },
+                    }}
+                  />
+                )}
+
+                {(!email.encryptedPayload || email.encryptedPayload.status === "decrypted") && (
+                  <ReaderBody body={email.body} />
+                )}
 
                 {email.attachments?.length ? (
                   <div className="mt-7 max-w-[500px]">

--- a/src/components/mail/EncryptedPayloadBanner.tsx
+++ b/src/components/mail/EncryptedPayloadBanner.tsx
@@ -1,0 +1,286 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { AlertTriangle, CheckCheck, KeyRound, Loader2, RefreshCw, ShieldAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { EncryptedPayload, PayloadFailureReason } from "./data";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function failureCopy(reason: PayloadFailureReason | undefined): {
+  headline: string;
+  detail: string;
+} {
+  switch (reason) {
+    case "key":
+      return {
+        headline: "Key not found",
+        detail: "The decryption key for this payload is missing or expired.",
+      };
+    case "payload":
+      return {
+        headline: "Payload unreadable",
+        detail: "The encrypted payload could not be decoded. It may be malformed.",
+      };
+    case "relay":
+      return {
+        headline: "Relay error",
+        detail: "The relay returned an error while fetching the encrypted payload.",
+      };
+    case "integrity":
+      return {
+        headline: "Integrity check failed",
+        detail: "The payload hash does not match. Possible tampering detected.",
+      };
+    default:
+      return {
+        headline: "Decryption failed",
+        detail: "An unknown error prevented decryption of this payload.",
+      };
+  }
+}
+
+// Reduced-motion-aware animation variant factory.
+function bannerVariants(reducedMotion: boolean) {
+  const duration = reducedMotion ? 0 : 0.25;
+  return {
+    initial: { opacity: 0, y: reducedMotion ? 0 : -6 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: reducedMotion ? 0 : -6 },
+    transition: { duration, ease: [0.2, 0.8, 0.2, 1] as const },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-state banners
+// ---------------------------------------------------------------------------
+
+function LockedBanner({
+  diagnosticId,
+  onUnlock,
+  reducedMotion,
+}: {
+  diagnosticId: string;
+  onUnlock?: () => void;
+  reducedMotion: boolean;
+}) {
+  const variants = bannerVariants(reducedMotion);
+  return (
+    <motion.div
+      {...variants}
+      data-testid="encrypted-banner-locked"
+      className="mt-5 flex items-center gap-3 rounded-lg border border-sky-400/20 bg-sky-400/[0.05] px-3 py-2.5"
+    >
+      <motion.div
+        animate={reducedMotion ? {} : { scale: [1, 1.12, 1] }}
+        transition={{ repeat: Infinity, duration: 2.4, ease: "easeInOut" }}
+      >
+        <KeyRound className="h-4 w-4 shrink-0 text-sky-300" aria-hidden="true" />
+      </motion.div>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium text-foreground">Payload locked</div>
+        <div className="font-mono text-[10px] text-muted-foreground truncate">
+          ID: {diagnosticId}
+        </div>
+      </div>
+      {onUnlock && (
+        <button
+          onClick={onUnlock}
+          className="shrink-0 rounded-md border border-sky-400/20 bg-sky-400/[0.08] px-2.5 py-1 text-[10px] font-medium text-sky-200 transition hover:bg-sky-400/[0.14]"
+        >
+          Unlock
+        </button>
+      )}
+    </motion.div>
+  );
+}
+
+function VerifyingBanner({
+  diagnosticId,
+  reducedMotion,
+}: {
+  diagnosticId: string;
+  reducedMotion: boolean;
+}) {
+  const variants = bannerVariants(reducedMotion);
+  return (
+    <motion.div
+      {...variants}
+      data-testid="encrypted-banner-verifying"
+      className="mt-5 flex items-center gap-3 rounded-lg border border-amber-200/20 bg-amber-200/[0.04] px-3 py-2.5"
+    >
+      <motion.div
+        animate={reducedMotion ? {} : { rotate: 360 }}
+        transition={{ repeat: Infinity, duration: 1.2, ease: "linear" }}
+      >
+        <Loader2 className="h-4 w-4 shrink-0 text-amber-200" aria-hidden="true" />
+      </motion.div>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium text-foreground">Verifying payload…</div>
+        <div className="font-mono text-[10px] text-muted-foreground truncate">
+          ID: {diagnosticId}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function DecryptedBanner({
+  diagnosticId,
+  reducedMotion,
+}: {
+  diagnosticId: string;
+  reducedMotion: boolean;
+}) {
+  const variants = bannerVariants(reducedMotion);
+  return (
+    <motion.div
+      {...variants}
+      data-testid="encrypted-banner-decrypted"
+      className="mt-5 flex items-center gap-3 rounded-lg border border-emerald-200/20 bg-emerald-200/[0.04] px-3 py-2.5"
+    >
+      <CheckCheck className="h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium text-foreground">Payload verified &amp; decrypted</div>
+        <div className="font-mono text-[10px] text-muted-foreground truncate">
+          ID: {diagnosticId}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function FailedBanner({
+  payload,
+  onRetry,
+  onCopyDiagnosticId,
+  onReportCorruption,
+  reducedMotion,
+}: {
+  payload: EncryptedPayload;
+  onRetry?: () => void;
+  onCopyDiagnosticId?: (id: string) => void;
+  onReportCorruption?: (id: string) => void;
+  reducedMotion: boolean;
+}) {
+  const variants = bannerVariants(reducedMotion);
+  const { headline, detail } = failureCopy(payload.failureReason);
+
+  return (
+    <motion.div
+      {...variants}
+      data-testid="encrypted-banner-failed"
+      className="mt-5 rounded-lg border border-red-300/20 bg-red-300/[0.04] px-3 py-3"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-300" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-foreground">{headline}</span>
+            {payload.failureReason && (
+              <span className="rounded border border-red-300/20 bg-red-300/[0.06] px-1.5 py-0.5 font-mono text-[9px] text-red-200 uppercase tracking-wide">
+                {payload.failureReason}
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-[11px] leading-5 text-muted-foreground">{detail}</p>
+          <div className="font-mono text-[10px] text-muted-foreground/70 mt-1 truncate">
+            ID: {payload.diagnosticId}
+          </div>
+        </div>
+      </div>
+      <div className="mt-2.5 flex flex-wrap gap-2">
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="inline-flex items-center gap-1.5 rounded-md border border-red-300/15 bg-red-300/[0.06] px-2.5 py-1 text-[10px] font-medium text-red-200 transition hover:bg-red-300/[0.12]"
+          >
+            <RefreshCw className="h-3 w-3" aria-hidden="true" />
+            Retry
+          </button>
+        )}
+        {onCopyDiagnosticId && (
+          <button
+            onClick={() => onCopyDiagnosticId(payload.diagnosticId)}
+            className="rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[10px] text-muted-foreground transition hover:bg-white/[0.08] hover:text-foreground"
+          >
+            Copy diagnostic ID
+          </button>
+        )}
+        {onReportCorruption && (
+          <button
+            onClick={() => onReportCorruption(payload.diagnosticId)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[10px] text-muted-foreground transition hover:bg-white/[0.08] hover:text-foreground"
+          >
+            <ShieldAlert className="h-3 w-3" aria-hidden="true" />
+            Report corruption
+          </button>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+export type EncryptedPayloadBannerActions = {
+  onUnlock?: () => void;
+  onRetry?: () => void;
+  onCopyDiagnosticId?: (id: string) => void;
+  onReportCorruption?: (id: string) => void;
+};
+
+export function EncryptedPayloadBanner({
+  payload,
+  actions = {},
+  className,
+  reducedMotion = false,
+}: {
+  payload: EncryptedPayload;
+  actions?: EncryptedPayloadBannerActions;
+  className?: string;
+  reducedMotion?: boolean;
+}) {
+  const { status, diagnosticId } = payload;
+
+  return (
+    <div className={cn("encrypted-payload-banner", className)}>
+      <AnimatePresence mode="wait">
+        {status === "locked" && (
+          <LockedBanner
+            key="locked"
+            diagnosticId={diagnosticId}
+            onUnlock={actions.onUnlock}
+            reducedMotion={reducedMotion}
+          />
+        )}
+        {status === "verifying" && (
+          <VerifyingBanner
+            key="verifying"
+            diagnosticId={diagnosticId}
+            reducedMotion={reducedMotion}
+          />
+        )}
+        {status === "decrypted" && (
+          <DecryptedBanner
+            key="decrypted"
+            diagnosticId={diagnosticId}
+            reducedMotion={reducedMotion}
+          />
+        )}
+        {status === "failed" && (
+          <FailedBanner
+            key="failed"
+            payload={payload}
+            onRetry={actions.onRetry}
+            onCopyDiagnosticId={actions.onCopyDiagnosticId}
+            onReportCorruption={actions.onReportCorruption}
+            reducedMotion={reducedMotion}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/mail/data.ts
+++ b/src/components/mail/data.ts
@@ -31,6 +31,30 @@ export type MailLocation = Exclude<MailFolder, VirtualMailFolder>;
 export type SenderPolicy = "allow" | "verify" | "block";
 
 export type ReceiptState = "none" | "pending" | "sent";
+
+/**
+ * Encrypted payload status for messages in the encrypted folder.
+ * - `locked`     : payload present but key not yet loaded — body must not render.
+ * - `verifying`  : decryption key found, integrity check in progress.
+ * - `decrypted`  : payload verified and unlocked, body can render.
+ * - `failed`     : decryption or integrity check failed; body must not render.
+ */
+export type PayloadStatus = "locked" | "verifying" | "decrypted" | "failed";
+
+/**
+ * Failure reason discriminator for the `failed` status.
+ * Used to present specific error copy and targeted retry / report CTAs.
+ */
+export type PayloadFailureReason = "key" | "payload" | "relay" | "integrity";
+
+export type EncryptedPayload = {
+  /** Current verification/unlock state for this payload. */
+  status: PayloadStatus;
+  /** Short opaque ID shown in the diagnostic copy and clipboard button. */
+  diagnosticId: string;
+  /** Only set when status === "failed". */
+  failureReason?: PayloadFailureReason;
+};
 /**
  * Reminder metadata attached when a message is snoozed. Persisted on the email
  * so the snoozed folder can show when it returns and offer edit/undo.
@@ -67,6 +91,7 @@ export type Email = {
   snooze?: SnoozeState;
   postageAmount?: string;
   verifiedSender?: boolean;
+  encryptedPayload?: EncryptedPayload;
 };
 
 export type MailFilters = {
@@ -322,6 +347,65 @@ export const emails: Email[] = [
       { name: "stealth-payload.bin", size: "256 B", type: "bin" },
     ],
     avatarColor: c(0),
+    encryptedPayload: {
+      status: "decrypted",
+      diagnosticId: "dec-7a3f-c18e",
+    },
+  },
+  {
+    id: "6-b",
+    from: "Kael Ortega",
+    email: "kael*nexus.io",
+    subject: "Sealed proposal — open to verify",
+    preview: "Unlock the encrypted envelope to read the funding proposal…",
+    body: "Unlock the encrypted envelope to read the funding proposal. The payload is sealed with your registered public key.",
+    time: "Yesterday",
+    unread: true,
+    starred: false,
+    folder: "encrypted",
+    labels: ["Encrypted", "Proposal"],
+    avatarColor: c(1),
+    encryptedPayload: {
+      status: "locked",
+      diagnosticId: "lck-4b2a-9d01",
+    },
+  },
+  {
+    id: "6-c",
+    from: "Cipher Relay",
+    email: "relay*cipher.network",
+    subject: "Verifying message integrity…",
+    preview: "Integrity check is running. Stand by for the decrypted payload.",
+    body: "Integrity check is running. Stand by for the decrypted payload.",
+    time: "Today",
+    unread: true,
+    starred: false,
+    folder: "encrypted",
+    labels: ["Encrypted", "Verifying"],
+    avatarColor: c(2),
+    encryptedPayload: {
+      status: "verifying",
+      diagnosticId: "vfy-8c5d-2e47",
+    },
+  },
+  {
+    id: "6-d",
+    from: "Vault Node",
+    email: "vault*stealth.network",
+    subject: "Decryption failed — payload corrupted",
+    preview: "The payload failed integrity verification. Possible relay tampering detected.",
+    body: "The payload failed integrity verification. Possible relay tampering detected.",
+    time: "2 days ago",
+    unread: false,
+    starred: false,
+    folder: "encrypted",
+    labels: ["Encrypted", "Failed"],
+    avatarColor: c(3),
+    encryptedPayload: {
+      status: "failed",
+      diagnosticId: "flt-1e9b-5f62",
+      failureReason: "integrity",
+    },
   },
   {
     id: "7",

--- a/tests/unit/encrypted-payload/EncryptedPayloadBanner.test.ts
+++ b/tests/unit/encrypted-payload/EncryptedPayloadBanner.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EncryptedPayload, PayloadFailureReason } from "@/components/mail/data";
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers extracted from EncryptedPayloadBanner to keep tests
+// framework-free (no JSDOM needed for pure-logic checks).
+// ---------------------------------------------------------------------------
+
+function shouldShowBody(payload: EncryptedPayload | undefined): boolean {
+  return !payload || payload.status === "decrypted";
+}
+
+function failureCopy(reason: PayloadFailureReason | undefined): string {
+  switch (reason) {
+    case "key":
+      return "Key not found";
+    case "payload":
+      return "Payload unreadable";
+    case "relay":
+      return "Relay error";
+    case "integrity":
+      return "Integrity check failed";
+    default:
+      return "Decryption failed";
+  }
+}
+
+function makePayload(overrides: Partial<EncryptedPayload>): EncryptedPayload {
+  return {
+    status: "locked",
+    diagnosticId: "test-diag-001",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EncryptedPayloadBanner — payload visibility guard", () => {
+  it("shows body when there is no encryptedPayload", () => {
+    expect(shouldShowBody(undefined)).toBe(true);
+  });
+
+  it("hides body when status is locked", () => {
+    expect(shouldShowBody(makePayload({ status: "locked" }))).toBe(false);
+  });
+
+  it("hides body when status is verifying", () => {
+    expect(shouldShowBody(makePayload({ status: "verifying" }))).toBe(false);
+  });
+
+  it("shows body when status is decrypted", () => {
+    expect(shouldShowBody(makePayload({ status: "decrypted" }))).toBe(true);
+  });
+
+  it("hides body when status is failed", () => {
+    expect(shouldShowBody(makePayload({ status: "failed" }))).toBe(false);
+  });
+});
+
+describe("EncryptedPayloadBanner — failure reason copy", () => {
+  it("returns key-specific copy for 'key' reason", () => {
+    expect(failureCopy("key")).toBe("Key not found");
+  });
+
+  it("returns payload-specific copy for 'payload' reason", () => {
+    expect(failureCopy("payload")).toBe("Payload unreadable");
+  });
+
+  it("returns relay-specific copy for 'relay' reason", () => {
+    expect(failureCopy("relay")).toBe("Relay error");
+  });
+
+  it("returns integrity-specific copy for 'integrity' reason", () => {
+    expect(failureCopy("integrity")).toBe("Integrity check failed");
+  });
+
+  it("returns generic copy when reason is undefined", () => {
+    expect(failureCopy(undefined)).toBe("Decryption failed");
+  });
+});
+
+describe("EncryptedPayloadBanner — data model", () => {
+  it("accepts all valid status values", () => {
+    const statuses: EncryptedPayload["status"][] = ["locked", "verifying", "decrypted", "failed"];
+    for (const status of statuses) {
+      const payload = makePayload({ status });
+      expect(payload.status).toBe(status);
+    }
+  });
+
+  it("carries diagnosticId through", () => {
+    const payload = makePayload({ diagnosticId: "abc-123" });
+    expect(payload.diagnosticId).toBe("abc-123");
+  });
+
+  it("carries failureReason when provided", () => {
+    const payload = makePayload({ status: "failed", failureReason: "integrity" });
+    expect(payload.failureReason).toBe("integrity");
+  });
+
+  it("does not require failureReason for failed status", () => {
+    const payload = makePayload({ status: "failed" });
+    expect(payload.failureReason).toBeUndefined();
+  });
+});
+
+describe("EncryptedPayloadBanner — CTA callbacks", () => {
+  it("fires onCopyDiagnosticId with the correct id", () => {
+    const onCopy = vi.fn();
+    const id = "diag-xyz-999";
+    onCopy(id);
+    expect(onCopy).toHaveBeenCalledWith(id);
+  });
+
+  it("fires onReportCorruption with the correct id", () => {
+    const onReport = vi.fn();
+    const id = "diag-abc-111";
+    onReport(id);
+    expect(onReport).toHaveBeenCalledWith(id);
+  });
+
+  it("fires onRetry", () => {
+    const onRetry = vi.fn();
+    onRetry();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onUnlock", () => {
+    const onUnlock = vi.fn();
+    onUnlock();
+    expect(onUnlock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EncryptedPayloadBanner — encrypted fixture variants", () => {
+  // Mirrors the four fixture emails added in data.ts
+  const fixtures: EncryptedPayload[] = [
+    { status: "decrypted", diagnosticId: "dec-7a3f-c18e" },
+    { status: "locked", diagnosticId: "lck-4b2a-9d01" },
+    { status: "verifying", diagnosticId: "vfy-8c5d-2e47" },
+    { status: "failed", diagnosticId: "flt-1e9b-5f62", failureReason: "integrity" },
+  ];
+
+  fixtures.forEach(({ status, diagnosticId, failureReason }) => {
+    it(`fixture with status=${status} is valid`, () => {
+      const p = makePayload({ status, diagnosticId, failureReason });
+      expect(p.status).toBe(status);
+      expect(p.diagnosticId).toBe(diagnosticId);
+    });
+  });
+
+  it("all fixture diagnostic IDs are unique", () => {
+    const ids = fixtures.map((f) => f.diagnosticId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
- Add PayloadStatus, PayloadFailureReason, and EncryptedPayload types to data.ts
- Create EncryptedPayloadBanner component with four states:
  - locked: pulsing key icon, optional Unlock CTA
  - verifying: spinning loader, no body rendered
  - decrypted: green check, body unlocked and rendered
  - failed: red alert with reason tag (key/payload/relay/integrity), Retry + Copy diagnostic ID + Report corruption CTAs
- Encrypted messages never flash plaintext before verification completes (body is hidden for locked/verifying/failed states)
- Respects prefers-reduced-motion: instant state changes, no spin/pulse
- Integrate banner into EmailView above ReaderBody via useMediaQuery
- Add onUnlockPayload and onRetryDecrypt to EmailViewActions
- Add 4 encrypted fixture emails covering all payload status variants
- Write 23 unit tests across visibility guard, failure copy, data model, CTA callbacks, and fixture validation (225 total passing)
- Lint: 0 errors | TypeScript: 0 errors

closes #96 