### PR TITLE
Feat: Add campaign analytics preview card

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/adminEmptyState.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/adminEmptyState.test.ts
@@ -6,13 +6,14 @@ import {
 } from "../constants/adminEmptyStates";
 
 describe("admin empty state presets", () => {
-  it("covers all five required panels", () => {
+  it("covers all required panels", () => {
     expect(ADMIN_EMPTY_STATE_KINDS).toEqual([
       "messages",
       "senders",
       "attachments",
       "events",
       "validation",
+      "kpis",
     ]);
     expect(Object.keys(ADMIN_EMPTY_STATE_PRESETS).sort()).toEqual(
       [...ADMIN_EMPTY_STATE_KINDS].sort(),

--- a/src/features/demo-admin-dashboard/__tests__/campaignAnalytics.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignAnalytics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { formatKpiTrend } from "../utils/campaignKpiHelpers";
+import { KPI_TREND_TOKENS, getKpiTrendToken } from "../constants/displayTokens";
+import { getAdminEmptyStatePreset } from "../constants/adminEmptyStates";
+import type { KpiTrend } from "../types/campaignKpi";
+
+const ALL_TREND_KINDS: KpiTrend[] = ["up", "down", "stable"];
+
+describe("formatKpiTrend", () => {
+  it('returns "↑ Up" for trend "up"', () => {
+    expect(formatKpiTrend("up")).toBe("↑ Up");
+  });
+
+  it('returns "↓ Down" for trend "down"', () => {
+    expect(formatKpiTrend("down")).toBe("↓ Down");
+  });
+
+  it('returns "→ Stable" for trend "stable"', () => {
+    expect(formatKpiTrend("stable")).toBe("→ Stable");
+  });
+});
+
+describe("KPI_TREND_TOKENS", () => {
+  it("covers all three trend kinds", () => {
+    for (const trend of ALL_TREND_KINDS) {
+      expect(KPI_TREND_TOKENS[trend]).toBeDefined();
+    }
+  });
+
+  it("each token has required display fields", () => {
+    for (const trend of ALL_TREND_KINDS) {
+      const token = KPI_TREND_TOKENS[trend];
+      expect(typeof token.bg).toBe("string");
+      expect(typeof token.text).toBe("string");
+      expect(typeof token.border).toBe("string");
+      expect(typeof token.label).toBe("string");
+      expect(token.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getKpiTrendToken", () => {
+  it('returns emerald text for "up"', () => {
+    expect(getKpiTrendToken("up").text).toBe("text-emerald-400");
+  });
+
+  it('returns rose text for "down"', () => {
+    expect(getKpiTrendToken("down").text).toBe("text-rose-400");
+  });
+
+  it('returns muted text for "stable"', () => {
+    expect(getKpiTrendToken("stable").text).toBe("text-muted-foreground");
+  });
+
+  it("returns the same object as KPI_TREND_TOKENS direct lookup", () => {
+    for (const trend of ALL_TREND_KINDS) {
+      expect(getKpiTrendToken(trend)).toBe(KPI_TREND_TOKENS[trend]);
+    }
+  });
+});
+
+describe('AdminEmptyState "kpis" preset', () => {
+  it('preset title is "No analytics yet"', () => {
+    expect(getAdminEmptyStatePreset("kpis").title).toBe("No analytics yet");
+  });
+
+  it("preset description is defined and non-empty", () => {
+    const preset = getAdminEmptyStatePreset("kpis");
+    expect(typeof preset.description).toBe("string");
+    expect(preset.description.length).toBeGreaterThan(0);
+  });
+
+  it("preset ctaLabel is defined", () => {
+    const preset = getAdminEmptyStatePreset("kpis");
+    expect(preset.ctaLabel).toBeDefined();
+  });
+});

--- a/src/features/demo-admin-dashboard/components/CampaignAnalyticsCard.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignAnalyticsCard.tsx
@@ -1,0 +1,79 @@
+import { cn } from "@/lib/utils";
+import type { CampaignKpiDefinition } from "../types/campaignKpi";
+import { computeKpiProgress, formatKpiTrend } from "../utils/campaignKpiHelpers";
+import { getKpiMetricToken, getKpiStatusToken, getKpiTrendToken } from "../constants/displayTokens";
+
+interface CampaignAnalyticsCardProps {
+  kpi: CampaignKpiDefinition;
+}
+
+export function CampaignAnalyticsCard({ kpi }: CampaignAnalyticsCardProps) {
+  const metricToken = getKpiMetricToken(kpi.metric);
+  const statusToken = getKpiStatusToken(kpi.status);
+  const trendToken = getKpiTrendToken(kpi.trend);
+  const progress = computeKpiProgress(kpi);
+  const progressPct = Math.round(progress * 100);
+
+  return (
+    <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 space-y-3">
+      {/* Header: metric kind badge + status badge */}
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+            metricToken.bg,
+            metricToken.text,
+            metricToken.border,
+          )}
+        >
+          {metricToken.label}
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+            statusToken.bg,
+            statusToken.text,
+            statusToken.border,
+          )}
+        >
+          {statusToken.label}
+        </span>
+      </div>
+
+      {/* Metric label + value */}
+      <div>
+        <p className="text-sm font-semibold text-foreground leading-snug">{kpi.label}</p>
+        <p className="mt-1 tabular-nums text-xl font-bold text-foreground">
+          {kpi.currentValue.toLocaleString()}
+          <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+            / {kpi.target.toLocaleString()}
+          </span>
+        </p>
+      </div>
+
+      {/* Progress bar */}
+      <div
+        className="h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden"
+        role="progressbar"
+        aria-valuenow={progressPct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${kpi.label} progress: ${progressPct}%`}
+      >
+        <div
+          className={cn("h-full rounded-full transition-all", statusToken.bg)}
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+
+      {/* Footer: trend + window label */}
+      <div className="flex items-center gap-2 pt-0.5">
+        <span className={cn("text-[11px] font-medium tabular-nums", trendToken.text)}>
+          {formatKpiTrend(kpi.trend)}
+        </span>
+        <span className="text-[11px] text-muted-foreground/60">·</span>
+        <span className="text-[11px] text-muted-foreground">{kpi.windowLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/components/CampaignAnalyticsPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignAnalyticsPanel.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { CAMPAIGN_KPI_DEFINITIONS } from "../fixtures/campaignKpiFixtures";
+import { getKpisForCampaign, sortKpisByMetric } from "../utils/campaignKpiHelpers";
+import { AdminEmptyState } from "./AdminEmptyState";
+import { CampaignAnalyticsCard } from "./CampaignAnalyticsCard";
+import type { KpiStatus } from "../types/campaignKpi";
+
+const CAMPAIGN_OPTIONS = [
+  {
+    id: "campaign-onboarding-2026",
+    label: "Onboarding 2026",
+    description: "Campaign total · 6 metrics",
+  },
+  {
+    id: "campaign-stellar-launch-2026",
+    label: "Stellar Launch 2026",
+    description: "Last 7 days · 6 metrics",
+  },
+];
+
+const STATUS_SUMMARY_TOKENS: Record<
+  "met" | "at-risk" | "missed",
+  { bg: string; text: string; border: string; label: string }
+> = {
+  met: {
+    bg: "bg-sky-500/10",
+    text: "text-sky-400",
+    border: "border-sky-500/20",
+    label: "Met",
+  },
+  "at-risk": {
+    bg: "bg-amber-500/10",
+    text: "text-amber-400",
+    border: "border-amber-500/20",
+    label: "At Risk",
+  },
+  missed: {
+    bg: "bg-rose-500/10",
+    text: "text-rose-400",
+    border: "border-rose-500/20",
+    label: "Missed",
+  },
+};
+
+function countByStatus(statuses: KpiStatus[], status: KpiStatus): number {
+  return statuses.filter((s) => s === status).length;
+}
+
+export function CampaignAnalyticsPanel() {
+  const [selectedId, setSelectedId] = useState<string>(CAMPAIGN_OPTIONS[0].id);
+
+  const allKpis = getKpisForCampaign(CAMPAIGN_KPI_DEFINITIONS, selectedId);
+  const kpis = sortKpisByMetric(allKpis);
+  const statuses = kpis.map((k) => k.status);
+
+  const metCount = countByStatus(statuses, "met");
+  const atRiskCount = countByStatus(statuses, "at-risk");
+  const missedCount = countByStatus(statuses, "missed");
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Deterministic demo KPI cards for campaign performance. All values are fake and safe for
+        public review.
+      </p>
+
+      {/* Campaign picker */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {CAMPAIGN_OPTIONS.map((opt) => {
+          const active = selectedId === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setSelectedId(opt.id)}
+              className={cn(
+                "rounded-xl border p-4 text-left transition",
+                active
+                  ? "border-teal-500/50 bg-teal-500/5 ring-1 ring-teal-500/20"
+                  : "border-white/[0.06] bg-white/[0.02] hover:border-white/10 hover:bg-white/[0.04]",
+              )}
+            >
+              <p className="text-xs font-semibold text-foreground">{opt.label}</p>
+              <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                {opt.description}
+              </p>
+              <p className="mt-2 text-[10px] font-mono text-muted-foreground/60">{opt.id}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Summary row */}
+      {kpis.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">
+            {kpis.length} metric{kpis.length !== 1 ? "s" : ""}
+          </span>
+          {(
+            [
+              { key: "met", count: metCount },
+              { key: "at-risk", count: atRiskCount },
+              { key: "missed", count: missedCount },
+            ] as const
+          )
+            .filter(({ count }) => count > 0)
+            .map(({ key, count }) => {
+              const token = STATUS_SUMMARY_TOKENS[key];
+              return (
+                <span
+                  key={key}
+                  className={cn(
+                    "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+                    token.bg,
+                    token.text,
+                    token.border,
+                  )}
+                >
+                  {count} {token.label}
+                </span>
+              );
+            })}
+        </div>
+      )}
+
+      {/* Card grid or empty state */}
+      {kpis.length === 0 ? (
+        <AdminEmptyState kind="kpis" />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {kpis.map((kpi) => (
+            <CampaignAnalyticsCard key={kpi.id} kpi={kpi} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/constants/adminEmptyStates.ts
+++ b/src/features/demo-admin-dashboard/constants/adminEmptyStates.ts
@@ -2,7 +2,13 @@
  * Preset copy for the demo admin dashboard empty states. Each entry is static,
  * fake, and safe for public review — no real user data, addresses, or secrets.
  */
-export type AdminEmptyStateKind = "messages" | "senders" | "attachments" | "events" | "validation";
+export type AdminEmptyStateKind =
+  | "messages"
+  | "senders"
+  | "attachments"
+  | "events"
+  | "validation"
+  | "kpis";
 
 export interface AdminEmptyStateCopy {
   /** Short, friendly heading. */
@@ -39,6 +45,11 @@ export const ADMIN_EMPTY_STATE_PRESETS: Record<AdminEmptyStateKind, AdminEmptySt
     description: "Run validation to see passes, warnings, and errors.",
     ctaLabel: "Run validation",
   },
+  kpis: {
+    title: "No analytics yet",
+    description: "KPI data will appear once the campaign fixture loads.",
+    ctaLabel: "Load KPI data",
+  },
 };
 
 /** Look up the preset copy for a given empty-state kind. */
@@ -53,4 +64,5 @@ export const ADMIN_EMPTY_STATE_KINDS: AdminEmptyStateKind[] = [
   "attachments",
   "events",
   "validation",
+  "kpis",
 ];

--- a/src/features/demo-admin-dashboard/constants/displayTokens.ts
+++ b/src/features/demo-admin-dashboard/constants/displayTokens.ts
@@ -1,4 +1,4 @@
-import type { KpiMetricKind, KpiStatus } from "../types/campaignKpi";
+import type { KpiMetricKind, KpiStatus, KpiTrend } from "../types/campaignKpi";
 
 export interface DisplayToken {
   bg: string;
@@ -438,4 +438,29 @@ export function getKpiMetricToken(metric: KpiMetricKind): DisplayToken {
 
 export function getKpiStatusToken(status: KpiStatus): DisplayToken {
   return KPI_STATUS_TOKENS[status];
+}
+
+export const KPI_TREND_TOKENS: Record<KpiTrend, DisplayToken> = {
+  up: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-400",
+    border: "border-emerald-500/20",
+    label: "Up",
+  },
+  down: {
+    bg: "bg-rose-500/10",
+    text: "text-rose-400",
+    border: "border-rose-500/20",
+    label: "Down",
+  },
+  stable: {
+    bg: "bg-white/[0.04]",
+    text: "text-muted-foreground",
+    border: "border-white/[0.08]",
+    label: "Stable",
+  },
+};
+
+export function getKpiTrendToken(trend: KpiTrend): DisplayToken {
+  return KPI_TREND_TOKENS[trend];
 }

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -268,6 +268,7 @@ export type {
 export { CAMPAIGN_KPI_DEFINITIONS } from "./fixtures/campaignKpiFixtures";
 export {
   computeKpiProgress,
+  formatKpiTrend,
   getKpiById,
   getKpisForCampaign,
   isKpiMet,
@@ -277,9 +278,15 @@ export {
 export {
   KPI_METRIC_TOKENS,
   KPI_STATUS_TOKENS,
+  KPI_TREND_TOKENS,
   getKpiMetricToken,
   getKpiStatusToken,
+  getKpiTrendToken,
 } from "./constants/displayTokens";
+
+// Campaign analytics preview cards (issue #264)
+export { CampaignAnalyticsCard } from "./components/CampaignAnalyticsCard";
+export { CampaignAnalyticsPanel } from "./components/CampaignAnalyticsPanel";
 
 export {
   MESSAGE_FOLDERS,

--- a/src/features/demo-admin-dashboard/utils/campaignKpiHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/campaignKpiHelpers.ts
@@ -1,5 +1,5 @@
 import type { ValidationIssue } from "../validation-types";
-import type { CampaignKpiDefinition, KpiMetricKind } from "../types/campaignKpi";
+import type { CampaignKpiDefinition, KpiMetricKind, KpiTrend } from "../types/campaignKpi";
 
 const KPI_METRIC_KIND_ORDER: KpiMetricKind[] = [
   "opens",
@@ -41,6 +41,16 @@ export function sortKpisByMetric(kpis: CampaignKpiDefinition[]): CampaignKpiDefi
   return [...kpis].sort(
     (a, b) => KPI_METRIC_KIND_ORDER.indexOf(a.metric) - KPI_METRIC_KIND_ORDER.indexOf(b.metric),
   );
+}
+
+const TREND_LABELS: Record<KpiTrend, string> = {
+  up: "↑ Up",
+  down: "↓ Down",
+  stable: "→ Stable",
+};
+
+export function formatKpiTrend(trend: KpiTrend): string {
+  return TREND_LABELS[trend];
 }
 
 export function validateCampaignKpiDefinition(kpi: CampaignKpiDefinition): ValidationIssue[] {


### PR DESCRIPTION
# Closes #264 

## Feat: Campaign Analytics Preview Cards ([#264](#))

### Overview

Implements the `CampaignAnalyticsPanel` and `CampaignAnalyticsCard` components — the UI layer explicitly called out as a follow-up in `CAMPAIGN_KPI_DEFINITIONS.md` from issue [#262](#). All data is deterministic, fake, and safe for public review. No files outside `src/features/demo-admin-dashboard/` were changed.

---

### New Components

#### `components/CampaignAnalyticsCard.tsx`

A single-KPI display card. Includes:

- Metric kind badge — colour-coded via `KPI_METRIC_TOKENS` (`sky`/`emerald`/`indigo`/`rose`/`amber`/`fuchsia`)
- Large `currentValue / target` readout
- Progress bar whose fill colour is driven by `KPI_STATUS_TOKENS[kpi.status].bg` — uses a plain two-div track+fill pattern consistent with `MilestoneCard`; includes `role="progressbar"` with `aria-valuenow`/`min`/`max` for accessibility
- Status badge (`on-track` / `at-risk` / `met` / `missed`)
- Footer row with trend indicator and window label

#### `components/CampaignAnalyticsPanel.tsx`

The container panel. Includes:

- Campaign picker — 2 buttons styled identically to the picker in `CampaignTimelinePanel`
- Summary chip row showing total KPI count plus `met` / `at-risk` / `missed` breakdowns
- Responsive card grid (1 col → 2 col at `md` → 3 col at `lg`)
- Delegates to `AdminEmptyState kind="kpis"` when no KPIs exist for the selected campaign
- KPIs passed through `sortKpisByMetric` before rendering to preserve canonical metric order

---

### New Helpers

#### `utils/campaignKpiHelpers.ts` — `formatKpiTrend`

Pure function mapping `KpiTrend → string`: `"up"` → `"↑ Up"`, `"down"` → `"↓ Down"`, `"stable"` → `"→ Stable"`. Used as the accessible text label on the trend chip in each card.

#### `constants/displayTokens.ts` — `KPI_TREND_TOKENS` + `getKpiTrendToken`

Display token record keyed by `KpiTrend`. `up = emerald`, `down = rose`, `stable = muted` — sentiment-consistent with `KPI_STATUS_TOKENS`. Follows the same `{ bg, text, border, label }` shape as every other token in the file.

---

### Extended Constants

#### `constants/adminEmptyStates.ts`

Added `"kpis"` to `AdminEmptyStateKind` (the union type), `ADMIN_EMPTY_STATE_PRESETS`, and `ADMIN_EMPTY_STATE_KINDS`.

Copy: `"No analytics yet"` / `"KPI data will appear once the campaign fixture loads."`

---

### Exports — `index.ts`

Exports `CampaignAnalyticsCard`, `CampaignAnalyticsPanel`, `formatKpiTrend`, `KPI_TREND_TOKENS`, and `getKpiTrendToken` from the feature's public surface.

---

### Tests

#### `__tests__/campaignAnalytics.test.ts` — 12 tests

Covers: all three `formatKpiTrend` outputs, `KPI_TREND_TOKENS` completeness and field shape, `getKpiTrendToken` colour values per direction, reference equality between accessor and direct record lookup, and the three fields of the new `"kpis"` empty state preset.

#### `__tests__/adminEmptyState.test.ts`

Updated the hardcoded kind list assertion to include `"kpis"`.