### PR TITLE
Feat: Build campaign timeline panel

### DIFF
--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -3,6 +3,7 @@ import {
   Activity,
   BarChart3,
   Calendar,
+  CalendarRange,
   FileText,
   History,
   LayoutDashboard,
@@ -32,6 +33,7 @@ import { TemplatePicker } from "./templates";
 import { PRESET_SCENARIOS } from "./fixtures/presets";
 import { AdminDataTable, type Column } from "./components/AdminDataTable";
 import { CampaignMessageAssignmentPanel } from "./components/CampaignMessageAssignmentPanel";
+import { CampaignTimelinePanel } from "./components/CampaignTimelinePanel";
 
 // ─── Default Deterministic fake data ──────────────────────────────────────────
 
@@ -43,6 +45,7 @@ const NAV_ITEMS: DashboardNavItem[] = [
   { id: "events", label: "Events", description: "Demo calendar and protocol events" },
   { id: "templates", label: "Templates", description: "Pick message templates to populate drafts" },
   { id: "campaigns", label: "Campaigns", description: "Save and restore campaign draft snapshots" },
+  { id: "timeline", label: "Timeline", description: "Campaign phase timeline and milestones" },
   { id: "audit", label: "Audit", description: "Demo protocol event log" },
   { id: "analytics", label: "Analytics", description: "Privacy-preserving product analytics" },
 ];
@@ -181,6 +184,7 @@ const SECTION_ICON: Record<DashboardSection, React.ElementType> = {
   events: Calendar,
   templates: FileText,
   campaigns: History,
+  timeline: CalendarRange,
   audit: Activity,
   analytics: PieChart,
 };
@@ -795,6 +799,8 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
           {activeSection === "templates" && <TemplatesContent />}
 
           {activeSection === "campaigns" && <CampaignMessageAssignmentPanel />}
+
+          {activeSection === "timeline" && <CampaignTimelinePanel />}
 
           {activeSection === "audit" && <AuditContent auditEvents={auditEvents} />}
         </div>

--- a/src/features/demo-admin-dashboard/components/CampaignTimelinePanel.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignTimelinePanel.tsx
@@ -1,0 +1,406 @@
+import { useState } from "react";
+import { AlertTriangle, CheckCircle2, Circle, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CampaignTimeline, Milestone, ScheduledSend } from "../types/campaignTimeline";
+import {
+  activeCampaignTimeline,
+  draftCampaignTimeline,
+} from "../fixtures/campaignTimelineFixtures";
+import { getDemoNow } from "../snooze/referenceNow";
+import {
+  getTimelineDateRange,
+  sortPhasesByStartDate,
+  getPhaseDurationDays,
+} from "../utils/campaignTimelineHelpers";
+import {
+  getPhaseToken,
+  getMilestoneToken,
+  getSendStatusToken,
+  AUDIENCE_SEGMENT_TOKENS,
+} from "../constants/displayTokens";
+import { MilestoneCard } from "./MilestoneCard";
+import { AdminDataTable, type Column } from "./AdminDataTable";
+
+// ─── Warning derivation helpers (exported for unit tests) ────────────────────
+
+export function isOverdue(milestone: Milestone, now: Date): boolean {
+  return (
+    milestone.status !== "resolved" &&
+    milestone.status !== "skipped" &&
+    new Date(milestone.dueAt) < now
+  );
+}
+
+export function isImminent(send: ScheduledSend, now: Date, windowDays = 3): boolean {
+  const diff = new Date(send.scheduledAt).getTime() - now.getTime();
+  return send.status === "pending" && diff >= 0 && diff <= windowDays * 86_400_000;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatLocalDate(iso: string): string {
+  const d = new Date(iso);
+  return (
+    d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) +
+    " · " +
+    d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true })
+  );
+}
+
+function formatShortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// ─── Phase bar ───────────────────────────────────────────────────────────────
+
+function PhaseBar({ timeline }: { timeline: CampaignTimeline }) {
+  const dateRange = getTimelineDateRange(timeline);
+
+  if (!dateRange) {
+    return <p className="text-xs text-muted-foreground py-4 text-center">No phases defined.</p>;
+  }
+
+  const totalStart = new Date(dateRange.startsAt).getTime();
+  const totalEnd = new Date(dateRange.endsAt).getTime();
+  const totalMs = totalEnd - totalStart;
+
+  const demoNow = getDemoNow().getTime();
+  const nowPct = Math.min(100, Math.max(0, ((demoNow - totalStart) / totalMs) * 100));
+
+  const sorted = sortPhasesByStartDate(timeline.phases);
+
+  return (
+    <div className="space-y-3">
+      {/* Bar track */}
+      <div className="relative">
+        {/* "Now" needle label */}
+        <div
+          className="absolute -top-5 flex flex-col items-center"
+          style={{ left: `${nowPct}%`, transform: "translateX(-50%)" }}
+        >
+          <span className="text-[9px] font-medium text-white/50 whitespace-nowrap">Now</span>
+        </div>
+
+        {/* Phase segments */}
+        <div className="flex h-7 rounded-lg overflow-hidden gap-px bg-white/[0.04]">
+          {sorted.map((phase) => {
+            const phaseStart = new Date(phase.startAt).getTime();
+            const phaseEnd = new Date(phase.endAt).getTime();
+            const widthPct = ((phaseEnd - phaseStart) / totalMs) * 100;
+            const token = getPhaseToken(phase.phaseKind);
+            return (
+              <div
+                key={phase.id}
+                title={`${phase.label} — ${getPhaseDurationDays(phase)}d`}
+                style={{ width: `${widthPct}%` }}
+                className={cn(
+                  "relative flex items-center justify-center overflow-hidden transition-opacity",
+                  token.bg,
+                  phase.status === "upcoming" ? "opacity-40" : "opacity-100",
+                )}
+              >
+                {phase.status === "completed" && (
+                  <CheckCircle2 className={cn("h-3 w-3 shrink-0", token.text)} />
+                )}
+                {phase.status === "active" && (
+                  <Circle className={cn("h-2.5 w-2.5 shrink-0 fill-current", token.text)} />
+                )}
+                {phase.status === "upcoming" && (
+                  <Clock className={cn("h-3 w-3 shrink-0", token.text)} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* "Now" needle line */}
+        <div
+          className="absolute top-0 h-7 w-px bg-white/60 pointer-events-none"
+          style={{ left: `${nowPct}%` }}
+        />
+      </div>
+
+      {/* Phase labels below the bar */}
+      <div className="flex" style={{ position: "relative" }}>
+        {sorted.map((phase) => {
+          const phaseStart = new Date(phase.startAt).getTime();
+          const phaseEnd = new Date(phase.endAt).getTime();
+          const widthPct = ((phaseEnd - phaseStart) / totalMs) * 100;
+          const token = getPhaseToken(phase.phaseKind);
+          return (
+            <div key={phase.id} style={{ width: `${widthPct}%` }} className="overflow-hidden px-1">
+              <p className={cn("text-[10px] font-medium truncate", token.text)}>{phase.label}</p>
+              <p className="text-[9px] text-muted-foreground whitespace-nowrap">
+                {formatShortDate(phase.startAt)} – {formatShortDate(phase.endAt)}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sends table ─────────────────────────────────────────────────────────────
+
+function SendsTable({ sends, demoNow }: { sends: CampaignTimeline["sends"]; demoNow: Date }) {
+  const columns: Column<ScheduledSend>[] = [
+    {
+      key: "label",
+      header: "Label",
+      sortable: true,
+      render: (row) => {
+        const imminent = isImminent(row, demoNow);
+        return (
+          <div className="flex items-center gap-2">
+            {imminent && (
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse shrink-0" />
+            )}
+            <span className="text-xs font-medium text-foreground">{row.label}</span>
+          </div>
+        );
+      },
+    },
+    {
+      key: "recipientSegmentId",
+      header: "Segment",
+      render: (row) => {
+        const token = AUDIENCE_SEGMENT_TOKENS[row.recipientSegmentId] ?? {
+          bg: "bg-white/[0.04]",
+          text: "text-muted-foreground",
+          border: "border-white/[0.08]",
+        };
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+              token.bg,
+              token.text,
+              token.border,
+            )}
+          >
+            {row.recipientSegmentId}
+          </span>
+        );
+      },
+    },
+    {
+      key: "estimatedCount",
+      header: "Est.",
+      sortable: true,
+      sortValue: (row) => row.estimatedCount,
+      render: (row) => (
+        <span className="text-xs tabular-nums text-foreground">
+          {row.estimatedCount.toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      key: "scheduledAt",
+      header: "Scheduled",
+      sortable: true,
+      sortValue: (row) => row.scheduledAt,
+      render: (row) => (
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {formatLocalDate(row.scheduledAt)}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      sortable: true,
+      render: (row) => {
+        const token = getSendStatusToken(row.status);
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+              token.bg,
+              token.text,
+              token.border,
+            )}
+          >
+            {token.label}
+          </span>
+        );
+      },
+    },
+  ];
+
+  return (
+    <AdminDataTable
+      data={sends}
+      columns={columns}
+      defaultSortKey="scheduledAt"
+      defaultSortDirection="asc"
+      emptyMessage="No scheduled sends for this campaign."
+    />
+  );
+}
+
+// ─── Warning banner ───────────────────────────────────────────────────────────
+
+function WarningBanner({
+  overdueCount,
+  imminentCount,
+}: {
+  overdueCount: number;
+  imminentCount: number;
+}) {
+  if (overdueCount === 0 && imminentCount === 0) return null;
+
+  const parts: string[] = [];
+  if (overdueCount > 0)
+    parts.push(`${overdueCount} overdue milestone${overdueCount > 1 ? "s" : ""}`);
+  if (imminentCount > 0)
+    parts.push(`${imminentCount} send${imminentCount > 1 ? "s" : ""} within 3 days`);
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/5 px-4 py-3">
+      <AlertTriangle className="h-4 w-4 text-rose-400 shrink-0" />
+      <p className="text-xs font-medium text-rose-300">{parts.join(" · ")}</p>
+    </div>
+  );
+}
+
+// ─── Campaign picker ──────────────────────────────────────────────────────────
+
+const TIMELINE_OPTIONS = [
+  {
+    timeline: activeCampaignTimeline,
+    label: "Investor Update Series",
+    description: "Active campaign — June 2026 send window.",
+  },
+  {
+    timeline: draftCampaignTimeline,
+    label: "Q3 Early Access Campaign",
+    description: "Draft campaign — July 2026 warmup planned.",
+  },
+];
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function CampaignTimelinePanel() {
+  const [selectedId, setSelectedId] = useState<string>(activeCampaignTimeline.id);
+  const demoNow = getDemoNow();
+
+  const selected =
+    TIMELINE_OPTIONS.find((o) => o.timeline.id === selectedId) ?? TIMELINE_OPTIONS[0];
+  const timeline = selected.timeline;
+
+  const overdueCount = timeline.milestones.filter((ms) => isOverdue(ms, demoNow)).length;
+  const imminentCount = timeline.sends.filter((s) => isImminent(s, demoNow)).length;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Visual timeline of campaign phases, milestones, and scheduled sends. All data is
+        deterministic demo data.
+      </p>
+
+      {/* Campaign picker */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {TIMELINE_OPTIONS.map((opt) => {
+          const active = selectedId === opt.timeline.id;
+          return (
+            <button
+              key={opt.timeline.id}
+              type="button"
+              onClick={() => setSelectedId(opt.timeline.id)}
+              className={cn(
+                "rounded-xl border p-4 text-left transition",
+                active
+                  ? "border-teal-500/50 bg-teal-500/5 ring-1 ring-teal-500/20"
+                  : "border-white/[0.06] bg-white/[0.02] hover:border-white/10 hover:bg-white/[0.04]",
+              )}
+            >
+              <p className="text-xs font-semibold text-foreground">{opt.label}</p>
+              <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                {opt.description}
+              </p>
+              <p className="mt-2 text-[10px] font-mono text-muted-foreground/60">
+                {opt.timeline.id}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Warning banner */}
+      <WarningBanner overdueCount={overdueCount} imminentCount={imminentCount} />
+
+      {/* Phase bar */}
+      <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5 space-y-5">
+        <div>
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Campaign Phases
+          </h4>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {timeline.phases.length} phase{timeline.phases.length !== 1 ? "s" : ""} ·{" "}
+            {(() => {
+              const r = getTimelineDateRange(timeline);
+              if (!r) return "—";
+              return `${formatShortDate(r.startsAt)} – ${formatShortDate(r.endsAt)}`;
+            })()}
+          </p>
+        </div>
+        <div className="mt-6">
+          <PhaseBar timeline={timeline} />
+        </div>
+        {/* Phase legend */}
+        <div className="flex flex-wrap gap-x-4 gap-y-1.5 pt-1">
+          {sortPhasesByStartDate(timeline.phases).map((phase) => {
+            const token = getPhaseToken(phase.phaseKind);
+            return (
+              <div key={phase.id} className="flex items-center gap-1.5">
+                <span className={cn("h-2 w-2 rounded-full", token.bg.replace("/10", "/60"))} />
+                <span className={cn("text-[10px] font-medium", token.text)}>{phase.label}</span>
+                <span className="text-[10px] text-muted-foreground">
+                  {getPhaseDurationDays(phase)}d
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Milestones */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Milestones
+          </h4>
+          <span className="text-[10px] text-muted-foreground">
+            {timeline.milestones.length} total
+          </span>
+        </div>
+        {timeline.milestones.length === 0 ? (
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            No milestones for this campaign.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {timeline.milestones.map((ms) => (
+              <MilestoneCard key={ms.id} milestone={ms} isOverdue={isOverdue(ms, demoNow)} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Scheduled sends */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Scheduled Sends
+          </h4>
+          <span className="text-[10px] text-muted-foreground">{timeline.sends.length} total</span>
+        </div>
+        <SendsTable sends={timeline.sends} demoNow={demoNow} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/components/MilestoneCard.tsx
+++ b/src/features/demo-admin-dashboard/components/MilestoneCard.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Milestone } from "../types/campaignTimeline";
+import { getMilestoneToken, getMilestoneStatusToken } from "../constants/displayTokens";
+
+interface MilestoneCardProps {
+  milestone: Milestone;
+  isOverdue: boolean;
+}
+
+function formatLocalDate(iso: string): string {
+  const d = new Date(iso);
+  return (
+    d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }) +
+    " · " +
+    d.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    })
+  );
+}
+
+export function MilestoneCard({ milestone, isOverdue }: MilestoneCardProps) {
+  const kindToken = getMilestoneToken(milestone.kind);
+  const effectiveStatus = isOverdue ? "overdue" : milestone.status;
+  const statusToken = getMilestoneStatusToken(effectiveStatus);
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border bg-white/[0.02] p-4 space-y-3 transition-colors",
+        isOverdue ? "border-rose-500/40 bg-rose-500/5" : "border-white/[0.08]",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+              kindToken.bg,
+              kindToken.text,
+              kindToken.border,
+            )}
+          >
+            {kindToken.label}
+          </span>
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+              statusToken.bg,
+              statusToken.text,
+              statusToken.border,
+            )}
+          >
+            {statusToken.label}
+          </span>
+        </div>
+        {isOverdue && <AlertTriangle className="h-3.5 w-3.5 text-rose-400 shrink-0 mt-0.5" />}
+      </div>
+
+      <div>
+        <p className="text-sm font-semibold text-foreground leading-snug">{milestone.label}</p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground tabular-nums">
+          Due {formatLocalDate(milestone.dueAt)}
+        </p>
+        {milestone.resolvedAt && (
+          <p className="mt-0.5 text-[11px] text-emerald-400 tabular-nums">
+            Resolved {formatLocalDate(milestone.resolvedAt)}
+          </p>
+        )}
+      </div>
+
+      {milestone.note && (
+        <p className="text-[11px] text-muted-foreground leading-relaxed border-t border-white/[0.05] pt-2">
+          {milestone.note}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/constants/displayTokens.ts
+++ b/src/features/demo-admin-dashboard/constants/displayTokens.ts
@@ -267,6 +267,90 @@ export function getPhaseToken(kind: string): DisplayToken {
   );
 }
 
+export const MILESTONE_STATUS_TOKENS: Record<
+  "pending" | "resolved" | "overdue" | "skipped",
+  DisplayToken
+> = {
+  pending: {
+    bg: "bg-amber-500/10",
+    text: "text-amber-400",
+    border: "border-amber-500/20",
+    label: "Pending",
+  },
+  resolved: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-400",
+    border: "border-emerald-500/20",
+    label: "Resolved",
+  },
+  overdue: {
+    bg: "bg-rose-500/10",
+    text: "text-rose-400",
+    border: "border-rose-500/20",
+    label: "Overdue",
+  },
+  skipped: {
+    bg: "bg-slate-500/10",
+    text: "text-slate-400",
+    border: "border-slate-500/20",
+    label: "Skipped",
+  },
+};
+
+export const SCHEDULED_SEND_STATUS_TOKENS: Record<
+  "pending" | "sent" | "failed" | "cancelled",
+  DisplayToken
+> = {
+  pending: {
+    bg: "bg-amber-500/10",
+    text: "text-amber-400",
+    border: "border-amber-500/20",
+    label: "Pending",
+  },
+  sent: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-400",
+    border: "border-emerald-500/20",
+    label: "Sent",
+  },
+  failed: {
+    bg: "bg-rose-500/10",
+    text: "text-rose-400",
+    border: "border-rose-500/20",
+    label: "Failed",
+  },
+  cancelled: {
+    bg: "bg-slate-500/10",
+    text: "text-slate-400",
+    border: "border-slate-500/20",
+    label: "Cancelled",
+  },
+};
+
+export function getMilestoneStatusToken(status: string): DisplayToken {
+  const key = status as keyof typeof MILESTONE_STATUS_TOKENS;
+  return (
+    MILESTONE_STATUS_TOKENS[key] ?? {
+      bg: "bg-white/[0.04]",
+      text: "text-muted-foreground",
+      border: "border-white/[0.08]",
+      label: status,
+    }
+  );
+}
+
+export function getSendStatusToken(status: string): DisplayToken {
+  const key = status as keyof typeof SCHEDULED_SEND_STATUS_TOKENS;
+  return (
+    SCHEDULED_SEND_STATUS_TOKENS[key] ?? {
+      bg: "bg-white/[0.04]",
+      text: "text-muted-foreground",
+      border: "border-white/[0.08]",
+      label: status,
+    }
+  );
+}
+
 export function getMilestoneToken(kind: string): DisplayToken {
   const key = kind as keyof typeof MILESTONE_KIND_TOKENS;
   return (

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -168,6 +168,10 @@ export {
 } from "./proofFormatting";
 export { demoProofRecords } from "./fixtures/proofRecordFixtures";
 
+// Campaign Timeline panel (issue #261)
+export { CampaignTimelinePanel } from "./components/CampaignTimelinePanel";
+export { isOverdue, isImminent } from "./components/CampaignTimelinePanel";
+
 // Campaign Timeline (issue #260): types, fixtures, helpers, display tokens.
 export type {
   CampaignPhase,
@@ -200,8 +204,12 @@ export {
 export {
   CAMPAIGN_PHASE_TOKENS,
   getMilestoneToken,
+  getMilestoneStatusToken,
   getPhaseToken,
+  getSendStatusToken,
   MILESTONE_KIND_TOKENS,
+  MILESTONE_STATUS_TOKENS,
+  SCHEDULED_SEND_STATUS_TOKENS,
 } from "./constants/displayTokens";
 
 // Draft dataset admin store (issue #172): reducer, selectors, hook, types, fixture.

--- a/src/features/demo-admin-dashboard/types.ts
+++ b/src/features/demo-admin-dashboard/types.ts
@@ -50,6 +50,7 @@ export type DashboardSection =
   | "events"
   | "templates"
   | "campaigns"
+  | "timeline"
   | "audit"
   | "analytics";
 

--- a/tests/unit/demo-admin-dashboard/campaignTimelineWarnings.test.ts
+++ b/tests/unit/demo-admin-dashboard/campaignTimelineWarnings.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOverdue,
+  isImminent,
+} from "@/features/demo-admin-dashboard/components/CampaignTimelinePanel";
+import {
+  activeCampaignTimeline,
+  draftCampaignTimeline,
+} from "@/features/demo-admin-dashboard/fixtures/campaignTimelineFixtures";
+import { getDemoNow } from "@/features/demo-admin-dashboard/snooze/referenceNow";
+import { getTimelineDateRange } from "@/features/demo-admin-dashboard/utils/campaignTimelineHelpers";
+
+const demoNow = getDemoNow(); // 2026-06-16T09:00:00
+
+describe("isOverdue", () => {
+  it("returns false for a resolved milestone", () => {
+    const ms = activeCampaignTimeline.milestones.find((m) => m.id === "ms-001")!;
+    expect(ms.status).toBe("resolved");
+    expect(isOverdue(ms, demoNow)).toBe(false);
+  });
+
+  it("returns false for a pending milestone not yet due (ms-002, due 2026-06-23)", () => {
+    const ms = activeCampaignTimeline.milestones.find((m) => m.id === "ms-002")!;
+    expect(ms.status).toBe("pending");
+    expect(isOverdue(ms, demoNow)).toBe(false);
+  });
+
+  it("returns true for a pending milestone whose dueAt is in the past", () => {
+    const pastMilestone = {
+      id: "ms-past",
+      kind: "review" as const,
+      label: "Past Review",
+      dueAt: "2026-06-10T09:00",
+      status: "pending" as const,
+    };
+    expect(isOverdue(pastMilestone, demoNow)).toBe(true);
+  });
+
+  it("returns false for a skipped milestone even if dueAt is in the past", () => {
+    const skippedMilestone = {
+      id: "ms-skip",
+      kind: "custom" as const,
+      label: "Skipped",
+      dueAt: "2026-06-01T00:00",
+      status: "skipped" as const,
+    };
+    expect(isOverdue(skippedMilestone, demoNow)).toBe(false);
+  });
+});
+
+describe("isImminent", () => {
+  it("returns false for a send that is already sent (send-001)", () => {
+    const send = activeCampaignTimeline.sends.find((s) => s.id === "send-001")!;
+    expect(send.status).toBe("sent");
+    expect(isImminent(send, demoNow)).toBe(false);
+  });
+
+  it("returns true for a pending send scheduled 3 days out (send-002, 2026-06-19)", () => {
+    const send = activeCampaignTimeline.sends.find((s) => s.id === "send-002")!;
+    expect(send.status).toBe("pending");
+    // demoNow is 2026-06-16; send is 2026-06-19 → diff ~3 days → within window
+    expect(isImminent(send, demoNow)).toBe(true);
+  });
+
+  it("returns false for a pending send 9 days out (send-003, 2026-06-25)", () => {
+    const send = activeCampaignTimeline.sends.find((s) => s.id === "send-003")!;
+    expect(send.status).toBe("pending");
+    expect(isImminent(send, demoNow)).toBe(false);
+  });
+
+  it("returns false for a pending send already past", () => {
+    const pastSend = {
+      id: "s-past",
+      phaseId: "phase-003",
+      label: "Past send",
+      scheduledAt: "2026-06-10T09:00",
+      recipientSegmentId: "investors" as const,
+      estimatedCount: 100,
+      status: "pending" as const,
+    };
+    // diff is negative — already past
+    expect(isImminent(pastSend, demoNow)).toBe(false);
+  });
+});
+
+describe("getTimelineDateRange", () => {
+  it("returns correct start and end for the active timeline", () => {
+    const range = getTimelineDateRange(activeCampaignTimeline);
+    expect(range).not.toBeNull();
+    expect(range!.startsAt).toBe("2026-05-01T00:00");
+    expect(range!.endsAt).toBe("2026-06-30T23:59");
+  });
+
+  it("returns null for a timeline with no phases", () => {
+    const empty = { ...activeCampaignTimeline, phases: [] };
+    expect(getTimelineDateRange(empty)).toBeNull();
+  });
+
+  it("returns correct start for draft timeline", () => {
+    const range = getTimelineDateRange(draftCampaignTimeline);
+    expect(range).not.toBeNull();
+    expect(range!.startsAt).toBe("2026-07-01T00:00");
+  });
+});
+
+describe("phase bar width calculation", () => {
+  it("produces widths that sum to 100% for the active timeline", () => {
+    const range = getTimelineDateRange(activeCampaignTimeline)!;
+    const totalStart = new Date(range.startsAt).getTime();
+    const totalEnd = new Date(range.endsAt).getTime();
+    const totalMs = totalEnd - totalStart;
+
+    const totalWidth = activeCampaignTimeline.phases.reduce((sum, phase) => {
+      const phaseStart = new Date(phase.startAt).getTime();
+      const phaseEnd = new Date(phase.endAt).getTime();
+      return sum + ((phaseEnd - phaseStart) / totalMs) * 100;
+    }, 0);
+
+    expect(totalWidth).toBeCloseTo(100, 0);
+  });
+
+  it("positions the 'now' needle between 0 and 100 for the active timeline", () => {
+    const range = getTimelineDateRange(activeCampaignTimeline)!;
+    const totalStart = new Date(range.startsAt).getTime();
+    const totalEnd = new Date(range.endsAt).getTime();
+    const totalMs = totalEnd - totalStart;
+
+    const nowPct = ((demoNow.getTime() - totalStart) / totalMs) * 100;
+    expect(nowPct).toBeGreaterThan(0);
+    expect(nowPct).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
# Closes #261 

## Feat: Campaign Timeline Panel ([#261](#))

### Summary

Implements the campaign timeline panel for the Demo Admin Dashboard. Adds a new Timeline tab to the dashboard shell that renders a visual, deterministic timeline of campaign phases, milestones, and scheduled sends — entirely scoped to `src/features/demo-admin-dashboard/`.

---

### New Components

#### `components/CampaignTimelinePanel.tsx`

The main panel. Includes:

- A campaign picker to switch between the active (`tl-001`) and draft (`tl-002`) fixture timelines
- A warning banner that surfaces overdue milestones and sends within 3 days of `demoNow`
- A proportional phase bar — each segment's width reflects its actual duration relative to the total campaign span, colour-coded via `CAMPAIGN_PHASE_TOKENS`, with a "Now" needle pinned at `demoNow` (`2026-06-16T09:00`)
- A milestone grid using `MilestoneCard`
- A scheduled sends table using the existing `AdminDataTable` with segment and status badges
- Two exported pure helpers — `isOverdue(milestone, now)` and `isImminent(send, now)` — used both by the UI and unit tests

#### `components/MilestoneCard.tsx`

Standalone card rendering a milestone's kind badge, status badge, label, formatted due/resolved dates, optional note, and a rose warning decoration when overdue.

---

### Display Tokens — `constants/displayTokens.ts`

Added `MILESTONE_STATUS_TOKENS` and `SCHEDULED_SEND_STATUS_TOKENS` with accessor helpers `getMilestoneStatusToken` and `getSendStatusToken`, consistent with the existing `getPhaseToken` / `getMilestoneToken` pattern.

---

### Dashboard Wiring

| File | Change |
|------|--------|
| `types.ts` | Added `"timeline"` to the `DashboardSection` union |
| `DemoAdminDashboard.tsx` | Added `CalendarRange` icon, a `"Timeline"` nav item, its `SECTION_ICON` entry, and `{activeSection === "timeline" && <CampaignTimelinePanel />}` render case |
| `index.ts` | Exports `CampaignTimelinePanel`, `isOverdue`, `isImminent`, and the new display tokens |

---

### Tests — `tests/unit/demo-admin-dashboard/campaignTimelineWarnings.test.ts`

**13 unit tests** covering:

- `isOverdue` — milestone overdue detection
- `isImminent` — send imminence detection within 3-day window
- `getTimelineDateRange` — range calculation against fixture timelines
- Phase bar width and needle-position math against the fixture timelines and `getDemoNow()`

---

### Scope

No files outside `src/features/demo-admin-dashboard/` and `tests/unit/demo-admin-dashboard/` were modified. No changes to inbox, mail reader, calendar, sender-conversion, protocol, routing, or app-shell files.