### PR TITLE
feat(demo-admin-dashboard): add draft dataset JSON export

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/datasetExport.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/datasetExport.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { Draft } from "../types/draft";
+import { draftDatasetSample } from "../fixtures/draftDatasetFixtures";
+import { DATASET_EXPORT_SCHEMA_VERSION } from "../types/datasetExport";
+import {
+  buildDatasetExport,
+  buildExportFilename,
+  serializeDraftDataset,
+  serializeDraftDatasetState,
+} from "../helpers/datasetExport";
+
+describe("dataset JSON export", () => {
+  it("builds an envelope with version, count, and drafts", () => {
+    const result = buildDatasetExport(draftDatasetSample);
+    expect(result.version).toBe(DATASET_EXPORT_SCHEMA_VERSION);
+    expect(result.count).toBe(draftDatasetSample.length);
+    expect(result.drafts).toHaveLength(draftDatasetSample.length);
+    expect(result.drafts[0]?.id).toBe("draft-dataset-001");
+  });
+
+  it("serializes deterministic, pretty JSON ending in a newline", () => {
+    const json = serializeDraftDataset(draftDatasetSample);
+    expect(json.endsWith("\n")).toBe(true);
+    expect(json).toContain('"version": 1');
+    expect(serializeDraftDataset(draftDatasetSample)).toBe(json);
+    const parsed = JSON.parse(json);
+    expect(parsed.count).toBe(draftDatasetSample.length);
+    expect(parsed.drafts).toHaveLength(draftDatasetSample.length);
+  });
+
+  it("normalizes drafts to only the known fields", () => {
+    const messy = [
+      {
+        id: "x1",
+        subject: "Hi",
+        body: "There",
+        recipients: ["a@example.com"],
+        secret: "should-not-export",
+      },
+    ] as unknown as Draft[];
+    const parsed = JSON.parse(serializeDraftDataset(messy));
+    expect(Object.keys(parsed.drafts[0]).sort()).toEqual(["body", "id", "recipients", "subject"]);
+  });
+
+  it("handles an empty dataset", () => {
+    const parsed = JSON.parse(serializeDraftDataset([]));
+    expect(parsed.count).toBe(0);
+    expect(parsed.drafts).toEqual([]);
+  });
+
+  it("serializes from dataset state", () => {
+    const json = serializeDraftDatasetState({
+      drafts: draftDatasetSample,
+      selectedId: null,
+    });
+    expect(JSON.parse(json).count).toBe(draftDatasetSample.length);
+  });
+
+  it("builds a UTC-dated filename", () => {
+    const date = new Date("2026-06-18T23:30:00Z");
+    expect(buildExportFilename(date)).toBe("draft-dataset-export-2026-06-18.json");
+  });
+
+  it("supports a custom filename prefix", () => {
+    const date = new Date("2026-01-05T00:00:00Z");
+    expect(buildExportFilename(date, "demo-drafts")).toBe("demo-drafts-2026-01-05.json");
+  });
+});

--- a/src/features/demo-admin-dashboard/components/ExportDatasetButton.tsx
+++ b/src/features/demo-admin-dashboard/components/ExportDatasetButton.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import type { Draft } from "../types/draft";
+import { buildExportFilename, serializeDraftDataset } from "../helpers/datasetExport";
+
+export interface ExportDatasetButtonProps {
+  /** Drafts to export. */
+  drafts: Draft[];
+  /** Optional explicit filename; defaults to a UTC-dated name. */
+  filename?: string;
+  /** Optional override for the export date used to build the filename. */
+  exportDate?: Date;
+  /** Force-disable the button. When omitted, it disables on an empty dataset. */
+  disabled?: boolean;
+  /** Optional class name for styling hooks. */
+  className?: string;
+  /** Visible button label. */
+  label?: string;
+  /** Optional callback invoked with the serialized payload. */
+  onExport?: (result: { filename: string; json: string }) => void;
+}
+
+/**
+ * Admin control that serializes the current draft dataset to JSON and triggers
+ * a browser download. DOM side effects are guarded so the component is safe to
+ * render during SSR or in non-DOM test environments.
+ */
+export function ExportDatasetButton({
+  drafts,
+  filename,
+  exportDate,
+  disabled,
+  className,
+  label = "Export JSON",
+  onExport,
+}: ExportDatasetButtonProps) {
+  const handleExport = useCallback(() => {
+    const json = serializeDraftDataset(drafts);
+    const resolvedName = filename ?? buildExportFilename(exportDate ?? new Date());
+
+    onExport?.({ filename: resolvedName, json });
+
+    const hasDom =
+      typeof document !== "undefined" &&
+      typeof URL !== "undefined" &&
+      typeof URL.createObjectURL === "function";
+    if (!hasDom) return;
+
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = resolvedName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [drafts, filename, exportDate, onExport]);
+
+  const isDisabled = disabled ?? drafts.length === 0;
+
+  return (
+    <button type="button" className={className} onClick={handleExport} disabled={isDisabled}>
+      {label}
+    </button>
+  );
+}

--- a/src/features/demo-admin-dashboard/docs/DATASET_JSON_EXPORT.md
+++ b/src/features/demo-admin-dashboard/docs/DATASET_JSON_EXPORT.md
@@ -1,0 +1,23 @@
+# Draft dataset JSON export
+
+Admin helper for exporting the current draft dataset as formatted JSON, part of
+the Demo Admin Dashboard initiative (issue #190).
+
+## What it does
+
+- `serializeDraftDataset(drafts, indent?)` — returns deterministic, pretty
+  printed JSON in the shape `{ version, count, drafts }`. Drafts are normalized
+  to known fields only, so nothing extra leaks into a shared export, and no
+  timestamps are embedded, keeping the output stable for review and tests.
+- `serializeDraftDatasetState(state, indent?)` — serializes `state.drafts`.
+- `buildExportFilename(date, prefix?)` — builds
+  `draft-dataset-export-YYYY-MM-DD.json` using a UTC date passed in by the caller.
+- `<ExportDatasetButton drafts={...} />` — renders a button that serializes the
+  drafts and triggers a browser download. DOM side effects are guarded so it is
+  safe under SSR and in tests; an optional `onExport` callback exposes the payload.
+
+## Scope
+
+All code lives under `src/features/demo-admin-dashboard/`. Data is fake and
+deterministic, with no network calls or secrets. Wiring the button into the
+dashboard shell is a deliberate follow-up.

--- a/src/features/demo-admin-dashboard/helpers/datasetExport.ts
+++ b/src/features/demo-admin-dashboard/helpers/datasetExport.ts
@@ -1,0 +1,51 @@
+import type { Draft } from "../types/draft";
+import type { DraftDatasetState } from "../types/draftDataset";
+import { DATASET_EXPORT_SCHEMA_VERSION, type DraftDatasetExport } from "../types/datasetExport";
+
+const DEFAULT_INDENT = 2;
+const DEFAULT_FILENAME_PREFIX = "draft-dataset-export";
+
+/**
+ * Build the export envelope from a list of drafts. Each draft is normalized to
+ * only the known fields, so stray properties never leak into a shared export.
+ */
+export function buildDatasetExport(drafts: Draft[]): DraftDatasetExport {
+  return {
+    version: DATASET_EXPORT_SCHEMA_VERSION,
+    count: drafts.length,
+    drafts: drafts.map((draft) => ({
+      id: draft.id,
+      subject: draft.subject,
+      body: draft.body,
+      recipients: [...draft.recipients],
+    })),
+  };
+}
+
+/**
+ * Serialize a list of drafts to formatted, deterministic JSON. The output is
+ * pretty-printed and ends with a trailing newline so it reads cleanly in files.
+ */
+export function serializeDraftDataset(drafts: Draft[], indent: number = DEFAULT_INDENT): string {
+  return `${JSON.stringify(buildDatasetExport(drafts), null, indent)}\n`;
+}
+
+/** Convenience wrapper to serialize directly from dataset state. */
+export function serializeDraftDatasetState(
+  state: DraftDatasetState,
+  indent: number = DEFAULT_INDENT,
+): string {
+  return serializeDraftDataset(state.drafts, indent);
+}
+
+/**
+ * Build a deterministic export filename of the form
+ * `draft-dataset-export-YYYY-MM-DD.json`. The date is taken in UTC and passed
+ * in explicitly so callers (and tests) stay deterministic.
+ */
+export function buildExportFilename(date: Date, prefix: string = DEFAULT_FILENAME_PREFIX): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${prefix}-${year}-${month}-${day}.json`;
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -154,3 +154,15 @@ export { useDraftDataset } from "./hooks/useDraftDataset";
 export type { UseDraftDatasetResult } from "./hooks/useDraftDataset";
 export type { DraftDatasetAction, DraftDatasetState } from "./types/draftDataset";
 export { draftDatasetSample } from "./fixtures/draftDatasetFixtures";
+
+// Draft dataset JSON export (issue #190): serializer, filename builder, button.
+export {
+  buildDatasetExport,
+  serializeDraftDataset,
+  serializeDraftDatasetState,
+  buildExportFilename,
+} from "./helpers/datasetExport";
+export { DATASET_EXPORT_SCHEMA_VERSION } from "./types/datasetExport";
+export type { DraftDatasetExport } from "./types/datasetExport";
+export { ExportDatasetButton } from "./components/ExportDatasetButton";
+export type { ExportDatasetButtonProps } from "./components/ExportDatasetButton";

--- a/src/features/demo-admin-dashboard/types/datasetExport.ts
+++ b/src/features/demo-admin-dashboard/types/datasetExport.ts
@@ -1,0 +1,18 @@
+import type { Draft } from "./draft";
+
+/** Current schema version for an exported draft dataset payload. */
+export const DATASET_EXPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Serializable envelope produced when a maintainer exports the current draft
+ * dataset as JSON. The payload is intentionally free of timestamps so the
+ * serialized output stays deterministic; the export date lives in the filename.
+ */
+export interface DraftDatasetExport {
+  /** Schema version, so future importers can detect the shape. */
+  version: number;
+  /** Number of drafts included in the export. */
+  count: number;
+  /** Exported drafts, in dataset order. */
+  drafts: Draft[];
+}


### PR DESCRIPTION
## What
Adds an admin JSON export flow for the draft dataset (#190): a serializer, filename builder, and ExportDatasetButton, building on the draft-store from #172.

## Changes (all under src/features/demo-admin-dashboard/)
- helpers/datasetExport.ts — buildDatasetExport, serializeDraftDataset, serializeDraftDatasetState, buildExportFilename
- types/datasetExport.ts — DraftDatasetExport envelope + schema version
- components/ExportDatasetButton.tsx — serializes drafts and triggers a browser download (SSR/test-safe)
- __tests__/datasetExport.test.ts — determinism, field normalization, empty case, filename format
- docs/DATASET_JSON_EXPORT.md and index.ts barrel exports

## Notes
JSON payload is deterministic (no embedded timestamps — the date lives in the filename) and drafts are normalized to known fields only, so it's safe for public review. Fake data, no network calls or secrets. Wiring the button into the dashboard shell is left as a follow-up.

## Testing
tsc clean, eslint 0 errors, 7 new export tests pass, vite build succeeds.

Closes #190