### PR TITLE
Add isolated Deadline Detector UI surface

### DIFF
--- a/tools/v2/individual/deadline-detector/README.md
+++ b/tools/v2/individual/deadline-detector/README.md
@@ -1,15 +1,82 @@
 # Deadline Detector
 
-This folder is the isolated workspace for the Deadline Detector tool.
+Deadline Detector is an isolated V2 individual tool workspace for detecting
+likely due dates in message content before a future inbox or reminder
+integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\deadline-detector\
-`
+```text
+tools/v2/individual/deadline-detector/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local UI components, a deterministic detection service,
+synthetic fixtures, and a standalone Node test. No app install is required to
+review the fixture contract.
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs
+```
+
+The test validates synthetic sample messages and expected deadline states.
+
+## Tool Workflow
+
+1. Accept message-like input through local `DeadlineMessage` objects.
+2. Detect ISO dates, US dates, relative phrases such as today/tomorrow/next
+   week, and simple 24-hour times.
+3. Classify each result as `detected`, `needs-review`, `missed`, or `ignored`.
+4. Rank urgent results first while preserving ambiguous rows for manual review.
+5. Offer UI actions for review or reminder creation without creating reminders
+   automatically.
+
+## UI Surface
+
+The folder-local React components cover:
+
+- empty state when no message sample is available
+- loading state with `aria-busy` and screen-reader status text
+- error state with retry affordance
+- success state with summary metrics, keyboard-accessible status filters, and
+  result cards
+- action buttons for reminder creation and manual review callbacks
+
+The components are exported from `components/index.ts` and the folder entrypoint
+`index.ts`.
+
+## Fixture Coverage
+
+`fixtures/sample-deadline-messages.json` includes synthetic examples for:
+
+- high-confidence renewal deadline
+- high-confidence relative due date
+- ambiguous deadline-like request that needs review
+- already missed deadline
+- ignored newsletter/digest content
+
+No real sender, mailbox, or personal data is used.
+
+## Documentation Map
+
+- `specs.md` defines scope, status rules, and the local detection contract.
+- `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
+- `docs/VISUAL_STYLE.md` documents the local visual treatment.
+- `docs/TEST_PLAN.md` lists automated and manual review checks.
+- `tests/deadline-fixtures.test.mjs` validates the fixture contract.
+
+## Known Limitations
+
+- This contribution does not register the tool in app routing.
+- The detector is intentionally deterministic and conservative.
+- Live email ingestion, reminder writes, calendar writes, notification delivery,
+  and database persistence remain out of scope.

--- a/tools/v2/individual/deadline-detector/components/DeadlineDetectorEmptyState.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineDetectorEmptyState.tsx
@@ -1,0 +1,34 @@
+import { CalendarClock } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface DeadlineDetectorEmptyStateProps {
+  action?: ReactNode;
+  description?: string;
+  title?: string;
+}
+
+export function DeadlineDetectorEmptyState({
+  action,
+  description = "Connect a message sample or paste deadline text to preview detection results.",
+  title = "No deadlines detected",
+}: DeadlineDetectorEmptyStateProps) {
+  return (
+    <section
+      aria-label="No deadline results"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="status"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-slate-200 bg-slate-50 text-slate-700"
+      >
+        <CalendarClock className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      {action ? <div className="mt-6">{action}</div> : null}
+    </section>
+  );
+}
+
+export type { DeadlineDetectorEmptyStateProps };

--- a/tools/v2/individual/deadline-detector/components/DeadlineDetectorErrorState.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineDetectorErrorState.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface DeadlineDetectorErrorStateProps {
+  details?: string;
+  onRetry?: () => void;
+  title?: string;
+}
+
+export function DeadlineDetectorErrorState({
+  details = "Deadline detection could not finish. Retry with the same local input or review the message manually.",
+  onRetry,
+  title = "Deadline detection failed",
+}: DeadlineDetectorErrorStateProps) {
+  return (
+    <section
+      aria-label="Deadline detector error"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="alert"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-red-700"
+      >
+        <AlertTriangle className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-red-900">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{details}</p>
+      {onRetry ? (
+        <button
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          onClick={onRetry}
+          type="button"
+        >
+          <RotateCcw aria-hidden="true" className="size-4" />
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+export type { DeadlineDetectorErrorStateProps };

--- a/tools/v2/individual/deadline-detector/components/DeadlineDetectorLoadingState.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineDetectorLoadingState.tsx
@@ -1,0 +1,34 @@
+interface DeadlineDetectorLoadingStateProps {
+  message?: string;
+  rowCount?: number;
+}
+
+export function DeadlineDetectorLoadingState({
+  message = "Scanning messages for deadlines...",
+  rowCount = 3,
+}: DeadlineDetectorLoadingStateProps) {
+  return (
+    <section aria-busy="true" aria-live="polite" className="space-y-4" role="status">
+      <span className="sr-only">{message}</span>
+      {Array.from({ length: rowCount }).map((_, index) => (
+        <div
+          aria-hidden="true"
+          className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          key={index}
+        >
+          <div className="flex items-start gap-4">
+            <div className="size-10 animate-pulse rounded-md bg-slate-200" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-full animate-pulse rounded bg-slate-100" />
+            </div>
+            <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export type { DeadlineDetectorLoadingStateProps };

--- a/tools/v2/individual/deadline-detector/components/DeadlineDetectorSummary.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineDetectorSummary.tsx
@@ -1,0 +1,27 @@
+import type { DeadlineDetectionSummary } from "../types";
+
+interface DeadlineDetectorSummaryProps {
+  summary: DeadlineDetectionSummary;
+}
+
+const summaryItems = [
+  ["detected", "Detected"],
+  ["needsReview", "Review"],
+  ["missed", "Missed"],
+  ["ignored", "Ignored"],
+] as const;
+
+export function DeadlineDetectorSummary({ summary }: DeadlineDetectorSummaryProps) {
+  return (
+    <dl aria-label="Deadline detection summary" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {summaryItems.map(([key, label]) => (
+        <div className="rounded-lg border border-slate-200 bg-white p-4" key={key}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-1 text-2xl font-semibold text-slate-950">{summary[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export type { DeadlineDetectorSummaryProps };

--- a/tools/v2/individual/deadline-detector/components/DeadlineDetectorTool.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineDetectorTool.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from "react";
+import { Filter, MailPlus } from "lucide-react";
+import { detectDeadlines } from "../services";
+import type { DeadlineMessage, DeadlineStatus, DetectedDeadline } from "../types";
+import { DeadlineDetectorEmptyState } from "./DeadlineDetectorEmptyState";
+import { DeadlineDetectorErrorState } from "./DeadlineDetectorErrorState";
+import { DeadlineDetectorLoadingState } from "./DeadlineDetectorLoadingState";
+import { DeadlineDetectorSummary } from "./DeadlineDetectorSummary";
+import { DeadlineResultCard } from "./DeadlineResultCard";
+
+type DetectorViewState = "loading" | "error" | "ready";
+type FilterValue = "all" | DeadlineStatus;
+
+interface DeadlineDetectorToolProps {
+  errorMessage?: string;
+  initialState?: DetectorViewState;
+  messages?: DeadlineMessage[];
+  now?: string;
+  onCreateReminder?: (deadline: DetectedDeadline) => void;
+  onRequestMessages?: () => void;
+  onReviewDeadline?: (deadline: DetectedDeadline) => void;
+}
+
+const filterOptions: Array<{ label: string; value: FilterValue }> = [
+  { label: "All", value: "all" },
+  { label: "Detected", value: "detected" },
+  { label: "Review", value: "needs-review" },
+  { label: "Missed", value: "missed" },
+  { label: "Ignored", value: "ignored" },
+];
+
+export function DeadlineDetectorTool({
+  errorMessage,
+  initialState = "ready",
+  messages = [],
+  now,
+  onCreateReminder,
+  onRequestMessages,
+  onReviewDeadline,
+}: DeadlineDetectorToolProps) {
+  const [viewState, setViewState] = useState<DetectorViewState>(initialState);
+  const [filter, setFilter] = useState<FilterValue>("all");
+
+  const result = useMemo(() => detectDeadlines(messages, { now }), [messages, now]);
+  const filteredDeadlines = useMemo(
+    () =>
+      filter === "all"
+        ? result.deadlines
+        : result.deadlines.filter((deadline) => deadline.status === filter),
+    [filter, result.deadlines],
+  );
+
+  if (viewState === "loading") {
+    return (
+      <DeadlineDetectorLoadingState message="Scanning selected messages for deadline signals..." />
+    );
+  }
+
+  if (viewState === "error") {
+    return (
+      <DeadlineDetectorErrorState details={errorMessage} onRetry={() => setViewState("ready")} />
+    );
+  }
+
+  if (messages.length === 0) {
+    return (
+      <DeadlineDetectorEmptyState
+        action={
+          onRequestMessages ? (
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={onRequestMessages}
+              type="button"
+            >
+              <MailPlus aria-hidden="true" className="size-4" />
+              Add message sample
+            </button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="deadline-detector-title"
+      className="mx-auto w-full max-w-5xl space-y-6 rounded-lg border border-slate-200 bg-slate-50 p-4 md:p-6"
+    >
+      <header>
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+            Individual V2 tool
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold text-slate-950" id="deadline-detector-title">
+            Deadline Detector
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            Detect likely due dates, expired requests, and ambiguous deadline language before a
+            future inbox integration creates reminders.
+          </p>
+        </div>
+      </header>
+
+      <DeadlineDetectorSummary summary={result.summary} />
+
+      <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <Filter aria-hidden="true" className="size-4" />
+          Filter results
+        </div>
+        <fieldset className="flex flex-wrap gap-2">
+          <legend className="sr-only">Deadline status filter</legend>
+          {filterOptions.map((option) => (
+            <label
+              className={`cursor-pointer rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                filter === option.value
+                  ? "border-slate-950 bg-slate-950 text-white"
+                  : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+              }`}
+              key={option.value}
+            >
+              <input
+                checked={filter === option.value}
+                className="sr-only"
+                name="deadline-filter"
+                onChange={() => setFilter(option.value)}
+                type="radio"
+                value={option.value}
+              />
+              {option.label}
+            </label>
+          ))}
+        </fieldset>
+      </div>
+
+      {filteredDeadlines.length > 0 ? (
+        <div aria-label="Detected deadline results" className="space-y-3" role="list">
+          {filteredDeadlines.map((deadline) => (
+            <div key={deadline.id} role="listitem">
+              <DeadlineResultCard
+                deadline={deadline}
+                onCreateReminder={onCreateReminder}
+                onReviewDeadline={onReviewDeadline}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <DeadlineDetectorEmptyState
+          description="No deadlines match the current filter. Choose another status to continue reviewing."
+          title="No matching deadlines"
+        />
+      )}
+    </section>
+  );
+}
+
+export type { DeadlineDetectorToolProps };

--- a/tools/v2/individual/deadline-detector/components/DeadlineResultCard.tsx
+++ b/tools/v2/individual/deadline-detector/components/DeadlineResultCard.tsx
@@ -1,0 +1,113 @@
+import { CalendarPlus, CheckCircle2, Clock, Eye, FileQuestion, XCircle } from "lucide-react";
+import type { DetectedDeadline } from "../types";
+
+interface DeadlineResultCardProps {
+  deadline: DetectedDeadline;
+  onCreateReminder?: (deadline: DetectedDeadline) => void;
+  onReviewDeadline?: (deadline: DetectedDeadline) => void;
+}
+
+const urgencyStyles: Record<DetectedDeadline["urgency"], string> = {
+  overdue: "border-red-200 bg-red-50 text-red-800",
+  today: "border-amber-200 bg-amber-50 text-amber-800",
+  soon: "border-blue-200 bg-blue-50 text-blue-800",
+  later: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  unknown: "border-slate-200 bg-slate-50 text-slate-700",
+};
+
+const statusIcon = {
+  detected: CheckCircle2,
+  "needs-review": FileQuestion,
+  missed: XCircle,
+  ignored: Eye,
+};
+
+function formatDueDate(deadline: DetectedDeadline): string {
+  if (!deadline.dueDate) {
+    return "No date found";
+  }
+  if (!deadline.dueTime) {
+    return deadline.dueDate;
+  }
+  return `${deadline.dueDate} at ${deadline.dueTime} ${deadline.timezone}`;
+}
+
+export function DeadlineResultCard({
+  deadline,
+  onCreateReminder,
+  onReviewDeadline,
+}: DeadlineResultCardProps) {
+  const StatusIcon = statusIcon[deadline.status];
+  const confidence = `${Math.round(deadline.confidence * 100)}% confidence`;
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        <div
+          aria-hidden="true"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-md border ${urgencyStyles[deadline.urgency]}`}
+        >
+          <StatusIcon className="size-5" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-slate-950">{deadline.title}</h3>
+            <span
+              className={`rounded-md border px-2 py-1 text-xs font-medium ${urgencyStyles[deadline.urgency]}`}
+            >
+              {deadline.urgency}
+            </span>
+          </div>
+
+          <p className="mt-2 flex items-center gap-2 text-sm text-slate-700">
+            <Clock aria-hidden="true" className="size-4 shrink-0 text-slate-500" />
+            <span>{formatDueDate(deadline)}</span>
+          </p>
+
+          <p className="mt-3 text-sm leading-6 text-slate-600">{deadline.evidence}</p>
+
+          <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
+            <span className="rounded-md bg-slate-100 px-2 py-1">{deadline.status}</span>
+            <span className="rounded-md bg-slate-100 px-2 py-1">{confidence}</span>
+            {deadline.reviewRequired ? (
+              <span className="rounded-md bg-amber-100 px-2 py-1 text-amber-800">
+                review required
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap gap-2 md:flex-col">
+          {onCreateReminder && deadline.status === "detected" ? (
+            <button
+              aria-label={`Create reminder for ${deadline.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onCreateReminder(deadline)}
+              type="button"
+            >
+              <CalendarPlus aria-hidden="true" className="size-4" />
+              Remind
+            </button>
+          ) : null}
+          {onReviewDeadline && deadline.reviewRequired ? (
+            <button
+              aria-label={`Review ${deadline.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onReviewDeadline(deadline)}
+              type="button"
+            >
+              <Eye aria-hidden="true" className="size-4" />
+              Review
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <p className="mt-4 border-t border-slate-100 pt-3 text-sm text-slate-600">
+        {deadline.suggestedAction}
+      </p>
+    </article>
+  );
+}
+
+export type { DeadlineResultCardProps };

--- a/tools/v2/individual/deadline-detector/components/index.ts
+++ b/tools/v2/individual/deadline-detector/components/index.ts
@@ -1,0 +1,12 @@
+export { DeadlineDetectorEmptyState } from "./DeadlineDetectorEmptyState";
+export { DeadlineDetectorErrorState } from "./DeadlineDetectorErrorState";
+export { DeadlineDetectorLoadingState } from "./DeadlineDetectorLoadingState";
+export { DeadlineDetectorSummary } from "./DeadlineDetectorSummary";
+export { DeadlineDetectorTool } from "./DeadlineDetectorTool";
+export { DeadlineResultCard } from "./DeadlineResultCard";
+export type { DeadlineDetectorEmptyStateProps } from "./DeadlineDetectorEmptyState";
+export type { DeadlineDetectorErrorStateProps } from "./DeadlineDetectorErrorState";
+export type { DeadlineDetectorLoadingStateProps } from "./DeadlineDetectorLoadingState";
+export type { DeadlineDetectorSummaryProps } from "./DeadlineDetectorSummary";
+export type { DeadlineDetectorToolProps } from "./DeadlineDetectorTool";
+export type { DeadlineResultCardProps } from "./DeadlineResultCard";

--- a/tools/v2/individual/deadline-detector/docs/ACCESSIBILITY.md
+++ b/tools/v2/individual/deadline-detector/docs/ACCESSIBILITY.md
@@ -1,0 +1,43 @@
+# Accessibility Notes
+
+## State Announcements
+
+- `DeadlineDetectorLoadingState` uses `role="status"`, `aria-live="polite"`,
+  and `aria-busy="true"` so screen readers can announce scan progress.
+- `DeadlineDetectorErrorState` uses `role="alert"` for immediate failure
+  announcement.
+- `DeadlineDetectorEmptyState` uses `role="status"` with a scoped
+  `aria-label`.
+- The success view is labelled by `deadline-detector-title`.
+
+## Keyboard Behavior
+
+- Status filters are native radio inputs wrapped by labels, so arrow-key and tab
+  behavior follows browser defaults.
+- Review and reminder controls are native buttons.
+- Focus indicators use `focus-visible` outlines with sufficient offset.
+- The UI does not trap focus or create hidden modal states.
+
+## Screen Reader Names
+
+- Decorative icons use `aria-hidden="true"`.
+- Reminder buttons include the deadline title in `aria-label`.
+- Review buttons include the deadline title in `aria-label`.
+- The result list uses `role="list"` and `role="listitem"` wrappers.
+
+## Color And Contrast
+
+- Status pills combine text labels with color.
+- Red, amber, blue, emerald, and slate states use text labels such as `missed`,
+  `soon`, and `review required`.
+- Primary action buttons use dark text contrast against white or white text
+  against slate.
+
+## Manual Checklist
+
+- Tab through the header action, status filters, and result actions.
+- Confirm focus outlines are visible at each stop.
+- Confirm loading and error states announce with screen-reader tooling.
+- Confirm each icon still has a neighboring text label or an accessible button
+  name.
+- Confirm the UI remains readable at narrow widths.

--- a/tools/v2/individual/deadline-detector/docs/TEST_PLAN.md
+++ b/tools/v2/individual/deadline-detector/docs/TEST_PLAN.md
@@ -1,0 +1,50 @@
+# Test Plan
+
+## Automated Fixture Test
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs
+```
+
+Expected result:
+
+- the sample fixture parses as JSON
+- each source message maps to one expected deadline
+- all local statuses are represented
+- dates and times use stable ISO-like formats
+- detected rows have high confidence and do not require review
+- missed rows are marked overdue
+- ignored rows do not schedule dates
+
+## Manual Review Checklist
+
+1. Confirm all changed files are under
+   `tools/v2/individual/deadline-detector/`.
+2. Confirm all fixture senders use `example.test` and no personal data.
+3. Inspect `DeadlineDetectorTool.tsx` for loading, error, empty, and success
+   render paths.
+4. Confirm reminder and review callbacks are passed in as props and do not
+   mutate mailbox, calendar, database, or app routing state.
+5. Confirm `docs/ACCESSIBILITY.md` and `docs/VISUAL_STYLE.md` cover the UI
+   requirements in the issue.
+
+## Edge Cases Covered
+
+- exact date with time
+- relative date with time
+- ambiguous timing that requires manual review
+- overdue deadline
+- newsletter or digest that should be ignored
+
+## Future Integration Tests
+
+When a future issue allows app wiring, add tests for:
+
+- real message adapter input normalization
+- locale-aware date parsing
+- reminder permission prompts
+- duplicate deadline suppression
+- calendar write failure recovery
+- persisted audit history

--- a/tools/v2/individual/deadline-detector/docs/VISUAL_STYLE.md
+++ b/tools/v2/individual/deadline-detector/docs/VISUAL_STYLE.md
@@ -1,0 +1,35 @@
+# Visual Style
+
+## Layout
+
+The tool uses one constrained workspace panel with a compact header, summary
+metrics, filter controls, and a vertical result list. This keeps the isolated
+tool readable without implying it is already part of the production app shell.
+
+## Color
+
+- Slate is the neutral base for text, borders, and primary actions.
+- Red marks missed deadlines.
+- Amber marks deadlines due today or requiring caution.
+- Blue marks soon deadlines.
+- Emerald marks later low-pressure deadlines.
+
+Color is paired with visible text labels so status never depends on hue alone.
+
+## Components
+
+- Cards use `8px` rounded corners and light borders.
+- Buttons use native `<button>` elements with icon and text labels.
+- Summary metrics are compact `<dl>` tiles.
+- Filters use segmented radio labels backed by native inputs.
+
+## Motion
+
+The loading skeleton uses subtle pulse animation only. No critical information
+depends on animation.
+
+## Responsive Behavior
+
+- Summary metrics collapse from four columns to two columns on narrow screens.
+- Result cards stack actions beneath content on small screens.
+- Long subjects and evidence text wrap instead of overflowing.

--- a/tools/v2/individual/deadline-detector/fixtures/sample-deadline-messages.json
+++ b/tools/v2/individual/deadline-detector/fixtures/sample-deadline-messages.json
@@ -1,0 +1,127 @@
+{
+  "tool": "deadline-detector",
+  "version": 1,
+  "runContext": {
+    "now": "2026-06-18T09:00:00Z",
+    "timezone": "Asia/Tokyo"
+  },
+  "sourceMessages": [
+    {
+      "id": "msg-renewal-001",
+      "type": "invoice",
+      "sender": "billing@example.test",
+      "subject": "Renewal deadline due 2026-06-20",
+      "body": "Please renew by 2026-06-20 at 17:00 to avoid service interruption.",
+      "receivedAt": "2026-06-18T00:30:00Z",
+      "containsPersonalData": false,
+      "userTimezone": "Asia/Tokyo"
+    },
+    {
+      "id": "msg-submit-002",
+      "type": "project-update",
+      "sender": "project@example.test",
+      "subject": "Submit final notes tomorrow",
+      "body": "The project notes are due tomorrow before 11:00. Please confirm when submitted.",
+      "receivedAt": "2026-06-18T02:15:00Z",
+      "containsPersonalData": false,
+      "userTimezone": "Asia/Tokyo"
+    },
+    {
+      "id": "msg-ambiguous-003",
+      "type": "email",
+      "sender": "team@example.test",
+      "subject": "Can you handle this soon?",
+      "body": "We should probably finish the response next week, but no exact commitment was provided.",
+      "receivedAt": "2026-06-18T03:45:00Z",
+      "containsPersonalData": false,
+      "userTimezone": "Asia/Tokyo"
+    },
+    {
+      "id": "msg-overdue-004",
+      "type": "calendar-forward",
+      "sender": "events@example.test",
+      "subject": "Registration expired 2026-06-14",
+      "body": "This is a reminder that the conference registration deadline was 2026-06-14.",
+      "receivedAt": "2026-06-18T04:00:00Z",
+      "containsPersonalData": false,
+      "userTimezone": "Asia/Tokyo"
+    },
+    {
+      "id": "msg-digest-005",
+      "type": "email",
+      "sender": "news@example.test",
+      "subject": "Weekly digest",
+      "body": "Newsletter only. No action required and no deadline action should be created.",
+      "receivedAt": "2026-06-18T05:30:00Z",
+      "containsPersonalData": false,
+      "userTimezone": "Asia/Tokyo"
+    }
+  ],
+  "expectedDeadlines": [
+    {
+      "id": "deadline-msg-renewal-001",
+      "sourceMessageId": "msg-renewal-001",
+      "title": "Renewal deadline due 2026-06-20",
+      "dueDate": "2026-06-20",
+      "dueTime": "17:00",
+      "timezone": "Asia/Tokyo",
+      "status": "detected",
+      "urgency": "soon",
+      "confidence": 0.96,
+      "reviewRequired": false
+    },
+    {
+      "id": "deadline-msg-submit-002",
+      "sourceMessageId": "msg-submit-002",
+      "title": "Submit final notes tomorrow",
+      "dueDate": "2026-06-19",
+      "dueTime": "11:00",
+      "timezone": "Asia/Tokyo",
+      "status": "detected",
+      "urgency": "soon",
+      "confidence": 0.96,
+      "reviewRequired": false
+    },
+    {
+      "id": "deadline-msg-ambiguous-003",
+      "sourceMessageId": "msg-ambiguous-003",
+      "title": "Can you handle this soon?",
+      "dueDate": "2026-06-25",
+      "dueTime": null,
+      "timezone": "Asia/Tokyo",
+      "status": "needs-review",
+      "urgency": "soon",
+      "confidence": 0.58,
+      "reviewRequired": true
+    },
+    {
+      "id": "deadline-msg-overdue-004",
+      "sourceMessageId": "msg-overdue-004",
+      "title": "Registration expired 2026-06-14",
+      "dueDate": "2026-06-14",
+      "dueTime": null,
+      "timezone": "Asia/Tokyo",
+      "status": "missed",
+      "urgency": "overdue",
+      "confidence": 0.95,
+      "reviewRequired": true
+    },
+    {
+      "id": "deadline-msg-digest-005",
+      "sourceMessageId": "msg-digest-005",
+      "title": "Weekly digest",
+      "dueDate": null,
+      "dueTime": null,
+      "timezone": "Asia/Tokyo",
+      "status": "ignored",
+      "urgency": "unknown",
+      "confidence": 0.1,
+      "reviewRequired": true
+    }
+  ],
+  "reviewNotes": [
+    "All senders, subjects, and message bodies are synthetic.",
+    "Detected deadlines are safe to offer as reminder candidates but do not create reminders automatically.",
+    "Ambiguous, missed, and ignored rows require manual review before any future integration takes action."
+  ]
+}

--- a/tools/v2/individual/deadline-detector/index.ts
+++ b/tools/v2/individual/deadline-detector/index.ts
@@ -1,0 +1,14 @@
+export { DeadlineDetectorTool } from "./components";
+export { detectDeadlines, sortDetectedDeadlines } from "./services";
+export type {
+  DeadlineDetectionResult,
+  DeadlineDetectionSummary,
+  DeadlineDetectorServiceOptions,
+  DeadlineId,
+  DeadlineMessage,
+  DeadlineSourceId,
+  DeadlineSourceType,
+  DeadlineStatus,
+  DeadlineUrgency,
+  DetectedDeadline,
+} from "./types";

--- a/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
+++ b/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
@@ -1,0 +1,219 @@
+import type {
+  DeadlineDetectionResult,
+  DeadlineDetectorServiceOptions,
+  DeadlineMessage,
+  DeadlineStatus,
+  DeadlineUrgency,
+  DetectedDeadline,
+} from "../types";
+
+const ISO_DATE_PATTERN = /\b(20\d{2})-(\d{2})-(\d{2})\b/;
+const US_DATE_PATTERN = /\b(\d{1,2})\/(\d{1,2})\/(20\d{2})\b/;
+const TIME_PATTERN = /\b([01]?\d|2[0-3]):([0-5]\d)\b/;
+const DEADLINE_WORDS = ["deadline", "due", "submit", "expires", "renewal", "by "];
+const IGNORE_WORDS = ["newsletter", "digest", "no action required", "for your records"];
+
+function toDateOnly(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function normalizeDateFromText(text: string, now: Date): string | null {
+  const isoMatch = text.match(ISO_DATE_PATTERN);
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+  }
+
+  const usMatch = text.match(US_DATE_PATTERN);
+  if (usMatch) {
+    const month = usMatch[1].padStart(2, "0");
+    const day = usMatch[2].padStart(2, "0");
+    return `${usMatch[3]}-${month}-${day}`;
+  }
+
+  const lowered = text.toLowerCase();
+  if (lowered.includes("today")) {
+    return toDateOnly(now);
+  }
+  if (lowered.includes("tomorrow")) {
+    return toDateOnly(addDays(now, 1));
+  }
+  if (lowered.includes("next week")) {
+    return toDateOnly(addDays(now, 7));
+  }
+
+  return null;
+}
+
+function normalizeTimeFromText(text: string): string | null {
+  const match = text.match(TIME_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return `${match[1].padStart(2, "0")}:${match[2]}`;
+}
+
+function containsDeadlineSignal(text: string): boolean {
+  const lowered = text.toLowerCase();
+  return DEADLINE_WORDS.some((word) => lowered.includes(word));
+}
+
+function shouldIgnore(text: string): boolean {
+  const lowered = text.toLowerCase();
+  return IGNORE_WORDS.some((word) => lowered.includes(word));
+}
+
+function getUrgency(dueDate: string | null, now: Date): DeadlineUrgency {
+  if (!dueDate) {
+    return "unknown";
+  }
+
+  const due = new Date(`${dueDate}T00:00:00Z`);
+  const today = new Date(`${toDateOnly(now)}T00:00:00Z`);
+  const daysUntilDue = Math.round((due.getTime() - today.getTime()) / 86_400_000);
+
+  if (daysUntilDue < 0) {
+    return "overdue";
+  }
+  if (daysUntilDue === 0) {
+    return "today";
+  }
+  if (daysUntilDue <= 7) {
+    return "soon";
+  }
+  return "later";
+}
+
+function getStatus(text: string, dueDate: string | null, now: Date): DeadlineStatus {
+  if (shouldIgnore(text)) {
+    return "ignored";
+  }
+
+  if (!dueDate) {
+    return "needs-review";
+  }
+
+  const urgency = getUrgency(dueDate, now);
+  if (urgency === "overdue") {
+    return "missed";
+  }
+
+  return containsDeadlineSignal(text) ? "detected" : "needs-review";
+}
+
+function getConfidence(status: DeadlineStatus, dueDate: string | null, hasTime: boolean): number {
+  if (status === "ignored") {
+    return 0.1;
+  }
+  if (status === "missed") {
+    return 0.95;
+  }
+  if (status === "detected" && dueDate && hasTime) {
+    return 0.96;
+  }
+  if (status === "detected" && dueDate) {
+    return 0.9;
+  }
+  return 0.58;
+}
+
+function titleFromMessage(message: DeadlineMessage): string {
+  const cleaned = message.subject.replace(/^(re|fw):\s*/i, "").trim();
+  return cleaned || "Untitled deadline";
+}
+
+export function detectDeadlines(
+  messages: DeadlineMessage[],
+  options: DeadlineDetectorServiceOptions = {},
+): DeadlineDetectionResult {
+  const now = new Date(options.now ?? new Date().toISOString());
+  const defaultTimezone = options.defaultTimezone ?? "UTC";
+
+  const deadlines = messages.map((message): DetectedDeadline => {
+    const combinedText = `${message.subject}\n${message.body}`;
+    const dueDate = normalizeDateFromText(combinedText, now);
+    const dueTime = normalizeTimeFromText(combinedText);
+    const status = getStatus(combinedText, dueDate, now);
+    const urgency = status === "ignored" ? "unknown" : getUrgency(dueDate, now);
+
+    return {
+      id: `deadline-${message.id}`,
+      sourceMessageId: message.id,
+      title: titleFromMessage(message),
+      dueDate,
+      dueTime,
+      timezone: message.userTimezone || defaultTimezone,
+      status,
+      urgency,
+      confidence: getConfidence(status, dueDate, Boolean(dueTime)),
+      evidence: combinedText.slice(0, 180),
+      suggestedAction:
+        status === "ignored"
+          ? "No deadline action is suggested."
+          : status === "needs-review"
+            ? "Review the message before creating a reminder."
+            : status === "missed"
+              ? "Review the overdue item and decide whether to follow up."
+              : "Create a reminder and confirm the detected due date.",
+      reviewRequired: status !== "detected",
+    };
+  });
+
+  const summary = deadlines.reduce(
+    (acc, deadline) => {
+      acc.totalDeadlines += 1;
+      if (deadline.status === "detected") {
+        acc.detected += 1;
+      }
+      if (deadline.status === "needs-review") {
+        acc.needsReview += 1;
+      }
+      if (deadline.status === "missed") {
+        acc.missed += 1;
+      }
+      if (deadline.status === "ignored") {
+        acc.ignored += 1;
+      }
+      return acc;
+    },
+    {
+      totalMessages: messages.length,
+      totalDeadlines: 0,
+      detected: 0,
+      needsReview: 0,
+      missed: 0,
+      ignored: 0,
+    },
+  );
+
+  return {
+    deadlines: sortDetectedDeadlines(deadlines),
+    summary,
+  };
+}
+
+export function sortDetectedDeadlines(deadlines: DetectedDeadline[]): DetectedDeadline[] {
+  const urgencyRank: Record<DeadlineUrgency, number> = {
+    overdue: 0,
+    today: 1,
+    soon: 2,
+    later: 3,
+    unknown: 4,
+  };
+
+  return [...deadlines].sort((a, b) => {
+    const urgencyDiff = urgencyRank[a.urgency] - urgencyRank[b.urgency];
+    if (urgencyDiff !== 0) {
+      return urgencyDiff;
+    }
+
+    const aDate = a.dueDate ?? "9999-12-31";
+    const bDate = b.dueDate ?? "9999-12-31";
+    return aDate.localeCompare(bDate);
+  });
+}

--- a/tools/v2/individual/deadline-detector/services/index.ts
+++ b/tools/v2/individual/deadline-detector/services/index.ts
@@ -1,0 +1,1 @@
+export { detectDeadlines, sortDetectedDeadlines } from "./deadline-detector.service";

--- a/tools/v2/individual/deadline-detector/specs.md
+++ b/tools/v2/individual/deadline-detector/specs.md
@@ -1,41 +1,91 @@
-# Deadline Detector
-
-Detect deadlines automatically.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/deadline-detector/README.md"
-  @"
-
 # Deadline Detector Specs
 
 ## Purpose
 
-Detect deadlines automatically.
+Define a self-contained V2 individual tool for detecting deadlines in message
+content and presenting reviewable reminder candidates.
 
-## Contributor boundary
+## Release Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: individual
+- Folder ownership: `tools/v2/individual/deadline-detector/`
+- Integration status: isolated mini-product workspace
 
-$dir/
+## In-Scope Behavior
 
-## Required issue categories
+- Model message-like inputs with sender, subject, body, received time, and user
+  timezone.
+- Extract obvious due dates from ISO dates, US dates, and simple relative
+  phrases.
+- Extract simple 24-hour due times when available.
+- Classify outputs into detected, review, missed, and ignored states.
+- Provide accessible UI states for loading, empty, error, and success flows.
+- Keep all fixture data synthetic and folder-local.
+- Give reviewers a single local test command.
+
+## Out-of-Scope Behavior
+
+- Main app routing or dashboard registration
+- Inbox ingestion, mailbox mutations, or message persistence
+- Calendar writes, reminder writes, notification delivery, or scheduling side
+  effects
+- Database schema changes
+- Stellar wallet, contract, or payment behavior
+- Shared design system changes
+
+## Detection Contract
+
+Each source message should include:
+
+- `id`: stable fixture-local message identifier
+- `type`: message category used for review context
+- `sender`: synthetic sender address
+- `subject`: message subject
+- `body`: message body
+- `receivedAt`: ISO timestamp
+- `containsPersonalData`: false for local fixtures
+- `userTimezone`: timezone label used in the UI
+
+Each expected deadline should include:
+
+- `id`: stable fixture-local deadline identifier
+- `sourceMessageId`: source message identifier
+- `title`: display title
+- `dueDate`: ISO date or null
+- `dueTime`: 24-hour time or null
+- `timezone`: display timezone
+- `status`: one of `detected`, `needs-review`, `missed`, `ignored`
+- `urgency`: one of `overdue`, `today`, `soon`, `later`, `unknown`
+- `confidence`: number from 0 through 1
+- `reviewRequired`: true unless the result is high-confidence detected
+
+## Status Rules
+
+- `detected`: clear deadline language and a due date are present.
+- `needs-review`: the message has a possible due date or relative timing but
+  lacks enough deadline language to schedule automatically.
+- `missed`: the due date is before the detector run date.
+- `ignored`: the message is a digest, newsletter, or no-action message.
+
+## Accessibility Contract
+
+- Loading, empty, error, and success states must be screen-reader discoverable.
+- Filter controls must be keyboard accessible through native radio inputs.
+- Icon-only meaning must be paired with text, `aria-label`, or `aria-hidden`.
+- Color must never be the only status signal.
+- Reminder and review actions must expose descriptive accessible names.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Contributor Boundary
+
+Keep all changes for this issue in this folder. Future integration issues should
+define consent, reminder-write permissions, privacy handling, and audit behavior
+before this tool touches a real mailbox or calendar.

--- a/tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs
+++ b/tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-deadline-messages.json");
+
+const allowedStatuses = new Set(["detected", "needs-review", "missed", "ignored"]);
+const allowedUrgencies = new Set(["overdue", "today", "soon", "later", "unknown"]);
+const requiredStatuses = ["detected", "needs-review", "missed", "ignored"];
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample deadline fixture follows the local detection contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "deadline-detector");
+  assert.ok(Array.isArray(fixture.sourceMessages), "sourceMessages must be an array");
+  assert.ok(Array.isArray(fixture.expectedDeadlines), "expectedDeadlines must be an array");
+  assert.equal(fixture.sourceMessages.length, fixture.expectedDeadlines.length);
+  assert.match(fixture.runContext.now, /^\d{4}-\d{2}-\d{2}T/);
+
+  const sourceIds = new Set(fixture.sourceMessages.map((message) => message.id));
+  const seenStatuses = new Set();
+
+  for (const source of fixture.sourceMessages) {
+    assert.ok(source.id, "source message needs a stable id");
+    assert.ok(source.sender.endsWith(".test"), `${source.id} must use synthetic sender data`);
+    assert.equal(source.containsPersonalData, false, `${source.id} must not include personal data`);
+    assert.match(source.receivedAt, /^\d{4}-\d{2}-\d{2}T/);
+  }
+
+  for (const deadline of fixture.expectedDeadlines) {
+    assert.ok(deadline.id, "deadline needs a stable id");
+    assert.ok(deadline.title, `${deadline.id} needs a title`);
+    assert.ok(sourceIds.has(deadline.sourceMessageId), `${deadline.id} source message is missing`);
+    assert.ok(allowedStatuses.has(deadline.status), `${deadline.id} has invalid status`);
+    assert.ok(allowedUrgencies.has(deadline.urgency), `${deadline.id} has invalid urgency`);
+    assert.equal(typeof deadline.confidence, "number", `${deadline.id} confidence is numeric`);
+    assert.ok(deadline.confidence >= 0 && deadline.confidence <= 1);
+
+    if (deadline.dueDate !== null) {
+      assert.match(deadline.dueDate, /^\d{4}-\d{2}-\d{2}$/);
+    }
+
+    if (deadline.dueTime !== null) {
+      assert.match(deadline.dueTime, /^\d{2}:\d{2}$/);
+    }
+
+    if (deadline.status === "detected") {
+      assert.equal(deadline.reviewRequired, false, `${deadline.id} should be ready to offer`);
+      assert.ok(deadline.dueDate, `${deadline.id} detected rows need dueDate`);
+      assert.ok(deadline.confidence >= 0.9, `${deadline.id} detected rows need high confidence`);
+    }
+
+    if (deadline.status !== "detected") {
+      assert.equal(
+        deadline.reviewRequired,
+        true,
+        `${deadline.id} non-detected rows must require review`,
+      );
+    }
+
+    if (deadline.status === "missed") {
+      assert.equal(deadline.urgency, "overdue", `${deadline.id} missed rows must be overdue`);
+    }
+
+    if (deadline.status === "ignored") {
+      assert.equal(deadline.dueDate, null, `${deadline.id} ignored rows must not schedule dates`);
+      assert.equal(deadline.urgency, "unknown", `${deadline.id} ignored rows use unknown urgency`);
+    }
+
+    seenStatuses.add(deadline.status);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status} status`);
+  }
+});

--- a/tools/v2/individual/deadline-detector/types/deadline.ts
+++ b/tools/v2/individual/deadline-detector/types/deadline.ts
@@ -1,0 +1,51 @@
+export type DeadlineId = string;
+export type DeadlineSourceId = string;
+
+export type DeadlineStatus = "detected" | "needs-review" | "missed" | "ignored";
+export type DeadlineUrgency = "overdue" | "today" | "soon" | "later" | "unknown";
+export type DeadlineSourceType = "email" | "calendar-forward" | "invoice" | "project-update";
+
+export interface DeadlineMessage {
+  id: DeadlineSourceId;
+  type: DeadlineSourceType;
+  sender: string;
+  subject: string;
+  body: string;
+  receivedAt: string;
+  containsPersonalData: boolean;
+  userTimezone: string;
+}
+
+export interface DetectedDeadline {
+  id: DeadlineId;
+  sourceMessageId: DeadlineSourceId;
+  title: string;
+  dueDate: string | null;
+  dueTime: string | null;
+  timezone: string;
+  status: DeadlineStatus;
+  urgency: DeadlineUrgency;
+  confidence: number;
+  evidence: string;
+  suggestedAction: string;
+  reviewRequired: boolean;
+}
+
+export interface DeadlineDetectionSummary {
+  totalMessages: number;
+  totalDeadlines: number;
+  detected: number;
+  needsReview: number;
+  missed: number;
+  ignored: number;
+}
+
+export interface DeadlineDetectionResult {
+  deadlines: DetectedDeadline[];
+  summary: DeadlineDetectionSummary;
+}
+
+export interface DeadlineDetectorServiceOptions {
+  now?: string;
+  defaultTimezone?: string;
+}

--- a/tools/v2/individual/deadline-detector/types/index.ts
+++ b/tools/v2/individual/deadline-detector/types/index.ts
@@ -1,0 +1,12 @@
+export type {
+  DeadlineDetectionResult,
+  DeadlineDetectionSummary,
+  DeadlineDetectorServiceOptions,
+  DeadlineId,
+  DeadlineMessage,
+  DeadlineSourceId,
+  DeadlineSourceType,
+  DeadlineStatus,
+  DeadlineUrgency,
+  DetectedDeadline,
+} from "./deadline";


### PR DESCRIPTION
Closes #481

## Summary
- adds a folder-local Deadline Detector UI surface with empty, loading, error, summary, filter, and result-card states
- adds typed deadline models plus a deterministic detection service for obvious dates, relative phrases, times, urgency, and review status
- adds synthetic fixtures, a standalone Node fixture test, and accessibility/visual/test documentation

## Boundary
All changes stay under `tools/v2/individual/deadline-detector/`. This does not wire the tool into app routing, mailbox ingestion, reminders, calendars, database state, wallet code, or the shared design system.

## Validation
- `node --test tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs`
- `./node_modules/.bin/tsc --noEmit --jsx react-jsx --moduleResolution Bundler --module ESNext --target ES2022 --lib ES2022,DOM,DOM.Iterable --strict --skipLibCheck tools/v2/individual/deadline-detector/index.ts tools/v2/individual/deadline-detector/components/*.tsx tools/v2/individual/deadline-detector/services/*.ts tools/v2/individual/deadline-detector/types/*.ts`
- `./node_modules/.bin/prettier --check tools/v2/individual/deadline-detector`
- `git diff --check`
- cached boundary check: 19 files, all under `tools/v2/individual/deadline-detector/`