### PR TITLE
feat(demo-admin-dashboard): add campaign status model with draft, rea…

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/campaignStatus.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignStatus.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAMPAIGN_STATUSES,
+  INITIAL_CAMPAIGN_STATUS,
+  TERMINAL_STATUSES,
+  type CampaignStatus,
+  type CampaignStatusRecord,
+} from "../types/campaignStatus";
+import {
+  getAllowedTransitions,
+  canTransitionTo,
+  validateCampaignStatusTransition,
+  isTerminal,
+  isInitial,
+} from "../helpers/campaignStatusTransitions";
+import {
+  demoCampaignStatusRecords,
+  getCampaignStatusRecordById,
+  getCampaignsByStatus,
+} from "../fixtures/campaignStatusFixtures";
+import { CAMPAIGN_STATUS_TOKENS } from "../constants/displayTokens";
+
+describe("CampaignStatus type", () => {
+  it("should define all six statuses", () => {
+    expect(CAMPAIGN_STATUSES).toEqual([
+      "draft",
+      "ready",
+      "active",
+      "paused",
+      "archived",
+      "failed",
+    ]);
+  });
+
+  it("should start from draft", () => {
+    expect(INITIAL_CAMPAIGN_STATUS).toBe("draft");
+  });
+
+  it("should have archived as the only terminal status", () => {
+    expect(TERMINAL_STATUSES).toEqual(["archived"]);
+  });
+});
+
+describe("CAMPAIGN_STATUS_TOKENS", () => {
+  it("should define tokens for all six statuses", () => {
+    for (const s of CAMPAIGN_STATUSES) {
+      expect(CAMPAIGN_STATUS_TOKENS[s]).toBeDefined();
+      expect(CAMPAIGN_STATUS_TOKENS[s].label).toBeDefined();
+      expect(CAMPAIGN_STATUS_TOKENS[s].bg).toBeDefined();
+      expect(CAMPAIGN_STATUS_TOKENS[s].text).toBeDefined();
+      expect(CAMPAIGN_STATUS_TOKENS[s].border).toBeDefined();
+    }
+  });
+});
+
+describe("canTransitionTo", () => {
+  const cases: [CampaignStatus, CampaignStatus, boolean][] = [
+    ["draft", "ready", true],
+    ["draft", "archived", true],
+    ["draft", "active", false],
+    ["draft", "paused", false],
+    ["draft", "failed", false],
+
+    ["ready", "active", true],
+    ["ready", "draft", true],
+    ["ready", "archived", true],
+    ["ready", "paused", false],
+    ["ready", "failed", false],
+
+    ["active", "paused", true],
+    ["active", "archived", true],
+    ["active", "failed", true],
+    ["active", "draft", false],
+    ["active", "ready", false],
+
+    ["paused", "active", true],
+    ["paused", "archived", true],
+    ["paused", "failed", true],
+    ["paused", "draft", false],
+    ["paused", "ready", false],
+
+    ["archived", "draft", false],
+    ["archived", "ready", false],
+    ["archived", "active", false],
+    ["archived", "paused", false],
+    ["archived", "failed", false],
+
+    ["failed", "draft", true],
+    ["failed", "archived", true],
+    ["failed", "ready", false],
+    ["failed", "active", false],
+    ["failed", "paused", false],
+  ];
+
+  it.each(cases)("canTransitionFrom(%s → %s) should be %s", (from, to, expected) => {
+    expect(canTransitionTo(from, to)).toBe(expected);
+  });
+});
+
+describe("getAllowedTransitions", () => {
+  it("should return transitions from draft", () => {
+    const transitions = getAllowedTransitions("draft");
+    expect(transitions).toHaveLength(2);
+    expect(transitions.map((t) => t.to)).toEqual(["ready", "archived"]);
+  });
+
+  it("should return transitions from active", () => {
+    const transitions = getAllowedTransitions("active");
+    expect(transitions).toHaveLength(3);
+    expect(transitions.map((t) => t.to)).toEqual(["paused", "archived", "failed"]);
+  });
+
+  it("should return empty for terminal status", () => {
+    expect(getAllowedTransitions("archived")).toEqual([]);
+  });
+
+  it("should include transition metadata labels", () => {
+    const transitions = getAllowedTransitions("failed");
+    expect(transitions).toHaveLength(2);
+    expect(transitions[0].label).toBe("Retry");
+    expect(transitions[1].label).toBe("Archive Failed");
+  });
+});
+
+describe("validateCampaignStatusTransition", () => {
+  it("should reject same-status transition", () => {
+    const result = validateCampaignStatusTransition("draft", "draft");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("already set");
+  });
+
+  it("should reject transition from terminal status", () => {
+    const result = validateCampaignStatusTransition("archived", "draft");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("terminal");
+  });
+
+  it("should reject invalid transition", () => {
+    const result = validateCampaignStatusTransition("draft", "active");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("not allowed");
+  });
+
+  it("should accept valid transition", () => {
+    const result = validateCampaignStatusTransition("draft", "ready");
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+});
+
+describe("isTerminal / isInitial", () => {
+  it("should identify archived as terminal", () => {
+    expect(isTerminal("archived")).toBe(true);
+  });
+
+  it("should not identify other statuses as terminal", () => {
+    for (const s of ["draft", "ready", "active", "paused", "failed"] as CampaignStatus[]) {
+      expect(isTerminal(s)).toBe(false);
+    }
+  });
+
+  it("should identify draft as initial", () => {
+    expect(isInitial("draft")).toBe(true);
+  });
+
+  it("should not identify other statuses as initial", () => {
+    for (const s of ["ready", "active", "paused", "archived", "failed"] as CampaignStatus[]) {
+      expect(isInitial(s)).toBe(false);
+    }
+  });
+});
+
+describe("demoCampaignStatusRecords", () => {
+  it("should provide at least one record per status", () => {
+    for (const s of CAMPAIGN_STATUSES) {
+      const records = getCampaignsByStatus(s);
+      expect(records.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should have valid statuses on all records", () => {
+    for (const record of demoCampaignStatusRecords) {
+      expect(CAMPAIGN_STATUSES).toContain(record.status);
+    }
+  });
+
+  it("should have unique ids", () => {
+    const ids = demoCampaignStatusRecords.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("should provide consistent metadata", () => {
+    for (const record of demoCampaignStatusRecords) {
+      expect(record.name).toBeDefined();
+      expect(record.description).toBeDefined();
+      expect(record.tags).toBeInstanceOf(Array);
+      expect(record.createdAt).toBeDefined();
+      expect(record.updatedAt).toBeDefined();
+    }
+  });
+
+  it("should find a record by id", () => {
+    const found = getCampaignStatusRecordById("camp-active-01");
+    expect(found).toBeDefined();
+    expect(found!.name).toBe("Welcome Onboarding Series");
+  });
+
+  it("should return undefined for unknown id", () => {
+    expect(getCampaignStatusRecordById("nonexistent")).toBeUndefined();
+  });
+
+  it("should filter by status", () => {
+    const drafts = getCampaignsByStatus("draft");
+    expect(drafts.every((r) => r.status === "draft")).toBe(true);
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/displayTokens.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/displayTokens.test.ts
@@ -50,11 +50,11 @@ describe("Campaign Display Tokens Utilities", () => {
   });
 
   describe("CAMPAIGN_STATUS_TOKENS", () => {
-    it("should define statuses including active, draft, needs-review, and archived", () => {
-      expect(CAMPAIGN_STATUS_TOKENS.active).toBeDefined();
-      expect(CAMPAIGN_STATUS_TOKENS.draft).toBeDefined();
-      expect(CAMPAIGN_STATUS_TOKENS["needs-review"]).toBeDefined();
-      expect(CAMPAIGN_STATUS_TOKENS.archived).toBeDefined();
+    it("should define tokens for all six campaign statuses", () => {
+      const expected = ["draft", "ready", "active", "paused", "archived", "failed"];
+      for (const s of expected) {
+        expect(CAMPAIGN_STATUS_TOKENS[s as keyof typeof CAMPAIGN_STATUS_TOKENS]).toBeDefined();
+      }
     });
   });
 });

--- a/src/features/demo-admin-dashboard/components/CampaignSnapshots.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignSnapshots.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { Draft } from "../types/draft";
 import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import type { CampaignStatus } from "../types/campaignStatus";
 import { saveCampaignSnapshots, loadCampaignSnapshots } from "../persistence/localStorageAdapter";
 import { deterministicSnapshotId, normalizeLabels } from "../utils/normalizeDemoData";
 import {
@@ -46,7 +47,7 @@ export function CampaignSnapshots({
   const [description, setDescription] = useState("");
   const [targetAudience, setTargetAudience] = useState("");
   const [tagsInput, setTagsInput] = useState("");
-  const [status, setStatus] = useState<"active" | "draft" | "needs-review" | "archived">("draft");
+  const [status, setStatus] = useState<CampaignStatus>("draft");
   const [formError, setFormError] = useState("");
 
   // State for reference section visibility
@@ -295,15 +296,17 @@ export function CampaignSnapshots({
                 id="snap-status"
                 value={status}
                 onChange={(e) =>
-                  setStatus(e.target.value as "active" | "draft" | "needs-review" | "archived")
+                  setStatus(e.target.value as CampaignStatus)
                 }
                 className="w-full rounded-lg border border-white/[0.08] bg-black-90 px-3 py-2 text-xs text-foreground focus:border-white/20 focus:outline-none"
                 style={{ backgroundColor: "rgb(24 24 27)" }}
               >
                 <option value="draft">Draft</option>
+                <option value="ready">Ready</option>
                 <option value="active">Active</option>
-                <option value="needs-review">Needs Review</option>
+                <option value="paused">Paused</option>
                 <option value="archived">Archived</option>
+                <option value="failed">Failed</option>
               </select>
             </div>
           </div>

--- a/src/features/demo-admin-dashboard/constants/displayTokens.ts
+++ b/src/features/demo-admin-dashboard/constants/displayTokens.ts
@@ -6,32 +6,44 @@ export interface DisplayToken {
 }
 
 export const CAMPAIGN_STATUS_TOKENS: Record<
-  "active" | "draft" | "needs-review" | "archived",
+  "draft" | "ready" | "active" | "paused" | "archived" | "failed",
   DisplayToken
 > = {
-  active: {
-    bg: "bg-emerald-500/10",
-    text: "text-emerald-400",
-    border: "border-emerald-500/20",
-    label: "Active",
-  },
   draft: {
     bg: "bg-white/[0.04]",
     text: "text-muted-foreground",
     border: "border-white/[0.08]",
     label: "Draft",
   },
-  "needs-review": {
+  ready: {
+    bg: "bg-sky-500/10",
+    text: "text-sky-400",
+    border: "border-sky-500/20",
+    label: "Ready",
+  },
+  active: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-400",
+    border: "border-emerald-500/20",
+    label: "Active",
+  },
+  paused: {
     bg: "bg-amber-500/10",
     text: "text-amber-400",
     border: "border-amber-500/20",
-    label: "Needs Review",
+    label: "Paused",
   },
   archived: {
     bg: "bg-rose-500/10",
     text: "text-rose-400",
     border: "border-rose-500/20",
     label: "Archived",
+  },
+  failed: {
+    bg: "bg-red-500/10",
+    text: "text-red-400",
+    border: "border-red-500/20",
+    label: "Failed",
   },
 };
 

--- a/src/features/demo-admin-dashboard/docs/CAMPAIGN_STATUS_MODEL.md
+++ b/src/features/demo-admin-dashboard/docs/CAMPAIGN_STATUS_MODEL.md
@@ -1,0 +1,85 @@
+# Campaign Status Model
+
+Defines the six valid campaign lifecycle states and the allowed transitions between them.
+
+## States
+
+| Status     | Meaning                                                      | Terminal | Initial |
+|------------|--------------------------------------------------------------|----------|---------|
+| `draft`    | Campaign is being created or edited. Not yet ready for review. | No       | **Yes** |
+| `ready`    | Campaign is complete and ready for review or approval.       | No       | No      |
+| `active`   | Campaign is live and sending.                                | No       | No      |
+| `paused`   | Campaign was active but temporarily stopped.                 | No       | No      |
+| `archived` | Campaign is finished and kept for records. No further changes. | **Yes** | No      |
+| `failed`   | Campaign encountered an error. Can be retried or archived.   | No       | No      |
+
+## Transition Diagram
+
+```
+                    ┌──────────┐
+                    │  draft   │
+                    └────┬─────┘
+                   ┌─────┴──────┐
+                   ▼            ▼
+              ┌────────┐  ┌──────────┐
+              │ ready  │  │ archived │
+              └───┬────┘  └──────────┘
+           ┌──────┼──────┐
+           ▼      ▼      ▼
+      ┌────────┐  │  ┌──────┐
+      │ active │◄─┘  │failed│
+      └───┬────┘     └──┬───┘
+      ┌────┴────┐       │
+      ▼         ▼       │
+   ┌──────┐  ┌──────┐   │
+   │paused│  │arch'd│   │
+   └──┬───┘  └──────┘   │
+      │                 │
+      └── active ───────┘
+           (resume)
+```
+
+## Allowed Transitions
+
+| From       | To         | Label             | Description                                |
+|------------|------------|-------------------|--------------------------------------------|
+| `draft`    | `ready`    | Mark Ready        | Campaign is complete and ready for review. |
+| `draft`    | `archived` | Archive Draft     | Discard the draft campaign.                |
+| `ready`    | `active`   | Launch            | Start the campaign and begin sending.      |
+| `ready`    | `draft`    | Send Back to Draft | Return campaign for further edits.        |
+| `ready`    | `archived` | Cancel            | Cancel the campaign before launch.         |
+| `active`   | `paused`   | Pause             | Temporarily stop the campaign.             |
+| `active`   | `archived` | End Campaign      | Finish the campaign successfully.          |
+| `active`   | `failed`   | Mark Failed       | Campaign encountered an error.             |
+| `paused`   | `active`   | Resume            | Resume the paused campaign.                |
+| `paused`   | `archived` | End Campaign      | End the campaign while paused.             |
+| `paused`   | `failed`   | Mark Failed       | Fail the campaign while paused.            |
+| `failed`   | `draft`    | Retry             | Reset failed campaign for revision.        |
+| `failed`   | `archived` | Archive Failed    | Archive a failed campaign.                 |
+
+## Key Files
+
+| File                                                 | Purpose                                |
+|------------------------------------------------------|----------------------------------------|
+| `types/campaignStatus.ts`                            | Type definitions and constants         |
+| `helpers/campaignStatusTransitions.ts`               | Transition validation and metadata     |
+| `fixtures/campaignStatusFixtures.ts`                 | Deterministic demo records per status  |
+| `constants/displayTokens.ts`                         | UI token mapping for each status       |
+| `__tests__/campaignStatus.test.ts`                   | Full test coverage for the model       |
+
+## Usage Example
+
+```ts
+import { canTransitionTo, getAllowedTransitions } from "./helpers/campaignStatusTransitions";
+
+// Check if a transition is allowed
+if (canTransitionTo("draft", "ready")) {
+  // campaign.status = "ready";
+}
+
+// Get all possible next states
+const next = getAllowedTransitions("active");
+// [{ from: "active", to: "paused", label: "Pause", ... }, ...]
+```
+
+All data is fake, deterministic, and safe for public repository review.

--- a/src/features/demo-admin-dashboard/fixtures/campaignSnapshotFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/campaignSnapshotFixtures.ts
@@ -33,7 +33,7 @@ export const defaultCampaignSnapshots: CampaignSnapshot[] = [
     targetAudience: "High-Value Accounts",
     tags: ["security", "onboarding", "alert"],
     timestamp: "2026-06-15T09:30:00Z",
-    status: "needs-review",
+    status: "ready",
     drafts: [
       {
         id: "draft-security-1",
@@ -51,7 +51,7 @@ export const defaultCampaignSnapshots: CampaignSnapshot[] = [
     targetAudience: "Newsletter Subscribers",
     tags: ["newsletter", "marketing", "announcement"],
     timestamp: "2026-06-14T15:45:00Z",
-    status: "draft",
+    status: "ready",
     drafts: [
       {
         id: "draft-news-1",

--- a/src/features/demo-admin-dashboard/fixtures/campaignStatusFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/campaignStatusFixtures.ts
@@ -1,0 +1,76 @@
+import type { CampaignStatusRecord } from "../types/campaignStatus";
+
+export const demoCampaignStatusRecords: CampaignStatusRecord[] = [
+  {
+    id: "camp-draft-01",
+    name: "Q3 Product Launch",
+    description:
+      "Initial draft for the Q3 product launch campaign. Targeting early adopters.",
+    status: "draft",
+    tags: ["marketing", "announcement"],
+    createdAt: "2026-06-10T08:00:00Z",
+    updatedAt: "2026-06-12T14:30:00Z",
+  },
+  {
+    id: "camp-ready-01",
+    name: "Security Advisory",
+    description:
+      "Security best-practices advisory for high-value accounts. Ready for manager review.",
+    status: "ready",
+    tags: ["security", "alert"],
+    createdAt: "2026-06-08T09:00:00Z",
+    updatedAt: "2026-06-14T10:00:00Z",
+  },
+  {
+    id: "camp-active-01",
+    name: "Welcome Onboarding Series",
+    description:
+      "Active onboarding sequence for new signups. Sending in batches.",
+    status: "active",
+    tags: ["onboarding", "welcome", "stellar"],
+    createdAt: "2026-06-01T12:00:00Z",
+    updatedAt: "2026-06-17T08:00:00Z",
+  },
+  {
+    id: "camp-paused-01",
+    name: "June Newsletter",
+    description:
+      "Monthly newsletter paused pending content review from the editorial team.",
+    status: "paused",
+    tags: ["newsletter", "marketing"],
+    createdAt: "2026-06-05T11:00:00Z",
+    updatedAt: "2026-06-15T16:45:00Z",
+  },
+  {
+    id: "camp-archived-01",
+    name: "Legacy Relay Migration",
+    description:
+      "Completed migration campaign for legacy relay operators. No longer active.",
+    status: "archived",
+    tags: ["announcement"],
+    createdAt: "2026-05-01T07:00:00Z",
+    updatedAt: "2026-05-30T18:00:00Z",
+  },
+  {
+    id: "camp-failed-01",
+    name: "Testnet Incentive Round",
+    description:
+      "Failed due to relay connectivity issues. Scheduled for retry after network audit.",
+    status: "failed",
+    tags: ["marketing", "announcement"],
+    createdAt: "2026-06-12T10:00:00Z",
+    updatedAt: "2026-06-13T09:15:00Z",
+  },
+];
+
+export function getCampaignStatusRecordById(
+  id: string,
+): CampaignStatusRecord | undefined {
+  return demoCampaignStatusRecords.find((r) => r.id === id);
+}
+
+export function getCampaignsByStatus(
+  status: CampaignStatusRecord["status"],
+): CampaignStatusRecord[] {
+  return demoCampaignStatusRecords.filter((r) => r.status === status);
+}

--- a/src/features/demo-admin-dashboard/helpers/campaignStatusTransitions.ts
+++ b/src/features/demo-admin-dashboard/helpers/campaignStatusTransitions.ts
@@ -1,0 +1,151 @@
+import type {
+  CampaignStatus,
+  CampaignStatusTransition,
+} from "../types/campaignStatus";
+import { TERMINAL_STATUSES, INITIAL_CAMPAIGN_STATUS } from "../types/campaignStatus";
+
+const TRANSITION_MAP: Record<CampaignStatus, CampaignStatus[]> = {
+  draft: ["ready", "archived"],
+  ready: ["active", "draft", "archived"],
+  active: ["paused", "archived", "failed"],
+  paused: ["active", "archived", "failed"],
+  archived: [],
+  failed: ["draft", "archived"],
+};
+
+const TRANSITION_METADATA: Record<string, CampaignStatusTransition> = {
+  "draft→ready": {
+    from: "draft",
+    to: "ready",
+    label: "Mark Ready",
+    description: "Campaign is complete and ready for review.",
+  },
+  "draft→archived": {
+    from: "draft",
+    to: "archived",
+    label: "Archive Draft",
+    description: "Discard the draft campaign.",
+  },
+  "ready→active": {
+    from: "ready",
+    to: "active",
+    label: "Launch",
+    description: "Start the campaign and begin sending.",
+  },
+  "ready→draft": {
+    from: "ready",
+    to: "draft",
+    label: "Send Back to Draft",
+    description: "Return campaign for further edits.",
+  },
+  "ready→archived": {
+    from: "ready",
+    to: "archived",
+    label: "Cancel",
+    description: "Cancel the campaign before launch.",
+  },
+  "active→paused": {
+    from: "active",
+    to: "paused",
+    label: "Pause",
+    description: "Temporarily stop the campaign.",
+  },
+  "active→archived": {
+    from: "active",
+    to: "archived",
+    label: "End Campaign",
+    description: "Finish the campaign successfully.",
+  },
+  "active→failed": {
+    from: "active",
+    to: "failed",
+    label: "Mark Failed",
+    description: "Campaign encountered an error.",
+  },
+  "paused→active": {
+    from: "paused",
+    to: "active",
+    label: "Resume",
+    description: "Resume the paused campaign.",
+  },
+  "paused→archived": {
+    from: "paused",
+    to: "archived",
+    label: "End Campaign",
+    description: "End the campaign while paused.",
+  },
+  "paused→failed": {
+    from: "paused",
+    to: "failed",
+    label: "Mark Failed",
+    description: "Fail the campaign while paused.",
+  },
+  "failed→draft": {
+    from: "failed",
+    to: "draft",
+    label: "Retry",
+    description: "Reset failed campaign for revision.",
+  },
+  "failed→archived": {
+    from: "failed",
+    to: "archived",
+    label: "Archive Failed",
+    description: "Archive a failed campaign.",
+  },
+};
+
+export function getAllowedTransitions(
+  status: CampaignStatus,
+): CampaignStatusTransition[] {
+  const next = TRANSITION_MAP[status];
+  if (!next || next.length === 0) return [];
+  return next.map((to) => {
+    const key = `${status}→${to}`;
+    return (
+      TRANSITION_METADATA[key] ?? {
+        from: status,
+        to,
+        label: `Move to ${to}`,
+        description: `Transition from ${status} to ${to}.`,
+      }
+    );
+  });
+}
+
+export function canTransitionTo(
+  from: CampaignStatus,
+  to: CampaignStatus,
+): boolean {
+  const allowed = TRANSITION_MAP[from];
+  return allowed ? allowed.includes(to) : false;
+}
+
+export function validateCampaignStatusTransition(
+  from: CampaignStatus,
+  to: CampaignStatus,
+): { valid: boolean; reason?: string } {
+  if (from === to) {
+    return { valid: false, reason: "Status is already set to " + to };
+  }
+  if (TERMINAL_STATUSES.includes(from)) {
+    return {
+      valid: false,
+      reason: `Cannot transition from terminal status "${from}".`,
+    };
+  }
+  if (canTransitionTo(from, to)) {
+    return { valid: true };
+  }
+  return {
+    valid: false,
+    reason: `Transition from "${from}" to "${to}" is not allowed.`,
+  };
+}
+
+export function isTerminal(status: CampaignStatus): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
+
+export function isInitial(status: CampaignStatus): boolean {
+  return status === INITIAL_CAMPAIGN_STATUS;
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -38,6 +38,31 @@ export type {
 export type { CampaignSnapshot } from "./types/campaignSnapshot";
 export type { CampaignTag, TagColorKey } from "./types/campaignTag";
 
+// Campaign Status Model (issue #34): types, transitions, fixtures.
+export type {
+  CampaignStatus,
+  CampaignStatusRecord,
+  CampaignStatusTransition,
+  CampaignStatusSummary,
+} from "./types/campaignStatus";
+export {
+  CAMPAIGN_STATUSES,
+  INITIAL_CAMPAIGN_STATUS,
+  TERMINAL_STATUSES,
+} from "./types/campaignStatus";
+export {
+  getAllowedTransitions,
+  canTransitionTo,
+  validateCampaignStatusTransition,
+  isTerminal,
+  isInitial,
+} from "./helpers/campaignStatusTransitions";
+export {
+  demoCampaignStatusRecords,
+  getCampaignStatusRecordById,
+  getCampaignsByStatus,
+} from "./fixtures/campaignStatusFixtures";
+
 export type {
   DemoAttachment,
   DemoCalendarEvent,

--- a/src/features/demo-admin-dashboard/types/campaignSnapshot.ts
+++ b/src/features/demo-admin-dashboard/types/campaignSnapshot.ts
@@ -1,3 +1,4 @@
+import type { CampaignStatus } from "./campaignStatus";
 import { Draft } from "./draft";
 
 export interface CampaignSnapshot {
@@ -8,5 +9,5 @@ export interface CampaignSnapshot {
   tags: string[];
   timestamp: string;
   drafts: Draft[];
-  status?: "active" | "draft" | "needs-review" | "archived";
+  status?: CampaignStatus;
 }

--- a/src/features/demo-admin-dashboard/types/campaignStatus.ts
+++ b/src/features/demo-admin-dashboard/types/campaignStatus.ts
@@ -1,0 +1,39 @@
+export type CampaignStatus =
+  | "draft"
+  | "ready"
+  | "active"
+  | "paused"
+  | "archived"
+  | "failed";
+
+export const CAMPAIGN_STATUSES: CampaignStatus[] = [
+  "draft",
+  "ready",
+  "active",
+  "paused",
+  "archived",
+  "failed",
+];
+
+export const INITIAL_CAMPAIGN_STATUS: CampaignStatus = "draft";
+
+export const TERMINAL_STATUSES: readonly CampaignStatus[] = ["archived"];
+
+export interface CampaignStatusTransition {
+  from: CampaignStatus;
+  to: CampaignStatus;
+  label: string;
+  description: string;
+}
+
+export interface CampaignStatusRecord {
+  id: string;
+  name: string;
+  description: string;
+  status: CampaignStatus;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CampaignStatusSummary = Record<CampaignStatus, number>;


### PR DESCRIPTION
Close #285 


PR Description
## Summary

Implements the campaign status lifecycle model for the Demo Admin
Dashboard. Defines six states — **draft**, **ready**, **active**,
**paused**, **archived**, **failed** — with explicit transition rules,
validation, deterministic demo fixtures, UI display tokens, and docs.

All changes are scoped to `src/features/demo-admin-dashboard/`.

## State Machine

draft ──► ready ──► active ◄──► paused
  │         │         │  │         │
  │         │         │  │         │
  └──► archived ◄────┘  └──► failed ──► draft

- `draft` → `ready`, `archived`
- `ready` → `active`, `draft`, `archived`
- `active` → `paused`, `archived`, `failed`
- `paused` → `active`, `archived`, `failed`
- `archived` → (terminal, no outgoing transitions)
- `failed` → `draft`, `archived`

## Files Changed

**New (5):**
- `types/campaignStatus.ts` — types, constants, terminal/initial markers
- `helpers/campaignStatusTransitions.ts` — `canTransitionTo()`,
  `validateCampaignStatusTransition()`, `getAllowedTransitions()`
- `fixtures/campaignStatusFixtures.ts` — 6 deterministic demo records
- `__tests__/campaignStatus.test.ts` — 53 tests (all pass)
- `docs/CAMPAIGN_STATUS_MODEL.md` — state diagram, transition table

**Modified (6):**
- `types/campaignSnapshot.ts` — status field now uses `CampaignStatus`
- `constants/displayTokens.ts` — `CAMPAIGN_STATUS_TOKENS` updated
- `fixtures/campaignSnapshotFixtures.ts` — status values aligned
- `components/CampaignSnapshots.tsx` — type + UI updated
- `__tests__/displayTokens.test.ts` — test updated for 6 statuses
- `index.ts` — exports for all new modules

