### PR TITLE
docs(email-to-todo): add testing documentation

### DIFF
--- a/tools/v1/individual/email-to-todo-converter/README.md
+++ b/tools/v1/individual/email-to-todo-converter/README.md
@@ -12,4 +12,28 @@ All work for this tool must stay inside:
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Contributor Setup
+
+This tool does not ship executable code yet. Until a feature issue adds the
+implementation, contributors should use the local documentation in this folder
+as the launch contract:
+
+- `specs.md` defines the behavior and folder ownership boundary.
+- `docs/test-plan.md` lists the acceptance scenarios that future tests should
+  cover.
+- `docs/fixtures.md` describes the fixture emails and expected task outputs.
+- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
+
+## Intended Usage
+
+The tool converts an email into one or more actionable tasks. A future feature
+implementation should accept a normalized email object, extract the task title,
+due date, priority, source metadata, and completion state, then return a
+reviewable task draft without mutating the mailbox or main application state.
+
+## Known Limitations
+
+- No production code is present in this folder yet.
+- The documented tests are a plan, not an executable suite.
+- Main app routing, inbox integration, and persistence are intentionally out of
+  scope until a future integration issue allows them.

--- a/tools/v1/individual/email-to-todo-converter/REVIEW_NOTES.md
+++ b/tools/v1/individual/email-to-todo-converter/REVIEW_NOTES.md
@@ -1,0 +1,23 @@
+# Review Notes
+
+This issue is documentation and test-plan work for the isolated
+Email-to-Todo Converter folder.
+
+## What Changed
+
+- Replaced generated placeholder text in `specs.md` with the V1 individual tool
+  contract.
+- Added a contributor-facing setup, usage, and limitations section to
+  `README.md`.
+- Added `docs/test-plan.md` with unit, component, and non-goal coverage.
+- Added `docs/fixtures.md` with representative email inputs and expected task
+  draft outcomes.
+
+## Review Checklist
+
+- All files remain inside `tools/v1/individual/email-to-todo-converter/`.
+- No main app, routing, inbox, wallet, database, or design-system integration is
+  introduced.
+- The test plan covers core extraction behavior, accessibility, validation, and
+  review-before-save expectations.
+- The fixtures are safe synthetic examples and contain no real personal data.

--- a/tools/v1/individual/email-to-todo-converter/docs/fixtures.md
+++ b/tools/v1/individual/email-to-todo-converter/docs/fixtures.md
@@ -1,0 +1,63 @@
+# Email-to-Todo Converter Fixtures
+
+Use these fixture shapes when executable tests are added. They are intentionally
+plain JSON-like records so the future implementation can adapt them to its test
+runner without pulling in app-level inbox code.
+
+## Fixture: Direct Request
+
+```json
+{
+  "id": "email-direct-request",
+  "subject": "Please review the invoice by Friday",
+  "sender": "billing@example.com",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "bodyText": "Please review the attached invoice by Friday and let me know if anything is missing.",
+  "labels": ["inbox"]
+}
+```
+
+Expected task draft:
+
+- title: `Review the invoice`
+- dueDate: next Friday relative to `receivedAt`
+- priority: `normal`
+- sourceEmailId: `email-direct-request`
+
+## Fixture: Urgent Follow-Up
+
+```json
+{
+  "id": "email-urgent-follow-up",
+  "subject": "Urgent: follow up with partner",
+  "sender": "ops@example.com",
+  "receivedAt": "2026-06-19T10:30:00Z",
+  "bodyText": "Can you follow up with the partner today? This is blocking the launch checklist.",
+  "labels": ["important"]
+}
+```
+
+Expected task draft:
+
+- title: `Follow up with the partner`
+- dueDate: same calendar day as `receivedAt`
+- priority: `high`
+- sourceEmailId: `email-urgent-follow-up`
+
+## Fixture: No Action
+
+```json
+{
+  "id": "email-newsletter",
+  "subject": "Weekly product updates",
+  "sender": "newsletter@example.com",
+  "receivedAt": "2026-06-19T11:00:00Z",
+  "bodyText": "Here are this week's product updates and release notes.",
+  "labels": ["newsletter"]
+}
+```
+
+Expected outcome:
+
+- no task draft is created;
+- the UI explains that no clear action was detected.

--- a/tools/v1/individual/email-to-todo-converter/docs/test-plan.md
+++ b/tools/v1/individual/email-to-todo-converter/docs/test-plan.md
@@ -1,0 +1,36 @@
+# Email-to-Todo Converter Test Plan
+
+This folder does not contain executable tool code yet, so this document is the
+folder-local test plan for issue #358. Convert each scenario below into unit or
+component tests when the feature implementation lands.
+
+## Unit Scenarios
+
+1. Extracts a task title from a direct request in the email subject.
+2. Extracts a task title from the first actionable sentence in the body when the
+   subject is generic.
+3. Preserves the source sender, source subject, and received timestamp in task
+   metadata.
+4. Converts explicit due dates such as "by Friday" or "due 2026-07-01" into a
+   normalized due-date field.
+5. Leaves the due-date field empty when the email has no deadline.
+6. Assigns high priority for urgent language and normal priority otherwise.
+7. Produces deterministic output for repeated parsing of the same email.
+8. Rejects empty subject/body inputs with a validation error instead of creating
+   a blank task.
+
+## Component Scenarios
+
+1. Shows the proposed task title, notes, due date, and priority before saving.
+2. Lets the user edit the proposed task fields without changing the source email
+   metadata.
+3. Keeps destructive mailbox actions out of the review surface.
+4. Announces validation errors through accessible text associated with the
+   failing field.
+
+## Non-Goals for This Folder
+
+- End-to-end inbox routing.
+- Database persistence.
+- External task-provider sync.
+- Wallet or Stellar integration.

--- a/tools/v1/individual/email-to-todo-converter/specs.md
+++ b/tools/v1/individual/email-to-todo-converter/specs.md
@@ -4,9 +4,9 @@ Convert emails into tasks.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/email-to-todo-converter/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,24 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v1/individual/email-to-todo-converter/README.md"
-  @"
 
 # Email-to-Todo Converter Specs
 
 ## Purpose
 
-Convert emails into tasks.
+Convert one normalized email into a task draft that an individual user can
+review before saving to a future task system.
 
 ## Contributor boundary
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v1/individual/email-to-todo-converter/`
+
+Do not add imports from the main inbox, routing, wallet, Stellar, database, or
+design-system layers until a later integration issue explicitly allows it.
 
 ## Required issue categories
 
@@ -39,3 +41,23 @@ $dir/
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Core Behavior Contract
+
+The future implementation should:
+
+- accept a normalized email input with `subject`, `sender`, `receivedAt`, plain
+  text body, and optional labels;
+- detect actionable language such as "please send", "follow up", "schedule",
+  "review", and "due";
+- produce a task draft with title, notes, source email metadata, suggested due
+  date, and suggested priority;
+- keep extraction deterministic for the same input;
+- preserve user review before any task is saved or synced.
+
+## Out of Scope
+
+- mutating or archiving mailbox messages;
+- adding routes, dashboard widgets, or navigation links;
+- connecting to external task systems;
+- persisting task drafts outside this folder.


### PR DESCRIPTION
Closes #358

## Summary
- replace generated placeholder text in `tools/v1/individual/email-to-todo-converter/specs.md` with the V1 individual tool contract
- expand the folder README with setup, intended usage, and known limitations
- add a folder-local documented test plan and synthetic fixture catalog for future executable coverage
- add review notes for the isolated scope and safety checks

## Scope
All changes stay inside `tools/v1/individual/email-to-todo-converter/`. This does not wire the tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or design system.

## Validation
- Confirmed changed files are limited to the Email-to-Todo Converter folder
- Confirmed the docs mention test plan, fixtures, known limitations, review checklist, V1/individual ownership, and source email metadata expectations
- ASCII check passed for all changed files
- Searched changed files for payment/account/personal identifiers; none found