### PR TITLE
Add demo admin local inbox preview

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/localInboxPreview.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/localInboxPreview.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { inboxSeedDataset } from "../fixtures/inboxSeedDataset";
+import {
+  formatLocalInboxPreviewSubtitle,
+  getLocalInboxPreviewReader,
+  getLocalInboxPreviewRows,
+  getLocalInboxPreviewRowsForFolder,
+} from "../utils/localInboxPreview";
+
+describe("localInboxPreview", () => {
+  it("maps seed messages into newest-first preview rows", () => {
+    const rows = getLocalInboxPreviewRows(inboxSeedDataset);
+
+    expect(rows).toHaveLength(inboxSeedDataset.messages.length);
+    for (let index = 1; index < rows.length; index++) {
+      expect(rows[index].date <= rows[index - 1].date).toBe(true);
+    }
+    expect(rows[0]).toMatchObject({
+      subject: "Waiting for wallet signature",
+      folder: "outbox",
+      hasProof: true,
+    });
+  });
+
+  it("filters rows by local folder mapping", () => {
+    const requests = getLocalInboxPreviewRowsForFolder(inboxSeedDataset, "requests");
+
+    expect(requests.map((row) => row.id).sort()).toEqual([
+      "seed-msg-05",
+      "seed-msg-05b",
+      "seed-msg-05c",
+    ]);
+  });
+
+  it("builds a reader preview for a selected message", () => {
+    const reader = getLocalInboxPreviewReader(inboxSeedDataset, "seed-msg-01");
+
+    expect(reader?.row.subject).toBe("Q2 brand system - final direction");
+    expect(reader?.attachmentNames).toContain("vantage-identity-v3.pdf");
+    expect(reader?.proofStatus).toBe("verified");
+    expect(reader?.recipients).toEqual(["eve@stealth.xyz"]);
+  });
+
+  it("falls back to the newest unread message when selection is missing", () => {
+    const reader = getLocalInboxPreviewReader(inboxSeedDataset, "missing");
+
+    expect(reader?.row.isRead).toBe(false);
+    expect(reader?.row.id).toBe("seed-msg-13");
+  });
+
+  it("formats list subtitles with folder and read state", () => {
+    const row = getLocalInboxPreviewRows(inboxSeedDataset).find(
+      (item) => item.id === "seed-msg-01",
+    );
+
+    expect(row).toBeDefined();
+    expect(formatLocalInboxPreviewSubtitle(row!)).toBe("priority / unread, starred");
+  });
+});

--- a/src/features/demo-admin-dashboard/components/DemoInboxPreview.tsx
+++ b/src/features/demo-admin-dashboard/components/DemoInboxPreview.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { CalendarDays, FileText, Mail, ShieldCheck, Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { inboxSeedDataset } from "../fixtures/inboxSeedDataset";
+import { getSeedDatasetPreview } from "../utils/seedDatasetPreview";
+import type { DemoDataset } from "../types/dataset";
+import {
+  formatLocalInboxPreviewSubtitle,
+  getLocalInboxPreviewReader,
+  getLocalInboxPreviewRows,
+} from "../utils/localInboxPreview";
+
+export interface DemoInboxPreviewProps {
+  dataset?: DemoDataset;
+  selectedId?: string | null;
+  onSelectMessage?: (id: string) => void;
+  className?: string;
+}
+
+export function DemoInboxPreview({
+  dataset = inboxSeedDataset,
+  selectedId,
+  onSelectMessage,
+  className,
+}: DemoInboxPreviewProps) {
+  const rows = useMemo(() => getLocalInboxPreviewRows(dataset), [dataset]);
+  const summary = useMemo(() => getSeedDatasetPreview(dataset), [dataset]);
+  const [localSelectedId, setLocalSelectedId] = useState<string | null>(rows[0]?.id ?? null);
+  const activeId = selectedId ?? localSelectedId;
+  const reader = getLocalInboxPreviewReader(dataset, activeId);
+
+  const selectMessage = (id: string) => {
+    setLocalSelectedId(id);
+    onSelectMessage?.(id);
+  };
+
+  return (
+    <section
+      className={cn(
+        "grid gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium">{summary.name}</h3>
+            <p className="text-xs text-muted-foreground">{summary.totalMessages} local messages</p>
+          </div>
+          <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-xs text-muted-foreground">
+            {summary.uniqueSenders} senders
+          </span>
+        </header>
+
+        <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+          <Metric label="Unread" value={summary.stats.unread} />
+          <Metric label="Proofs" value={summary.stats.withProof} />
+          <Metric label="Files" value={summary.stats.withAttachments} />
+          <Metric label="Events" value={summary.stats.withCalendarEvent} />
+        </div>
+
+        <div className="flex max-h-[32rem] flex-col gap-2 overflow-y-auto pr-1">
+          {rows.map((row) => {
+            const selected = row.id === reader?.row.id;
+            return (
+              <button
+                key={row.id}
+                type="button"
+                onClick={() => selectMessage(row.id)}
+                className={cn(
+                  "flex flex-col gap-2 rounded-lg border px-3 py-3 text-left transition-colors",
+                  selected
+                    ? "border-sky-500/40 bg-sky-500/10"
+                    : "border-white/[0.06] hover:bg-white/[0.04]",
+                )}
+              >
+                <span className="flex items-center justify-between gap-3">
+                  <span className="truncate text-sm font-medium">{row.subject}</span>
+                  {row.isStarred ? <Star className="h-4 w-4 shrink-0 text-amber-300" /> : null}
+                </span>
+                <span className="truncate text-xs text-muted-foreground">{row.senderName}</span>
+                <span className="line-clamp-2 text-xs text-muted-foreground">{row.snippet}</span>
+                <span className="flex flex-wrap gap-1">
+                  {row.labels.slice(0, 3).map((label) => (
+                    <span
+                      key={label}
+                      className="rounded-full border border-white/[0.08] px-2 py-0.5 text-[0.7rem] text-muted-foreground"
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <article className="flex min-w-0 flex-col gap-4 rounded-xl border border-white/[0.06] bg-black/[0.08] p-4">
+        {reader ? (
+          <>
+            <header className="flex flex-col gap-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h4 className="truncate text-base font-semibold">{reader.row.subject}</h4>
+                  <p className="text-sm text-muted-foreground">
+                    {reader.row.senderName} &lt;{reader.row.senderAddress}&gt;
+                  </p>
+                </div>
+                <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-xs text-muted-foreground">
+                  {formatLocalInboxPreviewSubtitle(reader.row)}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground">To {reader.recipients.join(", ")}</p>
+            </header>
+
+            <p className="whitespace-pre-line text-sm leading-6 text-foreground">{reader.body}</p>
+
+            <div className="grid gap-2 text-xs sm:grid-cols-2">
+              <ReaderFlag
+                icon={<ShieldCheck className="h-4 w-4" />}
+                label="Proof"
+                value={reader.proofStatus}
+              />
+              <ReaderFlag
+                icon={<FileText className="h-4 w-4" />}
+                label="Attachments"
+                value={reader.attachmentNames.length.toString()}
+              />
+              <ReaderFlag
+                icon={<CalendarDays className="h-4 w-4" />}
+                label="Calendar"
+                value={reader.calendarTitle ?? "none"}
+              />
+              <ReaderFlag
+                icon={<Mail className="h-4 w-4" />}
+                label="Thread"
+                value={reader.row.threadId}
+              />
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">No local inbox messages available.</p>
+        )}
+      </article>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <p className="text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function ReaderFlag({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <span className="text-muted-foreground">{icon}</span>
+      <span className="min-w-0">
+        <span className="block text-muted-foreground">{label}</span>
+        <span className="block truncate text-foreground">{value}</span>
+      </span>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,6 +56,8 @@ export {
 } from "./constants/displayTokens";
 
 export { CampaignTagManager } from "./components/CampaignTagManager";
+export { DemoInboxPreview } from "./components/DemoInboxPreview";
+export type { DemoInboxPreviewProps } from "./components/DemoInboxPreview";
 export { MockPublishPanel } from "./components/MockPublishPanel";
 export type { MockPublishPanelProps } from "./components/MockPublishPanel";
 export {
@@ -72,6 +74,13 @@ export type {
   MockPublishStatus,
   MockPublishStep,
 } from "./mockPublishWorkflow";
+export {
+  formatLocalInboxPreviewSubtitle,
+  getLocalInboxPreviewReader,
+  getLocalInboxPreviewRows,
+  getLocalInboxPreviewRowsForFolder,
+} from "./utils/localInboxPreview";
+export type { LocalInboxPreviewReader, LocalInboxPreviewRow } from "./utils/localInboxPreview";
 
 export {
   createTag,

--- a/src/features/demo-admin-dashboard/utils/localInboxPreview.ts
+++ b/src/features/demo-admin-dashboard/utils/localInboxPreview.ts
@@ -1,0 +1,95 @@
+import type { DemoDataset, DemoMessage } from "../types/dataset";
+import { inboxSeedFolderMap } from "../fixtures/inboxSeedMetadata";
+
+export interface LocalInboxPreviewRow {
+  id: string;
+  threadId: string;
+  subject: string;
+  senderName: string;
+  senderAddress: string;
+  folder: string;
+  date: string;
+  snippet: string;
+  labels: string[];
+  isRead: boolean;
+  isStarred: boolean;
+  hasProof: boolean;
+  hasAttachments: boolean;
+  hasCalendarEvent: boolean;
+  isSnoozed: boolean;
+}
+
+export interface LocalInboxPreviewReader {
+  row: LocalInboxPreviewRow;
+  body: string;
+  recipients: string[];
+  attachmentNames: string[];
+  proofStatus: string;
+  calendarTitle: string | null;
+}
+
+export function getLocalInboxPreviewRows(dataset: DemoDataset): LocalInboxPreviewRow[] {
+  return dataset.messages
+    .map((message) => toPreviewRow(message))
+    .sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export function getLocalInboxPreviewRowsForFolder(
+  dataset: DemoDataset,
+  folder: string,
+): LocalInboxPreviewRow[] {
+  return getLocalInboxPreviewRows(dataset).filter((row) => row.folder === folder);
+}
+
+export function getLocalInboxPreviewReader(
+  dataset: DemoDataset,
+  selectedId?: string | null,
+): LocalInboxPreviewReader | null {
+  const rows = getLocalInboxPreviewRows(dataset);
+  const selectedRow =
+    rows.find((row) => row.id === selectedId) ?? rows.find((row) => !row.isRead) ?? rows[0] ?? null;
+
+  if (!selectedRow) {
+    return null;
+  }
+
+  const message = dataset.messages.find((item) => item.id === selectedRow.id);
+  if (!message) {
+    return null;
+  }
+
+  return {
+    row: selectedRow,
+    body: message.body,
+    recipients: [...message.recipients],
+    attachmentNames: message.attachments.map((attachment) => attachment.filename),
+    proofStatus: message.proofRecord?.status ?? "none",
+    calendarTitle: message.calendarEvent?.title ?? null,
+  };
+}
+
+export function formatLocalInboxPreviewSubtitle(row: LocalInboxPreviewRow): string {
+  const state = row.isRead ? "read" : "unread";
+  const star = row.isStarred ? ", starred" : "";
+  return `${row.folder} / ${state}${star}`;
+}
+
+function toPreviewRow(message: DemoMessage): LocalInboxPreviewRow {
+  return {
+    id: message.id,
+    threadId: message.threadId,
+    subject: message.subject,
+    senderName: message.sender.name ?? message.sender.address,
+    senderAddress: message.sender.address,
+    folder: inboxSeedFolderMap[message.id] ?? "unknown",
+    date: message.date,
+    snippet: message.snippet,
+    labels: [...message.labels],
+    isRead: message.isRead,
+    isStarred: message.isStarred,
+    hasProof: message.proofRecord != null,
+    hasAttachments: message.attachments.length > 0,
+    hasCalendarEvent: message.calendarEvent != null,
+    isSnoozed: message.snoozeRemindAt != null,
+  };
+}


### PR DESCRIPTION
Closes #188

## Summary
- add local inbox preview row/reader helpers for the seed inbox dataset
- add a dashboard-only DemoInboxPreview with list preview, reader preview, and dataset metrics
- keep the preview isolated to fake demo-admin data without wiring into production inbox flows
- cover newest-first ordering, folder filtering, reader selection, fallback selection, and subtitle copy with focused tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/utils/localInboxPreview.ts src/features/demo-admin-dashboard/components/DemoInboxPreview.tsx src/features/demo-admin-dashboard/__tests__/localInboxPreview.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for account/payment/private-key markers returned no matches

Note: targeted Vitest could not start in this fresh workspace because 
ode_modules is not installed and the project Vite plugins are unavailable locally. The PR includes the focused unit test file for normal CI dependency installation.