### PR TITLE
docs: add test plan and documentation for deal-lead-mail-tracker

### DIFF
--- a/src/tools/v2/team/deal-lead-mail-tracker/README.md
+++ b/src/tools/v2/team/deal-lead-mail-tracker/README.md
@@ -1,0 +1,31 @@
+# Deal/Lead Mail Tracker (V2)
+
+## Goal
+The Deal/Lead Mail Tracker is a contributor-friendly, isolated tool for tracking deals and leads via mail interactions. This is a V2 later-release tool designed specifically for the team. 
+
+**Note:** This tool is built as complete, isolated work and is not yet linked to the main app, main application shell, dashboard layout, or existing inbox architecture.
+
+## Setup
+To work on this tool independently:
+1. Ensure you have the standard repository dependencies installed (`npm install` / `bun install`).
+2. Run tests and verify the UI strictly within this directory boundary.
+3. Use the localized mock fixtures provided in `test-plan.md` or local subdirectories to emulate the main application context.
+
+## Usage
+Currently, this module serves as an isolated feature package. When reviewing or working on the `Deal/Lead Mail Tracker`:
+- Keep all modifications inside `src/tools/v2/team/deal-lead-mail-tracker/`.
+- Do not modify existing routing, the Stellar integration core, database schemas, or the design system unless explicitly stated in a follow-up integration issue.
+
+## Fixtures
+For development and testing, use strictly folder-local fixtures (e.g., mock email payloads, fake wallet connections, dummy deal tracking states). These fixtures should emulate the larger app environment without actually importing main app services that require complex setup.
+
+## Known Limitations
+- Not currently integrated with the main routing or navigation system.
+- Not connected to the real production database schema or live Stellar network.
+- Lacks main app authentication wrappers.
+
+## OSS Contributor Notes
+- **Scope:** Keep your work small, reviewable, and limited to this specific folder (`$rel/`).
+- **Dependencies:** Prefer folder-local components, services, and hooks over global shared utilities to minimize breaking changes.
+- **Reviewability:** The contribution should be reviewable as a self-contained mini-product change. If this tool requires a future connection to the main mail app, that will be addressed in a follow-up issue rather than adding integration complexity here.
+- **Testing:** Add test coverage locally or follow the guidelines in `test-plan.md`. The issue must remain isolated from app-wide tests.

--- a/src/tools/v2/team/deal-lead-mail-tracker/README.md
+++ b/src/tools/v2/team/deal-lead-mail-tracker/README.md
@@ -1,30 +1,38 @@
 # Deal/Lead Mail Tracker (V2)
 
 ## Goal
-The Deal/Lead Mail Tracker is a contributor-friendly, isolated tool for tracking deals and leads via mail interactions. This is a V2 later-release tool designed specifically for the team. 
+
+The Deal/Lead Mail Tracker is a contributor-friendly, isolated tool for tracking deals and leads via mail interactions. This is a V2 later-release tool designed specifically for the team.
 
 **Note:** This tool is built as complete, isolated work and is not yet linked to the main app, main application shell, dashboard layout, or existing inbox architecture.
 
 ## Setup
+
 To work on this tool independently:
+
 1. Ensure you have the standard repository dependencies installed (`npm install` / `bun install`).
 2. Run tests and verify the UI strictly within this directory boundary.
 3. Use the localized mock fixtures provided in `test-plan.md` or local subdirectories to emulate the main application context.
 
 ## Usage
+
 Currently, this module serves as an isolated feature package. When reviewing or working on the `Deal/Lead Mail Tracker`:
+
 - Keep all modifications inside `src/tools/v2/team/deal-lead-mail-tracker/`.
 - Do not modify existing routing, the Stellar integration core, database schemas, or the design system unless explicitly stated in a follow-up integration issue.
 
 ## Fixtures
+
 For development and testing, use strictly folder-local fixtures (e.g., mock email payloads, fake wallet connections, dummy deal tracking states). These fixtures should emulate the larger app environment without actually importing main app services that require complex setup.
 
 ## Known Limitations
+
 - Not currently integrated with the main routing or navigation system.
 - Not connected to the real production database schema or live Stellar network.
 - Lacks main app authentication wrappers.
 
 ## OSS Contributor Notes
+
 - **Scope:** Keep your work small, reviewable, and limited to this specific folder (`$rel/`).
 - **Dependencies:** Prefer folder-local components, services, and hooks over global shared utilities to minimize breaking changes.
 - **Reviewability:** The contribution should be reviewable as a self-contained mini-product change. If this tool requires a future connection to the main mail app, that will be addressed in a follow-up issue rather than adding integration complexity here.

--- a/src/tools/v2/team/deal-lead-mail-tracker/test-plan.md
+++ b/src/tools/v2/team/deal-lead-mail-tracker/test-plan.md
@@ -1,0 +1,32 @@
+# Test Plan: Deal/Lead Mail Tracker
+
+This document outlines the testing strategy for the Deal/Lead Mail Tracker tool. Because this tool is built as an isolated V2 component and is not yet linked to the main app, tests should strictly remain localized within `src/tools/v2/team/deal-lead-mail-tracker/`.
+
+## 1. Unit Testing Strategy
+Once the core logic is implemented, the following unit tests must be added:
+- **Mail Parsing Validation:** Ensure that incoming mock mail payloads correctly extract sender details, intent (Deal vs Lead), and any associated timeline/budget parameters.
+- **Classification Engine:** Test functions that determine whether a record is a `Deal` or a `Lead` based on folder-local configuration or predefined rules.
+- **State Management:** Verify that internal states (e.g., `New`, `Contacted`, `Negotiating`, `Closed`) correctly transition based on mocked actions.
+
+## 2. Component Testing (UI)
+If frontend components are developed, they should be tested using isolated rendering (e.g., via React Testing Library):
+- **Dashboard View:** Render the Tracker UI using local fixture data and verify that elements are displayed correctly without relying on the main app shell.
+- **Interaction Tests:** Simulate user interactions (like marking a Lead as a Deal) and assert that the internal state updates accordingly.
+
+## 3. Fixtures and Mocks
+To maintain isolation from the rest of the application, contributors must create and use local mock data:
+- **`__fixtures__/mockMails.ts`**: Sample email JSON payloads containing typical Deal/Lead negotiation language.
+- **`__fixtures__/mockTrackerState.ts`**: Snapshot states of the tracker database for testing initial renders and updates.
+- **Service Mocks**: If the module requires external services (like a dummy auth token or a mocked Stellar transaction), stub these interfaces directly inside the test files.
+
+## 4. Acceptance Criteria for Tests
+Before considering a PR complete for this tool:
+- [ ] Test files exist inside the `deal-lead-mail-tracker` folder.
+- [ ] No tests depend on global `stealth` testing configurations or app-wide test suites unless explicitly provided by the framework (like Playwright config).
+- [ ] Tests execute successfully using standard test commands (e.g., `bun test` or equivalent) on the specific folder path.
+
+## 5. Review Guidelines for OSS Contributors
+When validating test coverage:
+1. Ensure the scope of tests does not exceed the `$rel/` directory boundaries.
+2. Confirm that mock data accurately reflects what would be expected from the real mail rendering engine, without actually importing it.
+3. Validate that adding or running tests here does not break existing app-wide continuous integration pipelines.

--- a/src/tools/v2/team/deal-lead-mail-tracker/test-plan.md
+++ b/src/tools/v2/team/deal-lead-mail-tracker/test-plan.md
@@ -3,30 +3,40 @@
 This document outlines the testing strategy for the Deal/Lead Mail Tracker tool. Because this tool is built as an isolated V2 component and is not yet linked to the main app, tests should strictly remain localized within `src/tools/v2/team/deal-lead-mail-tracker/`.
 
 ## 1. Unit Testing Strategy
+
 Once the core logic is implemented, the following unit tests must be added:
+
 - **Mail Parsing Validation:** Ensure that incoming mock mail payloads correctly extract sender details, intent (Deal vs Lead), and any associated timeline/budget parameters.
 - **Classification Engine:** Test functions that determine whether a record is a `Deal` or a `Lead` based on folder-local configuration or predefined rules.
 - **State Management:** Verify that internal states (e.g., `New`, `Contacted`, `Negotiating`, `Closed`) correctly transition based on mocked actions.
 
 ## 2. Component Testing (UI)
+
 If frontend components are developed, they should be tested using isolated rendering (e.g., via React Testing Library):
+
 - **Dashboard View:** Render the Tracker UI using local fixture data and verify that elements are displayed correctly without relying on the main app shell.
 - **Interaction Tests:** Simulate user interactions (like marking a Lead as a Deal) and assert that the internal state updates accordingly.
 
 ## 3. Fixtures and Mocks
+
 To maintain isolation from the rest of the application, contributors must create and use local mock data:
+
 - **`__fixtures__/mockMails.ts`**: Sample email JSON payloads containing typical Deal/Lead negotiation language.
 - **`__fixtures__/mockTrackerState.ts`**: Snapshot states of the tracker database for testing initial renders and updates.
 - **Service Mocks**: If the module requires external services (like a dummy auth token or a mocked Stellar transaction), stub these interfaces directly inside the test files.
 
 ## 4. Acceptance Criteria for Tests
+
 Before considering a PR complete for this tool:
+
 - [ ] Test files exist inside the `deal-lead-mail-tracker` folder.
 - [ ] No tests depend on global `stealth` testing configurations or app-wide test suites unless explicitly provided by the framework (like Playwright config).
 - [ ] Tests execute successfully using standard test commands (e.g., `bun test` or equivalent) on the specific folder path.
 
 ## 5. Review Guidelines for OSS Contributors
+
 When validating test coverage:
+
 1. Ensure the scope of tests does not exceed the `$rel/` directory boundaries.
 2. Confirm that mock data accurately reflects what would be expected from the real mail rendering engine, without actually importing it.
 3. Validate that adding or running tests here does not break existing app-wide continuous integration pipelines.


### PR DESCRIPTION
- Initialized isolated directory structure for `Deal/Lead Mail Tracker`.
- Added `README.md` defining setup, usage, limitations, and specific review guidelines for OSS contributors.
- Added `test-plan.md` outlining the future testing strategy and fixture requirements to ensure isolated validation without relying on main application integration.
## Why it was done
This establishes the foundational isolation boundaries for the Deal/Lead Mail Tracker V2 tool. It allows external contributors to build and test this feature independently before we wire it into the main app architecture, protecting the main mail engine and dashboard from regressions.
## How it was verified
- Verified that all changes are strictly localized inside `src/tools/v2/team/deal-lead-mail-tracker/`.
- Confirmed that no global dependencies, app-wide tests, routing mechanisms, or authentication wrappers were modified.
closes #593 