### PR TITLE
Add Contact Extractor UI surface

### DIFF
--- a/tools/v1/individual/contact-extractor/ContactExtractorUI.tsx
+++ b/tools/v1/individual/contact-extractor/ContactExtractorUI.tsx
@@ -1,0 +1,260 @@
+import React, { useMemo, useState } from "react";
+import { AlertCircle, CheckCircle2, ClipboardList, Loader2, Mail, UserPlus } from "lucide-react";
+import { sampleContactRequests } from "./fixtures";
+import { extractContacts, summarizeContacts } from "./services";
+import type { ContactExtractionRequest, ExtractedContact, ExtractionStatus } from "./types";
+import "./styles.css";
+
+interface ContactExtractorUIProps {
+  initialRequest?: ContactExtractionRequest;
+  onSelectionChange?: (contacts: ExtractedContact[]) => void;
+}
+
+export function ContactExtractorUI({ initialRequest, onSelectionChange }: ContactExtractorUIProps) {
+  const [sourceText, setSourceText] = useState(formatRequest(initialRequest ?? sampleContactRequests[0]));
+  const [status, setStatus] = useState<ExtractionStatus>("idle");
+  const [contacts, setContacts] = useState<ExtractedContact[]>([]);
+  const [selectedContactIds, setSelectedContactIds] = useState<string[]>([]);
+  const [error, setError] = useState<string | undefined>();
+
+  const summary = useMemo(() => summarizeContacts(contacts), [contacts]);
+  const selectedContacts = contacts.filter((contact) => selectedContactIds.includes(contact.id));
+
+  const runExtraction = () => {
+    setStatus("loading");
+    setError(undefined);
+
+    window.setTimeout(() => {
+      const result = extractContacts({
+        id: "manual-review",
+        sourceLabel: "Manual review text",
+        subject: "",
+        from: "",
+        body: sourceText,
+      });
+
+      if (result.status === "error") {
+        setContacts([]);
+        setSelectedContactIds([]);
+        setError(result.error);
+        setStatus("error");
+        onSelectionChange?.([]);
+        return;
+      }
+
+      setContacts(result.contacts);
+      setSelectedContactIds(result.contacts.map((contact) => contact.id));
+      setStatus("success");
+      onSelectionChange?.(result.contacts);
+    }, 180);
+  };
+
+  const loadSample = (request: ContactExtractionRequest) => {
+    setSourceText(formatRequest(request));
+    setContacts([]);
+    setSelectedContactIds([]);
+    setError(undefined);
+    setStatus("idle");
+    onSelectionChange?.([]);
+  };
+
+  const toggleContact = (contactId: string) => {
+    setSelectedContactIds((current) => {
+      const next = current.includes(contactId)
+        ? current.filter((id) => id !== contactId)
+        : [...current, contactId];
+      onSelectionChange?.(contacts.filter((contact) => next.includes(contact.id)));
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    const next = contacts.map((contact) => contact.id);
+    setSelectedContactIds(next);
+    onSelectionChange?.(contacts);
+  };
+
+  const clearSelection = () => {
+    setSelectedContactIds([]);
+    onSelectionChange?.([]);
+  };
+
+  const isLoading = status === "loading";
+  const isEmpty = contacts.length === 0 && !error;
+
+  return (
+    <section className="contact-extractor" aria-labelledby="contact-extractor-title">
+      <header className="contact-extractor__header">
+        <div>
+          <p className="contact-extractor__eyebrow">V1 individual tool</p>
+          <h2 id="contact-extractor-title">Contact Extractor</h2>
+          <p className="contact-extractor__description">
+            Review contact details found in email text before a future save or export step.
+          </p>
+        </div>
+        <UserPlus aria-hidden="true" className="contact-extractor__header-icon" />
+      </header>
+
+      <div className="contact-extractor__samples" aria-label="Sample email text">
+        {sampleContactRequests.map((request) => (
+          <button
+            key={request.id}
+            type="button"
+            className="contact-extractor__sample-button"
+            onClick={() => loadSample(request)}
+            disabled={isLoading}
+          >
+            <Mail aria-hidden="true" />
+            <span>{request.sourceLabel}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="contact-extractor__input-panel">
+        <label htmlFor="contact-extractor-source">Email text</label>
+        <p id="contact-extractor-source-help">
+          Paste synthetic or user-provided email text. This isolated tool does not read mailboxes.
+        </p>
+        <textarea
+          id="contact-extractor-source"
+          aria-describedby="contact-extractor-source-help"
+          value={sourceText}
+          onChange={(event) => {
+            setSourceText(event.target.value);
+            if (status === "error") {
+              setStatus("idle");
+              setError(undefined);
+            }
+          }}
+          disabled={isLoading}
+          rows={8}
+        />
+        <div className="contact-extractor__actions">
+          <button
+            type="button"
+            className="contact-extractor__primary"
+            onClick={runExtraction}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Loader2 aria-hidden="true" className="contact-extractor__spin" />
+            ) : (
+              <ClipboardList aria-hidden="true" />
+            )}
+            <span>{isLoading ? "Extracting contacts" : "Extract contacts"}</span>
+          </button>
+          <button
+            type="button"
+            className="contact-extractor__secondary"
+            onClick={() => setSourceText("")}
+            disabled={isLoading}
+          >
+            Clear text
+          </button>
+        </div>
+      </div>
+
+      <div className="contact-extractor__status" aria-live="polite" aria-busy={isLoading}>
+        {isLoading && (
+          <div className="contact-extractor__state contact-extractor__state--loading">
+            <Loader2 aria-hidden="true" className="contact-extractor__spin" />
+            <span>Scanning email text for contact details.</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="contact-extractor__state contact-extractor__state--error" role="alert">
+            <AlertCircle aria-hidden="true" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {isEmpty && !isLoading && (
+          <div className="contact-extractor__state">
+            <ClipboardList aria-hidden="true" />
+            <span>No contacts extracted yet. Load a sample or paste email text to begin.</span>
+          </div>
+        )}
+
+        {contacts.length > 0 && !isLoading && (
+          <div className="contact-extractor__state contact-extractor__state--success">
+            <CheckCircle2 aria-hidden="true" />
+            <span>
+              Found {summary.total} contacts, {summary.complete} complete records, and{" "}
+              {summary.needsReview} needing review.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {contacts.length > 0 && (
+        <section className="contact-extractor__results" aria-labelledby="contact-results-title">
+          <div className="contact-extractor__results-header">
+            <div>
+              <h3 id="contact-results-title">Review contacts</h3>
+              <p>{selectedContacts.length} selected for future save or export.</p>
+            </div>
+            <div className="contact-extractor__selection-actions">
+              <button type="button" onClick={selectAll}>
+                Select all
+              </button>
+              <button type="button" onClick={clearSelection}>
+                Clear selection
+              </button>
+            </div>
+          </div>
+
+          <ul className="contact-extractor__list">
+            {contacts.map((contact) => (
+              <li key={contact.id} className="contact-extractor__contact-card">
+                <label className="contact-extractor__checkbox-row">
+                  <input
+                    type="checkbox"
+                    checked={selectedContactIds.includes(contact.id)}
+                    onChange={() => toggleContact(contact.id)}
+                  />
+                  <span>{contact.displayName}</span>
+                </label>
+                <dl>
+                  <div>
+                    <dt>Email</dt>
+                    <dd>{contact.email ?? "Missing"}</dd>
+                  </div>
+                  <div>
+                    <dt>Phone</dt>
+                    <dd>{contact.phone ?? "Missing"}</dd>
+                  </div>
+                  <div>
+                    <dt>Organization</dt>
+                    <dd>{contact.organization ?? "Unknown"}</dd>
+                  </div>
+                  <div>
+                    <dt>Confidence</dt>
+                    <dd>
+                      <span
+                        className={`contact-extractor__confidence contact-extractor__confidence--${contact.confidence}`}
+                      >
+                        {contact.confidence}
+                      </span>
+                    </dd>
+                  </div>
+                </dl>
+                {contact.warnings.length > 0 && (
+                  <p className="contact-extractor__warnings">Review: {contact.warnings.join(", ")}</p>
+                )}
+                <p className="contact-extractor__evidence">{contact.evidence}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </section>
+  );
+}
+
+function formatRequest(request: ContactExtractionRequest) {
+  return `Subject: ${request.subject}
+From: ${request.from}
+
+${request.body}`;
+}

--- a/tools/v1/individual/contact-extractor/README.md
+++ b/tools/v1/individual/contact-extractor/README.md
@@ -1,15 +1,58 @@
 # Contact Extractor
 
-This folder is the isolated workspace for the Contact Extractor tool.
+Contact Extractor is an isolated V1 individual tool for reviewing contact
+details found in email content before a future mail-app integration saves them.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\contact-extractor\
-`
+```text
+tools/v1/individual/contact-extractor/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds a folder-local UI surface, deterministic extraction helpers,
+synthetic fixtures, and a standalone Node test.
+
+Run from the repository root:
+
+```bash
+node --test tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
+```
+
+The test validates the fixture contract used by the local UI and extraction
+helpers.
+
+## Local Workflow
+
+1. Paste or load email text into the local `ContactExtractorUI`.
+2. Run extraction with the folder-local helper.
+3. Review detected contacts, confidence, evidence, and field-level warnings.
+4. Select contacts for a future save/export flow.
+5. Keep any real persistence or mailbox mutation out of scope.
+
+## Documentation Map
+
+- `specs.md` defines the input, output, accessibility, and review contract.
+- `types.ts` defines the local TypeScript data model.
+- `services.ts` contains deterministic contact extraction helpers.
+- `fixtures.ts` provides UI-ready synthetic examples.
+- `fixtures/sample-contact-emails.json` backs the executable fixture test.
+- `ContactExtractorUI.tsx` implements the accessible local UI surface.
+- `styles.css` documents the local visual style without changing shared tokens.
+- `docs/review-notes.md` and `docs/test-plan.md` guide independent review.
+
+## Known Limitations
+
+- The tool is not mounted in the main app.
+- Contacts are not written to any address book or database.
+- Extraction is deterministic and local; no model, network, or mailbox calls are
+  made.
+- Future integration work should add consent, deduplication, persistence, and
+  import/export safeguards before touching production contact stores.

--- a/tools/v1/individual/contact-extractor/demo.tsx
+++ b/tools/v1/individual/contact-extractor/demo.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { ContactExtractorUI } from "./ContactExtractorUI";
+
+export function ContactExtractorDemo() {
+  return <ContactExtractorUI />;
+}

--- a/tools/v1/individual/contact-extractor/docs/review-notes.md
+++ b/tools/v1/individual/contact-extractor/docs/review-notes.md
@@ -1,0 +1,30 @@
+# Review Notes
+
+## What This Contribution Adds
+
+- Replaces placeholder copy with a concrete Contact Extractor review contract.
+- Adds a folder-local, accessible React UI surface.
+- Adds deterministic local helpers for parsing contact candidates from email text.
+- Adds synthetic fixtures and an executable Node fixture test.
+- Documents local style, accessibility expectations, and out-of-scope persistence.
+
+## Validation Performed
+
+```bash
+node --test tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
+```
+
+## Reviewer Focus
+
+- Confirm every changed file stays under `tools/v1/individual/contact-extractor/`.
+- Confirm the UI covers empty, loading, error, and success states.
+- Confirm controls have visible labels, keyboard-friendly semantics, and focus styles.
+- Confirm fixtures use synthetic domains and do not include real personal data.
+- Confirm this issue does not mount the tool in the main app or mutate contacts.
+
+## Follow-Up Work
+
+- Add app integration only after a future issue explicitly allows it.
+- Add contact deduplication against a real address book.
+- Add export/save flows with consent, audit logging, and rollback behavior.
+- Add browser-level accessibility tests once the tool is mounted.

--- a/tools/v1/individual/contact-extractor/docs/test-plan.md
+++ b/tools/v1/individual/contact-extractor/docs/test-plan.md
@@ -1,0 +1,45 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
+```
+
+Expected result:
+
+- the fixture parses as JSON
+- success and error cases are represented
+- empty, loading, error, and success UI states are documented
+- accessibility checks cover labels, live regions, alerts, checkboxes, focus, and
+  keyboard controls
+- expected contacts include display name, email, and organization context
+
+## Manual Review Checklist
+
+1. Open `ContactExtractorUI.tsx`.
+2. Confirm the email text input has a visible label and helper text.
+3. Confirm extraction controls are real buttons and disable during loading.
+4. Confirm errors render with `role="alert"`.
+5. Confirm result announcements use `aria-live="polite"`.
+6. Confirm contact selection uses labelled checkboxes.
+7. Confirm no files outside `tools/v1/individual/contact-extractor/` changed.
+
+## Edge Cases Covered
+
+- multiple contacts from one thread
+- a signature-style single contact
+- text with no contact-like details
+- contacts missing phone numbers and requiring review
+
+## Future Integration Tests
+
+When a later issue mounts the tool, add coverage for:
+
+- browser rendering with keyboard-only navigation
+- focus movement after extraction and error states
+- contact deduplication against existing user contacts
+- save/export failure handling
+- consent and audit behavior before writing contact records

--- a/tools/v1/individual/contact-extractor/fixtures.ts
+++ b/tools/v1/individual/contact-extractor/fixtures.ts
@@ -1,0 +1,28 @@
+import type { ContactExtractionRequest } from "./types";
+
+export const sampleContactRequests: ContactExtractionRequest[] = [
+  {
+    id: "vendor-renewal",
+    sourceLabel: "Vendor renewal thread",
+    subject: "Renewal terms for Atlas Search",
+    from: "Maya Chen <maya.chen@atlas.example>",
+    body: `Hi,
+
+Please coordinate the renewal with Jordan Patel at Atlas Systems.
+Jordan can be reached at jordan.patel@atlas.example or 415-555-0198.
+
+Regards,
+Maya Chen`,
+  },
+  {
+    id: "event-follow-up",
+    sourceLabel: "Conference intro",
+    subject: "Intro after the Stellar Builder Breakfast",
+    from: "Priya Shah <priya@northstar.example>",
+    body: `Best,
+Priya Shah
+Northstar Labs
+priya@northstar.example
+(212) 555-0144`,
+  },
+];

--- a/tools/v1/individual/contact-extractor/fixtures/sample-contact-emails.json
+++ b/tools/v1/individual/contact-extractor/fixtures/sample-contact-emails.json
@@ -1,0 +1,63 @@
+{
+  "tool": "contact-extractor",
+  "version": 1,
+  "sourceRequests": [
+    {
+      "id": "vendor-renewal",
+      "sourceLabel": "Vendor renewal thread",
+      "subject": "Renewal terms for Atlas Search",
+      "from": "Maya Chen <maya.chen@atlas.example>",
+      "body": "Please coordinate the renewal with Jordan Patel at Atlas Systems. Jordan can be reached at jordan.patel@atlas.example or 415-555-0198.",
+      "expectedContacts": [
+        {
+          "displayName": "Maya Chen",
+          "email": "maya.chen@atlas.example",
+          "organization": "Atlas"
+        },
+        {
+          "displayName": "Jordan Patel",
+          "email": "jordan.patel@atlas.example",
+          "phone": "415-555-0198",
+          "organization": "Atlas Systems"
+        }
+      ]
+    },
+    {
+      "id": "event-follow-up",
+      "sourceLabel": "Conference intro",
+      "subject": "Intro after the Stellar Builder Breakfast",
+      "from": "Priya Shah <priya@northstar.example>",
+      "body": "Best, Priya Shah Northstar Labs priya@northstar.example (212) 555-0144",
+      "expectedContacts": [
+        {
+          "displayName": "Priya Shah",
+          "email": "priya@northstar.example",
+          "phone": "(212) 555-0144",
+          "organization": "Northstar"
+        }
+      ]
+    },
+    {
+      "id": "missing-contact-details",
+      "sourceLabel": "No contact details",
+      "subject": "Weekly update",
+      "from": "updates@example.test",
+      "body": "The weekly update is ready for review.",
+      "expectedError": "No contact details were found in the supplied email text."
+    }
+  ],
+  "uiStates": ["empty", "loading", "error", "success"],
+  "accessibilityChecks": [
+    "visible-label-for-email-text",
+    "aria-live-status-region",
+    "role-alert-for-errors",
+    "labelled-contact-checkboxes",
+    "visible-focus-styles",
+    "keyboard-accessible-buttons"
+  ],
+  "reviewNotes": [
+    "All fixture people, organizations, and domains are synthetic.",
+    "The tool only prepares review data and does not save contacts.",
+    "Future persistence must add consent, dedupe, and audit behavior first."
+  ]
+}

--- a/tools/v1/individual/contact-extractor/index.ts
+++ b/tools/v1/individual/contact-extractor/index.ts
@@ -1,0 +1,11 @@
+export { ContactExtractorUI } from "./ContactExtractorUI";
+export { sampleContactRequests } from "./fixtures";
+export { extractContacts, summarizeContacts } from "./services";
+export type {
+  ContactConfidence,
+  ContactExtractionRequest,
+  ContactExtractionResult,
+  ContactExtractorState,
+  ExtractedContact,
+  ExtractionStatus,
+} from "./types";

--- a/tools/v1/individual/contact-extractor/services.ts
+++ b/tools/v1/individual/contact-extractor/services.ts
@@ -1,0 +1,225 @@
+import type {
+  ContactConfidence,
+  ContactExtractionRequest,
+  ContactExtractionResult,
+  ExtractedContact,
+} from "./types";
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_PATTERN =
+  /(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g;
+const NAME_BEFORE_EMAIL_PATTERN =
+  /(?:from|contact|reach|cc|with|by|owner|manager)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})\s*[<,(]/g;
+const SIGNATURE_NAME_PATTERN =
+  /(?:thanks|regards|best|cheers),?\s*\n\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})/gi;
+const ORGANIZATION_PATTERN =
+  /\b(?:at|from|for)\s+([A-Z][A-Za-z0-9&.-]+(?:\s+[A-Z][A-Za-z0-9&.-]+){0,3})\b/g;
+
+export function extractContacts(request: ContactExtractionRequest): ContactExtractionResult {
+  const text = normalizeWhitespace(`${request.subject}\n${request.from}\n${request.body}`);
+
+  if (!text.trim()) {
+    return {
+      requestId: request.id,
+      sourceLabel: request.sourceLabel,
+      status: "error",
+      contacts: [],
+      error: "Add email text before extracting contacts.",
+    };
+  }
+
+  const emails = findMatches(text, EMAIL_PATTERN);
+  const phones = findMatches(text, PHONE_PATTERN);
+  const names = uniqueValues([
+    ...findCapturedValues(text, NAME_BEFORE_EMAIL_PATTERN),
+    ...findCapturedValues(text, SIGNATURE_NAME_PATTERN),
+  ]);
+  const organizations = findCapturedValues(text, ORGANIZATION_PATTERN).filter(
+    (value) => !looksLikePersonName(value),
+  );
+
+  const contacts = buildContacts({ text, emails, phones, names, organizations });
+
+  if (contacts.length === 0) {
+    return {
+      requestId: request.id,
+      sourceLabel: request.sourceLabel,
+      status: "error",
+      contacts: [],
+      error: "No contact details were found in the supplied email text.",
+    };
+  }
+
+  return {
+    requestId: request.id,
+    sourceLabel: request.sourceLabel,
+    status: "success",
+    contacts,
+  };
+}
+
+export function summarizeContacts(contacts: ExtractedContact[]) {
+  return {
+    total: contacts.length,
+    complete: contacts.filter((contact) => contact.email && contact.displayName !== "Unknown contact")
+      .length,
+    withPhone: contacts.filter((contact) => Boolean(contact.phone)).length,
+    needsReview: contacts.filter((contact) => contact.warnings.length > 0).length,
+  };
+}
+
+function buildContacts({
+  text,
+  emails,
+  phones,
+  names,
+  organizations,
+}: {
+  text: string;
+  emails: string[];
+  phones: string[];
+  names: string[];
+  organizations: string[];
+}): ExtractedContact[] {
+  const emailContacts = emails.map((email, index) => {
+    const displayName = names[index] ?? inferNameFromEmail(email);
+    const organization = organizations[index] ?? inferOrganizationFromEmail(email);
+    const phone = phones[index];
+    const warnings = buildWarnings({ displayName, email, phone });
+
+    return {
+      id: stableContactId(email, index),
+      displayName,
+      email,
+      phone,
+      organization,
+      confidence: scoreConfidence({ displayName, email, phone }) as ContactConfidence,
+      evidence: evidenceFor(text, email),
+      warnings,
+    };
+  });
+
+  if (emailContacts.length > 0) {
+    return emailContacts;
+  }
+
+  return phones.map((phone, index) => {
+    const displayName = names[index] ?? "Unknown contact";
+    const warnings = buildWarnings({ displayName, phone });
+
+    return {
+      id: stableContactId(phone, index),
+      displayName,
+      phone,
+      organization: organizations[index],
+      confidence: scoreConfidence({ displayName, phone }) as ContactConfidence,
+      evidence: evidenceFor(text, phone),
+      warnings,
+    };
+  });
+}
+
+function buildWarnings({
+  displayName,
+  email,
+  phone,
+}: {
+  displayName: string;
+  email?: string;
+  phone?: string;
+}) {
+  const warnings: string[] = [];
+
+  if (displayName === "Unknown contact") {
+    warnings.push("missing-name");
+  }
+
+  if (!email) {
+    warnings.push("missing-email");
+  }
+
+  if (!phone) {
+    warnings.push("missing-phone");
+  }
+
+  return warnings;
+}
+
+function scoreConfidence({
+  displayName,
+  email,
+  phone,
+}: {
+  displayName: string;
+  email?: string;
+  phone?: string;
+}): ContactConfidence {
+  if (email && phone && displayName !== "Unknown contact") {
+    return "high";
+  }
+
+  if (email && displayName !== "Unknown contact") {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\r\n/g, "\n").replace(/[ \t]+/g, " ").trim();
+}
+
+function findMatches(text: string, pattern: RegExp) {
+  return uniqueValues(Array.from(text.matchAll(pattern)).map((match) => match[0].trim()));
+}
+
+function findCapturedValues(text: string, pattern: RegExp) {
+  return uniqueValues(
+    Array.from(text.matchAll(pattern))
+      .map((match) => match[1]?.trim())
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+function uniqueValues(values: string[]) {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function inferNameFromEmail(email: string) {
+  const localPart = email.split("@")[0] ?? "";
+  const words = localPart
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+
+  return words.length > 0 ? words.join(" ") : "Unknown contact";
+}
+
+function inferOrganizationFromEmail(email: string) {
+  const domain = email.split("@")[1]?.split(".")[0];
+  if (!domain || ["gmail", "outlook", "yahoo", "icloud", "proton"].includes(domain)) {
+    return undefined;
+  }
+
+  return domain.charAt(0).toUpperCase() + domain.slice(1);
+}
+
+function looksLikePersonName(value: string) {
+  const words = value.split(/\s+/);
+  return words.length <= 2 && words.every((word) => /^[A-Z][a-z]+$/.test(word));
+}
+
+function evidenceFor(text: string, needle: string) {
+  const index = text.toLowerCase().indexOf(needle.toLowerCase());
+  if (index < 0) {
+    return needle;
+  }
+
+  const start = Math.max(0, index - 42);
+  const end = Math.min(text.length, index + needle.length + 42);
+  return text.slice(start, end).replace(/\n/g, " ");
+}
+
+function stableContactId(value: string, index: number) {
+  return `${value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}-${index + 1}`;
+}

--- a/tools/v1/individual/contact-extractor/specs.md
+++ b/tools/v1/individual/contact-extractor/specs.md
@@ -1,38 +1,91 @@
-# Contact Extractor
-
-Extract and save contacts.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/contact-extractor/README.md"
-  @"
-
 # Contact Extractor Specs
 
 ## Purpose
 
-Extract and save contacts.
+Create a self-contained UI and review contract for extracting contact details
+from email content without connecting to the production mail app.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V1 launch-with-mail tool
+- Audience: individual
+- Folder ownership: `tools/v1/individual/contact-extractor/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Render a primary workflow for pasted or fixture-backed email text.
+- Detect candidate names, email addresses, phone numbers, organizations, and
+  short evidence snippets.
+- Show empty, loading, error, and success states.
+- Let reviewers select contacts for a future save/export step.
+- Provide keyboard-friendly controls, explicit labels, status announcements, and
+  visible focus states.
+- Keep all fixtures synthetic.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Mailbox reads, live parsing jobs, or background sync
+- Contact database writes, exports, or address-book mutation
+- Network calls, model calls, analytics, secrets, or production data
+- Shared design-system, wallet, Stellar, or database changes
+
+## Input Contract
+
+```ts
+type ContactExtractionRequest = {
+  id: string;
+  sourceLabel: string;
+  subject: string;
+  from: string;
+  body: string;
+};
+```
+
+## Output Contract
+
+```ts
+type ExtractedContact = {
+  id: string;
+  displayName: string;
+  email?: string;
+  phone?: string;
+  organization?: string;
+  confidence: "high" | "medium" | "low";
+  evidence: string;
+  warnings: string[];
+};
+```
+
+## UI States
+
+| State   | Expected behavior                                                                 |
+| ------- | --------------------------------------------------------------------------------- |
+| Empty   | Explains that no email text has been loaded and exposes a labelled input.        |
+| Loading | Disables extraction controls and announces that contact extraction is in progress. |
+| Error   | Shows a clear message when text is missing or no contact-like data is present.    |
+| Success | Presents a selectable, keyboard-friendly contact review list and summary counts.  |
+
+## Accessibility Contract
+
+- Text input uses a visible label and helper text.
+- Primary actions are real buttons with accessible names.
+- Contact selection uses labelled checkboxes.
+- Results are announced through `aria-live="polite"`.
+- Error feedback uses `role="alert"`.
+- Focusable controls have visible focus styles in `styles.css`.
+- Loading controls set `aria-busy` and disable duplicate submissions.
+
+## Review Rules
+
+- Preserve source evidence for each extracted contact.
+- Prefer complete contacts over partial contacts.
+- Do not save, send, or mutate mailbox/contact data from this isolated tool.
+- Do not expose real personal data in fixtures or docs.
+- Keep all changed files under the folder ownership boundary.
+
+## Required Issue Categories
 
 - Architecture
 - Feature

--- a/tools/v1/individual/contact-extractor/styles.css
+++ b/tools/v1/individual/contact-extractor/styles.css
@@ -1,0 +1,286 @@
+.contact-extractor {
+  --contact-surface: #ffffff;
+  --contact-ink: #17202a;
+  --contact-muted: #59636e;
+  --contact-line: #d8dee5;
+  --contact-accent: #1769aa;
+  --contact-accent-strong: #0f4f82;
+  --contact-success: #166534;
+  --contact-warning: #8a4b05;
+  --contact-error: #b42318;
+  --contact-soft: #f4f7fb;
+
+  color: var(--contact-ink);
+  background: var(--contact-surface);
+  border: 1px solid var(--contact-line);
+  border-radius: 8px;
+  display: grid;
+  gap: 18px;
+  max-width: 960px;
+  padding: 20px;
+}
+
+.contact-extractor *,
+.contact-extractor *::before,
+.contact-extractor *::after {
+  box-sizing: border-box;
+}
+
+.contact-extractor__header,
+.contact-extractor__results-header,
+.contact-extractor__actions,
+.contact-extractor__selection-actions,
+.contact-extractor__samples {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.contact-extractor__header,
+.contact-extractor__results-header {
+  justify-content: space-between;
+}
+
+.contact-extractor__eyebrow {
+  color: var(--contact-accent-strong);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.contact-extractor h2,
+.contact-extractor h3,
+.contact-extractor p {
+  margin-top: 0;
+}
+
+.contact-extractor h2 {
+  font-size: 1.4rem;
+  margin-bottom: 6px;
+}
+
+.contact-extractor h3 {
+  font-size: 1rem;
+  margin-bottom: 4px;
+}
+
+.contact-extractor__description,
+.contact-extractor__results-header p,
+.contact-extractor__input-panel p {
+  color: var(--contact-muted);
+  line-height: 1.45;
+  margin-bottom: 0;
+}
+
+.contact-extractor__header-icon {
+  color: var(--contact-accent);
+  flex: 0 0 auto;
+  height: 32px;
+  width: 32px;
+}
+
+.contact-extractor__samples {
+  flex-wrap: wrap;
+}
+
+.contact-extractor button {
+  align-items: center;
+  border: 1px solid var(--contact-line);
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.contact-extractor button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.contact-extractor button:focus-visible,
+.contact-extractor textarea:focus-visible,
+.contact-extractor input[type="checkbox"]:focus-visible {
+  outline: 3px solid rgba(23, 105, 170, 0.35);
+  outline-offset: 2px;
+}
+
+.contact-extractor__sample-button,
+.contact-extractor__secondary,
+.contact-extractor__selection-actions button {
+  background: var(--contact-surface);
+  color: var(--contact-ink);
+}
+
+.contact-extractor__primary {
+  background: var(--contact-accent);
+  border-color: var(--contact-accent);
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.contact-extractor__input-panel {
+  background: var(--contact-soft);
+  border: 1px solid var(--contact-line);
+  border-radius: 8px;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.contact-extractor__input-panel label {
+  font-weight: 700;
+}
+
+.contact-extractor textarea {
+  border: 1px solid var(--contact-line);
+  border-radius: 6px;
+  color: var(--contact-ink);
+  font: inherit;
+  line-height: 1.5;
+  min-height: 180px;
+  padding: 10px;
+  resize: vertical;
+  width: 100%;
+}
+
+.contact-extractor__state {
+  align-items: center;
+  background: var(--contact-soft);
+  border: 1px solid var(--contact-line);
+  border-radius: 8px;
+  display: flex;
+  gap: 10px;
+  padding: 12px;
+}
+
+.contact-extractor__state--loading {
+  color: var(--contact-accent-strong);
+}
+
+.contact-extractor__state--error {
+  background: #fff4f2;
+  border-color: #ffc9c2;
+  color: var(--contact-error);
+}
+
+.contact-extractor__state--success {
+  background: #eefcf3;
+  border-color: #b8e6c9;
+  color: var(--contact-success);
+}
+
+.contact-extractor__spin {
+  animation: contact-spin 0.9s linear infinite;
+}
+
+.contact-extractor__results {
+  display: grid;
+  gap: 12px;
+}
+
+.contact-extractor__list {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.contact-extractor__contact-card {
+  border: 1px solid var(--contact-line);
+  border-radius: 8px;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.contact-extractor__checkbox-row {
+  align-items: center;
+  display: flex;
+  font-weight: 700;
+  gap: 10px;
+}
+
+.contact-extractor__contact-card dl {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+
+.contact-extractor__contact-card dt {
+  color: var(--contact-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.contact-extractor__contact-card dd {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.contact-extractor__confidence {
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 3px 8px;
+}
+
+.contact-extractor__confidence--high {
+  background: #dcfce7;
+  color: var(--contact-success);
+}
+
+.contact-extractor__confidence--medium {
+  background: #e0f2fe;
+  color: var(--contact-accent-strong);
+}
+
+.contact-extractor__confidence--low {
+  background: #fef3c7;
+  color: var(--contact-warning);
+}
+
+.contact-extractor__warnings {
+  color: var(--contact-warning);
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.contact-extractor__evidence {
+  background: var(--contact-soft);
+  border-left: 3px solid var(--contact-accent);
+  color: var(--contact-muted);
+  margin-bottom: 0;
+  padding: 8px 10px;
+}
+
+@keyframes contact-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 720px) {
+  .contact-extractor {
+    padding: 14px;
+  }
+
+  .contact-extractor__header,
+  .contact-extractor__results-header,
+  .contact-extractor__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .contact-extractor__contact-card dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
+++ b/tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-contact-emails.json");
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample contact extraction fixture follows the local review contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "contact-extractor");
+  assert.equal(fixture.version, 1);
+  assert.ok(Array.isArray(fixture.sourceRequests), "sourceRequests must be an array");
+  assert.ok(fixture.sourceRequests.length >= 3, "fixture should include success and error cases");
+
+  const stateSet = new Set(fixture.uiStates);
+  for (const state of ["empty", "loading", "error", "success"]) {
+    assert.ok(stateSet.has(state), `fixture must document ${state} UI state`);
+  }
+
+  const accessibilitySet = new Set(fixture.accessibilityChecks);
+  for (const check of [
+    "visible-label-for-email-text",
+    "aria-live-status-region",
+    "role-alert-for-errors",
+    "labelled-contact-checkboxes",
+    "visible-focus-styles",
+    "keyboard-accessible-buttons",
+  ]) {
+    assert.ok(accessibilitySet.has(check), `fixture must document ${check}`);
+  }
+
+  for (const request of fixture.sourceRequests) {
+    assert.ok(request.id, "request needs an id");
+    assert.ok(request.sourceLabel, `${request.id} needs a sourceLabel`);
+    assert.ok(typeof request.subject === "string", `${request.id} subject must be a string`);
+    assert.ok(typeof request.from === "string", `${request.id} from must be a string`);
+    assert.ok(typeof request.body === "string", `${request.id} body must be a string`);
+
+    if (request.expectedContacts) {
+      assert.ok(
+        Array.isArray(request.expectedContacts),
+        `${request.id} expectedContacts must be an array`,
+      );
+      assert.ok(request.expectedContacts.length > 0, `${request.id} should include expected contacts`);
+
+      for (const contact of request.expectedContacts) {
+        assert.ok(contact.displayName, `${request.id} contact needs a displayName`);
+        assert.match(contact.email, /^[^@\s]+@[^@\s]+\.[^@\s]+$/, `${request.id} contact email must be valid`);
+        assert.ok(contact.organization, `${request.id} contact should include organization context`);
+      }
+    }
+
+    if (request.expectedError) {
+      assert.equal(
+        request.expectedError,
+        "No contact details were found in the supplied email text.",
+        `${request.id} should use the documented no-contact error`,
+      );
+    }
+  }
+});

--- a/tools/v1/individual/contact-extractor/types.ts
+++ b/tools/v1/individual/contact-extractor/types.ts
@@ -1,0 +1,38 @@
+export type ContactConfidence = "high" | "medium" | "low";
+
+export type ExtractionStatus = "empty" | "idle" | "loading" | "success" | "error";
+
+export interface ContactExtractionRequest {
+  id: string;
+  sourceLabel: string;
+  subject: string;
+  from: string;
+  body: string;
+}
+
+export interface ExtractedContact {
+  id: string;
+  displayName: string;
+  email?: string;
+  phone?: string;
+  organization?: string;
+  confidence: ContactConfidence;
+  evidence: string;
+  warnings: string[];
+}
+
+export interface ContactExtractionResult {
+  requestId: string;
+  sourceLabel: string;
+  status: "success" | "error";
+  contacts: ExtractedContact[];
+  error?: string;
+}
+
+export interface ContactExtractorState {
+  status: ExtractionStatus;
+  sourceText: string;
+  selectedContactIds: string[];
+  result?: ContactExtractionResult;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- add a folder-local Contact Extractor UI with empty, loading, error, and success states
- add deterministic extraction helpers, synthetic fixtures, local styles, and typed exports
- document the isolated review boundary, accessibility contract, and future integration limits

## Validation
- node --test tools/v1/individual/contact-extractor/tests/contact-extractor-fixtures.test.mjs
- npx --yes tsx -e "import { extractContacts, summarizeContacts } from './tools/v1/individual/contact-extractor/services.ts'; import { sampleContactRequests } from './tools/v1/individual/contact-extractor/fixtures.ts'; const result = extractContacts(sampleContactRequests[0]); if (result.status !== 'success' || result.contacts.length < 2) { throw new Error(JSON.stringify(result)); } const summary = summarizeContacts(result.contacts); if (summary.total < 2 || summary.needsReview < 1) { throw new Error(JSON.stringify(summary)); } console.log('service_runtime_ok', result.contacts.length, summary.needsReview);"
- git diff --check
- boundary check confirmed changed files stay under tools/v1/individual/contact-extractor/

## Notes
- npm ci was not usable because package.json and package-lock.json are out of sync upstream; no package or lockfile changes are included.

Closes #336