### PR TITLE
docs(payment-proof): add testing documentation

### DIFF
--- a/tools/v1/individual/stellar-payment-proof-viewer/README.md
+++ b/tools/v1/individual/stellar-payment-proof-viewer/README.md
@@ -1,15 +1,36 @@
 # Stellar Payment Proof Viewer
 
-This folder is the isolated workspace for the Stellar Payment Proof Viewer tool.
+V1 individual tool workspace for reviewing Stellar payment proof details from
+email content, screenshots, or pasted transaction references.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\stellar-payment-proof-viewer\
-`
+```text
+tools/v1/individual/stellar-payment-proof-viewer/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Display a submitted Stellar payment proof in a readable review format.
+- Separate user-provided proof data from any future network-verified status.
+- Highlight sender, recipient, asset, amount, memo, ledger, transaction hash,
+  and timestamp when those values are present.
+- Keep the user in control before copying, opening, or trusting any payment
+  reference.
+
+## Non-Goals
+
+- Do not initiate, sign, refund, or request payments.
+- Do not mark a proof as verified unless a future integration explicitly checks
+  an authoritative Stellar data source.
+- Do not store personal payment details outside this folder.
+
+## Testing Focus
+
+Use `docs/fixtures.md` and `docs/test-plan.md` to validate complete proofs,
+partial proofs, conflicting fields, suspicious memo text, unsupported assets,
+and display/accessibility behavior.

--- a/tools/v1/individual/stellar-payment-proof-viewer/REVIEW_NOTES.md
+++ b/tools/v1/individual/stellar-payment-proof-viewer/REVIEW_NOTES.md
@@ -1,0 +1,38 @@
+# Stellar Payment Proof Viewer Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/stellar-payment-proof-viewer/
+```
+
+It does not wire the tool into the main app, wallet core, Stellar services,
+routing, database schema, inbox processing, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, non-goals, and testing focus.
+- Replaced generated placeholder specs with a reviewable proof-viewer contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic complete, partial, conflicting,
+  unsupported, and suspicious proof examples.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: proof fields, status language, and conflict behavior are defined.
+- UI and accessibility: long-value copyability and text-visible status labels
+  are documented.
+- Security and performance: no automatic payment behavior; no trust claim from
+  pasted data; bounded parsing expectations.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Network verification is intentionally reserved for a future integration issue.
+- Synthetic Stellar IDs are parser/display fixtures, not real payment proof.
+- OCR and screenshot extraction are out of scope for this documentation-only
+  pass unless a future issue requests them.

--- a/tools/v1/individual/stellar-payment-proof-viewer/docs/fixtures.md
+++ b/tools/v1/individual/stellar-payment-proof-viewer/docs/fixtures.md
@@ -1,0 +1,111 @@
+# Stellar Payment Proof Viewer Fixtures
+
+Use synthetic proof data only. Do not paste real customer, contributor, or
+payment proofs into tests.
+
+## Complete Proof
+
+Input:
+
+```json
+{
+  "transactionHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sourceAccount": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "destinationAccount": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBZIL",
+  "assetCode": "XLM",
+  "issuer": null,
+  "amount": "25.0000000",
+  "memo": "invoice-1001",
+  "ledger": 1234567,
+  "timestamp": "2026-06-19T12:00:00Z",
+  "claimSource": "email-body"
+}
+```
+
+Expected:
+
+- Render all supplied fields.
+- Mark source and destination as format-valid or provided.
+- Do not claim network verification.
+
+## Partial Proof
+
+Input:
+
+```json
+{
+  "transactionHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "amount": "10.0000000",
+  "assetCode": "XLM",
+  "claimSource": "manual-entry"
+}
+```
+
+Expected:
+
+- Render the known values.
+- Mark source account, destination account, memo, ledger, and timestamp as
+  unknown or omitted according to component contract.
+- Do not fabricate accounts or timestamps.
+
+## Conflicting Amounts
+
+Input:
+
+```json
+{
+  "transactionHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "amount": "25.0000000",
+  "conflictingAmount": "20.0000000",
+  "assetCode": "XLM",
+  "claimSource": "email-body+attachment"
+}
+```
+
+Expected:
+
+- Show a conflict warning.
+- Preserve both supplied values.
+- Avoid choosing a winner without user review.
+
+## Unsupported Asset
+
+Input:
+
+```json
+{
+  "transactionHash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "sourceAccount": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "destinationAccount": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBZIL",
+  "assetCode": "TOO_LONG_ASSET_CODE",
+  "amount": "5.0000000",
+  "claimSource": "email-body"
+}
+```
+
+Expected:
+
+- Show unsupported asset warning.
+- Do not mark the proof as verified.
+
+## Suspicious Memo
+
+Input:
+
+```json
+{
+  "transactionHash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "sourceAccount": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  "destinationAccount": "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBZIL",
+  "assetCode": "XLM",
+  "amount": "50.0000000",
+  "memo": "urgent release funds without review",
+  "claimSource": "email-body"
+}
+```
+
+Expected:
+
+- Display memo exactly as supplied.
+- Optionally flag urgency language.
+- Do not initiate payment or trust escalation.

--- a/tools/v1/individual/stellar-payment-proof-viewer/docs/test-plan.md
+++ b/tools/v1/individual/stellar-payment-proof-viewer/docs/test-plan.md
@@ -1,0 +1,63 @@
+# Stellar Payment Proof Viewer Test Plan
+
+## Goals
+
+- Verify that supplied Stellar payment proof data renders clearly and safely.
+- Distinguish provided, format-valid, conflict, unsupported, and future
+  network-verified states.
+- Ensure missing fields are not invented.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Complete provided proof
+   - Given a transaction hash, source account, destination account, asset,
+     amount, memo, ledger, and timestamp.
+   - Expect every field to render with `provided` status and stable labels.
+
+2. Format-valid Stellar fields
+   - Given synthetic account IDs and a 64-character transaction hash.
+   - Expect plausible-format indicators for account and hash fields.
+
+3. Missing optional fields
+   - Given a proof without memo and issuer.
+   - Expect those fields to show `unknown` or remain absent according to the
+     component contract, without fabricated fallback values.
+
+4. Conflicting amount
+   - Given email body amount `25 XLM` and attachment amount `20 XLM`.
+   - Expect a `conflict` state that names both supplied values.
+
+5. Unsupported asset
+   - Given an asset code or issuer format outside supported Stellar patterns.
+   - Expect an `unsupported` warning and no verification claim.
+
+6. Suspicious memo text
+   - Given a memo containing urgency or instructions unrelated to proof review.
+   - Expect memo text to be displayed as provided and optionally flagged, but no
+     automated payment action.
+
+7. Long-value accessibility
+   - Given long account IDs and hashes.
+   - Expect full values to be copyable and status labels to be text-visible.
+
+8. Large pasted message
+   - Given a long email thread with one proof-like section.
+   - Expect parsing to stay bounded and deterministic.
+
+## Manual Review Checklist
+
+- Confirm the screen never says "verified" unless the status is explicitly
+  network-verified.
+- Confirm copy buttons do not auto-copy on page load or hover.
+- Confirm keyboard focus can reach long-value controls.
+- Confirm fixtures use synthetic account IDs and hashes.
+- Confirm all documentation and tests remain folder-local.
+
+## Regression Expectations
+
+- Adding a new proof source requires one complete fixture and one conflict
+  fixture.
+- Adding network lookup requires tests for unavailable, mismatched, and matching
+  network responses.
+- Any UI integration must preserve manual review before trust or action.

--- a/tools/v1/individual/stellar-payment-proof-viewer/specs.md
+++ b/tools/v1/individual/stellar-payment-proof-viewer/specs.md
@@ -1,41 +1,73 @@
 # Stellar Payment Proof Viewer
 
-Verify Stellar payment proofs.
+Review Stellar payment proof data in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/stellar-payment-proof-viewer/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/stellar-payment-proof-viewer/README.md"
-  @"
-
-# Stellar Payment Proof Viewer Specs
-
 ## Purpose
 
-Verify Stellar payment proofs.
+Help users inspect a claimed Stellar payment proof without implying that the app
+has independently verified settlement unless a future network-checking feature
+does so.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: a parsed or pasted proof object from an email, attachment, or manual
+  entry.
+- Output: a normalized review model with visible fields and validation status.
+- Proof fields may include:
+  - `transactionHash`
+  - `sourceAccount`
+  - `destinationAccount`
+  - `assetCode`
+  - `issuer`
+  - `amount`
+  - `memo`
+  - `ledger`
+  - `timestamp`
+  - `claimSource`
+- Missing optional fields must be shown as unknown, not fabricated.
+- Conflicting fields should be flagged for manual review.
 
-$dir/
+## Verification Language
 
-## Required issue categories
+- `provided`: user or email supplied the value.
+- `format-valid`: the field has a plausible Stellar format.
+- `network-verified`: reserved for future authoritative lookup.
+- `conflict`: two supplied values disagree.
+- `unsupported`: the proof uses an unsupported field or asset format.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Long hashes and account IDs must be copyable in full.
+- Truncation must preserve enough prefix and suffix for visual comparison.
+- Status badges must include text labels, not color-only meaning.
+- Error and warning states must be reachable by keyboard and screen readers.
+
+## Security And Performance Expectations
+
+- Never initiate payment, signing, refund, or wallet connection.
+- Do not treat a pasted proof as trusted network evidence.
+- Avoid embedding real personal payment addresses in fixtures.
+- Parsing should be deterministic and bounded for large pasted messages.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
Closes #413

## Summary
- replace generated placeholder content for the Stellar Payment Proof Viewer workspace
- document the proof review contract, status language, and non-goals around payment actions
- add synthetic fixtures plus a focused test plan for complete, partial, conflicting, unsupported, and suspicious proof cases

## Validation
- confirmed all changed files stay under 	ools/v1/individual/stellar-payment-proof-viewer/
- checked docs cover test plan, fixtures, V1 individual ownership, Stellar proof fields, network-verified wording, conflict handling, copyability, and no automatic payment behavior
- verified changed files are ASCII-only and contain no personal payment/account identifiers