### PR TITLE
docs: add phishing link scanner test documentation

### DIFF
--- a/tools/v1/individual/phishing-link-scanner/README.md
+++ b/tools/v1/individual/phishing-link-scanner/README.md
@@ -1,15 +1,35 @@
 # Phishing Link Scanner
 
-This folder is the isolated workspace for the Phishing Link Scanner tool.
+V1 individual tool workspace for reviewing email links before a user opens
+them.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\phishing-link-scanner\
-`
+```text
+tools/v1/individual/phishing-link-scanner/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Inspect normalized links extracted from an email subject and body.
+- Flag suspicious URL patterns, mismatched display text, and high-risk domains.
+- Return a reviewable result that helps the user decide whether to open a link.
+- Keep the scanner advisory; it must not click, fetch, rewrite, quarantine, or
+  delete links automatically.
+
+## Risk Labels
+
+- `blocked`: link should not be opened without additional user review.
+- `suspicious`: link has one or more phishing indicators.
+- `unknown`: not enough context to classify safely.
+- `safe`: no configured phishing indicators were found.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover display-text mismatch,
+punycode, URL shorteners, credential-reset lures, trusted-domain allowlists,
+benign newsletters, empty input, and deterministic scoring.

--- a/tools/v1/individual/phishing-link-scanner/REVIEW_NOTES.md
+++ b/tools/v1/individual/phishing-link-scanner/REVIEW_NOTES.md
@@ -1,0 +1,38 @@
+# Phishing Link Scanner Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/phishing-link-scanner/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, risk labels, and testing focus.
+- Replaced generated placeholder specs with a reviewable phishing scan contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic mismatch, punycode, shortener,
+  trusted-domain, newsletter, and empty-input cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: risk, confidence, per-link results, signals, warnings, and
+  recommended action are defined.
+- UI and accessibility: text-visible labels, accessible warnings, and long URL
+  handling are documented.
+- Security and performance: no link opening/fetching, no external reputation
+  service requirement, bounded parsing, and synthetic fixtures.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Baseline tests do not perform live reputation lookups or redirect expansion.
+- Trusted-domain handling is only a caller-provided hint in this pass.
+- Future inbox integration must preserve explicit user control before mutation.

--- a/tools/v1/individual/phishing-link-scanner/docs/fixtures.md
+++ b/tools/v1/individual/phishing-link-scanner/docs/fixtures.md
@@ -1,0 +1,136 @@
+# Phishing Link Scanner Fixtures
+
+Use synthetic senders, reserved domains, and non-live links only.
+
+## Display-Text Mismatch
+
+Input:
+
+```json
+{
+  "subject": "Security notice",
+  "from": "security@example.test",
+  "links": [
+    {
+      "displayText": "accounts.example.test",
+      "href": "https://accounts-example-login.invalid/session"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Risk: `suspicious` or `blocked`.
+- Signals include display-text mismatch and account-security context.
+- No link open, fetch, rewrite, or inbox mutation.
+
+## Punycode Lookalike
+
+Input:
+
+```json
+{
+  "subject": "Review your account",
+  "from": "notice@example.test",
+  "links": [
+    {
+      "displayText": "billing.example.test",
+      "href": "https://xn--billing-exmple-9db.invalid/update"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Risk: `suspicious`.
+- Warning mentions punycode or lookalike-domain handling.
+
+## Shortened Payment Link
+
+Input:
+
+```json
+{
+  "subject": "Payment failed, action required",
+  "from": "billing@example.test",
+  "links": [
+    {
+      "displayText": "Fix payment",
+      "href": "https://short.example.invalid/a1b2"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Risk: `suspicious`.
+- Signals include payment lure and shortened URL.
+
+## Trusted Internal Link
+
+Input:
+
+```json
+{
+  "subject": "Internal handbook update",
+  "from": "people@example.test",
+  "trustedDomainHints": ["docs.example.test"],
+  "links": [
+    {
+      "displayText": "docs.example.test/handbook",
+      "href": "https://docs.example.test/handbook"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Risk: `safe` or low-risk result.
+- Explanation names the trusted-domain hint.
+
+## Newsletter Links
+
+Input:
+
+```json
+{
+  "subject": "Weekly digest",
+  "from": "digest@example.test",
+  "links": [
+    {
+      "displayText": "Read story",
+      "href": "https://news.example.test/story"
+    },
+    {
+      "displayText": "Unsubscribe",
+      "href": "https://news.example.test/unsubscribe"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Risk: `unknown` or `safe`.
+- Promotional tracking alone should not create a credential-theft warning.
+
+## Empty Link Set
+
+Input:
+
+```json
+{
+  "subject": "",
+  "from": "unknown@example.test",
+  "links": []
+}
+```
+
+Expected:
+
+- Risk: `unknown`.
+- Warning: no links or insufficient content.

--- a/tools/v1/individual/phishing-link-scanner/docs/test-plan.md
+++ b/tools/v1/individual/phishing-link-scanner/docs/test-plan.md
@@ -1,0 +1,59 @@
+# Phishing Link Scanner Test Plan
+
+## Goals
+
+- Verify phishing labels are conservative, explainable, and deterministic.
+- Guard against opening, fetching, or rewriting links during review.
+- Confirm display-text mismatch and lookalike-domain warnings are surfaced.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Display-text mismatch
+   - Given display text for a trusted brand but an unrelated target domain.
+   - Expect `suspicious` or `blocked`, high confidence, and a mismatch signal.
+
+2. Punycode domain
+   - Given a link with an `xn--` domain that resembles a trusted domain.
+   - Expect `suspicious` and a punycode warning.
+
+3. URL shortener
+   - Given a shortened link in a payment or account-security message.
+   - Expect `suspicious` with shortener and lure signals.
+
+4. Credential reset lure
+   - Given reset-password language and a non-allowlisted domain.
+   - Expect `blocked` or high-confidence `suspicious`.
+
+5. Trusted domain hint
+   - Given a caller-supplied trusted domain and matching target link.
+   - Expect `safe` or low-risk output with the hint named.
+
+6. Newsletter link
+   - Given a benign newsletter with unsubscribe and tracking-style links.
+   - Expect `unknown` or `safe` without credential-theft warnings.
+
+7. Empty input
+   - Given no links and minimal message content.
+   - Expect `unknown` with an insufficient-content warning.
+
+8. Determinism
+   - Given the same message twice.
+   - Expect identical risk, confidence, signal ordering, and warnings.
+
+## Manual Review Checklist
+
+- Confirm risk labels are visible as text.
+- Confirm warnings name the suspicious domain or pattern.
+- Confirm the UI never auto-clicks, expands, fetches, or rewrites links.
+- Confirm long URLs remain readable without breaking layout.
+- Confirm fixtures do not include real recipients, senders, payment accounts,
+  wallet addresses, or live phishing URLs.
+
+## Regression Expectations
+
+- Adding a new risk signal requires one positive fixture and one false-positive
+  fixture.
+- Adding allowlist logic requires tests for exact-match, subdomain, and
+  lookalike-domain cases.
+- Any future inbox integration must keep explicit user control before mutation.

--- a/tools/v1/individual/phishing-link-scanner/specs.md
+++ b/tools/v1/individual/phishing-link-scanner/specs.md
@@ -1,41 +1,78 @@
 # Phishing Link Scanner
 
-Link verification and phishing detection.
+Review email links for phishing indicators in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/phishing-link-scanner/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/phishing-link-scanner/README.md"
-  @"
-
-# Phishing Link Scanner Specs
-
 ## Purpose
 
-Link verification and phishing detection.
+Help an individual user review links found in email content without opening
+them, mutating the mailbox, or relying on real customer messages.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject, body, sender display/address, and extracted
+  link objects.
+- Each link object should include:
+  - `href`
+  - optional `displayText`
+  - optional `source`
+  - optional caller-provided `trustedDomainHints`
+- Output: one phishing review model.
+- The review model should include:
+  - `risk`
+  - `confidence`
+  - `links`
+  - `signals`
+  - `warnings`
+  - `recommendedAction`
+- The scanner must be deterministic for the same input.
+- If signals conflict, return `unknown` or a lower confidence result.
+- The scanner must not click links, fetch remote pages, send email, delete
+  email, label messages, or rewrite inbox content.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- Display text domain does not match the target `href` domain.
+- Punycode, homoglyph-like, or lookalike domain patterns.
+- URL shorteners or redirect-heavy patterns.
+- Credential, wallet, payment, security, or urgent account lures.
+- Suspicious TLD/domain age hints when supplied by the caller.
+- Safe-list hints supplied by the caller for known internal domains.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Risk labels must be visible as text, not color alone.
+- Link domains and warning reasons should be keyboard and screen-reader
+  reachable.
+- Long URLs should wrap or truncate with an accessible full-value view.
+- Users must be able to ignore a warning or copy the link for manual review.
+
+## Security And Performance Expectations
+
+- Do not open, prefetch, expand, or resolve links in the baseline scanner.
+- Do not transmit links to an external reputation service in baseline tests.
+- Parsing must be bounded for long email bodies and many links.
+- Fixtures must use reserved domains and synthetic email content only.
+- The scanner should treat allowlists as hints, not absolute proof of safety.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
## Summary
- replaces generated placeholder text for the Phishing Link Scanner workspace
- documents the review contract, risk labels, UI/security expectations, and folder boundary
- adds synthetic fixtures and a regression-focused test plan for phishing indicators

Closes #388