### PR TITLE
docs: add auto label suggestion review plan

### DIFF
--- a/tools/v1/individual/auto-label-suggestion/README.md
+++ b/tools/v1/individual/auto-label-suggestion/README.md
@@ -1,15 +1,39 @@
 # Auto Label Suggestion
 
-This folder is the isolated workspace for the Auto Label Suggestion tool.
+Auto Label Suggestion is an isolated V1 individual tool for proposing labels from email
+metadata and message content. It is not wired into the main mail app yet; this folder
+captures the review surface for the tool until a future integration issue connects it.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\auto-label-suggestion\
-`
+```text
+tools/v1/individual/auto-label-suggestion/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not modify the main application shell, routing, inbox architecture, wallet core,
+Stellar integration, database schema, or shared design system from this issue.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `specs.md` defines the expected input, output, label taxonomy, and decision rules.
+- `fixtures/email-label-cases.json` provides representative emails and expected labels.
+- `tests/test-plan.md` lists the folder-local validation scenarios for future code.
+- `docs/review-notes.md` gives maintainers a short checklist for reviewing this tool
+  independently from the main application.
+
+## Intended Behavior
+
+The tool should inspect an email subject, sender, snippet, body preview, and existing
+labels, then return ranked label suggestions. A suggestion should include a label,
+confidence level, reason, and short evidence string so the user can understand why the
+label was proposed.
+
+## Known Limitations
+
+- No production model, service, hook, or UI component is implemented in this issue.
+- The test plan is fixture-backed documentation because the tool has no executable
+  implementation yet.
+- Future implementation work should keep confidence thresholds configurable and avoid
+  sending message content outside the user-controlled execution boundary.

--- a/tools/v1/individual/auto-label-suggestion/docs/review-notes.md
+++ b/tools/v1/individual/auto-label-suggestion/docs/review-notes.md
@@ -1,0 +1,26 @@
+# Review Notes
+
+This contribution prepares the Auto Label Suggestion tool for independent review before
+implementation work starts.
+
+## What To Review
+
+- The tool boundary is explicit and limited to this folder.
+- The taxonomy covers the first practical labels for an individual inbox.
+- Fixtures include positive, mixed, and low-risk examples.
+- The test plan documents privacy and prioritization edge cases.
+
+## What Is Intentionally Not Included
+
+- No app route, navigation item, database migration, wallet integration, or shared design
+  system change.
+- No model call, external API, background job, or analytics event.
+- No executable test harness until the first service/hook implementation is introduced.
+
+## Follow-Up Implementation Shape
+
+A future implementation can add:
+
+- `services/suggestLabels.ts` for deterministic label ranking.
+- `tests/suggestLabels.test.ts` using the fixture file in this folder.
+- A local demo component only if a future UI issue asks for it.

--- a/tools/v1/individual/auto-label-suggestion/fixtures/email-label-cases.json
+++ b/tools/v1/individual/auto-label-suggestion/fixtures/email-label-cases.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "invoice-overdue",
+    "from": "billing@example-vendor.com",
+    "subject": "Invoice INV-1042 is due today",
+    "snippet": "Please review and pay the attached invoice before end of day.",
+    "bodyPreview": "The payment link expires tonight. Contact billing if you need the PO updated.",
+    "existingLabels": [],
+    "expectedLabels": ["Finance", "Action needed"]
+  },
+  {
+    "id": "stellar-payout",
+    "from": "payments@stellar.example",
+    "subject": "USDC payout confirmation",
+    "snippet": "Your USDC payout was sent to wallet GBZX... with memo GF-328.",
+    "bodyPreview": "Transaction hash: 7f0a1c9e. Keep this for reconciliation.",
+    "existingLabels": ["Receipts"],
+    "expectedLabels": ["Finance", "Stellar"]
+  },
+  {
+    "id": "security-code",
+    "from": "security@example-mail.com",
+    "subject": "Your verification code",
+    "snippet": "Use this one-time code to finish signing in.",
+    "bodyPreview": "If you did not request this code, reset your password immediately.",
+    "existingLabels": [],
+    "expectedLabels": ["Security"]
+  },
+  {
+    "id": "calendar-reschedule",
+    "from": "maya@example.com",
+    "subject": "Reschedule tomorrow's onboarding review",
+    "snippet": "Can we move the review to 3 PM? Please confirm before noon.",
+    "bodyPreview": "I added the agenda and the latest notes to the invite.",
+    "existingLabels": ["Team"],
+    "expectedLabels": ["Calendar", "Action needed"]
+  },
+  {
+    "id": "newsletter-product-update",
+    "from": "updates@example-product.com",
+    "subject": "June product update and release digest",
+    "snippet": "This month's release digest covers improvements, tips, and events.",
+    "bodyPreview": "You can unsubscribe or update email preferences at any time.",
+    "existingLabels": [],
+    "expectedLabels": ["Newsletter"]
+  }
+]

--- a/tools/v1/individual/auto-label-suggestion/specs.md
+++ b/tools/v1/individual/auto-label-suggestion/specs.md
@@ -1,41 +1,67 @@
-# Auto Label Suggestion
-
-Suggest labels automatically.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/auto-label-suggestion/README.md"
-  @"
-
 # Auto Label Suggestion Specs
 
 ## Purpose
 
-Suggest labels automatically.
+Suggest practical labels for individual inbox users so they can triage messages faster
+without manually scanning every thread.
 
-## Contributor boundary
+## Input Contract
 
-All work for this tool should stay in:
+Each label decision should be based on a normalized email record:
 
-$dir/
+```ts
+type AutoLabelEmail = {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  bodyPreview?: string;
+  existingLabels?: string[];
+  receivedAt?: string;
+};
+```
 
-## Required issue categories
+## Output Contract
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+Each suggestion should be explainable and safe to render in a review UI:
+
+```ts
+type AutoLabelSuggestion = {
+  label: string;
+  confidence: "high" | "medium" | "low";
+  reason: string;
+  evidence: string;
+};
+```
+
+## Initial Label Taxonomy
+
+| Label         | Trigger examples                                           | Notes                                                                                |
+| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Action needed | "please review", "approval required", "due today"          | Prefer high confidence when a deadline or explicit request is present.               |
+| Finance       | invoice, receipt, payout, refund, payment                  | Keep separate from Stellar unless the message references wallet or on-chain details. |
+| Stellar       | XLM, USDC, wallet, transaction hash, memo                  | Use when the email has blockchain-specific payment context.                          |
+| Security      | OTP, verification code, suspicious sign-in, password reset | Never expose codes in logs or analytics.                                             |
+| Calendar      | meeting, invite, reschedule, agenda                        | Include date/time evidence when available.                                           |
+| Newsletter    | unsubscribe, weekly digest, product update                 | Do not override higher-risk Security or Finance labels.                              |
+
+## Decision Rules
+
+- Preserve existing user labels and add suggestions separately.
+- Return at most three suggestions per email.
+- Prefer fewer high-quality labels over broad keyword matching.
+- If multiple labels are possible, rank Security and Finance above Newsletter.
+- Explanations should quote only the minimal evidence needed for review.
+- Suggestions must be deterministic for the same input fixture.
+
+## Test Fixtures
+
+Use `fixtures/email-label-cases.json` as the baseline fixture set for future unit tests.
+The fixture covers finance, Stellar payment, security, calendar, newsletter, and mixed
+priority scenarios.
+
+## Review Expectations
+
+Until executable code exists, reviewers can validate this tool by checking that the
+fixture labels and the test plan cover the taxonomy, edge cases, and privacy boundaries
+without modifying the main app.

--- a/tools/v1/individual/auto-label-suggestion/tests/test-plan.md
+++ b/tools/v1/individual/auto-label-suggestion/tests/test-plan.md
@@ -1,0 +1,42 @@
+# Auto Label Suggestion Test Plan
+
+This test plan is folder-local because the tool is not integrated with the app shell yet.
+It should become executable unit coverage when the first implementation lands.
+
+## Fixture Setup
+
+Use:
+
+```text
+tools/v1/individual/auto-label-suggestion/fixtures/email-label-cases.json
+```
+
+Each fixture contains the normalized email input and the expected labels. Future tests
+should assert the returned label names first, then validate confidence and explanations.
+
+## Scenarios
+
+| Scenario          | Fixture                     | Expected result                                                                         |
+| ----------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| Finance deadline  | `invoice-overdue`           | Suggests `Finance` and `Action needed`; reason mentions invoice and due timing.         |
+| On-chain payout   | `stellar-payout`            | Suggests `Finance` and `Stellar`; preserves existing `Receipts` label.                  |
+| Sign-in code      | `security-code`             | Suggests only `Security`; does not include the code value in logs or evidence.          |
+| Meeting follow-up | `calendar-reschedule`       | Suggests `Calendar` and `Action needed`; evidence includes reschedule/confirm language. |
+| Low-risk digest   | `newsletter-product-update` | Suggests `Newsletter`; does not add higher-priority labels.                             |
+
+## Negative Checks
+
+- Empty subject and snippet should return no suggestions, not a generic fallback label.
+- Existing labels should not be overwritten or duplicated.
+- Keyword-only matches should stay `low` confidence unless the subject or sender supports
+  the same label.
+- Security and Finance labels should outrank Newsletter in mixed-content emails.
+
+## Manual Review
+
+1. Confirm all changed files stay under `tools/v1/individual/auto-label-suggestion/`.
+2. Confirm fixture examples avoid real personal data, secrets, access tokens, and live
+   wallet addresses.
+3. Confirm the README documents setup, usage, fixtures, and limitations.
+4. Confirm future executable tests can be written from this plan without touching the
+   main application.


### PR DESCRIPTION
## Summary

Closes #328.

Prepares the isolated Auto Label Suggestion tool for review by replacing the broken template text with a usable spec, fixture-backed test plan, and maintainer review notes.

## Changes

- Defines the tool boundary, input/output contracts, label taxonomy, and decision rules.
- Adds representative email fixtures for finance, Stellar payout, security, calendar, and newsletter cases.
- Adds a folder-local test plan and review notes so the tool can be validated independently before implementation.

## Verification

- `npm.cmd ci`
- `npx.cmd --no-install prettier --check tools/v1/individual/auto-label-suggestion/README.md tools/v1/individual/auto-label-suggestion/specs.md tools/v1/individual/auto-label-suggestion/fixtures/email-label-cases.json tools/v1/individual/auto-label-suggestion/tests/test-plan.md tools/v1/individual/auto-label-suggestion/docs/review-notes.md`
- `npm.cmd run build`
- `git diff --check`