### PR TITLE
docs(email-summarizer): add testing documentation

### DIFF
--- a/tools/v1/individual/email-summarizer/README.md
+++ b/tools/v1/individual/email-summarizer/README.md
@@ -12,4 +12,28 @@ All work for this tool must stay inside:
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Contributor Setup
+
+This folder does not contain executable tool code yet. Until a feature issue
+adds the implementation, contributors should use these local documents as the
+launch contract:
+
+- `specs.md` defines the behavior and ownership boundary.
+- `docs/test-plan.md` lists the acceptance scenarios future unit and component
+  tests should cover.
+- `docs/fixtures.md` describes synthetic emails and expected summary outputs.
+- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
+
+## Intended Usage
+
+The tool helps an individual user turn a long email into a concise reviewable
+summary. A future implementation should accept a normalized email, produce a
+short summary, surface action items separately, and preserve enough source
+metadata for the user to verify the summary before acting on it.
+
+## Known Limitations
+
+- No production code is present in this folder yet.
+- The documented tests are a plan, not an executable suite.
+- Main app routing, inbox integration, and persistence are intentionally out of
+  scope until a future integration issue allows them.

--- a/tools/v1/individual/email-summarizer/REVIEW_NOTES.md
+++ b/tools/v1/individual/email-summarizer/REVIEW_NOTES.md
@@ -1,0 +1,23 @@
+# Review Notes
+
+This issue is documentation and test-plan work for the isolated Email Summarizer
+folder.
+
+## What Changed
+
+- Replaced generated placeholder text in `specs.md` with the V1 individual tool
+  contract.
+- Added a contributor-facing setup, usage, and limitations section to
+  `README.md`.
+- Added `docs/test-plan.md` with unit, component, and non-goal coverage.
+- Added `docs/fixtures.md` with representative email inputs and expected
+  summary outcomes.
+
+## Review Checklist
+
+- All files remain inside `tools/v1/individual/email-summarizer/`.
+- No main app, routing, inbox, wallet, database, or design-system integration is
+  introduced.
+- The test plan covers summary length, action item extraction, validation,
+  source metadata preservation, and factuality expectations.
+- The fixtures are safe synthetic examples and contain no real personal data.

--- a/tools/v1/individual/email-summarizer/docs/fixtures.md
+++ b/tools/v1/individual/email-summarizer/docs/fixtures.md
@@ -1,0 +1,60 @@
+# Email Summarizer Fixtures
+
+Use these fixture shapes when executable tests are added. They are intentionally
+plain JSON-like records so the future implementation can adapt them to its test
+runner without importing app-level inbox code.
+
+## Fixture: Project Update With Actions
+
+```json
+{
+  "id": "email-project-update",
+  "subject": "Project launch update and next steps",
+  "sender": "lead@example.com",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "bodyText": "The launch checklist is mostly complete. The payment copy still needs review, analytics tracking needs a final smoke test, and the release notes need one more pass before Monday. Please confirm the owner for each item today.",
+  "maxSentences": 2
+}
+```
+
+Expected summary:
+
+- mentions that launch prep is mostly complete;
+- mentions remaining review, smoke-test, and release-notes work;
+- actionItems includes confirming owners today.
+
+## Fixture: Informational Newsletter
+
+```json
+{
+  "id": "email-newsletter-summary",
+  "subject": "Weekly product updates",
+  "sender": "newsletter@example.com",
+  "receivedAt": "2026-06-19T11:00:00Z",
+  "bodyText": "This week we shipped search improvements, updated the dashboard layout, and fixed several accessibility bugs. No action is required.",
+  "maxSentences": 1
+}
+```
+
+Expected summary:
+
+- mentions shipped search, dashboard, and accessibility updates;
+- actionItems is empty.
+
+## Fixture: Empty Body
+
+```json
+{
+  "id": "email-empty-summary",
+  "subject": "Missing content",
+  "sender": "sender@example.com",
+  "receivedAt": "2026-06-19T12:00:00Z",
+  "bodyText": "",
+  "maxSentences": 2
+}
+```
+
+Expected outcome:
+
+- no summary is created;
+- validation explains that email body text is required.

--- a/tools/v1/individual/email-summarizer/docs/test-plan.md
+++ b/tools/v1/individual/email-summarizer/docs/test-plan.md
@@ -1,0 +1,34 @@
+# Email Summarizer Test Plan
+
+This folder does not contain executable tool code yet, so this document is the
+folder-local test plan for issue #348. Convert each scenario below into unit or
+component tests when the feature implementation lands.
+
+## Unit Scenarios
+
+1. Summarizes a long email into a configured maximum number of sentences.
+2. Preserves source subject, sender, and received timestamp in output metadata.
+3. Extracts action items into a separate list when the email includes requests.
+4. Returns an empty action item list when the email is informational only.
+5. Rejects empty body input with a validation error.
+6. Does not include facts that are absent from the source email.
+7. Produces deterministic output for repeated summarization of the same fixture.
+8. Truncates or flags oversized input according to the future implementation
+   limit instead of silently dropping content.
+
+## Component Scenarios
+
+1. Shows the summary, action items, and source metadata before the user copies
+   or saves anything.
+2. Presents validation errors through accessible text associated with the input
+   or summary region.
+3. Keeps destructive mailbox actions out of the summary review surface.
+4. Provides a clear "view source" path so the user can compare summary claims
+   against the original email.
+
+## Non-Goals for This Folder
+
+- End-to-end inbox routing.
+- Database persistence.
+- Real mailbox archive or label actions.
+- External AI-provider integration.

--- a/tools/v1/individual/email-summarizer/specs.md
+++ b/tools/v1/individual/email-summarizer/specs.md
@@ -4,9 +4,9 @@ Generate concise summaries of long emails.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/email-summarizer/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,24 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v1/individual/email-summarizer/README.md"
-  @"
 
 # Email Summarizer Specs
 
 ## Purpose
 
-Generate concise summaries of long emails.
+Generate a concise, reviewable summary of a single long email for an individual
+user.
 
 ## Contributor boundary
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v1/individual/email-summarizer/`
+
+Do not add imports from the main inbox, routing, wallet, Stellar, database, or
+design-system layers until a later integration issue explicitly allows it.
 
 ## Required issue categories
 
@@ -39,3 +41,22 @@ $dir/
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Core Behavior Contract
+
+The future implementation should:
+
+- accept a normalized email input with `subject`, `sender`, `receivedAt`, and
+  plain text body;
+- produce a summary no longer than the configured sentence or character limit;
+- extract action items separately from the narrative summary;
+- preserve source email metadata for review and traceability;
+- avoid inventing facts not present in the email body;
+- return a validation error for empty or unsupported input.
+
+## Out of Scope
+
+- mutating mailbox state;
+- adding routes, dashboard widgets, or navigation links;
+- calling external AI providers from this folder;
+- persisting summary history outside this folder.


### PR DESCRIPTION
Closes #348

## Summary
- replace generated placeholder text in `tools/v1/individual/email-summarizer/specs.md` with the V1 individual tool contract
- expand the folder README with setup, intended usage, and known limitations
- add a folder-local documented test plan and synthetic fixture catalog for future executable coverage
- add review notes for the isolated scope and safety checks

## Scope
All changes stay inside `tools/v1/individual/email-summarizer/`. This does not wire the tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or design system.

## Validation
- Confirmed changed files are limited to the Email Summarizer folder
- Confirmed the docs mention test plan, fixtures, known limitations, review checklist, V1/individual ownership, summary length, action items, and validation expectations
- ASCII check passed for all changed files
- Searched changed files for payment/account/personal identifiers; none found