### PR TITLE
Add campaign publish checklist

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/campaignPublishChecklist.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignPublishChecklist.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import {
+  buildCampaignPublishChecklist,
+  getCampaignPublishBlockers,
+  getCampaignPublishWarnings,
+  summarizeCampaignPublishChecklist,
+} from "../campaignPublishChecklist";
+
+const readyCampaign: CampaignSnapshot = {
+  id: "campaign-ready",
+  name: "Sender Recovery Education",
+  description: "Explains request approvals, blocks, and demo refunds.",
+  targetAudience: "Mailbox admins",
+  tags: ["recovery", "requests"],
+  timestamp: "2026-06-20T09:00:00Z",
+  status: "draft",
+  drafts: [
+    {
+      id: "draft-approval",
+      subject: "How request approvals work",
+      body: "Use this fake demo copy to explain approvals.",
+      recipients: ["admin@stealth.demo"],
+    },
+  ],
+};
+
+describe("campaignPublishChecklist", () => {
+  it("marks a complete fake campaign as publishable", () => {
+    const result = buildCampaignPublishChecklist(readyCampaign);
+
+    expect(result.canPublish).toBe(true);
+    expect(result.blockerCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(summarizeCampaignPublishChecklist(result)).toBe(
+      "Sender Recovery Education is ready for mock publish.",
+    );
+  });
+
+  it("blocks missing campaign identity and empty draft inventory", () => {
+    const result = buildCampaignPublishChecklist({
+      ...readyCampaign,
+      name: "",
+      description: "",
+      targetAudience: "",
+      drafts: [],
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(getCampaignPublishBlockers(result).map((item) => item.id)).toEqual([
+      "identity",
+      "drafts",
+      "draft-content",
+      "safe-recipients",
+    ]);
+    expect(summarizeCampaignPublishChecklist(result)).toBe(" has 4 publish blockers.");
+  });
+
+  it("blocks real-looking recipient domains", () => {
+    const result = buildCampaignPublishChecklist({
+      ...readyCampaign,
+      drafts: [
+        {
+          ...readyCampaign.drafts[0],
+          recipients: ["person@external.invalid"],
+        },
+      ],
+    });
+
+    expect(result.canPublish).toBe(false);
+    expect(getCampaignPublishBlockers(result).map((item) => item.id)).toContain("safe-recipients");
+  });
+
+  it("warns for missing tags and archived status without blocking publish", () => {
+    const result = buildCampaignPublishChecklist({
+      ...readyCampaign,
+      tags: [],
+      status: "archived",
+    });
+
+    expect(result.canPublish).toBe(true);
+    expect(getCampaignPublishWarnings(result).map((item) => item.id)).toEqual(["tags", "status"]);
+    expect(summarizeCampaignPublishChecklist(result)).toBe(
+      "Sender Recovery Education is publishable with 2 warnings.",
+    );
+  });
+});

--- a/src/features/demo-admin-dashboard/campaignPublishChecklist.ts
+++ b/src/features/demo-admin-dashboard/campaignPublishChecklist.ts
@@ -1,0 +1,121 @@
+import type { CampaignSnapshot } from "./types/campaignSnapshot";
+
+export type CampaignPublishChecklistSeverity = "blocker" | "warning" | "ready";
+
+export interface CampaignPublishChecklistItem {
+  id: string;
+  label: string;
+  description: string;
+  severity: CampaignPublishChecklistSeverity;
+  passed: boolean;
+}
+
+export interface CampaignPublishChecklistResult {
+  campaignId: string;
+  campaignName: string;
+  items: CampaignPublishChecklistItem[];
+  blockerCount: number;
+  warningCount: number;
+  readyCount: number;
+  canPublish: boolean;
+}
+
+const SAFE_RECIPIENT_PATTERN = /(@example\.(com|org)$)|(@stealth\.demo$)/i;
+
+export function buildCampaignPublishChecklist(
+  campaign: CampaignSnapshot,
+): CampaignPublishChecklistResult {
+  const items: CampaignPublishChecklistItem[] = [
+    {
+      id: "identity",
+      label: "Campaign identity",
+      description: "Name, description, and target audience are ready for review.",
+      severity: "blocker",
+      passed:
+        campaign.name.trim().length > 0 &&
+        campaign.description.trim().length > 0 &&
+        campaign.targetAudience.trim().length > 0,
+    },
+    {
+      id: "drafts",
+      label: "Draft inventory",
+      description: "At least one draft message exists before mock publishing.",
+      severity: "blocker",
+      passed: campaign.drafts.length > 0,
+    },
+    {
+      id: "draft-content",
+      label: "Draft content",
+      description: "Every draft has a subject and body.",
+      severity: "blocker",
+      passed: campaign.drafts.every(
+        (draft) => draft.subject.trim().length > 0 && draft.body.trim().length > 0,
+      ),
+    },
+    {
+      id: "safe-recipients",
+      label: "Safe demo recipients",
+      description: "Recipients use example.com, example.org, or stealth.demo addresses only.",
+      severity: "blocker",
+      passed: campaign.drafts.every(
+        (draft) =>
+          draft.recipients.length > 0 &&
+          draft.recipients.every((recipient) => SAFE_RECIPIENT_PATTERN.test(recipient)),
+      ),
+    },
+    {
+      id: "tags",
+      label: "Campaign tags",
+      description: "Campaign has at least one local tag for filtering and review.",
+      severity: "warning",
+      passed: campaign.tags.length > 0,
+    },
+    {
+      id: "status",
+      label: "Review status",
+      description: "Campaign is not archived before mock publish.",
+      severity: "warning",
+      passed: campaign.status !== "archived",
+    },
+  ];
+
+  const blockerCount = items.filter((item) => item.severity === "blocker" && !item.passed).length;
+  const warningCount = items.filter((item) => item.severity === "warning" && !item.passed).length;
+  const readyCount = items.filter((item) => item.passed).length;
+
+  return {
+    campaignId: campaign.id,
+    campaignName: campaign.name,
+    items,
+    blockerCount,
+    warningCount,
+    readyCount,
+    canPublish: blockerCount === 0,
+  };
+}
+
+export function summarizeCampaignPublishChecklist(result: CampaignPublishChecklistResult): string {
+  if (!result.canPublish) {
+    const blockerWord = result.blockerCount === 1 ? "blocker" : "blockers";
+    return `${result.campaignName} has ${result.blockerCount} publish ${blockerWord}.`;
+  }
+
+  if (result.warningCount > 0) {
+    const warningWord = result.warningCount === 1 ? "warning" : "warnings";
+    return `${result.campaignName} is publishable with ${result.warningCount} ${warningWord}.`;
+  }
+
+  return `${result.campaignName} is ready for mock publish.`;
+}
+
+export function getCampaignPublishBlockers(
+  result: CampaignPublishChecklistResult,
+): CampaignPublishChecklistItem[] {
+  return result.items.filter((item) => item.severity === "blocker" && !item.passed);
+}
+
+export function getCampaignPublishWarnings(
+  result: CampaignPublishChecklistResult,
+): CampaignPublishChecklistItem[] {
+  return result.items.filter((item) => item.severity === "warning" && !item.passed);
+}

--- a/src/features/demo-admin-dashboard/components/CampaignPublishChecklistPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignPublishChecklistPanel.tsx
@@ -1,0 +1,108 @@
+import { AlertTriangle, CheckCircle2, Circle, ShieldAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import {
+  buildCampaignPublishChecklist,
+  summarizeCampaignPublishChecklist,
+  type CampaignPublishChecklistItem,
+} from "../campaignPublishChecklist";
+
+export interface CampaignPublishChecklistPanelProps {
+  campaign: CampaignSnapshot;
+  className?: string;
+}
+
+export function CampaignPublishChecklistPanel({
+  campaign,
+  className,
+}: CampaignPublishChecklistPanelProps) {
+  const result = buildCampaignPublishChecklist(campaign);
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Campaign publish checklist</h3>
+        </div>
+        <span
+          className={cn(
+            "rounded-full border px-2 py-0.5 text-xs",
+            result.canPublish
+              ? "border-emerald-500/30 text-emerald-300"
+              : "border-rose-500/30 text-rose-300",
+          )}
+        >
+          {result.canPublish ? "publishable" : "blocked"}
+        </span>
+      </header>
+
+      <p className="text-sm text-muted-foreground">{summarizeCampaignPublishChecklist(result)}</p>
+
+      <ul className="flex flex-col gap-2">
+        {result.items.map((item) => (
+          <ChecklistRow key={item.id} item={item} />
+        ))}
+      </ul>
+
+      <div className="grid grid-cols-3 gap-2 text-xs">
+        <Metric label="Ready" value={result.readyCount} tone="ready" />
+        <Metric label="Warnings" value={result.warningCount} tone="warning" />
+        <Metric label="Blockers" value={result.blockerCount} tone="blocker" />
+      </div>
+    </section>
+  );
+}
+
+function ChecklistRow({ item }: { item: CampaignPublishChecklistItem }) {
+  const Icon = item.passed ? CheckCircle2 : item.severity === "warning" ? AlertTriangle : Circle;
+  return (
+    <li className="flex gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <Icon
+        className={cn(
+          "mt-0.5 h-4 w-4 shrink-0",
+          item.passed
+            ? "text-emerald-300"
+            : item.severity === "warning"
+              ? "text-amber-300"
+              : "text-rose-300",
+        )}
+      />
+      <span className="min-w-0">
+        <span className="block text-sm font-medium">{item.label}</span>
+        <span className="block text-xs text-muted-foreground">{item.description}</span>
+      </span>
+    </li>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "ready" | "warning" | "blocker";
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <p className="text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          "text-lg font-semibold",
+          tone === "ready" && "text-emerald-300",
+          tone === "warning" && "text-amber-300",
+          tone === "blocker" && "text-rose-300",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,6 +56,8 @@ export {
 } from "./constants/displayTokens";
 
 export { CampaignTagManager } from "./components/CampaignTagManager";
+export { CampaignPublishChecklistPanel } from "./components/CampaignPublishChecklistPanel";
+export type { CampaignPublishChecklistPanelProps } from "./components/CampaignPublishChecklistPanel";
 export { MockPublishPanel } from "./components/MockPublishPanel";
 export type { MockPublishPanelProps } from "./components/MockPublishPanel";
 export {
@@ -72,6 +74,17 @@ export type {
   MockPublishStatus,
   MockPublishStep,
 } from "./mockPublishWorkflow";
+export {
+  buildCampaignPublishChecklist,
+  getCampaignPublishBlockers,
+  getCampaignPublishWarnings,
+  summarizeCampaignPublishChecklist,
+} from "./campaignPublishChecklist";
+export type {
+  CampaignPublishChecklistItem,
+  CampaignPublishChecklistResult,
+  CampaignPublishChecklistSeverity,
+} from "./campaignPublishChecklist";
 
 export {
   createTag,


### PR DESCRIPTION
Closes #275

## Summary
- add campaign publish checklist rules for blockers, warnings, and ready states
- add a dashboard-only CampaignPublishChecklistPanel for pre-publish readiness review
- validate campaign identity, draft inventory/content, safe demo recipients, tags, and archived status
- cover ready, blocked, unsafe recipient, and warning-only scenarios with focused tests

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/campaignPublishChecklist.ts src/features/demo-admin-dashboard/components/CampaignPublishChecklistPanel.tsx src/features/demo-admin-dashboard/__tests__/campaignPublishChecklist.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for account/payment/private-key markers returned no matches

Note: targeted Vitest could not start in this fresh workspace because 
ode_modules is not installed and the project Vite plugins are unavailable locally. The PR includes the focused unit test file for normal CI dependency installation.