### PR TITLE
docs: add important email pinning test documentation

### DIFF
--- a/tools/v1/individual/important-email-pinning/README.md
+++ b/tools/v1/individual/important-email-pinning/README.md
@@ -1,15 +1,36 @@
 # Important Email Pinning
 
-This folder is the isolated workspace for the Important Email Pinning tool.
+V1 individual tool workspace for marking critical emails as pinned within a
+reviewable local experience.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\important-email-pinning\
-`
+```text
+tools/v1/individual/important-email-pinning/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Let a user pin emails that need persistent attention.
+- Track pinned state, pin reason, created time, and optional expiry/reminder
+  metadata.
+- Keep pinned items visible without hiding unpinned messages.
+- Keep the tool advisory; it must not archive, delete, label, forward, or send
+  email automatically.
+
+## Pin States
+
+- `pinned`: visible in the pinned list and marked as important by the user.
+- `unpinned`: ordinary message with no persistent pin.
+- `expired`: pin is no longer active because an expiry time passed.
+- `unknown`: state cannot be determined from the provided data.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover manual pin/unpin,
+duplicate prevention, expiry, sort order, keyboard access, false-positive
+importance hints, empty input, and non-mutating behavior.

--- a/tools/v1/individual/important-email-pinning/REVIEW_NOTES.md
+++ b/tools/v1/individual/important-email-pinning/REVIEW_NOTES.md
@@ -1,0 +1,40 @@
+# Important Email Pinning Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/important-email-pinning/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, or shared design system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, pin states, and testing focus.
+- Replaced generated placeholder specs with a reviewable pinning contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic manual pin, duplicate pin, expired
+  pin, advisory urgent message, and empty-input cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: message id, state, reason, timestamps, expiry, duplicate prevention,
+  and deterministic sorting behavior are defined.
+- UI and accessibility: keyboard controls, visible state, stable layout, reason
+  editing, and expired-state text are documented.
+- Security and performance: no mailbox mutation, no external metadata
+  transmission, summary-only storage, and bounded list handling are documented.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Baseline pinning is local and advisory until a future integration issue
+  defines persistence.
+- Importance hints do not pin automatically.
+- Future inbox integration must preserve explicit user action before mailbox
+  mutation.

--- a/tools/v1/individual/important-email-pinning/docs/fixtures.md
+++ b/tools/v1/individual/important-email-pinning/docs/fixtures.md
@@ -1,0 +1,117 @@
+# Important Email Pinning Fixtures
+
+Use synthetic messages and senders only.
+
+## Manual Pin
+
+Input:
+
+```json
+{
+  "messages": [
+    {
+      "messageId": "msg-001",
+      "subject": "Contract review due Friday",
+      "from": "legal@example.test"
+    }
+  ],
+  "action": {
+    "type": "pin",
+    "messageId": "msg-001",
+    "reason": "Review before Friday"
+  }
+}
+```
+
+Expected:
+
+- One active `pinned` record for `msg-001`.
+- Reason is preserved.
+- No mailbox mutation.
+
+## Duplicate Pin
+
+Input:
+
+```json
+{
+  "pins": [
+    {
+      "messageId": "msg-002",
+      "state": "pinned",
+      "reason": "Travel check-in"
+    }
+  ],
+  "action": {
+    "type": "pin",
+    "messageId": "msg-002",
+    "reason": "Travel check-in"
+  }
+}
+```
+
+Expected:
+
+- Exactly one active pin remains for `msg-002`.
+- Duplicate action does not create another active record.
+
+## Expired Pin
+
+Input:
+
+```json
+{
+  "now": "2026-06-19T09:00:00Z",
+  "pins": [
+    {
+      "messageId": "msg-003",
+      "state": "pinned",
+      "reason": "Renewal deadline",
+      "expiresAt": "2026-06-18T09:00:00Z"
+    }
+  ]
+}
+```
+
+Expected:
+
+- Pin is marked `expired` or omitted from active view by explicit filter.
+- Expired state is visible as text.
+
+## Advisory Urgent Message
+
+Input:
+
+```json
+{
+  "messages": [
+    {
+      "messageId": "msg-004",
+      "subject": "URGENT: weekly digest",
+      "from": "newsletter@example.test"
+    }
+  ],
+  "action": null
+}
+```
+
+Expected:
+
+- No automatic pin is created.
+- Urgent-looking text remains advisory only.
+
+## Empty Input
+
+Input:
+
+```json
+{
+  "messages": [],
+  "pins": []
+}
+```
+
+Expected:
+
+- Empty pinned result.
+- No errors or placeholder pins.

--- a/tools/v1/individual/important-email-pinning/docs/test-plan.md
+++ b/tools/v1/individual/important-email-pinning/docs/test-plan.md
@@ -1,0 +1,58 @@
+# Important Email Pinning Test Plan
+
+## Goals
+
+- Verify pinning is explicit, reversible, and deterministic.
+- Guard against automatic archive, delete, label, send, or read-state changes.
+- Confirm duplicate and expired pins are handled predictably.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Manual pin
+   - Given an unpinned message and an explicit pin action.
+   - Expect one active `pinned` record with message id, reason, and timestamp.
+
+2. Manual unpin
+   - Given an active pin and an explicit unpin action.
+   - Expect the active pin removed or marked `unpinned` without mailbox mutation.
+
+3. Duplicate pin prevention
+   - Given the same message pinned twice.
+   - Expect one active record with stable state, not two duplicate entries.
+
+4. Expired pin
+   - Given a pin with `expiresAt` before the current time.
+   - Expect `expired` state or explicit filtering in the active pinned view.
+
+5. Sort order
+   - Given multiple pins with different creation and expiry times.
+   - Expect deterministic ordering by active state, expiry urgency, and created
+     time.
+
+6. Advisory importance hint
+   - Given a message that looks urgent but has no user pin action.
+   - Expect no automatic pin.
+
+7. Empty input
+   - Given no messages or pin records.
+   - Expect an empty pinned result without errors.
+
+8. Accessibility state
+   - Given a pinned message row.
+   - Expect text-visible state and keyboard-reachable unpin/edit controls.
+
+## Manual Review Checklist
+
+- Confirm pin/unpin controls have accessible names.
+- Confirm pinned state is not communicated by color alone.
+- Confirm toggling a pin does not move unrelated content unexpectedly.
+- Confirm no archive, delete, label, send, reply, or read-state mutation occurs.
+- Confirm fixtures do not include real message ids, senders, or personal data.
+
+## Regression Expectations
+
+- Adding a new sort criterion requires a deterministic multi-pin fixture.
+- Adding reminder or expiry behavior requires active and expired fixtures.
+- Any future inbox integration must preserve explicit user action before
+  mailbox mutation.

--- a/tools/v1/individual/important-email-pinning/specs.md
+++ b/tools/v1/individual/important-email-pinning/specs.md
@@ -1,41 +1,74 @@
 # Important Email Pinning
 
-Pin critical emails.
+Define important-email pinning behavior in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/important-email-pinning/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/important-email-pinning/README.md"
-  @"
-
-# Important Email Pinning Specs
-
 ## Purpose
 
-Pin critical emails.
+Help an individual user keep critical emails visible through explicit,
+reversible pinning while avoiding automatic mailbox mutation.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email summary objects and optional existing pin records.
+- Output: a pin review model plus updated in-memory pin records.
+- A pin record should include:
+  - `messageId`
+  - `state`
+  - `reason`
+  - `createdAt`
+  - optional `expiresAt`
+  - optional `source`
+- Pinning the same message twice must not create duplicate active records.
+- Expired pins should be visible as expired or filtered by an explicit view
+  option.
+- The tool must be deterministic for the same inputs and current time.
+- The tool must not archive, delete, label, forward, reply, send, or mark email
+  read without a future integration issue and explicit user action.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- User-selected pin action.
+- User-provided reason such as deadline, invoice, travel, legal, security, or
+  family.
+- Optional expiry or reminder time.
+- Message metadata used only for display and sorting.
+- Importance hints are advisory and must not pin automatically.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Pin and unpin controls must be keyboard reachable.
+- Pinned state must be visible as text or accessible label, not color alone.
+- Pinned lists should have stable sorting and no layout shift when toggling.
+- Users must be able to view, edit, or clear a pin reason.
+- Expired pins need a clear visual and text state.
+
+## Security And Performance Expectations
+
+- Do not mutate the mailbox in baseline tests.
+- Do not send pinned metadata to external services in baseline tests.
+- Do not store full message bodies when a summary is enough.
+- Sorting and duplicate detection must be bounded for large message lists.
+- Fixtures must use synthetic messages and senders only.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
## Summary
- replaces generated placeholder text for the Important Email Pinning workspace
- documents the pinning contract, states, UI/security expectations, and folder boundary
- adds synthetic fixtures and a regression-focused test plan for pin/unpin, duplicate, expiry, and non-mutating behavior

Closes #373