### PR TITLE
docs(email-snooze): add testing documentation

### DIFF
--- a/tools/v1/individual/email-snooze/README.md
+++ b/tools/v1/individual/email-snooze/README.md
@@ -12,4 +12,29 @@ All work for this tool must stay inside:
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Contributor Setup
+
+This folder does not contain executable tool code yet. Until a feature issue
+adds the implementation, contributors should use these local documents as the
+launch contract:
+
+- `specs.md` defines the behavior and ownership boundary.
+- `docs/test-plan.md` lists the acceptance scenarios future unit and component
+  tests should cover.
+- `docs/fixtures.md` describes synthetic emails, snooze requests, and expected
+  outcomes.
+- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
+
+## Intended Usage
+
+The tool lets an individual user temporarily hide an email until a chosen time.
+A future feature implementation should accept a normalized email and snooze
+request, validate the target wake time, return a reviewable snooze draft, and
+avoid mutating mailbox state until the user confirms.
+
+## Known Limitations
+
+- No production code is present in this folder yet.
+- The documented tests are a plan, not an executable suite.
+- Main app routing, inbox integration, and persistence are intentionally out of
+  scope until a future integration issue allows them.

--- a/tools/v1/individual/email-snooze/REVIEW_NOTES.md
+++ b/tools/v1/individual/email-snooze/REVIEW_NOTES.md
@@ -1,0 +1,23 @@
+# Review Notes
+
+This issue is documentation and test-plan work for the isolated Email Snooze
+folder.
+
+## What Changed
+
+- Replaced generated placeholder text in `specs.md` with the V1 individual tool
+  contract.
+- Added a contributor-facing setup, usage, and limitations section to
+  `README.md`.
+- Added `docs/test-plan.md` with unit, component, and non-goal coverage.
+- Added `docs/fixtures.md` with representative snooze inputs and expected
+  outcomes.
+
+## Review Checklist
+
+- All files remain inside `tools/v1/individual/email-snooze/`.
+- No main app, routing, inbox, wallet, database, or design-system integration is
+  introduced.
+- The test plan covers time normalization, validation, accessibility, source
+  metadata preservation, and confirmation-before-mutation expectations.
+- The fixtures are safe synthetic examples and contain no real personal data.

--- a/tools/v1/individual/email-snooze/docs/fixtures.md
+++ b/tools/v1/individual/email-snooze/docs/fixtures.md
@@ -1,0 +1,70 @@
+# Email Snooze Fixtures
+
+Use these fixture shapes when executable tests are added. They are intentionally
+plain JSON-like records so the future implementation can adapt them to its test
+runner without importing app-level inbox code.
+
+## Fixture: Tomorrow Morning
+
+```json
+{
+  "email": {
+    "id": "email-snooze-tomorrow",
+    "subject": "Quarterly budget follow-up",
+    "sender": "finance@example.com",
+    "receivedAt": "2026-06-19T09:00:00Z"
+  },
+  "request": "tomorrow morning",
+  "clock": "2026-06-19T10:00:00Z",
+  "timezone": "Asia/Shanghai"
+}
+```
+
+Expected snooze draft:
+
+- sourceEmailId: `email-snooze-tomorrow`
+- wakeTime: next morning relative to the fixed clock and timezone
+- mutatesMailboxBeforeConfirm: `false`
+
+## Fixture: Explicit ISO Time
+
+```json
+{
+  "email": {
+    "id": "email-snooze-iso",
+    "subject": "Contract review",
+    "sender": "legal@example.com",
+    "receivedAt": "2026-06-19T11:30:00Z"
+  },
+  "request": "2026-06-22T01:00:00Z",
+  "clock": "2026-06-19T12:00:00Z",
+  "timezone": "UTC"
+}
+```
+
+Expected snooze draft:
+
+- sourceEmailId: `email-snooze-iso`
+- wakeTime: `2026-06-22T01:00:00Z`
+- timezone: `UTC`
+
+## Fixture: Past Time
+
+```json
+{
+  "email": {
+    "id": "email-snooze-past",
+    "subject": "Already late",
+    "sender": "ops@example.com",
+    "receivedAt": "2026-06-19T08:00:00Z"
+  },
+  "request": "2026-06-18T08:00:00Z",
+  "clock": "2026-06-19T12:00:00Z",
+  "timezone": "UTC"
+}
+```
+
+Expected outcome:
+
+- no snooze draft is created;
+- validation explains that the wake time must be in the future.

--- a/tools/v1/individual/email-snooze/docs/test-plan.md
+++ b/tools/v1/individual/email-snooze/docs/test-plan.md
@@ -1,0 +1,36 @@
+# Email Snooze Test Plan
+
+This folder does not contain executable tool code yet, so this document is the
+folder-local test plan for issue #343. Convert each scenario below into unit or
+component tests when the feature implementation lands.
+
+## Unit Scenarios
+
+1. Normalizes an explicit ISO wake time into a snooze draft.
+2. Converts relative requests such as "tomorrow morning" with a fixed test clock
+   and timezone.
+3. Rejects wake times that are earlier than the current clock.
+4. Rejects ambiguous free-text requests with a validation error.
+5. Preserves source email id, subject, sender, and received timestamp in the
+   snooze draft.
+6. Produces deterministic output for repeated parsing of the same request and
+   fixed clock.
+7. Keeps mailbox mutation flags disabled until confirmation.
+8. Handles missing email subject by falling back to sender and received time in
+   review copy.
+
+## Component Scenarios
+
+1. Shows the proposed wake time, timezone, and source email before confirmation.
+2. Lets the user edit the wake time without changing source email metadata.
+3. Disables confirmation when validation fails.
+4. Announces validation errors through accessible text associated with the wake
+   time field.
+5. Shows a non-destructive cancel path that leaves the source email untouched.
+
+## Non-Goals for This Folder
+
+- End-to-end inbox routing.
+- Database persistence.
+- Real mailbox archive or label actions.
+- Calendar or push-notification integration.

--- a/tools/v1/individual/email-snooze/specs.md
+++ b/tools/v1/individual/email-snooze/specs.md
@@ -4,9 +4,9 @@ Temporarily hide emails until a chosen time.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/email-snooze/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,24 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v1/individual/email-snooze/README.md"
-  @"
 
 # Email Snooze Specs
 
 ## Purpose
 
-Temporarily hide emails until a chosen time.
+Temporarily hide one email until a future wake time chosen by an individual
+user.
 
 ## Contributor boundary
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v1/individual/email-snooze/`
+
+Do not add imports from the main inbox, routing, wallet, Stellar, database, or
+design-system layers until a later integration issue explicitly allows it.
 
 ## Required issue categories
 
@@ -39,3 +41,24 @@ $dir/
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Core Behavior Contract
+
+The future implementation should:
+
+- accept a normalized email input with `id`, `subject`, `sender`, and
+  `receivedAt`;
+- accept an explicit snooze target such as an ISO timestamp, "tomorrow morning",
+  or "next Monday";
+- reject target times that are in the past or cannot be parsed safely;
+- return a snooze draft containing source email metadata, normalized wake time,
+  timezone, and review copy;
+- avoid archiving, deleting, labeling, or moving the email before user
+  confirmation.
+
+## Out of Scope
+
+- mutating mailbox state;
+- adding routes, dashboard widgets, or navigation links;
+- connecting to external calendar/reminder services;
+- persisting snooze records outside this folder.


### PR DESCRIPTION
Closes #343

## Summary
- replace generated placeholder text in `tools/v1/individual/email-snooze/specs.md` with the V1 individual tool contract
- expand the folder README with setup, intended usage, and known limitations
- add a folder-local documented test plan and synthetic fixture catalog for future executable coverage
- add review notes for the isolated scope and safety checks

## Scope
All changes stay inside `tools/v1/individual/email-snooze/`. This does not wire the tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or design system.

## Validation
- Confirmed changed files are limited to the Email Snooze folder
- Confirmed the docs mention test plan, fixtures, known limitations, review checklist, V1/individual ownership, wake-time normalization, validation, and confirmation-before-mutation expectations
- ASCII check passed for all changed files
- Searched changed files for payment/account/personal identifiers; none found