### PR TITLE
feat(demo-admin): add editable demo dataset types

### DIFF
--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -32,6 +32,15 @@ export type {
 export type { CampaignSnapshot } from "./types/campaignSnapshot";
 export type { CampaignTag, TagColorKey } from "./types/campaignTag";
 
+export type {
+  DemoAttachment,
+  DemoCalendarEvent,
+  DemoDataset,
+  DemoMessage,
+  DemoProofRecord,
+  DemoSender,
+} from "./types/dataset";
+
 export {
   CAMPAIGN_STATUS_TOKENS,
   TAG_COLOR_TOKENS,

--- a/src/features/demo-admin-dashboard/types/dataset.ts
+++ b/src/features/demo-admin-dashboard/types/dataset.ts
@@ -1,0 +1,100 @@
+/**
+ * Core TypeScript types for the editable demo dataset.
+ *
+ * IMPORTANT: All data conforming to these types must remain safe, fake, and
+ * deterministic. Do not include real user data, PII, live network secrets,
+ * or non-deterministic values (like Date.now() or Math.random()).
+ *
+ * Email addresses must use `@example.com`, `@example.org`, or `*.stealth.demo`.
+ */
+
+/**
+ * Represents a proof record for a demo protocol event.
+ * Used to simulate cryptographic proofs or postage without real secrets.
+ */
+export interface DemoProofRecord {
+  id: string;
+  status: "verified" | "pending" | "failed" | "none";
+  /** ISO 8601 local stamp */
+  timestamp: string;
+  /** Represented in fake currency or protocol tokens */
+  postageAmount?: number;
+  postageCurrency?: string;
+  policyId?: string;
+}
+
+/**
+ * Represents a sender in the demo ecosystem.
+ */
+export interface DemoSender {
+  /** Must use safe domains: example.com, example.org, or *.stealth.demo */
+  address: string;
+  name?: string;
+  avatarUrl?: string;
+  isTrusted: boolean;
+  relayNode?: string;
+}
+
+/**
+ * File attachment details linked to a demo message.
+ */
+export interface DemoAttachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  /** Size in bytes for UI rendering */
+  sizeBytes: number;
+  /** Fake URL for demo purposes */
+  url: string;
+}
+
+/**
+ * Calendar event details linked to a demo message.
+ */
+export interface DemoCalendarEvent {
+  id: string;
+  title: string;
+  /** ISO 8601 local stamp (e.g. yyyy-MM-ddTHH:mm) */
+  startTime: string;
+  /** ISO 8601 local stamp (e.g. yyyy-MM-ddTHH:mm) */
+  endTime: string;
+  location?: string;
+  /** List of safe email addresses */
+  attendees: string[];
+}
+
+/**
+ * The core email/message item for the demo inbox.
+ */
+export interface DemoMessage {
+  id: string;
+  threadId: string;
+  subject: string;
+  snippet: string;
+  /** HTML or plain text body (must not contain real PII) */
+  body: string;
+  sender: DemoSender;
+  /** Safe recipient addresses */
+  recipients: string[];
+  /** ISO 8601 local stamp */
+  date: string;
+  isRead: boolean;
+  isStarred: boolean;
+  /** Local yyyy-MM-ddTHH:mm stamp, if snoozed */
+  snoozeRemindAt?: string;
+  labels: string[];
+  attachments: DemoAttachment[];
+  proofRecord?: DemoProofRecord;
+  calendarEvent?: DemoCalendarEvent;
+}
+
+/**
+ * An aggregate root representing an entire editable demo dataset.
+ */
+export interface DemoDataset {
+  id: string;
+  name: string;
+  description: string;
+  messages: DemoMessage[];
+  senders?: DemoSender[];
+}


### PR DESCRIPTION
- closes #168 

## Description

This PR introduces the core TypeScript types for the editable demo dataset, which will power inbox messages and related UI previews within the Demo Admin Dashboard. 

## Changes

* **New Types:** Created `DemoDataset`, `DemoMessage`, `DemoSender`, `DemoAttachment`, `DemoCalendarEvent`, and `DemoProofRecord` inside a new `types/dataset.ts` file.
* **Safety Constraints:** Added comprehensive JSDoc documentation enforcing the use of safe, fake, and deterministic data (e.g., restricting emails to `@example.com` or `*.stealth.demo`, and using local ISO 8601 timestamps to prevent timezone drift).
* **Public API:** Exported the newly created types from `src/features/demo-admin-dashboard/index.ts`.

## Acceptance Criteria Met

- [x] Implemented strictly under `src/features/demo-admin-dashboard/`.
- [x] No files outside the target folder were modified.
- [x] The types support the broader goal of populating demo data into the UI.
- [x] Demo data constraints (fake, deterministic, safe) are properly documented.
- [x] The PR is entirely self-contained and ready for independent review.
