### PR TITLE
docs: add OTP detector test documentation

### DIFF
--- a/tools/v1/individual/otp-detector/README.md
+++ b/tools/v1/individual/otp-detector/README.md
@@ -1,15 +1,35 @@
 # OTP Detector
 
-This folder is the isolated workspace for the OTP Detector tool.
+V1 individual tool workspace for detecting one-time passcodes in email content.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\otp-detector\
-`
+```text
+tools/v1/individual/otp-detector/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Inspect normalized subject and body text for one-time passcode patterns.
+- Return candidate OTP values with confidence, nearby context, and warnings.
+- Avoid treating invoices, order IDs, phone numbers, dates, and ticket numbers
+  as OTPs.
+- Keep the detector advisory; it must not store, forward, auto-fill, or submit
+  codes.
+
+## Detection Labels
+
+- `otp`: high-confidence one-time passcode candidate.
+- `possible_otp`: code-like value with weaker or conflicting context.
+- `not_otp`: numeric or alphanumeric value with non-authentication context.
+- `unknown`: insufficient content or conflicting signals.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover six-digit codes,
+alphanumeric codes, expiration windows, multilingual auth context, false
+positives, empty content, redaction behavior, and deterministic ranking.

--- a/tools/v1/individual/otp-detector/REVIEW_NOTES.md
+++ b/tools/v1/individual/otp-detector/REVIEW_NOTES.md
@@ -1,0 +1,42 @@
+# OTP Detector Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/otp-detector/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, detection labels, and testing focus.
+- Replaced generated placeholder specs with a reviewable OTP detection
+  contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic OTP, MFA, expiration,
+  false-positive, tracking, mixed-value, and empty-content cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: status, confidence, candidates, signals, warnings, expiration, and
+  masked display behavior are defined.
+- UI and accessibility: masking, reveal/copy action, confidence, warnings, and
+  context excerpts are documented.
+- Security and performance: no storage, external transmission, auto-fill,
+  submission, or unbounded parsing is allowed.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Baseline detection is pattern/context based and does not verify external
+  account state.
+- Locale-specific terms are examples until a future implementation adds a full
+  dictionary.
+- Future inbox integration must preserve explicit user control before copying,
+  revealing, or submitting a code.

--- a/tools/v1/individual/otp-detector/docs/fixtures.md
+++ b/tools/v1/individual/otp-detector/docs/fixtures.md
@@ -1,0 +1,106 @@
+# OTP Detector Fixtures
+
+Use synthetic senders, fake codes, and reserved domains only.
+
+## Six-Digit Login Code
+
+Input:
+
+```json
+{
+  "subject": "Your login verification code",
+  "from": "security@example.test",
+  "body": "Your verification code is 123456. It expires in 10 minutes."
+}
+```
+
+Expected:
+
+- Status: `otp`.
+- Candidate is masked in display, for example `123***`.
+- Signals include verification-code context and expiration window.
+
+## Alphanumeric MFA Code
+
+Input:
+
+```json
+{
+  "subject": "MFA passcode",
+  "from": "auth@example.test",
+  "body": "Use passcode A7K9Q2 to finish signing in."
+}
+```
+
+Expected:
+
+- Status: `otp` or high-confidence `possible_otp`.
+- Signals include MFA/passcode language and code shape.
+
+## Invoice False Positive
+
+Input:
+
+```json
+{
+  "subject": "Invoice 123456 is ready",
+  "from": "billing@example.test",
+  "body": "Invoice 123456 for 89.00 is attached. No login action is required."
+}
+```
+
+Expected:
+
+- Status: `not_otp` or `unknown`.
+- Warning mentions invoice or billing false-positive context.
+
+## Tracking Number
+
+Input:
+
+```json
+{
+  "subject": "Package tracking update",
+  "from": "shipments@example.test",
+  "body": "Tracking number 9400110200881234567890 is in transit."
+}
+```
+
+Expected:
+
+- Status: `not_otp`.
+- Long tracking number is not ranked as an OTP.
+
+## Mixed Order And Code
+
+Input:
+
+```json
+{
+  "subject": "Complete sign in for order review",
+  "from": "orders@example.test",
+  "body": "Order 654321 is pending. Your sign-in code is 778899."
+}
+```
+
+Expected:
+
+- Status: `otp`.
+- Candidate `778899` ranks above order number `654321`.
+
+## Empty Content
+
+Input:
+
+```json
+{
+  "subject": "",
+  "from": "unknown@example.test",
+  "body": ""
+}
+```
+
+Expected:
+
+- Status: `unknown`.
+- Warning: insufficient content.

--- a/tools/v1/individual/otp-detector/docs/test-plan.md
+++ b/tools/v1/individual/otp-detector/docs/test-plan.md
@@ -1,0 +1,60 @@
+# OTP Detector Test Plan
+
+## Goals
+
+- Verify OTP detection is conservative, explainable, and deterministic.
+- Guard against storing, forwarding, auto-filling, or submitting codes.
+- Confirm likely false positives are rejected or downgraded.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Six-digit login code
+   - Given a login email with "Your verification code is 123456".
+   - Expect `otp`, high confidence, masked display, and auth-context signal.
+
+2. Alphanumeric passcode
+   - Given an MFA email with a short uppercase alphanumeric code.
+   - Expect `otp` or `possible_otp` with the code-shape signal.
+
+3. Expiration window
+   - Given a code and "expires in 10 minutes".
+   - Expect an expiration signal and optional `expiresAt` when timestamp input
+     is supplied.
+
+4. False-positive invoice number
+   - Given an invoice email with numeric invoice and amount values.
+   - Expect `not_otp` or `unknown` with invoice/amount false-positive signals.
+
+5. Tracking number
+   - Given a delivery email with a long tracking number.
+   - Expect no high-confidence OTP candidate.
+
+6. Multiple code-like values
+   - Given an email with an order number and one verification code.
+   - Expect the verification code ranked above the order number.
+
+7. Empty content
+   - Given missing subject and body.
+   - Expect `unknown` with an insufficient-content warning.
+
+8. Determinism
+   - Given the same message twice.
+   - Expect identical status, confidence, candidate order, and warnings.
+
+## Manual Review Checklist
+
+- Confirm code values are masked by default in summary surfaces.
+- Confirm reveal/copy actions require explicit user interaction.
+- Confirm confidence and warnings are visible as text.
+- Confirm no code is stored, sent, auto-filled, or submitted.
+- Confirm fixtures do not include real OTPs, accounts, or sender identities.
+
+## Regression Expectations
+
+- Adding a new code-shape rule requires one positive fixture and one
+  false-positive fixture.
+- Adding locale-specific auth terms requires tests for matching and
+  non-matching contexts.
+- Any future inbox integration must preserve explicit user control before
+  copying, revealing, or submitting a code.

--- a/tools/v1/individual/otp-detector/specs.md
+++ b/tools/v1/individual/otp-detector/specs.md
@@ -1,41 +1,76 @@
 # OTP Detector
 
-Detect OTP codes inside emails.
+Detect one-time passcode candidates in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/otp-detector/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/otp-detector/README.md"
-  @"
-
-# OTP Detector Specs
-
 ## Purpose
 
-Detect OTP codes inside emails.
+Help an individual user find verification codes in email while minimizing
+false positives and preventing unsafe code handling.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject, body, sender display/address, received time,
+  and optional locale.
+- Output: one OTP review model.
+- The review model should include:
+  - `status`
+  - `confidence`
+  - `candidates`
+  - `signals`
+  - `warnings`
+  - optional `expiresAt`
+- Each candidate should include the code value, masked display value, context
+  excerpt, and source field.
+- The detector must be deterministic for the same input.
+- If code-like values conflict with non-auth context, return `possible_otp` or
+  `not_otp` with a warning.
+- The detector must not persist, forward, auto-fill, submit, or copy codes
+  without explicit user action.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- Authentication terms such as verify, login, sign in, passcode, MFA, 2FA, OTP,
+  security code, or verification code.
+- Expiration windows such as "expires in 10 minutes".
+- Code shape such as 4-8 digits or short uppercase alphanumeric groups.
+- Sender or subject context supplied by the caller.
+- False-positive terms such as invoice, receipt, order, tracking, ticket,
+  phone, amount, date, or postal code.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- The code value should be masked by default in shared or list views.
+- Confidence and warning text must be visible as text, not color alone.
+- Users must be able to reveal or copy a code only through explicit action.
+- Context excerpts should be short and screen-reader reachable.
+
+## Security And Performance Expectations
+
+- Do not store OTP values outside the current review result.
+- Do not send OTP values to external services in baseline tests.
+- Do not auto-fill or submit a detected code.
+- Parsing must be bounded for long messages and multiple code-like values.
+- Fixtures must use synthetic senders and fake codes only.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
## Summary
- replaces generated placeholder text for the OTP Detector workspace
- documents the review contract, detection labels, UI/security expectations, and folder boundary
- adds synthetic fixtures and a regression-focused test plan for OTP and false-positive cases

Closes #383