### PR TITLE
Add demo admin mock publish workflow

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/mockPublishWorkflow.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/mockPublishWorkflow.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  canRetryMockPublish,
+  canRollbackMockPublish,
+  canStartMockPublish,
+  getMockPublishSummary,
+  initialMockPublishState,
+  mockPublishReducer,
+} from "../mockPublishWorkflow";
+
+describe("mockPublishWorkflow", () => {
+  it("previews queued demo drafts", () => {
+    const preview = mockPublishReducer(initialMockPublishState, {
+      type: "preview",
+      payload: { draftCount: 2 },
+    });
+
+    expect(preview.status).toBe("preview");
+    expect(preview.draftCount).toBe(2);
+    expect(canStartMockPublish(preview)).toBe(true);
+    expect(getMockPublishSummary(preview)).toBe("2 demo drafts ready for preview.");
+  });
+
+  it("rejects publishing without queued draft data", () => {
+    const failed = mockPublishReducer(initialMockPublishState, { type: "start" });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("Add at least one demo draft before publishing.");
+    expect(canRetryMockPublish(failed)).toBe(true);
+  });
+
+  it("starts and completes a local mock publish", () => {
+    const preview = mockPublishReducer(initialMockPublishState, {
+      type: "preview",
+      payload: { draftCount: 1 },
+    });
+    const publishing = mockPublishReducer(preview, {
+      type: "start",
+      payload: { now: "2026-06-20T09:00:00Z" },
+    });
+    const published = mockPublishReducer(publishing, {
+      type: "succeed",
+      payload: { now: "2026-06-20T09:00:05Z" },
+    });
+
+    expect(publishing.status).toBe("publishing");
+    expect(publishing.attempt).toBe(1);
+    expect(publishing.steps.map((step) => step.complete)).toEqual([true, true, false]);
+    expect(published.status).toBe("published");
+    expect(published.rollbackAvailable).toBe(true);
+    expect(published.steps.every((step) => step.complete)).toBe(true);
+    expect(getMockPublishSummary(published)).toBe("Mock publish completed for 1 demo draft.");
+  });
+
+  it("supports failure, retry, and rollback simulation", () => {
+    const preview = mockPublishReducer(initialMockPublishState, {
+      type: "preview",
+      payload: { draftCount: 3 },
+    });
+    const publishing = mockPublishReducer(preview, { type: "start" });
+    const failed = mockPublishReducer(publishing, {
+      type: "fail",
+      payload: { message: "Fixture validation failed." },
+    });
+    const retrying = mockPublishReducer(failed, { type: "retry" });
+    const published = mockPublishReducer(retrying, {
+      type: "succeed",
+      payload: { now: "2026-06-20T09:01:00Z" },
+    });
+    const rolledBack = mockPublishReducer(published, { type: "rollback" });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("Fixture validation failed.");
+    expect(retrying.status).toBe("publishing");
+    expect(retrying.attempt).toBe(2);
+    expect(canRollbackMockPublish(published)).toBe(true);
+    expect(rolledBack.status).toBe("rolled-back");
+    expect(rolledBack.rollbackAvailable).toBe(false);
+    expect(rolledBack.steps.every((step) => !step.complete)).toBe(true);
+  });
+
+  it("resets the workflow back to idle", () => {
+    const preview = mockPublishReducer(initialMockPublishState, {
+      type: "preview",
+      payload: { draftCount: 1 },
+    });
+
+    expect(mockPublishReducer(preview, { type: "reset" })).toEqual(initialMockPublishState);
+  });
+});

--- a/src/features/demo-admin-dashboard/components/MockPublishPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/MockPublishPanel.tsx
@@ -1,0 +1,107 @@
+import { RotateCcw, RotateCw, Send, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MockPublishState } from "../mockPublishWorkflow";
+import {
+  canRetryMockPublish,
+  canRollbackMockPublish,
+  canStartMockPublish,
+  getMockPublishSummary,
+} from "../mockPublishWorkflow";
+
+export interface MockPublishPanelProps {
+  state: MockPublishState;
+  onStart: () => void;
+  onRetry: () => void;
+  onRollback: () => void;
+  className?: string;
+}
+
+export function MockPublishPanel({
+  state,
+  onStart,
+  onRetry,
+  onRollback,
+  className,
+}: MockPublishPanelProps) {
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Mock publish workflow</h3>
+        </div>
+        <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-xs text-muted-foreground">
+          {state.status}
+        </span>
+      </header>
+
+      <p className="text-sm text-muted-foreground">{getMockPublishSummary(state)}</p>
+
+      <ol className="flex flex-col gap-2">
+        {state.steps.map((step) => (
+          <li key={step.id} className="flex items-center gap-2 text-sm">
+            <span
+              className={cn(
+                "h-2.5 w-2.5 rounded-full border",
+                step.complete ? "border-emerald-400 bg-emerald-400" : "border-white/20",
+              )}
+            />
+            <span className={step.complete ? "text-foreground" : "text-muted-foreground"}>
+              {step.label}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {state.error ? (
+        <p className="rounded-lg border border-rose-500/20 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          {state.error}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={!canStartMockPublish(state)}
+          onClick={onStart}
+          className={actionButtonClass(canStartMockPublish(state))}
+        >
+          <Send className="h-4 w-4" />
+          Start
+        </button>
+        <button
+          type="button"
+          disabled={!canRetryMockPublish(state)}
+          onClick={onRetry}
+          className={actionButtonClass(canRetryMockPublish(state))}
+        >
+          <RotateCw className="h-4 w-4" />
+          Retry
+        </button>
+        <button
+          type="button"
+          disabled={!canRollbackMockPublish(state)}
+          onClick={onRollback}
+          className={actionButtonClass(canRollbackMockPublish(state))}
+        >
+          <RotateCcw className="h-4 w-4" />
+          Roll back
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function actionButtonClass(enabled: boolean): string {
+  return cn(
+    "inline-flex items-center gap-1 rounded-lg border px-3 py-2 text-sm transition-colors",
+    enabled
+      ? "border-white/[0.08] text-foreground hover:bg-white/[0.04]"
+      : "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60",
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,6 +56,22 @@ export {
 } from "./constants/displayTokens";
 
 export { CampaignTagManager } from "./components/CampaignTagManager";
+export { MockPublishPanel } from "./components/MockPublishPanel";
+export type { MockPublishPanelProps } from "./components/MockPublishPanel";
+export {
+  canRetryMockPublish,
+  canRollbackMockPublish,
+  canStartMockPublish,
+  getMockPublishSummary,
+  initialMockPublishState,
+  mockPublishReducer,
+} from "./mockPublishWorkflow";
+export type {
+  MockPublishAction,
+  MockPublishState,
+  MockPublishStatus,
+  MockPublishStep,
+} from "./mockPublishWorkflow";
 
 export {
   createTag,

--- a/src/features/demo-admin-dashboard/mockPublishWorkflow.ts
+++ b/src/features/demo-admin-dashboard/mockPublishWorkflow.ts
@@ -1,0 +1,161 @@
+export type MockPublishStatus =
+  | "idle"
+  | "preview"
+  | "publishing"
+  | "published"
+  | "failed"
+  | "rolled-back";
+
+export interface MockPublishStep {
+  id: string;
+  label: string;
+  complete: boolean;
+}
+
+export interface MockPublishState {
+  status: MockPublishStatus;
+  draftCount: number;
+  attempt: number;
+  lastPublishedAt: string | null;
+  rollbackAvailable: boolean;
+  error: string | null;
+  steps: MockPublishStep[];
+}
+
+export type MockPublishAction =
+  | { type: "preview"; payload: { draftCount: number } }
+  | { type: "start"; payload?: { now?: string } }
+  | { type: "succeed"; payload: { now: string } }
+  | { type: "fail"; payload: { message: string } }
+  | { type: "retry" }
+  | { type: "rollback" }
+  | { type: "reset" };
+
+const initialSteps: MockPublishStep[] = [
+  { id: "validate", label: "Validate demo records", complete: false },
+  { id: "snapshot", label: "Create local snapshot", complete: false },
+  { id: "publish", label: "Simulate draft publish", complete: false },
+];
+
+export const initialMockPublishState: MockPublishState = {
+  status: "idle",
+  draftCount: 0,
+  attempt: 0,
+  lastPublishedAt: null,
+  rollbackAvailable: false,
+  error: null,
+  steps: initialSteps,
+};
+
+export function mockPublishReducer(
+  state: MockPublishState,
+  action: MockPublishAction,
+): MockPublishState {
+  switch (action.type) {
+    case "preview":
+      return {
+        ...initialMockPublishState,
+        status: action.payload.draftCount > 0 ? "preview" : "idle",
+        draftCount: Math.max(0, action.payload.draftCount),
+      };
+    case "start":
+      if (state.draftCount === 0) {
+        return {
+          ...state,
+          status: "failed",
+          error: "Add at least one demo draft before publishing.",
+        };
+      }
+      return {
+        ...state,
+        status: "publishing",
+        attempt: state.attempt + 1,
+        error: null,
+        steps: markSteps(["validate", "snapshot"]),
+        lastPublishedAt: action.payload?.now ?? state.lastPublishedAt,
+      };
+    case "succeed":
+      return {
+        ...state,
+        status: "published",
+        lastPublishedAt: action.payload.now,
+        rollbackAvailable: true,
+        error: null,
+        steps: markSteps(["validate", "snapshot", "publish"]),
+      };
+    case "fail":
+      return {
+        ...state,
+        status: "failed",
+        error: action.payload.message,
+        steps: markSteps(["validate", "snapshot"]),
+      };
+    case "retry":
+      if (state.status !== "failed") {
+        return state;
+      }
+      return {
+        ...state,
+        status: "publishing",
+        attempt: state.attempt + 1,
+        error: null,
+        steps: markSteps(["validate", "snapshot"]),
+      };
+    case "rollback":
+      if (!state.rollbackAvailable) {
+        return state;
+      }
+      return {
+        ...state,
+        status: "rolled-back",
+        rollbackAvailable: false,
+        error: null,
+        steps: initialSteps,
+      };
+    case "reset":
+      return initialMockPublishState;
+    default:
+      return state;
+  }
+}
+
+export function getMockPublishSummary(state: MockPublishState): string {
+  if (state.status === "idle") {
+    return "No demo drafts queued for mock publish.";
+  }
+  if (state.status === "preview") {
+    return `${state.draftCount} demo draft${state.draftCount === 1 ? "" : "s"} ready for preview.`;
+  }
+  if (state.status === "publishing") {
+    return `Mock publish attempt ${state.attempt} is running locally.`;
+  }
+  if (state.status === "published") {
+    return `Mock publish completed for ${state.draftCount} demo draft${
+      state.draftCount === 1 ? "" : "s"
+    }.`;
+  }
+  if (state.status === "rolled-back") {
+    return "Mock publish rolled back to the previous local snapshot.";
+  }
+  return state.error ?? "Mock publish failed.";
+}
+
+export function canStartMockPublish(state: MockPublishState): boolean {
+  return state.status === "preview" && state.draftCount > 0;
+}
+
+export function canRetryMockPublish(state: MockPublishState): boolean {
+  return state.status === "failed";
+}
+
+export function canRollbackMockPublish(state: MockPublishState): boolean {
+  return state.rollbackAvailable;
+}
+
+function markSteps(completeIds: string[]): MockPublishStep[] {
+  const completed = new Set(completeIds);
+  return initialSteps.map((step) => ({
+    ...step,
+    complete: completed.has(step.id),
+  }));
+}


### PR DESCRIPTION
Closes #195

## Summary
- add a local mock publish workflow state machine for demo-admin draft data
- add a dashboard-only MockPublishPanel with start, retry, and rollback actions
- keep the flow deterministic and non-production: no network calls, live inbox writes, or real data
- cover preview, no-draft failure, publish success, retry, rollback, and reset behavior with focused tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/mockPublishWorkflow.ts src/features/demo-admin-dashboard/components/MockPublishPanel.tsx src/features/demo-admin-dashboard/__tests__/mockPublishWorkflow.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for account/payment/private-key markers returned no matches

Note: targeted Vitest could not start in this fresh workspace because 
ode_modules is not installed and the project Vite plugins are unavailable locally. The PR includes the focused unit test file for normal CI dependency installation.