### PR TITLE
Feat: Build campaign-to-message assignment tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test-results/
 
 CLAUDE.md
 plan.md
+ASSUMPTIONS.md

--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -29,6 +29,7 @@ import type {
 import { TemplatePicker } from "./templates";
 import { PRESET_SCENARIOS } from "./fixtures/presets";
 import { AdminDataTable, type Column } from "./components/AdminDataTable";
+import { CampaignMessageAssignmentPanel } from "./components/CampaignMessageAssignmentPanel";
 
 // ─── Default Deterministic fake data ──────────────────────────────────────────
 
@@ -790,6 +791,8 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
           {activeSection === "events" && <EventsContent events={events} />}
 
           {activeSection === "templates" && <TemplatesContent />}
+
+          {activeSection === "campaigns" && <CampaignMessageAssignmentPanel />}
 
           {activeSection === "audit" && <AuditContent auditEvents={auditEvents} />}
         </div>

--- a/src/features/demo-admin-dashboard/__tests__/assignmentHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/assignmentHelpers.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMessageAssigned,
+  getAssignedMessages,
+  assignMessage,
+  unassignMessage,
+  getCampaignsForMessage,
+  assignToManyCampaigns,
+} from "../utils/assignmentHelpers";
+import { CampaignSnapshot } from "../types/campaignSnapshot";
+import { AssignableMessage } from "../types/assignment";
+
+const makeMsg = (id: string): AssignableMessage => ({
+  id,
+  subject: `Subject ${id}`,
+  preview: "Preview text",
+  body: "Body text",
+  recipients: ["test@stealth.demo"],
+  tags: ["onboarding"],
+  folderHint: "inbox",
+});
+
+const makeCampaign = (id: string, draftIds: string[] = []): CampaignSnapshot => ({
+  id,
+  name: `Campaign ${id}`,
+  description: "desc",
+  targetAudience: "Test",
+  tags: [],
+  timestamp: "2026-06-17T00:00:00Z",
+  status: "active",
+  drafts: draftIds.map((dId) => ({
+    id: dId,
+    subject: `Draft ${dId}`,
+    body: "body",
+    recipients: ["r@stealth.demo"],
+  })),
+});
+
+describe("isMessageAssigned", () => {
+  it("returns true when draft id matches", () => {
+    const campaign = makeCampaign("c1", ["msg-1", "msg-2"]);
+    expect(isMessageAssigned(campaign, "msg-1")).toBe(true);
+  });
+
+  it("returns false when draft id is absent", () => {
+    const campaign = makeCampaign("c1", ["msg-1"]);
+    expect(isMessageAssigned(campaign, "msg-99")).toBe(false);
+  });
+
+  it("returns false on empty drafts", () => {
+    const campaign = makeCampaign("c1");
+    expect(isMessageAssigned(campaign, "msg-1")).toBe(false);
+  });
+});
+
+describe("getAssignedMessages", () => {
+  it("returns pool messages whose ids appear in campaign drafts", () => {
+    const campaign = makeCampaign("c1", ["msg-a", "msg-c"]);
+    const pool = [makeMsg("msg-a"), makeMsg("msg-b"), makeMsg("msg-c")];
+    const result = getAssignedMessages(campaign, pool);
+    expect(result.map((m) => m.id)).toEqual(["msg-a", "msg-c"]);
+  });
+
+  it("skips draft ids not in the pool", () => {
+    const campaign = makeCampaign("c1", ["msg-x"]);
+    const pool = [makeMsg("msg-a")];
+    expect(getAssignedMessages(campaign, pool)).toHaveLength(0);
+  });
+});
+
+describe("assignMessage", () => {
+  it("adds the message draft to the campaign", () => {
+    const campaign = makeCampaign("c1");
+    const msg = makeMsg("msg-new");
+    const updated = assignMessage(campaign, msg);
+    expect(updated.drafts).toHaveLength(1);
+    expect(updated.drafts[0].id).toBe("msg-new");
+  });
+
+  it("is idempotent — does not duplicate", () => {
+    const campaign = makeCampaign("c1", ["msg-new"]);
+    const msg = makeMsg("msg-new");
+    const updated = assignMessage(campaign, msg);
+    expect(updated.drafts).toHaveLength(1);
+  });
+
+  it("does not mutate the original campaign", () => {
+    const campaign = makeCampaign("c1");
+    assignMessage(campaign, makeMsg("msg-x"));
+    expect(campaign.drafts).toHaveLength(0);
+  });
+});
+
+describe("unassignMessage", () => {
+  it("removes the draft with the given id", () => {
+    const campaign = makeCampaign("c1", ["msg-1", "msg-2"]);
+    const updated = unassignMessage(campaign, "msg-1");
+    expect(updated.drafts.map((d) => d.id)).toEqual(["msg-2"]);
+  });
+
+  it("is a no-op when id is not present", () => {
+    const campaign = makeCampaign("c1", ["msg-1"]);
+    const updated = unassignMessage(campaign, "msg-99");
+    expect(updated.drafts).toHaveLength(1);
+  });
+});
+
+describe("getCampaignsForMessage", () => {
+  it("returns all campaigns that have the message assigned", () => {
+    const campaigns = [
+      makeCampaign("c1", ["msg-1"]),
+      makeCampaign("c2", ["msg-2"]),
+      makeCampaign("c3", ["msg-1", "msg-3"]),
+    ];
+    const result = getCampaignsForMessage(campaigns, "msg-1");
+    expect(result.map((c) => c.id)).toEqual(["c1", "c3"]);
+  });
+
+  it("returns empty array when no campaign has the message", () => {
+    const campaigns = [makeCampaign("c1", ["msg-1"])];
+    expect(getCampaignsForMessage(campaigns, "msg-99")).toHaveLength(0);
+  });
+});
+
+describe("assignToManyCampaigns", () => {
+  it("assigns a message to the specified campaign ids only", () => {
+    const campaigns = [makeCampaign("c1"), makeCampaign("c2"), makeCampaign("c3")];
+    const msg = makeMsg("msg-x");
+    const updated = assignToManyCampaigns(campaigns, msg, ["c1", "c3"]);
+    expect(isMessageAssigned(updated[0], "msg-x")).toBe(true);
+    expect(isMessageAssigned(updated[1], "msg-x")).toBe(false);
+    expect(isMessageAssigned(updated[2], "msg-x")).toBe(true);
+  });
+
+  it("is idempotent for already-assigned campaigns", () => {
+    const campaigns = [makeCampaign("c1", ["msg-x"])];
+    const msg = makeMsg("msg-x");
+    const updated = assignToManyCampaigns(campaigns, msg, ["c1"]);
+    expect(updated[0].drafts).toHaveLength(1);
+  });
+});

--- a/src/features/demo-admin-dashboard/components/CampaignMessageAssignmentPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignMessageAssignmentPanel.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CampaignSnapshot } from "../types/campaignSnapshot";
+import { AssignableMessage } from "../types/assignment";
+import { messagePool, defaultAssignmentState } from "../fixtures/assignmentFixtures";
+import { getAssignedMessages, assignMessage, unassignMessage } from "../utils/assignmentHelpers";
+import { CAMPAIGN_STATUS_TOKENS, TAG_COLOR_TOKENS, getTagToken } from "../constants/displayTokens";
+import { saveAssignments, loadAssignments } from "../persistence/localStorageAdapter";
+import { AdminDataTable, type Column } from "./AdminDataTable";
+import { MessagePicker } from "./MessagePicker";
+
+interface CampaignMessageAssignmentPanelProps {
+  className?: string;
+}
+
+export function CampaignMessageAssignmentPanel({ className }: CampaignMessageAssignmentPanelProps) {
+  const [campaigns, setCampaigns] = useState<CampaignSnapshot[]>(() => {
+    const saved = loadAssignments();
+    return saved?.campaigns ?? defaultAssignmentState.campaigns;
+  });
+  const [pool] = useState<AssignableMessage[]>(messagePool);
+  const [selectedCampaignId, setSelectedCampaignId] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const selectedCampaign = campaigns.find((c) => c.id === selectedCampaignId) ?? null;
+
+  useEffect(() => {
+    saveAssignments({ campaigns, pool });
+  }, [campaigns, pool]);
+
+  function handleAssign(msg: AssignableMessage) {
+    if (!selectedCampaign) return;
+    const updated = assignMessage(selectedCampaign, msg);
+    setCampaigns((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+    setPickerOpen(false);
+  }
+
+  function handleUnassign(messageId: string) {
+    if (!selectedCampaign) return;
+    const updated = unassignMessage(selectedCampaign, messageId);
+    setCampaigns((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+  }
+
+  // Campaign list columns
+  const campaignColumns: Column<CampaignSnapshot>[] = [
+    {
+      key: "name",
+      header: "Campaign",
+      sortable: true,
+      render: (c) => (
+        <div>
+          <p className="font-medium text-foreground">{c.name}</p>
+          <p className="text-[10px] text-muted-foreground mt-0.5">{c.targetAudience}</p>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      sortable: true,
+      sortValue: (c) => c.status ?? "draft",
+      render: (c) => {
+        const tk = CAMPAIGN_STATUS_TOKENS[c.status ?? "draft"];
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+              tk.bg,
+              tk.text,
+              tk.border,
+            )}
+          >
+            {tk.label}
+          </span>
+        );
+      },
+    },
+    {
+      key: "drafts",
+      header: "Messages",
+      sortable: true,
+      sortValue: (c) => c.drafts.length,
+      render: (c) => <span className="tabular-nums text-muted-foreground">{c.drafts.length}</span>,
+    },
+    {
+      key: "tags",
+      header: "Tags",
+      render: (c) => (
+        <div className="flex flex-wrap gap-1">
+          {c.tags.slice(0, 2).map((tag) => {
+            const tk = TAG_COLOR_TOKENS[tag.toLowerCase()] ?? {
+              bg: TAG_COLOR_TOKENS.default.bg,
+              text: TAG_COLOR_TOKENS.default.text,
+              border: TAG_COLOR_TOKENS.default.border,
+              label: tag,
+            };
+            return (
+              <span
+                key={tag}
+                className={cn(
+                  "rounded-full border px-1.5 py-0.5 text-[9px] font-medium",
+                  tk.bg,
+                  tk.text,
+                  tk.border,
+                )}
+              >
+                {tk.label}
+              </span>
+            );
+          })}
+          {c.tags.length > 2 && (
+            <span className="text-[9px] text-muted-foreground">+{c.tags.length - 2}</span>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  // Assigned message columns
+  const assignedMessages = selectedCampaign ? getAssignedMessages(selectedCampaign, pool) : [];
+
+  const messageColumns: Column<AssignableMessage>[] = [
+    {
+      key: "subject",
+      header: "Subject",
+      sortable: true,
+      render: (msg) => (
+        <div>
+          <p className="font-medium text-foreground">{msg.subject}</p>
+          <p className="text-[10px] text-muted-foreground mt-0.5 line-clamp-1">{msg.preview}</p>
+        </div>
+      ),
+    },
+    {
+      key: "tags",
+      header: "Tags",
+      render: (msg) => (
+        <div className="flex flex-wrap gap-1">
+          {msg.tags.map((tag) => {
+            const tk = getTagToken(tag);
+            return (
+              <span
+                key={tag}
+                className={cn(
+                  "rounded-full border px-1.5 py-0.5 text-[9px] font-medium",
+                  tk.bg,
+                  tk.text,
+                  tk.border,
+                )}
+              >
+                {tk.label}
+              </span>
+            );
+          })}
+        </div>
+      ),
+    },
+    {
+      key: "remove",
+      header: "",
+      render: (msg) => (
+        <button
+          type="button"
+          aria-label={`Remove ${msg.subject}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleUnassign(msg.id);
+          }}
+          className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-rose-500/10 hover:text-rose-400"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <section aria-label="Campaign message assignments" className={cn("space-y-4", className)}>
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Campaign Message Assignments</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Select a campaign to view and manage its assigned messages.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 md:flex-row">
+        {/* Left: Campaign list (~40%) */}
+        <div className="md:w-[40%] space-y-2">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground px-1">
+            Campaigns
+          </p>
+          <AdminDataTable
+            data={campaigns}
+            columns={campaignColumns}
+            onRowClick={(c) => setSelectedCampaignId(selectedCampaignId === c.id ? null : c.id)}
+            selectedRowKey={(c) => c.id === selectedCampaignId}
+            defaultSortKey="name"
+            emptyMessage="No campaigns found."
+          />
+        </div>
+
+        {/* Right: Assigned messages (~60%) */}
+        <div className="flex-1 space-y-2">
+          <div className="flex items-center justify-between px-1">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {selectedCampaign ? `Messages — ${selectedCampaign.name}` : "Messages"}
+            </p>
+            {selectedCampaign && (
+              <button
+                type="button"
+                onClick={() => setPickerOpen(true)}
+                className="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-white/[0.07]"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add messages
+              </button>
+            )}
+          </div>
+
+          {!selectedCampaign ? (
+            <div className="flex h-40 items-center justify-center rounded-xl border border-white/[0.06] bg-white/[0.01] text-sm text-muted-foreground">
+              Select a campaign to view its messages.
+            </div>
+          ) : (
+            <AdminDataTable
+              data={assignedMessages}
+              columns={messageColumns}
+              defaultSortKey="subject"
+              emptyMessage="No messages assigned yet — click Add messages."
+            />
+          )}
+        </div>
+      </div>
+
+      {pickerOpen && selectedCampaign && (
+        <MessagePicker
+          pool={pool}
+          campaign={selectedCampaign}
+          onAssign={handleAssign}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/components/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/components/DemoAdminDashboard.tsx
@@ -4,6 +4,7 @@ import {
   adminDashboardWidthNotes,
 } from "../fixtures/demoData";
 import { ADMIN_DASHBOARD_MIN_SUPPORTED_WIDTH } from "../layout";
+import { CampaignMessageAssignmentPanel } from "./CampaignMessageAssignmentPanel";
 import "./DemoAdminDashboard.css";
 
 const statusLabels = {
@@ -77,6 +78,8 @@ export function DemoAdminDashboard() {
           ))}
         </section>
       </div>
+
+      <CampaignMessageAssignmentPanel />
     </section>
   );
 }

--- a/src/features/demo-admin-dashboard/components/MessagePicker.tsx
+++ b/src/features/demo-admin-dashboard/components/MessagePicker.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AssignableMessage } from "../types/assignment";
+import { CampaignSnapshot } from "../types/campaignSnapshot";
+import { isMessageAssigned } from "../utils/assignmentHelpers";
+import { getTagToken } from "../constants/displayTokens";
+import { AdminSearchBar } from "../AdminSearchBar";
+
+interface MessagePickerProps {
+  pool: AssignableMessage[];
+  campaign: CampaignSnapshot;
+  onAssign: (msg: AssignableMessage) => void;
+  onClose: () => void;
+}
+
+export function MessagePicker({ pool, campaign, onAssign, onClose }: MessagePickerProps) {
+  const [query, setQuery] = useState("");
+
+  const filtered = pool.filter((msg) => {
+    if (!query.trim()) return true;
+    const q = query.toLowerCase();
+    return (
+      msg.subject.toLowerCase().includes(q) ||
+      msg.tags.some((t) => t.toLowerCase().includes(q)) ||
+      msg.folderHint.toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick messages to assign"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div className="relative flex w-full max-w-lg flex-col rounded-2xl border border-white/[0.10] bg-black/90 shadow-2xl backdrop-blur-xl overflow-hidden max-h-[80vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-white/[0.06] px-5 py-4">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Add messages</h3>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">
+              Assigning to <span className="text-foreground">{campaign.name}</span>
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close message picker"
+            className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="border-b border-white/[0.06] px-5 py-3">
+          <AdminSearchBar
+            value={query}
+            onChange={setQuery}
+            resultCount={filtered.length}
+            totalCount={pool.length}
+            placeholder="Search by subject or tag…"
+          />
+        </div>
+
+        {/* Message list */}
+        <div className="flex-1 overflow-y-auto divide-y divide-white/[0.04]">
+          {filtered.length === 0 ? (
+            <p className="px-5 py-10 text-center text-sm text-muted-foreground">
+              No messages available.
+            </p>
+          ) : (
+            filtered.map((msg) => {
+              const assigned = isMessageAssigned(campaign, msg.id);
+              return (
+                <button
+                  key={msg.id}
+                  type="button"
+                  disabled={assigned}
+                  onClick={() => !assigned && onAssign(msg)}
+                  className={cn(
+                    "w-full px-5 py-3 text-left transition",
+                    assigned ? "cursor-default opacity-50" : "hover:bg-white/[0.03] cursor-pointer",
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-foreground">{msg.subject}</p>
+                      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                        {msg.preview}
+                      </p>
+                      <div className="mt-1.5 flex flex-wrap gap-1">
+                        {msg.tags.map((tag) => {
+                          const tk = getTagToken(tag);
+                          return (
+                            <span
+                              key={tag}
+                              className={cn(
+                                "rounded-full border px-2 py-0.5 text-[10px] font-medium",
+                                tk.bg,
+                                tk.text,
+                                tk.border,
+                              )}
+                            >
+                              {tk.label}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    </div>
+                    {assigned ? (
+                      <span className="shrink-0 rounded-full bg-emerald-500/10 border border-emerald-500/20 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+                        Assigned
+                      </span>
+                    ) : (
+                      <span className="shrink-0 rounded-full bg-white/[0.04] border border-white/[0.08] px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        {msg.folderHint}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/fixtures/assignmentFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/assignmentFixtures.ts
@@ -1,0 +1,189 @@
+import { AssignableMessage, AssignmentState } from "../types/assignment";
+import { defaultCampaignSnapshots } from "./campaignSnapshotFixtures";
+import { CampaignSnapshot } from "../types/campaignSnapshot";
+
+export const messagePool: AssignableMessage[] = [
+  {
+    id: "msg-pool-001",
+    subject: "Welcome to Stealth",
+    preview:
+      "Your mailbox is ready. You decide who can reach you — trusted contacts arrive instantly.",
+    body: "Your mailbox is ready. You decide who can reach you — trusted contacts arrive instantly, everyone else follows the policy you choose.\n\n— The Stealth Team",
+    recipients: ["newuser@stealth.demo"],
+    tags: ["welcome", "onboarding"],
+    folderHint: "inbox",
+  },
+  {
+    id: "msg-pool-002",
+    subject: "Set up your Stellar wallet",
+    preview:
+      "To start receiving postage refunds, connect your Stellar account address in settings.",
+    body: "To start receiving postage refunds, connect your Stellar account address in settings. This lets the postage contract route credits directly back to you.\n\n— Stealth Finance",
+    recipients: ["newuser@stealth.demo"],
+    tags: ["stellar", "onboarding"],
+    folderHint: "inbox",
+  },
+  {
+    id: "msg-pool-003",
+    subject: "Postage receipt: msg_relay_8a2c",
+    preview: "Your postage of 0.05 XLM has been settled on-chain. Ledger hash attached.",
+    body: "Your postage of 0.05 XLM has been settled on-chain. Ledger hash: 3f2a1...b9cd.\n\nThis receipt is cryptographically verifiable at any time.",
+    recipients: ["user@stealth.demo"],
+    tags: ["stellar", "announcement"],
+    folderHint: "receipts",
+  },
+  {
+    id: "msg-pool-004",
+    subject: "Relay node registered: relay-east-01",
+    preview: "A new relay node has been registered and is awaiting on-chain verification.",
+    body: "A new relay node (relay-east-01) has been registered and is awaiting on-chain verification. Estimated confirmation time: 2–4 ledger cycles.",
+    recipients: ["admin@stealth.demo"],
+    tags: ["stellar", "announcement"],
+    folderHint: "priority",
+  },
+  {
+    id: "msg-pool-005",
+    subject: "Action required: confirm backup passphrase",
+    preview:
+      "We detected a sign-in from a new device. Verify your 24-word recovery phrase to continue.",
+    body: "We detected a sign-in from a new device. Please verify your 24-word recovery phrase to confirm this was you and protect your account.\n\n— Stealth Security",
+    recipients: ["sec-audit@stealth.demo"],
+    tags: ["security", "alert"],
+    folderHint: "priority",
+  },
+  {
+    id: "msg-pool-006",
+    subject: "Stealth Digest — June 2026",
+    preview:
+      "Two new regional relays online. Postage routing latency down 18%. Read the full update.",
+    body: "This month we brought two new regional relays online, cutting median routing latency by 18%. The postage contract upgrade shipped on testnet — mainnet follows next sprint.\n\nRead more on the blog.",
+    recipients: ["subscribers@stealth.demo"],
+    tags: ["newsletter", "marketing"],
+    folderHint: "inbox",
+  },
+  {
+    id: "msg-pool-007",
+    subject: "You're invited: Stealth demo roundtable",
+    preview: "Join us on July 9 at 3 PM for a live walkthrough of the Stealth protocol and Q&A.",
+    body: "Join us on July 9 at 3 PM (virtual) for a live walkthrough of the Stealth protocol and an open Q&A session. RSVP by replying to this message.",
+    recipients: ["invitee@stealth.demo"],
+    tags: ["announcement", "onboarding"],
+    folderHint: "inbox",
+  },
+  {
+    id: "msg-pool-008",
+    subject: "Cryptographic proof confirmed",
+    preview: "Your message proof for msg_abc123 has been anchored to ledger block #8,204,451.",
+    body: "Your message proof for msg_abc123 has been anchored to ledger block #8,204,451. The payload commitment is now immutable and verifiable by any third party.",
+    recipients: ["user@stealth.demo"],
+    tags: ["stellar", "security"],
+    folderHint: "receipts",
+  },
+  {
+    id: "msg-pool-009",
+    subject: "Admin note: data freeze reminder",
+    preview: "Demo data freeze begins 2026-07-01. Finalise all fixture sets before then.",
+    body: "This is an internal admin reminder: demo data freeze begins 2026-07-01. Please finalise all fixture sets and campaign assignments before that date.",
+    recipients: ["admin@stealth.demo"],
+    tags: ["alert", "marketing"],
+    folderHint: "priority",
+  },
+  {
+    id: "msg-pool-010",
+    subject: "Your sender policy has been updated",
+    preview: "You changed your default policy to 'request'. New senders will now require approval.",
+    body: "You changed your default sender policy to 'request'. New senders will now need to pay postage and await your approval before their messages are delivered.",
+    recipients: ["user@stealth.demo"],
+    tags: ["security", "onboarding"],
+    folderHint: "inbox",
+  },
+];
+
+// Pre-seed campaigns with a subset of the pool
+const seededSnapshots: CampaignSnapshot[] = defaultCampaignSnapshots.map((snap) => {
+  if (snap.id === "snap-welcome") {
+    return {
+      ...snap,
+      drafts: [
+        ...snap.drafts,
+        {
+          id: "msg-pool-001",
+          subject: messagePool[0].subject,
+          body: messagePool[0].body,
+          recipients: messagePool[0].recipients,
+        },
+        {
+          id: "msg-pool-002",
+          subject: messagePool[1].subject,
+          body: messagePool[1].body,
+          recipients: messagePool[1].recipients,
+        },
+        {
+          id: "msg-pool-007",
+          subject: messagePool[6].subject,
+          body: messagePool[6].body,
+          recipients: messagePool[6].recipients,
+        },
+      ],
+    };
+  }
+  if (snap.id === "snap-security") {
+    return {
+      ...snap,
+      drafts: [
+        ...snap.drafts,
+        {
+          id: "msg-pool-005",
+          subject: messagePool[4].subject,
+          body: messagePool[4].body,
+          recipients: messagePool[4].recipients,
+        },
+        {
+          id: "msg-pool-008",
+          subject: messagePool[7].subject,
+          body: messagePool[7].body,
+          recipients: messagePool[7].recipients,
+        },
+      ],
+    };
+  }
+  if (snap.id === "snap-newsletter") {
+    return {
+      ...snap,
+      drafts: [
+        ...snap.drafts,
+        {
+          id: "msg-pool-006",
+          subject: messagePool[5].subject,
+          body: messagePool[5].body,
+          recipients: messagePool[5].recipients,
+        },
+        {
+          id: "msg-pool-003",
+          subject: messagePool[2].subject,
+          body: messagePool[2].body,
+          recipients: messagePool[2].recipients,
+        },
+      ],
+    };
+  }
+  return snap;
+});
+
+// De-duplicate drafts by id (pool messages were already in defaultCampaignSnapshots as different ids)
+function dedupDrafts(snap: CampaignSnapshot): CampaignSnapshot {
+  const seen = new Set<string>();
+  return {
+    ...snap,
+    drafts: snap.drafts.filter((d) => {
+      if (seen.has(d.id)) return false;
+      seen.add(d.id);
+      return true;
+    }),
+  };
+}
+
+export const defaultAssignmentState: AssignmentState = {
+  campaigns: seededSnapshots.map(dedupDrafts),
+  pool: messagePool,
+};

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -89,3 +89,25 @@ export type { ValidationResultsPanelProps } from "./ValidationResultsPanel";
 
 export { AdminSearchBar } from "./AdminSearchBar";
 export type { AdminSearchBarProps } from "./AdminSearchBar";
+
+export { CampaignMessageAssignmentPanel } from "./components/CampaignMessageAssignmentPanel";
+export { MessagePicker } from "./components/MessagePicker";
+
+export type { AssignableMessage, AssignmentState } from "./types/assignment";
+
+export {
+  getAssignedMessages,
+  isMessageAssigned,
+  assignMessage,
+  unassignMessage,
+  getCampaignsForMessage,
+  assignToManyCampaigns,
+} from "./utils/assignmentHelpers";
+
+export {
+  saveAssignments,
+  loadAssignments,
+  clearAssignments,
+} from "./persistence/localStorageAdapter";
+
+export { messagePool, defaultAssignmentState } from "./fixtures/assignmentFixtures";

--- a/src/features/demo-admin-dashboard/persistence/localStorageAdapter.ts
+++ b/src/features/demo-admin-dashboard/persistence/localStorageAdapter.ts
@@ -123,3 +123,21 @@ export function loadCampaignTags(): CampaignTag[] {
 export function clearCampaignTags(): void {
   tagAdapter.clear(TAGS_KEY);
 }
+
+// Campaign message assignment persistence
+import { AssignmentState } from "../types/assignment";
+
+const assignmentsAdapter = new LocalStorageAdapter<AssignmentState>();
+const ASSIGNMENTS_KEY = "stealth-demo-assignments";
+
+export function saveAssignments(state: AssignmentState): void {
+  assignmentsAdapter.save(ASSIGNMENTS_KEY, state);
+}
+
+export function loadAssignments(): AssignmentState | null {
+  return assignmentsAdapter.load(ASSIGNMENTS_KEY);
+}
+
+export function clearAssignments(): void {
+  assignmentsAdapter.clear(ASSIGNMENTS_KEY);
+}

--- a/src/features/demo-admin-dashboard/types/assignment.ts
+++ b/src/features/demo-admin-dashboard/types/assignment.ts
@@ -1,0 +1,16 @@
+import { CampaignSnapshot } from "./campaignSnapshot";
+
+export interface AssignableMessage {
+  id: string;
+  subject: string;
+  preview: string;
+  body: string;
+  recipients: string[];
+  tags: string[];
+  folderHint: string;
+}
+
+export interface AssignmentState {
+  campaigns: CampaignSnapshot[];
+  pool: AssignableMessage[];
+}

--- a/src/features/demo-admin-dashboard/utils/assignmentHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/assignmentHelpers.ts
@@ -1,0 +1,47 @@
+import { CampaignSnapshot } from "../types/campaignSnapshot";
+import { AssignableMessage } from "../types/assignment";
+import { Draft } from "../types/draft";
+
+function messageToDraft(msg: AssignableMessage): Draft {
+  return { id: msg.id, subject: msg.subject, body: msg.body, recipients: msg.recipients };
+}
+
+export function isMessageAssigned(campaign: CampaignSnapshot, messageId: string): boolean {
+  return campaign.drafts.some((d) => d.id === messageId);
+}
+
+export function getAssignedMessages(
+  campaign: CampaignSnapshot,
+  pool: AssignableMessage[],
+): AssignableMessage[] {
+  return campaign.drafts
+    .map((d) => pool.find((m) => m.id === d.id))
+    .filter((m): m is AssignableMessage => m !== undefined);
+}
+
+export function assignMessage(
+  campaign: CampaignSnapshot,
+  msg: AssignableMessage,
+): CampaignSnapshot {
+  if (isMessageAssigned(campaign, msg.id)) return campaign;
+  return { ...campaign, drafts: [...campaign.drafts, messageToDraft(msg)] };
+}
+
+export function unassignMessage(campaign: CampaignSnapshot, messageId: string): CampaignSnapshot {
+  return { ...campaign, drafts: campaign.drafts.filter((d) => d.id !== messageId) };
+}
+
+export function getCampaignsForMessage(
+  campaigns: CampaignSnapshot[],
+  messageId: string,
+): CampaignSnapshot[] {
+  return campaigns.filter((c) => isMessageAssigned(c, messageId));
+}
+
+export function assignToManyCampaigns(
+  campaigns: CampaignSnapshot[],
+  msg: AssignableMessage,
+  campaignIds: string[],
+): CampaignSnapshot[] {
+  return campaigns.map((c) => (campaignIds.includes(c.id) ? assignMessage(c, msg) : c));
+}


### PR DESCRIPTION
# Closes #257 

## Feat: Campaign-to-Message Assignment Tool ([#257](#))

### Summary

Delivers the campaign-to-message assignment UI and helpers. Admins can now select a campaign, view which demo messages are assigned to it, add messages from a shared pool, and remove them — all persisted to `localStorage` between sessions.

Everything stays inside `src/features/demo-admin-dashboard/`. No routes, API endpoints, contracts, or inbox components were touched.

---

###  What's New

#### `types/assignment.ts`
Two new interfaces:
- `AssignableMessage` — a richer `Draft` with `preview`, `tags`, `folderHint`
- `AssignmentState` — `campaigns` + `pool` as a single persistable unit

#### `fixtures/assignmentFixtures.ts`
A pool of **10 demo `AssignableMessage` objects** covering: welcome, wallet setup, postage receipt, relay notification, security alert, newsletter digest, event invite, proof confirmation, admin note, and policy update — all using `@stealth.demo` addresses. The three existing `defaultCampaignSnapshots` are pre-seeded with a relevant subset so the panel is non-empty on first load.

#### `utils/assignmentHelpers.ts`
Six pure, side-effect-free functions:

| Function | Behaviour |
|----------|-----------|
| `isMessageAssigned(campaign, messageId)` | O(n) membership check |
| `getAssignedMessages(campaign, pool)` | Maps draft IDs back to pool objects |
| `assignMessage(campaign, msg)` | Idempotent; returns new snapshot without mutating |
| `unassignMessage(campaign, messageId)` | Filters by ID |
| `getCampaignsForMessage(campaigns, messageId)` | Reverse lookup |
| `assignToManyCampaigns(campaigns, msg, campaignIds)` | Bulk assign |

#### `components/CampaignMessageAssignmentPanel.tsx`
Two-column layout: campaign list on the left (~40%), assigned messages on the right (~60%). Stacks vertically on narrow viewports. State is initialised from `loadAssignments()` and persisted after every mutation. Uses `AdminDataTable` for both panels. Clicking a campaign row selects it; clicking it again deselects.

#### `components/MessagePicker.tsx`
Fixed `role=dialog` overlay with no router dependency. Renders the full message pool with `AdminSearchBar` for subject/tag/folder filtering. Already-assigned messages are shown but disabled with an `"Assigned"` badge. Clicking an unassigned message calls `onAssign` and closes the picker.

#### `persistence/localStorageAdapter.ts` — Extended
Added `saveAssignments`, `loadAssignments`, `clearAssignments` using `stealth-demo-assignments` as the storage key — same pattern as the existing snapshot and tag adapters. `localStorage` unavailability is already handled gracefully by the base `LocalStorageAdapter`.

#### `DemoAdminDashboard.tsx` *(root, full nav dashboard)*
The "Campaigns" nav tab now renders `CampaignMessageAssignmentPanel` instead of nothing.

#### `components/DemoAdminDashboard.tsx` *(layout dashboard)*
`CampaignMessageAssignmentPanel` appended as a new section below the existing shell content.

#### `index.ts`
Exports: `CampaignMessageAssignmentPanel`, `MessagePicker`, `AssignableMessage`, `AssignmentState`, all six helpers, `saveAssignments`/`loadAssignments`/`clearAssignments`, `messagePool`, `defaultAssignmentState`.

---

### Tests — `__tests__/assignmentHelpers.test.ts`

**14 unit tests** covering:

| Function | Cases |
|----------|-------|
| `isMessageAssigned` | 3 |
| `getAssignedMessages` | 2 |
| `assignMessage` | 3 *(including idempotency and immutability)* |
| `unassignMessage` | 2 |
| `getCampaignsForMessage` | 2 |
| `assignToManyCampaigns` | 2 *(including idempotency)* |

---

### Edge Cases Handled

| Concern | Handling |
|---------|----------|
| Duplicate assignment | `assignMessage` checks `isMessageAssigned` first — no-op if already assigned |
| Pool immutability | Unassign only removes from one campaign's drafts; pool is read-only fixtures |
| Empty pool | `MessagePicker` shows `"No messages available."` empty state |
| No campaign selected | Right panel shows a `"Select a campaign"` placeholder |
| `localStorage` unavailable | Base adapter catches and logs; panel falls back to `defaultAssignmentState` |
| Pre-existing drafts in snapshots | `dedupDrafts` in fixtures ensures no ID collisions when pool messages overlap with existing draft IDs |