### PR TITLE
fix(design-system): improve trust badge and feedback accessibility

### DIFF
--- a/src/features/design-system/components/trust-badge.test.tsx
+++ b/src/features/design-system/components/trust-badge.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TrustBadge } from "./trust-badge";
+
+describe("TrustBadge accessibility", () => {
+  it("names tooltip badges and makes the trigger keyboard reachable", () => {
+    const markup = renderToStaticMarkup(<TrustBadge state="verified" showLabel={false} />);
+
+    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('aria-label="Verified: This sender');
+    expect(markup).toContain("cryptographically verified");
+    expect(markup).toContain("sr-only");
+  });
+
+  it("does not add a tab stop when tooltip behavior is disabled", () => {
+    const markup = renderToStaticMarkup(
+      <TrustBadge state="paid" showLabel={false} showTooltip={false} />,
+    );
+
+    expect(markup).not.toContain("tabindex=");
+    expect(markup).toContain("Paid");
+  });
+});

--- a/src/features/design-system/components/trust-badge.tsx
+++ b/src/features/design-system/components/trust-badge.tsx
@@ -89,6 +89,11 @@ export interface TrustBadgeProps {
   className?: string;
 }
 
+export function getTrustBadgeAccessibleLabel(state: TrustState) {
+  const meta = TRUST_STATE_META[state];
+  return `${meta.label}: ${meta.tooltip}`;
+}
+
 /**
  * A single, consistent sender-trust pill. Presentational only so it can be
  * reused in list rows, the reader header, compose chips, and sender cards.
@@ -105,12 +110,14 @@ export function TrustBadge({
 
   const pill = (
     <span
+      aria-label={showTooltip ? getTrustBadgeAccessibleLabel(state) : undefined}
       className={cn(
         "inline-flex items-center gap-1 rounded-full border font-medium leading-none",
         size === "sm" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs",
         meta.className,
         className,
       )}
+      tabIndex={showTooltip ? 0 : undefined}
     >
       <Icon className={size === "sm" ? "h-2.5 w-2.5" : "h-3 w-3"} aria-hidden />
       {showLabel ? meta.label : <span className="sr-only">{meta.label}</span>}

--- a/src/features/design-system/feedback/feedback-viewport.tsx
+++ b/src/features/design-system/feedback/feedback-viewport.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { AlertTriangle, CheckCircle2, Info, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -25,6 +25,8 @@ interface FeedbackViewportProps {
 }
 
 export function FeedbackViewport({ items, onDismiss }: FeedbackViewportProps) {
+  const shouldReduceMotion = useReducedMotion();
+
   return (
     <div
       aria-atomic="true"
@@ -39,10 +41,14 @@ export function FeedbackViewport({ items, onDismiss }: FeedbackViewportProps) {
             <motion.div
               key={item.id}
               layout
-              initial={{ opacity: 0, y: 20, scale: 0.96 }}
+              initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.96 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 10, scale: 0.97 }}
-              transition={{ type: "spring", stiffness: 340, damping: 30 }}
+              exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 10, scale: 0.97 }}
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0.01 }
+                  : { type: "spring", stiffness: 340, damping: 30 }
+              }
               className={cn(
                 "glass-strong pointer-events-auto flex w-full max-w-md items-center gap-3 rounded-2xl border px-4 py-3 shadow-[0_18px_50px_-12px_rgba(0,0,0,0.7)]",
                 toneStyles[item.tone],


### PR DESCRIPTION
## Summary

- make tooltip-enabled trust badges keyboard reachable and give them an accessible label that includes the state explanation
- preserve non-tooltip badges as non-focusable presentational status pills
- respect OS/browser reduced-motion preferences in feedback notification entrance and exit transitions
- add regression coverage for the trust badge keyboard/name behavior

Fixes #967

## Before / After

Before, a tooltip-enabled trust badge rendered as a non-focusable span, so keyboard users could not reach the explanation. Feedback notifications also always used spring motion. After this change, tooltip badges expose a keyboard focus target and accessible state explanation, while feedback toasts use near-static opacity transitions when reduced motion is requested.

## Validation

- `pnpm exec vitest run src/features/design-system/components/trust-badge.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/features/design-system/components/trust-badge.tsx src/features/design-system/components/trust-badge.test.tsx src/features/design-system/feedback/feedback-viewport.tsx`