### PR TITLE
docs(schedule-send): add testing documentation

### DIFF
--- a/tools/v1/individual/schedule-send/README.md
+++ b/tools/v1/individual/schedule-send/README.md
@@ -1,15 +1,34 @@
 # Schedule Send
 
-This folder is the isolated workspace for the Schedule Send tool.
+V1 individual tool workspace for preparing and reviewing future email delivery
+requests before they are handed to any mail-sending integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\schedule-send\
-`
+```text
+tools/v1/individual/schedule-send/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Capture a draft message, recipient set, and scheduled send time.
+- Normalize local dates and times into a reviewable scheduled timestamp.
+- Show timezone, recurrence, cancellation, and edit state clearly.
+- Require explicit user confirmation before any future integration sends or
+  queues an email.
+
+## Non-Goals
+
+- Do not send email from this isolated workspace.
+- Do not modify Gmail, SMTP, queue, routing, or inbox behavior.
+- Do not store passwords, OAuth tokens, or account credentials.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to validate timezone handling,
+past-time rejection, daylight-saving boundaries, recipient review, cancellation,
+and confirmation-before-mutation behavior.

--- a/tools/v1/individual/schedule-send/REVIEW_NOTES.md
+++ b/tools/v1/individual/schedule-send/REVIEW_NOTES.md
@@ -1,0 +1,38 @@
+# Schedule Send Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/schedule-send/
+```
+
+It does not wire the tool into the main app, Gmail, SMTP, queue workers,
+routing, database schema, wallet services, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, non-goals, and testing focus.
+- Replaced generated placeholder specs with a reviewable schedule-send contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic future, past, missing-recipient,
+  multi-recipient, cancellation, and DST ambiguity cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: schedule model, status language, warnings, and confirmation behavior
+  are defined.
+- UI and accessibility: timezone visibility, recipient review, and keyboard
+  access are documented.
+- Security and performance: no automatic send, no credentials, deterministic
+  date parsing, and explicit confirmation expectations.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Actual queue creation is intentionally reserved for a future integration issue.
+- Recurrence is documented as a future regression area, not implemented here.
+- Fixtures use `.test` recipients and must not be replaced with real contacts.

--- a/tools/v1/individual/schedule-send/docs/fixtures.md
+++ b/tools/v1/individual/schedule-send/docs/fixtures.md
@@ -1,0 +1,137 @@
+# Schedule Send Fixtures
+
+Use synthetic recipients and draft IDs only.
+
+## Future One-Time Schedule
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_001",
+  "recipients": {
+    "to": ["alex@example.test"],
+    "cc": [],
+    "bcc": []
+  },
+  "subject": "Project update",
+  "scheduledLocalTime": "2026-06-20T09:30:00",
+  "timezone": "Pacific/Auckland"
+}
+```
+
+Expected:
+
+- Status: `ready-for-confirmation`.
+- UTC timestamp is present.
+- Timezone is visible in review output.
+
+## Past Time
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_002",
+  "recipients": {
+    "to": ["alex@example.test"],
+    "cc": [],
+    "bcc": []
+  },
+  "subject": "Late update",
+  "scheduledLocalTime": "2020-01-01T09:30:00",
+  "timezone": "Pacific/Auckland"
+}
+```
+
+Expected:
+
+- Blocking warning for past scheduled time.
+- No queue or send action.
+
+## Missing Recipients
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_003",
+  "recipients": {
+    "to": [],
+    "cc": [],
+    "bcc": []
+  },
+  "subject": "No recipient",
+  "scheduledLocalTime": "2026-06-20T09:30:00",
+  "timezone": "UTC"
+}
+```
+
+Expected:
+
+- Blocking warning for missing recipients.
+- Status remains `draft` or invalid.
+
+## Multiple Recipient Groups
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_004",
+  "recipients": {
+    "to": ["primary@example.test"],
+    "cc": ["copy@example.test"],
+    "bcc": ["hidden@example.test"]
+  },
+  "subject": "Recipient review",
+  "scheduledLocalTime": "2026-06-20T15:00:00",
+  "timezone": "Asia/Shanghai"
+}
+```
+
+Expected:
+
+- Recipient count is three.
+- To, cc, and bcc groups remain distinguishable before confirmation.
+
+## Cancellation
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_005",
+  "status": "scheduled",
+  "scheduledUtc": "2026-06-20T01:30:00Z",
+  "cancelRequested": true
+}
+```
+
+Expected:
+
+- Status becomes `cancelled`.
+- No send behavior occurs during cancellation.
+
+## Daylight-Saving Ambiguity
+
+Input:
+
+```json
+{
+  "draftId": "draft_test_006",
+  "recipients": {
+    "to": ["dst@example.test"],
+    "cc": [],
+    "bcc": []
+  },
+  "subject": "DST check",
+  "scheduledLocalTime": "2026-11-01T01:30:00",
+  "timezone": "America/New_York"
+}
+```
+
+Expected:
+
+- Ambiguous-time warning.
+- Manual review required before confirmation.

--- a/tools/v1/individual/schedule-send/docs/test-plan.md
+++ b/tools/v1/individual/schedule-send/docs/test-plan.md
@@ -1,0 +1,58 @@
+# Schedule Send Test Plan
+
+## Goals
+
+- Verify schedule review behavior before any future mail queue integration.
+- Validate timezone and daylight-saving handling.
+- Confirm user intent before queue mutation or send behavior.
+- Keep implementation and documentation inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Future one-time schedule
+   - Given a draft, recipients, timezone, and future local time.
+   - Expect `ready-for-confirmation` with a normalized UTC timestamp.
+
+2. Past-time rejection
+   - Given a local scheduled time earlier than the current clock.
+   - Expect a blocking warning and no `ready-for-confirmation` status.
+
+3. Timezone display
+   - Given `Pacific/Auckland` and a future local time.
+   - Expect the timezone label and UTC conversion to be visible in the model.
+
+4. Daylight-saving ambiguous time
+   - Given a time that repeats during DST fallback.
+   - Expect an ambiguity warning and manual review requirement.
+
+5. Missing recipients
+   - Given a draft without recipients.
+   - Expect a blocking warning before confirmation.
+
+6. Multiple recipients
+   - Given to, cc, and bcc values.
+   - Expect all recipient groups to be counted and reviewable.
+
+7. Cancel scheduled draft
+   - Given an existing schedule record.
+   - Expect cancel action to move status to `cancelled` without sending.
+
+8. Edit scheduled time
+   - Given an existing schedule record and a new valid time.
+   - Expect updated local and UTC times plus a new confirmation requirement.
+
+## Manual Review Checklist
+
+- Confirm the UI never sends or queues an email on page load.
+- Confirm confirm/edit/cancel controls are keyboard reachable.
+- Confirm warning copy includes the selected timezone.
+- Confirm recipient details are visible before confirmation.
+- Confirm fixtures do not contain real customer email addresses.
+
+## Regression Expectations
+
+- Adding recurrence requires at least one daily, weekly, and invalid recurrence
+  fixture.
+- Adding a queue integration requires tests for queue success, queue failure,
+  retry, and cancellation race behavior.
+- Any future Gmail/SMTP integration must keep explicit confirmation before send.

--- a/tools/v1/individual/schedule-send/specs.md
+++ b/tools/v1/individual/schedule-send/specs.md
@@ -1,41 +1,72 @@
 # Schedule Send
 
-Schedule future email delivery.
+Prepare future email delivery requests in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/schedule-send/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/schedule-send/README.md"
-  @"
-
-# Schedule Send Specs
-
 ## Purpose
 
-Schedule future email delivery.
+Let a user review a message and delivery time before a future integration queues
+or sends the email.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: draft message metadata, recipient list, local scheduled date/time,
+  timezone, optional recurrence, and optional cancellation/edit state.
+- Output: normalized schedule review model.
+- The review model should include:
+  - `draftId`
+  - `recipients`
+  - `subject`
+  - `scheduledLocalTime`
+  - `timezone`
+  - `scheduledUtc`
+  - `status`
+  - `warnings`
+  - optional `recurrence`
+- Past times must be rejected or flagged before confirmation.
+- Ambiguous daylight-saving times must be flagged for manual review.
+- Sending or queue mutation must require explicit confirmation.
 
-$dir/
+## Schedule Status Language
 
-## Required issue categories
+- `draft`: not ready for scheduling.
+- `ready-for-confirmation`: valid schedule awaiting explicit user action.
+- `scheduled`: reserved for future integration after confirmed queue creation.
+- `cancelled`: schedule was removed before delivery.
+- `failed`: scheduling attempt failed and did not queue delivery.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Timezone must be visible near the selected time.
+- Recipient counts and individual recipients must be reviewable before confirm.
+- Confirm, edit, and cancel actions must be keyboard accessible.
+- Warning states must use text labels, not color alone.
+
+## Security And Performance Expectations
+
+- No automatic send, queue creation, or background delivery from this folder.
+- No credentials, tokens, or personal payment details in fixtures.
+- Date parsing must be deterministic and bounded.
+- Confirmation copy must make the delivery time and timezone explicit.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
Closes #398

## Summary
- replace generated placeholder content for the Schedule Send workspace
- document the schedule review model, status language, and confirmation-before-send boundary
- add synthetic fixtures plus a focused test plan for future times, past-time rejection, timezone display, DST ambiguity, recipient review, edit, and cancellation cases

## Validation
- confirmed all changed files stay under 	ools/v1/individual/schedule-send/
- checked docs cover test plan, fixtures, V1 individual ownership, timezone handling, past-time rejection, confirmation, cancellation, and no automatic send behavior
- verified changed files are ASCII-only and contain no personal payment/account identifiers