### PR TITLE
Add draft bulk label editor

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/bulkLabelEditor.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkLabelEditor.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBulkLabelEdit,
+  normalizeDraftLabels,
+  parseDraftLabelInput,
+  summarizeBulkLabelEdit,
+  type DraftLabelMessage,
+} from "../bulkLabelEditor";
+
+const messages: DraftLabelMessage[] = [
+  {
+    id: "draft-alpha",
+    subject: "Alpha update",
+    labels: ["review", "Investor"],
+  },
+  {
+    id: "draft-beta",
+    subject: "Beta reply",
+    labels: ["follow-up"],
+  },
+  {
+    id: "draft-gamma",
+    subject: "Gamma memo",
+    labels: [],
+  },
+];
+
+describe("bulkLabelEditor", () => {
+  it("normalizes and de-duplicates label input", () => {
+    expect(normalizeDraftLabels([" Investor ", "investor", "", "Review"])).toEqual([
+      "investor",
+      "review",
+    ]);
+    expect(parseDraftLabelInput("QA, qa  Legal")).toEqual(["qa", "legal"]);
+  });
+
+  it("adds labels across selected draft messages without mutating input", () => {
+    const result = applyBulkLabelEdit(messages, ["draft-alpha", "draft-gamma"], ["QA"], "add");
+
+    expect(messages[0].labels).toEqual(["review", "Investor"]);
+    expect(result.messages.find((message) => message.id === "draft-alpha")?.labels).toEqual([
+      "review",
+      "investor",
+      "qa",
+    ]);
+    expect(result.messages.find((message) => message.id === "draft-gamma")?.labels).toEqual(["qa"]);
+    expect(result.summary.totalApplied).toBe(2);
+  });
+
+  it("skips duplicate labels during add operations", () => {
+    const result = applyBulkLabelEdit(messages, ["draft-alpha"], ["review", "legal"], "add");
+
+    expect(result.changes[0]).toMatchObject({
+      id: "draft-alpha",
+      applied: ["legal"],
+      skipped: ["review"],
+    });
+    expect(result.summary.totalSkipped).toBe(1);
+  });
+
+  it("removes selected labels and skips labels that are missing", () => {
+    const result = applyBulkLabelEdit(
+      messages,
+      ["draft-alpha", "draft-beta"],
+      ["investor", "missing"],
+      "remove",
+    );
+
+    expect(result.messages.find((message) => message.id === "draft-alpha")?.labels).toEqual([
+      "review",
+    ]);
+    expect(result.messages.find((message) => message.id === "draft-beta")?.labels).toEqual([
+      "follow-up",
+    ]);
+    expect(result.summary.affectedCount).toBe(1);
+    expect(result.summary.totalApplied).toBe(1);
+    expect(result.summary.totalSkipped).toBe(3);
+  });
+
+  it("summarizes changed and no-op edits", () => {
+    const changed = applyBulkLabelEdit(messages, ["draft-beta"], ["review"], "add");
+    expect(summarizeBulkLabelEdit(changed)).toBe("Added 1 label across 1 message.");
+
+    const noChange = applyBulkLabelEdit(messages, ["draft-alpha"], ["review"], "add");
+    expect(summarizeBulkLabelEdit(noChange)).toBe(
+      "No changes - all labels were duplicates (1 skipped).",
+    );
+  });
+});

--- a/src/features/demo-admin-dashboard/bulkLabelEditor.ts
+++ b/src/features/demo-admin-dashboard/bulkLabelEditor.ts
@@ -1,0 +1,143 @@
+export type BulkLabelOperation = "add" | "remove";
+
+export interface DraftLabelMessage {
+  id: string;
+  subject: string;
+  labels: string[];
+}
+
+export interface BulkLabelChange {
+  id: string;
+  subject: string;
+  applied: string[];
+  skipped: string[];
+}
+
+export interface BulkLabelSummary {
+  operation: BulkLabelOperation;
+  selectedCount: number;
+  affectedCount: number;
+  totalApplied: number;
+  totalSkipped: number;
+}
+
+export interface BulkLabelEditResult {
+  messages: DraftLabelMessage[];
+  operation: BulkLabelOperation;
+  requestedLabels: string[];
+  changes: BulkLabelChange[];
+  summary: BulkLabelSummary;
+}
+
+export function normalizeDraftLabel(label: string): string {
+  return label.trim().toLowerCase();
+}
+
+export function normalizeDraftLabels(labels: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const raw of labels) {
+    const label = normalizeDraftLabel(raw);
+    if (label.length === 0 || seen.has(label)) {
+      continue;
+    }
+    seen.add(label);
+    result.push(label);
+  }
+
+  return result;
+}
+
+export function parseDraftLabelInput(input: string): string[] {
+  return normalizeDraftLabels(input.split(/[\s,]+/));
+}
+
+export function applyBulkLabelEdit(
+  messages: DraftLabelMessage[],
+  selectedIds: string[],
+  labels: string[],
+  operation: BulkLabelOperation,
+): BulkLabelEditResult {
+  const selected = new Set(selectedIds);
+  const requestedLabels = normalizeDraftLabels(labels);
+  const changes: BulkLabelChange[] = [];
+
+  const nextMessages = messages.map((message) => {
+    if (!selected.has(message.id)) {
+      return message;
+    }
+
+    const existingLabels = normalizeDraftLabels(message.labels);
+    const existing = new Set(existingLabels);
+    const applied: string[] = [];
+    const skipped: string[] = [];
+
+    if (operation === "add") {
+      const nextLabels = [...existingLabels];
+      for (const label of requestedLabels) {
+        if (existing.has(label)) {
+          skipped.push(label);
+        } else {
+          existing.add(label);
+          nextLabels.push(label);
+          applied.push(label);
+        }
+      }
+      changes.push({ id: message.id, subject: message.subject, applied, skipped });
+      return applied.length === 0 ? message : { ...message, labels: nextLabels };
+    }
+
+    const remove = new Set(requestedLabels);
+    for (const label of requestedLabels) {
+      if (existing.has(label)) {
+        applied.push(label);
+      } else {
+        skipped.push(label);
+      }
+    }
+    changes.push({ id: message.id, subject: message.subject, applied, skipped });
+    return applied.length === 0
+      ? message
+      : { ...message, labels: existingLabels.filter((label) => !remove.has(label)) };
+  });
+
+  const affectedCount = changes.filter((change) => change.applied.length > 0).length;
+  const totalApplied = changes.reduce((sum, change) => sum + change.applied.length, 0);
+  const totalSkipped = changes.reduce((sum, change) => sum + change.skipped.length, 0);
+
+  return {
+    messages: nextMessages,
+    operation,
+    requestedLabels,
+    changes,
+    summary: {
+      operation,
+      selectedCount: changes.length,
+      affectedCount,
+      totalApplied,
+      totalSkipped,
+    },
+  };
+}
+
+export function summarizeBulkLabelEdit(result: BulkLabelEditResult): string {
+  const { operation, summary } = result;
+
+  if (summary.totalApplied === 0) {
+    const reason = operation === "add" ? "all labels were duplicates" : "no labels were present";
+    return `No changes - ${reason} (${summary.totalSkipped} skipped).`;
+  }
+
+  const verb = operation === "add" ? "Added" : "Removed";
+  const labelWord = summary.totalApplied === 1 ? "label" : "labels";
+  const messageWord = summary.affectedCount === 1 ? "message" : "messages";
+  const base = `${verb} ${summary.totalApplied} ${labelWord} across ${summary.affectedCount} ${messageWord}`;
+
+  if (summary.totalSkipped === 0) {
+    return `${base}.`;
+  }
+
+  const skipped = operation === "add" ? "skipped as duplicates" : "skipped as missing";
+  return `${base} (${summary.totalSkipped} ${skipped}).`;
+}

--- a/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from "react";
+import { Plus, Tag, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  applyBulkLabelEdit,
+  parseDraftLabelInput,
+  summarizeBulkLabelEdit,
+  type BulkLabelEditResult,
+  type BulkLabelOperation,
+  type DraftLabelMessage,
+} from "../bulkLabelEditor";
+
+export interface BulkLabelPanelProps {
+  messages: DraftLabelMessage[];
+  selectedIds: string[];
+  onApply?: (result: BulkLabelEditResult) => void;
+  className?: string;
+}
+
+export function BulkLabelPanel({ messages, selectedIds, onApply, className }: BulkLabelPanelProps) {
+  const [input, setInput] = useState("");
+  const [lastResult, setLastResult] = useState<BulkLabelEditResult | null>(null);
+  const parsedLabels = useMemo(() => parseDraftLabelInput(input), [input]);
+  const selectedCount = selectedIds.filter((id) =>
+    messages.some((message) => message.id === id),
+  ).length;
+  const canApply = selectedCount > 0 && parsedLabels.length > 0;
+
+  const runEdit = (operation: BulkLabelOperation) => {
+    if (!canApply) {
+      return;
+    }
+    const result = applyBulkLabelEdit(messages, selectedIds, parsedLabels, operation);
+    setLastResult(result);
+    onApply?.(result);
+  };
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Tag className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Bulk label panel</h3>
+        </div>
+        <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-xs text-muted-foreground">
+          {selectedCount} selected
+        </span>
+      </header>
+
+      <input
+        type="text"
+        value={input}
+        onChange={(event) => setInput(event.target.value)}
+        aria-label="Draft labels to add or remove"
+        placeholder="Labels, e.g. review, investor"
+        className="rounded-lg border border-white/[0.08] bg-transparent px-3 py-2 text-sm outline-none focus:border-sky-500/40"
+      />
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={!canApply}
+          onClick={() => runEdit("add")}
+          className={actionButtonClass(canApply)}
+        >
+          <Plus className="h-4 w-4" />
+          Add labels
+        </button>
+        <button
+          type="button"
+          disabled={!canApply}
+          onClick={() => runEdit("remove")}
+          className={actionButtonClass(canApply)}
+        >
+          <X className="h-4 w-4" />
+          Remove labels
+        </button>
+      </div>
+
+      {lastResult ? (
+        <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 text-sm">
+          <p className="font-medium">{summarizeBulkLabelEdit(lastResult)}</p>
+          <ul className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
+            {lastResult.changes.map((change) => (
+              <li key={change.id}>
+                {change.subject}: {change.applied.join(", ") || "no changes"}
+                {change.skipped.length > 0 ? ` (${change.skipped.join(", ")} skipped)` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function actionButtonClass(enabled: boolean): string {
+  return cn(
+    "inline-flex items-center gap-1 rounded-lg border px-3 py-2 text-sm transition-colors",
+    enabled
+      ? "border-white/[0.08] text-foreground hover:bg-white/[0.04]"
+      : "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60",
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,6 +56,8 @@ export {
 } from "./constants/displayTokens";
 
 export { CampaignTagManager } from "./components/CampaignTagManager";
+export { BulkLabelPanel } from "./components/BulkLabelPanel";
+export type { BulkLabelPanelProps } from "./components/BulkLabelPanel";
 export { MockPublishPanel } from "./components/MockPublishPanel";
 export type { MockPublishPanelProps } from "./components/MockPublishPanel";
 export {
@@ -72,6 +74,20 @@ export type {
   MockPublishStatus,
   MockPublishStep,
 } from "./mockPublishWorkflow";
+export {
+  applyBulkLabelEdit,
+  normalizeDraftLabel,
+  normalizeDraftLabels,
+  parseDraftLabelInput,
+  summarizeBulkLabelEdit,
+} from "./bulkLabelEditor";
+export type {
+  BulkLabelChange,
+  BulkLabelEditResult,
+  BulkLabelOperation,
+  BulkLabelSummary,
+  DraftLabelMessage,
+} from "./bulkLabelEditor";
 
 export {
   createTag,


### PR DESCRIPTION
Closes #205

## Summary
- add draft-message bulk label helper logic for add/remove operations
- normalize and de-duplicate labels, preserving deterministic message order
- add a dashboard-only BulkLabelPanel for selected draft messages
- cover duplicate handling, add/remove summaries, and no-op behavior with focused tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/bulkLabelEditor.ts src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx src/features/demo-admin-dashboard/__tests__/bulkLabelEditor.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for account/payment/private-key markers returned no matches

Note: targeted Vitest could not start in this fresh workspace because 
ode_modules is not installed and the project Vite plugins are unavailable locally. The PR includes the focused unit test file for normal CI dependency installation.