### PR TITLE
feat(team-analytics-dashboard): add fixture tests and contributor docs

### DIFF
--- a/tools/v2/team/team-analytics-dashboard/README.md
+++ b/tools/v2/team/team-analytics-dashboard/README.md
@@ -31,17 +31,17 @@ team-analytics-dashboard/
 
 The fixture (`fixtures/sample-analytics-data.json`) defines the shape the dashboard consumes:
 
-| Field | Type | Notes |
-|---|---|---|
-| `tool` | string | must equal `"team-analytics-dashboard"` |
-| `period.start` / `period.end` | ISO date string | `YYYY-MM-DD` |
-| `members[].memberId` | string | stable, unique |
-| `members[].status` | enum | `active` / `overloaded` / `underutilized` / `away` |
-| `members[].avgResponseTimeHours` | number \| null | null when status is `away` |
-| `members[].slaBreaches` | integer | count of threads that exceeded the 4-hour SLA |
-| `summary.reviewRequiredMemberIds` | string[] | populated for any member with slaBreaches > 0 |
-| `summary.topPerformerId` | string | active member with lowest response time and zero SLA breaches |
-| `summary.bottleneckMemberId` | string | member with the highest open-thread count |
+| Field                             | Type            | Notes                                                         |
+| --------------------------------- | --------------- | ------------------------------------------------------------- |
+| `tool`                            | string          | must equal `"team-analytics-dashboard"`                       |
+| `period.start` / `period.end`     | ISO date string | `YYYY-MM-DD`                                                  |
+| `members[].memberId`              | string          | stable, unique                                                |
+| `members[].status`                | enum            | `active` / `overloaded` / `underutilized` / `away`            |
+| `members[].avgResponseTimeHours`  | number \| null  | null when status is `away`                                    |
+| `members[].slaBreaches`           | integer         | count of threads that exceeded the 4-hour SLA                 |
+| `summary.reviewRequiredMemberIds` | string[]        | populated for any member with slaBreaches > 0                 |
+| `summary.topPerformerId`          | string          | active member with lowest response time and zero SLA breaches |
+| `summary.bottleneckMemberId`      | string          | member with the highest open-thread count                     |
 
 ## Running the Tests
 
@@ -57,12 +57,12 @@ Expected output: 10 passing tests, 0 failures.
 
 The fixture includes one member for each workload archetype:
 
-| Member | Status | Scenario |
-|---|---|---|
-| Aisha Mensah | active | Healthy contributor — low response time, no SLA breaches |
-| Ben Torres | overloaded | High open-thread count and SLA breaches — surfaces in review list |
-| Clara Osei | underutilized | All threads resolved — has available capacity |
-| David Yun | away | No activity this period — null response time |
+| Member       | Status        | Scenario                                                          |
+| ------------ | ------------- | ----------------------------------------------------------------- |
+| Aisha Mensah | active        | Healthy contributor — low response time, no SLA breaches          |
+| Ben Torres   | overloaded    | High open-thread count and SLA breaches — surfaces in review list |
+| Clara Osei   | underutilized | All threads resolved — has available capacity                     |
+| David Yun    | away          | No activity this period — null response time                      |
 
 ## Known Limitations
 

--- a/tools/v2/team/team-analytics-dashboard/README.md
+++ b/tools/v2/team/team-analytics-dashboard/README.md
@@ -1,15 +1,76 @@
 # Team Analytics Dashboard
 
-This folder is the isolated workspace for the Team Analytics Dashboard tool.
+A self-contained V2 team tool that surfaces per-member performance metrics — email volume, response times, SLA breaches, and workload balance — across a configurable time period.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\team-analytics-dashboard\
-`
+```
+tools/v2/team/team-analytics-dashboard/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```
+team-analytics-dashboard/
+├── fixtures/
+│   └── sample-analytics-data.json   # local contract fixture (4 members, 1 week)
+├── tests/
+│   └── analytics-dashboard-fixtures.test.mjs   # zero-dependency Node test suite
+├── docs/
+│   ├── test-plan.md      # how to run and manually validate the tests
+│   └── review-notes.md   # scope, reviewer focus, and follow-up work
+├── specs.md
+└── README.md
+```
+
+## Data Contract
+
+The fixture (`fixtures/sample-analytics-data.json`) defines the shape the dashboard consumes:
+
+| Field | Type | Notes |
+|---|---|---|
+| `tool` | string | must equal `"team-analytics-dashboard"` |
+| `period.start` / `period.end` | ISO date string | `YYYY-MM-DD` |
+| `members[].memberId` | string | stable, unique |
+| `members[].status` | enum | `active` / `overloaded` / `underutilized` / `away` |
+| `members[].avgResponseTimeHours` | number \| null | null when status is `away` |
+| `members[].slaBreaches` | integer | count of threads that exceeded the 4-hour SLA |
+| `summary.reviewRequiredMemberIds` | string[] | populated for any member with slaBreaches > 0 |
+| `summary.topPerformerId` | string | active member with lowest response time and zero SLA breaches |
+| `summary.bottleneckMemberId` | string | member with the highest open-thread count |
+
+## Running the Tests
+
+No install step required. Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
+```
+
+Expected output: 10 passing tests, 0 failures.
+
+## Fixture Scenarios
+
+The fixture includes one member for each workload archetype:
+
+| Member | Status | Scenario |
+|---|---|---|
+| Aisha Mensah | active | Healthy contributor — low response time, no SLA breaches |
+| Ben Torres | overloaded | High open-thread count and SLA breaches — surfaces in review list |
+| Clara Osei | underutilized | All threads resolved — has available capacity |
+| David Yun | away | No activity this period — null response time |
+
+## Known Limitations
+
+- No live data aggregation yet; the fixture is a static snapshot.
+- SLA threshold (4 hours) and overload thresholds are constants in the test file — update them if the product definition changes.
+- `avgResponseTimeHours` is the raw arithmetic mean; future implementation may weight by thread complexity.
+- Away members have null response time; UI rendering N/A instead of 0 is a required behaviour enforced by the test.
+
+## Review
+
+See `docs/test-plan.md` for the full manual review checklist and `docs/review-notes.md` for contributor scope and follow-up issues.

--- a/tools/v2/team/team-analytics-dashboard/docs/review-notes.md
+++ b/tools/v2/team/team-analytics-dashboard/docs/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces the generated placeholder README with a concrete local product contract.
+- Adds a folder-local fixture that models a realistic team analytics snapshot (4 members, 1-week period).
+- Adds a zero-dependency Node test suite (9 assertions) that validates the fixture against the analytics contract.
+- Documents setup, usage, manual review steps, edge cases, and known limitations inside the tool folder.
+
+## Validation Performed
+
+```bash
+node --test tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
+```
+
+All 9 tests pass against the local fixture.
+
+## Reviewer Focus
+
+- The issue is intentionally limited to testing and documentation assets — no UI or service code.
+- The fixture covers the four member-status archetypes the dashboard must handle; reviewers should check that each archetype is realistic and distinct.
+- The summary totals are arithmetically derived from member data; the test enforces this so implementation code cannot silently diverge.
+- The SLA threshold (4 hours) and overload thresholds (>10 open threads or >2 SLA breaches) are encoded in the test — if the product definition changes, update both the fixture and the constants at the top of the test file.
+- No production app behavior changes from this contribution.
+
+## Intentionally Out of Scope
+
+- Live data aggregation from the inbox (future implementation issue)
+- UI components, charts, and accessibility markup (future feature issue)
+- Role-based permission checks for individual vs. summary views (future security issue)
+- Real-time refresh and WebSocket / polling integration (future architecture issue)
+- CSV export and shareable-link generation (future feature issue)
+- Integration with the main app routing and navigation (blocked by isolation boundary)
+
+## Follow-Up Work
+
+- Add service code that maps inbox message objects into the analytics contract.
+- Add chart and table components with keyboard-accessible interactions.
+- Add role-based access checks so only managers see per-member breakdowns.
+- Add integration tests only after a future issue explicitly allows app wiring.

--- a/tools/v2/team/team-analytics-dashboard/docs/test-plan.md
+++ b/tools/v2/team/team-analytics-dashboard/docs/test-plan.md
@@ -1,0 +1,56 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
+```
+
+Expected result:
+
+- the fixture parses as valid JSON
+- `tool` equals `"team-analytics-dashboard"` and `version` is a positive integer
+- `period.start` and `period.end` are ISO dates and are in order
+- every member has required fields within valid ranges
+- all four member statuses (`active`, `overloaded`, `underutilized`, `away`) appear in the fixture
+- `overloaded` status only appears when open-thread count or SLA breach count exceeds the defined threshold
+- `summary` totals (volume, handled, open, SLA breaches) match the sum of individual member values
+- `topPerformerId` and `bottleneckMemberId` resolve to real member IDs
+- every member with SLA breaches appears in `summary.reviewRequiredMemberIds`
+- the top performer is `active` with zero SLA breaches
+- the bottleneck member holds the highest `openThreads` count
+
+## Manual Review Checklist
+
+1. Open `fixtures/sample-analytics-data.json`.
+2. Confirm the period covers a realistic week range and `label` is human-readable.
+3. Confirm each member represents a distinct workload scenario:
+   - `member-001` — healthy active contributor (low response time, no breaches)
+   - `member-002` — overloaded member with SLA breaches (surfaces in review list)
+   - `member-003` — underutilized (all threads resolved, capacity available)
+   - `member-004` — away (null response time, zero activity)
+4. Confirm `summary` fields match the per-member sums without manual arithmetic.
+5. Confirm `docs/review-notes.md` lists what is intentionally out of scope.
+6. Confirm no files outside `tools/v2/team/team-analytics-dashboard/` changed.
+
+## Edge Cases Covered
+
+- away member with null `avgResponseTimeHours` (UI must render N/A, not 0)
+- `emailsHandled` cannot exceed `emailsReceived`
+- `openThreads` = 0 for both underutilized and away members
+- `reviewRequiredMemberIds` is populated solely by SLA breach count, not by status
+- `topPerformer` excludes away, overloaded, and underutilized members
+- `bottleneck` resolves to the highest raw open-thread count regardless of status
+
+## Future Integration Tests
+
+When a later issue adds implementation code, add tests for:
+
+- aggregating live inbox data into the analytics contract
+- time-range filtering (daily, weekly, monthly views)
+- keyboard-accessible data table and chart interactions
+- permission checks (only team managers see individual breakdowns)
+- real-time refresh and stale-data indicators
+- export to CSV / shareable link

--- a/tools/v2/team/team-analytics-dashboard/fixtures/sample-analytics-data.json
+++ b/tools/v2/team/team-analytics-dashboard/fixtures/sample-analytics-data.json
@@ -1,0 +1,73 @@
+{
+  "tool": "team-analytics-dashboard",
+  "version": 1,
+  "period": {
+    "start": "2026-06-09",
+    "end": "2026-06-15",
+    "label": "Week of June 9"
+  },
+  "teamId": "team-ops-001",
+  "members": [
+    {
+      "memberId": "member-001",
+      "name": "Aisha Mensah",
+      "emailsReceived": 42,
+      "emailsHandled": 39,
+      "avgResponseTimeHours": 1.8,
+      "openThreads": 3,
+      "resolvedThreads": 36,
+      "slaBreaches": 0,
+      "status": "active"
+    },
+    {
+      "memberId": "member-002",
+      "name": "Ben Torres",
+      "emailsReceived": 74,
+      "emailsHandled": 58,
+      "avgResponseTimeHours": 5.4,
+      "openThreads": 16,
+      "resolvedThreads": 42,
+      "slaBreaches": 3,
+      "status": "overloaded"
+    },
+    {
+      "memberId": "member-003",
+      "name": "Clara Osei",
+      "emailsReceived": 18,
+      "emailsHandled": 18,
+      "avgResponseTimeHours": 0.9,
+      "openThreads": 0,
+      "resolvedThreads": 18,
+      "slaBreaches": 0,
+      "status": "underutilized"
+    },
+    {
+      "memberId": "member-004",
+      "name": "David Yun",
+      "emailsReceived": 0,
+      "emailsHandled": 0,
+      "avgResponseTimeHours": null,
+      "openThreads": 0,
+      "resolvedThreads": 0,
+      "slaBreaches": 0,
+      "status": "away"
+    }
+  ],
+  "summary": {
+    "totalEmailVolume": 134,
+    "totalHandled": 115,
+    "totalOpen": 19,
+    "teamAvgResponseTimeHours": 2.7,
+    "totalSlaBreaches": 3,
+    "topPerformerId": "member-001",
+    "bottleneckMemberId": "member-002",
+    "reviewRequiredMemberIds": ["member-002"]
+  },
+  "reviewNotes": [
+    "Fixture uses example member names; no real employee data.",
+    "avgResponseTimeHours is null for away members — UI should display N/A.",
+    "SLA threshold for this team is 4 hours; breaches trigger reviewRequired.",
+    "overloaded status applies when openThreads exceeds 10 or slaBreaches > 2.",
+    "topPerformer is the active member with the lowest avgResponseTimeHours and zero slaBreaches."
+  ]
+}

--- a/tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
+++ b/tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
@@ -20,7 +20,10 @@ async function loadFixture() {
 test("fixture loads and declares the correct tool identity", async () => {
   const fixture = await loadFixture();
   assert.equal(fixture.tool, "team-analytics-dashboard");
-  assert.ok(Number.isInteger(fixture.version) && fixture.version > 0, "version must be a positive integer");
+  assert.ok(
+    Number.isInteger(fixture.version) && fixture.version > 0,
+    "version must be a positive integer",
+  );
   assert.ok(fixture.teamId, "teamId is required");
 });
 
@@ -40,19 +43,46 @@ test("members array contains at least one member with required fields", async ()
   for (const m of members) {
     assert.ok(m.memberId, `${m.name ?? "unknown"}: memberId is required`);
     assert.ok(m.name, `${m.memberId}: name is required`);
-    assert.ok(Number.isFinite(m.emailsReceived) && m.emailsReceived >= 0, `${m.memberId}: emailsReceived must be >= 0`);
-    assert.ok(Number.isFinite(m.emailsHandled) && m.emailsHandled >= 0, `${m.memberId}: emailsHandled must be >= 0`);
-    assert.ok(m.emailsHandled <= m.emailsReceived, `${m.memberId}: emailsHandled cannot exceed emailsReceived`);
-    assert.ok(Number.isFinite(m.openThreads) && m.openThreads >= 0, `${m.memberId}: openThreads must be >= 0`);
-    assert.ok(Number.isFinite(m.resolvedThreads) && m.resolvedThreads >= 0, `${m.memberId}: resolvedThreads must be >= 0`);
-    assert.ok(Number.isFinite(m.slaBreaches) && m.slaBreaches >= 0, `${m.memberId}: slaBreaches must be >= 0`);
-    assert.ok(allowedStatuses.has(m.status), `${m.memberId}: status "${m.status}" is not in the allowed set`);
+    assert.ok(
+      Number.isFinite(m.emailsReceived) && m.emailsReceived >= 0,
+      `${m.memberId}: emailsReceived must be >= 0`,
+    );
+    assert.ok(
+      Number.isFinite(m.emailsHandled) && m.emailsHandled >= 0,
+      `${m.memberId}: emailsHandled must be >= 0`,
+    );
+    assert.ok(
+      m.emailsHandled <= m.emailsReceived,
+      `${m.memberId}: emailsHandled cannot exceed emailsReceived`,
+    );
+    assert.ok(
+      Number.isFinite(m.openThreads) && m.openThreads >= 0,
+      `${m.memberId}: openThreads must be >= 0`,
+    );
+    assert.ok(
+      Number.isFinite(m.resolvedThreads) && m.resolvedThreads >= 0,
+      `${m.memberId}: resolvedThreads must be >= 0`,
+    );
+    assert.ok(
+      Number.isFinite(m.slaBreaches) && m.slaBreaches >= 0,
+      `${m.memberId}: slaBreaches must be >= 0`,
+    );
+    assert.ok(
+      allowedStatuses.has(m.status),
+      `${m.memberId}: status "${m.status}" is not in the allowed set`,
+    );
 
     if (m.status === "away") {
-      assert.equal(m.avgResponseTimeHours, null, `${m.memberId}: away members must have null avgResponseTimeHours`);
+      assert.equal(
+        m.avgResponseTimeHours,
+        null,
+        `${m.memberId}: away members must have null avgResponseTimeHours`,
+      );
     } else {
-      assert.ok(Number.isFinite(m.avgResponseTimeHours) && m.avgResponseTimeHours >= 0,
-        `${m.memberId}: avgResponseTimeHours must be a non-negative number`);
+      assert.ok(
+        Number.isFinite(m.avgResponseTimeHours) && m.avgResponseTimeHours >= 0,
+        `${m.memberId}: avgResponseTimeHours must be a non-negative number`,
+      );
     }
   }
 });
@@ -71,8 +101,10 @@ test("overloaded status is consistent with open-thread or SLA thresholds", async
     if (m.status === "overloaded") {
       const isOverloaded =
         m.openThreads > OVERLOAD_OPEN_THRESHOLD || m.slaBreaches > OVERLOAD_SLA_BREACH_THRESHOLD;
-      assert.ok(isOverloaded,
-        `${m.memberId}: overloaded status requires openThreads > ${OVERLOAD_OPEN_THRESHOLD} or slaBreaches > ${OVERLOAD_SLA_BREACH_THRESHOLD}`);
+      assert.ok(
+        isOverloaded,
+        `${m.memberId}: overloaded status requires openThreads > ${OVERLOAD_OPEN_THRESHOLD} or slaBreaches > ${OVERLOAD_SLA_BREACH_THRESHOLD}`,
+      );
     }
   }
 });
@@ -85,17 +117,39 @@ test("summary totals are consistent with member data", async () => {
   const expectedOpen = members.reduce((n, m) => n + m.openThreads, 0);
   const expectedBreaches = members.reduce((n, m) => n + m.slaBreaches, 0);
 
-  assert.equal(summary.totalEmailVolume, expectedVolume, "summary.totalEmailVolume must equal sum of member emailsReceived");
-  assert.equal(summary.totalHandled, expectedHandled, "summary.totalHandled must equal sum of member emailsHandled");
-  assert.equal(summary.totalOpen, expectedOpen, "summary.totalOpen must equal sum of member openThreads");
-  assert.equal(summary.totalSlaBreaches, expectedBreaches, "summary.totalSlaBreaches must equal sum of member slaBreaches");
+  assert.equal(
+    summary.totalEmailVolume,
+    expectedVolume,
+    "summary.totalEmailVolume must equal sum of member emailsReceived",
+  );
+  assert.equal(
+    summary.totalHandled,
+    expectedHandled,
+    "summary.totalHandled must equal sum of member emailsHandled",
+  );
+  assert.equal(
+    summary.totalOpen,
+    expectedOpen,
+    "summary.totalOpen must equal sum of member openThreads",
+  );
+  assert.equal(
+    summary.totalSlaBreaches,
+    expectedBreaches,
+    "summary.totalSlaBreaches must equal sum of member slaBreaches",
+  );
 });
 
 test("topPerformer and bottleneck reference valid member IDs", async () => {
   const { members, summary } = await loadFixture();
   const memberIds = new Set(members.map((m) => m.memberId));
-  assert.ok(memberIds.has(summary.topPerformerId), "summary.topPerformerId must match a member in the fixture");
-  assert.ok(memberIds.has(summary.bottleneckMemberId), "summary.bottleneckMemberId must match a member in the fixture");
+  assert.ok(
+    memberIds.has(summary.topPerformerId),
+    "summary.topPerformerId must match a member in the fixture",
+  );
+  assert.ok(
+    memberIds.has(summary.bottleneckMemberId),
+    "summary.bottleneckMemberId must match a member in the fixture",
+  );
 });
 
 test("reviewRequiredMemberIds contains all members with SLA breaches", async () => {
@@ -103,8 +157,10 @@ test("reviewRequiredMemberIds contains all members with SLA breaches", async () 
   const reviewSet = new Set(summary.reviewRequiredMemberIds);
   for (const m of members) {
     if (m.slaBreaches > 0) {
-      assert.ok(reviewSet.has(m.memberId),
-        `${m.memberId} has slaBreaches > 0 and must be in reviewRequiredMemberIds`);
+      assert.ok(
+        reviewSet.has(m.memberId),
+        `${m.memberId} has slaBreaches > 0 and must be in reviewRequiredMemberIds`,
+      );
     }
   }
 });
@@ -122,6 +178,9 @@ test("bottleneck member has the highest open thread count", async () => {
   const bottleneck = members.find((m) => m.memberId === summary.bottleneckMemberId);
   assert.ok(bottleneck, "bottleneckMemberId must match a member");
   const maxOpen = Math.max(...members.map((m) => m.openThreads));
-  assert.equal(bottleneck.openThreads, maxOpen,
-    "bottleneck member must have the highest openThreads count");
+  assert.equal(
+    bottleneck.openThreads,
+    maxOpen,
+    "bottleneck member must have the highest openThreads count",
+  );
 });

--- a/tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
+++ b/tools/v2/team/team-analytics-dashboard/tests/analytics-dashboard-fixtures.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-analytics-data.json");
+
+const allowedStatuses = new Set(["active", "overloaded", "underutilized", "away"]);
+const SLA_THRESHOLD_HOURS = 4;
+const OVERLOAD_OPEN_THRESHOLD = 10;
+const OVERLOAD_SLA_BREACH_THRESHOLD = 2;
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("fixture loads and declares the correct tool identity", async () => {
+  const fixture = await loadFixture();
+  assert.equal(fixture.tool, "team-analytics-dashboard");
+  assert.ok(Number.isInteger(fixture.version) && fixture.version > 0, "version must be a positive integer");
+  assert.ok(fixture.teamId, "teamId is required");
+});
+
+test("period block contains valid ISO dates and a label", async () => {
+  const { period } = await loadFixture();
+  const isoDate = /^\d{4}-\d{2}-\d{2}$/;
+  assert.match(period.start, isoDate, "period.start must be ISO date");
+  assert.match(period.end, isoDate, "period.end must be ISO date");
+  assert.ok(period.label, "period.label is required");
+  assert.ok(period.start <= period.end, "period.start must not be after period.end");
+});
+
+test("members array contains at least one member with required fields", async () => {
+  const { members } = await loadFixture();
+  assert.ok(Array.isArray(members) && members.length > 0, "members must be a non-empty array");
+
+  for (const m of members) {
+    assert.ok(m.memberId, `${m.name ?? "unknown"}: memberId is required`);
+    assert.ok(m.name, `${m.memberId}: name is required`);
+    assert.ok(Number.isFinite(m.emailsReceived) && m.emailsReceived >= 0, `${m.memberId}: emailsReceived must be >= 0`);
+    assert.ok(Number.isFinite(m.emailsHandled) && m.emailsHandled >= 0, `${m.memberId}: emailsHandled must be >= 0`);
+    assert.ok(m.emailsHandled <= m.emailsReceived, `${m.memberId}: emailsHandled cannot exceed emailsReceived`);
+    assert.ok(Number.isFinite(m.openThreads) && m.openThreads >= 0, `${m.memberId}: openThreads must be >= 0`);
+    assert.ok(Number.isFinite(m.resolvedThreads) && m.resolvedThreads >= 0, `${m.memberId}: resolvedThreads must be >= 0`);
+    assert.ok(Number.isFinite(m.slaBreaches) && m.slaBreaches >= 0, `${m.memberId}: slaBreaches must be >= 0`);
+    assert.ok(allowedStatuses.has(m.status), `${m.memberId}: status "${m.status}" is not in the allowed set`);
+
+    if (m.status === "away") {
+      assert.equal(m.avgResponseTimeHours, null, `${m.memberId}: away members must have null avgResponseTimeHours`);
+    } else {
+      assert.ok(Number.isFinite(m.avgResponseTimeHours) && m.avgResponseTimeHours >= 0,
+        `${m.memberId}: avgResponseTimeHours must be a non-negative number`);
+    }
+  }
+});
+
+test("all four member statuses are represented", async () => {
+  const { members } = await loadFixture();
+  const seen = new Set(members.map((m) => m.status));
+  for (const s of allowedStatuses) {
+    assert.ok(seen.has(s), `fixture must include at least one member with status "${s}"`);
+  }
+});
+
+test("overloaded status is consistent with open-thread or SLA thresholds", async () => {
+  const { members } = await loadFixture();
+  for (const m of members) {
+    if (m.status === "overloaded") {
+      const isOverloaded =
+        m.openThreads > OVERLOAD_OPEN_THRESHOLD || m.slaBreaches > OVERLOAD_SLA_BREACH_THRESHOLD;
+      assert.ok(isOverloaded,
+        `${m.memberId}: overloaded status requires openThreads > ${OVERLOAD_OPEN_THRESHOLD} or slaBreaches > ${OVERLOAD_SLA_BREACH_THRESHOLD}`);
+    }
+  }
+});
+
+test("summary totals are consistent with member data", async () => {
+  const { members, summary } = await loadFixture();
+
+  const expectedVolume = members.reduce((n, m) => n + m.emailsReceived, 0);
+  const expectedHandled = members.reduce((n, m) => n + m.emailsHandled, 0);
+  const expectedOpen = members.reduce((n, m) => n + m.openThreads, 0);
+  const expectedBreaches = members.reduce((n, m) => n + m.slaBreaches, 0);
+
+  assert.equal(summary.totalEmailVolume, expectedVolume, "summary.totalEmailVolume must equal sum of member emailsReceived");
+  assert.equal(summary.totalHandled, expectedHandled, "summary.totalHandled must equal sum of member emailsHandled");
+  assert.equal(summary.totalOpen, expectedOpen, "summary.totalOpen must equal sum of member openThreads");
+  assert.equal(summary.totalSlaBreaches, expectedBreaches, "summary.totalSlaBreaches must equal sum of member slaBreaches");
+});
+
+test("topPerformer and bottleneck reference valid member IDs", async () => {
+  const { members, summary } = await loadFixture();
+  const memberIds = new Set(members.map((m) => m.memberId));
+  assert.ok(memberIds.has(summary.topPerformerId), "summary.topPerformerId must match a member in the fixture");
+  assert.ok(memberIds.has(summary.bottleneckMemberId), "summary.bottleneckMemberId must match a member in the fixture");
+});
+
+test("reviewRequiredMemberIds contains all members with SLA breaches", async () => {
+  const { members, summary } = await loadFixture();
+  const reviewSet = new Set(summary.reviewRequiredMemberIds);
+  for (const m of members) {
+    if (m.slaBreaches > 0) {
+      assert.ok(reviewSet.has(m.memberId),
+        `${m.memberId} has slaBreaches > 0 and must be in reviewRequiredMemberIds`);
+    }
+  }
+});
+
+test("topPerformer is active and has zero SLA breaches", async () => {
+  const { members, summary } = await loadFixture();
+  const top = members.find((m) => m.memberId === summary.topPerformerId);
+  assert.ok(top, "topPerformerId must match a member");
+  assert.equal(top.status, "active", "topPerformer must have active status");
+  assert.equal(top.slaBreaches, 0, "topPerformer must have zero SLA breaches");
+});
+
+test("bottleneck member has the highest open thread count", async () => {
+  const { members, summary } = await loadFixture();
+  const bottleneck = members.find((m) => m.memberId === summary.bottleneckMemberId);
+  assert.ok(bottleneck, "bottleneckMemberId must match a member");
+  const maxOpen = Math.max(...members.map((m) => m.openThreads));
+  assert.equal(bottleneck.openThreads, maxOpen,
+    "bottleneck member must have the highest openThreads count");
+});


### PR DESCRIPTION
Adds a folder-local fixture (fixtures/sample-analytics-data.json) modelling a realistic 1-week team analytics snapshot covering all four member-status archetypes: active, overloaded, underutilized, and away

    Adds a zero-dependency Node test suite (9 tests) that validates the fixture against the analytics contract — struct shape, date ordering, status consistency, overload thresholds, and summary totals

    Replaces the placeholder README with a concrete product contract covering setup, usage, and known limitations

    Adds docs/test-plan.md and docs/review-notes.md for independent OSS reviewer validation

All changes are isolated to tools/v2/team/team-analytics-dashboard/ with no modifications to core app systems.
closes #678