### PR TITLE
docs(priority-detector): add testing documentation

### DIFF
--- a/tools/v1/individual/priority-detector/README.md
+++ b/tools/v1/individual/priority-detector/README.md
@@ -1,15 +1,36 @@
 # Priority Detector
 
-This folder is the isolated workspace for the Priority Detector tool.
+V1 individual tool workspace for classifying email priority signals into a
+reviewable, user-controlled result.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\priority-detector\
-`
+```text
+tools/v1/individual/priority-detector/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Inspect normalized subject, body, sender metadata, and optional timestamps.
+- Produce a priority label that helps a user triage messages.
+- Explain which signals contributed to the label.
+- Keep the result advisory; the detector must not move, archive, delete, or send
+  mail.
+
+## Priority Labels
+
+- `urgent`: likely time-sensitive and action-oriented.
+- `high`: important but not immediate.
+- `normal`: ordinary message with no strong urgency signal.
+- `low`: low-action or FYI-style message.
+- `unknown`: insufficient content or conflicting signals.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover deadline language,
+sender context, conflicting urgency copy, newsletters, FYI messages, empty
+content, and explainability requirements.

--- a/tools/v1/individual/priority-detector/REVIEW_NOTES.md
+++ b/tools/v1/individual/priority-detector/REVIEW_NOTES.md
@@ -1,0 +1,39 @@
+# Priority Detector Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/priority-detector/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, priority labels, and testing focus.
+- Replaced generated placeholder specs with a reviewable priority model
+  contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic urgent, high, normal, low,
+  conflicting, security, and empty-content cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: labels, confidence, signals, explanations, warnings, and conflict
+  behavior are defined.
+- UI and accessibility: text-visible labels, explanations, warnings, and user
+  override expectations are documented.
+- Security and performance: no inbox mutation, no external service required,
+  bounded parsing, and synthetic fixtures.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Sender relationship weighting is only a caller-provided hint in this pass.
+- The detector is advisory and cannot prove real-world urgency.
+- Future inbox integration must preserve explicit user control before mutation.

--- a/tools/v1/individual/priority-detector/docs/fixtures.md
+++ b/tools/v1/individual/priority-detector/docs/fixtures.md
@@ -1,0 +1,124 @@
+# Priority Detector Fixtures
+
+Use synthetic senders and message content only.
+
+## Urgent Deadline
+
+Input:
+
+```json
+{
+  "subject": "Action needed today: approve deployment window",
+  "from": "ops@example.test",
+  "body": "Please approve the deployment window by 17:00 today so the release can proceed."
+}
+```
+
+Expected:
+
+- Priority: `urgent`.
+- Signals include deadline and direct request.
+- No inbox mutation.
+
+## High Importance
+
+Input:
+
+```json
+{
+  "subject": "Review contract notes this week",
+  "from": "legal@example.test",
+  "body": "Could you review these contract notes before Friday?"
+}
+```
+
+Expected:
+
+- Priority: `high`.
+- Explanation mentions review request and later deadline.
+
+## Normal Update
+
+Input:
+
+```json
+{
+  "subject": "Project status update",
+  "from": "teammate@example.test",
+  "body": "The project is on track. No action needed right now."
+}
+```
+
+Expected:
+
+- Priority: `normal`.
+- Signals mention informational update.
+
+## Newsletter With Urgency Copy
+
+Input:
+
+```json
+{
+  "subject": "Last chance to read this weekly digest",
+  "from": "newsletter@example.test",
+  "body": "Weekly digest with unsubscribe footer and promotional summaries."
+}
+```
+
+Expected:
+
+- Priority: `low`.
+- Promotional urgency should not create an urgent label.
+
+## Conflicting Signals
+
+Input:
+
+```json
+{
+  "subject": "URGENT: FYI only",
+  "from": "updates@example.test",
+  "body": "Sharing this for awareness. No response is required."
+}
+```
+
+Expected:
+
+- Priority: `unknown` or low-confidence `normal`.
+- Warning notes conflicting subject/body signals.
+
+## Security Alert
+
+Input:
+
+```json
+{
+  "subject": "Security review requested for account access",
+  "from": "security@example.test",
+  "body": "Please review the attached account access change request today."
+}
+```
+
+Expected:
+
+- Priority: `urgent` or `high`.
+- Security and review-request signals are present.
+- No automatic link-click or reply recommendation.
+
+## Empty Content
+
+Input:
+
+```json
+{
+  "subject": "",
+  "from": "unknown@example.test",
+  "body": ""
+}
+```
+
+Expected:
+
+- Priority: `unknown`.
+- Warning: insufficient content.

--- a/tools/v1/individual/priority-detector/docs/test-plan.md
+++ b/tools/v1/individual/priority-detector/docs/test-plan.md
@@ -1,0 +1,59 @@
+# Priority Detector Test Plan
+
+## Goals
+
+- Verify priority labels are conservative, explainable, and deterministic.
+- Guard against over-prioritizing promotional or deceptive urgency copy.
+- Confirm the detector never mutates inbox state.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Urgent deadline
+   - Given an email with a deadline today and a direct request.
+   - Expect `urgent`, high confidence, and signals naming deadline plus action.
+
+2. High importance without immediate deadline
+   - Given a direct work request due later this week.
+   - Expect `high` with an explanation that avoids immediate urgency wording.
+
+3. Normal message
+   - Given a neutral update with no direct action.
+   - Expect `normal` and low-risk signals.
+
+4. Low-priority newsletter
+   - Given newsletter/digest language and unsubscribe footer.
+   - Expect `low` even if promotional urgency words appear.
+
+5. Conflicting signals
+   - Given "urgent" in a promotional subject but FYI body content.
+   - Expect `unknown` or low confidence rather than `urgent`.
+
+6. Security alert
+   - Given account-security wording with a review request.
+   - Expect `urgent` or `high` with security signal noted and no link-click
+     recommendation.
+
+7. Empty content
+   - Given missing body and vague subject.
+   - Expect `unknown` with an insufficient-content warning.
+
+8. Determinism
+   - Given the same message twice.
+   - Expect identical priority, confidence, and signal ordering.
+
+## Manual Review Checklist
+
+- Confirm labels and warnings are text-visible.
+- Confirm the explanation is short enough for triage surfaces.
+- Confirm no archive, delete, send, reply, or label mutation occurs.
+- Confirm user override behavior is documented.
+- Confirm fixtures do not include real sender identities.
+
+## Regression Expectations
+
+- Adding a new signal requires one positive fixture and one false-positive
+  fixture.
+- Adding sender relationship weighting requires tests for unknown, trusted, and
+  untrusted sender hints.
+- Any future inbox integration must keep explicit user control before mutation.

--- a/tools/v1/individual/priority-detector/specs.md
+++ b/tools/v1/individual/priority-detector/specs.md
@@ -1,41 +1,69 @@
 # Priority Detector
 
-Detect message importance level.
+Detect message priority signals in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/priority-detector/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/priority-detector/README.md"
-  @"
-
-# Priority Detector Specs
-
 ## Purpose
 
-Detect message importance level.
+Help an individual user triage email by surfacing priority hints with readable
+reasoning and conservative fallbacks.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject, body, sender display/address, received time,
+  and optional thread metadata.
+- Output: one priority review model.
+- The review model should include:
+  - `priority`
+  - `confidence`
+  - `signals`
+  - `explanation`
+  - `warnings`
+  - optional `suggestedReviewBy`
+- The detector must be deterministic for the same input.
+- If signals conflict, return `unknown` or a lower confidence result.
+- The detector must not mutate inbox state.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- Deadline or time-window language.
+- Direct request or explicit action requirement.
+- Sender relationship hint supplied by caller.
+- Escalation terms such as outage, failed payment, security, or legal notice.
+- Low-priority terms such as newsletter, digest, FYI, receipt, or promotion.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Priority labels must be visible as text, not color alone.
+- Signal explanations should be short and scannable.
+- Users must be able to override or ignore the classification.
+- Confidence and warning text must be keyboard and screen-reader reachable.
+
+## Security And Performance Expectations
+
+- No automatic archive, delete, label, send, or reply action.
+- No external model or service call is required for baseline tests.
+- Parsing and scoring must be bounded for long email bodies.
+- Fixtures must use synthetic senders and content only.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
Closes #393

## Summary
- replace generated placeholder content for the Priority Detector workspace
- document priority labels, confidence, signal explanations, and the no-inbox-mutation boundary
- add synthetic fixtures plus a focused test plan for urgent, high, normal, low, conflicting, security, empty-content, and determinism cases

## Validation
- confirmed all changed files stay under 	ools/v1/individual/priority-detector/
- checked docs cover test plan, fixtures, V1 individual ownership, labels, confidence, signals, unknown fallback, and no inbox mutation behavior
- verified changed files are ASCII-only and contain no personal payment/account identifiers