### PR TITLE
docs(email-tone): add testing documentation

### DIFF
--- a/tools/v1/individual/email-tone-rewriter/README.md
+++ b/tools/v1/individual/email-tone-rewriter/README.md
@@ -12,4 +12,28 @@ All work for this tool must stay inside:
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Contributor Setup
+
+This folder does not contain executable tool code yet. Until a feature issue
+adds the implementation, contributors should use these local documents as the
+launch contract:
+
+- `specs.md` defines the behavior and ownership boundary.
+- `docs/test-plan.md` lists the acceptance scenarios future unit and component
+  tests should cover.
+- `docs/fixtures.md` describes synthetic rewrite requests and expected outputs.
+- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
+
+## Intended Usage
+
+The tool helps an individual user rewrite a draft email into a selected tone,
+such as concise, friendly, formal, or apologetic. A future implementation should
+accept a draft, requested tone, and optional constraints, then return a
+reviewable rewrite without sending or saving anything automatically.
+
+## Known Limitations
+
+- No production code is present in this folder yet.
+- The documented tests are a plan, not an executable suite.
+- Main app routing, inbox integration, send actions, and persistence are
+  intentionally out of scope until a future integration issue allows them.

--- a/tools/v1/individual/email-tone-rewriter/REVIEW_NOTES.md
+++ b/tools/v1/individual/email-tone-rewriter/REVIEW_NOTES.md
@@ -1,0 +1,23 @@
+# Review Notes
+
+This issue is documentation and test-plan work for the isolated Email Tone
+Rewriter folder.
+
+## What Changed
+
+- Replaced generated placeholder text in `specs.md` with the V1 individual tool
+  contract.
+- Added a contributor-facing setup, usage, and limitations section to
+  `README.md`.
+- Added `docs/test-plan.md` with unit, component, and non-goal coverage.
+- Added `docs/fixtures.md` with representative rewrite inputs and expected
+  outcomes.
+
+## Review Checklist
+
+- All files remain inside `tools/v1/individual/email-tone-rewriter/`.
+- No main app, routing, inbox, wallet, database, compose, or design-system
+  integration is introduced.
+- The test plan covers supported tones, validation, factual preservation, length
+  constraints, review-before-action, and non-destructive cancellation.
+- The fixtures are safe synthetic examples and contain no real personal data.

--- a/tools/v1/individual/email-tone-rewriter/docs/fixtures.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/fixtures.md
@@ -1,0 +1,59 @@
+# Email Tone Rewriter Fixtures
+
+Use these fixture shapes when executable tests are added. They are intentionally
+plain JSON-like records so the future implementation can adapt them to its test
+runner without importing app-level compose code.
+
+## Fixture: Formal Rewrite
+
+```json
+{
+  "id": "tone-formal-follow-up",
+  "subject": "Following up",
+  "bodyText": "Hey Sam, can you send the Q3 invoice by Friday? We need it before the launch review.",
+  "tone": "formal",
+  "maxWords": 80
+}
+```
+
+Expected rewrite:
+
+- keeps the recipient name `Sam`;
+- keeps `Q3 invoice`, `Friday`, and `launch review`;
+- sounds formal without adding new facts;
+- send/save flags remain disabled.
+
+## Fixture: Friendly Rewrite
+
+```json
+{
+  "id": "tone-friendly-apology",
+  "subject": "Delay update",
+  "bodyText": "The report is late. I will send it tomorrow morning.",
+  "tone": "friendly",
+  "maxWords": 60
+}
+```
+
+Expected rewrite:
+
+- keeps the delay and tomorrow-morning delivery promise;
+- softens the tone;
+- does not invent a reason for the delay.
+
+## Fixture: Unsupported Tone
+
+```json
+{
+  "id": "tone-unsupported",
+  "subject": "Unsupported tone",
+  "bodyText": "Please review this draft.",
+  "tone": "sarcastic",
+  "maxWords": 50
+}
+```
+
+Expected outcome:
+
+- no rewrite is created;
+- validation explains that the tone is unsupported.

--- a/tools/v1/individual/email-tone-rewriter/docs/test-plan.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/test-plan.md
@@ -1,0 +1,33 @@
+# Email Tone Rewriter Test Plan
+
+This folder does not contain executable tool code yet, so this document is the
+folder-local test plan for issue #353. Convert each scenario below into unit or
+component tests when the feature implementation lands.
+
+## Unit Scenarios
+
+1. Rewrites a draft into a supported tone while preserving the core request.
+2. Preserves dates, names, amounts, links, and other factual details.
+3. Returns a deterministic validation error for an unsupported tone.
+4. Rejects empty draft body input with a validation error.
+5. Applies configured length constraints without dropping required facts.
+6. Separates preserved key points from the rewritten body for review.
+7. Produces deterministic output for repeated rewriting of the same fixture.
+8. Keeps send/save/mutate flags disabled until explicit confirmation.
+
+## Component Scenarios
+
+1. Shows original draft, target tone, rewritten body, and preserved key points
+   before any action is available.
+2. Lets the user switch tone and re-run the rewrite without changing the
+   original draft.
+3. Announces validation errors through accessible text associated with the tone
+   or draft field.
+4. Provides a non-destructive cancel path that leaves the draft untouched.
+
+## Non-Goals for This Folder
+
+- End-to-end compose or inbox routing.
+- Database persistence.
+- Real email send actions.
+- External AI-provider integration.

--- a/tools/v1/individual/email-tone-rewriter/specs.md
+++ b/tools/v1/individual/email-tone-rewriter/specs.md
@@ -4,9 +4,9 @@ Rewrite email tone for different contexts.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/email-tone-rewriter/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,24 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v1/individual/email-tone-rewriter/README.md"
-  @"
 
 # Email Tone Rewriter Specs
 
 ## Purpose
 
-Rewrite email tone for different contexts.
+Rewrite a draft email into a requested tone while preserving the user's meaning
+and keeping the result reviewable before any send action.
 
 ## Contributor boundary
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v1/individual/email-tone-rewriter/`
+
+Do not add imports from the main inbox, routing, wallet, Stellar, database, or
+design-system layers until a later integration issue explicitly allows it.
 
 ## Required issue categories
 
@@ -39,3 +41,26 @@ $dir/
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Core Behavior Contract
+
+The future implementation should:
+
+- accept a normalized draft input with `subject`, `bodyText`, target `tone`, and
+  optional length constraints;
+- support a bounded set of tones such as `concise`, `friendly`, `formal`, and
+  `apologetic`;
+- preserve factual claims, dates, names, and requested actions from the source
+  draft;
+- return a reviewable rewritten body and a list of preserved key points;
+- reject empty drafts or unsupported tone values with deterministic validation
+  errors;
+- never send, save, or mutate the mailbox before explicit user confirmation.
+
+## Out of Scope
+
+- sending emails;
+- mutating mailbox state;
+- adding routes, dashboard widgets, or navigation links;
+- calling external AI providers from this folder;
+- persisting rewrite history outside this folder.


### PR DESCRIPTION
Closes #353

## Summary
- replace generated placeholder text in `tools/v1/individual/email-tone-rewriter/specs.md` with the V1 individual tool contract
- expand the folder README with setup, intended usage, and known limitations
- add a folder-local documented test plan and synthetic fixture catalog for future executable coverage
- add review notes for the isolated scope and safety checks

## Scope
All changes stay inside `tools/v1/individual/email-tone-rewriter/`. This does not wire the tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, compose flow, or design system.

## Validation
- Confirmed changed files are limited to the Email Tone Rewriter folder
- Confirmed the docs mention test plan, fixtures, known limitations, review checklist, V1/individual ownership, supported tone handling, preserved key points, and validation expectations
- ASCII check passed for all changed files
- Searched changed files for payment/account/personal identifiers; none found