### PR TITLE
Feat/cal invite data editor

### DIFF
--- a/src/features/demo-admin-dashboard/.gitattributes
+++ b/src/features/demo-admin-dashboard/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for all files in this directory
+# This ensures prettier and ESLint pass on Linux CI runners
+* text eol=lf

--- a/src/features/demo-admin-dashboard/__tests__/CalendarEventEditor.test.tsx
+++ b/src/features/demo-admin-dashboard/__tests__/CalendarEventEditor.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  CalendarEventEditor,
+  prepareAttendees,
+  formatAttendeesDisplay,
+} from "../components/CalendarEventEditor";
+
+describe("CalendarEventEditor module", () => {
+  it("exports the CalendarEventEditor component", () => {
+    expect(CalendarEventEditor).toBeDefined();
+    expect(typeof CalendarEventEditor).toBe("function");
+  });
+
+  it("exports prepareAttendees helper", () => {
+    expect(prepareAttendees).toBeDefined();
+    expect(typeof prepareAttendees).toBe("function");
+  });
+
+  it("exports formatAttendeesDisplay helper", () => {
+    expect(formatAttendeesDisplay).toBeDefined();
+    expect(typeof formatAttendeesDisplay).toBe("function");
+  });
+});
+
+describe("prepareAttendees", () => {
+  it("returns an empty array for empty input", () => {
+    expect(prepareAttendees("")).toEqual([]);
+  });
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(prepareAttendees("   ")).toEqual([]);
+  });
+
+  it("parses a single attendee", () => {
+    expect(prepareAttendees("eve@stealth.xyz")).toEqual(["eve@stealth.xyz"]);
+  });
+
+  it("parses multiple comma-separated attendees", () => {
+    expect(prepareAttendees("eve@stealth.xyz, lina@vantage.studio")).toEqual([
+      "eve@stealth.xyz",
+      "lina@vantage.studio",
+    ]);
+  });
+
+  it("trims whitespace around attendees", () => {
+    expect(prepareAttendees("  eve@stealth.xyz  ,  lina@vantage.studio  ")).toEqual([
+      "eve@stealth.xyz",
+      "lina@vantage.studio",
+    ]);
+  });
+
+  it("filters out empty entries from trailing commas", () => {
+    expect(prepareAttendees("eve@stealth.xyz, ")).toEqual(["eve@stealth.xyz"]);
+  });
+});
+
+describe("formatAttendeesDisplay", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatAttendeesDisplay([])).toBe("");
+  });
+
+  it("returns a single attendee unchanged", () => {
+    expect(formatAttendeesDisplay(["eve@stealth.xyz"])).toBe("eve@stealth.xyz");
+  });
+
+  it("joins multiple attendees with comma and space", () => {
+    expect(formatAttendeesDisplay(["eve@stealth.xyz", "lina@vantage.studio"])).toBe(
+      "eve@stealth.xyz, lina@vantage.studio",
+    );
+  });
+
+  it("round-trips with prepareAttendees", () => {
+    const input = "eve@stealth.xyz, lina@vantage.studio";
+    const parsed = prepareAttendees(input);
+    const formatted = formatAttendeesDisplay(parsed);
+    expect(prepareAttendees(formatted)).toEqual(parsed);
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/calendarEventHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/calendarEventHelpers.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  calendarEventToEditorState,
+  editorStateToCalendarEvent,
+  getResponseStateOption,
+  CALENDAR_RESPONSE_STATES,
+  CALENDAR_RESPONSE_STATE_OPTIONS,
+  DEFAULT_RESPONSE_STATE,
+} from "../types/calendarEvent";
+import type { DemoCalendarEvent } from "../types/dataset";
+
+describe("calendarEventToEditorState", () => {
+  it("converts a DemoCalendarEvent to editor state", () => {
+    const event: DemoCalendarEvent = {
+      id: "evt-test",
+      title: "Test Event",
+      startTime: "2026-06-23T09:00",
+      endTime: "2026-06-23T10:00",
+      location: "Room 1",
+      attendees: ["eve@stealth.xyz"],
+    };
+
+    const state = calendarEventToEditorState(event);
+    expect(state.id).toBe("evt-test");
+    expect(state.title).toBe("Test Event");
+    expect(state.startTime).toBe("2026-06-23T09:00");
+    expect(state.endTime).toBe("2026-06-23T10:00");
+    expect(state.location).toBe("Room 1");
+    expect(state.attendees).toEqual(["eve@stealth.xyz"]);
+    expect(state.responseState).toBe("needsAction");
+  });
+
+  it("handles missing location", () => {
+    const event: DemoCalendarEvent = {
+      id: "evt-no-loc",
+      title: "No Location",
+      startTime: "2026-06-23T09:00",
+      endTime: "2026-06-23T10:00",
+      attendees: [],
+    };
+
+    const state = calendarEventToEditorState(event);
+    expect(state.location).toBe("");
+  });
+
+  it("copies attendees array (does not share reference)", () => {
+    const attendees = ["eve@stealth.xyz"];
+    const event: DemoCalendarEvent = {
+      id: "evt-ref",
+      title: "Ref Test",
+      startTime: "2026-06-23T09:00",
+      endTime: "2026-06-23T10:00",
+      attendees,
+    };
+
+    const state = calendarEventToEditorState(event);
+    state.attendees.push("lina@vantage.studio");
+    expect(event.attendees).toHaveLength(1);
+    expect(state.attendees).toHaveLength(2);
+  });
+});
+
+describe("editorStateToCalendarEvent", () => {
+  it("converts editor state back to DemoCalendarEvent", () => {
+    const state = {
+      id: "evt-roundtrip",
+      title: "Roundtrip Event",
+      startTime: "2026-06-23T09:00",
+      endTime: "2026-06-23T10:00",
+      location: "Room 2",
+      attendees: ["eve@stealth.xyz"],
+      responseState: "accepted" as const,
+    };
+
+    const event = editorStateToCalendarEvent(state);
+    expect(event.id).toBe("evt-roundtrip");
+    expect(event.title).toBe("Roundtrip Event");
+    expect(event.startTime).toBe("2026-06-23T09:00");
+    expect(event.endTime).toBe("2026-06-23T10:00");
+    expect(event.location).toBe("Room 2");
+    expect(event.attendees).toEqual(["eve@stealth.xyz"]);
+  });
+
+  it("strips empty location to undefined", () => {
+    const state = {
+      id: "evt-no-loc",
+      title: "No Location",
+      startTime: "2026-06-23T09:00",
+      endTime: "2026-06-23T10:00",
+      location: "",
+      attendees: [],
+      responseState: "needsAction" as const,
+    };
+
+    const event = editorStateToCalendarEvent(state);
+    expect(event.location).toBeUndefined();
+  });
+
+  it("round-trips with calendarEventToEditorState", () => {
+    const original: DemoCalendarEvent = {
+      id: "evt-rt",
+      title: "Round Trip",
+      startTime: "2026-06-23T14:00",
+      endTime: "2026-06-23T15:00",
+      location: "Virtual",
+      attendees: ["alice@example.com", "bob@example.org"],
+    };
+
+    const editorState = calendarEventToEditorState(original);
+    const restored = editorStateToCalendarEvent(editorState);
+
+    expect(restored.id).toBe(original.id);
+    expect(restored.title).toBe(original.title);
+    expect(restored.startTime).toBe(original.startTime);
+    expect(restored.endTime).toBe(original.endTime);
+    expect(restored.location).toBe(original.location);
+    expect(restored.attendees).toEqual(original.attendees);
+  });
+});
+
+describe("CalendarResponseState constants", () => {
+  it("defines all response states", () => {
+    expect(CALENDAR_RESPONSE_STATES).toEqual([
+      "needsAction",
+      "accepted",
+      "declined",
+      "tentative",
+    ]);
+  });
+
+  it("has options for every state", () => {
+    for (const state of CALENDAR_RESPONSE_STATES) {
+      expect(CALENDAR_RESPONSE_STATE_OPTIONS[state]).toBeDefined();
+      expect(CALENDAR_RESPONSE_STATE_OPTIONS[state].state).toBe(state);
+    }
+  });
+
+  it("default response state is needsAction", () => {
+    expect(DEFAULT_RESPONSE_STATE).toBe("needsAction");
+  });
+
+  it("getResponseStateOption returns the correct option", () => {
+    const opt = getResponseStateOption("accepted");
+    expect(opt.label).toBe("Accepted");
+    expect(opt.description).toBe("The recipient accepted the invitation.");
+  });
+});
+
+describe("calendarEventFixtures", () => {
+  it("exports deterministic fixtures", async () => {
+    const { calendarEventFixtures } = await import("../fixtures/calendarEventFixtures");
+    expect(calendarEventFixtures.length).toBeGreaterThan(0);
+    for (const evt of calendarEventFixtures) {
+      expect(evt.id).toBeTruthy();
+      expect(evt.title).toBeTruthy();
+      expect(evt.startTime).toBeTruthy();
+      expect(evt.endTime).toBeTruthy();
+    }
+  });
+
+  it("exports defaultCalendarEvent", async () => {
+    const { defaultCalendarEvent } = await import("../fixtures/calendarEventFixtures");
+    expect(defaultCalendarEvent.id).toBe("evt-new");
+    expect(defaultCalendarEvent.title).toBe("");
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/calendarEventHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/calendarEventHelpers.test.ts
@@ -120,12 +120,7 @@ describe("editorStateToCalendarEvent", () => {
 
 describe("CalendarResponseState constants", () => {
   it("defines all response states", () => {
-    expect(CALENDAR_RESPONSE_STATES).toEqual([
-      "needsAction",
-      "accepted",
-      "declined",
-      "tentative",
-    ]);
+    expect(CALENDAR_RESPONSE_STATES).toEqual(["needsAction", "accepted", "declined", "tentative"]);
   });
 
   it("has options for every state", () => {

--- a/src/features/demo-admin-dashboard/__tests__/calendarEventValidation.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/calendarEventValidation.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { validateCalendarEventEditor } from "../calendarEventValidation";
+import type { CalendarEventEditorState } from "../types/calendarEvent";
+
+const validState: CalendarEventEditorState = {
+  id: "evt-test",
+  title: "Team Standup",
+  startTime: "2026-06-23T09:00",
+  endTime: "2026-06-23T09:30",
+  location: "Room 101",
+  attendees: ["eve@stealth.xyz"],
+  responseState: "needsAction",
+};
+
+describe("validateCalendarEventEditor", () => {
+  it("returns no errors for a valid event", () => {
+    const issues = validateCalendarEventEditor(validState);
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("returns an error when title is empty", () => {
+    const issues = validateCalendarEventEditor({ ...validState, title: "" });
+    const titleIssues = issues.filter((i) => i.fieldPath === "title");
+    expect(titleIssues.length).toBeGreaterThan(0);
+    expect(titleIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when title is whitespace only", () => {
+    const issues = validateCalendarEventEditor({ ...validState, title: "   " });
+    const titleIssues = issues.filter((i) => i.fieldPath === "title");
+    expect(titleIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns an error when startTime is empty", () => {
+    const issues = validateCalendarEventEditor({ ...validState, startTime: "" });
+    const startIssues = issues.filter((i) => i.fieldPath === "startTime");
+    expect(startIssues.length).toBeGreaterThan(0);
+    expect(startIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when endTime is empty", () => {
+    const issues = validateCalendarEventEditor({ ...validState, endTime: "" });
+    const endIssues = issues.filter((i) => i.fieldPath === "endTime");
+    expect(endIssues.length).toBeGreaterThan(0);
+    expect(endIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when startTime is invalid", () => {
+    const issues = validateCalendarEventEditor({ ...validState, startTime: "not-a-date" });
+    const startIssues = issues.filter((i) => i.fieldPath === "startTime");
+    expect(startIssues.length).toBeGreaterThan(0);
+    expect(startIssues[0].severity).toBe("error");
+  });
+
+  it("returns an error when endTime is invalid", () => {
+    const issues = validateCalendarEventEditor({ ...validState, endTime: "not-a-date" });
+    const endIssues = issues.filter((i) => i.fieldPath === "endTime");
+    expect(endIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns an error when endTime is before startTime", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      startTime: "2026-06-23T10:00",
+      endTime: "2026-06-23T09:00",
+    });
+    const endIssues = issues.filter((i) => i.fieldPath === "endTime" && i.message.includes("after"));
+    expect(endIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns an error for invalid attendee address", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["invalid-address"],
+    });
+    const formatIssues = issues.filter((i) => i.message.includes("is not a valid"));
+    expect(formatIssues.length).toBeGreaterThan(0);
+  });
+
+  it("returns a warning for unsafe attendee domain", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["user@unknown-domain.com"],
+    });
+    const domainIssues = issues.filter((i) => i.severity === "warning");
+    expect(domainIssues.length).toBeGreaterThan(0);
+  });
+
+  it("passes for federated attendee addresses with *", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["eve*stealth.demo"],
+    });
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("passes for example.com attendee addresses", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["alice@example.com"],
+    });
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("passes for example.org attendee addresses", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["bob@example.org"],
+    });
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("passes for subdomain stealth.demo attendee addresses", () => {
+    const issues = validateCalendarEventEditor({
+      ...validState,
+      attendees: ["user@relay.stealth.demo"],
+    });
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("sets the correct datasetId", () => {
+    const issues = validateCalendarEventEditor({ ...validState, title: "" });
+    for (const issue of issues) {
+      expect(issue.datasetId).toBe("calendar-event-editor");
+    }
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/calendarEventValidation.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/calendarEventValidation.test.ts
@@ -65,7 +65,9 @@ describe("validateCalendarEventEditor", () => {
       startTime: "2026-06-23T10:00",
       endTime: "2026-06-23T09:00",
     });
-    const endIssues = issues.filter((i) => i.fieldPath === "endTime" && i.message.includes("after"));
+    const endIssues = issues.filter(
+      (i) => i.fieldPath === "endTime" && i.message.includes("after"),
+    );
     expect(endIssues.length).toBeGreaterThan(0);
   });
 

--- a/src/features/demo-admin-dashboard/calendarEventValidation.ts
+++ b/src/features/demo-admin-dashboard/calendarEventValidation.ts
@@ -3,9 +3,7 @@ import type { CalendarEventEditorState } from "./types/calendarEvent";
 
 const SAFE_DOMAIN_PATTERN = /(@example\.(com|org)|@([\w.-]+)?\.stealth\.demo)$/i;
 
-export function validateCalendarEventEditor(
-  state: CalendarEventEditorState,
-): ValidationIssue[] {
+export function validateCalendarEventEditor(state: CalendarEventEditorState): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const datasetId = "calendar-event-editor";
 

--- a/src/features/demo-admin-dashboard/calendarEventValidation.ts
+++ b/src/features/demo-admin-dashboard/calendarEventValidation.ts
@@ -1,0 +1,110 @@
+import type { ValidationIssue } from "./validation-types";
+import type { CalendarEventEditorState } from "./types/calendarEvent";
+
+const SAFE_DOMAIN_PATTERN = /(@example\.(com|org)|@([\w.-]+)?\.stealth\.demo)$/i;
+
+export function validateCalendarEventEditor(
+  state: CalendarEventEditorState,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const datasetId = "calendar-event-editor";
+
+  if (!state.title.trim()) {
+    issues.push({
+      id: "event-title-empty",
+      severity: "error",
+      fieldPath: "title",
+      message: "Event title is required.",
+      datasetId,
+      hint: "Enter a title for the calendar event.",
+    });
+  }
+
+  if (!state.startTime.trim()) {
+    issues.push({
+      id: "event-start-time-empty",
+      severity: "error",
+      fieldPath: "startTime",
+      message: "Start time is required.",
+      datasetId,
+      hint: "Pick a start date and time.",
+    });
+  }
+
+  if (!state.endTime.trim()) {
+    issues.push({
+      id: "event-end-time-empty",
+      severity: "error",
+      fieldPath: "endTime",
+      message: "End time is required.",
+      datasetId,
+      hint: "Pick an end date and time.",
+    });
+  }
+
+  if (state.startTime.trim() && state.endTime.trim()) {
+    const start = new Date(state.startTime);
+    const end = new Date(state.endTime);
+    if (isNaN(start.getTime())) {
+      issues.push({
+        id: "event-start-time-invalid",
+        severity: "error",
+        fieldPath: "startTime",
+        message: "Start time is not a valid date.",
+        datasetId,
+        hint: "Enter a date in yyyy-MM-ddTHH:mm format.",
+      });
+    }
+    if (isNaN(end.getTime())) {
+      issues.push({
+        id: "event-end-time-invalid",
+        severity: "error",
+        fieldPath: "endTime",
+        message: "End time is not a valid date.",
+        datasetId,
+        hint: "Enter a date in yyyy-MM-ddTHH:mm format.",
+      });
+    }
+    if (!isNaN(start.getTime()) && !isNaN(end.getTime()) && end <= start) {
+      issues.push({
+        id: "event-end-before-start",
+        severity: "error",
+        fieldPath: "endTime",
+        message: "End time must be after start time.",
+        datasetId,
+        hint: "Choose an end time that is later than the start time.",
+      });
+    }
+  }
+
+  if (state.attendees.length > 0) {
+    state.attendees.forEach((attendee, idx) => {
+      const normalized = attendee.replace("*", "@");
+      const hasAt = normalized.includes("@");
+      if (!hasAt) {
+        issues.push({
+          id: `event-attendee-${idx}-invalid`,
+          severity: "error",
+          fieldPath: `attendees[${idx}]`,
+          message: `Attendee "${attendee}" is not a valid email or federated address.`,
+          datasetId,
+          hint: "Use format like user@example.com or user*federation.",
+        });
+        return;
+      }
+      const isSafe = SAFE_DOMAIN_PATTERN.test(normalized);
+      if (!isSafe) {
+        issues.push({
+          id: `event-attendee-${idx}-unsafe-domain`,
+          severity: "warning",
+          fieldPath: `attendees[${idx}]`,
+          message: `Attendee "${attendee}" uses an external or unverified domain for demo data.`,
+          datasetId,
+          hint: "Stick to example.com, example.org, or *.stealth.demo.",
+        });
+      }
+    });
+  }
+
+  return issues;
+}

--- a/src/features/demo-admin-dashboard/components/CalendarEventEditor.tsx
+++ b/src/features/demo-admin-dashboard/components/CalendarEventEditor.tsx
@@ -1,11 +1,8 @@
 import { useMemo, useState } from "react";
-import { Calendar, X, Plus } from "lucide-react";
+import { Calendar, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CalendarEventEditorState, CalendarResponseState } from "../types/calendarEvent";
-import {
-  CALENDAR_RESPONSE_STATES,
-  getResponseStateOption,
-} from "../types/calendarEvent";
+import { CALENDAR_RESPONSE_STATES, getResponseStateOption } from "../types/calendarEvent";
 import { validateCalendarEventEditor } from "../calendarEventValidation";
 import { ValidationResultsPanel } from "../ValidationResultsPanel";
 import type { ValidationIssue } from "../validation-types";

--- a/src/features/demo-admin-dashboard/components/CalendarEventEditor.tsx
+++ b/src/features/demo-admin-dashboard/components/CalendarEventEditor.tsx
@@ -1,0 +1,258 @@
+import { useMemo, useState } from "react";
+import { Calendar, X, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CalendarEventEditorState, CalendarResponseState } from "../types/calendarEvent";
+import {
+  CALENDAR_RESPONSE_STATES,
+  getResponseStateOption,
+} from "../types/calendarEvent";
+import { validateCalendarEventEditor } from "../calendarEventValidation";
+import { ValidationResultsPanel } from "../ValidationResultsPanel";
+import type { ValidationIssue } from "../validation-types";
+
+export interface CalendarEventEditorProps {
+  state: CalendarEventEditorState;
+  onChange: (state: CalendarEventEditorState) => void;
+  onSave?: () => void;
+  onCancel?: () => void;
+  className?: string;
+}
+
+export function prepareAttendees(input: string): string[] {
+  return input
+    .split(",")
+    .map((a) => a.trim())
+    .filter((a) => a.length > 0);
+}
+
+export function formatAttendeesDisplay(attendees: string[]): string {
+  return attendees.join(", ");
+}
+
+export function CalendarEventEditor({
+  state,
+  onChange,
+  onSave,
+  onCancel,
+  className,
+}: CalendarEventEditorProps) {
+  const [attendeesInput, setAttendeesInput] = useState(() =>
+    formatAttendeesDisplay(state.attendees),
+  );
+
+  const issues = useMemo(() => validateCalendarEventEditor(state), [state]);
+  const hasErrors = issues.some((i) => i.severity === "error");
+
+  const fieldIssues = (field: string): ValidationIssue[] =>
+    issues.filter((i) => i.fieldPath === field || i.fieldPath.startsWith(`${field}[`));
+
+  const titleIssues = fieldIssues("title");
+  const startTimeIssues = fieldIssues("startTime");
+  const endTimeIssues = fieldIssues("endTime");
+  const attendeeIssues = issues.filter(
+    (i) => i.fieldPath.startsWith("attendees[") || i.fieldPath === "attendees",
+  );
+
+  const handleAttendeesChange = (value: string) => {
+    setAttendeesInput(value);
+    onChange({ ...state, attendees: prepareAttendees(value) });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && onSave && !hasErrors) {
+      e.preventDefault();
+      onSave();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/[0.08] bg-white/[0.02] p-5 space-y-4",
+        className,
+      )}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
+          <h4 className="text-sm font-semibold text-foreground">Edit Calendar Event</h4>
+        </div>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Cancel editing"
+            className="rounded-md p-1 text-muted-foreground hover:bg-white/[0.04] hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="cal-title" className="text-xs font-medium text-muted-foreground">
+          Event Title *
+        </label>
+        <input
+          id="cal-title"
+          type="text"
+          value={state.title}
+          onChange={(e) => onChange({ ...state, title: e.target.value })}
+          placeholder="e.g. Design Review"
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40",
+            titleIssues.length > 0
+              ? "border-red-500/50 focus:border-red-400"
+              : "border-white/[0.08] focus:border-white/20",
+          )}
+          required
+        />
+        {titleIssues.length > 0 && (
+          <p className="text-xs font-medium text-rose-400">{titleIssues[0].message}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <label htmlFor="cal-start" className="text-xs font-medium text-muted-foreground">
+            Start Date & Time *
+          </label>
+          <input
+            id="cal-start"
+            type="datetime-local"
+            value={state.startTime}
+            onChange={(e) => onChange({ ...state, startTime: e.target.value })}
+            className={cn(
+              "w-full rounded-lg border px-3 py-2 text-xs text-foreground focus:outline-none bg-black/40",
+              startTimeIssues.length > 0
+                ? "border-red-500/50 focus:border-red-400"
+                : "border-white/[0.08] focus:border-white/20",
+            )}
+            required
+          />
+          {startTimeIssues.length > 0 && (
+            <p className="text-xs font-medium text-rose-400">{startTimeIssues[0].message}</p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="cal-end" className="text-xs font-medium text-muted-foreground">
+            End Date & Time *
+          </label>
+          <input
+            id="cal-end"
+            type="datetime-local"
+            value={state.endTime}
+            onChange={(e) => onChange({ ...state, endTime: e.target.value })}
+            className={cn(
+              "w-full rounded-lg border px-3 py-2 text-xs text-foreground focus:outline-none bg-black/40",
+              endTimeIssues.length > 0
+                ? "border-red-500/50 focus:border-red-400"
+                : "border-white/[0.08] focus:border-white/20",
+            )}
+            required
+          />
+          {endTimeIssues.length > 0 && (
+            <p className="text-xs font-medium text-rose-400">{endTimeIssues[0].message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="cal-location" className="text-xs font-medium text-muted-foreground">
+          Location
+        </label>
+        <input
+          id="cal-location"
+          type="text"
+          value={state.location}
+          onChange={(e) => onChange({ ...state, location: e.target.value })}
+          placeholder="e.g. Conference Room A"
+          className="w-full rounded-lg border border-white/[0.08] px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40 focus:border-white/20"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="cal-attendees" className="text-xs font-medium text-muted-foreground">
+          Attendees (comma-separated)
+        </label>
+        <input
+          id="cal-attendees"
+          type="text"
+          value={attendeesInput}
+          onChange={(e) => handleAttendeesChange(e.target.value)}
+          placeholder="e.g. eve@stealth.xyz, lina@vantage.studio"
+          className={cn(
+            "w-full rounded-lg border px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none bg-black/40",
+            attendeeIssues.length > 0
+              ? "border-red-500/50 focus:border-red-400"
+              : "border-white/[0.08] focus:border-white/20",
+          )}
+        />
+        {attendeeIssues.length > 0 && (
+          <p className="text-xs font-medium text-rose-400">{attendeeIssues[0].message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor="cal-response" className="text-xs font-medium text-muted-foreground">
+          Response State
+        </label>
+        <select
+          id="cal-response"
+          value={state.responseState}
+          onChange={(e) =>
+            onChange({ ...state, responseState: e.target.value as CalendarResponseState })
+          }
+          className="w-full rounded-lg border border-white/[0.08] px-3 py-2 text-xs text-foreground focus:outline-none bg-black/40 focus:border-white/20"
+        >
+          {CALENDAR_RESPONSE_STATES.map((rs) => {
+            const opt = getResponseStateOption(rs);
+            return (
+              <option key={rs} value={rs}>
+                {opt.label}
+              </option>
+            );
+          })}
+        </select>
+        <p className="text-[10px] text-muted-foreground">
+          {getResponseStateOption(state.responseState).description}
+        </p>
+      </div>
+
+      {issues.length > 0 && (
+        <ValidationResultsPanel issues={issues} title="Calendar event validation" />
+      )}
+
+      {(onSave || onCancel) && (
+        <div className="flex justify-end gap-3 pt-2">
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-lg border border-white/[0.08] bg-white/[0.01] px-4 py-2 text-xs font-medium text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+            >
+              Cancel
+            </button>
+          )}
+          {onSave && (
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={hasErrors}
+              className={cn(
+                "rounded-lg px-4 py-2 text-xs font-semibold transition",
+                hasErrors
+                  ? "cursor-not-allowed bg-white/[0.04] text-muted-foreground"
+                  : "bg-foreground text-background hover:opacity-90",
+              )}
+            >
+              Save
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/docs/CALENDAR_EVENT_EDITOR.md
+++ b/src/features/demo-admin-dashboard/docs/CALENDAR_EVENT_EDITOR.md
@@ -6,13 +6,13 @@ All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on
 
 ## Props
 
-| Prop       | Type                              | Default   | Description                                           |
-| ---------- | --------------------------------- | --------- | ----------------------------------------------------- |
-| `state`    | `CalendarEventEditorState`        | required  | The event being edited (controlled).                  |
-| `onChange` | `(state: CalendarEventEditorState) => void` | required  | Called whenever a field value changes.              |
-| `onSave`   | `() => void`                      | undefined | Called when the user clicks Save.                     |
-| `onCancel` | `() => void`                      | undefined | Called when the user clicks Cancel.                   |
-| `className`| `string`                          | undefined | Extra CSS classes for the root element.               |
+| Prop        | Type                                        | Default   | Description                             |
+| ----------- | ------------------------------------------- | --------- | --------------------------------------- |
+| `state`     | `CalendarEventEditorState`                  | required  | The event being edited (controlled).    |
+| `onChange`  | `(state: CalendarEventEditorState) => void` | required  | Called whenever a field value changes.  |
+| `onSave`    | `() => void`                                | undefined | Called when the user clicks Save.       |
+| `onCancel`  | `() => void`                                | undefined | Called when the user clicks Cancel.     |
+| `className` | `string`                                    | undefined | Extra CSS classes for the root element. |
 
 When switching between different events, the parent should use a React `key` prop on `<CalendarEventEditor>` to reset internal state:
 
@@ -26,14 +26,14 @@ Validation uses `validateCalendarEventEditor` from `calendarEventValidation.ts`.
 
 ### Rules enforced
 
-| Field       | Rule                                              | Severity |
-| ----------- | ------------------------------------------------- | -------- |
-| title       | Must be non-empty                                 | error    |
-| startTime   | Must be non-empty and parseable as a date         | error    |
-| endTime     | Must be non-empty and parseable as a date         | error    |
-| endTime     | Must be later than startTime                      | error    |
-| attendees   | Each entry must contain `@` or `*`                | error    |
-| attendees   | Domain must be a safe demo domain                 | warning  |
+| Field     | Rule                                      | Severity |
+| --------- | ----------------------------------------- | -------- |
+| title     | Must be non-empty                         | error    |
+| startTime | Must be non-empty and parseable as a date | error    |
+| endTime   | Must be non-empty and parseable as a date | error    |
+| endTime   | Must be later than startTime              | error    |
+| attendees | Each entry must contain `@` or `*`        | error    |
+| attendees | Domain must be a safe demo domain         | warning  |
 
 ### How it displays
 
@@ -44,12 +44,12 @@ Validation uses `validateCalendarEventEditor` from `calendarEventValidation.ts`.
 
 The `responseState` field represents the recipient's RSVP status. Options:
 
-| Value          | Label           | Description                                                  |
-| -------------- | --------------- | ------------------------------------------------------------ |
-| `needsAction`  | Needs action    | The recipient has not yet responded.                         |
-| `accepted`     | Accepted        | The recipient accepted the invitation.                       |
-| `declined`     | Declined        | The recipient declined the invitation.                       |
-| `tentative`    | Tentative       | The recipient tentatively accepted the invitation.           |
+| Value         | Label        | Description                                        |
+| ------------- | ------------ | -------------------------------------------------- |
+| `needsAction` | Needs action | The recipient has not yet responded.               |
+| `accepted`    | Accepted     | The recipient accepted the invitation.             |
+| `declined`    | Declined     | The recipient declined the invitation.             |
+| `tentative`   | Tentative    | The recipient tentatively accepted the invitation. |
 
 ## Exported helpers
 
@@ -71,7 +71,9 @@ These pure functions are exported from `components/CalendarEventEditor.tsx`:
 import { calendarEventToEditorState, editorStateToCalendarEvent } from "../types/calendarEvent";
 import type { DemoCalendarEvent } from "../types/dataset";
 
-const event: DemoCalendarEvent = { /* ... */ };
+const event: DemoCalendarEvent = {
+  /* ... */
+};
 const editorState = calendarEventToEditorState(event);
 // ... edit fields ...
 const updated: DemoCalendarEvent = editorStateToCalendarEvent(editorState);

--- a/src/features/demo-admin-dashboard/docs/CALENDAR_EVENT_EDITOR.md
+++ b/src/features/demo-admin-dashboard/docs/CALENDAR_EVENT_EDITOR.md
@@ -1,0 +1,86 @@
+# CalendarEventEditor
+
+A controlled form component for editing calendar invite cards attached to demo messages. Provides editable inputs for event title, start/end date-time, location, attendees, and response state, with live validation feedback.
+
+All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on deterministic demo data. Nothing here touches real mail flows, network calls, or data outside this folder.
+
+## Props
+
+| Prop       | Type                              | Default   | Description                                           |
+| ---------- | --------------------------------- | --------- | ----------------------------------------------------- |
+| `state`    | `CalendarEventEditorState`        | required  | The event being edited (controlled).                  |
+| `onChange` | `(state: CalendarEventEditorState) => void` | required  | Called whenever a field value changes.              |
+| `onSave`   | `() => void`                      | undefined | Called when the user clicks Save.                     |
+| `onCancel` | `() => void`                      | undefined | Called when the user clicks Cancel.                   |
+| `className`| `string`                          | undefined | Extra CSS classes for the root element.               |
+
+When switching between different events, the parent should use a React `key` prop on `<CalendarEventEditor>` to reset internal state:
+
+```tsx
+<CalendarEventEditor key={event.id} state={event} onChange={...} />
+```
+
+## Validation behavior
+
+Validation uses `validateCalendarEventEditor` from `calendarEventValidation.ts`.
+
+### Rules enforced
+
+| Field       | Rule                                              | Severity |
+| ----------- | ------------------------------------------------- | -------- |
+| title       | Must be non-empty                                 | error    |
+| startTime   | Must be non-empty and parseable as a date         | error    |
+| endTime     | Must be non-empty and parseable as a date         | error    |
+| endTime     | Must be later than startTime                      | error    |
+| attendees   | Each entry must contain `@` or `*`                | error    |
+| attendees   | Domain must be a safe demo domain                 | warning  |
+
+### How it displays
+
+- **Field-level:** invalid fields show a red border and an inline error message below the input (only the first error per field).
+- **Summary:** a `ValidationResultsPanel` below the form fields displays all issues grouped by severity.
+
+## Response State
+
+The `responseState` field represents the recipient's RSVP status. Options:
+
+| Value          | Label           | Description                                                  |
+| -------------- | --------------- | ------------------------------------------------------------ |
+| `needsAction`  | Needs action    | The recipient has not yet responded.                         |
+| `accepted`     | Accepted        | The recipient accepted the invitation.                       |
+| `declined`     | Declined        | The recipient declined the invitation.                       |
+| `tentative`    | Tentative       | The recipient tentatively accepted the invitation.           |
+
+## Exported helpers
+
+These pure functions are exported from `components/CalendarEventEditor.tsx`:
+
+- `prepareAttendees(input: string): string[]` — splits on comma, trims, filters empties.
+- `formatAttendeesDisplay(attendees: string[]): string` — joins with `", "`.
+
+## Types
+
+- `CalendarEventEditorState` — the controlled editor state shape.
+- `CalendarResponseState` — the RSVP response state union type.
+- `calendarEventToEditorState(event)` — converts a `DemoCalendarEvent` to editor state.
+- `editorStateToCalendarEvent(state)` — converts editor state back to `DemoCalendarEvent`.
+
+## Converting from / to DemoCalendarEvent
+
+```ts
+import { calendarEventToEditorState, editorStateToCalendarEvent } from "../types/calendarEvent";
+import type { DemoCalendarEvent } from "../types/dataset";
+
+const event: DemoCalendarEvent = { /* ... */ };
+const editorState = calendarEventToEditorState(event);
+// ... edit fields ...
+const updated: DemoCalendarEvent = editorStateToCalendarEvent(editorState);
+```
+
+## Fixtures
+
+```ts
+import { calendarEventFixtures, defaultCalendarEvent } from "../fixtures/calendarEventFixtures";
+```
+
+`calendarEventFixtures` provides five deterministic demo events. `defaultCalendarEvent` is a blank starter.

--- a/src/features/demo-admin-dashboard/fixtures/calendarEventFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/calendarEventFixtures.ts
@@ -1,0 +1,53 @@
+import type { DemoCalendarEvent } from "../types/dataset";
+
+export const calendarEventFixtures: DemoCalendarEvent[] = [
+  {
+    id: "evt-all-hands",
+    title: "Company All-Hands",
+    startTime: "2026-07-01T15:00",
+    endTime: "2026-07-01T16:30",
+    location: "Main Auditorium",
+    attendees: ["eve@stealth.xyz", "lina@vantage.studio"],
+  },
+  {
+    id: "evt-design-review",
+    title: "Design Review — Q3 Identity",
+    startTime: "2026-06-25T10:00",
+    endTime: "2026-06-25T11:00",
+    location: "Mission studio",
+    attendees: ["eve@stealth.xyz", "aria@studio.aria"],
+  },
+  {
+    id: "evt-protocol-workshop",
+    title: "Protocol Workshop — Relay Routing",
+    startTime: "2026-06-28T13:00",
+    endTime: "2026-06-28T15:00",
+    location: "Virtual / Zoom",
+    attendees: ["eve@stealth.xyz", "marcus@northwind.io", "nadia@atlas.dev"],
+  },
+  {
+    id: "evt-one-on-one",
+    title: "1:1 with Manager",
+    startTime: "2026-06-23T14:00",
+    endTime: "2026-06-23T14:30",
+    location: "Conference Room B",
+    attendees: ["eve@stealth.xyz"],
+  },
+  {
+    id: "evt-conference-call",
+    title: "Stealth Demo Roundtable",
+    startTime: "2026-07-09T15:00",
+    endTime: "2026-07-09T16:00",
+    location: "Demo room",
+    attendees: ["eve@stealth.xyz", "bob@stealth.demo"],
+  },
+];
+
+export const defaultCalendarEvent: DemoCalendarEvent = {
+  id: "evt-new",
+  title: "",
+  startTime: "",
+  endTime: "",
+  location: "",
+  attendees: [],
+};

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -337,3 +337,23 @@ export {
 export type { DemoFolder, MailboxGroup, FolderDefinition } from "./constants/folderTaxonomy";
 export { FolderTaxonomySelector } from "./components/FolderTaxonomySelector";
 export type { FolderTaxonomySelectorProps } from "./components/FolderTaxonomySelector";
+
+// Calendar Event Editor (issue #16): editor component, types, fixtures, validation.
+export { CalendarEventEditor } from "./components/CalendarEventEditor";
+export type { CalendarEventEditorProps } from "./components/CalendarEventEditor";
+export { prepareAttendees, formatAttendeesDisplay } from "./components/CalendarEventEditor";
+export type {
+  CalendarEventEditorState,
+  CalendarResponseState,
+  CalendarResponseStateOption,
+} from "./types/calendarEvent";
+export {
+  CALENDAR_RESPONSE_STATES,
+  CALENDAR_RESPONSE_STATE_OPTIONS,
+  DEFAULT_RESPONSE_STATE,
+  getResponseStateOption,
+  calendarEventToEditorState,
+  editorStateToCalendarEvent,
+} from "./types/calendarEvent";
+export { calendarEventFixtures, defaultCalendarEvent } from "./fixtures/calendarEventFixtures";
+export { validateCalendarEventEditor } from "./calendarEventValidation";

--- a/src/features/demo-admin-dashboard/types/calendarEvent.ts
+++ b/src/features/demo-admin-dashboard/types/calendarEvent.ts
@@ -15,7 +15,10 @@ export const CALENDAR_RESPONSE_STATES: CalendarResponseState[] = [
   "tentative",
 ];
 
-export const CALENDAR_RESPONSE_STATE_OPTIONS: Record<CalendarResponseState, CalendarResponseStateOption> = {
+export const CALENDAR_RESPONSE_STATE_OPTIONS: Record<
+  CalendarResponseState,
+  CalendarResponseStateOption
+> = {
   needsAction: {
     state: "needsAction",
     label: "Needs action",

--- a/src/features/demo-admin-dashboard/types/calendarEvent.ts
+++ b/src/features/demo-admin-dashboard/types/calendarEvent.ts
@@ -1,0 +1,78 @@
+import type { DemoCalendarEvent } from "./dataset";
+
+export type CalendarResponseState = "needsAction" | "accepted" | "declined" | "tentative";
+
+export interface CalendarResponseStateOption {
+  state: CalendarResponseState;
+  label: string;
+  description: string;
+}
+
+export const CALENDAR_RESPONSE_STATES: CalendarResponseState[] = [
+  "needsAction",
+  "accepted",
+  "declined",
+  "tentative",
+];
+
+export const CALENDAR_RESPONSE_STATE_OPTIONS: Record<CalendarResponseState, CalendarResponseStateOption> = {
+  needsAction: {
+    state: "needsAction",
+    label: "Needs action",
+    description: "The recipient has not yet responded to the invitation.",
+  },
+  accepted: {
+    state: "accepted",
+    label: "Accepted",
+    description: "The recipient accepted the invitation.",
+  },
+  declined: {
+    state: "declined",
+    label: "Declined",
+    description: "The recipient declined the invitation.",
+  },
+  tentative: {
+    state: "tentative",
+    label: "Tentative",
+    description: "The recipient tentatively accepted the invitation.",
+  },
+};
+
+export const DEFAULT_RESPONSE_STATE: CalendarResponseState = "needsAction";
+
+export function getResponseStateOption(state: CalendarResponseState): CalendarResponseStateOption {
+  return CALENDAR_RESPONSE_STATE_OPTIONS[state];
+}
+
+export interface CalendarEventEditorState {
+  id: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  location: string;
+  attendees: string[];
+  responseState: CalendarResponseState;
+}
+
+export function calendarEventToEditorState(event: DemoCalendarEvent): CalendarEventEditorState {
+  return {
+    id: event.id,
+    title: event.title,
+    startTime: event.startTime,
+    endTime: event.endTime,
+    location: event.location ?? "",
+    attendees: [...event.attendees],
+    responseState: "needsAction",
+  };
+}
+
+export function editorStateToCalendarEvent(state: CalendarEventEditorState): DemoCalendarEvent {
+  return {
+    id: state.id,
+    title: state.title,
+    startTime: state.startTime,
+    endTime: state.endTime,
+    location: state.location || undefined,
+    attendees: state.attendees,
+  };
+}


### PR DESCRIPTION
closes #180 

All done. Here's a summary of what was implemented:

**Commit 1** (`8753402`) — Core logic:
- `types/calendarEvent.ts` — `CalendarResponseState` (needsAction/accepted/declined/tentative), `CalendarEventEditorState`, converter functions, response state options with labels/descriptions
- `fixtures/calendarEventFixtures.ts` — 5 deterministic demo events + a blank default
- `calendarEventValidation.ts` — Field-level rules (title required, valid start/end times, end after start, attendee format/domain checks)
- 3 test files (validation, helpers, component exports)

**Commit 2** (`e9449c0`) — UI + integration:
- `components/CalendarEventEditor.tsx` — Controlled form with title, datetime-local fields (start/end), location, attendees (comma-separated), response state select, live validation via `ValidationResultsPanel`, Save/Cancel buttons
- `docs/CALENDAR_EVENT_EDITOR.md` — Props, validation rules, response state table, usage examples
- `index.ts` — Barrel exports for all new public symbols

All changes are scoped to `src/features/demo-admin-dashboard/`. No files outside that folder were modified.