### PR TITLE
Add campaign diff panel

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/campaignDiff.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignDiff.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import {
+  compareCampaignSnapshots,
+  formatCampaignDiffSummary,
+  getCampaignDiffEntriesByKind,
+} from "../campaignDiff";
+
+const baseCampaign: CampaignSnapshot = {
+  id: "campaign-base",
+  name: "Sender Recovery Education",
+  description: "Explains sender request recovery.",
+  targetAudience: "Mailbox admins",
+  tags: ["recovery", "requests"],
+  timestamp: "2026-06-20T09:00:00Z",
+  status: "draft",
+  drafts: [
+    {
+      id: "draft-approval",
+      subject: "How request approvals work",
+      body: "Use demo copy to explain approvals.",
+      recipients: ["admin@stealth.demo"],
+    },
+    {
+      id: "draft-followup",
+      subject: "Follow up with senders",
+      body: "Share a safe fake sender follow-up.",
+      recipients: ["ops@stealth.demo"],
+    },
+  ],
+};
+
+describe("campaignDiff", () => {
+  it("reports no changes for identical campaign snapshots", () => {
+    const result = compareCampaignSnapshots(baseCampaign, {
+      ...baseCampaign,
+      id: "campaign-copy",
+      tags: [...baseCampaign.tags].reverse(),
+      drafts: [...baseCampaign.drafts],
+    });
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.summary.changed).toBe(0);
+    expect(result.summary.added).toBe(0);
+    expect(result.summary.removed).toBe(0);
+    expect(formatCampaignDiffSummary(result)).toBe("No campaign changes detected.");
+  });
+
+  it("tracks metadata changes", () => {
+    const result = compareCampaignSnapshots(baseCampaign, {
+      ...baseCampaign,
+      name: "Sender Recovery Relaunch",
+      targetAudience: "Support operators",
+      status: "needs-review",
+    });
+
+    expect(getCampaignDiffEntriesByKind(result, "changed").map((entry) => entry.id)).toEqual([
+      "metadata-name",
+      "metadata-targetAudience",
+      "metadata-status",
+    ]);
+    expect(formatCampaignDiffSummary(result)).toBe("Review 3 changed campaign differences.");
+  });
+
+  it("tracks tag additions and removals", () => {
+    const result = compareCampaignSnapshots(baseCampaign, {
+      ...baseCampaign,
+      tags: ["requests", "launch"],
+    });
+
+    expect(getCampaignDiffEntriesByKind(result, "added").map((entry) => entry.label)).toEqual([
+      "Tag: launch",
+    ]);
+    expect(getCampaignDiffEntriesByKind(result, "removed").map((entry) => entry.label)).toEqual([
+      "Tag: recovery",
+    ]);
+  });
+
+  it("tracks added, removed, and changed drafts", () => {
+    const result = compareCampaignSnapshots(baseCampaign, {
+      ...baseCampaign,
+      drafts: [
+        {
+          ...baseCampaign.drafts[0],
+          body: "Updated demo copy to explain approvals and evidence capture.",
+        },
+        {
+          id: "draft-new",
+          subject: "Escalation checklist",
+          body: "Explain escalation paths with fake demo records.",
+          recipients: ["lead@stealth.demo"],
+        },
+      ],
+    });
+
+    expect(getCampaignDiffEntriesByKind(result, "changed").map((entry) => entry.id)).toContain(
+      "draft-changed-draft-approval",
+    );
+    expect(getCampaignDiffEntriesByKind(result, "removed").map((entry) => entry.id)).toContain(
+      "draft-removed-draft-followup",
+    );
+    expect(getCampaignDiffEntriesByKind(result, "added").map((entry) => entry.id)).toContain(
+      "draft-added-draft-new",
+    );
+  });
+});

--- a/src/features/demo-admin-dashboard/campaignDiff.ts
+++ b/src/features/demo-admin-dashboard/campaignDiff.ts
@@ -1,0 +1,240 @@
+import type { Draft } from "./types/draft";
+import type { CampaignSnapshot } from "./types/campaignSnapshot";
+
+export type CampaignDiffKind = "added" | "removed" | "changed" | "unchanged";
+
+export type CampaignDiffSection = "metadata" | "tags" | "drafts";
+
+export interface CampaignDiffEntry {
+  id: string;
+  kind: CampaignDiffKind;
+  section: CampaignDiffSection;
+  label: string;
+  before?: string;
+  after?: string;
+  detail: string;
+}
+
+export interface CampaignDiffSummary {
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+  total: number;
+}
+
+export interface CampaignDiffResult {
+  baseId: string;
+  comparisonId: string;
+  entries: CampaignDiffEntry[];
+  summary: CampaignDiffSummary;
+  hasChanges: boolean;
+  canReview: boolean;
+}
+
+const metadataFields: Array<{
+  key: "name" | "description" | "targetAudience" | "status";
+  label: string;
+  section: CampaignDiffSection;
+}> = [
+  { key: "name", label: "Campaign name", section: "metadata" },
+  { key: "description", label: "Description", section: "metadata" },
+  { key: "targetAudience", label: "Target audience", section: "metadata" },
+  { key: "status", label: "Status", section: "metadata" },
+];
+
+export function compareCampaignSnapshots(
+  base: CampaignSnapshot,
+  comparison: CampaignSnapshot,
+): CampaignDiffResult {
+  const entries: CampaignDiffEntry[] = [
+    ...compareMetadata(base, comparison),
+    ...compareTags(base.tags, comparison.tags),
+    ...compareDrafts(base.drafts, comparison.drafts),
+  ];
+  const summary = summarizeCampaignDiff(entries);
+
+  return {
+    baseId: base.id,
+    comparisonId: comparison.id,
+    entries,
+    summary,
+    hasChanges: summary.added + summary.removed + summary.changed > 0,
+    canReview: entries.length > 0,
+  };
+}
+
+export function summarizeCampaignDiff(entries: CampaignDiffEntry[]): CampaignDiffSummary {
+  return entries.reduce<CampaignDiffSummary>(
+    (summary, entry) => ({
+      ...summary,
+      [entry.kind]: summary[entry.kind] + 1,
+      total: summary.total + 1,
+    }),
+    { added: 0, removed: 0, changed: 0, unchanged: 0, total: 0 },
+  );
+}
+
+export function getCampaignDiffEntriesByKind(
+  result: CampaignDiffResult,
+  kind: CampaignDiffKind,
+): CampaignDiffEntry[] {
+  return result.entries.filter((entry) => entry.kind === kind);
+}
+
+export function formatCampaignDiffSummary(result: CampaignDiffResult): string {
+  const { summary } = result;
+  const changeCount = summary.added + summary.removed + summary.changed;
+
+  if (changeCount === 0) {
+    return "No campaign changes detected.";
+  }
+
+  const parts = [
+    summary.added > 0 ? `${summary.added} added` : "",
+    summary.removed > 0 ? `${summary.removed} removed` : "",
+    summary.changed > 0 ? `${summary.changed} changed` : "",
+  ].filter(Boolean);
+
+  return `Review ${parts.join(", ")} campaign difference${changeCount === 1 ? "" : "s"}.`;
+}
+
+function compareMetadata(
+  base: CampaignSnapshot,
+  comparison: CampaignSnapshot,
+): CampaignDiffEntry[] {
+  return metadataFields.map(({ key, label, section }) => {
+    const before = normalizeValue(key === "status" ? (base.status ?? "draft") : base[key]);
+    const after = normalizeValue(
+      key === "status" ? (comparison.status ?? "draft") : comparison[key],
+    );
+    const changed = before !== after;
+
+    return {
+      id: `metadata-${key}`,
+      kind: changed ? "changed" : "unchanged",
+      section,
+      label,
+      before,
+      after,
+      detail: changed ? `${label} changed.` : `${label} is unchanged.`,
+    };
+  });
+}
+
+function compareTags(baseTags: string[], comparisonTags: string[]): CampaignDiffEntry[] {
+  const beforeTags = normalizeTagList(baseTags);
+  const afterTags = normalizeTagList(comparisonTags);
+  const beforeSet = new Set(beforeTags);
+  const afterSet = new Set(afterTags);
+  const added = afterTags.filter((tag) => !beforeSet.has(tag));
+  const removed = beforeTags.filter((tag) => !afterSet.has(tag));
+
+  if (added.length === 0 && removed.length === 0) {
+    return [
+      {
+        id: "tags-unchanged",
+        kind: "unchanged",
+        section: "tags",
+        label: "Tags",
+        before: beforeTags.join(", "),
+        after: afterTags.join(", "),
+        detail: "Tag set is unchanged.",
+      },
+    ];
+  }
+
+  return [
+    ...added.map((tag) => ({
+      id: `tag-added-${tag}`,
+      kind: "added" as const,
+      section: "tags" as const,
+      label: `Tag: ${tag}`,
+      after: tag,
+      detail: "Tag added to comparison campaign.",
+    })),
+    ...removed.map((tag) => ({
+      id: `tag-removed-${tag}`,
+      kind: "removed" as const,
+      section: "tags" as const,
+      label: `Tag: ${tag}`,
+      before: tag,
+      detail: "Tag removed from comparison campaign.",
+    })),
+  ];
+}
+
+function compareDrafts(baseDrafts: Draft[], comparisonDrafts: Draft[]): CampaignDiffEntry[] {
+  const entries: CampaignDiffEntry[] = [];
+  const baseById = new Map(baseDrafts.map((draft) => [draft.id, draft]));
+  const comparisonById = new Map(comparisonDrafts.map((draft) => [draft.id, draft]));
+  const draftIds = Array.from(new Set([...baseById.keys(), ...comparisonById.keys()])).sort();
+
+  for (const draftId of draftIds) {
+    const before = baseById.get(draftId);
+    const after = comparisonById.get(draftId);
+
+    if (!before && after) {
+      entries.push({
+        id: `draft-added-${draftId}`,
+        kind: "added",
+        section: "drafts",
+        label: `Draft: ${after.subject}`,
+        after: describeDraft(after),
+        detail: "Draft added to comparison campaign.",
+      });
+      continue;
+    }
+
+    if (before && !after) {
+      entries.push({
+        id: `draft-removed-${draftId}`,
+        kind: "removed",
+        section: "drafts",
+        label: `Draft: ${before.subject}`,
+        before: describeDraft(before),
+        detail: "Draft removed from comparison campaign.",
+      });
+      continue;
+    }
+
+    if (!before || !after) {
+      continue;
+    }
+
+    const beforeDescription = describeDraft(before);
+    const afterDescription = describeDraft(after);
+    const changed = beforeDescription !== afterDescription;
+
+    entries.push({
+      id: `draft-${changed ? "changed" : "unchanged"}-${draftId}`,
+      kind: changed ? "changed" : "unchanged",
+      section: "drafts",
+      label: `Draft: ${after.subject || before.subject || draftId}`,
+      before: beforeDescription,
+      after: afterDescription,
+      detail: changed ? "Draft content or recipients changed." : "Draft is unchanged.",
+    });
+  }
+
+  return entries;
+}
+
+function normalizeValue(value: string | undefined): string {
+  return (value ?? "").trim();
+}
+
+function normalizeTagList(tags: string[]): string[] {
+  return Array.from(new Set(tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean))).sort();
+}
+
+function describeDraft(draft: Draft): string {
+  return [
+    normalizeValue(draft.subject),
+    normalizeValue(draft.body),
+    draft.recipients
+      .map((recipient) => recipient.trim().toLowerCase())
+      .sort()
+      .join(","),
+  ].join("\n---\n");
+}

--- a/src/features/demo-admin-dashboard/components/CampaignDiffPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignDiffPanel.tsx
@@ -1,0 +1,134 @@
+import { FileDiff, MinusCircle, Pencil, PlusCircle, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CampaignDiffEntry, CampaignDiffKind } from "../campaignDiff";
+import { compareCampaignSnapshots, formatCampaignDiffSummary } from "../campaignDiff";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+
+export interface CampaignDiffPanelProps {
+  base: CampaignSnapshot;
+  comparison: CampaignSnapshot;
+  className?: string;
+}
+
+export function CampaignDiffPanel({ base, comparison, className }: CampaignDiffPanelProps) {
+  const result = compareCampaignSnapshots(base, comparison);
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <FileDiff className="h-4 w-4 text-muted-foreground" />
+          <h3 className="text-sm font-medium">Campaign diff panel</h3>
+        </div>
+        <span
+          className={cn(
+            "rounded-full border px-2 py-0.5 text-xs",
+            result.hasChanges
+              ? "border-amber-500/30 text-amber-300"
+              : "border-emerald-500/30 text-emerald-300",
+          )}
+        >
+          {result.hasChanges ? "needs review" : "no changes"}
+        </span>
+      </header>
+
+      <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+        <p className="text-sm font-medium">
+          {base.name} to {comparison.name}
+        </p>
+        <p className="text-sm text-muted-foreground">{formatCampaignDiffSummary(result)}</p>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 text-xs">
+        <Metric label="Added" value={result.summary.added} tone="added" />
+        <Metric label="Removed" value={result.summary.removed} tone="removed" />
+        <Metric label="Changed" value={result.summary.changed} tone="changed" />
+        <Metric label="Same" value={result.summary.unchanged} tone="unchanged" />
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {result.entries.map((entry) => (
+          <DiffRow key={entry.id} entry={entry} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function DiffRow({ entry }: { entry: CampaignDiffEntry }) {
+  const Icon = getKindIcon(entry.kind);
+
+  return (
+    <li className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <div className="flex gap-3">
+        <Icon className={cn("mt-0.5 h-4 w-4 shrink-0", getKindClass(entry.kind))} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium">{entry.label}</span>
+            <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-[11px] text-muted-foreground">
+              {entry.section}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{entry.detail}</p>
+          {entry.kind !== "unchanged" ? (
+            <div className="mt-2 grid gap-2 text-xs sm:grid-cols-2">
+              <ValueBlock label="Before" value={entry.before} />
+              <ValueBlock label="After" value={entry.after} />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: number; tone: CampaignDiffKind }) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+      <p className="text-muted-foreground">{label}</p>
+      <p className={cn("text-lg font-semibold", getKindClass(tone))}>{value}</p>
+    </div>
+  );
+}
+
+function ValueBlock({ label, value }: { label: string; value?: string }) {
+  return (
+    <div className="rounded-md border border-white/[0.06] bg-black/20 px-2 py-1.5">
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 line-clamp-3 whitespace-pre-wrap break-words text-foreground/80">
+        {value || "None"}
+      </p>
+    </div>
+  );
+}
+
+function getKindIcon(kind: CampaignDiffKind) {
+  if (kind === "added") {
+    return PlusCircle;
+  }
+  if (kind === "removed") {
+    return MinusCircle;
+  }
+  if (kind === "changed") {
+    return Pencil;
+  }
+  return ShieldCheck;
+}
+
+function getKindClass(kind: CampaignDiffKind): string {
+  if (kind === "added") {
+    return "text-emerald-300";
+  }
+  if (kind === "removed") {
+    return "text-rose-300";
+  }
+  if (kind === "changed") {
+    return "text-amber-300";
+  }
+  return "text-muted-foreground";
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -58,6 +58,8 @@ export {
 export { CampaignTagManager } from "./components/CampaignTagManager";
 export { MockPublishPanel } from "./components/MockPublishPanel";
 export type { MockPublishPanelProps } from "./components/MockPublishPanel";
+export { CampaignDiffPanel } from "./components/CampaignDiffPanel";
+export type { CampaignDiffPanelProps } from "./components/CampaignDiffPanel";
 export {
   canRetryMockPublish,
   canRollbackMockPublish,
@@ -72,6 +74,19 @@ export type {
   MockPublishStatus,
   MockPublishStep,
 } from "./mockPublishWorkflow";
+export {
+  compareCampaignSnapshots,
+  formatCampaignDiffSummary,
+  getCampaignDiffEntriesByKind,
+  summarizeCampaignDiff,
+} from "./campaignDiff";
+export type {
+  CampaignDiffEntry,
+  CampaignDiffKind,
+  CampaignDiffResult,
+  CampaignDiffSection,
+  CampaignDiffSummary,
+} from "./campaignDiff";
 
 export {
   createTag,


### PR DESCRIPTION
## Summary
- add a pure campaignDiff helper for comparing campaign snapshot metadata, tags, and draft inventories
- add a dashboard-only CampaignDiffPanel that surfaces added, removed, changed, and unchanged items
- cover identical snapshots, metadata edits, tag churn, and draft add/remove/change cases with focused tests

Closes #274

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/campaignDiff.ts src/features/demo-admin-dashboard/components/CampaignDiffPanel.tsx src/features/demo-admin-dashboard/__tests__/campaignDiff.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for payment/account/private-key markers returned no matches
- 
px vitest run src/features/demo-admin-dashboard/__tests__/campaignDiff.test.ts could not start locally because this fresh checkout is missing the Vite config packages (@cloudflare/vite-plugin, @tailwindcss/vite, @tanstack/react-start/plugin/vite, @vitejs/plugin-react, ite, ite-tsconfig-paths)