### PR TITLE
Feat: Add campaing timeline model

### DIFF
--- a/src/features/demo-admin-dashboard/constants/displayTokens.ts
+++ b/src/features/demo-admin-dashboard/constants/displayTokens.ts
@@ -176,3 +176,105 @@ export function getAudienceToken(audience: string): DisplayToken {
     }
   );
 }
+
+export const CAMPAIGN_PHASE_TOKENS: Record<
+  "planning" | "warmup" | "active" | "cooldown" | "completed" | "paused",
+  DisplayToken
+> = {
+  planning: {
+    bg: "bg-slate-500/10",
+    text: "text-slate-400",
+    border: "border-slate-500/20",
+    label: "Planning",
+  },
+  warmup: {
+    bg: "bg-sky-500/10",
+    text: "text-sky-400",
+    border: "border-sky-500/20",
+    label: "Warmup",
+  },
+  active: {
+    bg: "bg-teal-500/10",
+    text: "text-teal-400",
+    border: "border-teal-500/20",
+    label: "Active",
+  },
+  cooldown: {
+    bg: "bg-indigo-500/10",
+    text: "text-indigo-400",
+    border: "border-indigo-500/20",
+    label: "Cooldown",
+  },
+  completed: {
+    bg: "bg-green-500/10",
+    text: "text-green-400",
+    border: "border-green-500/20",
+    label: "Completed",
+  },
+  paused: {
+    bg: "bg-orange-500/10",
+    text: "text-orange-400",
+    border: "border-orange-500/20",
+    label: "Paused",
+  },
+};
+
+export const MILESTONE_KIND_TOKENS: Record<
+  "launch" | "review" | "approval" | "analysis" | "custom",
+  DisplayToken
+> = {
+  launch: {
+    bg: "bg-cyan-500/10",
+    text: "text-cyan-400",
+    border: "border-cyan-500/20",
+    label: "Launch",
+  },
+  review: {
+    bg: "bg-yellow-500/10",
+    text: "text-yellow-400",
+    border: "border-yellow-500/20",
+    label: "Review",
+  },
+  approval: {
+    bg: "bg-violet-500/10",
+    text: "text-violet-400",
+    border: "border-violet-500/20",
+    label: "Approval",
+  },
+  analysis: {
+    bg: "bg-blue-500/10",
+    text: "text-blue-400",
+    border: "border-blue-500/20",
+    label: "Analysis",
+  },
+  custom: {
+    bg: "bg-white/[0.04]",
+    text: "text-muted-foreground",
+    border: "border-white/[0.08]",
+    label: "Custom",
+  },
+};
+
+export function getPhaseToken(kind: string): DisplayToken {
+  const key = kind as keyof typeof CAMPAIGN_PHASE_TOKENS;
+  return (
+    CAMPAIGN_PHASE_TOKENS[key] ?? {
+      bg: "bg-white/[0.04]",
+      text: "text-muted-foreground",
+      border: "border-white/[0.08]",
+      label: kind,
+    }
+  );
+}
+
+export function getMilestoneToken(kind: string): DisplayToken {
+  const key = kind as keyof typeof MILESTONE_KIND_TOKENS;
+  return (
+    MILESTONE_KIND_TOKENS[key] ?? {
+      bg: "bg-white/[0.04]",
+      text: "text-muted-foreground",
+      border: "border-white/[0.08]",
+      label: kind,
+    }
+  );
+}

--- a/src/features/demo-admin-dashboard/fixtures/campaignTimelineFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/campaignTimelineFixtures.ts
@@ -1,0 +1,160 @@
+import type { CampaignTimeline } from "../types/campaignTimeline";
+
+/**
+ * Reference clock: 2026-06-16T09:00 — matches DEMO_REFERENCE_NOW in snooze/referenceNow.ts.
+ * All dates are hardcoded strings relative to that anchor.
+ */
+
+export const activeCampaignTimeline: CampaignTimeline = {
+  id: "tl-001",
+  campaignId: "snap-001",
+  createdAt: "2026-05-01T10:00",
+  updatedAt: "2026-06-10T14:30",
+  phases: [
+    {
+      id: "phase-001",
+      phaseKind: "planning",
+      label: "Planning",
+      startAt: "2026-05-01T00:00",
+      endAt: "2026-05-14T23:59",
+      status: "completed",
+      description: "Define campaign goals, audience targeting, and draft messaging.",
+    },
+    {
+      id: "phase-002",
+      phaseKind: "warmup",
+      label: "Warmup",
+      startAt: "2026-05-15T00:00",
+      endAt: "2026-05-31T23:59",
+      status: "completed",
+      description: "Gradually increase send volume to warm up relay reputation.",
+    },
+    {
+      id: "phase-003",
+      phaseKind: "active",
+      label: "Active Send",
+      startAt: "2026-06-01T00:00",
+      endAt: "2026-06-22T23:59",
+      status: "active",
+      description: "Main campaign send window — full audience delivery.",
+    },
+    {
+      id: "phase-004",
+      phaseKind: "cooldown",
+      label: "Cooldown",
+      startAt: "2026-06-23T00:00",
+      endAt: "2026-06-30T23:59",
+      status: "upcoming",
+      description: "Wind-down period; collect receipts and monitor delivery metrics.",
+    },
+  ],
+  sends: [
+    {
+      id: "send-001",
+      phaseId: "phase-003",
+      label: "Investor Update — June Batch A",
+      scheduledAt: "2026-06-05T09:00",
+      recipientSegmentId: "investors",
+      estimatedCount: 420,
+      status: "sent",
+      draftId: "draft-001",
+    },
+    {
+      id: "send-002",
+      phaseId: "phase-003",
+      label: "Investor Update — June Batch B",
+      scheduledAt: "2026-06-19T09:00",
+      recipientSegmentId: "founders",
+      estimatedCount: 185,
+      status: "pending",
+      draftId: "draft-002",
+    },
+    {
+      id: "send-003",
+      phaseId: "phase-004",
+      label: "Relay Operator Notice",
+      scheduledAt: "2026-06-25T11:00",
+      recipientSegmentId: "relay-operators",
+      estimatedCount: 62,
+      status: "pending",
+    },
+  ],
+  milestones: [
+    {
+      id: "ms-001",
+      kind: "launch",
+      label: "Campaign Launch",
+      dueAt: "2026-06-01T09:00",
+      resolvedAt: "2026-06-01T09:15",
+      status: "resolved",
+      note: "First send went out on schedule.",
+    },
+    {
+      id: "ms-002",
+      kind: "review",
+      label: "Mid-Campaign Review",
+      dueAt: "2026-06-23T10:00",
+      status: "pending",
+      note: "Review delivery rates and receipt confirmations before cooldown.",
+    },
+  ],
+  previewWindows: [
+    {
+      id: "pw-001",
+      label: "Active Phase Preview",
+      opensAt: "2026-05-28T00:00",
+      closesAt: "2026-06-22T23:59",
+      associatedPhaseId: "phase-003",
+      sendIds: ["send-001", "send-002"],
+    },
+  ],
+};
+
+export const draftCampaignTimeline: CampaignTimeline = {
+  id: "tl-002",
+  campaignId: "snap-002",
+  createdAt: "2026-06-14T08:00",
+  updatedAt: "2026-06-15T17:45",
+  phases: [
+    {
+      id: "phase-005",
+      phaseKind: "planning",
+      label: "Planning",
+      startAt: "2026-07-01T00:00",
+      endAt: "2026-07-14T23:59",
+      status: "upcoming",
+      description: "Define scope and prepare audience lists for the Q3 campaign.",
+    },
+    {
+      id: "phase-006",
+      phaseKind: "warmup",
+      label: "Warmup",
+      startAt: "2026-07-15T00:00",
+      endAt: "2026-07-31T23:59",
+      status: "upcoming",
+      description: "Gradual volume increase before the full send.",
+    },
+  ],
+  sends: [
+    {
+      id: "send-004",
+      phaseId: "phase-006",
+      label: "Q3 Announcement — Early Access",
+      scheduledAt: "2026-07-22T10:00",
+      recipientSegmentId: "founders",
+      estimatedCount: 310,
+      status: "pending",
+    },
+  ],
+  milestones: [
+    {
+      id: "ms-003",
+      kind: "approval",
+      label: "Legal & Compliance Sign-off",
+      dueAt: "2026-06-30T17:00",
+      status: "pending",
+      note: "Required before any sends go out.",
+    },
+  ],
+  previewWindows: [],
+};

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -168,6 +168,42 @@ export {
 } from "./proofFormatting";
 export { demoProofRecords } from "./fixtures/proofRecordFixtures";
 
+// Campaign Timeline (issue #260): types, fixtures, helpers, display tokens.
+export type {
+  CampaignPhase,
+  CampaignPhaseKind,
+  CampaignPhaseStatus,
+  CampaignTimeline,
+  Milestone,
+  MilestoneKind,
+  MilestoneStatus,
+  PreviewWindow,
+  ScheduledSend,
+  ScheduledSendStatus,
+} from "./types/campaignTimeline";
+export { activeCampaignTimeline, draftCampaignTimeline } from "./fixtures/campaignTimelineFixtures";
+export {
+  getActivePhase,
+  getPhaseForDate,
+  getPhaseDurationDays,
+  getSendsInWindow,
+  getTimelineDateRange,
+  getUpcomingMilestones,
+  isDateInPhase,
+  sortPhasesByStartDate,
+  validateCampaignTimeline,
+  validateMilestones,
+  validatePhases,
+  validatePreviewWindows,
+  validateScheduledSends,
+} from "./utils/campaignTimelineHelpers";
+export {
+  CAMPAIGN_PHASE_TOKENS,
+  getMilestoneToken,
+  getPhaseToken,
+  MILESTONE_KIND_TOKENS,
+} from "./constants/displayTokens";
+
 // Draft dataset admin store (issue #172): reducer, selectors, hook, types, fixture.
 export { draftDatasetReducer, initialDraftDatasetState } from "./reducers/draftDatasetReducer";
 export {

--- a/src/features/demo-admin-dashboard/types/campaignTimeline.ts
+++ b/src/features/demo-admin-dashboard/types/campaignTimeline.ts
@@ -1,0 +1,79 @@
+export type CampaignPhaseKind =
+  | "planning"
+  | "warmup"
+  | "active"
+  | "cooldown"
+  | "completed"
+  | "paused";
+
+export type CampaignPhaseStatus = "upcoming" | "active" | "completed" | "skipped";
+
+export type ScheduledSendStatus = "pending" | "sent" | "failed" | "cancelled";
+
+export type MilestoneKind = "launch" | "review" | "approval" | "analysis" | "custom";
+
+export type MilestoneStatus = "pending" | "resolved" | "overdue" | "skipped";
+
+export interface CampaignPhase {
+  id: string;
+  phaseKind: CampaignPhaseKind;
+  label: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  startAt: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  endAt: string;
+  status: CampaignPhaseStatus;
+  description?: string;
+}
+
+export interface ScheduledSend {
+  id: string;
+  /** References CampaignPhase.id */
+  phaseId: string;
+  label: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  scheduledAt: string;
+  /** AudienceSegmentId string */
+  recipientSegmentId: string;
+  estimatedCount: number;
+  status: ScheduledSendStatus;
+  /** References Draft.id if linked to a draft */
+  draftId?: string;
+}
+
+export interface Milestone {
+  id: string;
+  kind: MilestoneKind;
+  label: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  dueAt: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" — set when status is "resolved" */
+  resolvedAt?: string;
+  status: MilestoneStatus;
+  note?: string;
+}
+
+export interface PreviewWindow {
+  id: string;
+  label: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  opensAt: string;
+  /** ISO local "yyyy-MM-ddTHH:mm" */
+  closesAt: string;
+  /** References CampaignPhase.id */
+  associatedPhaseId?: string;
+  /** ScheduledSend.id[] visible within this window */
+  sendIds: string[];
+}
+
+export interface CampaignTimeline {
+  id: string;
+  /** References CampaignSnapshot id ("snap-*") */
+  campaignId: string;
+  phases: CampaignPhase[];
+  sends: ScheduledSend[];
+  milestones: Milestone[];
+  previewWindows: PreviewWindow[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/features/demo-admin-dashboard/utils/campaignTimelineHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/campaignTimelineHelpers.ts
@@ -1,0 +1,298 @@
+import type { ValidationIssue } from "../validation-types";
+import type {
+  CampaignPhase,
+  CampaignTimeline,
+  Milestone,
+  PreviewWindow,
+  ScheduledSend,
+} from "../types/campaignTimeline";
+
+/** Parses an ISO local "yyyy-MM-ddTHH:mm" string to a Date. */
+function parseLocalDate(iso: string): Date {
+  return new Date(iso);
+}
+
+// ---------------------------------------------------------------------------
+// Phase query helpers
+// ---------------------------------------------------------------------------
+
+export function isDateInPhase(date: Date, phase: CampaignPhase): boolean {
+  return date >= parseLocalDate(phase.startAt) && date <= parseLocalDate(phase.endAt);
+}
+
+export function getPhaseForDate(timeline: CampaignTimeline, date: Date): CampaignPhase | undefined {
+  return timeline.phases.find((p) => isDateInPhase(date, p));
+}
+
+export function getActivePhase(
+  timeline: CampaignTimeline,
+  now: Date = new Date(),
+): CampaignPhase | undefined {
+  return getPhaseForDate(timeline, now);
+}
+
+/** Returns the number of whole days between startAt and endAt (inclusive). */
+export function getPhaseDurationDays(phase: CampaignPhase): number {
+  const start = parseLocalDate(phase.startAt);
+  const end = parseLocalDate(phase.endAt);
+  const msPerDay = 1000 * 60 * 60 * 24;
+  return Math.max(0, Math.floor((end.getTime() - start.getTime()) / msPerDay));
+}
+
+export function sortPhasesByStartDate(phases: CampaignPhase[]): CampaignPhase[] {
+  return [...phases].sort(
+    (a, b) => parseLocalDate(a.startAt).getTime() - parseLocalDate(b.startAt).getTime(),
+  );
+}
+
+export function getUpcomingMilestones(
+  timeline: CampaignTimeline,
+  from: Date = new Date(),
+): Milestone[] {
+  return timeline.milestones.filter((m) => parseLocalDate(m.dueAt) > from);
+}
+
+export function getSendsInWindow(
+  timeline: CampaignTimeline,
+  window: PreviewWindow,
+): ScheduledSend[] {
+  const idSet = new Set(window.sendIds);
+  return timeline.sends.filter((s) => idSet.has(s.id));
+}
+
+/** Returns the earliest startAt and latest endAt across all phases, or null for an empty timeline. */
+export function getTimelineDateRange(
+  timeline: CampaignTimeline,
+): { startsAt: string; endsAt: string } | null {
+  if (timeline.phases.length === 0) return null;
+  const sorted = sortPhasesByStartDate(timeline.phases);
+  const latest = [...timeline.phases].sort(
+    (a, b) => parseLocalDate(b.endAt).getTime() - parseLocalDate(a.endAt).getTime(),
+  );
+  return { startsAt: sorted[0].startAt, endsAt: latest[0].endAt };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function issue(
+  id: string,
+  severity: ValidationIssue["severity"],
+  fieldPath: string,
+  message: string,
+  recordId?: string,
+  hint?: string,
+): ValidationIssue {
+  return {
+    id,
+    severity,
+    fieldPath,
+    message,
+    datasetId: "campaign-timeline",
+    recordId,
+    hint,
+  };
+}
+
+export function validatePhases(phases: CampaignPhase[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
+    const start = parseLocalDate(phase.startAt);
+    const end = parseLocalDate(phase.endAt);
+
+    if (start >= end) {
+      issues.push(
+        issue(
+          `phase-date-order-${phase.id}`,
+          "error",
+          `phases[${i}].endAt`,
+          `Phase "${phase.label}" has endAt before or equal to startAt.`,
+          phase.id,
+          "Set endAt to a date after startAt.",
+        ),
+      );
+    }
+  }
+
+  const sorted = sortPhasesByStartDate(phases);
+  for (let i = 0; i < sorted.length; i++) {
+    const phase = sorted[i];
+    const phaseIndex = phases.indexOf(phase);
+
+    if (i > 0) {
+      const prev = sorted[i - 1];
+      const prevEnd = parseLocalDate(prev.endAt);
+      const currStart = parseLocalDate(phase.startAt);
+
+      if (currStart < prevEnd) {
+        issues.push(
+          issue(
+            `phase-overlap-${phase.id}`,
+            "error",
+            `phases[${phaseIndex}].startAt`,
+            `Phase "${phase.label}" overlaps with "${prev.label}".`,
+            phase.id,
+            "Move startAt to after the previous phase ends.",
+          ),
+        );
+      }
+    }
+  }
+
+  const orderedIds = sorted.map((p) => p.id);
+  const inputIds = phases.map((p) => p.id);
+  if (JSON.stringify(orderedIds) !== JSON.stringify(inputIds)) {
+    issues.push(
+      issue(
+        "phases-order-warning",
+        "warning",
+        "phases",
+        "Phases are not in chronological order.",
+        undefined,
+        "Sort phases by startAt for clearer timeline representation.",
+      ),
+    );
+  }
+
+  return issues;
+}
+
+export function validateScheduledSends(
+  sends: ScheduledSend[],
+  phases: CampaignPhase[],
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const phaseMap = new Map(phases.map((p) => [p.id, p]));
+
+  for (let i = 0; i < sends.length; i++) {
+    const send = sends[i];
+
+    if (send.estimatedCount < 0) {
+      issues.push(
+        issue(
+          `send-count-${send.id}`,
+          "error",
+          `sends[${i}].estimatedCount`,
+          `Send "${send.label}" has a negative estimatedCount.`,
+          send.id,
+          "Set estimatedCount to 0 or a positive number.",
+        ),
+      );
+    }
+
+    const phase = phaseMap.get(send.phaseId);
+    if (!phase) continue;
+
+    const scheduledAt = parseLocalDate(send.scheduledAt);
+    if (!isDateInPhase(scheduledAt, phase)) {
+      issues.push(
+        issue(
+          `send-outside-phase-${send.id}`,
+          "warning",
+          `sends[${i}].scheduledAt`,
+          `Send "${send.label}" is scheduled outside its phase window ("${phase.label}").`,
+          send.id,
+          "Move scheduledAt within the phase's startAt–endAt range.",
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function validateMilestones(milestones: Milestone[]): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  for (let i = 0; i < milestones.length; i++) {
+    const ms = milestones[i];
+    const due = parseLocalDate(ms.dueAt);
+
+    if (isNaN(due.getTime())) {
+      issues.push(
+        issue(
+          `milestone-invalid-date-${ms.id}`,
+          "error",
+          `milestones[${i}].dueAt`,
+          `Milestone "${ms.label}" has an invalid dueAt value.`,
+          ms.id,
+          'Use ISO local format "yyyy-MM-ddTHH:mm".',
+        ),
+      );
+      continue;
+    }
+
+    if (ms.resolvedAt && ms.status !== "skipped") {
+      const resolved = parseLocalDate(ms.resolvedAt);
+      if (resolved < due) {
+        issues.push(
+          issue(
+            `milestone-resolved-before-due-${ms.id}`,
+            "warning",
+            `milestones[${i}].resolvedAt`,
+            `Milestone "${ms.label}" was resolved before its due date.`,
+            ms.id,
+          ),
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validatePreviewWindows(
+  windows: PreviewWindow[],
+  sends: ScheduledSend[],
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const sendIds = new Set(sends.map((s) => s.id));
+
+  for (let i = 0; i < windows.length; i++) {
+    const pw = windows[i];
+    const opens = parseLocalDate(pw.opensAt);
+    const closes = parseLocalDate(pw.closesAt);
+
+    if (opens >= closes) {
+      issues.push(
+        issue(
+          `preview-window-dates-${pw.id}`,
+          "error",
+          `previewWindows[${i}].closesAt`,
+          `Preview window "${pw.label}" has closesAt before or equal to opensAt.`,
+          pw.id,
+          "Set closesAt to a time after opensAt.",
+        ),
+      );
+    }
+
+    for (const sendId of pw.sendIds) {
+      if (!sendIds.has(sendId)) {
+        issues.push(
+          issue(
+            `preview-window-missing-send-${pw.id}-${sendId}`,
+            "warning",
+            `previewWindows[${i}].sendIds`,
+            `Preview window "${pw.label}" references unknown send "${sendId}".`,
+            pw.id,
+            "Remove the sendId or add the corresponding ScheduledSend.",
+          ),
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validateCampaignTimeline(timeline: CampaignTimeline): ValidationIssue[] {
+  return [
+    ...validatePhases(timeline.phases),
+    ...validateScheduledSends(timeline.sends, timeline.phases),
+    ...validateMilestones(timeline.milestones),
+    ...validatePreviewWindows(timeline.previewWindows, timeline.sends),
+  ];
+}

--- a/tests/unit/demo-admin-dashboard/campaignTimeline.test.ts
+++ b/tests/unit/demo-admin-dashboard/campaignTimeline.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CampaignPhase,
+  CampaignTimeline,
+} from "../../../src/features/demo-admin-dashboard/types/campaignTimeline";
+import {
+  activeCampaignTimeline,
+  draftCampaignTimeline,
+} from "../../../src/features/demo-admin-dashboard/fixtures/campaignTimelineFixtures";
+import {
+  getActivePhase,
+  getPhaseDurationDays,
+  getSendsInWindow,
+  getTimelineDateRange,
+  getUpcomingMilestones,
+  isDateInPhase,
+  sortPhasesByStartDate,
+  validateCampaignTimeline,
+  validateMilestones,
+  validatePhases,
+  validatePreviewWindows,
+  validateScheduledSends,
+} from "../../../src/features/demo-admin-dashboard/utils/campaignTimelineHelpers";
+
+const REF_NOW = new Date("2026-06-16T09:00");
+
+// ---------------------------------------------------------------------------
+// isDateInPhase
+// ---------------------------------------------------------------------------
+
+describe("isDateInPhase", () => {
+  const phase: CampaignPhase = {
+    id: "p",
+    phaseKind: "active",
+    label: "Active",
+    startAt: "2026-06-01T00:00",
+    endAt: "2026-06-30T23:59",
+    status: "active",
+  };
+
+  it("returns true when date is within the phase window", () => {
+    expect(isDateInPhase(new Date("2026-06-16T09:00"), phase)).toBe(true);
+  });
+
+  it("returns true on the boundary start date", () => {
+    expect(isDateInPhase(new Date("2026-06-01T00:00"), phase)).toBe(true);
+  });
+
+  it("returns false when date is before the phase", () => {
+    expect(isDateInPhase(new Date("2026-05-31T23:59"), phase)).toBe(false);
+  });
+
+  it("returns false when date is after the phase", () => {
+    expect(isDateInPhase(new Date("2026-07-01T00:00"), phase)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getActivePhase
+// ---------------------------------------------------------------------------
+
+describe("getActivePhase", () => {
+  it("returns the phase containing REF_NOW", () => {
+    const phase = getActivePhase(activeCampaignTimeline, REF_NOW);
+    expect(phase).toBeDefined();
+    expect(phase?.id).toBe("phase-003");
+    expect(phase?.phaseKind).toBe("active");
+  });
+
+  it("returns undefined when no phase contains the date", () => {
+    const result = getActivePhase(activeCampaignTimeline, new Date("2025-01-01T00:00"));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for a timeline with no phases", () => {
+    const empty: CampaignTimeline = { ...activeCampaignTimeline, phases: [] };
+    expect(getActivePhase(empty, REF_NOW)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPhaseDurationDays
+// ---------------------------------------------------------------------------
+
+describe("getPhaseDurationDays", () => {
+  it("returns correct day count for a 14-day phase", () => {
+    const phase = activeCampaignTimeline.phases.find((p) => p.id === "phase-001")!;
+    expect(getPhaseDurationDays(phase)).toBe(13);
+  });
+
+  it("returns 0 for a same-day phase", () => {
+    const phase: CampaignPhase = {
+      id: "x",
+      phaseKind: "planning",
+      label: "Same Day",
+      startAt: "2026-06-01T00:00",
+      endAt: "2026-06-01T23:59",
+      status: "upcoming",
+    };
+    expect(getPhaseDurationDays(phase)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortPhasesByStartDate
+// ---------------------------------------------------------------------------
+
+describe("sortPhasesByStartDate", () => {
+  it("returns phases ordered by startAt ascending", () => {
+    const shuffled = [...activeCampaignTimeline.phases].reverse();
+    const sorted = sortPhasesByStartDate(shuffled);
+    const ids = sorted.map((p) => p.id);
+    expect(ids).toEqual(["phase-001", "phase-002", "phase-003", "phase-004"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const original = [...activeCampaignTimeline.phases].reverse();
+    const originalIds = original.map((p) => p.id);
+    sortPhasesByStartDate(original);
+    expect(original.map((p) => p.id)).toEqual(originalIds);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUpcomingMilestones
+// ---------------------------------------------------------------------------
+
+describe("getUpcomingMilestones", () => {
+  it("returns only milestones due after the from date", () => {
+    const upcoming = getUpcomingMilestones(activeCampaignTimeline, REF_NOW);
+    expect(upcoming.length).toBe(1);
+    expect(upcoming[0].id).toBe("ms-002");
+  });
+
+  it("returns all milestones when from is far in the past", () => {
+    const all = getUpcomingMilestones(activeCampaignTimeline, new Date("2020-01-01T00:00"));
+    expect(all.length).toBe(activeCampaignTimeline.milestones.length);
+  });
+
+  it("returns empty array when from is in the future", () => {
+    const none = getUpcomingMilestones(activeCampaignTimeline, new Date("2030-01-01T00:00"));
+    expect(none).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSendsInWindow
+// ---------------------------------------------------------------------------
+
+describe("getSendsInWindow", () => {
+  it("returns only the sends referenced by the preview window", () => {
+    const window = activeCampaignTimeline.previewWindows[0];
+    const sends = getSendsInWindow(activeCampaignTimeline, window);
+    const ids = sends.map((s) => s.id);
+    expect(ids).toEqual(expect.arrayContaining(["send-001", "send-002"]));
+    expect(ids).not.toContain("send-003");
+  });
+
+  it("returns empty array when sendIds is empty", () => {
+    const emptyWindow = { ...activeCampaignTimeline.previewWindows[0], sendIds: [] };
+    expect(getSendsInWindow(activeCampaignTimeline, emptyWindow)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTimelineDateRange
+// ---------------------------------------------------------------------------
+
+describe("getTimelineDateRange", () => {
+  it("returns the earliest startAt and latest endAt", () => {
+    const range = getTimelineDateRange(activeCampaignTimeline);
+    expect(range).not.toBeNull();
+    expect(range?.startsAt).toBe("2026-05-01T00:00");
+    expect(range?.endsAt).toBe("2026-06-30T23:59");
+  });
+
+  it("returns null for an empty phases array", () => {
+    const empty: CampaignTimeline = { ...activeCampaignTimeline, phases: [] };
+    expect(getTimelineDateRange(empty)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePhases
+// ---------------------------------------------------------------------------
+
+describe("validatePhases", () => {
+  it("returns no issues for a valid phase sequence", () => {
+    expect(validatePhases(activeCampaignTimeline.phases)).toHaveLength(0);
+  });
+
+  it("emits an error when startAt >= endAt", () => {
+    const bad: CampaignPhase = {
+      id: "bad-phase",
+      phaseKind: "planning",
+      label: "Bad Phase",
+      startAt: "2026-06-10T00:00",
+      endAt: "2026-06-01T00:00",
+      status: "upcoming",
+    };
+    const issues = validatePhases([bad]);
+    expect(issues.some((i) => i.severity === "error" && i.fieldPath.includes("endAt"))).toBe(true);
+  });
+
+  it("emits an error when two phases overlap", () => {
+    const a: CampaignPhase = {
+      id: "a",
+      phaseKind: "planning",
+      label: "A",
+      startAt: "2026-06-01T00:00",
+      endAt: "2026-06-20T23:59",
+      status: "active",
+    };
+    const b: CampaignPhase = {
+      id: "b",
+      phaseKind: "warmup",
+      label: "B",
+      startAt: "2026-06-10T00:00",
+      endAt: "2026-06-30T23:59",
+      status: "upcoming",
+    };
+    const issues = validatePhases([a, b]);
+    expect(issues.some((i) => i.severity === "error" && i.id.startsWith("phase-overlap"))).toBe(
+      true,
+    );
+  });
+
+  it("emits a warning when phases are not in chronological order", () => {
+    const reversed = [...activeCampaignTimeline.phases].reverse();
+    const issues = validatePhases(reversed);
+    expect(issues.some((i) => i.severity === "warning" && i.fieldPath === "phases")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateScheduledSends
+// ---------------------------------------------------------------------------
+
+describe("validateScheduledSends", () => {
+  it("returns no issues for valid sends in the active fixture", () => {
+    const issues = validateScheduledSends(
+      activeCampaignTimeline.sends,
+      activeCampaignTimeline.phases,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("emits an error for negative estimatedCount", () => {
+    const badSend = { ...activeCampaignTimeline.sends[0], estimatedCount: -1 };
+    const issues = validateScheduledSends([badSend], activeCampaignTimeline.phases);
+    expect(
+      issues.some((i) => i.severity === "error" && i.fieldPath.includes("estimatedCount")),
+    ).toBe(true);
+  });
+
+  it("emits a warning when a send is outside its phase window", () => {
+    const outsideSend = {
+      ...activeCampaignTimeline.sends[0],
+      id: "send-outside",
+      scheduledAt: "2026-08-01T09:00",
+    };
+    const issues = validateScheduledSends([outsideSend], activeCampaignTimeline.phases);
+    expect(
+      issues.some((i) => i.severity === "warning" && i.fieldPath.includes("scheduledAt")),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateMilestones
+// ---------------------------------------------------------------------------
+
+describe("validateMilestones", () => {
+  it("returns no issues for valid milestones", () => {
+    expect(validateMilestones(activeCampaignTimeline.milestones)).toHaveLength(0);
+  });
+
+  it("emits an error for an invalid dueAt value", () => {
+    const bad = { ...activeCampaignTimeline.milestones[0], dueAt: "not-a-date" };
+    const issues = validateMilestones([bad]);
+    expect(issues.some((i) => i.severity === "error" && i.fieldPath.includes("dueAt"))).toBe(true);
+  });
+
+  it("emits a warning when resolvedAt is before dueAt for a non-skipped milestone", () => {
+    const early = {
+      ...activeCampaignTimeline.milestones[0],
+      id: "ms-early",
+      status: "resolved" as const,
+      dueAt: "2026-06-10T09:00",
+      resolvedAt: "2026-06-05T09:00",
+    };
+    const issues = validateMilestones([early]);
+    expect(issues.some((i) => i.severity === "warning" && i.fieldPath.includes("resolvedAt"))).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validatePreviewWindows
+// ---------------------------------------------------------------------------
+
+describe("validatePreviewWindows", () => {
+  it("returns no issues for valid preview windows", () => {
+    const issues = validatePreviewWindows(
+      activeCampaignTimeline.previewWindows,
+      activeCampaignTimeline.sends,
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it("emits an error when closesAt <= opensAt", () => {
+    const bad = {
+      ...activeCampaignTimeline.previewWindows[0],
+      opensAt: "2026-06-20T00:00",
+      closesAt: "2026-06-10T00:00",
+    };
+    const issues = validatePreviewWindows([bad], activeCampaignTimeline.sends);
+    expect(issues.some((i) => i.severity === "error" && i.fieldPath.includes("closesAt"))).toBe(
+      true,
+    );
+  });
+
+  it("emits a warning when a sendId does not exist", () => {
+    const ghost = {
+      ...activeCampaignTimeline.previewWindows[0],
+      sendIds: ["send-ghost-999"],
+    };
+    const issues = validatePreviewWindows([ghost], activeCampaignTimeline.sends);
+    expect(issues.some((i) => i.severity === "warning" && i.fieldPath.includes("sendIds"))).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCampaignTimeline (integration)
+// ---------------------------------------------------------------------------
+
+describe("validateCampaignTimeline", () => {
+  it("returns no issues for the active fixture", () => {
+    expect(validateCampaignTimeline(activeCampaignTimeline)).toHaveLength(0);
+  });
+
+  it("returns no issues for the draft fixture", () => {
+    expect(validateCampaignTimeline(draftCampaignTimeline)).toHaveLength(0);
+  });
+
+  it("returns no issues for an empty timeline", () => {
+    const empty: CampaignTimeline = {
+      id: "tl-empty",
+      campaignId: "snap-000",
+      phases: [],
+      sends: [],
+      milestones: [],
+      previewWindows: [],
+      createdAt: "2026-06-01T00:00",
+      updatedAt: "2026-06-01T00:00",
+    };
+    expect(validateCampaignTimeline(empty)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Closes #260 

## Feat: Add Campaign Timeline Model ([#260](#))

### Summary

Adds a self-contained campaign timeline subsystem to the `demo-admin-dashboard` feature. This is a pure data/type/utility layer — no UI wiring, no changes to inbox, mail reader, calendar, sender policy, protocol, or app-shell files. All data is fake, deterministic, and safe for public repository review.

---

### What Was Built

#### Types — `types/campaignTimeline.ts`

Five typed entities with discriminated literal unions throughout:

| Type | Description |
|------|-------------|
| `CampaignPhase` | A bounded time window within a campaign. `phaseKind`: `planning \| warmup \| active \| cooldown \| completed \| paused`. `status`: `upcoming \| active \| completed \| skipped`. All timestamps are ISO local strings (`yyyy-MM-ddTHH:mm`) — no `Date` objects stored. |
| `ScheduledSend` | A specific outbound send event tied to a `phaseId` and optionally a `draftId`. Carries `recipientSegmentId`, `estimatedCount`, and `status`: `pending \| sent \| failed \| cancelled`. |
| `Milestone` | A named checkpoint with a `kind` (`launch \| review \| approval \| analysis \| custom`), `dueAt`, optional `resolvedAt`, and `status`: `pending \| resolved \| overdue \| skipped`. |
| `PreviewWindow` | A time window scoping which sends are visible for preview, with `opensAt`, `closesAt`, optional `associatedPhaseId`, and a `sendIds` reference array. |
| `CampaignTimeline` | Aggregate root composing all four entities, keyed to a `campaignId` (`snap-*` slug). |

---

#### Helpers — `utils/campaignTimelineHelpers.ts`

**Eight pure query functions** (no side effects; accept optional `now?: Date` for testability):

| Function | Purpose |
|----------|---------|
| `getActivePhase(timeline, now?)` | Returns the phase whose window contains `now` |
| `getPhaseForDate(timeline, date)` | Returns the phase containing an arbitrary date |
| `isDateInPhase(date, phase)` | Boundary-inclusive date-in-range check |
| `getPhaseDurationDays(phase)` | Whole-day count between `startAt` and `endAt` |
| `sortPhasesByStartDate(phases)` | Immutable sort ascending by `startAt` |
| `getUpcomingMilestones(timeline, from?)` | Milestones with `dueAt` strictly after `from` |
| `getSendsInWindow(timeline, window)` | Sends whose IDs appear in a `PreviewWindow.sendIds` |
| `getTimelineDateRange(timeline)` | Earliest `startAt` / latest `endAt` across all phases, or `null` for empty |

**Five validators** returning `ValidationIssue[]` — fully compatible with the existing `validation-types.ts` shape (`datasetId: "campaign-timeline"`, `fieldPath` in bracket notation e.g. `"phases[0].endAt"`):

| Validator | Checks |
|-----------|--------|
| `validatePhases` | `startAt < endAt` (error); no overlaps between consecutive phases (error); unordered phases (warning) |
| `validateScheduledSends` | `estimatedCount >= 0` (error); `scheduledAt` within the referenced phase window (warning) |
| `validateMilestones` | `dueAt` parses as a valid date (error); `resolvedAt` not before `dueAt` for non-skipped milestones (warning) |
| `validatePreviewWindows` | `opensAt < closesAt` (error); all `sendIds` reference existing sends (warning) |
| `validateCampaignTimeline` | Runs all four validators and merges results |

A private `parseLocalDate(iso)` helper handles the ISO local format internally — no `date-fns` dependency introduced.

---

#### Display Tokens — `constants/displayTokens.ts`

Appended following the established `DisplayToken` (`bg`, `text`, `border`, `label`) pattern:

- **`CAMPAIGN_PHASE_TOKENS`** — covers all 6 `CampaignPhaseKind` values: `slate` (planning), `sky` (warmup), `teal` (active), `green` (completed), `orange` (paused)
- **`MILESTONE_KIND_TOKENS`** — covers all 5 `MilestoneKind` values: `cyan` (launch), `yellow` (review), `violet` (approval), `blue` (analysis), `neutral` (custom)
- **`getPhaseToken(kind)` / `getMilestoneToken(kind)`** — safe fallback helpers that return a neutral token for unknown values, following the pattern of `getTagToken` and `getAudienceToken`

---

#### Fixtures — `fixtures/campaignTimelineFixtures.ts`

Two deterministic `CampaignTimeline` objects anchored to the project's shared reference clock `2026-06-16T09:00` (same anchor used by `snooze/referenceNow.ts`):

**`activeCampaignTimeline`** (`tl-001`, `campaignId: snap-001`) — simulates a campaign mid-flight at the reference date:
- 4 phases: Planning (completed May 1–14), Warmup (completed May 15–31), Active Send (current, Jun 1–22), Cooldown (upcoming, Jun 23–30)
- 3 sends: one sent (Investor Batch A, Jun 5), two pending (Investor Batch B Jun 19, Relay Operator Notice Jun 25)
- 2 milestones: Campaign Launch (resolved, Jun 1), Mid-Campaign Review (pending, Jun 23)
- 1 preview window covering the Active Send phase sends

**`draftCampaignTimeline`** (`tl-002`, `campaignId: snap-002`) — simulates a future-dated Q3 campaign:
- 2 phases: Planning and Warmup (both upcoming, July 2026)
- 1 pending send (Q3 Announcement Early Access, Jul 22)
- 1 pending milestone (Legal & Compliance Sign-off, Jun 30)
- No preview windows yet

All IDs follow existing slug conventions (`tl-*`, `phase-*`, `send-*`, `ms-*`, `pw-*`). All `recipientSegmentId` values reference existing audience segment IDs (`investors`, `founders`, `relay-operators`).

---

#### Public API — `index.ts`

All new symbols re-exported under a `// Campaign Timeline (issue #260)` section comment:

- 10 exported types (`CampaignPhase`, `CampaignPhaseKind`, `CampaignPhaseStatus`, `CampaignTimeline`, `Milestone`, `MilestoneKind`, `MilestoneStatus`, `PreviewWindow`, `ScheduledSend`, `ScheduledSendStatus`)
- 2 fixture exports (`activeCampaignTimeline`, `draftCampaignTimeline`)
- 13 helper/validator exports
- 4 token/helper exports (`CAMPAIGN_PHASE_TOKENS`, `MILESTONE_KIND_TOKENS`, `getPhaseToken`, `getMilestoneToken`)

---

### Tests — `tests/unit/demo-admin-dashboard/campaignTimeline.test.ts`

**34 tests** across 9 `describe` blocks:

| Block | Key Cases |
|-------|-----------|
| `isDateInPhase` | Boundary inclusion (start date), before/after phase |
| `getActivePhase` | Correct phase at reference date, `undefined` for no-match, `undefined` for empty timeline |
| `getPhaseDurationDays` | 13-day phase, same-day phase (→ `0`) |
| `sortPhasesByStartDate` | Correct ordering, no mutation of input |
| `getUpcomingMilestones` | Filters by `from`, returns all when far past, returns none when far future |
| `getSendsInWindow` | Includes only referenced IDs, empty `sendIds` → empty result |
| `getTimelineDateRange` | Correct range on active fixture, `null` on empty phases |
| `validatePhases / validateScheduledSends / validateMilestones / validatePreviewWindows` | Clean on valid fixture, error/warning on each invalid condition |
| `validateCampaignTimeline` | Integration: clean on both fixtures, clean on empty timeline |

---

### Files Changed

| File | Change |
|------|--------|
| `src/features/demo-admin-dashboard/types/campaignTimeline.ts` | New — all timeline types |
| `src/features/demo-admin-dashboard/fixtures/campaignTimelineFixtures.ts` | New — two deterministic mock timelines |
| `src/features/demo-admin-dashboard/utils/campaignTimelineHelpers.ts` | New — 8 query helpers + 5 validators |
| `tests/unit/demo-admin-dashboard/campaignTimeline.test.ts` | New — 34 unit tests |
| `src/features/demo-admin-dashboard/constants/displayTokens.ts` | Modified — added phase and milestone token maps + helpers |
| `src/features/demo-admin-dashboard/index.ts` | Modified — re-exports for all new symbols |

> No files outside `src/features/demo-admin-dashboard/` were modified.