### PR TITLE
Feat/canonical message envelope

### DIFF
--- a/protocol/messages/README.md
+++ b/protocol/messages/README.md
@@ -1,3 +1,5 @@
 # Messages
 
 Protocol-level message envelope definitions, payload hashing rules, memo formats, and signing requirements.
+
+- [Cryptographic Message Envelope Specification](file:///c:/Users/USER/Desktop/stealth/protocol/messages/envelope_spec.md)

--- a/protocol/messages/envelope_spec.md
+++ b/protocol/messages/envelope_spec.md
@@ -40,6 +40,7 @@ The envelope is a JSON object with two top-level fields: `payload` and `signatur
 ### Fields
 
 #### Payload
+
 - `version` (string): The envelope format version (e.g. `"v1"`).
 - `sender` (string): Stellar G-address of the sender.
 - `recipient` (string): Stellar G-address of the recipient.
@@ -58,6 +59,7 @@ The envelope is a JSON object with two top-level fields: `payload` and `signatur
 - `critical` (array of strings, optional): List of mandatory header names.
 
 #### Signature
+
 - `scheme` (string): The signature scheme (e.g., `"Ed25519"`).
 - `value` (string): Hex-encoded signature bytes (128 hex characters for Ed25519).
 
@@ -68,12 +70,14 @@ The envelope is a JSON object with two top-level fields: `payload` and `signatur
 To verify the signature, the `payload` object must be serialized to an unambiguous, canonical byte representation. Stealth uses the **JSON Canonicalization Scheme (JCS)** as defined in [RFC 8785](https://tools.ietf.org/html/rfc8785).
 
 Key JCS rules:
+
 1. Object keys are sorted lexicographically by their UTF-16 code units.
 2. No unnecessary whitespace (e.g. spaces, tab characters, newlines) is included around structural delimiters (`:`, `,`, `{`, `}`, `[`, `]`).
 3. Strings are enclosed in double quotes (`"`), and standard JSON escaping is applied uniformly.
 4. Boolean values are serialized as `true` or `false`, and null is `null`.
 
 ### Signature Coverage
+
 The cryptographic signature covers the canonicalized byte representation of the `payload` object.
 
 ```text
@@ -86,5 +90,5 @@ signature = sign(private_key, jcs(payload))
 
 To allow safe feature updates, the envelope is extensible.
 
-1. **Unknown Optional Fields**: An implementation may ignore any key in the `payload` that is not defined in this specification, *unless* it is designated as critical.
-2. **Unknown Mandatory Fields**: If a key name is listed in the `critical` array, the recipient implementation *must* recognize and validate that field. If the parser encounters a field in `critical` that it does not recognize, validation must immediately fail (fail closed).
+1. **Unknown Optional Fields**: An implementation may ignore any key in the `payload` that is not defined in this specification, _unless_ it is designated as critical.
+2. **Unknown Mandatory Fields**: If a key name is listed in the `critical` array, the recipient implementation _must_ recognize and validate that field. If the parser encounters a field in `critical` that it does not recognize, validation must immediately fail (fail closed).

--- a/protocol/messages/envelope_spec.md
+++ b/protocol/messages/envelope_spec.md
@@ -1,0 +1,90 @@
+# Cryptographic Message Envelope Specification
+
+To ensure interoperability across independent client implementations, the Stealth protocol defines a single normative envelope and signature scheme.
+
+## 1. Envelope Structure
+
+The envelope is a JSON object with two top-level fields: `payload` and `signature`.
+
+```json
+{
+  "payload": {
+    "version": "v1",
+    "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    "timestamp": "2026-06-17T22:00:00Z",
+    "encryption_metadata": {
+      "algorithm": "X25519-XSalsa20-Poly1305",
+      "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "nonce": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mac": "86355651ecbc6e969d27038e8e78e86cf0f4e1f7a0756e0766a5cfbfcae29202"
+    },
+    "content_commitment": "5b40cf39e4a86e969d27038e8e78e86cf0f4e1f7a0756e0766a5cfbfcae29202",
+    "attachments": [
+      {
+        "filename": "invoice.pdf",
+        "content_type": "application/pdf",
+        "size_bytes": 10240,
+        "content_hash": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      }
+    ],
+    "critical": ["custom_mandatory_header"]
+  },
+  "signature": {
+    "scheme": "Ed25519",
+    "value": "86355651ecbc6e969d27038e8e78e86cf0f4e1f7a0756e0766a5cfbfcae2920286355651ecbc6e969d27038e8e78e86cf0f4e1f7a0756e0766a5cfbfcae29202"
+  }
+}
+```
+
+### Fields
+
+#### Payload
+- `version` (string): The envelope format version (e.g. `"v1"`).
+- `sender` (string): Stellar G-address of the sender.
+- `recipient` (string): Stellar G-address of the recipient.
+- `timestamp` (string): ISO 8601 UTC timestamp string.
+- `encryption_metadata` (object): Encryption parameters.
+  - `algorithm` (string): The scheme name (e.g., `"X25519-XSalsa20-Poly1305"`).
+  - `ephemeral_public_key` (string): Ephemeral public key (Stellar G-address).
+  - `nonce` (string): Hex-encoded encryption nonce.
+  - `mac` (string): 32-byte hex-encoded message authentication code.
+- `content_commitment` (string): SHA-256 digest of the encrypted payload ciphertext.
+- `attachments` (array): List of attachment descriptors.
+  - `filename` (string): File name.
+  - `content_type` (string): MIME type.
+  - `size_bytes` (integer): Size of attachment in bytes.
+  - `content_hash` (string): SHA-256 digest of the attachment data.
+- `critical` (array of strings, optional): List of mandatory header names.
+
+#### Signature
+- `scheme` (string): The signature scheme (e.g., `"Ed25519"`).
+- `value` (string): Hex-encoded signature bytes (128 hex characters for Ed25519).
+
+---
+
+## 2. Canonical Serialization (JCS)
+
+To verify the signature, the `payload` object must be serialized to an unambiguous, canonical byte representation. Stealth uses the **JSON Canonicalization Scheme (JCS)** as defined in [RFC 8785](https://tools.ietf.org/html/rfc8785).
+
+Key JCS rules:
+1. Object keys are sorted lexicographically by their UTF-16 code units.
+2. No unnecessary whitespace (e.g. spaces, tab characters, newlines) is included around structural delimiters (`:`, `,`, `{`, `}`, `[`, `]`).
+3. Strings are enclosed in double quotes (`"`), and standard JSON escaping is applied uniformly.
+4. Boolean values are serialized as `true` or `false`, and null is `null`.
+
+### Signature Coverage
+The cryptographic signature covers the canonicalized byte representation of the `payload` object.
+
+```text
+signature = sign(private_key, jcs(payload))
+```
+
+---
+
+## 3. Extensibility and Fail-Closed Validation
+
+To allow safe feature updates, the envelope is extensible.
+
+1. **Unknown Optional Fields**: An implementation may ignore any key in the `payload` that is not defined in this specification, *unless* it is designated as critical.
+2. **Unknown Mandatory Fields**: If a key name is listed in the `critical` array, the recipient implementation *must* recognize and validate that field. If the parser encounters a field in `critical` that it does not recognize, validation must immediately fail (fail closed).

--- a/protocol/schemas/envelope.schema.json
+++ b/protocol/schemas/envelope.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StealthEnvelope",
+  "description": "Cryptographic signature envelope for Stealth messages",
+  "type": "object",
+  "required": ["payload", "signature"],
+  "additionalProperties": false,
+  "properties": {
+    "payload": {
+      "type": "object",
+      "required": [
+        "version",
+        "sender",
+        "recipient",
+        "timestamp",
+        "encryption_metadata",
+        "content_commitment",
+        "attachments"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^v[0-9]+$"
+        },
+        "sender": {
+          "type": "string",
+          "pattern": "^G[A-Z2-7]{55}$"
+        },
+        "recipient": {
+          "type": "string",
+          "pattern": "^G[A-Z2-7]{55}$"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "encryption_metadata": {
+          "type": "object",
+          "required": ["algorithm", "ephemeral_public_key", "nonce", "mac"],
+          "additionalProperties": false,
+          "properties": {
+            "algorithm": {
+              "type": "string"
+            },
+            "ephemeral_public_key": {
+              "type": "string",
+              "pattern": "^G[A-Z2-7]{55}$"
+            },
+            "nonce": {
+              "type": "string",
+              "pattern": "^[a-f0-9]+$"
+            },
+            "mac": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            }
+          }
+        },
+        "content_commitment": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "attachments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["filename", "content_type", "size_bytes", "content_hash"],
+            "additionalProperties": false,
+            "properties": {
+              "filename": {
+                "type": "string"
+              },
+              "content_type": {
+                "type": "string"
+              },
+              "size_bytes": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "content_hash": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$"
+              }
+            }
+          }
+        },
+        "critical": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "required": ["scheme", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "enum": ["Ed25519"]
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{128}$"
+        }
+      }
+    }
+  }
+}

--- a/protocol/vectors/vectors.json
+++ b/protocol/vectors/vectors.json
@@ -537,6 +537,154 @@
           "expected": { "valid": false, "error": "Expected a non-negative integer string" }
         }
       ]
+    },
+    "envelope": {
+      "description": "Cryptographic envelope validation, canonical serialization (JCS), and fail-closed critical field test cases.",
+      "cases": [
+        {
+          "id": "envelope/valid/basic",
+          "description": "A fully valid message envelope with valid payload and signature.",
+          "input": {
+            "payload": {
+              "version": "v1",
+              "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+              "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+              "timestamp": "2026-06-17T22:00:00.000Z",
+              "encryption_metadata": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "nonce": "aabbccddeeff00112233445566778899",
+                "mac": "0000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "content_commitment": "1111111111111111111111111111111111111111111111111111111111111111",
+              "attachments": []
+            },
+            "signature": {
+              "scheme": "Ed25519",
+              "value": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+            }
+          },
+          "expected": {
+            "valid": true,
+            "canonical": "{\"attachments\":[],\"content_commitment\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"encryption_metadata\":{\"algorithm\":\"X25519-XSalsa20-Poly1305\",\"ephemeral_public_key\":\"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"mac\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"aabbccddeeff00112233445566778899\"},\"recipient\":\"GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\",\"sender\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\",\"timestamp\":\"2026-06-17T22:00:00.000Z\",\"version\":\"v1\"}"
+          }
+        },
+        {
+          "id": "envelope/valid/extensibility",
+          "description": "An envelope with unknown optional fields that are NOT listed in critical. It should pass.",
+          "input": {
+            "payload": {
+              "version": "v1",
+              "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+              "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+              "timestamp": "2026-06-17T22:00:00.000Z",
+              "encryption_metadata": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "nonce": "aabbccddeeff00112233445566778899",
+                "mac": "0000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "content_commitment": "1111111111111111111111111111111111111111111111111111111111111111",
+              "attachments": [],
+              "unknown_optional_field": "some_value"
+            },
+            "signature": {
+              "scheme": "Ed25519",
+              "value": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+            }
+          },
+          "expected": {
+            "valid": true,
+            "canonical": "{\"attachments\":[],\"content_commitment\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"encryption_metadata\":{\"algorithm\":\"X25519-XSalsa20-Poly1305\",\"ephemeral_public_key\":\"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"mac\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"aabbccddeeff00112233445566778899\"},\"recipient\":\"GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\",\"sender\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\",\"timestamp\":\"2026-06-17T22:00:00.000Z\",\"unknown_optional_field\":\"some_value\",\"version\":\"v1\"}"
+          }
+        },
+        {
+          "id": "envelope/invalid/unknown-mandatory",
+          "description": "An envelope containing an unknown field listed in critical. It must fail closed.",
+          "input": {
+            "payload": {
+              "version": "v1",
+              "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+              "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+              "timestamp": "2026-06-17T22:00:00.000Z",
+              "encryption_metadata": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "nonce": "aabbccddeeff00112233445566778899",
+                "mac": "0000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "content_commitment": "1111111111111111111111111111111111111111111111111111111111111111",
+              "attachments": [],
+              "unknown_mandatory_field": "critical_value",
+              "critical": ["unknown_mandatory_field"]
+            },
+            "signature": {
+              "scheme": "Ed25519",
+              "value": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+            }
+          },
+          "expected": {
+            "valid": false,
+            "error": "Unknown mandatory field: unknown_mandatory_field"
+          }
+        },
+        {
+          "id": "envelope/valid/known-mandatory-critical",
+          "description": "An envelope listing a known mandatory field (e.g. version) in the critical list. It should pass.",
+          "input": {
+            "payload": {
+              "version": "v1",
+              "sender": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+              "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+              "timestamp": "2026-06-17T22:00:00.000Z",
+              "encryption_metadata": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "nonce": "aabbccddeeff00112233445566778899",
+                "mac": "0000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "content_commitment": "1111111111111111111111111111111111111111111111111111111111111111",
+              "attachments": [],
+              "critical": ["version"]
+            },
+            "signature": {
+              "scheme": "Ed25519",
+              "value": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+            }
+          },
+          "expected": {
+            "valid": true,
+            "canonical": "{\"attachments\":[],\"content_commitment\":\"1111111111111111111111111111111111111111111111111111111111111111\",\"critical\":[\"version\"],\"encryption_metadata\":{\"algorithm\":\"X25519-XSalsa20-Poly1305\",\"ephemeral_public_key\":\"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"mac\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"aabbccddeeff00112233445566778899\"},\"recipient\":\"GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\",\"sender\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\",\"timestamp\":\"2026-06-17T22:00:00.000Z\",\"version\":\"v1\"}"
+          }
+        },
+        {
+          "id": "envelope/invalid/missing-sender",
+          "description": "An envelope missing the sender field in payload. It must fail validation.",
+          "input": {
+            "payload": {
+              "version": "v1",
+              "recipient": "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+              "timestamp": "2026-06-17T22:00:00.000Z",
+              "encryption_metadata": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ephemeral_public_key": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "nonce": "aabbccddeeff00112233445566778899",
+                "mac": "0000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "content_commitment": "1111111111111111111111111111111111111111111111111111111111111111",
+              "attachments": []
+            },
+            "signature": {
+              "scheme": "Ed25519",
+              "value": "22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+            }
+          },
+          "expected": {
+            "valid": false,
+            "error": "Required"
+          }
+        }
+      ]
     }
   }
 }

--- a/src/server/api/envelope.ts
+++ b/src/server/api/envelope.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import { stellarAddressSchema, hash32Schema } from "./domain";
+
+export const encryptionMetadataSchema = z.object({
+  algorithm: z.string(),
+  ephemeral_public_key: stellarAddressSchema,
+  nonce: z.string().regex(/^[a-f0-9]+$/, "Expected a hex string for nonce"),
+  mac: hash32Schema,
+});
+
+export const attachmentMetadataSchema = z.object({
+  filename: z.string(),
+  content_type: z.string(),
+  size_bytes: z.number().int().nonnegative(),
+  content_hash: hash32Schema,
+});
+
+export const envelopePayloadSchema = z
+  .object({
+    version: z.string().regex(/^v[0-9]+$/),
+    sender: stellarAddressSchema,
+    recipient: stellarAddressSchema,
+    timestamp: z.string().datetime(),
+    encryption_metadata: encryptionMetadataSchema,
+    content_commitment: hash32Schema,
+    attachments: z.array(attachmentMetadataSchema),
+    critical: z.array(z.string()).optional(),
+  })
+  .passthrough(); // Allow unknown fields for extensibility
+
+export const envelopeSignatureSchema = z.object({
+  scheme: z.enum(["Ed25519"]),
+  value: z.string().regex(/^[a-f0-9]{128}$/, "Expected a 64-byte (128 hex chars) signature"),
+});
+
+export const envelopeSchema = z.object({
+  payload: envelopePayloadSchema,
+  signature: envelopeSignatureSchema,
+});
+
+export type EnvelopePayload = z.infer<typeof envelopePayloadSchema>;
+export type EnvelopeSignature = z.infer<typeof envelopeSignatureSchema>;
+export type Envelope = z.infer<typeof envelopeSchema>;
+
+/**
+ * Standard known fields of the envelope payload.
+ * Any field in the `critical` array not in this list causes validation to fail closed.
+ */
+export const KNOWN_PAYLOAD_FIELDS = new Set([
+  "version",
+  "sender",
+  "recipient",
+  "timestamp",
+  "encryption_metadata",
+  "content_commitment",
+  "attachments",
+  "critical",
+]);
+
+/**
+ * Serializes any JSON-compatible value to its canonical JCS (RFC 8785) representation.
+ */
+export function canonicalize(val: any): string {
+  if (val === null) {
+    return "null";
+  }
+  if (typeof val === "boolean" || typeof val === "number") {
+    return JSON.stringify(val);
+  }
+  if (typeof val === "string") {
+    return JSON.stringify(val);
+  }
+  if (Array.isArray(val)) {
+    return "[" + val.map(canonicalize).join(",") + "]";
+  }
+  if (typeof val === "object") {
+    const keys = Object.keys(val).sort();
+    const parts = keys.map((key) => {
+      return JSON.stringify(key) + ":" + canonicalize(val[key]);
+    });
+    return "{" + parts.join(",") + "}";
+  }
+  throw new Error(`Unsupported type for canonical serialization: ${typeof val}`);
+}
+
+/**
+ * Validates the envelope structure and enforces that any unknown critical fields
+ * fail validation (fail closed).
+ */
+export function validateEnvelope(data: unknown): Envelope {
+  // 1. Structural validation using Zod
+  const parsed = envelopeSchema.parse(data);
+
+  // 2. Fail closed on unknown critical fields
+  if (parsed.payload.critical && parsed.payload.critical.length > 0) {
+    for (const field of parsed.payload.critical) {
+      if (!KNOWN_PAYLOAD_FIELDS.has(field)) {
+        throw new Error(`Unknown mandatory field: ${field}`);
+      }
+    }
+  }
+
+  return parsed;
+}

--- a/tests/unit/protocol/envelope.test.ts
+++ b/tests/unit/protocol/envelope.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { validateEnvelope, canonicalize } from "../../../src/server/api/envelope";
+import vectors from "../../../protocol/vectors/vectors.json";
+
+describe("protocol/envelope", () => {
+  // Check that the envelope test vectors are loaded
+  const envelopeVectors = (vectors as any).categories?.envelope;
+  if (!envelopeVectors) {
+    throw new Error("Envelope test vectors not found in vectors.json");
+  }
+
+  for (const c of envelopeVectors.cases) {
+    it(c.id, () => {
+      if (c.expected.valid) {
+        // 1. Validate the envelope successfully parses
+        const parsed = validateEnvelope(c.input);
+        expect(parsed).toBeDefined();
+
+        // 2. Validate canonical JCS serialization matches exactly
+        const canonical = canonicalize(c.input.payload);
+        expect(canonical).toBe(c.expected.canonical);
+      } else {
+        // 3. Validate validation fails closed and throws
+        expect(() => {
+          validateEnvelope(c.input);
+        }).toThrow();
+
+        // Check if the expected error string matches/contains part of the thrown error
+        try {
+          validateEnvelope(c.input);
+        } catch (err: any) {
+          expect(err.message).toContain(c.expected.error);
+        }
+      }
+    });
+  }
+
+  // Additional sanity tests for JCS canonicalization logic
+  describe("canonicalize JCS details", () => {
+    it("should sort keys lexicographically", () => {
+      const obj = { z: 1, a: 2, m: { y: 3, b: 4 } };
+      const canonical = canonicalize(obj);
+      expect(canonical).toBe('{"a":2,"m":{"b":4,"y":3},"z":1}');
+    });
+
+    it("should handle null and primitives correctly", () => {
+      expect(canonicalize(null)).toBe("null");
+      expect(canonicalize(true)).toBe("true");
+      expect(canonicalize(false)).toBe("false");
+      expect(canonicalize(123.45)).toBe("123.45");
+      expect(canonicalize("hello")).toBe('"hello"');
+    });
+
+    it("should handle empty arrays and nested arrays", () => {
+      const arr = [1, "two", [3, null]];
+      expect(canonicalize(arr)).toBe('[1,"two",[3,null]]');
+    });
+
+    it("should reject unsupported types like function/undefined", () => {
+      expect(() => canonicalize(undefined)).toThrow();
+      expect(() => canonicalize(() => {})).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
closes #53 

### Summary of Completed Work
1. **Cryptographic Specification**: Created [envelope_spec.md](file:///c:/Users/USER/Desktop/stealth/protocol/messages/envelope_spec.md) detailing the JSON structure, JCS canonicalization (RFC 8785), and fail-closed validation behavior for unknown mandatory fields.
2. **Machine-Readable Schema**: Created the Draft-07 JSON Schema at [envelope.schema.json](file:///c:/Users/USER/Desktop/stealth/protocol/schemas/envelope.schema.json).
3. **Canonicalization & Validation Logic**: Coded Zod schemas and a dependency-free JCS stringify/canonicalization function in [envelope.ts](file:///c:/Users/USER/Desktop/stealth/src/server/api/envelope.ts). Added the `validateEnvelope` function that checks the `critical` array to fail closed on unrecognized mandatory fields.
4. **Test Vectors**: Added 5 comprehensive test cases (valid JCS output, extensibility, unknown mandatory rejection, schema errors) to [vectors.json](file:///c:/Users/USER/Desktop/stealth/protocol/vectors/vectors.json).
5. **Unit Tests**: Added unit tests in [envelope.test.ts](file:///c:/Users/USER/Desktop/stealth/tests/unit/protocol/envelope.test.ts) driving all test vectors and sorting logic.

### Verification
- **Unit Tests**: All 234 unit tests (including the 9 new test cases) passed successfully.
- **Linter & Formatting**: Formatted with Prettier and ran ESLint checks cleanly with 0 errors.
- **Production Build**: Successfully compiled the entire client/server package (`npm run build`).

All code changes have been safely saved, styled, and committed to git on the local `feat/canonical-message-envelope` branch. *