### PR TITLE
docs: add architecture contract for team task board from emails

### DIFF
--- a/tools/v2/team/team-task-board-from-emails/README.md
+++ b/tools/v2/team/team-task-board-from-emails/README.md
@@ -53,6 +53,7 @@ about the expected behavior without running the main app.
 
 ## Documentation Map
 
+- `docs/architecture.md` defines the internal module boundaries, data ownership, and integration constraints.
 - `specs.md` defines the local product contract and boundaries.
 - `docs/test-plan.md` lists manual and automated review steps.
 - `docs/review-notes.md` explains what was validated and what remains out of

--- a/tools/v2/team/team-task-board-from-emails/docs/architecture.md
+++ b/tools/v2/team/team-task-board-from-emails/docs/architecture.md
@@ -1,0 +1,37 @@
+# Architecture Contract
+
+## Overview
+This document defines the folder-local architecture for the "Team Task Board from Emails" tool. It establishes the internal module boundaries and integration constraints required to keep this tool as a self-contained mini-product before any future connection to the main application.
+
+## Internal Module Boundaries
+
+To maintain isolation, the tool must organize its code strictly within `tools/v2/team/team-task-board-from-emails/` using the following boundaries:
+
+- **Components (`/components`)**: React components responsible for rendering the task board, columns, and individual task cards. These must be self-contained and must not import from the main app's design system or core component libraries unless explicitly passed as props in a future integration phase.
+- **Services (`/services`)**: Business logic for extracting tasks from emails, parsing metadata, and managing the board state. These services must rely on injected data rather than directly fetching from the main app's database or inbox architecture.
+- **Hooks (`/hooks`)**: Custom React hooks for managing local state, UI interactions, and drag-and-drop mechanics within the task board.
+- **Tests (`/tests`)**: Folder-local automated tests (e.g., fixture validations) to ensure extraction logic and board state management function correctly in isolation.
+- **Docs (`/docs`)**: Documentation detailing the tool's behavior, testing plans, review notes, and this architecture contract.
+
+## Data Ownership
+
+- **Local State**: The tool owns its internal representation of the board state (columns: `new`, `triage`, `blocked`, `done`) and the tasks within them.
+- **Data Source**: The tool expects email data to be provided to it (e.g., via props or a localized service wrapper) rather than fetching it directly from the core app's mail rendering engine or database.
+- **Persistence**: Any data persistence mechanism must be mocked or localized for the scope of this tool. Write operations to the main database are strictly forbidden in this phase.
+
+## Dependencies
+
+- **Internal**: Modules within this folder may freely depend on each other.
+- **External**: The tool may only depend on generic third-party libraries already present in the project (e.g., React).
+- **Prohibited Dependencies**: The tool must not import from or depend on:
+  - Main app shell or routing logic
+  - Existing inbox architecture or mail rendering engine
+  - Authentication, Wallet Core, or Stellar Core
+  - Existing Design System or core UI components
+
+## Integration Constraints
+
+Contributors must adhere to the following constraints:
+- **No Core App Modifications**: Do not touch files outside of `tools/v2/team/team-task-board-from-emails/`.
+- **Future Integration**: The tool must be designed so that a future integration issue can connect it to the main app by simply importing its top-level component or service and passing the required data/callbacks.
+- **Reviewability**: The entire module must remain small, reviewable, and fully functional using local fixtures without needing the main application running.

--- a/tools/v2/team/team-task-board-from-emails/docs/architecture.md
+++ b/tools/v2/team/team-task-board-from-emails/docs/architecture.md
@@ -1,6 +1,7 @@
 # Architecture Contract
 
 ## Overview
+
 This document defines the folder-local architecture for the "Team Task Board from Emails" tool. It establishes the internal module boundaries and integration constraints required to keep this tool as a self-contained mini-product before any future connection to the main application.
 
 ## Internal Module Boundaries
@@ -32,6 +33,7 @@ To maintain isolation, the tool must organize its code strictly within `tools/v2
 ## Integration Constraints
 
 Contributors must adhere to the following constraints:
+
 - **No Core App Modifications**: Do not touch files outside of `tools/v2/team/team-task-board-from-emails/`.
 - **Future Integration**: The tool must be designed so that a future integration issue can connect it to the main app by simply importing its top-level component or service and passing the required data/callbacks.
 - **Reviewability**: The entire module must remain small, reviewable, and fully functional using local fixtures without needing the main application running.


### PR DESCRIPTION
**PR Title:**
docs: add architecture contract for team task board from emails

**PR Description:**
**What was done**
- Created the folder-local architecture contract (`docs/architecture.md`) for the isolated Team Task Board from Emails mini-product.
- Defined module boundaries for components, services, hooks, tests, and docs to ensure isolation from the core application shell.
- Documented data ownership, internal/external dependencies, and future integration constraints.
- Updated the existing folder `README.md` Documentation Map to include the new architecture document.

**Why it was done**
- To establish a clear boundary and development guidelines for this V2 later-release tool.
- To prevent accidental tight coupling with the main application (e.g., routing, wallet core, Stellar core, design system) before it is officially integrated.
- To fulfill the initial architecture specification required for this issue.

**How it was verified**
- Verified that all new changes are completely restricted to the local `tools/v2/team/team-task-board-from-emails/` folder.
- Verified that the `README.md` correctly references the newly created architecture contract.
- Confirmed that no core app files or shared structures were modified.

Closes #704
