### PR TITLE
docs: add follow-up reminder test documentation

### DIFF
--- a/tools/v1/individual/follow-up-reminder/README.md
+++ b/tools/v1/individual/follow-up-reminder/README.md
@@ -1,15 +1,36 @@
 # Follow-up Reminder
 
-This folder is the isolated workspace for the Follow-up Reminder tool.
+V1 individual tool workspace for creating reviewable follow-up reminders from
+email content.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\follow-up-reminder\
-`
+```text
+tools/v1/individual/follow-up-reminder/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Inspect normalized email subject, body, sender, and received time.
+- Suggest follow-up reminder drafts from explicit requests and dates.
+- Let a user confirm, edit, snooze, complete, or dismiss a reminder.
+- Keep the tool advisory; it must not send email, create external calendar
+  events, change labels, or mark messages read automatically.
+
+## Reminder States
+
+- `draft`: suggested but not confirmed by the user.
+- `scheduled`: confirmed reminder with a due time.
+- `snoozed`: temporarily delayed by explicit user action.
+- `completed`: user marked the follow-up done.
+- `dismissed`: user rejected the reminder.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover explicit requests,
+relative dates, missing dates, snooze/complete/dismiss actions, duplicate
+prevention, empty content, accessibility, and non-mutating behavior.

--- a/tools/v1/individual/follow-up-reminder/REVIEW_NOTES.md
+++ b/tools/v1/individual/follow-up-reminder/REVIEW_NOTES.md
@@ -1,0 +1,41 @@
+# Follow-up Reminder Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/follow-up-reminder/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, calendar integrations, or shared design
+system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, reminder states, and testing focus.
+- Replaced generated placeholder specs with a reviewable reminder contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic explicit, relative-date, ambiguous,
+  duplicate, FYI false-positive, and empty-content cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: draft/scheduled/snoozed/completed/dismissed states, due time,
+  source message, duplicate prevention, warnings, and confidence are defined.
+- UI and accessibility: text-visible state, editable due time, keyboard
+  controls, and screen-reader-reachable warnings are documented.
+- Security and performance: no mailbox mutation, no external calendar events,
+  no automatic email sending, and bounded date parsing are documented.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Baseline reminder suggestions are local drafts until a future integration
+  issue defines persistence.
+- Natural-language date support is intentionally scoped to testable examples.
+- Future inbox or calendar integration must preserve explicit user action
+  before external side effects.

--- a/tools/v1/individual/follow-up-reminder/docs/fixtures.md
+++ b/tools/v1/individual/follow-up-reminder/docs/fixtures.md
@@ -1,0 +1,123 @@
+# Follow-up Reminder Fixtures
+
+Use synthetic senders, message ids, and dates only.
+
+## Explicit Follow-up Request
+
+Input:
+
+```json
+{
+  "messageId": "msg-101",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "timezone": "UTC",
+  "subject": "Contract notes",
+  "from": "legal@example.test",
+  "body": "Please follow up with comments by Friday at 17:00."
+}
+```
+
+Expected:
+
+- State: `draft`.
+- Signals include follow-up request and due time.
+- No email, calendar, label, read-state, archive, or delete mutation.
+
+## Relative Date
+
+Input:
+
+```json
+{
+  "messageId": "msg-102",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "timezone": "UTC",
+  "subject": "Check back",
+  "from": "ops@example.test",
+  "body": "Can you remind me to check back tomorrow morning?"
+}
+```
+
+Expected:
+
+- State: `draft`.
+- Due time is resolved relative to the received time and timezone.
+
+## Ambiguous Date
+
+Input:
+
+```json
+{
+  "messageId": "msg-103",
+  "subject": "Need this soon",
+  "from": "teammate@example.test",
+  "body": "Please follow up soon when you have time."
+}
+```
+
+Expected:
+
+- State: `draft` or no scheduled reminder.
+- Warning mentions ambiguous due time.
+
+## Duplicate Existing Reminder
+
+Input:
+
+```json
+{
+  "messageId": "msg-104",
+  "existingReminders": [
+    {
+      "sourceMessageId": "msg-104",
+      "state": "scheduled",
+      "dueAt": "2026-06-20T09:00:00Z"
+    }
+  ],
+  "action": {
+    "type": "schedule",
+    "dueAt": "2026-06-20T09:00:00Z"
+  }
+}
+```
+
+Expected:
+
+- No duplicate reminder is created.
+- Existing scheduled reminder remains stable.
+
+## FYI False Positive
+
+Input:
+
+```json
+{
+  "messageId": "msg-105",
+  "subject": "Weekly FYI digest",
+  "from": "digest@example.test",
+  "body": "FYI only. No response is needed."
+}
+```
+
+Expected:
+
+- No scheduled reminder.
+- FYI/no-action signal prevents high-confidence follow-up.
+
+## Empty Content
+
+Input:
+
+```json
+{
+  "messageId": "msg-empty",
+  "subject": "",
+  "body": ""
+}
+```
+
+Expected:
+
+- No reminder or warning-only result.
+- No errors.

--- a/tools/v1/individual/follow-up-reminder/docs/test-plan.md
+++ b/tools/v1/individual/follow-up-reminder/docs/test-plan.md
@@ -1,0 +1,58 @@
+# Follow-up Reminder Test Plan
+
+## Goals
+
+- Verify reminder suggestions are explainable, editable, and deterministic.
+- Guard against automatic mailbox, calendar, or email-sending side effects.
+- Confirm ambiguous dates stay as drafts with warnings.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Explicit follow-up request
+   - Given an email asking for a reply by Friday.
+   - Expect a `draft` reminder with title, due time, confidence, and signals.
+
+2. Relative date
+   - Given received time, timezone, and "follow up tomorrow".
+   - Expect deterministic `dueAt` resolution.
+
+3. Ambiguous date
+   - Given "follow up soon" without a concrete date.
+   - Expect `draft` with an ambiguous-date warning.
+
+4. Duplicate prevention
+   - Given an existing reminder for the same message and due time.
+   - Expect no duplicate scheduled reminder.
+
+5. Snooze action
+   - Given a scheduled reminder and explicit snooze action.
+   - Expect `snoozed` state and updated due time.
+
+6. Complete action
+   - Given a scheduled reminder and explicit complete action.
+   - Expect `completed` state without mailbox mutation.
+
+7. FYI false positive
+   - Given an FYI-only newsletter or receipt.
+   - Expect no scheduled reminder and low-confidence or no draft.
+
+8. Empty content
+   - Given missing subject and body.
+   - Expect no reminder or an `unknown`/warning state without errors.
+
+## Manual Review Checklist
+
+- Confirm controls have accessible names.
+- Confirm date warnings are visible as text.
+- Confirm reminder title and due time can be edited before scheduling.
+- Confirm no email is sent and no external calendar item is created.
+- Confirm fixtures do not include real senders, message ids, or dates.
+
+## Regression Expectations
+
+- Adding a date parser rule requires one positive fixture and one ambiguous or
+  false-positive fixture.
+- Adding a new reminder action requires state-transition coverage.
+- Any future inbox or calendar integration must preserve explicit user action
+  before external side effects.

--- a/tools/v1/individual/follow-up-reminder/specs.md
+++ b/tools/v1/individual/follow-up-reminder/specs.md
@@ -1,41 +1,78 @@
 # Follow-up Reminder
 
-Create reminders from emails.
+Create reviewable reminder drafts from emails in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/follow-up-reminder/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/follow-up-reminder/README.md"
-  @"
-
-# Follow-up Reminder Specs
-
 ## Purpose
 
-Create reminders from emails.
+Help an individual user remember email follow-ups while keeping reminder
+creation explicit, editable, and reversible.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject, body, sender display/address, received time,
+  and optional timezone.
+- Output: one reminder review model.
+- The review model should include:
+  - `state`
+  - `confidence`
+  - `title`
+  - `dueAt`
+  - `sourceMessageId`
+  - `signals`
+  - `warnings`
+- Suggested reminders start as `draft` until the user confirms them.
+- If a due date is ambiguous, return a draft with a warning instead of a
+  scheduled reminder.
+- Duplicate reminders for the same message and due date must be avoided.
+- The tool must not send email, create external calendar events, change labels,
+  mark messages read, archive, or delete messages.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- Explicit request terms such as follow up, remind me, check back, reply by,
+  due, deadline, or waiting on response.
+- Absolute dates and times.
+- Relative dates such as tomorrow, next week, or in two days, resolved with the
+  caller-provided timezone.
+- Sender and thread hints supplied by the caller.
+- Low-confidence contexts such as newsletters, receipts, FYI-only messages, or
+  no-action updates.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Reminder title, due time, and state must be visible as text.
+- Confirm, snooze, complete, edit, and dismiss controls must be keyboard
+  reachable.
+- Ambiguous date warnings must be screen-reader reachable.
+- Users must be able to edit the due time before scheduling.
+
+## Security And Performance Expectations
+
+- Do not mutate the mailbox in baseline tests.
+- Do not send reminder data to external services in baseline tests.
+- Do not create external calendar events or send replies automatically.
+- Date parsing must be bounded for long messages.
+- Fixtures must use synthetic senders, message ids, and dates only.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
## Summary
- replaces generated placeholder text for the Follow-up Reminder workspace
- documents the reminder contract, states, UI/security expectations, and folder boundary
- adds synthetic fixtures and a regression-focused test plan for follow-up, date, duplicate, and non-mutating behavior

Closes #363