### PR TITLE
fix(preferences): normalize stored preference hydration

### DIFF
--- a/src/features/preferences/preferences.test.ts
+++ b/src/features/preferences/preferences.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { defaultLayoutPreferences } from "./layout-types";
+import { normalizeLayoutPreferences } from "./useLayoutPreferences";
+import { defaultPreferences } from "./types";
+import { normalizeUiPreferences } from "./usePreferences";
+
+describe("preference normalization", () => {
+  it("keeps receipt defaults when a stored UI preference record is partial", () => {
+    const preferences = normalizeUiPreferences({
+      compactMode: true,
+      onboardingCompleted: true,
+      receipts: {
+        unknown: "never",
+      },
+    });
+
+    expect(preferences).toEqual({
+      ...defaultPreferences,
+      compactMode: true,
+      density: "compact",
+      onboardingCompleted: true,
+      receipts: {
+        ...defaultPreferences.receipts,
+        unknown: "never",
+      },
+    });
+  });
+
+  it("falls back to defaults for unsupported UI preference values", () => {
+    const preferences = normalizeUiPreferences({
+      theme: "neon",
+      density: "dense",
+      glassIntensity: "opaque",
+      readerTypography: "comic",
+      lowerMotion: "yes",
+      showAvatars: "false",
+      unknownSenders: "accept-all",
+      minimumPostage: 0.25,
+      receipts: {
+        trusted: "always",
+        paid: "sometimes",
+      },
+    });
+
+    expect(preferences).toEqual(defaultPreferences);
+  });
+
+  it("clamps stored layout widths and restores missing values from defaults", () => {
+    const layout = normalizeLayoutPreferences({
+      sidebarWidth: 100,
+      sidebarCollapsed: true,
+      listWidth: "wide",
+      readerWidth: Number.NaN,
+      rightPanelCollapsed: true,
+    });
+
+    expect(layout).toEqual({
+      ...defaultLayoutPreferences,
+      sidebarWidth: 40,
+      sidebarCollapsed: true,
+      rightPanelCollapsed: true,
+    });
+  });
+});

--- a/src/features/preferences/useLayoutPreferences.ts
+++ b/src/features/preferences/useLayoutPreferences.ts
@@ -7,13 +7,44 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
-function clampPreferences(prefs: LayoutPreferences): LayoutPreferences {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function finiteNumberOrDefault(value: unknown, fallback: number) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function booleanOrDefault(value: unknown, fallback: boolean) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function clampPreferences(prefs: LayoutPreferences): LayoutPreferences {
   return {
     ...prefs,
     sidebarWidth: clamp(prefs.sidebarWidth, 5, 40),
     listWidth: clamp(prefs.listWidth, 10, 60),
     readerWidth: clamp(prefs.readerWidth, 15, 80),
   };
+}
+
+export function normalizeLayoutPreferences(value: unknown): LayoutPreferences {
+  const stored = isRecord(value) ? value : {};
+
+  return clampPreferences({
+    sidebarWidth: finiteNumberOrDefault(stored.sidebarWidth, defaultLayoutPreferences.sidebarWidth),
+    sidebarCollapsed: booleanOrDefault(
+      stored.sidebarCollapsed,
+      defaultLayoutPreferences.sidebarCollapsed,
+    ),
+    listWidth: finiteNumberOrDefault(stored.listWidth, defaultLayoutPreferences.listWidth),
+    readerWidth: finiteNumberOrDefault(stored.readerWidth, defaultLayoutPreferences.readerWidth),
+    compactMode: booleanOrDefault(stored.compactMode, defaultLayoutPreferences.compactMode),
+    rightPanelCollapsed: booleanOrDefault(
+      stored.rightPanelCollapsed,
+      defaultLayoutPreferences.rightPanelCollapsed,
+    ),
+  });
 }
 
 export function useLayoutPreferences() {
@@ -24,8 +55,7 @@ export function useLayoutPreferences() {
     const stored = window.localStorage.getItem(storageKey);
     if (stored) {
       try {
-        const parsed = JSON.parse(stored);
-        setLayout(clampPreferences({ ...defaultLayoutPreferences, ...parsed }));
+        setLayout(normalizeLayoutPreferences(JSON.parse(stored)));
       } catch {
         window.localStorage.removeItem(storageKey);
       }

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -2,10 +2,106 @@ import { useEffect, useState } from "react";
 import { defaultPreferences, type UiPreferences } from "./types";
 
 const storageKey = "stealth-ui-preferences";
+const themePreferences = ["dark", "light", "system"] as const;
+const densityPreferences = ["comfortable", "compact"] as const;
+const glassIntensityPreferences = ["subtle", "medium", "strong"] as const;
+const readerTypographyPreferences = ["sans", "serif", "large"] as const;
+const unknownSenderPolicies = ["request", "verified", "block"] as const;
+const receiptPreferences = ["auto", "manual", "never"] as const;
 
 function resolveTheme(theme: UiPreferences["theme"]) {
   if (theme !== "system") return theme;
   return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function booleanOrDefault(value: unknown, fallback: boolean) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function stringOrDefault(value: unknown, fallback: string) {
+  return typeof value === "string" ? value : fallback;
+}
+
+function allowedOrDefault<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  fallback: T[number],
+): T[number] {
+  return typeof value === "string" && allowed.includes(value) ? (value as T[number]) : fallback;
+}
+
+export function normalizeUiPreferences(value: unknown): UiPreferences {
+  const stored = isRecord(value) ? value : {};
+  const storedReceipts = isRecord(stored.receipts) ? stored.receipts : {};
+  const compactMode = booleanOrDefault(stored.compactMode, defaultPreferences.compactMode);
+  const densityFallback = compactMode ? "compact" : defaultPreferences.density;
+
+  return {
+    theme: allowedOrDefault(stored.theme, themePreferences, defaultPreferences.theme),
+    compactMode,
+    density: allowedOrDefault(stored.density, densityPreferences, densityFallback),
+    glassIntensity: allowedOrDefault(
+      stored.glassIntensity,
+      glassIntensityPreferences,
+      defaultPreferences.glassIntensity,
+    ),
+    readerTypography: allowedOrDefault(
+      stored.readerTypography,
+      readerTypographyPreferences,
+      defaultPreferences.readerTypography,
+    ),
+    lowerMotion: booleanOrDefault(stored.lowerMotion, defaultPreferences.lowerMotion),
+    showAvatars: booleanOrDefault(stored.showAvatars, defaultPreferences.showAvatars),
+    emailNotifications: booleanOrDefault(
+      stored.emailNotifications,
+      defaultPreferences.emailNotifications,
+    ),
+    desktopNotifications: booleanOrDefault(
+      stored.desktopNotifications,
+      defaultPreferences.desktopNotifications,
+    ),
+    sound: booleanOrDefault(stored.sound, defaultPreferences.sound),
+    unknownSenders: allowedOrDefault(
+      stored.unknownSenders,
+      unknownSenderPolicies,
+      defaultPreferences.unknownSenders,
+    ),
+    minimumPostage: stringOrDefault(stored.minimumPostage, defaultPreferences.minimumPostage),
+    onboardingCompleted: booleanOrDefault(
+      stored.onboardingCompleted,
+      defaultPreferences.onboardingCompleted,
+    ),
+    receiptOnDelivery: booleanOrDefault(
+      stored.receiptOnDelivery,
+      defaultPreferences.receiptOnDelivery,
+    ),
+    receipts: {
+      trusted: allowedOrDefault(
+        storedReceipts.trusted,
+        receiptPreferences,
+        defaultPreferences.receipts.trusted,
+      ),
+      unknown: allowedOrDefault(
+        storedReceipts.unknown,
+        receiptPreferences,
+        defaultPreferences.receipts.unknown,
+      ),
+      paid: allowedOrDefault(
+        storedReceipts.paid,
+        receiptPreferences,
+        defaultPreferences.receipts.paid,
+      ),
+      organizations: allowedOrDefault(
+        storedReceipts.organizations,
+        receiptPreferences,
+        defaultPreferences.receipts.organizations,
+      ),
+    },
+  };
 }
 
 export function usePreferences() {
@@ -18,8 +114,7 @@ export function usePreferences() {
       const legacyStored = window.localStorage.getItem("stealth-preferences");
       if (legacyStored) {
         try {
-          const parsed = JSON.parse(legacyStored);
-          stored = JSON.stringify({ ...defaultPreferences, ...parsed });
+          stored = JSON.stringify(normalizeUiPreferences(JSON.parse(legacyStored)));
         } catch {
           // ignore
         }
@@ -27,7 +122,7 @@ export function usePreferences() {
     }
     if (stored) {
       try {
-        setPreferences({ ...defaultPreferences, ...JSON.parse(stored) });
+        setPreferences(normalizeUiPreferences(JSON.parse(stored)));
       } catch {
         window.localStorage.removeItem(storageKey);
       }


### PR DESCRIPTION
## Summary

- normalize stored UI preferences before hydration so partial or legacy records keep nested receipt defaults
- validate enum-like preference fields and fall back to supported defaults for unsupported stored values
- normalize stored layout preferences so invalid widths fall back to defaults and valid widths stay clamped
- add regression coverage for partial UI records, unsupported UI values, and layout width restoration

Fixes #971

## Before / After

Before, a partial stored `receipts` object could replace the default receipt policy object during hydration, and invalid stored layout width values could restore unpredictably. After this change, hydration produces a complete preference record with preserved defaults and bounded layout values.

## Validation

- `pnpm exec vitest run src/features/preferences/preferences.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/features/preferences/usePreferences.ts src/features/preferences/useLayoutPreferences.ts src/features/preferences/preferences.test.ts`