### PR TITLE
feat(stellar-team-payout-request): implement core feature engine [#665]

### DIFF
--- a/tests/unit/stellar-team-payout-request/payout.service.test.ts
+++ b/tests/unit/stellar-team-payout-request/payout.service.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Stellar Team Payout Request — Unit Tests
+ *
+ * Tests for PayoutService and validation helpers.
+ * No live network calls. All external data is provided via fixtures.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { PayoutService } from "../../../tools/v2/team/stellar-team-payout-request/services/payout.service";
+import {
+  isValidEmail,
+  isValidAmount,
+  isValidMemo,
+  isValidStellarAccountId,
+  validatePayoutFormData,
+} from "../../../tools/v2/team/stellar-team-payout-request/services/validation";
+import {
+  mockValidFormData,
+  MOCK_USER_ID,
+  MOCK_STELLAR_ID,
+  allMockPayouts,
+} from "../../../tools/v2/team/stellar-team-payout-request/fixtures/mock-payouts";
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+describe("isValidEmail", () => {
+  it("accepts a well-formed email", () => {
+    expect(isValidEmail("alice@example.com")).toBe(true);
+  });
+
+  it("rejects missing @ symbol", () => {
+    expect(isValidEmail("aliceexample.com")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidEmail("")).toBe(false);
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(isValidEmail("   ")).toBe(false);
+  });
+});
+
+describe("isValidAmount", () => {
+  it("accepts a whole number", () => {
+    expect(isValidAmount("100")).toBe(true);
+  });
+
+  it("accepts up to 7 decimal places", () => {
+    expect(isValidAmount("0.0000001")).toBe(true);
+  });
+
+  it("rejects zero", () => {
+    expect(isValidAmount("0")).toBe(false);
+  });
+
+  it("rejects negative values", () => {
+    expect(isValidAmount("-10")).toBe(false);
+  });
+
+  it("rejects more than 7 decimal places", () => {
+    expect(isValidAmount("1.00000001")).toBe(false);
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(isValidAmount("abc")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidAmount("")).toBe(false);
+  });
+});
+
+describe("isValidMemo", () => {
+  it("accepts a short memo", () => {
+    expect(isValidMemo("Team payout Q1")).toBe(true);
+  });
+
+  it("accepts exactly 28 ASCII characters", () => {
+    expect(isValidMemo("a".repeat(28))).toBe(true);
+  });
+
+  it("rejects a memo exceeding 28 bytes", () => {
+    expect(isValidMemo("a".repeat(29))).toBe(false);
+  });
+
+  it("accepts an empty memo", () => {
+    expect(isValidMemo("")).toBe(true);
+  });
+});
+
+describe("isValidStellarAccountId", () => {
+  it("accepts a valid-looking Stellar public key", () => {
+    expect(isValidStellarAccountId(MOCK_STELLAR_ID)).toBe(true);
+  });
+
+  it("rejects a key that does not start with G", () => {
+    expect(isValidStellarAccountId("SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN")).toBe(
+      false,
+    );
+  });
+
+  it("rejects a short key", () => {
+    expect(isValidStellarAccountId("GABC")).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidStellarAccountId("")).toBe(false);
+  });
+});
+
+describe("validatePayoutFormData", () => {
+  it("returns valid for correct form data", () => {
+    const result = validatePayoutFormData(mockValidFormData);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual({});
+  });
+
+  it("returns errors for empty recipientEmail", () => {
+    const result = validatePayoutFormData({ ...mockValidFormData, recipientEmail: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveProperty("recipientEmail");
+  });
+
+  it("returns errors for invalid amount", () => {
+    const result = validatePayoutFormData({ ...mockValidFormData, amount: "-5" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveProperty("amount");
+  });
+
+  it("returns errors for a memo that is too long", () => {
+    const result = validatePayoutFormData({ ...mockValidFormData, memo: "a".repeat(29) });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveProperty("memo");
+  });
+
+  it("returns errors for an invalid scheduledFor date", () => {
+    const result = validatePayoutFormData({ ...mockValidFormData, scheduledFor: "not-a-date" });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveProperty("scheduledFor");
+  });
+
+  it("accepts undefined memo and scheduledFor", () => {
+    const result = validatePayoutFormData({
+      recipientEmail: "user@test.com",
+      amount: "10",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── PayoutService ─────────────────────────────────────────────────────────────
+
+describe("PayoutService", () => {
+  let service: PayoutService;
+
+  beforeEach(() => {
+    service = new PayoutService();
+  });
+
+  // ── create ──────────────────────────────────────────────────────────────────
+
+  describe("create", () => {
+    it("creates a pending request with valid data", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+
+      expect(req.id).toBeDefined();
+      expect(req.userId).toBe(MOCK_USER_ID);
+      expect(req.recipientEmail).toBe(mockValidFormData.recipientEmail);
+      expect(req.amount).toBe(mockValidFormData.amount);
+      expect(req.status).toBe("pending");
+      expect(req.createdAt).toBeDefined();
+      expect(req.updatedAt).toBe(req.createdAt);
+    });
+
+    it("trims whitespace from email and amount", () => {
+      const req = service.create(MOCK_USER_ID, {
+        recipientEmail: "  alice@example.com  ",
+        amount: "  50.00  ",
+      });
+      expect(req.recipientEmail).toBe("alice@example.com");
+      expect(req.amount).toBe("50.00");
+    });
+
+    it("stores the memo when provided", () => {
+      const req = service.create(MOCK_USER_ID, { ...mockValidFormData, memo: "Sprint bonus" });
+      expect(req.memo).toBe("Sprint bonus");
+    });
+
+    it("omits memo when it is an empty string", () => {
+      const req = service.create(MOCK_USER_ID, { ...mockValidFormData, memo: "" });
+      expect(req.memo).toBeUndefined();
+    });
+
+    it("throws on invalid form data", () => {
+      expect(() => service.create(MOCK_USER_ID, { recipientEmail: "bad", amount: "-1" })).toThrow();
+    });
+
+    it("attaches field errors to the thrown error", () => {
+      try {
+        service.create(MOCK_USER_ID, { recipientEmail: "bad", amount: "0" });
+      } catch (err) {
+        expect((err as { errors?: unknown }).errors).toBeDefined();
+      }
+    });
+
+    it("generates unique IDs for each request", () => {
+      const a = service.create(MOCK_USER_ID, mockValidFormData);
+      const b = service.create(MOCK_USER_ID, mockValidFormData);
+      expect(a.id).not.toBe(b.id);
+    });
+  });
+
+  // ── getById ─────────────────────────────────────────────────────────────────
+
+  describe("getById", () => {
+    it("returns the created request", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      const found = service.getById(req.id);
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(req.id);
+    });
+
+    it("returns undefined for an unknown ID", () => {
+      expect(service.getById("nonexistent")).toBeUndefined();
+    });
+
+    it("returns a copy — mutations do not affect the store", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      const copy = service.getById(req.id)!;
+      copy.status = "confirmed"; // mutate the copy
+      expect(service.getById(req.id)?.status).toBe("pending");
+    });
+  });
+
+  // ── getByUser ───────────────────────────────────────────────────────────────
+
+  describe("getByUser", () => {
+    it("returns only requests belonging to the given user", () => {
+      service.create(MOCK_USER_ID, mockValidFormData);
+      service.create("other-user", mockValidFormData);
+      const results = service.getByUser(MOCK_USER_ID);
+      expect(results).toHaveLength(1);
+      expect(results[0].userId).toBe(MOCK_USER_ID);
+    });
+
+    it("returns empty array when user has no requests", () => {
+      expect(service.getByUser("nobody")).toEqual([]);
+    });
+  });
+
+  // ── getByStatus ─────────────────────────────────────────────────────────────
+
+  describe("getByStatus", () => {
+    it("returns only requests with the matching status", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      const pending = service.getByStatus("pending");
+      const submitted = service.getByStatus("submitted");
+      expect(pending).toHaveLength(0);
+      expect(submitted).toHaveLength(1);
+    });
+  });
+
+  // ── markSubmitted ────────────────────────────────────────────────────────────
+
+  describe("markSubmitted", () => {
+    it("transitions pending → submitted and stores transactionId", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      const updated = service.markSubmitted(req.id, "tx-hash-001");
+
+      expect(updated.status).toBe("submitted");
+      expect(updated.transactionId).toBe("tx-hash-001");
+      expect(updated.submittedAt).toBeDefined();
+    });
+
+    it("throws when payout does not exist", () => {
+      expect(() => service.markSubmitted("nope", "tx")).toThrow("Payout not found");
+    });
+
+    it("throws when status is not pending", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      expect(() => service.markSubmitted(req.id, "tx-002")).toThrow();
+    });
+  });
+
+  // ── markConfirmed ────────────────────────────────────────────────────────────
+
+  describe("markConfirmed", () => {
+    it("transitions submitted → confirmed and records confirmedAt", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      const confirmed = service.markConfirmed(req.id);
+
+      expect(confirmed.status).toBe("confirmed");
+      expect(confirmed.confirmedAt).toBeDefined();
+    });
+
+    it("throws when payout is not in submitted state", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      expect(() => service.markConfirmed(req.id)).toThrow();
+    });
+  });
+
+  // ── markFailed ───────────────────────────────────────────────────────────────
+
+  describe("markFailed", () => {
+    it("transitions pending → failed with an error message", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      const failed = service.markFailed(req.id, "Destination account not found");
+
+      expect(failed.status).toBe("failed");
+      expect(failed.error).toBe("Destination account not found");
+    });
+
+    it("transitions submitted → failed", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      const failed = service.markFailed(req.id, "Network timeout");
+      expect(failed.status).toBe("failed");
+    });
+
+    it("throws when payout is already confirmed", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      service.markConfirmed(req.id);
+      expect(() => service.markFailed(req.id, "oops")).toThrow();
+    });
+  });
+
+  // ── cancel ───────────────────────────────────────────────────────────────────
+
+  describe("cancel", () => {
+    it("transitions pending → cancelled", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      const cancelled = service.cancel(req.id);
+      expect(cancelled.status).toBe("cancelled");
+    });
+
+    it("throws when payout is not pending", () => {
+      const req = service.create(MOCK_USER_ID, mockValidFormData);
+      service.markSubmitted(req.id, "tx-001");
+      expect(() => service.cancel(req.id)).toThrow();
+    });
+  });
+
+  // ── clear ─────────────────────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all stored requests", () => {
+      service.create(MOCK_USER_ID, mockValidFormData);
+      service.clear();
+      expect(service.getByUser(MOCK_USER_ID)).toHaveLength(0);
+    });
+  });
+});
+
+// ── Fixtures sanity check ─────────────────────────────────────────────────────
+
+describe("allMockPayouts fixture", () => {
+  it("contains 5 deterministic entries", () => {
+    expect(allMockPayouts).toHaveLength(5);
+  });
+
+  it("covers all payout statuses", () => {
+    const statuses = allMockPayouts.map((p) => p.status);
+    expect(statuses).toContain("pending");
+    expect(statuses).toContain("submitted");
+    expect(statuses).toContain("confirmed");
+    expect(statuses).toContain("failed");
+    expect(statuses).toContain("cancelled");
+  });
+
+  it("has unique IDs", () => {
+    const ids = allMockPayouts.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/tools/v2/team/stellar-team-payout-request/fixtures/mock-payouts.ts
+++ b/tools/v2/team/stellar-team-payout-request/fixtures/mock-payouts.ts
@@ -1,0 +1,95 @@
+/**
+ * Stellar Team Payout Request — Mock Fixtures
+ *
+ * Deterministic test data. Never use production keys or real account IDs.
+ * All Stellar account IDs below are well-formed but fictitious testnet keys.
+ */
+
+import type { PayoutRequest, PayoutFormData, StellarAccountInfo } from "../types";
+
+export const MOCK_USER_ID = "user-test-001";
+
+/**
+ * A valid 56-character testnet-style Stellar public key used as a placeholder.
+ * This is the Stellar Friendbot account — safe to use in fixtures.
+ */
+export const MOCK_STELLAR_ID = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+export const mockPendingPayout: PayoutRequest = {
+  id: "payout-001",
+  userId: MOCK_USER_ID,
+  recipientEmail: "alice@example.com",
+  recipientStellarId: MOCK_STELLAR_ID,
+  amount: "50.0000000",
+  memo: "Q2 team bonus",
+  status: "pending",
+  createdAt: "2025-01-15T10:00:00.000Z",
+  updatedAt: "2025-01-15T10:00:00.000Z",
+};
+
+export const mockSubmittedPayout: PayoutRequest = {
+  id: "payout-002",
+  userId: MOCK_USER_ID,
+  recipientEmail: "bob@example.com",
+  amount: "120.5000000",
+  status: "submitted",
+  transactionId: "tx-abc123",
+  createdAt: "2025-01-14T08:30:00.000Z",
+  updatedAt: "2025-01-14T08:35:00.000Z",
+  submittedAt: "2025-01-14T08:35:00.000Z",
+};
+
+export const mockConfirmedPayout: PayoutRequest = {
+  id: "payout-003",
+  userId: MOCK_USER_ID,
+  recipientEmail: "carol@example.com",
+  amount: "200.0000000",
+  memo: "Sprint 42 completion",
+  status: "confirmed",
+  transactionId: "tx-def456",
+  createdAt: "2025-01-10T12:00:00.000Z",
+  updatedAt: "2025-01-10T12:10:00.000Z",
+  submittedAt: "2025-01-10T12:05:00.000Z",
+  confirmedAt: "2025-01-10T12:10:00.000Z",
+};
+
+export const mockFailedPayout: PayoutRequest = {
+  id: "payout-004",
+  userId: MOCK_USER_ID,
+  recipientEmail: "dave@example.com",
+  amount: "75.0000000",
+  status: "failed",
+  error: "Destination account does not exist",
+  createdAt: "2025-01-13T16:00:00.000Z",
+  updatedAt: "2025-01-13T16:02:00.000Z",
+};
+
+export const mockCancelledPayout: PayoutRequest = {
+  id: "payout-005",
+  userId: MOCK_USER_ID,
+  recipientEmail: "eve@example.com",
+  amount: "30.0000000",
+  status: "cancelled",
+  createdAt: "2025-01-12T09:00:00.000Z",
+  updatedAt: "2025-01-12T09:01:00.000Z",
+};
+
+export const allMockPayouts: PayoutRequest[] = [
+  mockPendingPayout,
+  mockSubmittedPayout,
+  mockConfirmedPayout,
+  mockFailedPayout,
+  mockCancelledPayout,
+];
+
+export const mockValidFormData: PayoutFormData = {
+  recipientEmail: "alice@example.com",
+  amount: "50.00",
+  memo: "Team payout",
+};
+
+export const mockStellarAccount: StellarAccountInfo = {
+  id: MOCK_STELLAR_ID,
+  balance: "1000.0000000",
+  sequenceNumber: "123456789",
+};

--- a/tools/v2/team/stellar-team-payout-request/index.ts
+++ b/tools/v2/team/stellar-team-payout-request/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Stellar Team Payout Request — Public API Surface
+ *
+ * Import only from this file when consuming the tool from sibling tooling.
+ * Do NOT wire this into the main application shell, routing, or wallet core.
+ */
+
+// Types
+export type {
+  PayoutFormData,
+  PayoutRequest,
+  PayoutStatus,
+  ValidationResult,
+  StellarAccountInfo,
+} from "./types";
+
+// Services
+export { PayoutService, payoutService } from "./services/payout.service";
+export {
+  validatePayoutFormData,
+  isValidEmail,
+  isValidAmount,
+  isValidMemo,
+  isValidStellarAccountId,
+} from "./services/validation";
+
+// Fixtures (for testing / demo usage only)
+export {
+  allMockPayouts,
+  mockPendingPayout,
+  mockSubmittedPayout,
+  mockConfirmedPayout,
+  mockFailedPayout,
+  mockCancelledPayout,
+  mockValidFormData,
+  mockStellarAccount,
+  MOCK_USER_ID,
+  MOCK_STELLAR_ID,
+} from "./fixtures/mock-payouts";

--- a/tools/v2/team/stellar-team-payout-request/services/payout.service.ts
+++ b/tools/v2/team/stellar-team-payout-request/services/payout.service.ts
@@ -1,0 +1,217 @@
+/**
+ * Stellar Team Payout Request — Payout Service
+ *
+ * Core business logic for managing payout requests in memory.
+ * No live network calls, no Stellar SDK, no secrets.
+ * External submission is handled by a future integration layer.
+ */
+
+import type { PayoutFormData, PayoutRequest, PayoutStatus, ValidationResult } from "../types";
+import { validatePayoutFormData } from "./validation";
+
+/** Incrementing counter used to generate deterministic IDs in tests. */
+let _idCounter = 0;
+
+function generateId(): string {
+  return `payout-${Date.now()}-${++_idCounter}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export class PayoutService {
+  private store: Map<string, PayoutRequest> = new Map();
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  /**
+   * Validates form data without creating a request.
+   *
+   * Input:  PayoutFormData
+   * Output: ValidationResult { valid, errors }
+   */
+  validate(data: PayoutFormData): ValidationResult {
+    return validatePayoutFormData(data);
+  }
+
+  // ── Create ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a new payout request.
+   *
+   * Input:  valid PayoutFormData + userId
+   * Output: PayoutRequest with status "pending"
+   * Error:  throws Error when validation fails (errors attached as `.errors`)
+   */
+  create(userId: string, data: PayoutFormData): PayoutRequest {
+    const validation = this.validate(data);
+    if (!validation.valid) {
+      const err = new Error("Invalid payout form data");
+      (err as Error & { errors: Record<string, string> }).errors = validation.errors;
+      throw err;
+    }
+
+    const timestamp = now();
+    const request: PayoutRequest = {
+      id: generateId(),
+      userId,
+      recipientEmail: data.recipientEmail.trim(),
+      amount: data.amount.trim(),
+      ...(data.memo?.trim() ? { memo: data.memo.trim() } : {}),
+      ...(data.scheduledFor ? { scheduledFor: data.scheduledFor } : {}),
+      status: "pending",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    this.store.set(request.id, request);
+    return { ...request };
+  }
+
+  // ── Read ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns a copy of the request or undefined.
+   *
+   * Input:  payout ID
+   * Output: PayoutRequest | undefined
+   */
+  getById(id: string): PayoutRequest | undefined {
+    const req = this.store.get(id);
+    return req ? { ...req } : undefined;
+  }
+
+  /**
+   * Returns all requests for a given user.
+   *
+   * Input:  userId
+   * Output: PayoutRequest[]
+   */
+  getByUser(userId: string): PayoutRequest[] {
+    return Array.from(this.store.values())
+      .filter((r) => r.userId === userId)
+      .map((r) => ({ ...r }));
+  }
+
+  /**
+   * Returns all requests with a specific status.
+   *
+   * Input:  PayoutStatus
+   * Output: PayoutRequest[]
+   */
+  getByStatus(status: PayoutStatus): PayoutRequest[] {
+    return Array.from(this.store.values())
+      .filter((r) => r.status === status)
+      .map((r) => ({ ...r }));
+  }
+
+  // ── Status transitions ──────────────────────────────────────────────────────
+
+  /**
+   * Marks a pending request as submitted with a transaction ID.
+   *
+   * Input:  payout ID, Stellar transaction hash
+   * Output: updated PayoutRequest
+   * Error:  throws when not found or not in "pending" status
+   */
+  markSubmitted(id: string, transactionId: string): PayoutRequest {
+    const req = this._requirePayout(id);
+    this._requireStatus(req, ["pending"]);
+
+    const updated: PayoutRequest = {
+      ...req,
+      status: "submitted",
+      transactionId,
+      submittedAt: now(),
+      updatedAt: now(),
+    };
+    this.store.set(id, updated);
+    return { ...updated };
+  }
+
+  /**
+   * Marks a submitted request as confirmed.
+   *
+   * Input:  payout ID
+   * Output: updated PayoutRequest
+   * Error:  throws when not found or not in "submitted" status
+   */
+  markConfirmed(id: string): PayoutRequest {
+    const req = this._requirePayout(id);
+    this._requireStatus(req, ["submitted"]);
+
+    const updated: PayoutRequest = {
+      ...req,
+      status: "confirmed",
+      confirmedAt: now(),
+      updatedAt: now(),
+    };
+    this.store.set(id, updated);
+    return { ...updated };
+  }
+
+  /**
+   * Marks a request as failed with an error message.
+   *
+   * Input:  payout ID, error message
+   * Output: updated PayoutRequest
+   * Error:  throws when not found or already confirmed/cancelled
+   */
+  markFailed(id: string, error: string): PayoutRequest {
+    const req = this._requirePayout(id);
+    this._requireStatus(req, ["pending", "submitted"]);
+
+    const updated: PayoutRequest = {
+      ...req,
+      status: "failed",
+      error,
+      updatedAt: now(),
+    };
+    this.store.set(id, updated);
+    return { ...updated };
+  }
+
+  /**
+   * Cancels a pending request.
+   *
+   * Input:  payout ID
+   * Output: updated PayoutRequest
+   * Error:  throws when not found or not in "pending" status
+   */
+  cancel(id: string): PayoutRequest {
+    const req = this._requirePayout(id);
+    this._requireStatus(req, ["pending"]);
+
+    const updated: PayoutRequest = { ...req, status: "cancelled", updatedAt: now() };
+    this.store.set(id, updated);
+    return { ...updated };
+  }
+
+  // ── Misc ────────────────────────────────────────────────────────────────────
+
+  /** Clears all stored requests (useful for test isolation). */
+  clear(): void {
+    this.store.clear();
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private _requirePayout(id: string): PayoutRequest {
+    const req = this.store.get(id);
+    if (!req) throw new Error(`Payout not found: ${id}`);
+    return req;
+  }
+
+  private _requireStatus(req: PayoutRequest, allowed: PayoutStatus[]): void {
+    if (!allowed.includes(req.status)) {
+      throw new Error(
+        `Cannot transition payout ${req.id} from "${req.status}". ` +
+          `Allowed source statuses: ${allowed.join(", ")}.`,
+      );
+    }
+  }
+}
+
+/** Module-level singleton for convenience. */
+export const payoutService = new PayoutService();

--- a/tools/v2/team/stellar-team-payout-request/services/validation.ts
+++ b/tools/v2/team/stellar-team-payout-request/services/validation.ts
@@ -1,0 +1,79 @@
+/**
+ * Stellar Team Payout Request — Validation Helpers
+ *
+ * Pure functions. No side effects, no network calls, no external state.
+ */
+
+import type { PayoutFormData, ValidationResult } from "../types";
+
+// Stellar public key: starts with 'G', 56 alphanumeric chars (base32 encoded).
+const STELLAR_PUBLIC_KEY_RE = /^G[A-Z2-7]{55}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/** XLM memo text is limited to 28 bytes. */
+const MEMO_MAX_BYTES = 28;
+
+/** Returns true when the string is a valid-looking email address. */
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email.trim());
+}
+
+/**
+ * Returns true when the string is a syntactically valid Stellar public key.
+ * Does NOT confirm account existence on-chain.
+ */
+export function isValidStellarAccountId(id: string): boolean {
+  return STELLAR_PUBLIC_KEY_RE.test(id.trim());
+}
+
+/**
+ * Returns true when the amount string represents a positive number
+ * with at most 7 decimal places (XLM precision).
+ */
+export function isValidAmount(amount: string): boolean {
+  const trimmed = amount.trim();
+  if (!trimmed) return false;
+  const n = Number(trimmed);
+  if (!isFinite(n) || n <= 0) return false;
+  // XLM supports up to 7 decimal places (1 stroop = 0.0000001 XLM).
+  const match = trimmed.match(/^(\d+)(?:\.(\d+))?$/);
+  if (!match) return false;
+  const decimals = match[2] ?? "";
+  return decimals.length <= 7;
+}
+
+/**
+ * Returns true when the memo fits within the 28-byte UTF-8 limit
+ * imposed by the Stellar memo-text field.
+ */
+export function isValidMemo(memo: string): boolean {
+  return new TextEncoder().encode(memo).byteLength <= MEMO_MAX_BYTES;
+}
+
+/**
+ * Validates all fields in PayoutFormData.
+ * Returns a ValidationResult with field-keyed error messages.
+ */
+export function validatePayoutFormData(data: PayoutFormData): ValidationResult {
+  const errors: Record<string, string> = {};
+
+  if (!data.recipientEmail || !isValidEmail(data.recipientEmail)) {
+    errors.recipientEmail = "A valid recipient email address is required.";
+  }
+
+  if (!data.amount || !isValidAmount(data.amount)) {
+    errors.amount = "Amount must be a positive number with at most 7 decimal places.";
+  }
+
+  if (data.memo !== undefined && data.memo !== "" && !isValidMemo(data.memo)) {
+    errors.memo = `Memo must not exceed ${MEMO_MAX_BYTES} bytes.`;
+  }
+
+  if (data.scheduledFor !== undefined) {
+    const d = new Date(data.scheduledFor);
+    if (isNaN(d.getTime())) {
+      errors.scheduledFor = "Scheduled date must be a valid ISO-8601 date string.";
+    }
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors };
+}

--- a/tools/v2/team/stellar-team-payout-request/types.ts
+++ b/tools/v2/team/stellar-team-payout-request/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Stellar Team Payout Request — Type Definitions
+ *
+ * All types are local to this tool. Do not import from the main app.
+ */
+
+/** Lifecycle status of a payout request. */
+export type PayoutStatus = "pending" | "submitted" | "confirmed" | "failed" | "cancelled";
+
+/** Form data submitted by the user before a PayoutRequest is created. */
+export interface PayoutFormData {
+  /** Valid email address of the intended recipient. */
+  recipientEmail: string;
+  /** Amount in XLM, stored as string to avoid floating-point drift. */
+  amount: string;
+  /** Optional transaction memo (max 28 bytes UTF-8). */
+  memo?: string;
+  /** Optional future submission date (ISO-8601). */
+  scheduledFor?: string;
+}
+
+/** A persisted payout request record. */
+export interface PayoutRequest {
+  id: string;
+  userId: string;
+  recipientEmail: string;
+  /** Resolved Stellar public key of the recipient, if known. */
+  recipientStellarId?: string;
+  /** Amount in XLM as a decimal string, e.g. "50.0000000". */
+  amount: string;
+  memo?: string;
+  status: PayoutStatus;
+  /** Stellar transaction hash once submitted. */
+  transactionId?: string;
+  /** Human-readable error message when status is "failed". */
+  error?: string;
+  createdAt: string; // ISO-8601
+  updatedAt: string; // ISO-8601
+  scheduledFor?: string; // ISO-8601
+  submittedAt?: string; // ISO-8601
+  confirmedAt?: string; // ISO-8601
+}
+
+/** Result returned by validation helpers. */
+export interface ValidationResult {
+  valid: boolean;
+  /** Field-keyed error messages. */
+  errors: Record<string, string>;
+}
+
+/** Lightweight Stellar account info used by the tool. */
+export interface StellarAccountInfo {
+  id: string;
+  /** XLM balance as a decimal string. */
+  balance: string;
+  sequenceNumber: string;
+}


### PR DESCRIPTION
## Summary

Implements the core feature engine for the **Stellar Team Payout Request** tool as described in issue #665.

All work is contained inside `tools/v2/team/stellar-team-payout-request/`. Nothing in the main application shell, routing, wallet core, Stellar integration, or design system was modified.

---

## What was added

### `tools/v2/team/stellar-team-payout-request/`

| File | Purpose |
|---|---|
| `types.ts` | `PayoutRequest`, `PayoutFormData`, `ValidationResult`, `StellarAccountInfo` |
| `services/validation.ts` | Pure helpers: `isValidEmail`, `isValidAmount`, `isValidMemo`, `isValidStellarAccountId`, `validatePayoutFormData` |
| `services/payout.service.ts` | `PayoutService` — create / read / status-transition logic (no network, no secrets) |
| `fixtures/mock-payouts.ts` | Deterministic test data covering all 5 payout statuses |
| `index.ts` | Folder-local API surface |

### `tests/unit/stellar-team-payout-request/`

| File | Coverage |
|---|---|
| `payout.service.test.ts` | 52 vitest unit tests — all passing ✅ |

---

## Acceptance criteria

- [x] Core logic is implemented without linking into the main app
- [x] Inputs, outputs, loading states, and error states are documented (types + JSDoc)
- [x] No live network calls, secrets, or production data introduced
- [x] All 52 unit tests pass
- [x] ESLint + Prettier clean
- [x] TypeScript strict-mode compliant (no new errors)

---

## Test coverage

```
✓ tests/unit/stellar-team-payout-request/payout.service.test.ts (52 tests) 19ms

Test Files  1 passed (1)
     Tests  52 passed (52)
```

Covers:
- `isValidEmail` — 4 cases
- `isValidAmount` — 7 cases (zero, negative, overflow decimals, non-numeric)
- `isValidMemo` — 4 cases (byte-length boundary)
- `isValidStellarAccountId` — 4 cases
- `validatePayoutFormData` — 6 cases
- `PayoutService.create` — 7 cases (whitespace trim, error attachment, unique IDs)
- `PayoutService.getById` — 3 cases (copy isolation verified)
- `PayoutService.getByUser` — 2 cases
- `PayoutService.getByStatus` — 1 case
- `PayoutService.markSubmitted` — 3 cases
- `PayoutService.markConfirmed` — 2 cases
- `PayoutService.markFailed` — 3 cases
- `PayoutService.cancel` — 2 cases
- `PayoutService.clear` — 1 case
- Fixture sanity checks — 3 cases

---

Closes 