### PR TITLE
feat(demo-admin-dashboard): add MessageEditor UI for demo message editing

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/MessageEditor.test.tsx
+++ b/src/features/demo-admin-dashboard/__tests__/MessageEditor.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  MessageEditor,
+  validateMessage,
+  parseRecipientsInput,
+  formatRecipientsDisplay,
+  formatMessagePreview,
+} from "../components/MessageEditor";
+
+describe("MessageEditor module", () => {
+  it("exports the MessageEditor component", () => {
+    expect(MessageEditor).toBeDefined();
+    expect(typeof MessageEditor).toBe("function");
+  });
+
+  it("exports validateMessage helper", () => {
+    expect(validateMessage).toBeDefined();
+    expect(typeof validateMessage).toBe("function");
+  });
+
+  it("exports parseRecipientsInput helper", () => {
+    expect(parseRecipientsInput).toBeDefined();
+    expect(typeof parseRecipientsInput).toBe("function");
+  });
+
+  it("exports formatRecipientsDisplay helper", () => {
+    expect(formatRecipientsDisplay).toBeDefined();
+    expect(typeof formatRecipientsDisplay).toBe("function");
+  });
+
+  it("exports formatMessagePreview helper", () => {
+    expect(formatMessagePreview).toBeDefined();
+    expect(typeof formatMessagePreview).toBe("function");
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/messageEditorHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/messageEditorHelpers.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateMessage,
+  parseRecipientsInput,
+  formatRecipientsDisplay,
+  formatMessagePreview,
+} from "../components/MessageEditor";
+import type { Draft } from "../types/draft";
+
+const validDraft: Draft = {
+  id: "draft-test-1",
+  subject: "Test Subject",
+  body: "Test body content.",
+  recipients: ["alice@example.com"],
+};
+
+describe("validateMessage", () => {
+  it("returns no errors for a valid draft", () => {
+    const issues = validateMessage(validDraft);
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("returns an error when subject is empty", () => {
+    const issues = validateMessage({ ...validDraft, subject: "" });
+    const subjectIssues = issues.filter((i) => i.fieldPath === "subject");
+    expect(subjectIssues.length).toBeGreaterThan(0);
+    expect(subjectIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when subject is whitespace only", () => {
+    const issues = validateMessage({ ...validDraft, subject: "   " });
+    const subjectIssues = issues.filter((i) => i.fieldPath === "subject");
+    expect(subjectIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns an error when body is empty", () => {
+    const issues = validateMessage({ ...validDraft, body: "" });
+    const bodyIssues = issues.filter((i) => i.fieldPath === "body");
+    expect(bodyIssues.length).toBeGreaterThan(0);
+    expect(bodyIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when recipients is empty", () => {
+    const issues = validateMessage({ ...validDraft, recipients: [] });
+    const recipientIssues = issues.filter((i) => i.fieldPath === "recipients");
+    expect(recipientIssues.length).toBeGreaterThan(0);
+    expect(recipientIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error for invalid recipient format", () => {
+    const issues = validateMessage({
+      ...validDraft,
+      recipients: ["invalid"],
+    });
+    const formatIssues = issues.filter((i) => i.message.includes("format is invalid"));
+    expect(formatIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns a warning for unsafe recipient domain", () => {
+    const issues = validateMessage({
+      ...validDraft,
+      recipients: ["user@unknown-domain.com"],
+    });
+    const domainIssues = issues.filter((i) => i.severity === "warning");
+    expect(domainIssues.length).toBeGreaterThan(0);
+  });
+
+  it("strips the drafts[0]. prefix from field paths", () => {
+    const issues = validateMessage({ ...validDraft, subject: "" });
+    for (const issue of issues) {
+      expect(issue.fieldPath).not.toMatch(/^drafts\[\d+\]\./);
+    }
+  });
+});
+
+describe("parseRecipientsInput", () => {
+  it("returns an empty array for empty input", () => {
+    expect(parseRecipientsInput("")).toEqual([]);
+  });
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(parseRecipientsInput("   ")).toEqual([]);
+  });
+
+  it("parses a single recipient", () => {
+    expect(parseRecipientsInput("alice@example.com")).toEqual(["alice@example.com"]);
+  });
+
+  it("parses multiple comma-separated recipients", () => {
+    expect(parseRecipientsInput("alice@example.com, bob@example.com")).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+    ]);
+  });
+
+  it("trims whitespace around recipients", () => {
+    expect(parseRecipientsInput("  alice@example.com  ,  bob@example.com  ")).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+    ]);
+  });
+
+  it("filters out empty entries from trailing commas", () => {
+    expect(parseRecipientsInput("alice@example.com, ")).toEqual(["alice@example.com"]);
+  });
+
+  it("handles a single entry with a trailing comma", () => {
+    expect(parseRecipientsInput("alice@example.com,")).toEqual(["alice@example.com"]);
+  });
+});
+
+describe("formatRecipientsDisplay", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatRecipientsDisplay([])).toBe("");
+  });
+
+  it("returns a single recipient unchanged", () => {
+    expect(formatRecipientsDisplay(["alice@example.com"])).toBe("alice@example.com");
+  });
+
+  it("joins multiple recipients with comma and space", () => {
+    expect(formatRecipientsDisplay(["alice@example.com", "bob@example.com"])).toBe(
+      "alice@example.com, bob@example.com",
+    );
+  });
+
+  it("round-trips with parseRecipientsInput", () => {
+    const input = "alice@example.com, bob@example.com";
+    const parsed = parseRecipientsInput(input);
+    const formatted = formatRecipientsDisplay(parsed);
+    expect(parseRecipientsInput(formatted)).toEqual(parsed);
+  });
+});
+
+describe("formatMessagePreview", () => {
+  it("includes the subject line", () => {
+    const result = formatMessagePreview(validDraft);
+    expect(result).toContain(`Subject: ${validDraft.subject}`);
+  });
+
+  it("includes the To line with recipients", () => {
+    const result = formatMessagePreview(validDraft);
+    expect(result).toContain(`To: ${validDraft.recipients.join(", ")}`);
+  });
+
+  it("includes a separator", () => {
+    const result = formatMessagePreview(validDraft);
+    expect(result).toContain("---");
+  });
+
+  it("includes the body text", () => {
+    const result = formatMessagePreview(validDraft);
+    expect(result).toContain(validDraft.body);
+  });
+
+  it("joins all sections with newlines", () => {
+    const result = formatMessagePreview(validDraft);
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(4);
+    expect(lines[0]).toBe(`Subject: ${validDraft.subject}`);
+    expect(lines[1]).toBe(`To: ${validDraft.recipients.join(", ")}`);
+    expect(lines[2]).toBe("---");
+  });
+});

--- a/src/features/demo-admin-dashboard/components/MessageEditor.tsx
+++ b/src/features/demo-admin-dashboard/components/MessageEditor.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from "react";
+import { FileText, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Draft } from "../types/draft";
+import { validateCampaignDrafts } from "../validation";
+import { ValidationResultsPanel } from "../ValidationResultsPanel";
+import type { ValidationIssue } from "../validation-types";
+
+export interface MessageEditorProps {
+  draft: Draft;
+  onChange: (draft: Draft) => void;
+  onSave?: () => void;
+  onCancel?: () => void;
+  showPreview?: boolean;
+  className?: string;
+}
+
+export function validateMessage(draft: Draft): ValidationIssue[] {
+  return validateCampaignDrafts([draft]).map((issue) => ({
+    ...issue,
+    fieldPath: issue.fieldPath.replace(/^drafts\[\d+\]\./, ""),
+  }));
+}
+
+export function parseRecipientsInput(input: string): string[] {
+  return input
+    .split(",")
+    .map((r) => r.trim())
+    .filter((r) => r.length > 0);
+}
+
+export function formatRecipientsDisplay(recipients: string[]): string {
+  return recipients.join(", ");
+}
+
+export function formatMessagePreview(draft: Draft): string {
+  return [
+    `Subject: ${draft.subject}`,
+    `To: ${draft.recipients.join(", ")}`,
+    "---",
+    draft.body,
+  ].join("\n");
+}
+
+export function MessageEditor({
+  draft,
+  onChange,
+  onSave,
+  onCancel,
+  showPreview = true,
+  className,
+}: MessageEditorProps) {
+  const [recipientsInput, setRecipientsInput] = useState(() =>
+    formatRecipientsDisplay(draft.recipients),
+  );
+
+  const issues = useMemo(() => validateMessage(draft), [draft]);
+  const hasErrors = issues.some((i) => i.severity === "error");
+
+  const fieldIssues = (field: string): ValidationIssue[] =>
+    issues.filter((i) => i.fieldPath === field || i.fieldPath.startsWith(`${field}[`));
+
+  const subjectIssues = fieldIssues("subject");
+  const bodyIssues = fieldIssues("body");
+  const recipientIssues = fieldIssues("recipients");
+
+  const handleSubjectChange = (value: string) => {
+    onChange({ ...draft, subject: value });
+  };
+
+  const handleBodyChange = (value: string) => {
+    onChange({ ...draft, body: value });
+  };
+
+  const handleRecipientsChange = (value: string) => {
+    setRecipientsInput(value);
+    onChange({ ...draft, recipients: parseRecipientsInput(value) });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && onSave && !hasErrors) {
+      e.preventDefault();
+      onSave();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/[0.08] bg-white/[0.02] p-5 space-y-4",
+        className,
+      )}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FileText className="h-4 w-4 text-muted-foreground" />
+          <h4 className="text-sm font-semibold text-foreground">Edit Message</h4>
+        </div>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Cancel editing"
+            className="rounded-md p-1 text-muted-foreground hover:bg-white/[0.04] hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="editor-subject" className="text-xs font-medium text-muted-foreground">
+          Subject *
+        </label>
+        <input
+          id="editor-subject"
+          type="text"
+          value={draft.subject}
+          onChange={(e) => handleSubjectChange(e.target.value)}
+          placeholder="Enter message subject"
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40",
+            subjectIssues.length > 0
+              ? "border-red-500/50 focus:border-red-400"
+              : "border-white/[0.08] focus:border-white/20",
+          )}
+          required
+        />
+        {subjectIssues.length > 0 && (
+          <p className="text-xs font-medium text-rose-400">{subjectIssues[0].message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="editor-recipients" className="text-xs font-medium text-muted-foreground">
+          Recipients (comma-separated) *
+        </label>
+        <input
+          id="editor-recipients"
+          type="text"
+          value={recipientsInput}
+          onChange={(e) => handleRecipientsChange(e.target.value)}
+          placeholder="e.g. alice@example.com, bob*stealth.demo"
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40",
+            recipientIssues.length > 0
+              ? "border-red-500/50 focus:border-red-400"
+              : "border-white/[0.08] focus:border-white/20",
+          )}
+          required
+        />
+        {recipientIssues.length > 0 && (
+          <p className="text-xs font-medium text-rose-400">{recipientIssues[0].message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="editor-body" className="text-xs font-medium text-muted-foreground">
+          Message Body *
+        </label>
+        <textarea
+          id="editor-body"
+          value={draft.body}
+          onChange={(e) => handleBodyChange(e.target.value)}
+          placeholder="Enter message body"
+          rows={6}
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40 resize-vertical",
+            bodyIssues.length > 0
+              ? "border-red-500/50 focus:border-red-400"
+              : "border-white/[0.08] focus:border-white/20",
+          )}
+          required
+        />
+        {bodyIssues.length > 0 && (
+          <p className="text-xs font-medium text-rose-400">{bodyIssues[0].message}</p>
+        )}
+      </div>
+
+      {issues.length > 0 && <ValidationResultsPanel issues={issues} title="Message validation" />}
+
+      {showPreview && (
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+          <h5 className="mb-3 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+            Preview
+          </h5>
+          <dl className="space-y-2 text-xs">
+            <div className="grid grid-cols-[72px_1fr] gap-2">
+              <dt className="text-muted-foreground">Subject</dt>
+              <dd className="text-foreground">{draft.subject || "(no subject)"}</dd>
+            </div>
+            <div className="grid grid-cols-[72px_1fr] gap-2">
+              <dt className="text-muted-foreground">To</dt>
+              <dd className="font-mono text-[11px] text-foreground">
+                {draft.recipients.length > 0 ? draft.recipients.join(", ") : "(no recipients)"}
+              </dd>
+            </div>
+          </dl>
+          <pre className="mt-3 max-h-44 overflow-y-auto whitespace-pre-wrap rounded-lg border border-white/[0.06] bg-black/30 p-3 font-sans text-xs leading-5 text-foreground/90">
+            {draft.body || "(no body)"}
+          </pre>
+        </div>
+      )}
+
+      {(onSave || onCancel) && (
+        <div className="flex justify-end gap-3 pt-2">
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-lg border border-white/[0.08] bg-white/[0.01] px-4 py-2 text-xs font-medium text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+            >
+              Cancel
+            </button>
+          )}
+          {onSave && (
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={hasErrors}
+              className={cn(
+                "rounded-lg px-4 py-2 text-xs font-semibold transition",
+                hasErrors
+                  ? "cursor-not-allowed bg-white/[0.04] text-muted-foreground"
+                  : "bg-foreground text-background hover:opacity-90",
+              )}
+            >
+              Save
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/docs/MESSAGE_EDITOR.md
+++ b/src/features/demo-admin-dashboard/docs/MESSAGE_EDITOR.md
@@ -1,0 +1,122 @@
+# MessageEditor
+
+A controlled form component for editing a single demo message draft. Provides
+editable inputs for subject, recipients, and body, with live validation feedback
+and a preview section.
+
+All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on
+deterministic demo data (`Draft`). Nothing here touches real mail flows, network
+calls, or data outside this folder.
+
+## Props
+
+| Prop          | Type                     | Default   | Description                             |
+| ------------- | ------------------------ | --------- | --------------------------------------- |
+| `draft`       | `Draft`                  | required  | The draft being edited (controlled).    |
+| `onChange`    | `(draft: Draft) => void` | required  | Called whenever a field value changes.  |
+| `onSave`      | `() => void`             | undefined | Called when the user clicks Save.       |
+| `onCancel`    | `() => void`             | undefined | Called when the user clicks Cancel.     |
+| `showPreview` | `boolean`                | `true`    | Whether to render the preview section.  |
+| `className`   | `string`                 | undefined | Extra CSS classes for the root element. |
+
+When switching between different drafts, the parent should use a React `key`
+prop on `<MessageEditor>` to reset internal state (e.g., the recipients text
+input):
+
+```tsx
+<MessageEditor key={draft.id} draft={draft} onChange={...} />
+```
+
+## Validation behavior
+
+Validation reuses `validateCampaignDrafts` from `validation.ts` via the
+`validateMessage` wrapper which strips the `drafts[0].` prefix from field paths.
+
+### Rules enforced
+
+| Field      | Rule                               | Severity |
+| ---------- | ---------------------------------- | -------- |
+| subject    | Must be non-empty                  | error    |
+| body       | Must be non-empty                  | error    |
+| recipients | Must have at least one entry       | error    |
+| recipients | Each entry must contain `@` or `*` | error    |
+| recipients | Domain must be a safe demo domain  | warning  |
+
+### How it displays
+
+- **Field-level:** invalid fields show a red border and an inline error message
+  below the input (only the first error per field).
+- **Summary:** a `ValidationResultsPanel` below the form fields displays all
+  issues grouped by severity.
+
+## Preview behavior
+
+The preview section follows the same styling as the
+[TemplatePicker](../templates/TemplatePicker.tsx) detail panel:
+
+- Subject line and recipients rendered as a `<dl>` grid
+- Body rendered in a `<pre>` block with the same dark border, `bg-black/30`
+  background, and monospace-friendly font stack
+
+## Example usage
+
+```tsx
+import { useState } from "react";
+import { MessageEditor } from "./components/MessageEditor";
+import type { Draft } from "../types/draft";
+
+function MyEditor() {
+  const [draft, setDraft] = useState<Draft>({
+    id: "draft-edit-1",
+    subject: "",
+    body: "",
+    recipients: [],
+  });
+
+  const handleSave = () => {
+    console.log("Saving draft:", draft);
+  };
+
+  return <MessageEditor key={draft.id} draft={draft} onChange={setDraft} onSave={handleSave} />;
+}
+```
+
+### Integration with `draftReducer`
+
+```tsx
+import { useReducer } from "react";
+import { draftReducer, initialState } from "../reducers/draftReducer";
+import { MessageEditor } from "./components/MessageEditor";
+
+function ReducerEditor() {
+  const [state, dispatch] = useReducer(draftReducer, initialState);
+
+  return (
+    <MessageEditor
+      key={state.current?.id}
+      draft={state.current ?? { id: "", subject: "", body: "", recipients: [] }}
+      onChange={(draft) => dispatch({ type: "editDraft", payload: draft })}
+      onSave={() => console.log("Saved:", state.current)}
+    />
+  );
+}
+```
+
+## Exported helpers
+
+These pure functions are exported from `components/MessageEditor.tsx` and tested
+independently:
+
+- `validateMessage(draft: Draft): ValidationIssue[]` — validates a single draft.
+- `parseRecipientsInput(input: string): string[]` — splits on comma, trims,
+  filters empties.
+- `formatRecipientsDisplay(recipients: string[]): string` — joins with `", "`.
+- `formatMessagePreview(draft: Draft): string` — formats a plain-text preview.
+
+## Future integration notes
+
+- The component is intentionally kept controlled so it can be wired into a
+  campaign snapshot editor, the template picker flow, or a standalone draft
+  creation form without modification.
+- To support multi-draft editing, wrap each `MessageEditor` in a list with
+  unique keys and manage the draft array in the parent.


### PR DESCRIPTION
## Summary

Adds a controlled **MessageEditor** UI for editing a single demo message record within the demo-admin-dashboard feature.

The component supports editing:
- Subject
- Recipients
- Body

It also provides inline validation feedback and a structured preview section aligned with existing dashboard UI patterns.


## Changes

### New UI Component

**MessageEditor.tsx**
- Controlled editor for `Draft` objects
- Editable fields:
  - Subject input
  - Recipients input (comma-separated)
  - Body textarea
- Cmd/Ctrl + Enter shortcut to trigger save
- Cancel and Save actions


### Validation

- Uses existing `validateCampaignDrafts` logic
- Field-level validation mapping for inline feedback
- Summary validation via `ValidationResultsPanel`
- Red border + inline error messages per field


### Helper Functions

All exported and fully tested:

- `validateMessage`
- `parseRecipientsInput`
- `formatRecipientsDisplay`
- `formatMessagePreview`


### Tests

- 26 unit tests covering helper functions
- 1 module export verification test suite
- Covers validation logic, parsing, formatting, and preview generation

Note:
- No rendering tests exist in the repository (project uses helper-level testing only)


### Documentation

Added:
- `docs/MESSAGE_EDITOR.md`

Includes:
- Component API
- Validation rules
- Preview behavior
- Integration guidance
- Usage examples


## Acceptance Criteria

- [x] MessageEditor exists as admin UI component
- [x] Editable subject input
- [x] Editable recipients input
- [x] Editable body textarea
- [x] Validation feedback displayed in UI
- [x] Preview section renders correctly
- [x] Save and Cancel actions implemented
- [x] Reuses existing dashboard styling system
- [x] Fully scoped to `src/features/demo-admin-dashboard/`
- [x] No changes outside feature folder


## Notes

- 1 pre-existing test failure exists in `presets.test.ts` (unrelated to this PR)
- TypeScript errors exist in unrelated modules outside feature scope
- All changes are strictly scoped to `src/features/demo-admin-dashboard/`
- Repository does not include React rendering tests or testing-library setup; helper-level tests are consistent with existing patterns

## Closing

Closes #174