### PR TITLE
Add architecture and folder contract for Email Template Library tool

### DIFF
--- a/tools/v2/individual/email-template-library/DATA_OWNERSHIP.md
+++ b/tools/v2/individual/email-template-library/DATA_OWNERSHIP.md
@@ -1,0 +1,116 @@
+# Email Template Library - Data Ownership & Flow
+
+This document details the data structures, storage parameters, state lifecycles, and mutation restrictions inside the Email Template Library tool.
+
+---
+
+## 1. Domain Entities & Data Model
+
+The core structures are declared in `types/index.ts`:
+
+```
+
+export interface TemplateVariable {
+
+key: string;
+
+label: string;
+
+}
+
+export interface EmailTemplate {
+
+id: string;
+
+name: string;
+
+categoryId: string | null;
+
+subject: string;
+
+body: string;
+
+variables: TemplateVariable[];
+
+}
+
+export interface TemplateCategory {
+
+id: string;
+
+name: string;
+
+}
+
+```
+
+---
+
+## 2. Data Lifecycle
+
+```
+
+[Editor Form Input]
+
+|  |
+| --- |
+
+v
+
+[useEmailTemplateLibrary Hook]
+
+|  |
+| --- |
+
+v
+
+[TemplateService.saveTemplate() / renderTemplate()]
+
+|  |
+| --- |
+
+v
+
+[In-memory template collection updated]
+
+|  |
+| --- |
+
+v
+
+[Hook updates React state -> list and preview re-render]
+
+```
+
+- **Validation Checkpoint**: Every saved template runs through service validation (non-empty `id` and `name`, string `subject` and `body`, well-formed `variables`).
+- **Stateless Sessions**: Templates live in in-memory service state seeded from `fixtures/` and reset on page refresh during this phase.
+
+---
+
+## 3. Data Storage Boundaries
+
+- **Local RAM State only**: No database integration, blockchain sync, or cookie caching.
+- **Seed Fixtures**: Initial templates come from deterministic mock data in `fixtures/`.
+- **No Persistence**: If durable storage is required later, it must be added through a new adapter layer in a follow-up issue.
+
+---
+
+## 4. Mutability & Mutation Constraints
+
+### Immutable
+
+- **Fixture Vectors**: The mock templates in `fixtures/` must remain read-only at runtime.
+- **Template `id`**: Once assigned, a template's `id` must never change; edits update the other fields, not the identity.
+
+### Mutable
+
+- **Template Collection**: Saving or deleting produces a new cloned collection rather than mutating in place.
+- **Component visual state**: Local indicators such as the selected template and edit buffer.
+
+---
+
+## 5. Security & Privacy Safeguards
+
+- **Fake Demo Data Only**: All sample templates and addresses are fake, deterministic, and safe for public repository review.
+- **No Real Recipients or Secrets**: No real email addresses, private keys, secrets, or live network calls are ever included.
+- **Safe Variable Substitution**: Rendering only substitutes declared variables and reports missing keys instead of leaking unintended data.

--- a/tools/v2/individual/email-template-library/INTEGRATION_CONSTRAINTS.md
+++ b/tools/v2/individual/email-template-library/INTEGRATION_CONSTRAINTS.md
@@ -1,0 +1,81 @@
+# Email Template Library - Integration Constraints
+
+This document defines the constraints and hard isolation boundaries for the Email Template Library tool.
+
+---
+
+## 1. Golden Rules (Non-Negotiable)
+
+```
+
+1. Never import from src/ (the main app folder).
+2. Never modify files outside tools/v2/individual/email-template-library/.
+3. Never export hooks, services, or components for direct use in the main application.
+4. Never query the main app database, Stellar blockchain, or mail engine.
+5. Never add routes to src/router.tsx or routeTree.gen.ts.
+6. Never depend on main app authentication contexts or session keys.
+7. Never call core app API backend routers.
+
+```
+
+---
+
+## 2. Dependency & Imports Control
+
+### Forbidden Imports
+
+```
+
+// DO NOT import core components or utilities
+
+import { MailInbox } from "../../../src/components/inbox";
+
+import { useAuth } from "../../../src/hooks/useAuth";
+
+import { sendPayment } from "../../../src/services/stellar";
+
+import { db } from "../../../src/server/db";
+
+```
+
+### Allowed Imports
+
+```
+
+// OK to import local modules
+
+import { createTemplateService } from "./services/template.service";
+
+import { useEmailTemplateLibrary } from "./hooks/use-email-template-library";
+
+// OK to import standard libraries and presentational assets
+
+import React, { useState } from "react";
+
+import { Copy } from "lucide-react";
+
+```
+
+---
+
+## 3. Allowed vs. Forbidden Modifications
+
+- **Forbidden to Modify**:
+  - `src/` (router, navigation, core database models).
+  - `infra/` (deployment files, configs).
+  - `package.json` (adding generic third-party packages without maintainer review).
+  - `tsconfig.json` & `vite.config.ts`.
+- **Allowed to Modify**:
+  - Any file located inside `tools/v2/individual/email-template-library/`.
+
+---
+
+## 4. Integration Guidelines for Future Tasks
+
+When an integration task is explicitly authorized by a separate issue:
+
+1. **Bridge adapters**: Create a bridge adapter under `src/features/` that mounts this tool inside the compose experience.
+2. **Context mappings**: Map the active user profile into default template variable values.
+3. **Persistence syncing**: Hook into a storage layer to persist user templates.
+
+**Do not attempt these integrations within this issue.**

--- a/tools/v2/individual/email-template-library/MODULE_BOUNDARIES.md
+++ b/tools/v2/individual/email-template-library/MODULE_BOUNDARIES.md
@@ -1,0 +1,227 @@
+# Email Template Library - Module Boundaries
+
+This document defines the internal contracts, public interfaces, and dependency rules for each module inside the Email Template Library tool. The tool is a V2, individual-audience mini-product that lets a single user create, organize, preview, and reuse email templates. It is built in isolation and is not wired into the main application yet.
+
+---
+
+## 1. Module: Types (Shared Contracts)
+
+**Location:** `types/` (e.g., `types/index.ts`)
+
+### Responsibility
+
+Declares the shared TypeScript interfaces used across the tool. Owns no logic and imports nothing.
+
+### Public API
+
+```
+
+export interface TemplateVariable {
+
+key: string; // e.g. "firstName"
+
+label: string; // human-readable label shown in the editor
+
+}
+
+export interface EmailTemplate {
+
+id: string;
+
+name: string;
+
+categoryId: string | null;
+
+subject: string;
+
+body: string;
+
+variables: TemplateVariable[];
+
+}
+
+export interface TemplateCategory {
+
+id: string;
+
+name: string;
+
+}
+
+export interface TemplateRenderResult {
+
+subject: string;
+
+body: string;
+
+missingVariables: string[];
+
+}
+
+```
+
+### Dependencies
+
+- No imports from `components/`, `services/`, `hooks/`, or the main application.
+
+---
+
+## 2. Module: Services (Business Logic)
+
+**Location:** `services/` (e.g., `services/template.service.ts`)
+
+### Responsibility
+
+Encapsulates all framework-free logic: in-memory template CRUD, validation, variable substitution, and search/sort. Services never import React and never reach outside this folder.
+
+### Public API
+
+```
+
+export function createTemplateService(initialTemplates?: EmailTemplate[]): {
+
+getTemplates: () => EmailTemplate[];
+
+getTemplate: (id: string) => EmailTemplate | undefined;
+
+saveTemplate: (template: EmailTemplate) => void;
+
+deleteTemplate: (id: string) => void;
+
+searchTemplates: (query: string) => EmailTemplate[];
+
+renderTemplate: (
+
+id: string,
+
+values: Record<string, string>,
+
+) => TemplateRenderResult;
+
+};
+
+```
+
+### Dependencies
+
+- **Allowed to import:**
+  - TypeScript types from `../types/`
+- **Forbidden:**
+  - Import React or hooks directly.
+  - Import presentational components.
+  - Import main app stores or APIs.
+
+---
+
+## 3. Module: Hooks (React Integration)
+
+**Location:** `hooks/` (e.g., `hooks/use-email-template-library.ts`)
+
+### Responsibility
+
+Synchronizes the service state with React components, managing the selected template, the edit buffer, and preview values.
+
+### Public API
+
+```
+
+export function useEmailTemplateLibrary(): {
+
+templates: EmailTemplate[];
+
+selectedId: string | null;
+
+select: (id: string | null) => void;
+
+save: (template: EmailTemplate) => void;
+
+remove: (id: string) => void;
+
+search: (query: string) => void;
+
+preview: (id: string, values: Record<string, string>) => TemplateRenderResult;
+
+};
+
+```
+
+### Dependencies
+
+- **Allowed to import:**
+  - React hooks (`useState`, `useCallback`, `useMemo`)
+  - Service factory from `../services/`
+  - Types from `../types/`
+- **Forbidden:**
+  - Presentational components.
+  - Core app state contexts.
+
+---
+
+## 4. Module: Components (User Interface)
+
+**Location:** `components/`
+
+### Responsibility
+
+Renders the visual elements of the library (template list, editor form, and live preview). Components remain presentational and delegate all actions to the hook.
+
+### Public API
+
+```
+
+// TemplateList.tsx
+
+export const TemplateList: React.FC<{
+
+templates: EmailTemplate[];
+
+selectedId: string | null;
+
+onSelect: (id: string) => void;
+
+}>;
+
+// TemplateEditor.tsx
+
+export const TemplateEditor: React.FC<{
+
+template: EmailTemplate;
+
+onSave: (template: EmailTemplate) => void;
+
+}>;
+
+// TemplatePreview.tsx
+
+export const TemplatePreview: React.FC<{
+
+result: TemplateRenderResult;
+
+}>;
+
+// TemplateLibraryConsole.tsx
+
+export const TemplateLibraryConsole: React.FC;
+
+```
+
+### Dependencies
+
+- **Allowed to import:**
+  - Hooks from `../hooks/`
+  - Types from `../types/`
+  - External presentational assets (lucide-react icons, etc.)
+- **Forbidden:**
+  - Importing core app features, layout navigation components, or side-effect triggers.
+  - Importing service functions directly.
+
+---
+
+## Import Rules Checklist
+
+When implementing or extending this tool:
+
+- [ ] Only import from files located inside `tools/v2/individual/email-template-library/`.
+- [ ] Strictly maintain clean dependency boundaries: `Components -> Hooks -> Services -> Types`.
+- [ ] No circular dependencies.
+- [ ] All shared interfaces must be imported from `types/`.


### PR DESCRIPTION
## Summary

Establishes the isolated architecture contract for the Email Template Library tool (V2, individual) inside `tools/v2/individual/email-template-library/`. The tool is defined as a self-contained mini-product and is not wired into the main app.

## Deliverables

1. **`MODULE_BOUNDARIES.md`** — Responsibilities and public interface signatures for each module: types, services (pure logic), React hooks, and presentational components, plus the dependency direction and an import-rules checklist.
2. **`DATA_OWNERSHIP.md`** — Domain entities, data lifecycle, in-memory storage boundaries, mutability constraints, and privacy/security safeguards (fake demo data only).
3. **`INTEGRATION_CONSTRAINTS.md`** — Non-negotiable isolation rules, forbidden vs. allowed imports, allowed vs. forbidden modifications, and guidance for future integration tasks.

## Scope

- All changes are limited to `tools/v2/individual/email-template-library/`.
- No changes to the main app, routing, inbox, wallet, Stellar, or the design system.

Closes #489