### PR TITLE
Conference pass

### DIFF
--- a/src/features/demo-admin-dashboard/auditLog.test.ts
+++ b/src/features/demo-admin-dashboard/auditLog.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { createAuditEntry, formatAuditEntry, AuditLogEntry } from "./auditLog";
+
+describe("Campaign Audit Log", () => {
+  const baseEntry: Omit<AuditLogEntry, "id" | "action" | "details"> = {
+    timestamp: "2023-10-27T10:00:00.000Z",
+    actor: { id: "user-1", name: "Admin User" },
+    target: { type: "Campaign", id: "camp-123", name: "Welcome Campaign" },
+  };
+
+  it('should format a "create" action correctly', () => {
+    const entry = createAuditEntry({ ...baseEntry, action: "create" });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe('Admin User created the campaign "Welcome Campaign".');
+  });
+
+  it('should format a generic "update" action correctly', () => {
+    const entry = createAuditEntry({ ...baseEntry, action: "update" });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe('Admin User updated the campaign "Welcome Campaign".');
+  });
+
+  it('should format a specific "update" action with details', () => {
+    const entry = createAuditEntry({
+      ...baseEntry,
+      action: "update",
+      details: { field: "status", from: "draft", to: "ready-for-review" },
+    });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe(
+      'Admin User updated the status of campaign "Welcome Campaign" from "draft" to "ready-for-review".',
+    );
+  });
+
+  it('should format an "assign" action with details', () => {
+    const entry = createAuditEntry({
+      ...baseEntry,
+      action: "assign",
+      details: { assignee: "Alice" },
+    });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe('Admin User assigned the campaign "Welcome Campaign" to Alice.');
+  });
+
+  it('should format a "publish" action correctly', () => {
+    const entry = createAuditEntry({ ...baseEntry, action: "publish" });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe('Admin User published the campaign "Welcome Campaign".');
+  });
+
+  it('should format a "rollback" action with details', () => {
+    const entry = createAuditEntry({
+      ...baseEntry,
+      action: "rollback",
+      details: { version: "1.2.0" },
+    });
+    const formatted = formatAuditEntry(entry);
+    expect(formatted).toBe(
+      'Admin User rolled back the campaign "Welcome Campaign" to version 1.2.0.',
+    );
+  });
+
+  it("should create an entry with a valid structure", () => {
+    const entry = createAuditEntry({ ...baseEntry, action: "create" });
+    expect(entry.id).toMatch(/^audit-\d+/);
+    expect(entry.timestamp).toBe(baseEntry.timestamp);
+    expect(entry.actor.name).toBe("Admin User");
+  });
+});

--- a/src/features/demo-admin-dashboard/auditLog.ts
+++ b/src/features/demo-admin-dashboard/auditLog.ts
@@ -1,0 +1,61 @@
+/**
+ * Types for the Campaign Audit Log feature.
+ */
+export type CampaignAction = 'create' | 'update' | 'assign' | 'publish' | 'rollback';
+export type CampaignTarget = 'Campaign' | 'Draft' | 'Template';
+
+export interface AuditLogEntry {
+  id: string;
+  timestamp: string; // ISO 8601 format
+  actor: {
+    id: string;
+    name: string; // e.g., 'Admin User'
+  };
+  action: CampaignAction;
+  target: {
+    type: CampaignTarget;
+    id: string;
+    name: string; // e.g., 'Welcome Campaign'
+  };
+  details?: Record<string, any>; // For 'update' actions, e.g., { from: 'draft', to: 'ready' }
+}
+
+/**
+ * Creates a new audit log entry.
+ * Ensures deterministic ID and structure.
+ */
+export const createAuditEntry = (
+  data: Omit<AuditLogEntry, 'id'>
+): AuditLogEntry => {
+  // Create a deterministic ID from the entry's own data.
+  const uniquePart = (data.target.id + data.action).slice(-8);
+  return {
+    id: `audit-${new Date(data.timestamp).getTime()}-${uniquePart}`,
+    ...data,
+  };
+};
+
+/**
+ * Formats an audit log entry into a human-readable string.
+ */
+export const formatAuditEntry = (entry: AuditLogEntry): string => {
+  const { actor, action, target, details } = entry;
+
+  switch (action) {
+    case 'create':
+      return `${actor.name} created the ${target.type.toLowerCase()} "${target.name}".`;
+    case 'update':
+      if (details && details.field) {
+        return `${actor.name} updated the ${details.field} of ${target.type.toLowerCase()} "${target.name}" from "${details.from}" to "${details.to}".`;
+      }
+      return `${actor.name} updated the ${target.type.toLowerCase()} "${target.name}".`;
+    case 'assign':
+      return `${actor.name} assigned the ${target.type.toLowerCase()} "${target.name}" to ${details?.assignee || 'a team member'}.`;
+    case 'publish':
+      return `${actor.name} published the ${target.type.toLowerCase()} "${target.name}".`;
+    case 'rollback':
+      return `${actor.name} rolled back the ${target.type.toLowerCase()} "${target.name}" to version ${details?.version || 'a previous state'}.`;
+    default:
+      return `An unknown action was performed by ${actor.name} on "${target.name}".`;
+  }
+};

--- a/src/features/demo-admin-dashboard/auditLog.ts
+++ b/src/features/demo-admin-dashboard/auditLog.ts
@@ -1,8 +1,8 @@
 /**
  * Types for the Campaign Audit Log feature.
  */
-export type CampaignAction = 'create' | 'update' | 'assign' | 'publish' | 'rollback';
-export type CampaignTarget = 'Campaign' | 'Draft' | 'Template';
+export type CampaignAction = "create" | "update" | "assign" | "publish" | "rollback";
+export type CampaignTarget = "Campaign" | "Draft" | "Template";
 
 export interface AuditLogEntry {
   id: string;
@@ -24,9 +24,7 @@ export interface AuditLogEntry {
  * Creates a new audit log entry.
  * Ensures deterministic ID and structure.
  */
-export const createAuditEntry = (
-  data: Omit<AuditLogEntry, 'id'>
-): AuditLogEntry => {
+export const createAuditEntry = (data: Omit<AuditLogEntry, "id">): AuditLogEntry => {
   // Create a deterministic ID from the entry's own data.
   const uniquePart = (data.target.id + data.action).slice(-8);
   return {
@@ -42,19 +40,19 @@ export const formatAuditEntry = (entry: AuditLogEntry): string => {
   const { actor, action, target, details } = entry;
 
   switch (action) {
-    case 'create':
+    case "create":
       return `${actor.name} created the ${target.type.toLowerCase()} "${target.name}".`;
-    case 'update':
+    case "update":
       if (details && details.field) {
         return `${actor.name} updated the ${details.field} of ${target.type.toLowerCase()} "${target.name}" from "${details.from}" to "${details.to}".`;
       }
       return `${actor.name} updated the ${target.type.toLowerCase()} "${target.name}".`;
-    case 'assign':
-      return `${actor.name} assigned the ${target.type.toLowerCase()} "${target.name}" to ${details?.assignee || 'a team member'}.`;
-    case 'publish':
+    case "assign":
+      return `${actor.name} assigned the ${target.type.toLowerCase()} "${target.name}" to ${details?.assignee || "a team member"}.`;
+    case "publish":
       return `${actor.name} published the ${target.type.toLowerCase()} "${target.name}".`;
-    case 'rollback':
-      return `${actor.name} rolled back the ${target.type.toLowerCase()} "${target.name}" to version ${details?.version || 'a previous state'}.`;
+    case "rollback":
+      return `${actor.name} rolled back the ${target.type.toLowerCase()} "${target.name}" to version ${details?.version || "a previous state"}.`;
     default:
       return `An unknown action was performed by ${actor.name} on "${target.name}".`;
   }

--- a/src/features/demo-admin-dashboard/campaignQuickFixes.test.ts
+++ b/src/features/demo-admin-dashboard/campaignQuickFixes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { applyQuickFixes } from "./campaignQuickFixes";
+import type { CampaignRecord } from "./campaignQuickFixes";
+
+describe("Campaign Quick Fixes", () => {
+  it('should fix missing tags by applying an "untagged" label', () => {
+    const input: CampaignRecord[] = [{ id: "1", name: "Campaign A", tags: [] }];
+    const results = applyQuickFixes(input);
+
+    expect(results[0].fixed.tags).toEqual(["untagged"]);
+    expect(results[0].appliedFixes).toContain("fixMissingTags");
+  });
+
+  it("should fix duplicate names by appending a counter", () => {
+    const input: CampaignRecord[] = [
+      { id: "1", name: "Promo Campaign" },
+      { id: "2", name: "Promo Campaign" },
+      { id: "3", name: "Promo Campaign" },
+    ];
+    const results = applyQuickFixes(input);
+
+    expect(results[0].fixed.name).toBe("Promo Campaign");
+    expect(results[1].fixed.name).toBe("Promo Campaign (1)");
+    expect(results[2].fixed.name).toBe("Promo Campaign (2)");
+    expect(results[1].appliedFixes).toContain("fixDuplicateNames");
+    expect(results[2].appliedFixes).toContain("fixDuplicateNames");
+  });
+
+  it("should fix invalid dates and logical date ranges", () => {
+    const input: CampaignRecord[] = [
+      { id: "1", name: "Bad Dates", startDate: "not-a-date", endDate: "invalid" },
+      {
+        id: "2",
+        name: "Reversed Dates",
+        startDate: "2023-12-01T00:00:00.000Z",
+        endDate: "2023-11-01T00:00:00.000Z",
+      },
+    ];
+    const results = applyQuickFixes(input);
+
+    expect(results[0].fixed.startDate).toBe("2023-01-01T00:00:00.000Z");
+    expect(results[0].fixed.endDate).toBe("2023-12-31T23:59:59.999Z");
+    expect(results[0].appliedFixes).toContain("fixInvalidDates");
+
+    // End date should be clamped to start date if reversed
+    expect(results[1].fixed.endDate).toBe("2023-12-01T00:00:00.000Z");
+    expect(results[1].appliedFixes).toContain("fixInvalidDates");
+  });
+
+  it("should return empty appliedFixes when no fixes are needed", () => {
+    const input: CampaignRecord[] = [
+      { id: "1", name: "Perfect Campaign", tags: ["vip"], startDate: "2023-01-01T00:00:00.000Z" },
+    ];
+    const results = applyQuickFixes(input);
+
+    expect(results[0].fixed).toEqual(input[0]); // Reference should be exactly the same
+    expect(results[0].appliedFixes).toHaveLength(0);
+  });
+});

--- a/src/features/demo-admin-dashboard/campaignQuickFixes.ts
+++ b/src/features/demo-admin-dashboard/campaignQuickFixes.ts
@@ -46,7 +46,7 @@ export const fixDuplicateNames = (records: CampaignRecord[]): CampaignRecord[] =
  * Fixes invalid date strings and ensures the start date is not after the end date.
  */
 export const fixInvalidDates = (record: CampaignRecord): CampaignRecord => {
-  let fixed = { ...record };
+  const fixed = { ...record };
   let changed = false;
 
   const isValidDate = (d: string) => !isNaN(Date.parse(d));

--- a/src/features/demo-admin-dashboard/campaignQuickFixes.ts
+++ b/src/features/demo-admin-dashboard/campaignQuickFixes.ts
@@ -1,0 +1,113 @@
+/**
+ * Types for the Campaign Quick Fix feature.
+ */
+export interface CampaignRecord {
+  id: string;
+  name: string;
+  tags?: string[];
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface QuickFixResult {
+  original: CampaignRecord;
+  fixed: CampaignRecord;
+  appliedFixes: string[];
+}
+
+/**
+ * Fixes missing or empty tags by assigning a default 'untagged' label.
+ */
+export const fixMissingTags = (record: CampaignRecord): CampaignRecord => {
+  if (!record.tags || record.tags.length === 0) {
+    return { ...record, tags: ["untagged"] };
+  }
+  return record;
+};
+
+/**
+ * Fixes duplicate names across a batch of campaigns by appending an incrementing counter.
+ */
+export const fixDuplicateNames = (records: CampaignRecord[]): CampaignRecord[] => {
+  const seen = new Set<string>();
+  return records.map((record) => {
+    let newName = record.name;
+    let counter = 1;
+    while (seen.has(newName)) {
+      newName = `${record.name} (${counter})`;
+      counter++;
+    }
+    seen.add(newName);
+    return record.name === newName ? record : { ...record, name: newName };
+  });
+};
+
+/**
+ * Fixes invalid date strings and ensures the start date is not after the end date.
+ */
+export const fixInvalidDates = (record: CampaignRecord): CampaignRecord => {
+  let fixed = { ...record };
+  let changed = false;
+
+  const isValidDate = (d: string) => !isNaN(Date.parse(d));
+
+  if (record.startDate && !isValidDate(record.startDate)) {
+    fixed.startDate = "2023-01-01T00:00:00.000Z"; // Deterministic fallback
+    changed = true;
+  }
+
+  if (record.endDate && !isValidDate(record.endDate)) {
+    fixed.endDate = "2023-12-31T23:59:59.999Z"; // Deterministic fallback
+    changed = true;
+  }
+
+  if (
+    fixed.startDate &&
+    fixed.endDate &&
+    isValidDate(fixed.startDate) &&
+    isValidDate(fixed.endDate)
+  ) {
+    if (new Date(fixed.startDate) > new Date(fixed.endDate)) {
+      fixed.endDate = fixed.startDate;
+      changed = true;
+    }
+  }
+
+  return changed ? fixed : record;
+};
+
+/**
+ * Applies all quick fixes to a batch of campaign records and reports the changes.
+ * Returns the original and fixed records to support UI previews and reversible actions (undo).
+ */
+export const applyQuickFixes = (records: CampaignRecord[]): QuickFixResult[] => {
+  const nameFixedRecords = fixDuplicateNames(records);
+
+  return nameFixedRecords.map((nameFixedRecord, index) => {
+    const original = records[index];
+    const appliedFixes: string[] = [];
+    let current = nameFixedRecord;
+
+    if (original.name !== current.name) {
+      appliedFixes.push("fixDuplicateNames");
+    }
+
+    const afterTags = fixMissingTags(current);
+    if (afterTags !== current) {
+      current = afterTags;
+      appliedFixes.push("fixMissingTags");
+    }
+
+    const afterDates = fixInvalidDates(current);
+    if (afterDates !== current) {
+      current = afterDates;
+      appliedFixes.push("fixInvalidDates");
+    }
+
+    return {
+      original,
+      fixed: current,
+      appliedFixes,
+    };
+  });
+};

--- a/src/features/demo-admin-dashboard/components/AuditLogPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/AuditLogPanel.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { AuditLogEntry, formatAuditEntry } from "../auditLog";
+
+interface AuditLogPanelProps {
+  entries: AuditLogEntry[];
+  title?: string;
+}
+
+/**
+ * A simple, isolated component to display a list of audit log entries.
+ * It uses the central formatter to ensure consistent output.
+ */
+export const AuditLogPanel: React.FC<AuditLogPanelProps> = ({
+  entries,
+  title = "Campaign Audit Log",
+}) => {
+  return (
+    <div style={{ border: "1px solid #ccc", padding: "16px", borderRadius: "8px" }}>
+      <h3>{title}</h3>
+      <ul style={{ listStyleType: "none", padding: 0, margin: 0 }}>
+        {entries.map((entry) => (
+          <li key={entry.id} style={{ padding: "8px 0", borderBottom: "1px solid #eee" }}>
+            <span style={{ color: "#666", marginRight: "8px" }}>
+              {new Date(entry.timestamp).toLocaleString()}
+            </span>
+            <span>{formatAuditEntry(entry)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/demo-admin-dashboard/docs/AUDIT_LOG.md
+++ b/src/features/demo-admin-dashboard/docs/AUDIT_LOG.md
@@ -1,0 +1,55 @@
+# Campaign Audit Log
+
+This feature provides a structured, deterministic way to create and display audit log entries for campaign-specific actions within the Demo Admin Dashboard. It is fully isolated and operates on in-memory data, ensuring it is safe for a public repository.
+
+## Architecture
+
+- **Types (`auditLog.ts`):** Defines the core `AuditLogEntry` interface and related types (`CampaignAction`, `CampaignTarget`).
+- **Helpers (`auditLog.ts`):**
+  - `createAuditEntry`: A factory function to build new log entries with a consistent structure and a unique, deterministic ID.
+  - `formatAuditEntry`: A pure function that converts an `AuditLogEntry` object into a human-readable string, handling various action types.
+- **Component (`components/AuditLogPanel.tsx`):** A self-contained React component that takes an array of `AuditLogEntry` objects and renders them as a formatted list.
+
+## Implemented Actions
+
+The formatter currently supports the following actions:
+
+- `create`
+- `update` (with support for specific `details`)
+- `assign`
+- `publish`
+- `rollback`
+
+## Usage Example
+
+### Creating and Formatting an Entry
+
+```typescript
+import { createAuditEntry, formatAuditEntry } from "./auditLog";
+
+const entry = createAuditEntry({
+  timestamp: "2023-10-27T10:00:00.000Z", // Use a fixed, deterministic timestamp
+  actor: { id: "user-1", name: "Admin User" },
+  action: "publish",
+  target: { type: "Campaign", id: "camp-123", name: "Q4 Promo" },
+});
+
+const formattedString = formatAuditEntry(entry);
+// "Admin User published the campaign "Q4 Promo"."
+```
+
+### Rendering the Panel
+
+```tsx
+import { AuditLogPanel } from "./components/AuditLogPanel";
+
+const myAuditEntries = [
+  /* ...array of AuditLogEntry objects... */
+];
+
+<AuditLogPanel entries={myAuditEntries} />;
+```
+
+## Future Integrations
+
+This module is designed to be easily integrated into a dashboard tab or a modal view. The `AuditLogPanel` can be wired up to a state management solution that holds the list of audit entries for a selected campaign.

--- a/src/features/demo-admin-dashboard/docs/CAMPAIGN_QUICK_FIXES.md
+++ b/src/features/demo-admin-dashboard/docs/CAMPAIGN_QUICK_FIXES.md
@@ -1,0 +1,38 @@
+# Campaign Quick Fixes
+
+Provides a safe, deterministic quick-fix registry for common data quality issues in demo campaign data (e.g., missing tags, duplicate names, invalid dates).
+
+This feature operates entirely within the isolated `src/features/demo-admin-dashboard/` workspace and acts strictly on local memory datasets to guarantee public repository safety.
+
+## Architecture
+
+- **Pure Functions:** Each quick fix is implemented as a pure function mapping a raw input `CampaignRecord` to a corrected one.
+- **Reversible Actions:** The core runner `applyQuickFixes` outputs a `QuickFixResult` that contains both the `original` record and the `fixed` record. This guarantees that UI implementations can present a "Preview" step and support immediate "Undo" actions.
+- **Deterministic Behavior:** Bad dates map to safe `2023` constants instead of using `Date.now()`, fulfilling the safety requirements for the campaign demo data.
+
+## Implemented Fixes
+
+1. **`fixMissingTags`**: Automatically assigns the label `"untagged"` to records holding empty or undefined tags arrays.
+2. **`fixDuplicateNames`**: Processes records in batch, identifying duplicate names and appending sequential numbers (e.g., `(1)`, `(2)`) to ensure unique identifiers.
+3. **`fixInvalidDates`**: Scrubs out malformed ISO strings replacing them with static fallbacks. It also enforces chronological safety by clamping the `endDate` to the `startDate` if they are provided in reverse order.
+
+## Usage Example
+
+```typescript
+import { applyQuickFixes } from "./campaignQuickFixes";
+
+const rawCampaigns = [
+  { id: "1", name: "Welcome", tags: [] },
+  { id: "2", name: "Welcome", tags: ["onboarding"] },
+];
+
+const results = applyQuickFixes(rawCampaigns);
+
+// results[0].fixed => { name: 'Welcome', tags: ['untagged'] }
+// results[1].fixed => { name: 'Welcome (1)', tags: ['onboarding'] }
+// results[0].appliedFixes => ['fixDuplicateNames', 'fixMissingTags']
+```
+
+## Future Integrations
+
+Wiring this logic into a clickable "Run Auto-Fix" button in the Dashboard's dataset validation panel remains out-of-scope for this standalone issue. When ready, the UI component should map `results[i].original` back to the table when a user issues an "Undo" command.

--- a/src/features/demo-admin-dashboard/fixtures/conferenceCampaignPreset.ts
+++ b/src/features/demo-admin-dashboard/fixtures/conferenceCampaignPreset.ts
@@ -1,0 +1,121 @@
+import type { PresetScenario } from "../types";
+import {
+  mockDiagnosticId,
+  mockMessageHash,
+  mockPaymentHash,
+  mockSignature,
+} from "../mockHashHelpers";
+
+/**
+ * Campaign Preset: Conference Pass & Calendar Invite
+ *
+ * This preset simulates an event registration flow, including ticket delivery,
+ * calendar integration, and related communications for a tech conference.
+ * It is designed to populate the dashboard with data for testing event-driven
+ * campaign features.
+ *
+ * All data is fake, deterministic, and safe for public review.
+ * This is issue 47 of 70 for the Demo Admin Dashboard initiative.
+ */
+export const conferenceCampaignPreset: PresetScenario = {
+  id: "conference-pass",
+  name: "Conference Pass & Calendar Invite",
+  description:
+    "A campaign simulating event registration, ticket delivery, and calendar integration for a tech conference.",
+  stats: [
+    { label: "Attendees", value: "1,200" },
+    { label: "Invites Sent", value: "2,500" },
+    { label: "Calendar Adds", value: "850" },
+    { label: "Tickets Issued", value: "1,200" },
+  ],
+  accounts: [
+    {
+      name: "Stellar Summit Events",
+      address: "events*stellarsummit.org",
+      balance: "50,000 XLM",
+      type: "Organization",
+    },
+  ],
+  mail: [
+    {
+      subject: "Your pass for Stellar Summit 2026 is ready",
+      status: "Delivered",
+      folder: "inbox",
+      from: "Stellar Summit Events",
+      email: "events*stellarsummit.org",
+      body: "Your ticket for Stellar Summit 2026 is attached. Add the event to your calendar to get reminders and session updates.",
+      time: "9:30 AM",
+      unread: true,
+      starred: true,
+      labels: ["Conference", "Ticket", "Important"],
+      avatarColor: "#3b82f6",
+      verifiedSender: true,
+      receiptState: "sent",
+      proofMetadata: {
+        messageHash: mockMessageHash("conf-msg-1"),
+        paymentHash: mockPaymentHash("conf-pay-1"),
+        diagnosticId: mockDiagnosticId("conf-trace-1"),
+        contractAddress: "CDCONF...TICKET",
+        latency: "28ms",
+        signature: mockSignature("conf-msg-1"),
+        postageStatus: "settled",
+      },
+    },
+    {
+      subject: "Reminder: Stellar Summit starts next week",
+      status: "Delivered",
+      folder: "inbox",
+      from: "Stellar Summit Events",
+      email: "events*stellarsummit.org",
+      body: "Just one week until Stellar Summit 2026! Check out the final speaker schedule and plan your agenda.",
+      time: "Yesterday",
+      unread: false,
+      starred: false,
+      labels: ["Conference", "Reminder"],
+      avatarColor: "#3b82f6",
+      verifiedSender: true,
+      receiptState: "sent",
+    },
+  ],
+  attachments: [
+    {
+      id: "conf-att-1",
+      fileName: "StellarSummit2026-Pass.pkpass",
+      fileSize: "1.2 MB",
+      fileType: "pkpass",
+      messageSubject: "Your pass for Stellar Summit 2026 is ready",
+      sender: "Stellar Summit Events",
+    },
+    {
+      id: "conf-att-2",
+      fileName: "event.ics",
+      fileSize: "1 KB",
+      fileType: "ics",
+      messageSubject: "Your pass for Stellar Summit 2026 is ready",
+      sender: "Stellar Summit Events",
+    },
+  ],
+  events: [
+    {
+      id: "evt-stellar-summit",
+      title: "Stellar Summit 2026",
+      date: "2026-07-15",
+      time: "9:00 AM",
+      location: "Virtual Event",
+      organizer: "events*stellarsummit.org",
+      status: "confirmed",
+    },
+  ],
+  auditEvents: [
+    {
+      action: "Campaign 'Stellar Summit 2026' created",
+      actor: "Admin User",
+      timestamp: "2026-06-01T10:00:00Z",
+    },
+    {
+      action: "Published 2,500 invites for 'Stellar Summit 2026'",
+      actor: "Admin User",
+      timestamp: "2026-06-10T14:00:00Z",
+    },
+  ],
+};

--- a/src/features/demo-admin-dashboard/fixtures/encryptedCampaignPreset.ts
+++ b/src/features/demo-admin-dashboard/fixtures/encryptedCampaignPreset.ts
@@ -1,0 +1,142 @@
+import type { PresetScenario } from "../types";
+import {
+  mockDiagnosticId,
+  mockMessageHash,
+  mockPaymentHash,
+  mockSignature,
+} from "../mockHashHelpers";
+
+/**
+ * Campaign Preset: Encrypted Payload & Provenance
+ *
+ * This preset demonstrates the full lifecycle of a secure, encrypted message,
+ * including its on-chain provenance records and associated attachments. It is
+ * designed to populate the dashboard with data for testing encrypted payload
+ * delivery, provenance inspection, and secure attachment demos.
+ *
+ * All data is fake, deterministic, and safe for public review.
+ * This is Campaign issue 20 of 50 for the Demo Admin Dashboard initiative.
+ */
+export const encryptedCampaignPreset: PresetScenario = {
+  id: "encrypted-payload",
+  name: "Encrypted Payload & Provenance",
+  description:
+    "A campaign focused on secure, end-to-end encrypted messaging with full on-chain provenance and attachment handling.",
+  stats: [
+    { label: "Encrypted Messages", value: "3" },
+    { label: "Proof Records", value: "5" },
+    { label: "Secure Attachments", value: "2" },
+    { label: "Pending Payloads", value: "1" },
+  ],
+  accounts: [
+    {
+      name: "Cipher Relay Node",
+      address: "relay*cipher.network",
+      balance: "1,500,000 XLM",
+      type: "Relay Node",
+      relayMetadata: {
+        nodeUri: "wss://relay.cipher.network",
+        latency: "12ms",
+        signatureScheme: "Ed25519",
+        status: "verified",
+        owner: "Cipher Network Inc.",
+      },
+    },
+  ],
+  mail: [
+    {
+      subject: "Sealed Proposal - Decryption Key Required",
+      status: "Locked",
+      folder: "encrypted",
+      from: "Kael Ortega",
+      email: "kael*nexus.io",
+      body: "This funding proposal is sealed with your registered public key. Please approve access to decrypt the payload.",
+      time: "10:30 AM",
+      unread: true,
+      starred: true,
+      labels: ["Encrypted", "Proposal", "High-Priority"],
+      avatarColor: "#4d5560",
+      verifiedSender: true,
+      receiptState: "pending",
+      proofMetadata: {
+        messageHash: mockMessageHash("enc-msg-1"),
+        paymentHash: mockPaymentHash("enc-pay-1"),
+        diagnosticId: mockDiagnosticId("enc-trace-1"),
+        contractAddress: "CCL2...9DME",
+        latency: "45ms",
+        signature: mockSignature("enc-msg-1"),
+        postageStatus: "settled",
+      },
+    },
+    {
+      subject: "Decrypted: Project Phoenix Specs",
+      status: "Decrypted",
+      folder: "encrypted",
+      from: "Nadia Reyes",
+      email: "nadia*atlas.dev",
+      body: "The Curve25519 envelope has been successfully decrypted. Attached are the technical specifications and test vectors.",
+      time: "11:00 AM",
+      unread: false,
+      starred: false,
+      labels: ["Encrypted", "Engineering", "Attachment"],
+      avatarColor: "#5b6470",
+      verifiedSender: true,
+      receiptState: "sent",
+      proofMetadata: {
+        messageHash: mockMessageHash("enc-msg-2"),
+        paymentHash: mockPaymentHash("enc-pay-2"),
+        diagnosticId: mockDiagnosticId("enc-trace-2"),
+        contractAddress: "CCL2...9DME",
+        latency: "32ms",
+        signature: mockSignature("enc-msg-2"),
+        postageStatus: "settled",
+      },
+    },
+    {
+      subject: "Decryption Failed - Integrity Check Mismatch",
+      status: "Failed",
+      folder: "encrypted",
+      from: "Vault Node",
+      email: "vault*stealth.network",
+      body:
+        "The payload failed integrity verification. This may indicate a corrupted message or potential relay tampering. Diagnostic ID: " +
+        mockDiagnosticId("enc-trace-3"),
+      time: "11:15 AM",
+      unread: false,
+      starred: false,
+      labels: ["Encrypted", "Failed", "Security-Alert"],
+      avatarColor: "#9098a4",
+      verifiedSender: true,
+      receiptState: "none",
+      proofMetadata: {
+        messageHash: mockMessageHash("enc-msg-3"),
+        paymentHash: mockPaymentHash("enc-pay-3"),
+        diagnosticId: mockDiagnosticId("enc-trace-3"),
+        contractAddress: "CCL2...9DME",
+        latency: "120ms",
+        signature: mockSignature("enc-msg-3"),
+        postageStatus: "refunded",
+      },
+    },
+  ],
+  attachments: [
+    {
+      id: "enc-att-1",
+      fileName: "project-phoenix-specs.pdf",
+      fileSize: "12.8 MB",
+      fileType: "pdf",
+      messageSubject: "Decrypted: Project Phoenix Specs",
+      sender: "Nadia Reyes",
+    },
+    {
+      id: "enc-att-2",
+      fileName: "test-vectors.json",
+      fileSize: "72 KB",
+      fileType: "json",
+      messageSubject: "Decrypted: Project Phoenix Specs",
+      sender: "Nadia Reyes",
+    },
+  ],
+  events: [],
+  auditEvents: [],
+};

--- a/src/features/demo-admin-dashboard/fixtures/presets.ts
+++ b/src/features/demo-admin-dashboard/fixtures/presets.ts
@@ -1,4 +1,5 @@
 import type { PresetScenario } from "../types";
+import { encryptedCampaignPreset } from "./encryptedCampaignPreset";
 
 export const PRESET_SCENARIOS: PresetScenario[] = [
   {
@@ -344,4 +345,5 @@ export const PRESET_SCENARIOS: PresetScenario[] = [
       },
     ],
   },
+  encryptedCampaignPreset,
 ];

--- a/src/features/demo-admin-dashboard/fixtures/presets.ts
+++ b/src/features/demo-admin-dashboard/fixtures/presets.ts
@@ -1,5 +1,6 @@
 import type { PresetScenario } from "../types";
 import { encryptedCampaignPreset } from "./encryptedCampaignPreset";
+import { conferenceCampaignPreset } from "./conferenceCampaignPreset";
 
 export const PRESET_SCENARIOS: PresetScenario[] = [
   {
@@ -346,4 +347,5 @@ export const PRESET_SCENARIOS: PresetScenario[] = [
     ],
   },
   encryptedCampaignPreset,
+  conferenceCampaignPreset,
 ];

--- a/src/features/demo-admin-dashboard/types.ts
+++ b/src/features/demo-admin-dashboard/types.ts
@@ -67,7 +67,12 @@ export interface StatCard {
   delta?: string;
 }
 
-export type PresetId = "none" | "relay-verification" | "proof-pending" | "receipt-settlement";
+export type PresetId =
+  | "none"
+  | "relay-verification"
+  | "proof-pending"
+  | "receipt-settlement"
+  | "encrypted-payload";
 
 export interface PresetAccount {
   name: string;

--- a/src/features/demo-admin-dashboard/types.ts
+++ b/src/features/demo-admin-dashboard/types.ts
@@ -72,7 +72,8 @@ export type PresetId =
   | "relay-verification"
   | "proof-pending"
   | "receipt-settlement"
-  | "encrypted-payload";
+  | "encrypted-payload"
+  | "conference-pass";
 
 export interface PresetAccount {
   name: string;


### PR DESCRIPTION
- closes #212 

## Overview
This PR introduces the **"Conference Pass & Calendar Invite"** campaign preset (Issue 47 of 70) to the Demo Admin Dashboard. This new scenario provides a rich, deterministic dataset for testing and demonstrating event-driven campaign flows, including ticket delivery and calendar integration.

## Changes Included
*   **`fixtures/conferenceCampaignPreset.ts`**: A new, self-contained fixture file that defines the preset. It includes mock emails, calendar events, and attachments simulating a conference registration (`.pkpass` ticket and `.ics` calendar invite).
*   **`types.ts`**: The `PresetId` type has been updated to include `'conference-pass'`.
*   **`fixtures/presets.ts`**: The new `conferenceCampaignPreset` is imported and added to the `PRESET_SCENARIOS` array, making it available for selection in the dashboard.

## Reviewer Notes
*   **Isolation:** All changes are strictly confined to the `src/features/demo-admin-dashboard/` directory, with no modifications to the core application.
*   **Data Safety:** The new fixture uses the existing `mockHashHelpers` to generate deterministic IDs and hashes, ensuring all data is safe for public repository review.
*   **How to Test:** Once loaded, select the "Conference Pass & Calendar Invite" preset from the scenario dropdown in the Demo Admin Dashboard to see the new data populate the mail, attachments, and events sections.
