### PR TITLE
docs: add calendar event extractor test documentation

### DIFF
--- a/tools/v1/individual/calendar-event-extractor/README.md
+++ b/tools/v1/individual/calendar-event-extractor/README.md
@@ -1,15 +1,36 @@
 # Calendar Event Extractor
 
-This folder is the isolated workspace for the Calendar Event Extractor tool.
+V1 individual tool workspace for extracting reviewable calendar event drafts
+from email content.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\calendar-event-extractor\
-`
+```text
+tools/v1/individual/calendar-event-extractor/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Intended Use
+
+- Inspect normalized subject, body, sender, received time, and optional timezone.
+- Extract candidate event title, start/end time, location, attendees, and notes.
+- Return an editable event draft that the user can confirm or dismiss.
+- Keep the extractor advisory; it must not create external calendar events,
+  send invites, RSVP, or mutate email automatically.
+
+## Event Draft States
+
+- `draft`: extracted event candidate waiting for user review.
+- `ready`: sufficient details exist and the user can confirm creation.
+- `ambiguous`: missing or conflicting time/location details need review.
+- `dismissed`: user rejected the event candidate.
+
+## Testing Focus
+
+Use `docs/test-plan.md` and `docs/fixtures.md` to cover absolute dates,
+relative dates, timezones, missing end times, location extraction, duplicate
+event prevention, FYI false positives, empty content, accessibility, and
+non-mutating behavior.

--- a/tools/v1/individual/calendar-event-extractor/REVIEW_NOTES.md
+++ b/tools/v1/individual/calendar-event-extractor/REVIEW_NOTES.md
@@ -1,0 +1,44 @@
+# Calendar Event Extractor Review Notes
+
+## Scope
+
+This documentation pass is limited to:
+
+```text
+tools/v1/individual/calendar-event-extractor/
+```
+
+It does not wire the tool into the main app, inbox architecture, Gmail, routing,
+database schema, wallet services, calendar integrations, or shared design
+system.
+
+## What Changed
+
+- Replaced generated placeholder README content with V1 individual ownership,
+  intended usage, event draft states, and testing focus.
+- Replaced generated placeholder specs with a reviewable event extraction
+  contract.
+- Added `docs/test-plan.md` with automated, manual, and regression coverage.
+- Added `docs/fixtures.md` with synthetic absolute-date, relative-date, missing
+  end time, conflict, duplicate, newsletter false-positive, and empty cases.
+
+## Acceptance Coverage
+
+- Architecture: folder boundary and non-integration constraints are explicit.
+- Feature: draft/ready/ambiguous/dismissed states, title, start/end time,
+  location, attendees, duplicate prevention, warnings, and confidence are
+  defined.
+- UI and accessibility: text-visible state, editable fields, keyboard controls,
+  ambiguity warnings, and long text handling are documented.
+- Security and performance: no mailbox mutation, no external calendar events,
+  no invites/RSVPs, no external transmission, and bounded parsing are
+  documented.
+- Testing and documentation: test plan and fixture catalog are included.
+
+## Known Limitations
+
+- Baseline extraction is local and advisory until a future integration issue
+  defines persistence.
+- Natural-language date support is intentionally scoped to testable examples.
+- Future calendar integration must preserve explicit user action before
+  external side effects.

--- a/tools/v1/individual/calendar-event-extractor/docs/fixtures.md
+++ b/tools/v1/individual/calendar-event-extractor/docs/fixtures.md
@@ -1,0 +1,135 @@
+# Calendar Event Extractor Fixtures
+
+Use synthetic senders, attendees, locations, and dates only.
+
+## Absolute Meeting
+
+Input:
+
+```json
+{
+  "messageId": "msg-201",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "timezone": "UTC",
+  "subject": "Planning meeting on June 22",
+  "from": "team@example.test",
+  "body": "Planning meeting: June 22, 2026 at 10:00 UTC in Room 4B."
+}
+```
+
+Expected:
+
+- State: `draft` or `ready`.
+- Title, `startAt`, location, and event-date signals are present.
+- No calendar, invite, RSVP, email, or mailbox mutation.
+
+## Relative Date
+
+Input:
+
+```json
+{
+  "messageId": "msg-202",
+  "receivedAt": "2026-06-19T09:00:00Z",
+  "timezone": "UTC",
+  "subject": "Demo tomorrow",
+  "from": "demo@example.test",
+  "body": "Let's do the product demo tomorrow at 10:00."
+}
+```
+
+Expected:
+
+- State: `draft`.
+- `startAt` resolves relative to received time and timezone.
+
+## Missing End Time
+
+Input:
+
+```json
+{
+  "messageId": "msg-203",
+  "subject": "Interview slot",
+  "from": "recruiting@example.test",
+  "body": "Your interview is July 1 at 14:00."
+}
+```
+
+Expected:
+
+- Event draft includes `startAt`.
+- Warning mentions missing end time or duration.
+
+## Conflicting Dates
+
+Input:
+
+```json
+{
+  "messageId": "msg-204",
+  "subject": "Call on Monday",
+  "body": "Actually, let's meet Tuesday at 09:00."
+}
+```
+
+Expected:
+
+- State: `ambiguous`.
+- Warning mentions conflicting date signals.
+
+## Duplicate Existing Draft
+
+Input:
+
+```json
+{
+  "messageId": "msg-205",
+  "existingDrafts": [
+    {
+      "sourceMessageId": "msg-205",
+      "startAt": "2026-06-22T10:00:00Z"
+    }
+  ],
+  "body": "Meeting June 22 at 10:00 UTC."
+}
+```
+
+Expected:
+
+- No duplicate event draft is created.
+
+## Newsletter False Positive
+
+Input:
+
+```json
+{
+  "messageId": "msg-206",
+  "subject": "This week's public events",
+  "from": "newsletter@example.test",
+  "body": "Public webinar listings for the week. No RSVP required."
+}
+```
+
+Expected:
+
+- No ready event.
+- Newsletter/FYI context lowers confidence.
+
+## Empty Content
+
+Input:
+
+```json
+{
+  "messageId": "msg-empty",
+  "subject": "",
+  "body": ""
+}
+```
+
+Expected:
+
+- No event draft or warning-only result.
+- No errors.

--- a/tools/v1/individual/calendar-event-extractor/docs/test-plan.md
+++ b/tools/v1/individual/calendar-event-extractor/docs/test-plan.md
@@ -1,0 +1,57 @@
+# Calendar Event Extractor Test Plan
+
+## Goals
+
+- Verify extracted event drafts are explainable, editable, and deterministic.
+- Guard against automatic mailbox, RSVP, invite, or calendar side effects.
+- Confirm ambiguous dates and duplicate events are handled predictably.
+- Keep all work inside the V1 individual tool folder.
+
+## Automated Cases
+
+1. Absolute date and time
+   - Given an email with a meeting date, time, and title.
+   - Expect `draft` or `ready` with title, `startAt`, confidence, and signals.
+
+2. Relative date with timezone
+   - Given received time, timezone, and "tomorrow at 10".
+   - Expect deterministic `startAt` resolution.
+
+3. Missing end time
+   - Given a start time but no end time.
+   - Expect draft with `endAt` omitted and a duration warning.
+
+4. Location extraction
+   - Given room or venue text.
+   - Expect the location field populated without altering the message.
+
+5. Duplicate event prevention
+   - Given an existing draft for the same message and start time.
+   - Expect no duplicate draft.
+
+6. Conflicting date signals
+   - Given subject and body with different dates.
+   - Expect `ambiguous` with a conflict warning.
+
+7. FYI false positive
+   - Given a newsletter advertising an event without a personal action.
+   - Expect no ready event or a low-confidence draft.
+
+8. Empty content
+   - Given missing subject and body.
+   - Expect no draft or warning-only result without errors.
+
+## Manual Review Checklist
+
+- Confirm title, time, timezone, and state are text-visible.
+- Confirm edit, confirm, and dismiss controls have accessible names.
+- Confirm no external calendar entry, invite, RSVP, or email mutation occurs.
+- Confirm ambiguity warnings are visible before confirmation.
+- Confirm fixtures do not include real attendees, senders, locations, or dates.
+
+## Regression Expectations
+
+- Adding a new date rule requires a positive and ambiguous fixture.
+- Adding location parsing requires long-location and missing-location fixtures.
+- Any future calendar integration must preserve explicit user action before
+  external side effects.

--- a/tools/v1/individual/calendar-event-extractor/specs.md
+++ b/tools/v1/individual/calendar-event-extractor/specs.md
@@ -1,41 +1,78 @@
 # Calendar Event Extractor
 
-Create events from email content.
+Extract reviewable calendar event drafts in a V1 individual workspace.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V1
+- Audience: individual
+- Folder ownership: `tools/v1/individual/calendar-event-extractor/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/calendar-event-extractor/README.md"
-  @"
-
-# Calendar Event Extractor Specs
-
 ## Purpose
 
-Create events from email content.
+Help an individual user turn event-like email content into editable calendar
+drafts without creating external calendar entries automatically.
 
-## Contributor boundary
+## Functional Contract
 
-All work for this tool should stay in:
+- Input: normalized email subject, body, sender display/address, received time,
+  optional timezone, and optional existing event draft records.
+- Output: one event extraction review model.
+- The review model should include:
+  - `state`
+  - `confidence`
+  - `title`
+  - `startAt`
+  - optional `endAt`
+  - optional `location`
+  - optional `attendees`
+  - `signals`
+  - `warnings`
+- Extracted events start as drafts until the user confirms creation.
+- If date or time signals conflict, return `ambiguous` with warnings.
+- Duplicate event drafts for the same message and start time must be avoided.
+- The tool must not create external calendar events, send invites, RSVP, mark
+  messages read, archive, delete, label, reply, or forward email.
 
-$dir/
+## Signal Categories
 
-## Required issue categories
+- Event terms such as meeting, appointment, call, demo, interview, webinar,
+  deadline, or schedule.
+- Absolute dates and times.
+- Relative dates resolved with the caller-provided timezone.
+- Location hints such as address, room, video link label, or venue name.
+- Attendee hints from sender and body context.
+- False-positive contexts such as newsletters, receipts, historical summaries,
+  or event advertisements without a personal action.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI And Accessibility Expectations
+
+- Draft title, time, timezone, and state must be visible as text.
+- Edit, confirm, and dismiss controls must be keyboard reachable.
+- Ambiguity warnings must be screen-reader reachable.
+- Long locations or attendee lists must not break layout.
+
+## Security And Performance Expectations
+
+- Do not mutate the mailbox in baseline tests.
+- Do not create external calendar events or send invites in baseline tests.
+- Do not transmit event details to external services in baseline tests.
+- Date parsing must be bounded for long messages.
+- Fixtures must use synthetic senders, attendees, locations, and dates only.
+
+## Testing Expectations
+
+See:
+
+- `docs/test-plan.md`
+- `docs/fixtures.md`


### PR DESCRIPTION
## Summary
- replaces generated placeholder text for the Calendar Event Extractor workspace
- documents the event draft contract, states, UI/security expectations, and folder boundary
- adds synthetic fixtures and a regression-focused test plan for date, timezone, duplicate, ambiguity, and non-mutating behavior

Closes #333