### PR TITLE
feat(team-security-flagging): add tests, fixtures, service, and docs

### DIFF
--- a/tools/v2/team/team-security-flagging/README.md
+++ b/tools/v2/team/team-security-flagging/README.md
@@ -1,15 +1,181 @@
 # Team Security Flagging
 
-This folder is the isolated workspace for the Team Security Flagging tool.
+A V2 team tool for reporting, classifying, and tracking security incidents in team email.
+Isolated to this folder — not wired into the main app yet.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\team-security-flagging\
-`
+```
+tools/v2/team/team-security-flagging/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet core,
+Stellar integration, database schema, or design system unless a future integration issue
+explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+---
+
+## Folder Structure
+
+```
+team-security-flagging/
+  types.ts                             TypeScript types (no runtime)
+  services/
+    security-flagging.service.mjs      Core pure functions — classification, validation,
+                                       status transitions
+  fixtures/
+    security-flag-cases.json           Test data: email signals, valid flags, hostile
+                                       inputs, status transition pairs
+  tests/
+    security-flagging.test.mjs         50 executable tests (node:test, zero deps)
+  docs/
+    test-plan.md                       Scenario table, negative checks, manual checklist
+    review-notes.md                    OSS contributor review guide
+  specs.md                             Issue categories and contributor expectations
+  README.md                            This file
+```
+
+---
+
+## Setup
+
+No install step is required. The service and tests use only Node built-ins.
+
+**Requirements:** Node 18 or later.
+
+---
+
+## Running the Tests
+
+From the repo root:
+
+```
+node --test tools/v2/team/team-security-flagging/tests/security-flagging.test.mjs
+```
+
+Or from inside the tool folder:
+
+```
+node --test tests/security-flagging.test.mjs
+```
+
+Expected output: **50 tests, 0 failures**.
+
+---
+
+## Core Concepts
+
+### SecurityFlag
+
+A flag marks an email thread as a security incident. Key fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `severity` | `critical \| high \| medium \| low` | Set by reporter or auto-classifier |
+| `category` | `phishing \| credential-theft \| malware \| data-breach \| suspicious-sender \| unauthorized-access \| social-engineering \| other` | Nature of threat |
+| `status` | `new \| under-review \| escalated \| resolved \| dismissed` | Lifecycle state |
+| `evidence` | `string[]` | Up to 10 items, 500 chars each |
+| `description` | `string` | Up to 2000 chars |
+
+### Auto-Classification
+
+`classifyEmail(signal)` takes a minimal email signal (subject, snippet, bodyPreview,
+senderEmail) and returns a `ClassificationResult` with severity, category, confidence,
+and the matched signal phrases. It uses keyword matching across six threat categories.
+
+### Status Lifecycle
+
+```
+new ──► under-review ──► escalated ──► resolved
+  │            │               │
+  └────────────┴───────────────┴──► dismissed
+```
+
+`resolved` and `dismissed` are terminal — no further transitions are allowed.
+`validateStatusTransition(from, to)` throws `SecurityFlagError` for any invalid move.
+
+---
+
+## Using the Service
+
+```js
+import {
+  classifyEmail,
+  validateCreateFlagInput,
+  validateStatusTransition,
+  SecurityFlagError,
+} from "./services/security-flagging.service.mjs";
+
+// Auto-classify an incoming email
+const result = classifyEmail({
+  subject: "Urgent: Verify your account",
+  senderEmail: "support@unknown-domain.example",
+  snippet: "Click here to confirm your credentials before your account is suspended.",
+  bodyPreview: "Act now. Urgent action required.",
+});
+// { severity: "critical", category: "phishing", confidence: "high", matchedSignals: [...] }
+
+// Validate flag input before storing
+try {
+  validateCreateFlagInput({
+    emailId: "email-001",
+    threadId: "thread-001",
+    reportedBy: "alice@company.example",
+    senderEmail: "support@unknown-domain.example",
+    severity: "critical",
+    category: "phishing",
+    description: "Credential harvest attempt from unknown sender.",
+    evidence: ["Domain not in vendor list", "Urgent suspension threat language"],
+  });
+} catch (err) {
+  if (err instanceof SecurityFlagError) {
+    console.error(err.field, err.message);
+  }
+}
+
+// Guard a status change
+validateStatusTransition("new", "under-review"); // ok
+validateStatusTransition("resolved", "new");      // throws SecurityFlagError
+```
+
+---
+
+## Fixtures
+
+`fixtures/security-flag-cases.json` contains:
+
+- **`emailSignals`** — six emails from benign to critical, each with expected
+  classification output.
+- **`validFlags`** — three well-formed flag creation inputs.
+- **`hostileInputs`** — twelve rejection cases (path traversal, XSS, wrong-case enums,
+  empty strings, invalid email formats).
+- **`statusTransitions`** — valid and blocked transition pairs.
+
+All fixture emails use `*.example`, `*.example.net`, `*.example.com`, and
+`*.example.xyz` domains. No real addresses, credentials, or wallet values are included.
+
+---
+
+## Known Limitations
+
+- `classifyEmail` is keyword-based; it has no NLP model, sender-reputation lookup, or
+  link-analysis step. False positives and false negatives are expected in edge cases.
+- The service has no persistence layer. Storing and retrieving flags requires a future
+  integration issue.
+- `validateEmail` checks structure and injection vectors only — it does not verify DNS
+  or MX records.
+- CRLF and null-byte injection cases are tested with inline strings in the test file
+  because those characters cannot appear in JSON string literals.
+- No UI component, hook, or route exists yet. Those belong in future issues.
+
+---
+
+## Acceptance Checklist
+
+- [x] Tests live inside this folder and run with `node --test`.
+- [x] Documentation explains independent setup and review.
+- [x] No files changed outside `tools/v2/team/team-security-flagging/`.
+- [x] Fixtures contain no real personal data, credentials, or wallet addresses.
+- [x] The tool is reviewable as a self-contained mini-product change.

--- a/tools/v2/team/team-security-flagging/docs/review-notes.md
+++ b/tools/v2/team/team-security-flagging/docs/review-notes.md
@@ -1,0 +1,58 @@
+# Review Notes
+
+This contribution adds folder-local test coverage and documentation for the Team Security
+Flagging tool. It is self-contained and does not touch the main application shell,
+routing, inbox architecture, wallet core, Stellar integration, or design system.
+
+## What To Review
+
+### Service logic (`services/security-flagging.service.mjs`)
+- Input sanitizers strip control characters before any comparison, preventing injection of
+  raw CR/LF/NUL bytes from reaching downstream logic.
+- Validators enforce closed enumerations for `severity`, `category`, and `status`. Any
+  value not in the allow-list throws `SecurityFlagError` with the offending field named.
+- `validateEmail` guards against CRLF header injection and null bytes in addition to
+  structural validity.
+- `validateThreadId` / `validateEmailId` enforce `^[\w-]+$` to prevent path traversal and
+  XSS in IDs.
+- `classifyEmail` uses keyword signal maps and match counts to produce severity, category,
+  and confidence — all deterministic and testable without mocking.
+- `validateStatusTransition` enforces a directed acyclic transition graph. Terminal
+  statuses (`resolved`, `dismissed`) block all further changes.
+
+### Fixtures (`fixtures/security-flag-cases.json`)
+- Covers six email signal scenarios including phishing, malware, social engineering,
+  credential theft, data breach, and a benign newsletter as the low-risk baseline.
+- Twelve hostile inputs cover: missing local part, missing domain, empty string, path
+  traversal, XSS payload, spaces in IDs, wrong-case enum values, and unknown enum values.
+- CRLF and null-byte injection tests are exercised directly in the test file rather than
+  in the fixture because those characters are illegal in JSON string literals.
+- Seven valid status transitions and six blocked transitions (including all terminal-status
+  exit attempts) are fixture-driven.
+
+### Tests (`tests/security-flagging.test.mjs`)
+- 50 tests; 0 external dependencies; runs with `node --test` (Node 18+).
+- Inline direct tests cover sanitizers, individual validators, classifier categories, and
+  severity comparison utilities.
+- Fixture-driven tests validate all email signal classifications, all valid/invalid status
+  transitions, all hostile inputs, and all valid flag creation inputs.
+
+## What Is Intentionally Not Included
+
+- No app route, navigation link, database migration, or design-system change.
+- No background job, analytics event, or external API call.
+- No React/UI component — that belongs in a future UI issue.
+- No integration with the inbox's real email store — a future integration issue will wire
+  the service to a real data source.
+- No authentication check — the service is a pure-function core; authorization belongs at
+  the call site when integration happens.
+
+## Follow-Up Shape (Future Issues)
+
+A future implementation can add without touching this issue:
+
+- `hooks/use-security-flagging.ts` — React hook wrapping the service with local state.
+- `components/SecurityFlagForm.tsx` — form for submitting a new flag.
+- `components/SecurityFlagList.tsx` — list of flags for team review.
+- Integration issue: wire `classifyEmail` to the actual inbox email event stream.
+- Integration issue: persist flags to the team database.

--- a/tools/v2/team/team-security-flagging/docs/test-plan.md
+++ b/tools/v2/team/team-security-flagging/docs/test-plan.md
@@ -1,0 +1,143 @@
+# Test Plan — Team Security Flagging
+
+Tests live in `tests/security-flagging.test.mjs` and are executable today.
+Run with:
+
+```
+node --test tests/security-flagging.test.mjs
+```
+
+No build step, no extra packages. Node 18+ is the only requirement.
+
+---
+
+## Fixture Setup
+
+Load test data from:
+
+```
+fixtures/security-flag-cases.json
+```
+
+The fixture contains four top-level keys:
+
+| Key | Purpose |
+|---|---|
+| `emailSignals` | Six email scenarios with expected classification output |
+| `validFlags` | Three well-formed flag creation inputs that must pass validation |
+| `hostileInputs` | Twelve rejection cases covering injection and enum misuse |
+| `statusTransitions` | Seven valid and six blocked status transitions |
+
+---
+
+## Scenarios
+
+### Classification (`classifyEmail`)
+
+| Fixture ID | Email type | Expected severity | Expected category |
+|---|---|---|---|
+| `phishing-credential-harvest` | Credential phishing with suspension threat | `critical` | `phishing` |
+| `malware-invoice-attachment` | Invoice with macro attachment | `critical` | `malware` |
+| `social-engineering-wire-transfer` | BEC wire-transfer request | `critical` | `social-engineering` |
+| `credential-reset-otp` | Multi-signal credential-theft attempt | `critical` | `credential-theft` |
+| `data-breach-notification` | Breach notification with multiple signals | `critical` | `data-breach` |
+| `low-risk-newsletter` | Product digest with no threat signals | `low` | `other` |
+
+Confidence is asserted separately — all threat scenarios expect `"high"`, the benign
+newsletter expects `"low"`.
+
+### Input Validation (`validateCreateFlagInput`)
+
+| Fixture ID | Checks |
+|---|---|
+| `flag-001` | Phishing flag; all required fields valid |
+| `flag-002` | Malware flag; evidence array with two items |
+| `flag-003` | Social-engineering flag; critical severity |
+
+### Status Transitions (`canTransition` + `validateStatusTransition`)
+
+**Valid paths:**
+- `new → under-review`
+- `new → dismissed`
+- `under-review → escalated`
+- `under-review → resolved`
+- `under-review → dismissed`
+- `escalated → resolved`
+- `escalated → dismissed`
+
+**Blocked paths (must throw `SecurityFlagError`):**
+- `new → escalated` (cannot skip `under-review`)
+- `new → resolved` (cannot skip `under-review`)
+- `resolved → *` (terminal)
+- `dismissed → *` (terminal)
+
+---
+
+## Negative / Injection Checks
+
+| Field | Hostile value | Reason blocked |
+|---|---|---|
+| `email` | `@missinglocal.test` | Missing local part |
+| `email` | `nodomain` | Missing `@` sign |
+| `email` | `""` | Empty string |
+| `email` | `user@` | Missing domain |
+| `threadId` | `../../../etc/passwd` | Path traversal |
+| `threadId` | `<script>alert(1)</script>` | XSS payload |
+| `threadId` | `thread 001` | Space in ID |
+| `severity` | `CRITICAL` | Wrong case |
+| `severity` | `extreme` | Unknown value |
+| `category` | `hacking` | Unknown value |
+| `status` | `pending` | Unknown value |
+| `status` | `RESOLVED` | Wrong case |
+
+CRLF injection (`\r\n` in an email header field) and null-byte injection are tested
+directly in the test file with inline strings because those characters cannot appear in
+JSON string literals.
+
+---
+
+## Sanitizer Checks
+
+| Input | Expected output |
+|---|---|
+| `"  hello  "` | `"hello"` (trimmed) |
+| `"hello\x00world"` | `"helloworld"` (NUL stripped) |
+| `"line\x1Fbreak"` | `"linebreak"` (control char stripped) |
+| `null`, `42`, `{}` | `null` (non-string → null) |
+
+---
+
+## Severity Comparison
+
+| Assertion | Expected |
+|---|---|
+| `isMoreSevere("critical", "high")` | `true` |
+| `isMoreSevere("low", "high")` | `false` |
+| `maxSeverity("high", "critical")` | `"critical"` |
+| `maxSeverity("low", "high")` | `"high"` |
+| `maxSeverity("medium", "medium")` | `"medium"` |
+
+---
+
+## Manual Review Checklist
+
+1. All changed files are under `tools/v2/team/team-security-flagging/`.
+2. No import from the main app, no shared component, no database schema change.
+3. Fixture emails do not contain real email addresses, real credentials, or live wallet
+   addresses.
+4. `node --test` exits with code 0 and reports 50 pass / 0 fail.
+5. The README explains how to run tests independently.
+6. Future executable tests targeting UI or hook layers can be added to this same folder
+   without touching the main app test suite.
+
+---
+
+## Known Limitations
+
+- `classifyEmail` uses keyword matching only. It has no NLP model, sender reputation
+  lookup, or link analysis. Multi-signal thresholds approximate real-world heuristics.
+- The service holds no persistent state. Flag storage is intentionally left to a future
+  integration issue.
+- `validateEmail` enforces structural rules but does not verify DNS or MX records.
+- Status transitions are validated at the service layer; enforcement at the persistence
+  layer is a future concern.

--- a/tools/v2/team/team-security-flagging/fixtures/security-flag-cases.json
+++ b/tools/v2/team/team-security-flagging/fixtures/security-flag-cases.json
@@ -1,0 +1,188 @@
+{
+  "emailSignals": [
+    {
+      "id": "phishing-credential-harvest",
+      "emailId": "email-001",
+      "threadId": "thread-001",
+      "subject": "Urgent: Verify your account to avoid suspension",
+      "senderEmail": "support@secure-login-verify.example.net",
+      "senderName": "Account Security Team",
+      "snippet": "Your account has been flagged for unusual sign-in activity. Verify your account now.",
+      "bodyPreview": "Click here to confirm your credentials before your account is suspended. This is urgent action required.",
+      "hasAttachments": false,
+      "links": ["http://secure-login-verify.example.net/confirm"],
+      "expectedClassification": {
+        "severity": "critical",
+        "category": "phishing",
+        "confidence": "high"
+      }
+    },
+    {
+      "id": "malware-invoice-attachment",
+      "emailId": "email-002",
+      "threadId": "thread-002",
+      "subject": "Invoice payment receipt attached",
+      "senderEmail": "billing@invoices-dept.example.xyz",
+      "senderName": "Billing Department",
+      "snippet": "Please open the attachment and enable macros to view the invoice.",
+      "bodyPreview": "Your invoice is ready. Download the file and run the installer to generate your receipt.",
+      "hasAttachments": true,
+      "links": [],
+      "expectedClassification": {
+        "severity": "critical",
+        "category": "malware",
+        "confidence": "high"
+      }
+    },
+    {
+      "id": "social-engineering-wire-transfer",
+      "emailId": "email-003",
+      "threadId": "thread-003",
+      "subject": "Urgent CEO request wire transfer needed",
+      "senderEmail": "ceo-urgent@company-hq.example.biz",
+      "senderName": "CEO Office",
+      "snippet": "This is an urgent request from your CEO. Please wire transfer funds immediately.",
+      "bodyPreview": "Keep this confidential. Do not share this with anyone. Do not reply to this email.",
+      "hasAttachments": false,
+      "links": [],
+      "expectedClassification": {
+        "severity": "critical",
+        "category": "social-engineering",
+        "confidence": "high"
+      }
+    },
+    {
+      "id": "credential-reset-otp",
+      "emailId": "email-004",
+      "threadId": "thread-004",
+      "subject": "Your one-time authentication code",
+      "senderEmail": "security@example-mail.com",
+      "senderName": "Security Team",
+      "snippet": "Use this one-time code to verify your identity. If you did not request this, reset your password.",
+      "bodyPreview": "Sign in to confirm your account. Two-factor authentication is required for this action.",
+      "hasAttachments": false,
+      "links": [],
+      "expectedClassification": {
+        "severity": "critical",
+        "category": "credential-theft",
+        "confidence": "high"
+      }
+    },
+    {
+      "id": "data-breach-notification",
+      "emailId": "email-005",
+      "threadId": "thread-005",
+      "subject": "Security incident: unauthorized access to your account",
+      "senderEmail": "alerts@platform.example.com",
+      "senderName": "Platform Security",
+      "snippet": "We detected a security incident affecting your account. Your data was exposed.",
+      "bodyPreview": "A breach notification has been issued. Your account was compromised. Please take immediate action.",
+      "hasAttachments": false,
+      "links": [],
+      "expectedClassification": {
+        "severity": "critical",
+        "category": "data-breach",
+        "confidence": "high"
+      }
+    },
+    {
+      "id": "low-risk-newsletter",
+      "emailId": "email-006",
+      "threadId": "thread-006",
+      "subject": "June product digest tips and updates",
+      "senderEmail": "updates@example-product.com",
+      "senderName": "Product Team",
+      "snippet": "This months digest covers improvements and events. Unsubscribe at any time.",
+      "bodyPreview": "Read the full newsletter on our website. No action needed from you.",
+      "hasAttachments": false,
+      "links": ["https://example-product.com/newsletter/june"],
+      "expectedClassification": {
+        "severity": "low",
+        "category": "other",
+        "confidence": "low"
+      }
+    }
+  ],
+  "validFlags": [
+    {
+      "id": "flag-001",
+      "emailId": "email-001",
+      "threadId": "thread-001",
+      "reportedBy": "alice@company.example",
+      "severity": "critical",
+      "category": "phishing",
+      "subject": "Urgent: Verify your account to avoid suspension",
+      "senderEmail": "support@secure-login-verify.example.net",
+      "description": "Email impersonates account security team and requests credential verification via external link.",
+      "evidence": [
+        "External domain does not match any known vendor",
+        "Contains urgent language designed to pressure immediate action",
+        "Link destination differs from displayed text"
+      ]
+    },
+    {
+      "id": "flag-002",
+      "emailId": "email-002",
+      "threadId": "thread-002",
+      "reportedBy": "bob@company.example",
+      "severity": "high",
+      "category": "malware",
+      "subject": "Invoice payment receipt attached",
+      "senderEmail": "billing@invoices-dept.example.xyz",
+      "description": "Attachment with macro-enabled document sent from unknown billing domain.",
+      "evidence": [
+        "Sender domain is not in approved vendor list",
+        "Email requests enabling macros which is a common malware delivery vector"
+      ]
+    },
+    {
+      "id": "flag-003",
+      "emailId": "email-003",
+      "threadId": "thread-003",
+      "reportedBy": "carol@company.example",
+      "severity": "critical",
+      "category": "social-engineering",
+      "subject": "Urgent CEO request wire transfer needed",
+      "senderEmail": "ceo-urgent@company-hq.example.biz",
+      "description": "Classic BEC attempt posing as executive requesting urgent wire transfer.",
+      "evidence": [
+        "CEO email domain does not match corporate domain",
+        "Requests secrecy and bypasses normal approval channels",
+        "No prior email thread with this sender"
+      ]
+    }
+  ],
+  "hostileInputs": [
+    { "field": "email", "value": "@missinglocal.test", "reason": "missing local part" },
+    { "field": "email", "value": "nodomain", "reason": "missing @ sign" },
+    { "field": "email", "value": "", "reason": "empty string" },
+    { "field": "email", "value": "user@", "reason": "missing domain" },
+    { "field": "threadId", "value": "../../../etc/passwd", "reason": "path traversal" },
+    { "field": "threadId", "value": "<script>alert(1)</script>", "reason": "XSS attempt" },
+    { "field": "threadId", "value": "thread 001", "reason": "space in ID" },
+    { "field": "severity", "value": "CRITICAL", "reason": "wrong case" },
+    { "field": "severity", "value": "extreme", "reason": "unknown value" },
+    { "field": "category", "value": "hacking", "reason": "unknown value" },
+    { "field": "status", "value": "pending", "reason": "unknown status value" },
+    { "field": "status", "value": "RESOLVED", "reason": "wrong case" }
+  ],
+  "statusTransitions": {
+    "valid": [
+      { "from": "new", "to": "under-review" },
+      { "from": "new", "to": "dismissed" },
+      { "from": "under-review", "to": "escalated" },
+      { "from": "under-review", "to": "resolved" },
+      { "from": "under-review", "to": "dismissed" },
+      { "from": "escalated", "to": "resolved" },
+      { "from": "escalated", "to": "dismissed" }
+    ],
+    "invalid": [
+      { "from": "new", "to": "escalated", "reason": "cannot skip under-review" },
+      { "from": "new", "to": "resolved", "reason": "cannot skip under-review" },
+      { "from": "resolved", "to": "new", "reason": "terminal status" },
+      { "from": "resolved", "to": "under-review", "reason": "terminal status" },
+      { "from": "dismissed", "to": "new", "reason": "terminal status" },
+      { "from": "dismissed", "to": "escalated", "reason": "terminal status" }
+    ]
+  }
+}

--- a/tools/v2/team/team-security-flagging/services/security-flagging.service.mjs
+++ b/tools/v2/team/team-security-flagging/services/security-flagging.service.mjs
@@ -1,0 +1,347 @@
+/**
+ * Team Security Flagging - Core Service
+ * Pure functions for security incident detection, classification, and flag management.
+ * No external dependencies — safe to test in isolation with node:test.
+ */
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class SecurityFlagError extends Error {
+  /** @param {string} message @param {string|null} [field] */
+  constructor(message, field) {
+    super(message);
+    this.name = "SecurityFlagError";
+    this.field = field ?? null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Limits / constants
+// ---------------------------------------------------------------------------
+
+export const LIMITS = Object.freeze({
+  MAX_DESCRIPTION_LENGTH: 2000,
+  MAX_EVIDENCE_ITEMS: 10,
+  MAX_EVIDENCE_LENGTH: 500,
+  MAX_EMAIL_LENGTH: 254,
+  MAX_THREAD_ID_LENGTH: 100,
+  MAX_EMAIL_ID_LENGTH: 100,
+  ALLOWED_SEVERITIES: /** @type {const} */ (["critical", "high", "medium", "low"]),
+  ALLOWED_CATEGORIES: /** @type {const} */ ([
+    "phishing",
+    "credential-theft",
+    "malware",
+    "data-breach",
+    "suspicious-sender",
+    "unauthorized-access",
+    "social-engineering",
+    "other",
+  ]),
+  ALLOWED_STATUSES: /** @type {const} */ ([
+    "new",
+    "under-review",
+    "escalated",
+    "resolved",
+    "dismissed",
+  ]),
+});
+
+// ---------------------------------------------------------------------------
+// Sanitizers
+// ---------------------------------------------------------------------------
+
+/** Strip control characters and trim. Returns null for non-strings. */
+export function sanitizeText(value) {
+  if (typeof value !== "string") return null;
+  // eslint-disable-next-line no-control-regex
+  return value.trim().replace(/[\x00-\x1F\x7F]/g, "");
+}
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+export function validateSeverity(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("severity is required", "severity");
+  if (!LIMITS.ALLOWED_SEVERITIES.includes(s)) {
+    throw new SecurityFlagError(`Unknown severity: "${s}"`, "severity");
+  }
+  return s;
+}
+
+export function validateCategory(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("category is required", "category");
+  if (!LIMITS.ALLOWED_CATEGORIES.includes(s)) {
+    throw new SecurityFlagError(`Unknown category: "${s}"`, "category");
+  }
+  return s;
+}
+
+export function validateStatus(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("status is required", "status");
+  if (!LIMITS.ALLOWED_STATUSES.includes(s)) {
+    throw new SecurityFlagError(`Unknown status: "${s}"`, "status");
+  }
+  return s;
+}
+
+/** Guards against CRLF injection, null bytes, and basic structural validity. */
+export function validateEmail(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new SecurityFlagError("email is required", "email");
+  }
+  if (/[\r\n\x00]/.test(value)) {
+    throw new SecurityFlagError("email contains illegal characters", "email");
+  }
+  if (value.length > LIMITS.MAX_EMAIL_LENGTH) {
+    throw new SecurityFlagError(
+      `email exceeds ${LIMITS.MAX_EMAIL_LENGTH} characters`,
+      "email",
+    );
+  }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value)) {
+    throw new SecurityFlagError("email format is invalid", "email");
+  }
+  return value.trim();
+}
+
+/** Guards against path traversal, spaces, and XSS in IDs. */
+export function validateThreadId(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("threadId is required", "threadId");
+  if (s.length > LIMITS.MAX_THREAD_ID_LENGTH) {
+    throw new SecurityFlagError(
+      `threadId exceeds ${LIMITS.MAX_THREAD_ID_LENGTH} characters`,
+      "threadId",
+    );
+  }
+  if (!/^[\w-]+$/.test(s)) {
+    throw new SecurityFlagError("threadId contains invalid characters", "threadId");
+  }
+  return s;
+}
+
+export function validateEmailId(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("emailId is required", "emailId");
+  if (s.length > LIMITS.MAX_EMAIL_ID_LENGTH) {
+    throw new SecurityFlagError(
+      `emailId exceeds ${LIMITS.MAX_EMAIL_ID_LENGTH} characters`,
+      "emailId",
+    );
+  }
+  if (!/^[\w-]+$/.test(s)) {
+    throw new SecurityFlagError("emailId contains invalid characters", "emailId");
+  }
+  return s;
+}
+
+export function validateDescription(value) {
+  const s = sanitizeText(value);
+  if (!s) throw new SecurityFlagError("description is required", "description");
+  if (s.length > LIMITS.MAX_DESCRIPTION_LENGTH) {
+    throw new SecurityFlagError(
+      `description exceeds ${LIMITS.MAX_DESCRIPTION_LENGTH} characters`,
+      "description",
+    );
+  }
+  return s;
+}
+
+export function validateEvidence(items) {
+  if (!Array.isArray(items)) {
+    throw new SecurityFlagError("evidence must be an array", "evidence");
+  }
+  if (items.length > LIMITS.MAX_EVIDENCE_ITEMS) {
+    throw new SecurityFlagError(
+      `evidence must not exceed ${LIMITS.MAX_EVIDENCE_ITEMS} items`,
+      "evidence",
+    );
+  }
+  return items.map((item, i) => {
+    const s = sanitizeText(item);
+    if (!s) throw new SecurityFlagError(`evidence[${i}] is empty`, "evidence");
+    if (s.length > LIMITS.MAX_EVIDENCE_LENGTH) {
+      throw new SecurityFlagError(
+        `evidence[${i}] exceeds ${LIMITS.MAX_EVIDENCE_LENGTH} characters`,
+        "evidence",
+      );
+    }
+    return s;
+  });
+}
+
+export function validateCreateFlagInput(input) {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new SecurityFlagError("input must be a plain object");
+  }
+  validateEmailId(input.emailId);
+  validateThreadId(input.threadId);
+  validateEmail(input.reportedBy);
+  validateEmail(input.senderEmail);
+  validateSeverity(input.severity);
+  validateCategory(input.category);
+  validateDescription(input.description);
+  if (input.evidence !== undefined) validateEvidence(input.evidence);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-classification
+// ---------------------------------------------------------------------------
+
+const SIGNAL_MAP = {
+  phishing: [
+    "click here",
+    "verify your account",
+    "your password has expired",
+    "unusual sign-in",
+    "suspended account",
+    "confirm your credentials",
+    "urgent action required",
+    "limited time",
+    "act now",
+    "security alert",
+  ],
+  "credential-theft": [
+    "enter your password",
+    "reset your password",
+    "sign in to confirm",
+    "two-factor",
+    "authentication code",
+    "verify your identity",
+    "one-time code",
+  ],
+  malware: [
+    "open the attachment",
+    "download the file",
+    "enable macros",
+    "run the installer",
+    "invoice attached",
+    "payment receipt attached",
+    "view the document",
+  ],
+  "social-engineering": [
+    "wire transfer",
+    "gift card",
+    "keep this confidential",
+    "do not share",
+    "ceo request",
+    "executive request",
+    "urgent request from",
+    "do not reply to this email",
+  ],
+  "data-breach": [
+    "unauthorized access",
+    "your data was exposed",
+    "breach notification",
+    "data leak",
+    "account compromised",
+    "security incident",
+  ],
+  "suspicious-sender": [
+    "noreply@",
+    "do-not-reply@",
+    "mailer-daemon",
+    "postmaster@",
+  ],
+};
+
+function matchSignals(text, signals) {
+  const lower = text.toLowerCase();
+  return signals.filter((s) => lower.includes(s));
+}
+
+/**
+ * Classify an email signal into a severity + category + confidence.
+ * @param {{ subject: string, snippet: string, bodyPreview: string, senderEmail: string }} signal
+ * @returns {{ severity: string, category: string, confidence: string, matchedSignals: string[] }}
+ */
+export function classifyEmail(signal) {
+  const combined =
+    `${signal.subject} ${signal.snippet} ${signal.bodyPreview} ${signal.senderEmail}`.toLowerCase();
+
+  const matches = {};
+  let totalMatched = 0;
+
+  for (const [category, signals] of Object.entries(SIGNAL_MAP)) {
+    const found = matchSignals(combined, signals);
+    matches[category] = found;
+    totalMatched += found.length;
+  }
+
+  // Pick the category with the most matched signals; default to "other"
+  let topCategory = "other";
+  let topCount = 0;
+  for (const [category, found] of Object.entries(matches)) {
+    if (found.length > topCount) {
+      topCount = found.length;
+      topCategory = category;
+    }
+  }
+
+  const allMatched = Object.values(matches).flat();
+
+  let severity = "low";
+  if (totalMatched >= 4 || (matches.phishing ?? []).length >= 3) severity = "critical";
+  else if (totalMatched >= 2) severity = "high";
+  else if (totalMatched === 1) severity = "medium";
+
+  let confidence = "low";
+  if (totalMatched >= 3) confidence = "high";
+  else if (totalMatched >= 1) confidence = "medium";
+
+  return { severity, category: topCategory, confidence, matchedSignals: allMatched };
+}
+
+// ---------------------------------------------------------------------------
+// Status-transition guard
+// ---------------------------------------------------------------------------
+
+/** Allowed next statuses for each status. Terminal statuses have empty arrays. */
+const VALID_TRANSITIONS = {
+  new: ["under-review", "dismissed"],
+  "under-review": ["escalated", "resolved", "dismissed"],
+  escalated: ["resolved", "dismissed"],
+  resolved: [],
+  dismissed: [],
+};
+
+export function canTransition(from, to) {
+  const allowed = VALID_TRANSITIONS[from];
+  if (!allowed) return false;
+  return allowed.includes(to);
+}
+
+export function validateStatusTransition(from, to) {
+  validateStatus(from);
+  validateStatus(to);
+  if (!canTransition(from, to)) {
+    throw new SecurityFlagError(
+      `Cannot transition from "${from}" to "${to}"`,
+      "status",
+    );
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Severity comparison utilities
+// ---------------------------------------------------------------------------
+
+const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+
+/** Returns true if a is strictly more severe than b. */
+export function isMoreSevere(a, b) {
+  return (SEVERITY_RANK[a] ?? 0) > (SEVERITY_RANK[b] ?? 0);
+}
+
+/** Returns the higher severity of the two. */
+export function maxSeverity(a, b) {
+  return isMoreSevere(a, b) ? a : b;
+}

--- a/tools/v2/team/team-security-flagging/tests/security-flagging.test.mjs
+++ b/tools/v2/team/team-security-flagging/tests/security-flagging.test.mjs
@@ -1,0 +1,469 @@
+/**
+ * Team Security Flagging — executable tests
+ * Run with: node --test tests/security-flagging.test.mjs
+ * (Node 18+ required; no extra dependencies needed)
+ */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  SecurityFlagError,
+  LIMITS,
+  sanitizeText,
+  validateSeverity,
+  validateCategory,
+  validateStatus,
+  validateEmail,
+  validateThreadId,
+  validateEmailId,
+  validateDescription,
+  validateEvidence,
+  validateCreateFlagInput,
+  classifyEmail,
+  canTransition,
+  validateStatusTransition,
+  isMoreSevere,
+  maxSeverity,
+} from "../services/security-flagging.service.mjs";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(__dir, "..", "fixtures", "security-flag-cases.json");
+
+async function loadFixtures() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeText
+// ---------------------------------------------------------------------------
+
+test("sanitizeText strips leading/trailing whitespace", () => {
+  assert.equal(sanitizeText("  hello  "), "hello");
+});
+
+test("sanitizeText strips control characters", () => {
+  assert.equal(sanitizeText("hello\x00world"), "helloworld");
+  assert.equal(sanitizeText("line\x1Fbreak"), "linebreak");
+});
+
+test("sanitizeText returns null for non-string input", () => {
+  assert.equal(sanitizeText(null), null);
+  assert.equal(sanitizeText(42), null);
+  assert.equal(sanitizeText({}), null);
+});
+
+// ---------------------------------------------------------------------------
+// validateSeverity
+// ---------------------------------------------------------------------------
+
+test("validateSeverity accepts all allowed values", () => {
+  for (const s of LIMITS.ALLOWED_SEVERITIES) {
+    assert.equal(validateSeverity(s), s);
+  }
+});
+
+test("validateSeverity throws for unknown value", () => {
+  assert.throws(() => validateSeverity("extreme"), SecurityFlagError);
+  assert.throws(() => validateSeverity("CRITICAL"), SecurityFlagError);
+});
+
+test("validateSeverity throws for empty and null", () => {
+  assert.throws(() => validateSeverity(""), SecurityFlagError);
+  assert.throws(() => validateSeverity(null), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// validateCategory
+// ---------------------------------------------------------------------------
+
+test("validateCategory accepts all allowed values", () => {
+  for (const c of LIMITS.ALLOWED_CATEGORIES) {
+    assert.equal(validateCategory(c), c);
+  }
+});
+
+test("validateCategory throws for unknown value", () => {
+  assert.throws(() => validateCategory("hacking"), SecurityFlagError);
+  assert.throws(() => validateCategory("Phishing"), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// validateStatus
+// ---------------------------------------------------------------------------
+
+test("validateStatus accepts all allowed values", () => {
+  for (const s of LIMITS.ALLOWED_STATUSES) {
+    assert.equal(validateStatus(s), s);
+  }
+});
+
+test("validateStatus throws for unknown value", () => {
+  assert.throws(() => validateStatus("pending"), SecurityFlagError);
+  assert.throws(() => validateStatus("RESOLVED"), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// validateEmail
+// ---------------------------------------------------------------------------
+
+test("validateEmail accepts well-formed addresses", () => {
+  assert.equal(validateEmail("alice@company.example"), "alice@company.example");
+  assert.equal(validateEmail("a+tag@sub.domain.test"), "a+tag@sub.domain.test");
+});
+
+test("validateEmail throws for CRLF injection", () => {
+  assert.throws(
+    () => validateEmail("user@evil.test\r\nBcc: victim@example.test"),
+    SecurityFlagError,
+  );
+  assert.throws(
+    () => validateEmail("user@evil.test\nX-Injected: yes"),
+    SecurityFlagError,
+  );
+});
+
+test("validateEmail throws for null byte", () => {
+  assert.throws(() => validateEmail("user\x00@evil.test"), SecurityFlagError);
+});
+
+test("validateEmail throws for missing local part or domain", () => {
+  assert.throws(() => validateEmail("@missinglocal.test"), SecurityFlagError);
+  assert.throws(() => validateEmail("user@"), SecurityFlagError);
+  assert.throws(() => validateEmail("nodomain"), SecurityFlagError);
+});
+
+test("validateEmail throws for empty string and non-string", () => {
+  assert.throws(() => validateEmail(""), SecurityFlagError);
+  assert.throws(() => validateEmail(null), SecurityFlagError);
+});
+
+test("validateEmail throws when email exceeds max length", () => {
+  const long = "a".repeat(LIMITS.MAX_EMAIL_LENGTH) + "@x.test";
+  assert.throws(() => validateEmail(long), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// validateThreadId
+// ---------------------------------------------------------------------------
+
+test("validateThreadId accepts alphanumeric IDs with _ and -", () => {
+  assert.equal(validateThreadId("thread-support-001"), "thread-support-001");
+  assert.equal(validateThreadId("THREAD_001"), "THREAD_001");
+});
+
+test("validateThreadId throws for path traversal", () => {
+  assert.throws(() => validateThreadId("../../../etc/passwd"), SecurityFlagError);
+});
+
+test("validateThreadId throws for XSS payload", () => {
+  assert.throws(
+    () => validateThreadId("<script>alert(1)</script>"),
+    SecurityFlagError,
+  );
+});
+
+test("validateThreadId throws for spaces", () => {
+  assert.throws(() => validateThreadId("thread 001"), SecurityFlagError);
+});
+
+test("validateThreadId throws for oversized ID", () => {
+  assert.throws(
+    () => validateThreadId("a".repeat(LIMITS.MAX_THREAD_ID_LENGTH + 1)),
+    SecurityFlagError,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// validateDescription
+// ---------------------------------------------------------------------------
+
+test("validateDescription accepts valid text", () => {
+  assert.equal(validateDescription("Suspicious link in body"), "Suspicious link in body");
+});
+
+test("validateDescription throws for empty string", () => {
+  assert.throws(() => validateDescription(""), SecurityFlagError);
+  assert.throws(() => validateDescription(null), SecurityFlagError);
+});
+
+test("validateDescription throws for text exceeding max length", () => {
+  assert.throws(
+    () => validateDescription("x".repeat(LIMITS.MAX_DESCRIPTION_LENGTH + 1)),
+    SecurityFlagError,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// validateEvidence
+// ---------------------------------------------------------------------------
+
+test("validateEvidence accepts a valid array of strings", () => {
+  const result = validateEvidence(["External domain", "Urgent language"]);
+  assert.deepEqual(result, ["External domain", "Urgent language"]);
+});
+
+test("validateEvidence throws for non-array input", () => {
+  assert.throws(() => validateEvidence("not-an-array"), SecurityFlagError);
+  assert.throws(() => validateEvidence(null), SecurityFlagError);
+});
+
+test("validateEvidence throws when item count exceeds max", () => {
+  const items = new Array(LIMITS.MAX_EVIDENCE_ITEMS + 1).fill("item");
+  assert.throws(() => validateEvidence(items), SecurityFlagError);
+});
+
+test("validateEvidence throws for oversized individual item", () => {
+  const longItem = "x".repeat(LIMITS.MAX_EVIDENCE_LENGTH + 1);
+  assert.throws(() => validateEvidence([longItem]), SecurityFlagError);
+});
+
+test("validateEvidence throws for empty item", () => {
+  assert.throws(() => validateEvidence([""]), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// validateCreateFlagInput
+// ---------------------------------------------------------------------------
+
+test("validateCreateFlagInput accepts a well-formed flag", () => {
+  assert.equal(
+    validateCreateFlagInput({
+      emailId: "email-001",
+      threadId: "thread-001",
+      reportedBy: "alice@company.example",
+      senderEmail: "attacker@evil.example",
+      severity: "high",
+      category: "phishing",
+      description: "Suspicious link detected in email body.",
+    }),
+    true,
+  );
+});
+
+test("validateCreateFlagInput throws for non-object input", () => {
+  assert.throws(() => validateCreateFlagInput(null), SecurityFlagError);
+  assert.throws(() => validateCreateFlagInput("admin"), SecurityFlagError);
+  assert.throws(() => validateCreateFlagInput([]), SecurityFlagError);
+});
+
+test("validateCreateFlagInput propagates field-level errors", () => {
+  assert.throws(
+    () =>
+      validateCreateFlagInput({
+        emailId: "email-001",
+        threadId: "thread-001",
+        reportedBy: "alice@company.example",
+        senderEmail: "attacker@evil.example",
+        severity: "EXTREME",
+        category: "phishing",
+        description: "Test",
+      }),
+    SecurityFlagError,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// classifyEmail
+// ---------------------------------------------------------------------------
+
+test("classifyEmail detects phishing signals", () => {
+  const result = classifyEmail({
+    subject: "Urgent: Verify your account to avoid suspension",
+    senderEmail: "support@fake-verify.example.net",
+    snippet: "Your account has been flagged for unusual sign-in activity.",
+    bodyPreview:
+      "Click here to confirm your credentials. This is urgent action required. Act now.",
+  });
+  assert.equal(result.category, "phishing");
+  assert.ok(["critical", "high"].includes(result.severity));
+  assert.ok(result.matchedSignals.length > 0);
+});
+
+test("classifyEmail detects malware signals", () => {
+  const result = classifyEmail({
+    subject: "Invoice attached — enable macros to view",
+    senderEmail: "billing@invoices.example.xyz",
+    snippet: "Please open the attachment and enable macros.",
+    bodyPreview: "Download the file and run the installer to generate your receipt.",
+  });
+  assert.equal(result.category, "malware");
+  assert.ok(result.matchedSignals.length > 0);
+});
+
+test("classifyEmail detects social-engineering signals", () => {
+  const result = classifyEmail({
+    subject: "Urgent request from CEO — Wire transfer needed",
+    senderEmail: "ceo-urgent@company-hq.example.biz",
+    snippet: "Keep this confidential. Do not share.",
+    bodyPreview: "Wire transfer required immediately. Do not reply to this email.",
+  });
+  assert.equal(result.category, "social-engineering");
+});
+
+test("classifyEmail detects credential-theft signals", () => {
+  const result = classifyEmail({
+    subject: "Reset your password now",
+    senderEmail: "security@accounts.example.com",
+    snippet: "Enter your password to verify your identity.",
+    bodyPreview: "Two-factor authentication required. Sign in to confirm your account.",
+  });
+  assert.equal(result.category, "credential-theft");
+});
+
+test("classifyEmail returns low severity and 'other' for benign content", () => {
+  const result = classifyEmail({
+    subject: "June product digest — tips and updates",
+    senderEmail: "updates@example-product.com",
+    snippet: "This month's digest covers improvements.",
+    bodyPreview: "Read the full newsletter on our website.",
+  });
+  assert.equal(result.severity, "low");
+  assert.equal(result.category, "other");
+  assert.equal(result.confidence, "low");
+});
+
+test("classifyEmail includes matchedSignals array", () => {
+  const result = classifyEmail({
+    subject: "Verify your account",
+    senderEmail: "noreply@fake.example",
+    snippet: "Click here to confirm your credentials.",
+    bodyPreview: "Urgent action required.",
+  });
+  assert.ok(Array.isArray(result.matchedSignals));
+});
+
+// ---------------------------------------------------------------------------
+// classifyEmail — fixture-driven
+// ---------------------------------------------------------------------------
+
+test("fixture email signals match expected classification severity tier", async () => {
+  const { emailSignals } = await loadFixtures();
+  for (const signal of emailSignals) {
+    const result = classifyEmail(signal);
+    const expected = signal.expectedClassification;
+    assert.equal(
+      result.severity,
+      expected.severity,
+      `${signal.id}: expected severity "${expected.severity}", got "${result.severity}"`,
+    );
+    assert.equal(
+      result.category,
+      expected.category,
+      `${signal.id}: expected category "${expected.category}", got "${result.category}"`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// canTransition
+// ---------------------------------------------------------------------------
+
+test("canTransition allows valid state progressions", async () => {
+  const { statusTransitions } = await loadFixtures();
+  for (const { from, to } of statusTransitions.valid) {
+    assert.equal(canTransition(from, to), true, `Expected ${from} → ${to} to be allowed`);
+  }
+});
+
+test("canTransition rejects invalid transitions", async () => {
+  const { statusTransitions } = await loadFixtures();
+  for (const { from, to, reason } of statusTransitions.invalid) {
+    assert.equal(
+      canTransition(from, to),
+      false,
+      `Expected ${from} → ${to} to be blocked (${reason})`,
+    );
+  }
+});
+
+test("canTransition returns false for unknown from-status", () => {
+  assert.equal(canTransition("nonexistent", "resolved"), false);
+});
+
+// ---------------------------------------------------------------------------
+// validateStatusTransition
+// ---------------------------------------------------------------------------
+
+test("validateStatusTransition does not throw for valid transitions", () => {
+  assert.doesNotThrow(() => validateStatusTransition("new", "under-review"));
+  assert.doesNotThrow(() => validateStatusTransition("under-review", "escalated"));
+  assert.doesNotThrow(() => validateStatusTransition("escalated", "resolved"));
+});
+
+test("validateStatusTransition throws for invalid transitions", () => {
+  assert.throws(() => validateStatusTransition("new", "resolved"), SecurityFlagError);
+  assert.throws(() => validateStatusTransition("resolved", "new"), SecurityFlagError);
+  assert.throws(() => validateStatusTransition("dismissed", "escalated"), SecurityFlagError);
+});
+
+test("validateStatusTransition throws for unknown status values", () => {
+  assert.throws(() => validateStatusTransition("pending", "resolved"), SecurityFlagError);
+  assert.throws(() => validateStatusTransition("new", "pending"), SecurityFlagError);
+});
+
+// ---------------------------------------------------------------------------
+// isMoreSevere / maxSeverity
+// ---------------------------------------------------------------------------
+
+test("isMoreSevere returns true when left is higher severity", () => {
+  assert.equal(isMoreSevere("critical", "high"), true);
+  assert.equal(isMoreSevere("high", "medium"), true);
+  assert.equal(isMoreSevere("medium", "low"), true);
+});
+
+test("isMoreSevere returns false when left is lower or equal", () => {
+  assert.equal(isMoreSevere("low", "high"), false);
+  assert.equal(isMoreSevere("high", "high"), false);
+  assert.equal(isMoreSevere("low", "critical"), false);
+});
+
+test("maxSeverity returns the higher of two severities", () => {
+  assert.equal(maxSeverity("high", "critical"), "critical");
+  assert.equal(maxSeverity("critical", "low"), "critical");
+  assert.equal(maxSeverity("medium", "medium"), "medium");
+  assert.equal(maxSeverity("low", "high"), "high");
+});
+
+// ---------------------------------------------------------------------------
+// Hostile input fixture — all rejected
+// ---------------------------------------------------------------------------
+
+test("fixture hostile inputs are rejected by the appropriate validator", async () => {
+  const { hostileInputs } = await loadFixtures();
+  const validators = {
+    email: validateEmail,
+    threadId: validateThreadId,
+    severity: validateSeverity,
+    category: validateCategory,
+    status: validateStatus,
+  };
+
+  for (const entry of hostileInputs) {
+    const fn = validators[entry.field];
+    assert.ok(fn, `No validator mapped for field "${entry.field}"`);
+    assert.throws(
+      () => fn(entry.value),
+      SecurityFlagError,
+      `Hostile input for ${entry.field} ("${entry.reason}") must throw SecurityFlagError`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Valid fixture flags all pass input validation
+// ---------------------------------------------------------------------------
+
+test("all fixture valid flags pass createFlagInput validation", async () => {
+  const { validFlags } = await loadFixtures();
+  for (const flag of validFlags) {
+    assert.doesNotThrow(
+      () => validateCreateFlagInput(flag),
+      `Flag "${flag.id}" should pass validation`,
+    );
+  }
+});

--- a/tools/v2/team/team-security-flagging/types.ts
+++ b/tools/v2/team/team-security-flagging/types.ts
@@ -1,0 +1,89 @@
+export type SecurityFlagSeverity = "critical" | "high" | "medium" | "low";
+
+export type SecurityFlagCategory =
+  | "phishing"
+  | "credential-theft"
+  | "malware"
+  | "data-breach"
+  | "suspicious-sender"
+  | "unauthorized-access"
+  | "social-engineering"
+  | "other";
+
+export type SecurityFlagStatus =
+  | "new"
+  | "under-review"
+  | "escalated"
+  | "resolved"
+  | "dismissed";
+
+export type SecurityFlag = {
+  id: string;
+  emailId: string;
+  threadId: string;
+  reportedBy: string;
+  assignedTo?: string;
+  severity: SecurityFlagSeverity;
+  category: SecurityFlagCategory;
+  status: SecurityFlagStatus;
+  subject: string;
+  senderEmail: string;
+  description: string;
+  evidence: string[];
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt?: string;
+  resolution?: string;
+};
+
+/** Minimal email signal used for auto-classification. */
+export type EmailSecuritySignal = {
+  emailId: string;
+  threadId: string;
+  subject: string;
+  senderEmail: string;
+  senderName?: string;
+  snippet: string;
+  bodyPreview: string;
+  hasAttachments: boolean;
+  links: string[];
+};
+
+export type CreateFlagInput = {
+  emailId: string;
+  threadId: string;
+  reportedBy: string;
+  severity: SecurityFlagSeverity;
+  category: SecurityFlagCategory;
+  subject: string;
+  senderEmail: string;
+  description: string;
+  evidence?: string[];
+};
+
+export type UpdateFlagInput = {
+  assignedTo?: string;
+  severity?: SecurityFlagSeverity;
+  status?: SecurityFlagStatus;
+  description?: string;
+  resolution?: string;
+};
+
+export type ClassificationResult = {
+  severity: SecurityFlagSeverity;
+  category: SecurityFlagCategory;
+  confidence: "high" | "medium" | "low";
+  matchedSignals: string[];
+};
+
+export type ServiceLimits = {
+  MAX_DESCRIPTION_LENGTH: number;
+  MAX_EVIDENCE_ITEMS: number;
+  MAX_EVIDENCE_LENGTH: number;
+  MAX_EMAIL_LENGTH: number;
+  MAX_THREAD_ID_LENGTH: number;
+  MAX_EMAIL_ID_LENGTH: number;
+  ALLOWED_SEVERITIES: readonly SecurityFlagSeverity[];
+  ALLOWED_CATEGORIES: readonly SecurityFlagCategory[];
+  ALLOWED_STATUSES: readonly SecurityFlagStatus[];
+};


### PR DESCRIPTION
PR #703 [V2][team] Team Security Flagging - Testing and documentation

 #feat(team-security-flagging): add tests, fixtures, service, and docs

## Summary

- Adds a complete folder-local service (`security-flagging.service.mjs`) with pure functions for input validation, email auto-classification, and status-transition enforcement.
- Adds 50 executable tests (`node:test`, zero external dependencies) covering sanitizers, validators, the keyword classifier, status transitions, and fixture-driven hostile-input rejection.
- Adds structured fixtures (`security-flag-cases.json`) with 6 email signal scenarios, 3 valid flag inputs, 12 hostile inputs, and 13 status transition pairs.
- Adds TypeScript type definitions (`types.ts`) for all domain objects.
- Adds `docs/test-plan.md` and `docs/review-notes.md` for independent OSS contributor review.
- Updates `README.md` with setup instructions, usage examples, fixture descriptions, and known limitations.

## What Changed

### New Files

| File | Description |
|---|---|
| `types.ts` | TypeScript types — `SecurityFlag`, `CreateFlagInput`, `ClassificationResult`, `ServiceLimits`, etc. |
| `services/security-flagging.service.mjs` | Core pure functions: sanitizers, per-field validators, `classifyEmail` keyword classifier, status-transition guard, severity comparison utilities |
| `fixtures/security-flag-cases.json` | Test data: email signals, valid flags, hostile inputs, transition pairs |
| `tests/security-flagging.test.mjs` | 50 passing tests using `node:test` with no extra packages |
| `docs/review-notes.md` | OSS contributor guide covering what to review, what was intentionally omitted, and the follow-up implementation shape |
| `docs/test-plan.md` | Full scenario table, injection checks, sanitizer checks, severity table, manual checklist, and known limitations |

### Modified Files

| File | Description |
|---|---|
| `README.md` | Rewritten with setup, folder structure, usage examples, fixture descriptions, known limitations, and an acceptance checklist |

## How to Run Tests

```bash
node --test tools/v2/team/team-security-flagging/tests/security-flagging.test.mjs
```

Expected: **50 tests, 0 failures**. Node 18+ required. No install step.

## Test Coverage Highlights

- **Sanitizers** — control character stripping, non-string null return
- **Validators** — closed enum enforcement for severity, category, and status; CRLF/null-byte/path-traversal/XSS guards on email and ID fields; length limits on description and evidence
- **Classifier** — detects phishing, malware, social engineering, credential theft, and data breach signals; returns low severity for benign content
- **Status transitions** — all 7 valid paths allowed; all 6 blocked paths (including terminal-status exits) rejected
- **Fixture-driven** — all 6 email classifications, all 12 hostile inputs, all valid flag inputs, and all transition pairs exercised from the JSON fixture

## Isolation Guarantee

- No files changed outside `tools/v2/team/team-security-flagging/`.
- No import from the main app, shared components, or design system.
- No database schema, route, navigation, wallet core, or Stellar integration change.
- No React/UI component — deferred to a future UI issue.
- No persistence layer — deferred to a future integration issue.

## Known Limitations

- `classifyEmail` uses keyword matching only; no NLP model, sender-reputation lookup, or link analysis.
- `validateEmail` checks structure and injection vectors but does not verify DNS or MX records.
- CRLF and null-byte injection cases are tested inline (not in the JSON fixture) because those characters are illegal in JSON string literals.
- Flag storage and retrieval require a future integration issue.

## Follow-Up Issues (Not In Scope Here)

- `hooks/use-security-flagging.ts` — React hook wrapping the service with local UI state.
- `components/SecurityFlagForm.tsx` — form for submitting a new flag.
- `components/SecurityFlagList.tsx` — list view for team review.
- Integration issue: wire `classifyEmail` to the inbox email event stream.
- Integration issue: persist flags to the team database.

## Checklist

- [x] All changed files are under `tools/v2/team/team-security-flagging/`
- [x] Tests run with `node --test` and produce 50 pass / 0 fail
- [x] Fixtures contain no real email addresses, credentials, or wallet addresses
- [x] No main app routes, navigation, or design-system changes
- [x] README documents setup, usage, fixtures, and known limitations
- [x] Review notes explain what to validate and what was intentionally deferred


Closes #703 