### PR TITLE
feat(role-based-mail-access): add security guards, threat model, and …

### DIFF
--- a/tools/v2/team/role-based-mail-access/README.md
+++ b/tools/v2/team/role-based-mail-access/README.md
@@ -1,15 +1,78 @@
 # Role-Based Mail Access
 
-This folder is the isolated workspace for the Role-Based Mail Access tool.
+A self-contained V2 team tool that enforces which team members can read, write, assign, delete, or manage mail threads based on a declared role. This contribution adds the safety and performance guard layer — validation, sanitisation, and size caps — before any future integration work begins.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\role-based-mail-access\
-`
+```
+tools/v2/team/role-based-mail-access/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```
+role-based-mail-access/
+├── guards/
+│   └── access-guards.mjs            # validation, sanitisation, and performance guard helpers
+├── fixtures/
+│   └── sample-access-requests.json  # valid requests + 19 named hostile inputs
+├── tests/
+│   └── access-guards.test.mjs       # 33-test Node suite covering guards and fixture
+├── docs/
+│   ├── threat-model.md              # trust boundary, attack categories, out-of-scope threats
+│   ├── performance-notes.md         # O(n) risks, size caps, future guidance
+│   └── review-notes.md              # scope, reviewer focus, follow-up issues
+├── specs.md
+└── README.md
+```
+
+## Running the Tests
+
+No install step required. Run from the repository root:
+
+```bash
+node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+```
+
+Expected output: 33 passing tests, 0 failures.
+
+## Guard API
+
+All helpers live in `guards/access-guards.mjs` and throw `AccessValidationError` on invalid input.
+
+| Export | Purpose |
+|---|---|
+| `sanitizeRole(raw)` | Trims, lowercases, strips non-alphanumeric chars — use before validation |
+| `validateRole(role)` | Allowlist check against 5 known roles |
+| `validateAccessLevel(level)` | Allowlist check against 5 known access levels |
+| `validateEmailAddress(email)` | Rejects CRLF injection, null bytes, missing local/domain parts |
+| `validateThreadId(threadId)` | Rejects path traversal, spaces, special chars |
+| `validateAccessRequest(req)` | Full object validation — calls all four field validators |
+| `checkAccess(role, level, policy)` | O(1) Set-based policy lookup — returns boolean |
+| `guardTeamSize(members)` | Rejects arrays > 500 before any role scan |
+| `guardAttachmentCount(attachments)` | Rejects arrays > 100 before any filter pass |
+| `LIMITS` | Exported constants for all thresholds |
+
+## Roles and Access Levels
+
+| Role | read | write | assign | delete | manage |
+|---|---|---|---|---|---|
+| `admin` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `manager` | ✓ | ✓ | ✓ | | |
+| `agent` | ✓ | ✓ | | | |
+| `viewer` | ✓ | | | | |
+| `guest` | | | | | |
+
+## Known Limitations
+
+- The guard module validates shape and allowlist membership only — it does not verify that the caller actually holds the declared role (authentication is a future issue).
+- `checkAccess` builds a `Set` on every call; callers checking access in a tight loop should pre-index the policy as `Map<role, Set<level>>` to avoid repeated construction.
+- Size caps (`MAX_TEAM_SIZE=500`, `MAX_ATTACHMENT_COUNT=100`) are conservative starting values — adjust them in `access-guards.mjs` if product requirements change, and update the corresponding fixture `performanceLimits` object.
+
+## Review
+
+See `docs/threat-model.md` for the full attack-surface analysis and `docs/review-notes.md` for contributor scope and follow-up issues.

--- a/tools/v2/team/role-based-mail-access/README.md
+++ b/tools/v2/team/role-based-mail-access/README.md
@@ -44,28 +44,28 @@ Expected output: 33 passing tests, 0 failures.
 
 All helpers live in `guards/access-guards.mjs` and throw `AccessValidationError` on invalid input.
 
-| Export | Purpose |
-|---|---|
-| `sanitizeRole(raw)` | Trims, lowercases, strips non-alphanumeric chars — use before validation |
-| `validateRole(role)` | Allowlist check against 5 known roles |
-| `validateAccessLevel(level)` | Allowlist check against 5 known access levels |
-| `validateEmailAddress(email)` | Rejects CRLF injection, null bytes, missing local/domain parts |
-| `validateThreadId(threadId)` | Rejects path traversal, spaces, special chars |
-| `validateAccessRequest(req)` | Full object validation — calls all four field validators |
-| `checkAccess(role, level, policy)` | O(1) Set-based policy lookup — returns boolean |
-| `guardTeamSize(members)` | Rejects arrays > 500 before any role scan |
-| `guardAttachmentCount(attachments)` | Rejects arrays > 100 before any filter pass |
-| `LIMITS` | Exported constants for all thresholds |
+| Export                              | Purpose                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| `sanitizeRole(raw)`                 | Trims, lowercases, strips non-alphanumeric chars — use before validation |
+| `validateRole(role)`                | Allowlist check against 5 known roles                                    |
+| `validateAccessLevel(level)`        | Allowlist check against 5 known access levels                            |
+| `validateEmailAddress(email)`       | Rejects CRLF injection, null bytes, missing local/domain parts           |
+| `validateThreadId(threadId)`        | Rejects path traversal, spaces, special chars                            |
+| `validateAccessRequest(req)`        | Full object validation — calls all four field validators                 |
+| `checkAccess(role, level, policy)`  | O(1) Set-based policy lookup — returns boolean                           |
+| `guardTeamSize(members)`            | Rejects arrays > 500 before any role scan                                |
+| `guardAttachmentCount(attachments)` | Rejects arrays > 100 before any filter pass                              |
+| `LIMITS`                            | Exported constants for all thresholds                                    |
 
 ## Roles and Access Levels
 
-| Role | read | write | assign | delete | manage |
-|---|---|---|---|---|---|
-| `admin` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `manager` | ✓ | ✓ | ✓ | | |
-| `agent` | ✓ | ✓ | | | |
-| `viewer` | ✓ | | | | |
-| `guest` | | | | | |
+| Role      | read | write | assign | delete | manage |
+| --------- | ---- | ----- | ------ | ------ | ------ |
+| `admin`   | ✓    | ✓     | ✓      | ✓      | ✓      |
+| `manager` | ✓    | ✓     | ✓      |        |        |
+| `agent`   | ✓    | ✓     |        |        |        |
+| `viewer`  | ✓    |       |        |        |        |
+| `guest`   |      |       |        |        |        |
 
 ## Known Limitations
 

--- a/tools/v2/team/role-based-mail-access/docs/performance-notes.md
+++ b/tools/v2/team/role-based-mail-access/docs/performance-notes.md
@@ -1,0 +1,46 @@
+# Performance Notes
+
+## Access Check — O(1) Policy Lookup
+
+`checkAccess(role, accessLevel, policy)` builds a `Set` from the allowed-levels array on each call. This keeps membership checks at O(1) regardless of how many levels a role holds. When implementation code caches the policy object across requests, the per-call cost is a single `Set` construction plus one `.has()` call.
+
+## Team Size Guard
+
+Scanning role membership across an entire team is O(n). Without a size cap, a team object with thousands of members can make access checks block the event loop for tens of milliseconds.
+
+**Guard:** `guardTeamSize(members)` rejects arrays longer than **500 members** and throws `AccessValidationError` before any iteration starts. Implementation code must paginate team data and call access checks per page rather than loading all members at once.
+
+```
+Team size       Estimated scan time (no guard)
+50 members      < 1 ms   ✓ safe
+500 members     ~5 ms    ✓ at the limit
+5 000 members   ~50 ms   ✗ blocks event loop
+50 000 members  ~500 ms  ✗ effectively DoS
+```
+
+## Attachment Count Guard
+
+Role-based attachment filtering (e.g., hiding attachments from `viewer` and `guest` roles) iterates over every attachment on a thread. Large threads with many attachments create the same O(n) risk.
+
+**Guard:** `guardAttachmentCount(attachments)` rejects arrays longer than **100 attachments** and throws before filtering begins. Implementation code must paginate attachment lists.
+
+## Field Length Limits
+
+Short-circuit rejection of oversized strings prevents downstream code from performing expensive regex evaluation, database lookups, or string comparisons against adversarially long values.
+
+| Field | Limit | Rationale |
+|---|---|---|
+| `role` | 64 chars | No real role name exceeds this; caps regex input length |
+| `threadId` | 128 chars | Prevents lookup table abuse with artificially long keys |
+| `email` | 254 chars | RFC 5321 maximum; rejects padding attacks |
+
+## Allowlist Over Regex
+
+Role and access-level validation uses `Set.has()` against a hard-coded allowlist rather than a regex pattern. This avoids ReDoS vulnerabilities from user-controlled strings matched against complex regular expressions.
+
+## Future Performance Considerations
+
+- **Policy caching** — if the policy object is fetched from a database, cache it per-request cycle rather than re-fetching per access check.
+- **Bulk access checks** — if a UI needs to filter a list of threads for a given role, implement a single policy-aware filter pass rather than calling `checkAccess` once per thread in a loop.
+- **Index by role** — when the policy grows to many roles, consider pre-indexing the policy as a `Map<role, Set<level>>` once at startup to eliminate repeated `Set` construction.
+- **Large email bodies** — role-based redaction of email body content (e.g., hiding financial data from `viewer`) should operate on a streaming/chunked basis rather than loading full message bodies into memory.

--- a/tools/v2/team/role-based-mail-access/docs/performance-notes.md
+++ b/tools/v2/team/role-based-mail-access/docs/performance-notes.md
@@ -28,11 +28,11 @@ Role-based attachment filtering (e.g., hiding attachments from `viewer` and `gue
 
 Short-circuit rejection of oversized strings prevents downstream code from performing expensive regex evaluation, database lookups, or string comparisons against adversarially long values.
 
-| Field | Limit | Rationale |
-|---|---|---|
-| `role` | 64 chars | No real role name exceeds this; caps regex input length |
+| Field      | Limit     | Rationale                                               |
+| ---------- | --------- | ------------------------------------------------------- |
+| `role`     | 64 chars  | No real role name exceeds this; caps regex input length |
 | `threadId` | 128 chars | Prevents lookup table abuse with artificially long keys |
-| `email` | 254 chars | RFC 5321 maximum; rejects padding attacks |
+| `email`    | 254 chars | RFC 5321 maximum; rejects padding attacks               |
 
 ## Allowlist Over Regex
 

--- a/tools/v2/team/role-based-mail-access/docs/review-notes.md
+++ b/tools/v2/team/role-based-mail-access/docs/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- A guard module (`guards/access-guards.mjs`) with validation, sanitisation, and performance-safety helpers — no UI, no service wiring, no app integration.
+- A fixture (`fixtures/sample-access-requests.json`) that encodes the valid-request contract and a named catalogue of 19 hostile inputs covering role escalation, injection, and traversal attacks.
+- A test suite (`tests/access-guards.test.mjs`) with 33 tests that validate every guard function against both normal and adversarial inputs, and verify that all fixture hostile inputs throw `AccessValidationError`.
+- A threat model (`docs/threat-model.md`) documenting trust boundaries, attack categories, and out-of-scope threats for future issues.
+- Performance notes (`docs/performance-notes.md`) covering O(n) risks, size caps, and future implementation guidance.
+- An updated `README.md` with setup, run command, file map, and known limitations.
+
+## Validation Performed
+
+```bash
+node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+```
+
+All 33 tests pass. No install step required.
+
+## Reviewer Focus
+
+- **Guard completeness** — every hostile input category in `docs/threat-model.md` should have a corresponding entry in `fixtures/sample-access-requests.json` and a passing rejection test.
+- **Allowlist discipline** — `validateRole` and `validateAccessLevel` use `Set.has()` against hard-coded allowlists, not regex. If the allowed roles or levels change in a future issue, update `ALLOWED_ROLES` / `ALLOWED_ACCESS_LEVELS` in the guard module and the `policy` object in the fixture.
+- **Error field tagging** — every `AccessValidationError` carries a `field` property so future UI code can surface per-field error messages without parsing the message string.
+- **No production code touched** — this contribution is self-contained. No files outside `tools/v2/team/role-based-mail-access/` were modified.
+
+## Intentionally Out of Scope
+
+- Authentication (verifying the caller owns the declared role) — requires session/token integration
+- Audit logging of access decisions — separate compliance concern
+- Rate limiting / brute-force protection — requires middleware outside this boundary
+- UI components for role assignment — future feature issue
+- Integration with the main inbox or routing — blocked by isolation boundary
+
+## Follow-Up Work
+
+- Add service code that loads the live role policy and wires `checkAccess` to inbox thread lookups.
+- Add authentication middleware that validates the declared role against the session token.
+- Add audit logging so every access decision is recorded for compliance review.
+- Add integration tests only after a future issue explicitly allows app wiring.

--- a/tools/v2/team/role-based-mail-access/docs/threat-model.md
+++ b/tools/v2/team/role-based-mail-access/docs/threat-model.md
@@ -1,0 +1,78 @@
+# Threat Model
+
+## Tool Overview
+
+Role-Based Mail Access enforces which team members can read, write, assign, delete, or manage mail threads based on a declared role. Before implementation code ships, this document defines the threat assumptions and categories of hostile input the guard layer must reject.
+
+## Trust Boundary
+
+The guard module (`guards/access-guards.mjs`) sits at the boundary between caller-supplied input and any downstream access decision. All inputs must be treated as untrusted until validated.
+
+## Roles and Access Levels
+
+| Role | Allowed levels |
+|---|---|
+| `admin` | read, write, assign, delete, manage |
+| `manager` | read, write, assign |
+| `agent` | read, write |
+| `viewer` | read |
+| `guest` | *(none)* |
+
+Any role or access level not in the above table must be rejected before reaching policy evaluation.
+
+## Threat Assumptions
+
+1. **Callers are untrusted.** Role and access-level values must never be taken from a request payload without allowlist validation. A caller claiming to be `admin` cannot be trusted without independent verification.
+2. **String inputs may be adversarially crafted.** Input may contain null bytes, Unicode lookalikes, control characters, path separators, or injection payloads.
+3. **Thread IDs are opaque identifiers.** They must not be treated as file paths or database queries. Path traversal sequences (`../`) and special characters must be rejected.
+4. **Email fields are a header-injection surface.** Any value placed into a mail header must be sanitised for CRLF sequences before use.
+5. **Large inputs are a denial-of-service surface.** Unbounded team arrays and attachment lists can cause O(n) scans to degrade. Size caps must be enforced before any iteration.
+
+## Hostile Input Categories
+
+### Role field
+
+| Input | Attack vector |
+|---|---|
+| `null` / `undefined` / `""` | Null-check bypass |
+| `"ADMIN"` | Case-sensitivity bypass |
+| `"superadmin"`, `"root"` | Non-existent role escalation |
+| `"аdmin"` (Cyrillic а) | Unicode homoglyph spoofing |
+| `"admin\0"` | Null-byte injection |
+| `"admin; DROP TABLE roles"` | SQL / command injection style |
+| 65+ character string | Regex or buffer exhaustion |
+
+### Access level field
+
+| Input | Attack vector |
+|---|---|
+| `"superwrite"`, `"*"`, `"all"` | Wildcard or non-existent level escalation |
+| `""` | Empty-string bypass |
+
+### Email field
+
+| Input | Attack vector |
+|---|---|
+| `"user@evil.test\r\nBcc: victim@..."` | CRLF header injection |
+| `"user\0@evil.test"` | Null-byte injection |
+| `"@domain.test"` | Missing local part |
+| `"user@"` | Missing domain |
+| `"nodomain"` | Missing `@` entirely |
+| 255+ character address | RFC 5321 violation / buffer risk |
+
+### Thread ID field
+
+| Input | Attack vector |
+|---|---|
+| `"../../../secret"` | Path traversal |
+| `"thread 001"`, `"thread\tid"` | Whitespace / tab injection |
+| `"<script>alert(1)</script>"` | XSS payload in stored ID |
+| `"thread\0id"` | Null-byte injection |
+| 129+ character string | ID exhaustion / lookup abuse |
+
+## Out-of-Scope Threats (follow-up issues)
+
+- Authentication — verifying that the declared role actually belongs to the requester requires session/token integration, which is not part of this isolated tool yet.
+- Audit logging — recording access decisions for compliance is a separate concern.
+- Rate limiting — preventing brute-force role enumeration requires middleware outside this tool's boundary.
+- Encrypted thread IDs — protecting thread IDs from enumeration attacks requires a future architecture decision.

--- a/tools/v2/team/role-based-mail-access/docs/threat-model.md
+++ b/tools/v2/team/role-based-mail-access/docs/threat-model.md
@@ -10,13 +10,13 @@ The guard module (`guards/access-guards.mjs`) sits at the boundary between calle
 
 ## Roles and Access Levels
 
-| Role | Allowed levels |
-|---|---|
-| `admin` | read, write, assign, delete, manage |
-| `manager` | read, write, assign |
-| `agent` | read, write |
-| `viewer` | read |
-| `guest` | *(none)* |
+| Role      | Allowed levels                      |
+| --------- | ----------------------------------- |
+| `admin`   | read, write, assign, delete, manage |
+| `manager` | read, write, assign                 |
+| `agent`   | read, write                         |
+| `viewer`  | read                                |
+| `guest`   | _(none)_                            |
 
 Any role or access level not in the above table must be rejected before reaching policy evaluation.
 
@@ -32,43 +32,43 @@ Any role or access level not in the above table must be rejected before reaching
 
 ### Role field
 
-| Input | Attack vector |
-|---|---|
-| `null` / `undefined` / `""` | Null-check bypass |
-| `"ADMIN"` | Case-sensitivity bypass |
-| `"superadmin"`, `"root"` | Non-existent role escalation |
-| `"аdmin"` (Cyrillic а) | Unicode homoglyph spoofing |
-| `"admin\0"` | Null-byte injection |
+| Input                       | Attack vector                 |
+| --------------------------- | ----------------------------- |
+| `null` / `undefined` / `""` | Null-check bypass             |
+| `"ADMIN"`                   | Case-sensitivity bypass       |
+| `"superadmin"`, `"root"`    | Non-existent role escalation  |
+| `"аdmin"` (Cyrillic а)      | Unicode homoglyph spoofing    |
+| `"admin\0"`                 | Null-byte injection           |
 | `"admin; DROP TABLE roles"` | SQL / command injection style |
-| 65+ character string | Regex or buffer exhaustion |
+| 65+ character string        | Regex or buffer exhaustion    |
 
 ### Access level field
 
-| Input | Attack vector |
-|---|---|
+| Input                          | Attack vector                             |
+| ------------------------------ | ----------------------------------------- |
 | `"superwrite"`, `"*"`, `"all"` | Wildcard or non-existent level escalation |
-| `""` | Empty-string bypass |
+| `""`                           | Empty-string bypass                       |
 
 ### Email field
 
-| Input | Attack vector |
-|---|---|
-| `"user@evil.test\r\nBcc: victim@..."` | CRLF header injection |
-| `"user\0@evil.test"` | Null-byte injection |
-| `"@domain.test"` | Missing local part |
-| `"user@"` | Missing domain |
-| `"nodomain"` | Missing `@` entirely |
-| 255+ character address | RFC 5321 violation / buffer risk |
+| Input                                 | Attack vector                    |
+| ------------------------------------- | -------------------------------- |
+| `"user@evil.test\r\nBcc: victim@..."` | CRLF header injection            |
+| `"user\0@evil.test"`                  | Null-byte injection              |
+| `"@domain.test"`                      | Missing local part               |
+| `"user@"`                             | Missing domain                   |
+| `"nodomain"`                          | Missing `@` entirely             |
+| 255+ character address                | RFC 5321 violation / buffer risk |
 
 ### Thread ID field
 
-| Input | Attack vector |
-|---|---|
-| `"../../../secret"` | Path traversal |
-| `"thread 001"`, `"thread\tid"` | Whitespace / tab injection |
-| `"<script>alert(1)</script>"` | XSS payload in stored ID |
-| `"thread\0id"` | Null-byte injection |
-| 129+ character string | ID exhaustion / lookup abuse |
+| Input                          | Attack vector                |
+| ------------------------------ | ---------------------------- |
+| `"../../../secret"`            | Path traversal               |
+| `"thread 001"`, `"thread\tid"` | Whitespace / tab injection   |
+| `"<script>alert(1)</script>"`  | XSS payload in stored ID     |
+| `"thread\0id"`                 | Null-byte injection          |
+| 129+ character string          | ID exhaustion / lookup abuse |
 
 ## Out-of-Scope Threats (follow-up issues)
 

--- a/tools/v2/team/role-based-mail-access/fixtures/sample-access-requests.json
+++ b/tools/v2/team/role-based-mail-access/fixtures/sample-access-requests.json
@@ -1,0 +1,88 @@
+{
+  "tool": "role-based-mail-access",
+  "version": 1,
+  "policy": {
+    "admin":   ["read", "write", "assign", "delete", "manage"],
+    "manager": ["read", "write", "assign"],
+    "agent":   ["read", "write"],
+    "viewer":  ["read"],
+    "guest":   []
+  },
+  "validRequests": [
+    {
+      "id": "req-001",
+      "requesterEmail": "alice@example.test",
+      "role": "manager",
+      "accessLevel": "assign",
+      "threadId": "thread-support-001",
+      "expectGranted": true
+    },
+    {
+      "id": "req-002",
+      "requesterEmail": "bob@example.test",
+      "role": "agent",
+      "accessLevel": "read",
+      "threadId": "thread-billing-042",
+      "expectGranted": true
+    },
+    {
+      "id": "req-003",
+      "requesterEmail": "carol@example.test",
+      "role": "viewer",
+      "accessLevel": "write",
+      "threadId": "thread-legal-007",
+      "expectGranted": false
+    },
+    {
+      "id": "req-004",
+      "requesterEmail": "dave@example.test",
+      "role": "guest",
+      "accessLevel": "read",
+      "threadId": "thread-onboarding-003",
+      "expectGranted": false
+    },
+    {
+      "id": "req-005",
+      "requesterEmail": "eve@example.test",
+      "role": "admin",
+      "accessLevel": "delete",
+      "threadId": "thread-archive-019",
+      "expectGranted": true
+    }
+  ],
+  "hostileInputs": [
+    { "field": "role",        "value": null,                                        "reason": "null role" },
+    { "field": "role",        "value": "",                                           "reason": "empty string role" },
+    { "field": "role",        "value": "ADMIN",                                      "reason": "uppercase bypass attempt" },
+    { "field": "role",        "value": "admin trailing-space ",                      "reason": "whitespace-padded role not in allowlist" },
+    { "field": "role",        "value": "admin; DROP TABLE roles--",                  "reason": "SQL-style injection" },
+    { "field": "role",        "value": "аdmin",                                 "reason": "homoglyph attack — Cyrillic U+0430 replacing Latin a" },
+    { "field": "role",        "value": "superadmin",                                 "reason": "non-existent role escalation attempt" },
+    { "field": "role",        "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "reason": "oversized role string (65 chars)" },
+    { "field": "accessLevel", "value": "superwrite",                                 "reason": "non-existent access level" },
+    { "field": "accessLevel", "value": "*",                                          "reason": "wildcard escalation attempt" },
+    { "field": "email",       "value": "user@evil.test\r\nBcc: victim@example.test", "reason": "CRLF header injection" },
+    { "field": "email",       "value": "user@evil.test\nX-Injected: yes",            "reason": "LF-only header injection" },
+    { "field": "email",       "value": "@missinglocal.test",                         "reason": "missing local part" },
+    { "field": "email",       "value": "user@",                                      "reason": "missing domain after @" },
+    { "field": "email",       "value": "nodomain",                                   "reason": "missing @ and domain entirely" },
+    { "field": "threadId",    "value": "../../../other-team/secret",                 "reason": "path traversal attempt" },
+    { "field": "threadId",    "value": "thread 001",                                 "reason": "space in threadId" },
+    { "field": "threadId",    "value": "<script>alert(1)</script>",                  "reason": "XSS payload in threadId" },
+    { "field": "threadId",    "value": "thread/001",                                 "reason": "slash separator — path traversal precursor" }
+  ],
+  "performanceLimits": {
+    "maxTeamSize": 500,
+    "maxAttachmentCount": 100,
+    "maxRoleLength": 64,
+    "maxThreadIdLength": 128,
+    "maxEmailLength": 254
+  },
+  "reviewNotes": [
+    "All email addresses use example.test to avoid real user data.",
+    "hostileInputs represent known attack vectors; the guard module must reject every entry.",
+    "Null-byte injection (\\u0000) is tested directly in the test suite, not in this fixture, because JSON encodes it as a unicode escape that is safe to parse.",
+    "validRequests cover all five roles and mix granted/denied outcomes to prevent over-permitting.",
+    "The policy object is the source of truth for access level grants in tests."
+  ]
+}

--- a/tools/v2/team/role-based-mail-access/fixtures/sample-access-requests.json
+++ b/tools/v2/team/role-based-mail-access/fixtures/sample-access-requests.json
@@ -2,11 +2,11 @@
   "tool": "role-based-mail-access",
   "version": 1,
   "policy": {
-    "admin":   ["read", "write", "assign", "delete", "manage"],
+    "admin": ["read", "write", "assign", "delete", "manage"],
     "manager": ["read", "write", "assign"],
-    "agent":   ["read", "write"],
-    "viewer":  ["read"],
-    "guest":   []
+    "agent": ["read", "write"],
+    "viewer": ["read"],
+    "guest": []
   },
   "validRequests": [
     {
@@ -51,25 +51,57 @@
     }
   ],
   "hostileInputs": [
-    { "field": "role",        "value": null,                                        "reason": "null role" },
-    { "field": "role",        "value": "",                                           "reason": "empty string role" },
-    { "field": "role",        "value": "ADMIN",                                      "reason": "uppercase bypass attempt" },
-    { "field": "role",        "value": "admin trailing-space ",                      "reason": "whitespace-padded role not in allowlist" },
-    { "field": "role",        "value": "admin; DROP TABLE roles--",                  "reason": "SQL-style injection" },
-    { "field": "role",        "value": "аdmin",                                 "reason": "homoglyph attack — Cyrillic U+0430 replacing Latin a" },
-    { "field": "role",        "value": "superadmin",                                 "reason": "non-existent role escalation attempt" },
-    { "field": "role",        "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "reason": "oversized role string (65 chars)" },
-    { "field": "accessLevel", "value": "superwrite",                                 "reason": "non-existent access level" },
-    { "field": "accessLevel", "value": "*",                                          "reason": "wildcard escalation attempt" },
-    { "field": "email",       "value": "user@evil.test\r\nBcc: victim@example.test", "reason": "CRLF header injection" },
-    { "field": "email",       "value": "user@evil.test\nX-Injected: yes",            "reason": "LF-only header injection" },
-    { "field": "email",       "value": "@missinglocal.test",                         "reason": "missing local part" },
-    { "field": "email",       "value": "user@",                                      "reason": "missing domain after @" },
-    { "field": "email",       "value": "nodomain",                                   "reason": "missing @ and domain entirely" },
-    { "field": "threadId",    "value": "../../../other-team/secret",                 "reason": "path traversal attempt" },
-    { "field": "threadId",    "value": "thread 001",                                 "reason": "space in threadId" },
-    { "field": "threadId",    "value": "<script>alert(1)</script>",                  "reason": "XSS payload in threadId" },
-    { "field": "threadId",    "value": "thread/001",                                 "reason": "slash separator — path traversal precursor" }
+    { "field": "role", "value": null, "reason": "null role" },
+    { "field": "role", "value": "", "reason": "empty string role" },
+    { "field": "role", "value": "ADMIN", "reason": "uppercase bypass attempt" },
+    {
+      "field": "role",
+      "value": "admin trailing-space ",
+      "reason": "whitespace-padded role not in allowlist"
+    },
+    { "field": "role", "value": "admin; DROP TABLE roles--", "reason": "SQL-style injection" },
+    {
+      "field": "role",
+      "value": "аdmin",
+      "reason": "homoglyph attack — Cyrillic U+0430 replacing Latin a"
+    },
+    { "field": "role", "value": "superadmin", "reason": "non-existent role escalation attempt" },
+    {
+      "field": "role",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reason": "oversized role string (65 chars)"
+    },
+    { "field": "accessLevel", "value": "superwrite", "reason": "non-existent access level" },
+    { "field": "accessLevel", "value": "*", "reason": "wildcard escalation attempt" },
+    {
+      "field": "email",
+      "value": "user@evil.test\r\nBcc: victim@example.test",
+      "reason": "CRLF header injection"
+    },
+    {
+      "field": "email",
+      "value": "user@evil.test\nX-Injected: yes",
+      "reason": "LF-only header injection"
+    },
+    { "field": "email", "value": "@missinglocal.test", "reason": "missing local part" },
+    { "field": "email", "value": "user@", "reason": "missing domain after @" },
+    { "field": "email", "value": "nodomain", "reason": "missing @ and domain entirely" },
+    {
+      "field": "threadId",
+      "value": "../../../other-team/secret",
+      "reason": "path traversal attempt"
+    },
+    { "field": "threadId", "value": "thread 001", "reason": "space in threadId" },
+    {
+      "field": "threadId",
+      "value": "<script>alert(1)</script>",
+      "reason": "XSS payload in threadId"
+    },
+    {
+      "field": "threadId",
+      "value": "thread/001",
+      "reason": "slash separator — path traversal precursor"
+    }
   ],
   "performanceLimits": {
     "maxTeamSize": 500,

--- a/tools/v2/team/role-based-mail-access/guards/access-guards.mjs
+++ b/tools/v2/team/role-based-mail-access/guards/access-guards.mjs
@@ -1,0 +1,134 @@
+const ALLOWED_ROLES = new Set(["admin", "manager", "agent", "viewer", "guest"]);
+const ALLOWED_ACCESS_LEVELS = new Set(["read", "write", "assign", "delete", "manage"]);
+
+const MAX_ROLE_LENGTH = 64;
+const MAX_THREAD_ID_LENGTH = 128;
+const MAX_EMAIL_LENGTH = 254; // RFC 5321
+const MAX_TEAM_SIZE = 500;
+const MAX_ATTACHMENT_COUNT = 100;
+
+const THREAD_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export class AccessValidationError extends Error {
+  constructor(message, field) {
+    super(message);
+    this.name = "AccessValidationError";
+    this.field = field;
+  }
+}
+
+export function sanitizeRole(raw) {
+  if (typeof raw !== "string") return null;
+  return raw.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "");
+}
+
+export function validateRole(role) {
+  if (typeof role !== "string" || role.length === 0) {
+    throw new AccessValidationError("role must be a non-empty string", "role");
+  }
+  if (role.length > MAX_ROLE_LENGTH) {
+    throw new AccessValidationError(`role exceeds max length of ${MAX_ROLE_LENGTH}`, "role");
+  }
+  if (!ALLOWED_ROLES.has(role)) {
+    throw new AccessValidationError(`"${role}" is not a recognised role`, "role");
+  }
+  return role;
+}
+
+export function validateAccessLevel(level) {
+  if (typeof level !== "string" || level.length === 0) {
+    throw new AccessValidationError("accessLevel must be a non-empty string", "accessLevel");
+  }
+  if (!ALLOWED_ACCESS_LEVELS.has(level)) {
+    throw new AccessValidationError(`"${level}" is not a recognised access level`, "accessLevel");
+  }
+  return level;
+}
+
+export function validateEmailAddress(email) {
+  if (typeof email !== "string" || email.length === 0) {
+    throw new AccessValidationError("email must be a non-empty string", "email");
+  }
+  if (email.length > MAX_EMAIL_LENGTH) {
+    throw new AccessValidationError(`email exceeds RFC 5321 max length of ${MAX_EMAIL_LENGTH}`, "email");
+  }
+  // Reject header injection characters before any further processing
+  if (/[\r\n\0]/.test(email)) {
+    throw new AccessValidationError("email contains illegal control characters", "email");
+  }
+  const atIndex = email.lastIndexOf("@");
+  if (atIndex < 1 || atIndex === email.length - 1) {
+    throw new AccessValidationError("email is malformed — missing local part or domain", "email");
+  }
+  return email;
+}
+
+export function validateThreadId(threadId) {
+  if (typeof threadId !== "string" || threadId.length === 0) {
+    throw new AccessValidationError("threadId must be a non-empty string", "threadId");
+  }
+  if (threadId.length > MAX_THREAD_ID_LENGTH) {
+    throw new AccessValidationError(`threadId exceeds max length of ${MAX_THREAD_ID_LENGTH}`, "threadId");
+  }
+  // Rejects path traversal (../), spaces, and any non-alphanumeric except _ and -
+  if (!THREAD_ID_PATTERN.test(threadId)) {
+    throw new AccessValidationError("threadId contains illegal characters", "threadId");
+  }
+  return threadId;
+}
+
+export function validateAccessRequest(req) {
+  if (req === null || typeof req !== "object" || Array.isArray(req)) {
+    throw new AccessValidationError("access request must be a plain object", "request");
+  }
+  validateRole(req.role);
+  validateAccessLevel(req.accessLevel);
+  validateEmailAddress(req.requesterEmail);
+  validateThreadId(req.threadId);
+  return true;
+}
+
+// O(1) access check — builds a Set once per call so callers don't need to pre-compute
+export function checkAccess(role, accessLevel, policy) {
+  const allowedLevels = policy[role];
+  if (!Array.isArray(allowedLevels)) return false;
+  return new Set(allowedLevels).has(accessLevel);
+}
+
+// Reject oversized team arrays before any per-member role scan
+export function guardTeamSize(members) {
+  if (!Array.isArray(members)) {
+    throw new AccessValidationError("members must be an array", "members");
+  }
+  if (members.length > MAX_TEAM_SIZE) {
+    throw new AccessValidationError(
+      `team size ${members.length} exceeds safe limit of ${MAX_TEAM_SIZE} — paginate before scanning`,
+      "members"
+    );
+  }
+  return true;
+}
+
+// Reject oversized attachment lists before any role-based filter pass
+export function guardAttachmentCount(attachments) {
+  if (!Array.isArray(attachments)) {
+    throw new AccessValidationError("attachments must be an array", "attachments");
+  }
+  if (attachments.length > MAX_ATTACHMENT_COUNT) {
+    throw new AccessValidationError(
+      `attachment count ${attachments.length} exceeds safe limit of ${MAX_ATTACHMENT_COUNT} — paginate before filtering`,
+      "attachments"
+    );
+  }
+  return true;
+}
+
+export const LIMITS = {
+  MAX_ROLE_LENGTH,
+  MAX_THREAD_ID_LENGTH,
+  MAX_EMAIL_LENGTH,
+  MAX_TEAM_SIZE,
+  MAX_ATTACHMENT_COUNT,
+  ALLOWED_ROLES: [...ALLOWED_ROLES],
+  ALLOWED_ACCESS_LEVELS: [...ALLOWED_ACCESS_LEVELS],
+};

--- a/tools/v2/team/role-based-mail-access/guards/access-guards.mjs
+++ b/tools/v2/team/role-based-mail-access/guards/access-guards.mjs
@@ -19,7 +19,10 @@ export class AccessValidationError extends Error {
 
 export function sanitizeRole(raw) {
   if (typeof raw !== "string") return null;
-  return raw.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "");
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "");
 }
 
 export function validateRole(role) {
@@ -50,7 +53,10 @@ export function validateEmailAddress(email) {
     throw new AccessValidationError("email must be a non-empty string", "email");
   }
   if (email.length > MAX_EMAIL_LENGTH) {
-    throw new AccessValidationError(`email exceeds RFC 5321 max length of ${MAX_EMAIL_LENGTH}`, "email");
+    throw new AccessValidationError(
+      `email exceeds RFC 5321 max length of ${MAX_EMAIL_LENGTH}`,
+      "email",
+    );
   }
   // Reject header injection characters before any further processing
   if (/[\r\n\0]/.test(email)) {
@@ -68,7 +74,10 @@ export function validateThreadId(threadId) {
     throw new AccessValidationError("threadId must be a non-empty string", "threadId");
   }
   if (threadId.length > MAX_THREAD_ID_LENGTH) {
-    throw new AccessValidationError(`threadId exceeds max length of ${MAX_THREAD_ID_LENGTH}`, "threadId");
+    throw new AccessValidationError(
+      `threadId exceeds max length of ${MAX_THREAD_ID_LENGTH}`,
+      "threadId",
+    );
   }
   // Rejects path traversal (../), spaces, and any non-alphanumeric except _ and -
   if (!THREAD_ID_PATTERN.test(threadId)) {
@@ -103,7 +112,7 @@ export function guardTeamSize(members) {
   if (members.length > MAX_TEAM_SIZE) {
     throw new AccessValidationError(
       `team size ${members.length} exceeds safe limit of ${MAX_TEAM_SIZE} — paginate before scanning`,
-      "members"
+      "members",
     );
   }
   return true;
@@ -117,7 +126,7 @@ export function guardAttachmentCount(attachments) {
   if (attachments.length > MAX_ATTACHMENT_COUNT) {
     throw new AccessValidationError(
       `attachment count ${attachments.length} exceeds safe limit of ${MAX_ATTACHMENT_COUNT} — paginate before filtering`,
-      "attachments"
+      "attachments",
     );
   }
   return true;

--- a/tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+++ b/tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  AccessValidationError,
+  sanitizeRole,
+  validateRole,
+  validateAccessLevel,
+  validateEmailAddress,
+  validateThreadId,
+  validateAccessRequest,
+  checkAccess,
+  guardTeamSize,
+  guardAttachmentCount,
+  LIMITS,
+} from "../guards/access-guards.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-access-requests.json");
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+// --- sanitizeRole ---
+
+test("sanitizeRole strips whitespace and lowercases", () => {
+  assert.equal(sanitizeRole("  Admin  "), "admin");
+});
+
+test("sanitizeRole removes non-alphanumeric characters except _ and -", () => {
+  assert.equal(sanitizeRole("admin; DROP TABLE"), "admindroptable");
+});
+
+test("sanitizeRole returns null for non-string input", () => {
+  assert.equal(sanitizeRole(null), null);
+  assert.equal(sanitizeRole(42), null);
+});
+
+// --- validateRole ---
+
+test("validateRole accepts all allowed roles", () => {
+  for (const role of LIMITS.ALLOWED_ROLES) {
+    assert.equal(validateRole(role), role);
+  }
+});
+
+test("validateRole throws for null and empty string", () => {
+  assert.throws(() => validateRole(null), AccessValidationError);
+  assert.throws(() => validateRole(""), AccessValidationError);
+});
+
+test("validateRole throws for unknown roles", () => {
+  assert.throws(() => validateRole("superadmin"), AccessValidationError);
+  assert.throws(() => validateRole("ADMIN"), AccessValidationError);
+});
+
+test("validateRole throws for oversized role string", () => {
+  assert.throws(() => validateRole("a".repeat(LIMITS.MAX_ROLE_LENGTH + 1)), AccessValidationError);
+});
+
+// --- validateAccessLevel ---
+
+test("validateAccessLevel accepts all allowed levels", () => {
+  for (const level of LIMITS.ALLOWED_ACCESS_LEVELS) {
+    assert.equal(validateAccessLevel(level), level);
+  }
+});
+
+test("validateAccessLevel throws for unknown levels", () => {
+  assert.throws(() => validateAccessLevel("superwrite"), AccessValidationError);
+  assert.throws(() => validateAccessLevel("*"), AccessValidationError);
+});
+
+// --- validateEmailAddress ---
+
+test("validateEmailAddress accepts well-formed addresses", () => {
+  assert.equal(validateEmailAddress("alice@example.test"), "alice@example.test");
+  assert.equal(validateEmailAddress("a+tag@sub.domain.test"), "a+tag@sub.domain.test");
+});
+
+test("validateEmailAddress throws for CRLF header injection", () => {
+  assert.throws(() => validateEmailAddress("user@evil.test\r\nBcc: victim@example.test"), AccessValidationError);
+  assert.throws(() => validateEmailAddress("user@evil.test\nX-Injected: yes"), AccessValidationError);
+});
+
+test("validateEmailAddress throws for null byte", () => {
+  assert.throws(() => validateEmailAddress("user\0@evil.test"), AccessValidationError);
+});
+
+test("validateEmailAddress throws for missing local part or domain", () => {
+  assert.throws(() => validateEmailAddress("@missinglocal.test"), AccessValidationError);
+  assert.throws(() => validateEmailAddress("user@"), AccessValidationError);
+  assert.throws(() => validateEmailAddress("nodomain"), AccessValidationError);
+});
+
+test("validateEmailAddress throws for empty string", () => {
+  assert.throws(() => validateEmailAddress(""), AccessValidationError);
+});
+
+// --- validateThreadId ---
+
+test("validateThreadId accepts alphanumeric IDs with _ and -", () => {
+  assert.equal(validateThreadId("thread-support-001"), "thread-support-001");
+  assert.equal(validateThreadId("THREAD_001"), "THREAD_001");
+});
+
+test("validateThreadId throws for path traversal", () => {
+  assert.throws(() => validateThreadId("../../../secret"), AccessValidationError);
+});
+
+test("validateThreadId throws for spaces and special characters", () => {
+  assert.throws(() => validateThreadId("thread 001"), AccessValidationError);
+  assert.throws(() => validateThreadId("<script>alert(1)</script>"), AccessValidationError);
+});
+
+test("validateThreadId throws for oversized ID", () => {
+  assert.throws(() => validateThreadId("a".repeat(LIMITS.MAX_THREAD_ID_LENGTH + 1)), AccessValidationError);
+});
+
+// --- validateAccessRequest ---
+
+test("validateAccessRequest passes a well-formed request", () => {
+  assert.equal(
+    validateAccessRequest({
+      role: "manager",
+      accessLevel: "assign",
+      requesterEmail: "alice@example.test",
+      threadId: "thread-001",
+    }),
+    true
+  );
+});
+
+test("validateAccessRequest throws for non-object input", () => {
+  assert.throws(() => validateAccessRequest(null), AccessValidationError);
+  assert.throws(() => validateAccessRequest("admin"), AccessValidationError);
+  assert.throws(() => validateAccessRequest([]), AccessValidationError);
+});
+
+test("validateAccessRequest propagates field-level errors", () => {
+  assert.throws(
+    () => validateAccessRequest({ role: "ADMIN", accessLevel: "read", requesterEmail: "a@b.test", threadId: "t-001" }),
+    AccessValidationError
+  );
+});
+
+// --- checkAccess ---
+
+test("checkAccess grants access when policy allows it", async () => {
+  const { policy } = await loadFixture();
+  assert.equal(checkAccess("manager", "assign", policy), true);
+  assert.equal(checkAccess("admin", "delete", policy), true);
+  assert.equal(checkAccess("agent", "read", policy), true);
+});
+
+test("checkAccess denies access when policy does not allow it", async () => {
+  const { policy } = await loadFixture();
+  assert.equal(checkAccess("viewer", "write", policy), false);
+  assert.equal(checkAccess("agent", "delete", policy), false);
+  assert.equal(checkAccess("guest", "read", policy), false);
+});
+
+test("checkAccess returns false for unknown role in policy", async () => {
+  const { policy } = await loadFixture();
+  assert.equal(checkAccess("superadmin", "manage", policy), false);
+});
+
+// --- fixture: valid requests match policy ---
+
+test("all fixture valid requests resolve correctly against the policy", async () => {
+  const { validRequests, policy } = await loadFixture();
+  for (const req of validRequests) {
+    assert.doesNotThrow(() => validateAccessRequest(req), `${req.id} should pass validation`);
+    const granted = checkAccess(req.role, req.accessLevel, policy);
+    assert.equal(granted, req.expectGranted, `${req.id}: expected granted=${req.expectGranted}`);
+  }
+});
+
+// --- fixture: hostile inputs are all rejected ---
+
+test("all fixture hostile inputs are rejected by the appropriate guard", async () => {
+  const { hostileInputs } = await loadFixture();
+  const validators = {
+    role: validateRole,
+    accessLevel: validateAccessLevel,
+    email: validateEmailAddress,
+    threadId: validateThreadId,
+  };
+  for (const entry of hostileInputs) {
+    const fn = validators[entry.field];
+    assert.ok(fn, `no validator mapped for field "${entry.field}"`);
+    assert.throws(
+      () => fn(entry.value),
+      AccessValidationError,
+      `hostile input for ${entry.field} ("${entry.reason}") must throw AccessValidationError`
+    );
+  }
+});
+
+// --- performance guards ---
+
+test("guardTeamSize passes for arrays within the limit", () => {
+  assert.equal(guardTeamSize(new Array(LIMITS.MAX_TEAM_SIZE).fill({})), true);
+});
+
+test("guardTeamSize throws when team exceeds the safe limit", () => {
+  assert.throws(() => guardTeamSize(new Array(LIMITS.MAX_TEAM_SIZE + 1).fill({})), AccessValidationError);
+});
+
+test("guardTeamSize throws for non-array input", () => {
+  assert.throws(() => guardTeamSize(null), AccessValidationError);
+});
+
+test("guardAttachmentCount passes for arrays within the limit", () => {
+  assert.equal(guardAttachmentCount(new Array(LIMITS.MAX_ATTACHMENT_COUNT).fill({})), true);
+});
+
+test("guardAttachmentCount throws when attachment count exceeds the safe limit", () => {
+  assert.throws(() => guardAttachmentCount(new Array(LIMITS.MAX_ATTACHMENT_COUNT + 1).fill({})), AccessValidationError);
+});
+
+test("guardAttachmentCount throws for non-array input", () => {
+  assert.throws(() => guardAttachmentCount("not-an-array"), AccessValidationError);
+});

--- a/tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+++ b/tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
@@ -84,8 +84,14 @@ test("validateEmailAddress accepts well-formed addresses", () => {
 });
 
 test("validateEmailAddress throws for CRLF header injection", () => {
-  assert.throws(() => validateEmailAddress("user@evil.test\r\nBcc: victim@example.test"), AccessValidationError);
-  assert.throws(() => validateEmailAddress("user@evil.test\nX-Injected: yes"), AccessValidationError);
+  assert.throws(
+    () => validateEmailAddress("user@evil.test\r\nBcc: victim@example.test"),
+    AccessValidationError,
+  );
+  assert.throws(
+    () => validateEmailAddress("user@evil.test\nX-Injected: yes"),
+    AccessValidationError,
+  );
 });
 
 test("validateEmailAddress throws for null byte", () => {
@@ -119,7 +125,10 @@ test("validateThreadId throws for spaces and special characters", () => {
 });
 
 test("validateThreadId throws for oversized ID", () => {
-  assert.throws(() => validateThreadId("a".repeat(LIMITS.MAX_THREAD_ID_LENGTH + 1)), AccessValidationError);
+  assert.throws(
+    () => validateThreadId("a".repeat(LIMITS.MAX_THREAD_ID_LENGTH + 1)),
+    AccessValidationError,
+  );
 });
 
 // --- validateAccessRequest ---
@@ -132,7 +141,7 @@ test("validateAccessRequest passes a well-formed request", () => {
       requesterEmail: "alice@example.test",
       threadId: "thread-001",
     }),
-    true
+    true,
   );
 });
 
@@ -144,8 +153,14 @@ test("validateAccessRequest throws for non-object input", () => {
 
 test("validateAccessRequest propagates field-level errors", () => {
   assert.throws(
-    () => validateAccessRequest({ role: "ADMIN", accessLevel: "read", requesterEmail: "a@b.test", threadId: "t-001" }),
-    AccessValidationError
+    () =>
+      validateAccessRequest({
+        role: "ADMIN",
+        accessLevel: "read",
+        requesterEmail: "a@b.test",
+        threadId: "t-001",
+      }),
+    AccessValidationError,
   );
 });
 
@@ -197,7 +212,7 @@ test("all fixture hostile inputs are rejected by the appropriate guard", async (
     assert.throws(
       () => fn(entry.value),
       AccessValidationError,
-      `hostile input for ${entry.field} ("${entry.reason}") must throw AccessValidationError`
+      `hostile input for ${entry.field} ("${entry.reason}") must throw AccessValidationError`,
     );
   }
 });
@@ -209,7 +224,10 @@ test("guardTeamSize passes for arrays within the limit", () => {
 });
 
 test("guardTeamSize throws when team exceeds the safe limit", () => {
-  assert.throws(() => guardTeamSize(new Array(LIMITS.MAX_TEAM_SIZE + 1).fill({})), AccessValidationError);
+  assert.throws(
+    () => guardTeamSize(new Array(LIMITS.MAX_TEAM_SIZE + 1).fill({})),
+    AccessValidationError,
+  );
 });
 
 test("guardTeamSize throws for non-array input", () => {
@@ -221,7 +239,10 @@ test("guardAttachmentCount passes for arrays within the limit", () => {
 });
 
 test("guardAttachmentCount throws when attachment count exceeds the safe limit", () => {
-  assert.throws(() => guardAttachmentCount(new Array(LIMITS.MAX_ATTACHMENT_COUNT + 1).fill({})), AccessValidationError);
+  assert.throws(
+    () => guardAttachmentCount(new Array(LIMITS.MAX_ATTACHMENT_COUNT + 1).fill({})),
+    AccessValidationError,
+  );
 });
 
 test("guardAttachmentCount throws for non-array input", () => {


### PR DESCRIPTION
…performance notes

Adds a guard module with validation, sanitisation, and size-cap helpers for all role-based access inputs. Documents threat assumptions and unsafe input categories across role, email, and threadId fields. Adds performance guards for large team and attachment datasets. All changes are isolated to tools/v2/team/role-based-mail-access

closes #652 