### PR TITLE
test(policy-editor): cover policy preview outcomes

### DIFF
--- a/src/routes/policy-editor/-policyPreview.test.ts
+++ b/src/routes/policy-editor/-policyPreview.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { simulatePolicySender } from "./-policyPreview";
+
+describe("policy editor preview", () => {
+  it("allows verified senders freely when unknown senders are allowed with no postage", () => {
+    expect(
+      simulatePolicySender(
+        { allowUnknown: true, requireVerified: false, minimumPostage: 0 },
+        "verified",
+      ),
+    ).toEqual({
+      allowed: true,
+      reason: "Allowed freely without restrictions.",
+    });
+  });
+
+  it("blocks unknown senders before applying verification or postage rules", () => {
+    expect(
+      simulatePolicySender(
+        { allowUnknown: false, requireVerified: true, minimumPostage: 0.25 },
+        "verified",
+      ),
+    ).toEqual({
+      allowed: false,
+      reason: "Unknown senders are disabled completely.",
+    });
+  });
+
+  it("blocks unverified senders when verification is required", () => {
+    expect(
+      simulatePolicySender(
+        { allowUnknown: true, requireVerified: true, minimumPostage: 0.01 },
+        "unverified",
+      ),
+    ).toEqual({
+      allowed: false,
+      reason: "Sender lacks verified cryptographic identity.",
+    });
+  });
+
+  it("shows the postage requirement for allowed unknown senders", () => {
+    expect(
+      simulatePolicySender(
+        { allowUnknown: true, requireVerified: false, minimumPostage: 0.015 },
+        "unverified",
+      ),
+    ).toEqual({
+      allowed: true,
+      reason: "Allowed if sender attaches >= 0.015 XLM postage.",
+    });
+  });
+});

--- a/src/routes/policy-editor/-policyPreview.ts
+++ b/src/routes/policy-editor/-policyPreview.ts
@@ -1,0 +1,38 @@
+export type PolicyPreviewSender = "trusted" | "blocked" | "verified" | "unverified";
+
+export type PolicyPreviewInput = {
+  allowUnknown: boolean;
+  requireVerified: boolean;
+  minimumPostage: number;
+};
+
+export type PolicyPreviewResult = {
+  allowed: boolean;
+  reason: string;
+};
+
+export function simulatePolicySender(
+  policy: PolicyPreviewInput,
+  type: PolicyPreviewSender,
+): PolicyPreviewResult {
+  if (type === "trusted") {
+    return { allowed: true, reason: "Sender is explicitly trusted in contact list." };
+  }
+  if (type === "blocked") {
+    return { allowed: false, reason: "Sender is explicitly blocked." };
+  }
+
+  if (!policy.allowUnknown) {
+    return { allowed: false, reason: "Unknown senders are disabled completely." };
+  }
+  if (policy.requireVerified && type === "unverified") {
+    return { allowed: false, reason: "Sender lacks verified cryptographic identity." };
+  }
+  if (policy.minimumPostage > 0) {
+    return {
+      allowed: true,
+      reason: `Allowed if sender attaches >= ${policy.minimumPostage.toFixed(3)} XLM postage.`,
+    };
+  }
+  return { allowed: true, reason: "Allowed freely without restrictions." };
+}

--- a/src/routes/policy-editor/route.tsx
+++ b/src/routes/policy-editor/route.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Surface, ActionButton, useFeedback } from "@/features/design-system";
 import { Check, X, Shield, ShieldAlert, Code } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { simulatePolicySender } from "./-policyPreview";
 
 export const Route = createFileRoute("/policy-editor")({
   component: PolicyEditorPage,
@@ -16,29 +17,6 @@ function PolicyEditorPage() {
   const [apiError, setApiError] = useState<string | null>(null);
 
   const { notify } = useFeedback();
-
-  const simulateSender = (type: "trusted" | "blocked" | "verified" | "unverified") => {
-    if (type === "trusted") {
-      return { allowed: true, reason: "Sender is explicitly trusted in contact list." };
-    }
-    if (type === "blocked") {
-      return { allowed: false, reason: "Sender is explicitly blocked." };
-    }
-
-    if (!allowUnknown) {
-      return { allowed: false, reason: "Unknown senders are disabled completely." };
-    }
-    if (requireVerified && type === "unverified") {
-      return { allowed: false, reason: "Sender lacks verified cryptographic identity." };
-    }
-    if (minimumPostage > 0) {
-      return {
-        allowed: true,
-        reason: `Allowed if sender attaches >= ${minimumPostage.toFixed(3)} XLM postage.`,
-      };
-    }
-    return { allowed: true, reason: "Allowed freely without restrictions." };
-  };
 
   const payload = {
     allowUnknown,
@@ -173,7 +151,10 @@ function PolicyEditorPage() {
               </h2>
               <div className="space-y-3">
                 {(["trusted", "blocked", "verified", "unverified"] as const).map((type) => {
-                  const result = simulateSender(type);
+                  const result = simulatePolicySender(
+                    { allowUnknown, requireVerified, minimumPostage },
+                    type,
+                  );
                   return (
                     <div
                       key={type}


### PR DESCRIPTION
## Summary

- extract the policy editor sender preview decision into a route-ignored pure helper
- keep the existing UI workflow and copy unchanged
- add regression coverage for allowed, unknown-blocked, verification-required, and postage-required outcomes

Fixes #939

## Before / After

Before, the live simulator behavior was embedded in the route component and had no focused unit coverage. After this change, the same decisions are covered by deterministic tests while the route continues to render the same user-visible simulator messages.

## Validation

- `pnpm exec vitest run src/routes/policy-editor/-policyPreview.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/routes/policy-editor/route.tsx src/routes/policy-editor/-policyPreview.ts src/routes/policy-editor/-policyPreview.test.ts`