### PR TITLE
feat(tools/v2): shared-draft-collaboration tests and documentation

### DIFF
--- a/tools/v2/team/shared-draft-collaboration/docs/review-notes.md
+++ b/tools/v2/team/shared-draft-collaboration/docs/review-notes.md
@@ -1,0 +1,55 @@
+# Review Notes — Shared Draft Collaboration
+
+## How to review this tool independently
+
+This folder is fully self-contained. No main app setup is required.
+
+### Run the tests
+
+```bash
+node --test tools/v2/team/shared-draft-collaboration/tests/shared-draft.test.mjs
+```
+
+Expected output: **25 tests pass, 0 fail**.
+
+### What is tested
+
+| Suite            | Coverage                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| Fixtures         | Shape validation, active/inactive counts                                                |
+| `computeMetrics` | totals, collaborator sum, empty list, single entry                                      |
+| `applyFilter`    | isActive, search (title + subject), combined filters                                    |
+| Service          | getDrafts, addDraft, updateDraft, removeDraft, setActive, getMetrics, mutation tracking |
+
+### Files changed in this issue
+
+```
+tools/v2/team/shared-draft-collaboration/
+├── fixtures/drafts.fixtures.mjs   ← 4 deterministic drafts
+├── services/draft.service.mjs     ← pure service factory (no network)
+├── tests/shared-draft.test.mjs    ← 25 node:test cases
+└── docs/review-notes.md           ← this file
+```
+
+### Inputs and outputs
+
+**`createDraftService(initialDrafts?)`**
+
+| Method               | Input                                 | Output                                            | Error state            |
+| -------------------- | ------------------------------------- | ------------------------------------------------- | ---------------------- |
+| `getDrafts(filter?)` | `{ isActive?, search? }`              | `SharedDraftData[]`                               | —                      |
+| `addDraft(input)`    | `{ title, subject?, collaborators? }` | `SharedDraftData`                                 | —                      |
+| `updateDraft(input)` | `{ id, ...fields }`                   | `SharedDraftData`                                 | throws if id not found |
+| `removeDraft(id)`    | `string`                              | `void`                                            | throws if id not found |
+| `setActive(id)`      | `string`                              | `SharedDraftData`                                 | throws if id not found |
+| `getMetrics()`       | —                                     | `{ total, active, inactive, totalCollaborators }` | —                      |
+
+### Known limitations
+
+- State is in-memory only; resets on each `createDraftService()` call.
+- No real-time collaboration (websocket/CRDT) — that requires a future integration issue.
+- UI components import from `src/components/ui/` (shared Radix/Tailwind primitives); the service layer has zero main-app dependencies.
+
+### Integration note
+
+Do **not** wire this into the main app in this PR. If real-time or persistence is needed, open a follow-up issue.

--- a/tools/v2/team/shared-draft-collaboration/fixtures/drafts.fixtures.mjs
+++ b/tools/v2/team/shared-draft-collaboration/fixtures/drafts.fixtures.mjs
@@ -1,0 +1,43 @@
+/**
+ * drafts.fixtures.mjs — Shared Draft Collaboration
+ *
+ * Deterministic local fixtures. No network calls, no secrets.
+ */
+
+export const DRAFT_FIXTURES = [
+  {
+    id: "draft-001",
+    title: "Q1 Team Updates",
+    subject: "Monthly updates for leadership",
+    lastModified: "2026-06-01T14:30:00Z",
+    collaborators: 3,
+    isActive: true,
+  },
+  {
+    id: "draft-002",
+    title: "Project Proposal - Feature X",
+    subject: "New product feature proposal",
+    lastModified: "2026-06-05T10:15:00Z",
+    collaborators: 2,
+    isActive: false,
+  },
+  {
+    id: "draft-003",
+    title: "Customer Response Template",
+    subject: "Template for common customer inquiries",
+    lastModified: "2026-06-08T16:45:00Z",
+    collaborators: 4,
+    isActive: false,
+  },
+  {
+    id: "draft-004",
+    title: "Security Incident Report",
+    subject: "Incident report for review",
+    lastModified: "2026-06-10T09:00:00Z",
+    collaborators: 1,
+    isActive: true,
+  },
+];
+
+export const ACTIVE_DRAFTS = DRAFT_FIXTURES.filter((d) => d.isActive);
+export const INACTIVE_DRAFTS = DRAFT_FIXTURES.filter((d) => !d.isActive);

--- a/tools/v2/team/shared-draft-collaboration/services/draft.service.mjs
+++ b/tools/v2/team/shared-draft-collaboration/services/draft.service.mjs
@@ -1,0 +1,96 @@
+/**
+ * draft.service.mjs — Shared Draft Collaboration
+ *
+ * Pure service factory. No network calls, no secrets.
+ * State is held in memory and seeded from local fixtures.
+ *
+ * Operations:
+ *   getDrafts(filter?)    → SharedDraftData[]
+ *   addDraft(input)       → SharedDraftData   (auto id + timestamp)
+ *   updateDraft(input)    → SharedDraftData   (throws if not found)
+ *   removeDraft(id)       → void              (throws if not found)
+ *   setActive(id)         → SharedDraftData   (throws if not found)
+ *   getMetrics()          → DraftMetrics
+ */
+
+import { DRAFT_FIXTURES } from "../fixtures/drafts.fixtures.mjs";
+
+let _counter = 100;
+function generateId() {
+  return `draft-${String(++_counter).padStart(3, "0")}`;
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+export function computeMetrics(drafts) {
+  return {
+    total: drafts.length,
+    active: drafts.filter((d) => d.isActive).length,
+    inactive: drafts.filter((d) => !d.isActive).length,
+    totalCollaborators: drafts.reduce((sum, d) => sum + d.collaborators, 0),
+  };
+}
+
+export function applyFilter(drafts, filter = {}) {
+  let result = drafts;
+  if (filter.isActive !== undefined) result = result.filter((d) => d.isActive === filter.isActive);
+  if (filter.search) {
+    const q = filter.search.toLowerCase();
+    result = result.filter(
+      (d) =>
+        d.title.toLowerCase().includes(q) || (d.subject && d.subject.toLowerCase().includes(q)),
+    );
+  }
+  return result;
+}
+
+export function createDraftService(initialDrafts = DRAFT_FIXTURES) {
+  let drafts = initialDrafts.map((d) => ({ ...d }));
+
+  async function getDrafts(filter = {}) {
+    return applyFilter(drafts, filter);
+  }
+
+  async function addDraft(input) {
+    const draft = {
+      id: generateId(),
+      title: input.title,
+      subject: input.subject ?? "",
+      lastModified: now(),
+      collaborators: input.collaborators ?? 1,
+      isActive: false,
+    };
+    drafts = [...drafts, draft];
+    return draft;
+  }
+
+  async function updateDraft(input) {
+    const idx = drafts.findIndex((d) => d.id === input.id);
+    if (idx === -1) throw new Error(`Draft ${input.id} not found.`);
+    const updated = { ...drafts[idx], ...input, lastModified: now() };
+    drafts = drafts.map((d, i) => (i === idx ? updated : d));
+    return updated;
+  }
+
+  async function removeDraft(id) {
+    const idx = drafts.findIndex((d) => d.id === id);
+    if (idx === -1) throw new Error(`Draft ${id} not found.`);
+    drafts = drafts.filter((d) => d.id !== id);
+  }
+
+  async function setActive(id) {
+    const idx = drafts.findIndex((d) => d.id === id);
+    if (idx === -1) throw new Error(`Draft ${id} not found.`);
+    const updated = { ...drafts[idx], isActive: true, lastModified: now() };
+    drafts = drafts.map((d, i) => (i === idx ? updated : d));
+    return updated;
+  }
+
+  async function getMetrics() {
+    return computeMetrics(drafts);
+  }
+
+  return { getDrafts, addDraft, updateDraft, removeDraft, setActive, getMetrics };
+}

--- a/tools/v2/team/shared-draft-collaboration/tests/shared-draft.test.mjs
+++ b/tools/v2/team/shared-draft-collaboration/tests/shared-draft.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * shared-draft.test.mjs — Shared Draft Collaboration
+ *
+ * Unit tests for core service logic. Runs with:
+ *   node --test tools/v2/team/shared-draft-collaboration/tests/shared-draft.test.mjs
+ *
+ * No React / DOM / TypeScript loader required.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeMetrics, applyFilter, createDraftService } from "../services/draft.service.mjs";
+
+import { DRAFT_FIXTURES, ACTIVE_DRAFTS, INACTIVE_DRAFTS } from "../fixtures/drafts.fixtures.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+describe("Shared Draft Collaboration — Fixtures", () => {
+  it("has 4 fixture drafts", () => {
+    assert.strictEqual(DRAFT_FIXTURES.length, 4);
+  });
+
+  it("has 2 active and 2 inactive drafts", () => {
+    assert.strictEqual(ACTIVE_DRAFTS.length, 2);
+    assert.strictEqual(INACTIVE_DRAFTS.length, 2);
+  });
+
+  it("every fixture has required fields", () => {
+    for (const d of DRAFT_FIXTURES) {
+      assert.ok(d.id, "missing id");
+      assert.ok(d.title, "missing title");
+      assert.ok(typeof d.collaborators === "number", "collaborators must be number");
+      assert.ok(typeof d.isActive === "boolean", "isActive must be boolean");
+      assert.ok(!isNaN(Date.parse(d.lastModified)), "lastModified must be valid ISO date");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeMetrics
+// ---------------------------------------------------------------------------
+
+describe("Shared Draft Collaboration — computeMetrics", () => {
+  it("returns correct totals for fixture data", () => {
+    const m = computeMetrics(DRAFT_FIXTURES);
+    assert.strictEqual(m.total, 4);
+    assert.strictEqual(m.active, 2);
+    assert.strictEqual(m.inactive, 2);
+    assert.strictEqual(m.totalCollaborators, 10); // 3+2+4+1
+  });
+
+  it("returns zero metrics for empty list", () => {
+    const m = computeMetrics([]);
+    assert.strictEqual(m.total, 0);
+    assert.strictEqual(m.active, 0);
+    assert.strictEqual(m.inactive, 0);
+    assert.strictEqual(m.totalCollaborators, 0);
+  });
+
+  it("counts correctly for a single-entry list", () => {
+    const m = computeMetrics([DRAFT_FIXTURES[0]]);
+    assert.strictEqual(m.total, 1);
+    assert.strictEqual(m.active, 1);
+    assert.strictEqual(m.inactive, 0);
+    assert.strictEqual(m.totalCollaborators, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFilter
+// ---------------------------------------------------------------------------
+
+describe("Shared Draft Collaboration — applyFilter", () => {
+  it("returns all entries with empty filter", () => {
+    assert.strictEqual(applyFilter(DRAFT_FIXTURES, {}).length, 4);
+  });
+
+  it("filters by isActive=true", () => {
+    const result = applyFilter(DRAFT_FIXTURES, { isActive: true });
+    assert.strictEqual(result.length, 2);
+    assert.ok(result.every((d) => d.isActive));
+  });
+
+  it("filters by isActive=false", () => {
+    const result = applyFilter(DRAFT_FIXTURES, { isActive: false });
+    assert.strictEqual(result.length, 2);
+    assert.ok(result.every((d) => !d.isActive));
+  });
+
+  it("filters by search matching title (case-insensitive)", () => {
+    const result = applyFilter(DRAFT_FIXTURES, { search: "q1 team" });
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].id, "draft-001");
+  });
+
+  it("filters by search matching subject", () => {
+    const result = applyFilter(DRAFT_FIXTURES, { search: "incident" });
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].id, "draft-004");
+  });
+
+  it("returns empty array when search matches nothing", () => {
+    const result = applyFilter(DRAFT_FIXTURES, { search: "zzz-no-match" });
+    assert.strictEqual(result.length, 0);
+  });
+
+  it("combines isActive and search filters", () => {
+    // isActive=true AND title contains "security"
+    const result = applyFilter(DRAFT_FIXTURES, { isActive: true, search: "security" });
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].id, "draft-004");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+describe("Shared Draft Collaboration — Service", () => {
+  it("getDrafts returns all fixture entries by default", async () => {
+    const svc = createDraftService();
+    const drafts = await svc.getDrafts();
+    assert.strictEqual(drafts.length, 4);
+  });
+
+  it("getDrafts respects isActive filter", async () => {
+    const svc = createDraftService();
+    const active = await svc.getDrafts({ isActive: true });
+    assert.strictEqual(active.length, 2);
+    assert.ok(active.every((d) => d.isActive));
+  });
+
+  it("addDraft creates a new inactive draft with auto id", async () => {
+    const svc = createDraftService();
+    const added = await svc.addDraft({
+      title: "New Draft",
+      subject: "Test subject",
+      collaborators: 2,
+    });
+
+    assert.ok(added.id.startsWith("draft-"));
+    assert.strictEqual(added.title, "New Draft");
+    assert.strictEqual(added.collaborators, 2);
+    assert.strictEqual(added.isActive, false);
+    assert.ok(!isNaN(Date.parse(added.lastModified)));
+
+    const all = await svc.getDrafts();
+    assert.strictEqual(all.length, 5);
+  });
+
+  it("addDraft defaults collaborators to 1 when not provided", async () => {
+    const svc = createDraftService();
+    const added = await svc.addDraft({ title: "Solo Draft" });
+    assert.strictEqual(added.collaborators, 1);
+  });
+
+  it("updateDraft changes title and updates lastModified", async () => {
+    const svc = createDraftService();
+    const updated = await svc.updateDraft({ id: "draft-002", title: "Updated Title" });
+    assert.strictEqual(updated.title, "Updated Title");
+    assert.ok(!isNaN(Date.parse(updated.lastModified)));
+  });
+
+  it("updateDraft throws for unknown id", async () => {
+    const svc = createDraftService();
+    await assert.rejects(() => svc.updateDraft({ id: "draft-999", title: "X" }), /not found/);
+  });
+
+  it("removeDraft deletes the entry permanently", async () => {
+    const svc = createDraftService();
+    await svc.removeDraft("draft-001");
+    const all = await svc.getDrafts();
+    assert.strictEqual(all.length, 3);
+    assert.ok(!all.some((d) => d.id === "draft-001"));
+  });
+
+  it("removeDraft throws for unknown id", async () => {
+    const svc = createDraftService();
+    await assert.rejects(() => svc.removeDraft("draft-999"), /not found/);
+  });
+
+  it("setActive marks a draft as active", async () => {
+    const svc = createDraftService();
+    const updated = await svc.setActive("draft-002");
+    assert.strictEqual(updated.isActive, true);
+
+    const active = await svc.getDrafts({ isActive: true });
+    assert.ok(active.some((d) => d.id === "draft-002"));
+  });
+
+  it("setActive throws for unknown id", async () => {
+    const svc = createDraftService();
+    await assert.rejects(() => svc.setActive("draft-999"), /not found/);
+  });
+
+  it("getMetrics reflects current state after mutations", async () => {
+    const svc = createDraftService();
+    await svc.removeDraft("draft-001");
+    const m = await svc.getMetrics();
+    assert.strictEqual(m.total, 3);
+    assert.strictEqual(m.active, 1);
+  });
+
+  it("service starts with empty list and tracks additions", async () => {
+    const svc = createDraftService([]);
+    let drafts = await svc.getDrafts();
+    assert.strictEqual(drafts.length, 0);
+
+    await svc.addDraft({ title: "First", collaborators: 1 });
+    drafts = await svc.getDrafts();
+    assert.strictEqual(drafts.length, 1);
+
+    const m = await svc.getMetrics();
+    assert.strictEqual(m.total, 1);
+    assert.strictEqual(m.active, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds contributor-friendly tests and documentation for the Shared Draft Collaboration tool.

All work is confined to `tools/v2/team/shared-draft-collaboration/`. No main app files were modified.

## What was added

| File | Purpose |
|---|---|
| `fixtures/drafts.fixtures.mjs` | 4 deterministic drafts (active/inactive) |
| `services/draft.service.mjs` | `createDraftService` with `getDrafts`, `addDraft`, `updateDraft`, `removeDraft`, `setActive`, `getMetrics` |
| `tests/shared-draft.test.mjs` | 25 passing tests via `node --test` |
| `docs/review-notes.md` | OSS contributor review guide with test instructions, input/output docs, and known limitations |

## Tests

```
node --test tools/v2/team/shared-draft-collaboration/tests/shared-draft.test.mjs

tests 25 | pass 25 | fail 0
```

## Acceptance criteria

- [x] Tests live inside the tool folder
- [x] Documentation explains how to review the tool independently
- [x] Isolated from app-wide tests
- [x] All changed files inside `tools/v2/team/shared-draft-collaboration/`
- [x] Self-contained and reviewable as a mini-product change

Closes #663