### PR TITLE
OTP Module update implemented

### DIFF
--- a/src/features/otp/components/OTPCard.tsx
+++ b/src/features/otp/components/OTPCard.tsx
@@ -5,15 +5,27 @@ import "../styles.css";
 
 export function OTPCard({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
-  const digits = code.split("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const safeCode = (code ?? "").trim();
+  const digits = safeCode ? safeCode.split("") : [];
+  const isEmpty = digits.length === 0;
 
   const handleCopy = async () => {
+    if (!safeCode) return;
+
+    setError(false);
+    setLoading(true);
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard?.writeText(safeCode);
       setCopied(true);
       setTimeout(() => setCopied(false), 1600);
     } catch {
-      /* noop */
+      setError(true);
+      setCopied(false);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -48,10 +60,23 @@ export function OTPCard({ code }: { code: string }) {
         </div>
 
         <button
+          type="button"
           onClick={handleCopy}
+          disabled={isEmpty || loading}
           className="otp-copy-btn mt-5 flex h-10 w-full items-center justify-center gap-2 rounded-full text-[13px] font-semibold"
+
         >
-          {copied ? (
+          {loading ? (
+            <>
+              <span className="otp-copy-spinner inline-block h-4 w-4" aria-hidden="true" />
+              Copying…
+            </>
+          ) : error ? (
+            <>
+              <span className="otp-copy-error-dot inline-block h-2.5 w-2.5 rounded-full" aria-hidden="true" />
+              Copy failed
+            </>
+          ) : copied ? (
             <>
               <Check className="h-4 w-4" /> Copied
             </>
@@ -62,8 +87,18 @@ export function OTPCard({ code }: { code: string }) {
           )}
         </button>
 
-        <p className="mt-3 text-center text-[10.5px] text-muted-foreground/80">
-          Code auto-detected from message body
+        <p
+          className={
+            "mt-3 text-center text-[10.5px] " +
+            (error ? "otp-copy-error-text" : "text-muted-foreground/80")
+          }
+          aria-live="polite"
+        >
+          {error
+            ? "Couldn’t access your clipboard. Please copy manually."
+            : isEmpty
+              ? "No code found in this message."
+              : "Code auto-detected from message body"}
         </p>
       </motion.div>
     </div>
@@ -137,3 +172,4 @@ function PadlockIcon() {
     </svg>
   );
 }
+

--- a/src/features/otp/detectOtp.ts
+++ b/src/features/otp/detectOtp.ts
@@ -5,17 +5,38 @@
 export function detectOtp(body: string): string | null {
   if (!body) return null;
 
-  const keyword =
-    /(?:otp|one[-\s]?time(?:\s+password)?|passkey|pass\s?code|verification(?:\s+code)?|security\s+code|code|pin)\b[^\d]{0,40}((?:\d[\s-]?){4,8})/i;
-  const match = body.match(keyword);
+  // Keep detection conservative to avoid false positives.
+  // We require explicit intent labels (OTP / passkey / verification / security code)
+  // instead of matching generic "code" / "pin" alone.
+  const contextOtp =
+    /(?:^|[\s\p{P}\p{S}])(?:otp|one[-\s]?time(?:\s+password)?|passkey|pass\s?code|verification(?:\s+code)?|security\s+code)(?:\b|\s)[^\d]{0,80}((?:\d[\s-]?){4,8})(?=$|[\s\p{P}\p{S}])/imu;
 
+  // Numeric value directly after the label.
+  const contextOnlyValue =
+    /(?:otp|one[-\s]?time(?:\s+password)?|passkey|pass\s?code|verification(?:\s+code)?|security\s+code)(?:\b|\s)[^\d]{0,30}(\d{4,8}(?:[\s-]\d{1,4})*)/imu;
+
+  const match = body.match(contextOtp) ?? body.match(contextOnlyValue);
   if (match) {
     const digits = match[1].replace(/\D/g, "");
     if (digits.length >= 4 && digits.length <= 8) return digits;
   }
 
+  // Fallback: common OTP emails often contain a 6-digit code on its own line.
+  // Keep it strict: only accept if there's an OTP-related hint near the line.
   const standalone = body.match(/(?:^|\n)\s*(\d{6})\s*(?:\n|$)/);
-  if (standalone) return standalone[1];
+  if (standalone) {
+    const line = standalone[0];
+    const idx = body.indexOf(line);
+    const window = body.slice(
+      Math.max(0, idx - 120),
+      Math.min(body.length, idx + line.length + 120),
+    );
+
+    if (/(otp|one[-\s]?time|passcode|verification|security\s+code|pass\s?code)/i.test(window)) {
+      return standalone[1];
+    }
+  }
 
   return null;
 }
+

--- a/src/features/otp/styles.css
+++ b/src/features/otp/styles.css
@@ -76,7 +76,8 @@
   transition:
     transform 180ms ease,
     box-shadow 180ms ease,
-    filter 180ms ease;
+    filter 180ms ease,
+    opacity 180ms ease;
 }
 
 .otp-copy-btn:hover {
@@ -88,3 +89,41 @@
   transform: translateY(0);
   filter: brightness(0.96);
 }
+
+.otp-copy-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px oklch(0.7 0.02 270 / 0.28),
+    inset 0 1px 0 oklch(1 0 0 / 0.7),
+    inset 0 -1px 0 oklch(0 0 0 / 0.2),
+    0 8px 20px oklch(0 0 0 / 0.45);
+}
+
+.otp-copy-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  filter: grayscale(20%);
+  transform: none;
+}
+
+.otp-copy-spinner {
+  border-radius: 9999px;
+  border: 2px solid oklch(0.16 0.005 270 / 0.2);
+  border-top-color: oklch(0.16 0.005 270 / 0.75);
+  animation: otpCopySpin 650ms linear infinite;
+}
+
+@keyframes otpCopySpin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.otp-copy-error-text {
+  color: oklch(0.75 0.18 25 / 0.9);
+}
+


### PR DESCRIPTION

Finished working
Implemented OTP surface polish (security-sensitive, no new module).

Changes:

src/features/otp/detectOtp.ts
Tightened OTP detection to require explicit intent context (OTP / passkey/verification/security code).
Kept conservative fallback: standalone 6-digit lines are only accepted when an OTP-related hint is nearby.
src/features/otp/components/OTPCard.tsx
Added explicit interaction states:
default: unchanged UX
loading: disables Copy and shows “Copying…” spinner
disabled: button disabled when empty or loading
error: shows “Copy failed” + helper copy line when clipboard access fails
empty: safe empty rendering + helper copy when code is missing
Copy button now uses type="button" and disables appropriately.
Added aria-live polite for status/help line.
src/features/otp/styles.css
Added Stealth-Mail-consistent surface states:
:focus-visible ring for keyboard users
: disabled styling
loading spinner animation
error text styling (tokenized via oklch)
Validation status:

ESLint couldn’t run in the current environment (“eslint is not recognized”).
npx tsc --noEmit is blocked by an interactive prompt to install tsc@2.0.4.
Note for PR screenshots/before-after:

Default/hover/active appearance is preserved.
New visible differences are: keyboard focus ring on the copy button, disabled styling during/loading and empty, and explicit error/loading helper text when clipboard access fails.

closes #986  