### PR TITLE
Add demo admin edit history reducer

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/historyReducer.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/historyReducer.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { DraftDatasetState } from "../types/draftDataset";
+import {
+  adminEditHistoryReducer,
+  canRedoAdminEdit,
+  canUndoAdminEdit,
+  createAdminEditHistory,
+  summarizeAdminEditHistory,
+} from "../reducers/historyReducer";
+
+const emptyDataset: DraftDatasetState = {
+  drafts: [],
+  selectedId: null,
+};
+
+const oneDraftDataset: DraftDatasetState = {
+  drafts: [
+    {
+      id: "draft-alpha",
+      subject: "Alpha",
+      body: "Safe fake message body.",
+      recipients: ["alpha@example.com"],
+    },
+  ],
+  selectedId: "draft-alpha",
+};
+
+const twoDraftDataset: DraftDatasetState = {
+  drafts: [
+    ...oneDraftDataset.drafts,
+    {
+      id: "draft-beta",
+      subject: "Beta",
+      body: "Another deterministic fake message.",
+      recipients: ["beta@example.org"],
+    },
+  ],
+  selectedId: "draft-beta",
+};
+
+describe("adminEditHistoryReducer", () => {
+  it("creates bounded edit history state", () => {
+    const history = createAdminEditHistory(emptyDataset, 3);
+
+    expect(history).toEqual({
+      past: [],
+      present: emptyDataset,
+      future: [],
+      limit: 3,
+    });
+    expect(canUndoAdminEdit(history)).toBe(false);
+    expect(canRedoAdminEdit(history)).toBe(false);
+  });
+
+  it("pushes a new present value and clears redo history", () => {
+    const withOneDraft = adminEditHistoryReducer(createAdminEditHistory(emptyDataset), {
+      type: "push",
+      payload: oneDraftDataset,
+    });
+    const undone = adminEditHistoryReducer(withOneDraft, { type: "undo" });
+    const replaced = adminEditHistoryReducer(undone, {
+      type: "push",
+      payload: twoDraftDataset,
+    });
+
+    expect(replaced.past).toEqual([emptyDataset]);
+    expect(replaced.present).toBe(twoDraftDataset);
+    expect(replaced.future).toEqual([]);
+  });
+
+  it("does not create a new history entry for the same object reference", () => {
+    const initial = createAdminEditHistory(emptyDataset);
+    const unchanged = adminEditHistoryReducer(initial, {
+      type: "push",
+      payload: emptyDataset,
+    });
+
+    expect(unchanged).toBe(initial);
+  });
+
+  it("undoes and redoes edits in order", () => {
+    const initial = createAdminEditHistory(emptyDataset);
+    const first = adminEditHistoryReducer(initial, { type: "push", payload: oneDraftDataset });
+    const second = adminEditHistoryReducer(first, { type: "push", payload: twoDraftDataset });
+
+    const undone = adminEditHistoryReducer(second, { type: "undo" });
+    expect(undone.present).toBe(oneDraftDataset);
+    expect(undone.future).toEqual([twoDraftDataset]);
+
+    const redone = adminEditHistoryReducer(undone, { type: "redo" });
+    expect(redone.present).toBe(twoDraftDataset);
+    expect(redone.past).toEqual([emptyDataset, oneDraftDataset]);
+    expect(redone.future).toEqual([]);
+  });
+
+  it("keeps only the latest past states when the limit is reached", () => {
+    let history = createAdminEditHistory(emptyDataset, 2);
+    history = adminEditHistoryReducer(history, { type: "push", payload: oneDraftDataset });
+    history = adminEditHistoryReducer(history, { type: "push", payload: twoDraftDataset });
+    history = adminEditHistoryReducer(history, {
+      type: "push",
+      payload: { ...twoDraftDataset, selectedId: null },
+    });
+
+    expect(history.past).toEqual([oneDraftDataset, twoDraftDataset]);
+    expect(history.limit).toBe(2);
+  });
+
+  it("resets history without changing the current limit", () => {
+    const history = adminEditHistoryReducer(createAdminEditHistory(emptyDataset, 4), {
+      type: "push",
+      payload: oneDraftDataset,
+    });
+    const reset = adminEditHistoryReducer(history, { type: "reset", payload: twoDraftDataset });
+
+    expect(reset).toEqual({
+      past: [],
+      present: twoDraftDataset,
+      future: [],
+      limit: 4,
+    });
+  });
+
+  it("normalizes limit changes and trims existing past states", () => {
+    let history = createAdminEditHistory(emptyDataset, 5);
+    history = adminEditHistoryReducer(history, { type: "push", payload: oneDraftDataset });
+    history = adminEditHistoryReducer(history, { type: "push", payload: twoDraftDataset });
+
+    const limited = adminEditHistoryReducer(history, { type: "setLimit", payload: 1.8 });
+
+    expect(limited.limit).toBe(1);
+    expect(limited.past).toEqual([oneDraftDataset]);
+  });
+
+  it("summarizes undo and redo availability for toolbar consumers", () => {
+    const pushed = adminEditHistoryReducer(createAdminEditHistory(emptyDataset), {
+      type: "push",
+      payload: oneDraftDataset,
+    });
+    const undone = adminEditHistoryReducer(pushed, { type: "undo" });
+
+    expect(summarizeAdminEditHistory(undone)).toEqual({
+      canUndo: false,
+      canRedo: true,
+      undoCount: 0,
+      redoCount: 1,
+      limit: 25,
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -233,6 +233,18 @@ export {
 // Draft dataset admin store (issue #172): reducer, selectors, hook, types, fixture.
 export { draftDatasetReducer, initialDraftDatasetState } from "./reducers/draftDatasetReducer";
 export {
+  adminEditHistoryReducer,
+  canRedoAdminEdit,
+  canUndoAdminEdit,
+  createAdminEditHistory,
+  summarizeAdminEditHistory,
+} from "./reducers/historyReducer";
+export type {
+  AdminEditHistoryAction,
+  AdminEditHistoryState,
+  AdminEditHistorySummary,
+} from "./reducers/historyReducer";
+export {
   selectAllDrafts,
   selectDraftById,
   selectDraftCount,

--- a/src/features/demo-admin-dashboard/reducers/historyReducer.ts
+++ b/src/features/demo-admin-dashboard/reducers/historyReducer.ts
@@ -1,0 +1,120 @@
+export interface AdminEditHistoryState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+  limit: number;
+}
+
+export type AdminEditHistoryAction<T> =
+  | { type: "push"; payload: T }
+  | { type: "undo" }
+  | { type: "redo" }
+  | { type: "reset"; payload: T }
+  | { type: "setLimit"; payload: number };
+
+export interface AdminEditHistorySummary {
+  canUndo: boolean;
+  canRedo: boolean;
+  undoCount: number;
+  redoCount: number;
+  limit: number;
+}
+
+const DEFAULT_HISTORY_LIMIT = 25;
+
+export function createAdminEditHistory<T>(
+  present: T,
+  limit = DEFAULT_HISTORY_LIMIT,
+): AdminEditHistoryState<T> {
+  return {
+    past: [],
+    present,
+    future: [],
+    limit: normalizeLimit(limit),
+  };
+}
+
+export function adminEditHistoryReducer<T>(
+  state: AdminEditHistoryState<T>,
+  action: AdminEditHistoryAction<T>,
+): AdminEditHistoryState<T> {
+  switch (action.type) {
+    case "push":
+      if (Object.is(state.present, action.payload)) {
+        return state;
+      }
+      return {
+        ...state,
+        past: trimPast([...state.past, state.present], state.limit),
+        present: action.payload,
+        future: [],
+      };
+    case "undo": {
+      if (state.past.length === 0) {
+        return state;
+      }
+      const previous = state.past[state.past.length - 1];
+      return {
+        ...state,
+        past: state.past.slice(0, -1),
+        present: previous,
+        future: [state.present, ...state.future],
+      };
+    }
+    case "redo": {
+      if (state.future.length === 0) {
+        return state;
+      }
+      const [next, ...future] = state.future;
+      return {
+        ...state,
+        past: trimPast([...state.past, state.present], state.limit),
+        present: next,
+        future,
+      };
+    }
+    case "reset":
+      return createAdminEditHistory(action.payload, state.limit);
+    case "setLimit": {
+      const limit = normalizeLimit(action.payload);
+      return {
+        ...state,
+        limit,
+        past: trimPast(state.past, limit),
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export function canUndoAdminEdit<T>(state: AdminEditHistoryState<T>): boolean {
+  return state.past.length > 0;
+}
+
+export function canRedoAdminEdit<T>(state: AdminEditHistoryState<T>): boolean {
+  return state.future.length > 0;
+}
+
+export function summarizeAdminEditHistory<T>(
+  state: AdminEditHistoryState<T>,
+): AdminEditHistorySummary {
+  return {
+    canUndo: canUndoAdminEdit(state),
+    canRedo: canRedoAdminEdit(state),
+    undoCount: state.past.length,
+    redoCount: state.future.length,
+    limit: state.limit,
+  };
+}
+
+function normalizeLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_HISTORY_LIMIT;
+  }
+  return Math.max(1, Math.floor(limit));
+}
+
+function trimPast<T>(past: T[], limit: number): T[] {
+  return past.length > limit ? past.slice(past.length - limit) : past;
+}


### PR DESCRIPTION
Closes #192

## Summary
- add a bounded admin edit history reducer for local demo-admin edits
- support push, undo, redo, reset, and runtime history-limit changes
- expose undo/redo summary helpers for future dashboard toolbar consumers
- cover ordering, redo clearing, bounded history, reset, limit normalization, and summary state with focused tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/reducers/historyReducer.ts src/features/demo-admin-dashboard/__tests__/historyReducer.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check

Note: targeted Vitest could not start in this fresh workspace because 
ode_modules is not installed and the project Vite plugins are unavailable locally. The PR includes the focused unit test file for normal CI dependency installation.