### PR TITLE
feat(tools): add team-task-board-from-emails core logic

### DIFF
--- a/src/tools/v2/team/team-task-board-from-emails/README.md
+++ b/src/tools/v2/team/team-task-board-from-emails/README.md
@@ -1,0 +1,32 @@
+# team-task-board-from-emails
+
+Parses email threads into structured tasks for a team kanban board.
+Self-contained. No network calls, no external dependencies, no app integration.
+
+## Public API
+
+### parseEmailsToTasks(emails: EmailFixture[]): ParseResult
+
+Takes an array of email objects and returns extracted tasks.
+
+### groupByAssignee(tasks: Task[]): Record<string, Task[]>
+
+Groups tasks by assignee. Unassigned tasks are keyed as "unassigned".
+
+### groupByStatus(tasks: Task[]): Record<string, Task[]>
+
+Groups tasks by status for board column rendering.
+
+## States
+
+idle: no parse started
+parsing: parseEmailsToTasks running
+done: parse complete
+error: individual email failed (non-fatal)
+
+## Usage
+
+import { parseEmailsToTasks, groupByAssignee, mockEmails } from "./index";
+
+const { tasks, skipped } = parseEmailsToTasks(mockEmails);
+const board = groupByAssignee(tasks);

--- a/src/tools/v2/team/team-task-board-from-emails/fixtures.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/fixtures.ts
@@ -1,0 +1,44 @@
+import { EmailFixture } from "./types";
+
+export const mockEmails: EmailFixture[] = [
+  {
+    id: "email-001",
+    from: "amara@grantfox.io",
+    to: ["team@grantfox.io"],
+    subject: "Sprint kickoff tasks",
+    body: `Hi team,\n\nPlease make sure the following gets done this week:\n\n- Kofi needs to finish the onboarding flow by Friday 2024-02-09.\n- Bisi should review the payment integration PR by tomorrow.\n- Everyone: update your status in Notion by end of day.\n\nThanks,\nAmara`,
+    receivedAt: "2024-02-05T09:00:00Z",
+  },
+  {
+    id: "email-002",
+    from: "kofi@grantfox.io",
+    to: ["amara@grantfox.io"],
+    subject: "Re: design handoff",
+    body: `Amara,\n\nI'll handle the mobile responsive fixes. Target is 2024-02-12.\nCan you assign the accessibility audit to Bisi? No hard deadline yet.\n\nKofi`,
+    receivedAt: "2024-02-05T11:30:00Z",
+  },
+  {
+    id: "email-003",
+    from: "bisi@grantfox.io",
+    to: ["team@grantfox.io"],
+    subject: "Bug triage",
+    body: `Team,\n\nTwo things that need owners:\n\n1. Fix the CSV export crash — due 2024-02-08, assigning to Kofi.\n2. Write regression tests for the auth flow. Unassigned for now, due 2024-02-15.\n\nBisi`,
+    receivedAt: "2024-02-06T08:15:00Z",
+  },
+  {
+    id: "email-004",
+    from: "amara@grantfox.io",
+    to: ["kofi@grantfox.io"],
+    subject: "Quick reminder",
+    body: `Kofi, just a reminder to deploy the staging build before the call today.`,
+    receivedAt: "2024-02-06T10:00:00Z",
+  },
+  {
+    id: "email-005",
+    from: "noreply@calendar.app",
+    to: ["team@grantfox.io"],
+    subject: "Meeting invite: Weekly sync",
+    body: `You have been invited to Weekly Sync on 2024-02-07 at 10:00 AM.`,
+    receivedAt: "2024-02-06T12:00:00Z",
+  },
+];

--- a/src/tools/v2/team/team-task-board-from-emails/index.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/index.ts
@@ -1,3 +1,10 @@
 export { parseEmailsToTasks, groupByAssignee, groupByStatus } from "./parser";
 export { mockEmails } from "./fixtures";
-export type { EmailFixture, Task, TaskStatus, ParseResult, ParseError, LoadingState } from "./types";
+export type {
+  EmailFixture,
+  Task,
+  TaskStatus,
+  ParseResult,
+  ParseError,
+  LoadingState,
+} from "./types";

--- a/src/tools/v2/team/team-task-board-from-emails/index.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/index.ts
@@ -1,0 +1,3 @@
+export { parseEmailsToTasks, groupByAssignee, groupByStatus } from "./parser";
+export { mockEmails } from "./fixtures";
+export type { EmailFixture, Task, TaskStatus, ParseResult, ParseError, LoadingState } from "./types";

--- a/src/tools/v2/team/team-task-board-from-emails/parser.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/parser.ts
@@ -29,7 +29,7 @@ function extractAssignee(text: string, knownNames: string[]): string | null {
   for (const name of knownNames) {
     const pattern = new RegExp(
       `\\b${name}\\b.{0,40}(needs? to|should|will|handle)|(assigning to\\s+${name})`,
-      "i"
+      "i",
     );
     if (pattern.test(text)) return name;
   }
@@ -40,16 +40,14 @@ function extractNames(emails: EmailFixture[]): string[] {
   const raw = emails.flatMap((e) => [e.from, ...e.to]);
   return [
     ...new Set(
-      raw
-        .map((addr) => addr.split("@")[0])
-        .map((n) => n.charAt(0).toUpperCase() + n.slice(1))
+      raw.map((addr) => addr.split("@")[0]).map((n) => n.charAt(0).toUpperCase() + n.slice(1)),
     ),
   ];
 }
 
 function parseEmail(
   email: EmailFixture,
-  knownNames: string[]
+  knownNames: string[],
 ): { tasks: Task[]; error: ParseError | null } {
   const lines = email.body
     .split("\n")

--- a/src/tools/v2/team/team-task-board-from-emails/parser.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/parser.ts
@@ -1,0 +1,108 @@
+import { EmailFixture, Task, ParseResult, ParseError } from "./types";
+
+const DATE_PATTERN = /\b(\d{4}-\d{2}-\d{2})\b/g;
+
+const ACTION_PATTERNS = [
+  /\b(needs? to|should|must|please|will handle|assigning to|assign)\b/i,
+  /\b(fix|finish|review|update|deploy|write|handle|complete)\b/i,
+];
+
+const NOISE_PATTERNS = [
+  /^(hi|hey|hello|thanks|regards|cheers|dear)\b/i,
+  /^you have been invited/i,
+  /^re:/i,
+];
+
+function isActionable(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.length < 10) return false;
+  if (NOISE_PATTERNS.some((p) => p.test(trimmed))) return false;
+  return ACTION_PATTERNS.some((p) => p.test(trimmed));
+}
+
+function extractDate(text: string): string | null {
+  const match = text.match(DATE_PATTERN);
+  return match ? match[0] : null;
+}
+
+function extractAssignee(text: string, knownNames: string[]): string | null {
+  for (const name of knownNames) {
+    const pattern = new RegExp(
+      `\\b${name}\\b.{0,40}(needs? to|should|will|handle)|(assigning to\\s+${name})`,
+      "i"
+    );
+    if (pattern.test(text)) return name;
+  }
+  return null;
+}
+
+function extractNames(emails: EmailFixture[]): string[] {
+  const raw = emails.flatMap((e) => [e.from, ...e.to]);
+  return [
+    ...new Set(
+      raw
+        .map((addr) => addr.split("@")[0])
+        .map((n) => n.charAt(0).toUpperCase() + n.slice(1))
+    ),
+  ];
+}
+
+function parseEmail(
+  email: EmailFixture,
+  knownNames: string[]
+): { tasks: Task[]; error: ParseError | null } {
+  const lines = email.body
+    .split("\n")
+    .map((l) => l.replace(/^[-\d.)\s]+/, "").trim())
+    .filter(isActionable);
+
+  if (lines.length === 0) {
+    return { tasks: [], error: { emailId: email.id, reason: "no actionable lines found" } };
+  }
+
+  const tasks: Task[] = lines.map((line, i) => ({
+    id: `${email.id}-task-${i}`,
+    title: line.length > 80 ? line.slice(0, 77) + "..." : line,
+    assignee: extractAssignee(line, knownNames),
+    dueDate: extractDate(line),
+    status: "todo",
+    sourceEmailId: email.id,
+    raw: line,
+  }));
+
+  return { tasks, error: null };
+}
+
+export function parseEmailsToTasks(emails: EmailFixture[]): ParseResult {
+  const knownNames = extractNames(emails);
+  const allTasks: Task[] = [];
+  let skipped = 0;
+
+  for (const email of emails) {
+    const { tasks, error } = parseEmail(email, knownNames);
+    if (error || tasks.length === 0) {
+      skipped++;
+    } else {
+      allTasks.push(...tasks);
+    }
+  }
+
+  return { tasks: allTasks, skipped };
+}
+
+export function groupByAssignee(tasks: Task[]): Record<string, Task[]> {
+  return tasks.reduce<Record<string, Task[]>>((acc, task) => {
+    const key = task.assignee ?? "unassigned";
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(task);
+    return acc;
+  }, {});
+}
+
+export function groupByStatus(tasks: Task[]): Record<string, Task[]> {
+  return tasks.reduce<Record<string, Task[]>>((acc, task) => {
+    if (!acc[task.status]) acc[task.status] = [];
+    acc[task.status].push(task);
+    return acc;
+  }, {});
+}

--- a/src/tools/v2/team/team-task-board-from-emails/types.ts
+++ b/src/tools/v2/team/team-task-board-from-emails/types.ts
@@ -1,0 +1,32 @@
+export type TaskStatus = "todo" | "in-progress" | "done";
+
+export interface EmailFixture {
+  id: string;
+  from: string;
+  to: string[];
+  subject: string;
+  body: string;
+  receivedAt: string;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  assignee: string | null;
+  dueDate: string | null;
+  status: TaskStatus;
+  sourceEmailId: string;
+  raw: string;
+}
+
+export interface ParseResult {
+  tasks: Task[];
+  skipped: number;
+}
+
+export type LoadingState = "idle" | "parsing" | "done" | "error";
+
+export interface ParseError {
+  emailId: string;
+  reason: string;
+}


### PR DESCRIPTION
## What this does
Implements the core logic for the Team Task Board from Emails tool.

Parses email threads into structured tasks with assignee, due date, and status fields.

## Files added
All files are isolated inside `src/tools/v2/team/team-task-board-from-emails/`:

- `types.ts` — shared types (EmailFixture, Task, ParseResult, etc.)
- `fixtures.ts` — 5 deterministic mock emails for local development
- `parser.ts` — core email-to-task extraction logic
- `index.ts` — folder-local public API surface
- `README.md` — documents inputs, outputs, and states

## Notes
- No app integration
- No live network calls
- No modifications to existing architecture
- Self-contained, reviewable as a standalone unit