### PR TITLE
Add message bulk selection tools

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/bulkSelection.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkSelection.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { Draft } from "../types/draft";
+import {
+  clearBulkSelection,
+  formatBulkSelectionSummary,
+  getBulkSelectionSummary,
+  invertBulkSelection,
+  normalizeSelectedDraftIds,
+  selectAllDrafts,
+  selectDraftRange,
+  updateBulkSelection,
+} from "../bulkSelection";
+
+const drafts: Draft[] = [
+  {
+    id: "draft-welcome",
+    subject: "Welcome to Stealth Mail",
+    body: "Deterministic welcome copy.",
+    recipients: ["alex@example.com"],
+  },
+  {
+    id: "draft-security",
+    subject: "Security policy update",
+    body: "Fake dashboard copy only.",
+    recipients: ["sam@example.org"],
+  },
+  {
+    id: "draft-postage",
+    subject: "Postage receipt",
+    body: "Demo receipt copy.",
+    recipients: ["ops@stealth.demo"],
+  },
+];
+
+describe("bulkSelection helpers", () => {
+  it("normalizes selected ids by draft order and drops unknown ids", () => {
+    expect(
+      normalizeSelectedDraftIds(drafts, ["missing", "draft-postage", "draft-welcome"]),
+    ).toEqual(["draft-welcome", "draft-postage"]);
+  });
+
+  it("selects all draft messages", () => {
+    const result = selectAllDrafts(drafts);
+
+    expect(result.selectedIds).toEqual(["draft-welcome", "draft-security", "draft-postage"]);
+    expect(result.lastFocusedId).toBe("draft-postage");
+  });
+
+  it("clears the current selection", () => {
+    expect(clearBulkSelection()).toEqual({
+      selectedIds: [],
+      lastFocusedId: null,
+    });
+  });
+
+  it("selects a contiguous range regardless of direction", () => {
+    expect(selectDraftRange(drafts, "draft-postage", "draft-welcome")).toEqual({
+      selectedIds: ["draft-welcome", "draft-security", "draft-postage"],
+      lastFocusedId: "draft-welcome",
+    });
+  });
+
+  it("updates selection in replace, add, remove, and toggle modes", () => {
+    expect(updateBulkSelection(drafts, ["draft-welcome"], ["draft-security"], "replace")).toEqual({
+      selectedIds: ["draft-security"],
+      lastFocusedId: "draft-security",
+    });
+
+    expect(
+      updateBulkSelection(drafts, ["draft-welcome"], ["draft-security"], "add").selectedIds,
+    ).toEqual(["draft-welcome", "draft-security"]);
+
+    expect(
+      updateBulkSelection(drafts, ["draft-welcome", "draft-security"], ["draft-welcome"], "remove")
+        .selectedIds,
+    ).toEqual(["draft-security"]);
+
+    expect(
+      updateBulkSelection(drafts, ["draft-welcome", "draft-security"], ["draft-security"], "toggle")
+        .selectedIds,
+    ).toEqual(["draft-welcome"]);
+  });
+
+  it("inverts selection against the current draft dataset", () => {
+    expect(invertBulkSelection(drafts, ["draft-security"]).selectedIds).toEqual([
+      "draft-welcome",
+      "draft-postage",
+    ]);
+  });
+
+  it("summarizes empty, partial, and complete selections", () => {
+    expect(formatBulkSelectionSummary(getBulkSelectionSummary([], []))).toBe(
+      "No draft messages available.",
+    );
+    expect(formatBulkSelectionSummary(getBulkSelectionSummary(drafts, []))).toBe(
+      "No draft messages selected out of 3.",
+    );
+    expect(formatBulkSelectionSummary(getBulkSelectionSummary(drafts, ["draft-welcome"]))).toBe(
+      "1 of 3 draft messages selected.",
+    );
+    expect(
+      formatBulkSelectionSummary(
+        getBulkSelectionSummary(drafts, selectAllDrafts(drafts).selectedIds),
+      ),
+    ).toBe("All 3 draft messages selected.");
+  });
+});

--- a/src/features/demo-admin-dashboard/bulkSelection.ts
+++ b/src/features/demo-admin-dashboard/bulkSelection.ts
@@ -1,0 +1,141 @@
+import type { Draft } from "./types/draft";
+
+export type BulkSelectionMode = "replace" | "add" | "remove" | "toggle";
+
+export interface BulkSelectionState {
+  selectedIds: string[];
+  lastFocusedId: string | null;
+}
+
+export interface BulkSelectionSummary {
+  totalCount: number;
+  selectedCount: number;
+  allSelected: boolean;
+  partiallySelected: boolean;
+}
+
+export const emptyBulkSelection: BulkSelectionState = {
+  selectedIds: [],
+  lastFocusedId: null,
+};
+
+function getDraftIds(drafts: Draft[]): string[] {
+  return drafts.map((draft) => draft.id);
+}
+
+function sortIdsByDraftOrder(ids: Iterable<string>, drafts: Draft[]): string[] {
+  const selected = new Set(ids);
+  return getDraftIds(drafts).filter((id) => selected.has(id));
+}
+
+export function normalizeSelectedDraftIds(drafts: Draft[], selectedIds: string[]): string[] {
+  return sortIdsByDraftOrder(selectedIds, drafts);
+}
+
+export function getBulkSelectionSummary(
+  drafts: Draft[],
+  selectedIds: string[],
+): BulkSelectionSummary {
+  const selectedCount = normalizeSelectedDraftIds(drafts, selectedIds).length;
+  const totalCount = drafts.length;
+
+  return {
+    totalCount,
+    selectedCount,
+    allSelected: totalCount > 0 && selectedCount === totalCount,
+    partiallySelected: selectedCount > 0 && selectedCount < totalCount,
+  };
+}
+
+export function selectAllDrafts(drafts: Draft[]): BulkSelectionState {
+  const selectedIds = getDraftIds(drafts);
+  return {
+    selectedIds,
+    lastFocusedId: selectedIds.at(-1) ?? null,
+  };
+}
+
+export function clearBulkSelection(): BulkSelectionState {
+  return emptyBulkSelection;
+}
+
+export function selectDraftRange(
+  drafts: Draft[],
+  startId: string,
+  endId: string,
+): BulkSelectionState {
+  const ids = getDraftIds(drafts);
+  const start = ids.indexOf(startId);
+  const end = ids.indexOf(endId);
+
+  if (start === -1 || end === -1) {
+    return clearBulkSelection();
+  }
+
+  const from = Math.min(start, end);
+  const to = Math.max(start, end);
+  return {
+    selectedIds: ids.slice(from, to + 1),
+    lastFocusedId: endId,
+  };
+}
+
+export function updateBulkSelection(
+  drafts: Draft[],
+  currentSelectedIds: string[],
+  targetIds: string[],
+  mode: BulkSelectionMode,
+): BulkSelectionState {
+  const draftIds = new Set(getDraftIds(drafts));
+  const cleanTargets = targetIds.filter((id) => draftIds.has(id));
+  const selected = new Set(normalizeSelectedDraftIds(drafts, currentSelectedIds));
+
+  if (mode === "replace") {
+    return {
+      selectedIds: sortIdsByDraftOrder(cleanTargets, drafts),
+      lastFocusedId: cleanTargets.at(-1) ?? null,
+    };
+  }
+
+  for (const id of cleanTargets) {
+    if (mode === "add") {
+      selected.add(id);
+    } else if (mode === "remove") {
+      selected.delete(id);
+    } else if (selected.has(id)) {
+      selected.delete(id);
+    } else {
+      selected.add(id);
+    }
+  }
+
+  return {
+    selectedIds: sortIdsByDraftOrder(selected, drafts),
+    lastFocusedId: cleanTargets.at(-1) ?? null,
+  };
+}
+
+export function invertBulkSelection(drafts: Draft[], selectedIds: string[]): BulkSelectionState {
+  const selected = new Set(normalizeSelectedDraftIds(drafts, selectedIds));
+  const inverted = getDraftIds(drafts).filter((id) => !selected.has(id));
+  return {
+    selectedIds: inverted,
+    lastFocusedId: inverted.at(-1) ?? null,
+  };
+}
+
+export function formatBulkSelectionSummary(summary: BulkSelectionSummary): string {
+  if (summary.totalCount === 0) {
+    return "No draft messages available.";
+  }
+
+  if (summary.selectedCount === 0) {
+    return `No draft messages selected out of ${summary.totalCount}.`;
+  }
+
+  if (summary.allSelected) {
+    return `All ${summary.totalCount} draft messages selected.`;
+  }
+
+  return `${summary.selectedCount} of ${summary.totalCount} draft messages selected.`;
+}

--- a/src/features/demo-admin-dashboard/components/BulkSelectionToolbar.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkSelectionToolbar.tsx
@@ -1,0 +1,81 @@
+import { CheckSquare, ListChecks, RotateCcw, Square, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Draft } from "../types/draft";
+import {
+  clearBulkSelection,
+  formatBulkSelectionSummary,
+  getBulkSelectionSummary,
+  invertBulkSelection,
+  selectAllDrafts,
+} from "../bulkSelection";
+
+export interface BulkSelectionToolbarProps {
+  drafts: Draft[];
+  selectedIds: string[];
+  onSelectionChange: (selectedIds: string[]) => void;
+  className?: string;
+}
+
+export function BulkSelectionToolbar({
+  drafts,
+  selectedIds,
+  onSelectionChange,
+  className,
+}: BulkSelectionToolbarProps) {
+  const summary = getBulkSelectionSummary(drafts, selectedIds);
+  const disabled = drafts.length === 0;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border border-white/[0.08] bg-white/[0.02] p-3 sm:flex-row sm:items-center sm:justify-between",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2 text-sm">
+        <ListChecks className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate font-medium">Bulk selection</span>
+        <span className="text-muted-foreground">{formatBulkSelectionSummary(summary)}</span>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={disabled || summary.allSelected}
+          onClick={() => onSelectionChange(selectAllDrafts(drafts).selectedIds)}
+          className={toolbarButtonClass(disabled || summary.allSelected)}
+        >
+          <CheckSquare className="h-4 w-4" />
+          Select all
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onSelectionChange(invertBulkSelection(drafts, selectedIds).selectedIds)}
+          className={toolbarButtonClass(disabled)}
+        >
+          <RotateCcw className="h-4 w-4" />
+          Invert
+        </button>
+        <button
+          type="button"
+          disabled={disabled || summary.selectedCount === 0}
+          onClick={() => onSelectionChange(clearBulkSelection().selectedIds)}
+          className={toolbarButtonClass(disabled || summary.selectedCount === 0)}
+        >
+          {summary.partiallySelected ? <Square className="h-4 w-4" /> : <X className="h-4 w-4" />}
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function toolbarButtonClass(disabled: boolean): string {
+  return cn(
+    "inline-flex items-center gap-1 rounded-lg border px-3 py-2 text-sm transition-colors",
+    disabled
+      ? "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60"
+      : "border-white/[0.08] text-foreground hover:bg-white/[0.04]",
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -244,6 +244,20 @@ export { useDraftDataset } from "./hooks/useDraftDataset";
 export type { UseDraftDatasetResult } from "./hooks/useDraftDataset";
 export type { DraftDatasetAction, DraftDatasetState } from "./types/draftDataset";
 export { draftDatasetSample } from "./fixtures/draftDatasetFixtures";
+export {
+  emptyBulkSelection,
+  normalizeSelectedDraftIds,
+  getBulkSelectionSummary,
+  selectAllDrafts as selectAllBulkDrafts,
+  clearBulkSelection,
+  selectDraftRange,
+  updateBulkSelection,
+  invertBulkSelection,
+  formatBulkSelectionSummary,
+} from "./bulkSelection";
+export type { BulkSelectionMode, BulkSelectionState, BulkSelectionSummary } from "./bulkSelection";
+export { BulkSelectionToolbar } from "./components/BulkSelectionToolbar";
+export type { BulkSelectionToolbarProps } from "./components/BulkSelectionToolbar";
 
 // Draft dataset JSON export (issue #190): serializer, filename builder, button.
 export {


### PR DESCRIPTION
Closes #203

## Summary
- add deterministic bulk selection helpers for demo draft messages
- add a dashboard-only BulkSelectionToolbar with select all, invert, and clear actions
- cover ordering, range selection, toggle/add/remove behavior, inversion, and summary copy with focused unit tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/bulkSelection.ts src/features/demo-admin-dashboard/components/BulkSelectionToolbar.tsx src/features/demo-admin-dashboard/__tests__/bulkSelection.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check

Note: this workspace did not have 
ode_modules, so targeted Vitest could not start locally because the project Vite plugins were not installed. The focused test file is included for CI to run with normal dependency installation.