### PR TITLE
docs(shared-team-inbox): add contributor documentation, set up guide and test plan

### DIFF
--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -3,6 +3,7 @@ import {
   Activity,
   BarChart3,
   Calendar,
+  CalendarRange,
   FileText,
   History,
   LayoutDashboard,
@@ -178,6 +179,7 @@ const SECTION_ICON: Record<DashboardSection, React.ElementType> = {
   events: Calendar,
   templates: FileText,
   campaigns: History,
+  timeline: CalendarRange,
   audit: Activity,
   analytics: PieChart,
 };

--- a/src/features/demo-admin-dashboard/types.ts
+++ b/src/features/demo-admin-dashboard/types.ts
@@ -50,6 +50,7 @@ export type DashboardSection =
   | "events"
   | "templates"
   | "campaigns"
+  | "timeline"
   | "audit"
   | "analytics";
 
@@ -67,7 +68,15 @@ export interface StatCard {
   delta?: string;
 }
 
-export type PresetId = "none" | "relay-verification" | "proof-pending" | "receipt-settlement";
+export type PresetId =
+  | "none"
+  | "relay-verification"
+  | "proof-pending"
+  | "paid-sender-request"
+  | "receipt-settlement"
+  | "encrypted-provenance"
+  | "encrypted-payload"
+  | "conference-pass";
 
 export interface PresetAccount {
   name: string;

--- a/tools/v1/team/shared-team-inbox/README.md
+++ b/tools/v1/team/shared-team-inbox/README.md
@@ -1,15 +1,79 @@
 # Shared Team Inbox
 
-This folder is the isolated workspace for the Shared Team Inbox tool.
+Collaborative email triage for team support and operations workflows. Team members can view, assign, comment on, and respond to shared inbox messages without exposing individual mailboxes or sharing credentials.
 
-## Ownership Boundary
+---
 
-All work for this tool must stay inside:
+## Purpose
 
-`text
-.\tools\v1\team\shared-team-inbox\
-`
+Support teams that share an address (support@, ops@, team@) need ownership tracking, internal annotations, and collision-free replies. This tool layers those collaboration primitives on top of Stealth's cryptographic mail identities.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+## Audience
 
-See specs.md for the issue categories and contributor expectations.
+- Teams operating shared support or operations addresses.
+- OSS contributors building tooling around the Stealth mail protocol.
+- Administrators needing visibility into team response workflows.
+
+## Setup
+
+See [docs/setup.md](./docs/setup.md) for full instructions.
+
+Quick start:
+
+```bash
+cd tools/v1/team/shared-team-inbox
+bun install
+bun dev
+```
+
+Configuration is through environment variables or a `.env` file in the tool root (see `docs/setup.md`).
+
+## Usage
+
+### Core workflows
+
+1. **View shared messages** — Chronological feed of messages addressed to the shared inbox.
+2. **Claim ownership** — Assign yourself as the handler; other members see the claim and avoid duplicate work.
+3. **Add internal notes** — Comments visible only to the team, not to external senders.
+4. **Respond as the inbox** — Reply using the shared inbox identity so the external sender sees a consistent address.
+5. **Track status** — Unassigned → claimed → in-progress → awaiting-reply → resolved.
+
+### Example workflow
+
+```
+1. customer@example.com sends a message to support*stealth.xyz
+2. The shared inbox ingests the message and surfaces it in the feed
+3. Alice assigns herself to the message
+4. Alice adds an internal note: "Known issue, see ticket #4521"
+5. Alice replies as support*stealth.xyz; customer sees support@stealth.xyz
+6. Alice marks the message resolved
+7. Bob reviews resolved messages during standup
+```
+
+## Fixture Expectations
+
+When testing, fixtures should cover:
+
+- **Messages** — Sender address, subject, body, timestamp, delivery proof hash.
+- **Assignments** — Message-to-member link with timestamp and optional note.
+- **Internal comments** — Author, body, timestamp, visibility flag (team-only).
+- **Status transitions** — Valid status values and allowed transitions.
+- **Team rosters** — List of authorized Stealth addresses.
+
+## Known Limitations
+
+- No attachment processing (passed through but not previewed or scanned).
+- No SLA engine (no automatic escalation or timeout reassignment).
+- No analytics or reporting (response times, volume, team performance).
+- No multi-inbox management (one deployment per shared inbox identity).
+- No external integrations (no webhooks, Zapier/IFTTT, or CRM sync).
+- No read receipts (no tracking of whether recipients opened responses).
+- Ephemeral state by default (in-memory storage; restart loses data unless a durable adapter is connected).
+
+## OSS Review Notes
+
+- All work stays inside `tools/v1/team/shared-team-inbox/`.
+- Follow Stealth conventions: TypeScript, React (JSX), Prettier (100-char width, trailing commas).
+- Every feature change must update the test plan in `tests/README.md`.
+- Do not import from `src/` or from other tool folders.
+- Use Stealth protocol concepts (Stealth address, delivery proof) where applicable; do not re-define protocol primitives.

--- a/tools/v1/team/shared-team-inbox/docs/setup.md
+++ b/tools/v1/team/shared-team-inbox/docs/setup.md
@@ -2,11 +2,11 @@
 
 ## Prerequisites
 
-| Tool | Version | Purpose |
-|---|---|---|
-| Node.js | 20+ | JavaScript runtime |
-| Bun | 1.1+ | Package manager and dev server |
-| Stealth dev environment | latest | Relay API, Stellar testnet access |
+| Tool                    | Version | Purpose                           |
+| ----------------------- | ------- | --------------------------------- |
+| Node.js                 | 20+     | JavaScript runtime                |
+| Bun                     | 1.1+    | Package manager and dev server    |
+| Stealth dev environment | latest  | Relay API, Stellar testnet access |
 
 ## Local Setup
 
@@ -23,14 +23,14 @@ cp .env.example .env
 
 ## Configuration
 
-| Variable | Required | Description |
-|---|---|---|
-| `STEALTH_API_URL` | Yes | Stealth relay API base URL (e.g., `http://localhost:8080`) |
-| `SHARED_INBOX_ID` | Yes | Unique identifier for this shared inbox deployment |
-| `SHARED_INBOX_MEMBERS` | No | Comma-separated Stealth addresses of team members |
-| `SHARED_INBOX_STORAGE` | No | Storage backend: `memory` (default) or `file` |
-| `SHARED_INBOX_DATA_DIR` | No | Directory for file-based storage (defaults to `./data/`) |
-| `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (defaults to `info`) |
+| Variable                | Required | Description                                                |
+| ----------------------- | -------- | ---------------------------------------------------------- |
+| `STEALTH_API_URL`       | Yes      | Stealth relay API base URL (e.g., `http://localhost:8080`) |
+| `SHARED_INBOX_ID`       | Yes      | Unique identifier for this shared inbox deployment         |
+| `SHARED_INBOX_MEMBERS`  | No       | Comma-separated Stealth addresses of team members          |
+| `SHARED_INBOX_STORAGE`  | No       | Storage backend: `memory` (default) or `file`              |
+| `SHARED_INBOX_DATA_DIR` | No       | Directory for file-based storage (defaults to `./data/`)   |
+| `LOG_LEVEL`             | No       | `debug`, `info`, `warn`, `error` (defaults to `info`)      |
 
 ## Running Locally
 
@@ -44,9 +44,9 @@ bun run lint     # Lint
 
 ## Troubleshooting
 
-| Problem | Likely cause | Fix |
-|---|---|---|
-| Relay connection refused | Stealth dev server not running | Start from repo root: `bun run dev` |
-| Empty feed | Wrong inbox identity or no messages addressed to it | Verify `SHARED_INBOX_ID` and that messages are sent to it |
-| Identity resolution fails | Member addresses not registered with relay | Confirm addresses in `SHARED_INBOX_MEMBERS` |
-| Changes not reflected after editing `.env` | Values read at startup | Restart the dev server |
+| Problem                                    | Likely cause                                        | Fix                                                       |
+| ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------- |
+| Relay connection refused                   | Stealth dev server not running                      | Start from repo root: `bun run dev`                       |
+| Empty feed                                 | Wrong inbox identity or no messages addressed to it | Verify `SHARED_INBOX_ID` and that messages are sent to it |
+| Identity resolution fails                  | Member addresses not registered with relay          | Confirm addresses in `SHARED_INBOX_MEMBERS`               |
+| Changes not reflected after editing `.env` | Values read at startup                              | Restart the dev server                                    |

--- a/tools/v1/team/shared-team-inbox/docs/setup.md
+++ b/tools/v1/team/shared-team-inbox/docs/setup.md
@@ -1,0 +1,52 @@
+# Setup Guide
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|---|---|---|
+| Node.js | 20+ | JavaScript runtime |
+| Bun | 1.1+ | Package manager and dev server |
+| Stealth dev environment | latest | Relay API, Stellar testnet access |
+
+## Local Setup
+
+```bash
+cd tools/v1/team/shared-team-inbox
+bun install
+```
+
+Copy and edit the environment file:
+
+```bash
+cp .env.example .env
+```
+
+## Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `STEALTH_API_URL` | Yes | Stealth relay API base URL (e.g., `http://localhost:8080`) |
+| `SHARED_INBOX_ID` | Yes | Unique identifier for this shared inbox deployment |
+| `SHARED_INBOX_MEMBERS` | No | Comma-separated Stealth addresses of team members |
+| `SHARED_INBOX_STORAGE` | No | Storage backend: `memory` (default) or `file` |
+| `SHARED_INBOX_DATA_DIR` | No | Directory for file-based storage (defaults to `./data/`) |
+| `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (defaults to `info`) |
+
+## Running Locally
+
+```bash
+bun dev          # Development server with hot reload
+bun run build    # Production build
+bun run preview  # Preview production build
+bun test         # Run tests
+bun run lint     # Lint
+```
+
+## Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| Relay connection refused | Stealth dev server not running | Start from repo root: `bun run dev` |
+| Empty feed | Wrong inbox identity or no messages addressed to it | Verify `SHARED_INBOX_ID` and that messages are sent to it |
+| Identity resolution fails | Member addresses not registered with relay | Confirm addresses in `SHARED_INBOX_MEMBERS` |
+| Changes not reflected after editing `.env` | Values read at startup | Restart the dev server |

--- a/tools/v1/team/shared-team-inbox/specs.md
+++ b/tools/v1/team/shared-team-inbox/specs.md
@@ -1,38 +1,42 @@
-# Shared Team Inbox
+# Shared Team Inbox — Specification
 
-Collaborative inbox.
+Collaborative triage and response tool for team mailboxes.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Ingest messages addressed to a shared Stealth identity and display them in a collaborative feed.
+- Claim/assign messages to individual team members with visible ownership state.
+- Add internal annotation threads (team-visible, sender-invisible) on any message.
+- Reply to external senders using the shared inbox identity.
+- Track status: unassigned → claimed → in-progress → awaiting-reply → resolved.
+- Persist state via a swappable storage adapter (in-memory reference implementation).
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+## Non-goals
 
-Recommended internal structure:
+- Multi-inbox management.
+- SLA engine (escalation, timeout, reassignment).
+- Analytics or reporting.
+- External integrations (webhooks, Zapier, CRM).
+- Attachment processing.
+- Read receipts.
+- Bulk operations.
+- Role-based access control (flat team membership only).
 
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/shared-team-inbox/README.md"
-  @"
+## Architecture Overview
 
-# Shared Team Inbox Specs
+The tool follows a layered pattern: UI components call hooks that delegate to services, which use a storage adapter (interface-based, swappable). The storage layer defaults to in-memory. The tool depends on the Stealth protocol for identity resolution and message delivery proofs but does not depend on the main application's routing, mail rendering engine, wallet core, or design system.
 
-## Purpose
+## Ownership Boundary
 
-Collaborative inbox.
+All source code, tests, documentation, fixtures, and configuration live under:
 
-## Contributor boundary
+```
+tools/v1/team/shared-team-inbox/
+```
 
-All work for this tool should stay in:
+Do not import from `src/`, `tools/v2/`, or sibling tool folders. Do not modify the main application's router, mail engine, or design system. Do not add dependencies to the root `package.json` — use a local `package.json` if needed.
 
-$dir/
-
-## Required issue categories
+## Required Issue Categories
 
 - Architecture
 - Feature

--- a/tools/v1/team/shared-team-inbox/tests/README.md
+++ b/tools/v1/team/shared-team-inbox/tests/README.md
@@ -8,11 +8,11 @@ Folder-local test strategy for the Shared Team Inbox tool.
 
 ## Test Strategy
 
-| Layer | Scope | Framework |
-|---|---|---|
-| **Unit** | Services, storage adapters, and utility functions in isolation | Vitest |
-| **Integration** | Multi-step workflows using the in-memory storage adapter | Vitest |
-| **Manual** | UI behavior, visual regression, accessibility, end-to-end flows | Review checklist |
+| Layer           | Scope                                                           | Framework        |
+| --------------- | --------------------------------------------------------------- | ---------------- |
+| **Unit**        | Services, storage adapters, and utility functions in isolation  | Vitest           |
+| **Integration** | Multi-step workflows using the in-memory storage adapter        | Vitest           |
+| **Manual**      | UI behavior, visual regression, accessibility, end-to-end flows | Review checklist |
 
 ---
 

--- a/tools/v1/team/shared-team-inbox/tests/README.md
+++ b/tools/v1/team/shared-team-inbox/tests/README.md
@@ -1,0 +1,138 @@
+# Test Plan
+
+Folder-local test strategy for the Shared Team Inbox tool.
+
+> Tests will be written as `.test.ts` files alongside the source implementation. This document defines the plan and coverage expectations.
+
+---
+
+## Test Strategy
+
+| Layer | Scope | Framework |
+|---|---|---|
+| **Unit** | Services, storage adapters, and utility functions in isolation | Vitest |
+| **Integration** | Multi-step workflows using the in-memory storage adapter | Vitest |
+| **Manual** | UI behavior, visual regression, accessibility, end-to-end flows | Review checklist |
+
+---
+
+## Unit Test Scenarios
+
+### Message ingestion
+
+- New message from relay is stored with normalized fields.
+- Duplicate message (same delivery proof hash) is skipped.
+- Message with missing required fields returns a validation error.
+
+### Assignment
+
+- Unassigned message can be claimed by a valid team member.
+- Already-assigned message can be reassigned to a different member.
+- Releasing an assignment returns the message to unassigned state.
+- Assigning to an address not in the team roster is rejected.
+
+### Status transitions
+
+- Valid transition (unassigned → claimed → in-progress → awaiting-reply → resolved) succeeds.
+- Invalid transition (unassigned → resolved) is rejected.
+- Status change records actor and timestamp.
+
+### Internal comments
+
+- Comment is stored with author, body, and timestamp.
+- Comment on a nonexistent message is rejected.
+- Deleting own comment sets it to deleted state.
+- Deleting another user's comment is rejected.
+
+### Reply
+
+- Reply to an existing message is sent via relay.
+- Reply with empty body is rejected.
+- Reply to a nonexistent message is rejected.
+
+### Storage adapter
+
+- Round-trip: set a value, get it back.
+- GetAll returns all stored entries.
+- Delete removes the entry; subsequent get returns null.
+- Fresh store returns empty from getAll.
+
+---
+
+## Integration Test Scenarios
+
+### Claim-and-reply workflow
+
+1. Message from external sender is ingested.
+2. Alice claims it → status becomes claimed, assignment recorded.
+3. Alice adds an internal comment.
+4. Alice replies → reply sent via relay, status becomes resolved.
+5. Verify: stores contain expected records, activity log shows all events in sequence.
+
+### Reassign workflow
+
+1. Alice claims a message.
+2. Bob claims the same message → Alice's assignment replaced, status stays claimed.
+3. Verify: assignment store reflects Bob as assignee, activity log records both events.
+
+### Reopen workflow
+
+1. Message is resolved.
+2. Carol reopens it → status becomes in-progress.
+3. Verify: status store shows in-progress, activity log records the reopen.
+
+---
+
+## Manual Review Checklist
+
+### Message feed
+
+- [ ] Feed shows messages in reverse chronological order.
+- [ ] Each message card displays: sender, subject, preview, received time, status badge, assignee.
+- [ ] Filtering by status and assignee works.
+
+### Message detail
+
+- [ ] Full message body is displayed.
+- [ ] Internal comment thread is visible below the message.
+- [ ] Claim / Release button updates the UI immediately.
+
+### Assignment
+
+- [ ] Claim button changes to indicate assignment after claiming.
+- [ ] Release button returns message to unassigned state.
+- [ ] Other team members see the assignee name.
+
+### Comments
+
+- [ ] Comment form submits on Enter (Cmd+Enter).
+- [ ] Delete button visible only on own comments.
+- [ ] Deleted comments show `[deleted]` placeholder.
+
+### Reply
+
+- [ ] Reply sends with the shared inbox identity as From address.
+- [ ] Status transitions to resolved after sending.
+
+### Status transitions
+
+- [ ] Status dropdown shows only valid next states.
+- [ ] Changes reflected immediately in feed and detail view.
+
+### Accessibility
+
+- [ ] All interactive elements keyboard accessible.
+- [ ] Status badges have accessible labels.
+- [ ] Color is not the only status indicator (text or icon accompanies it).
+
+---
+
+## Validation Steps for OSS Contributors
+
+Before opening a pull request:
+
+1. **`bun test`** — all tests pass.
+2. **`bun run tsc --noEmit`** — zero type errors.
+3. **`bun run lint`** — zero warnings.
+4. **All new files under `tools/v1/team/shared-team-inbox/`** — verify with `git diff --name-only`.
+5. **Test plan updated** — new features add or update scenarios in this file.


### PR DESCRIPTION

## Description

This PR improves the developer experience for the Shared Team Inbox V1 tool by adding contributor-focused documentation and a folder-local testing strategy while keeping all changes isolated to:

`tools/v1/team/shared-team-inbox/`

### Changes Made

* Rewrote `README.md` with:

  * Tool overview and purpose
  * Audience and usage guidance
  * Quick-start setup instructions
  * Example workflows
  * Fixture documentation
  * Known limitations
  * OSS contributor review notes

* Replaced the corrupted template content in `specs.md` with:

  * Clear scope definition
  * Non-goals
  * Ownership boundaries
  * Tool-specific requirements

* Added `docs/setup.md` containing:

  * Prerequisites
  * Local setup instructions
  * Configuration guidance
  * Development commands
  * Troubleshooting information

* Added `tests/README.md` with:

  * Folder-local test strategy
  * Unit and integration test scenarios
  * Manual validation checklist
  * OSS review guidance

### Acceptance Criteria Covered

* Added folder-local test documentation.
* Added setup and usage documentation.
* Documented fixtures and known limitations.
* Added contributor review notes.
* Kept all work isolated to the Shared Team Inbox tool folder.
* No application-wide files were modified.

## Related Issue

Fixes #448 

## Testing

* Documentation reviewed for completeness and consistency.
* Verified all files remain within the Shared Team Inbox implementation folder.
* No application-wide changes introduced.

## Notes

This PR intentionally avoids any integration with the main application and focuses only on making the Shared Team Inbox tool easier to understand, review, and contribute to as an isolated V1 component.
