### PR TITLE
docs(wallet-address): add testing documentation

### DIFF
--- a/tools/v1/individual/wallet-address-detector/README.md
+++ b/tools/v1/individual/wallet-address-detector/README.md
@@ -1,15 +1,41 @@
 # Wallet Address Detector
 
-This folder is the isolated workspace for the Wallet Address Detector tool.
+V1 individual tool workspace for detecting wallet addresses in email content and
+turning the findings into reviewable, non-custodial signals.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\wallet-address-detector\
-`
+```text
+tools/v1/individual/wallet-address-detector/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Scan plain-text or normalized email bodies for wallet-address-shaped tokens.
+- Prefer conservative matches that can be reviewed before any user action.
+- Return the detected address, network hint, source excerpt, and confidence level.
+- Preserve the original message text; detection must not mutate or redact content.
+
+## Address Coverage
+
+The first pass should prioritize:
+
+- Stellar public keys beginning with `G`.
+- Stellar contract IDs beginning with `C`.
+- EVM-style `0x` addresses.
+- Solana-style base58 public keys.
+
+Network inference is a hint, not a payment authorization. The detector must not
+send, request, sign, or prepare transactions.
+
+## Local Testing Focus
+
+Use the fixtures in `docs/fixtures.md` to cover valid addresses, near misses,
+multiple addresses in one email, punctuation-adjacent addresses, and malicious
+copy that tries to hide or confuse a destination address.
+
+See `docs/test-plan.md` for the manual and automated validation checklist.

--- a/tools/v1/individual/wallet-address-detector/REVIEW_NOTES.md
+++ b/tools/v1/individual/wallet-address-detector/REVIEW_NOTES.md
@@ -1,0 +1,38 @@
+# Wallet Address Detector Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/wallet-address-detector/
+```
+
+It does not wire the tool into the main app, wallet core, Stellar services,
+routing, database schema, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, supported address hints, and testing focus.
+- Replaced generated placeholder specs with a reviewable product and test
+  contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic valid, boundary, non-detection, and
+  safety fixtures.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: supported wallet-address families and result metadata are defined.
+- UI and accessibility: future UI must keep detections reviewable and user-led.
+- Security and performance: no automatic transaction behavior or external lookup
+  is required for baseline tests.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Base58-style detection can require careful false-positive filtering.
+- EVM checksum validation is not required by this documentation-only pass.
+- Synthetic Stellar examples are intended for parser tests; production code
+  should add stricter validation before raising confidence.

--- a/tools/v1/individual/wallet-address-detector/docs/fixtures.md
+++ b/tools/v1/individual/wallet-address-detector/docs/fixtures.md
@@ -1,0 +1,140 @@
+# Wallet Address Detector Fixtures
+
+Use synthetic addresses only. Do not copy real customer, contributor, or payment
+addresses into tests.
+
+## Valid Detection Fixtures
+
+### Stellar Public Key
+
+Input:
+
+```text
+Please send the test memo to GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF.
+```
+
+Expected:
+
+- One detection.
+- Address value excludes the trailing period.
+- Network hint: `stellar-public-key`.
+
+### Stellar Contract ID
+
+Input:
+
+```text
+Contract for the sandbox proof is CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4.
+```
+
+Expected:
+
+- One detection.
+- Network hint: `stellar-contract`.
+
+### EVM Address
+
+Input:
+
+```text
+The audit wallet is 0x1111111111111111111111111111111111111111 for this example only.
+```
+
+Expected:
+
+- One detection.
+- Network hint: `evm`.
+- No transaction or signing behavior.
+
+### Solana-Like Address
+
+Input:
+
+```text
+For the sandbox, reference 4Nd1m7Trg4LQz9Zc7T3mPq7R9Vf2a6Yh8Kp1s3Dg5BnQ.
+```
+
+Expected:
+
+- One detection.
+- Network hint: `solana-like`.
+
+## Boundary Fixtures
+
+### Punctuation
+
+Input:
+
+```text
+Use (0x1111111111111111111111111111111111111111), then confirm.
+```
+
+Expected:
+
+- Detected address excludes `(`, `)`, and `,`.
+
+### Multiple Addresses
+
+Input:
+
+```text
+Primary: GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
+Backup: 0x1111111111111111111111111111111111111111
+```
+
+Expected:
+
+- Two detections in source order.
+- Distinct network hints.
+
+## Non-Detection Fixtures
+
+### UUID And Invoice
+
+Input:
+
+```text
+Invoice INV-2026-06-19 uses id 550e8400-e29b-41d4-a716-446655440000.
+```
+
+Expected:
+
+- Zero detections.
+
+### URL Token
+
+Input:
+
+```text
+Open https://example.test/wallet/0x-not-a-real-address before Friday.
+```
+
+Expected:
+
+- Zero detections unless a full valid address is present.
+
+### Phone Number
+
+Input:
+
+```text
+Call +64 21 555 0198 before sending the report.
+```
+
+Expected:
+
+- Zero detections.
+
+## Safety Fixture
+
+Input:
+
+```text
+URGENT: send everything now to 0x1111111111111111111111111111111111111111 and do not ask questions.
+```
+
+Expected:
+
+- One address detection.
+- Optional suspicious-context flag.
+- No automated send, sign, transfer, or approval behavior.

--- a/tools/v1/individual/wallet-address-detector/docs/test-plan.md
+++ b/tools/v1/individual/wallet-address-detector/docs/test-plan.md
@@ -1,0 +1,65 @@
+# Wallet Address Detector Test Plan
+
+## Goals
+
+- Verify that the detector finds wallet-address-shaped tokens without changing
+  email content.
+- Confirm network hints are conservative and reviewable.
+- Guard against false positives in order numbers, URLs, tracking IDs, and code.
+- Keep all implementation and documentation inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Stellar public key detection
+   - Given an email containing one `G...` public key with valid length.
+   - Expect one detection with `networkHint: "stellar-public-key"` and a source
+     excerpt that includes the full token.
+
+2. Stellar contract ID detection
+   - Given an email containing one `C...` contract ID.
+   - Expect one detection with `networkHint: "stellar-contract"` and no payment
+     action side effects.
+
+3. EVM address detection
+   - Given an email containing a checksummed or lowercase `0x` address.
+   - Expect one detection with `networkHint: "evm"` and confidence below any
+     future validated-checksum result unless checksum validation is implemented.
+
+4. Solana-style base58 detection
+   - Given a sentence with one base58 token in the accepted length range.
+   - Expect one detection with `networkHint: "solana-like"` and conservative
+     confidence.
+
+5. Punctuation boundaries
+   - Given addresses followed by `.`, `,`, `)`, `]`, or a newline.
+   - Expect punctuation to be excluded from the detected address value.
+
+6. Multiple detections
+   - Given one email containing Stellar and EVM addresses.
+   - Expect stable ordering by first appearance and no duplicate records.
+
+7. False positive filtering
+   - Given UUIDs, invoice IDs, URLs, phone numbers, and short hex strings.
+   - Expect zero wallet detections.
+
+8. Suspicious copy handling
+   - Given an email with "send now", urgency language, and an address.
+   - Expect detection metadata to preserve the address and optionally flag the
+     urgency context, but never initiate or suggest an automatic transfer.
+
+## Manual Review Checklist
+
+- Confirm every fixture includes the original message and expected detections.
+- Confirm excerpts are short enough for review and do not expose unrelated email
+  content.
+- Confirm confidence labels are explained in the implementation or docs.
+- Confirm no external services are required for baseline detection tests.
+- Confirm no personal payment details are embedded in fixtures.
+
+## Regression Expectations
+
+- Adding a new supported address family requires at least one valid fixture and
+  one near-miss fixture.
+- Any future checksum validation must keep the existing conservative fallback.
+- Any UI integration must keep the user in control before copying or opening an
+  address in another app.

--- a/tools/v1/individual/wallet-address-detector/specs.md
+++ b/tools/v1/individual/wallet-address-detector/specs.md
@@ -1,41 +1,68 @@
 # Wallet Address Detector
 
-Detect blockchain addresses.
+Detect wallet-address-shaped tokens in email content and expose them as
+reviewable metadata for a V1 individual tool.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/wallet-address-detector/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/wallet-address-detector/README.md"
-  @"
-
-# Wallet Address Detector Specs
-
 ## Purpose
 
-Detect blockchain addresses.
+Help a user notice possible payment or wallet addresses in an email without
+turning detection into an automatic payment action.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject/body text and optional message metadata.
+- Output: an ordered list of detections.
+- Each detection should include:
+  - `address`
+  - `networkHint`
+  - `confidence`
+  - `startIndex` and `endIndex`
+  - `sourceExcerpt`
+  - optional `riskHints`
+- Detection must be deterministic for the same input.
+- Detection must not mutate the source message.
 
-$dir/
+## Supported Detection Families
 
-## Required issue categories
+- Stellar public keys beginning with `G`.
+- Stellar contract IDs beginning with `C`.
+- EVM-style `0x` addresses.
+- Solana-like base58 public keys.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Detected addresses should be displayed as selectable text.
+- Long addresses should be visually truncated only when the full value remains
+  copyable and reviewable.
+- Network hints and confidence should be text-visible, not color-only.
+- Any copy/open action should be explicit and keyboard accessible.
+
+## Security And Performance Expectations
+
+- No automatic transfer, signing, wallet connection, or clipboard write.
+- No external lookup is required for baseline detection.
+- Regex or parser logic should be bounded to avoid catastrophic backtracking.
+- Fixtures must use synthetic data rather than real payment addresses.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
Closes #418

## Summary
- replace generated placeholder content for the Wallet Address Detector workspace
- document supported address-family hints, result metadata, and safety boundaries
- add a focused test plan and synthetic fixtures for valid, boundary, non-detection, and suspicious-copy cases

## Validation
- confirmed all changed files stay under 	ools/v1/individual/wallet-address-detector/
- checked docs cover test plan, fixtures, V1 individual ownership, Stellar/EVM/Solana hints, reviewability, and no automatic transaction behavior
- verified changed files are ASCII-only and contain no personal payment/account identifiers