### PR TITLE
Add campaign list table

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/campaignListTable.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignListTable.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { defaultCampaignSnapshots } from "../fixtures/campaignSnapshotFixtures";
+import {
+  buildCampaignListRows,
+  clearCampaignSelection,
+  defaultCampaignListSort,
+  nextCampaignListSort,
+  selectAllCampaigns,
+  summarizeCampaignSelection,
+  toggleCampaignSelection,
+} from "../campaignListTable";
+
+describe("campaignListTable", () => {
+  it("builds sorted rows with selection state", () => {
+    const rows = buildCampaignListRows(defaultCampaignSnapshots, ["snap-security"]);
+
+    expect(rows.map((row) => row.id)).toEqual(["snap-welcome", "snap-security", "snap-newsletter"]);
+    expect(rows.find((row) => row.id === "snap-security")?.selected).toBe(true);
+    expect(rows[0].draftCount).toBe(2);
+  });
+
+  it("sorts by campaign name in ascending order", () => {
+    const rows = buildCampaignListRows(defaultCampaignSnapshots, [], {
+      key: "name",
+      direction: "asc",
+    });
+
+    expect(rows.map((row) => row.name)).toEqual([
+      "Monthly Newsletter",
+      "Security Auditing Flow",
+      "Welcome Onboarding Series",
+    ]);
+  });
+
+  it("toggles and clears campaign selection deterministically", () => {
+    expect(toggleCampaignSelection(["snap-security"], "snap-welcome")).toEqual([
+      "snap-security",
+      "snap-welcome",
+    ]);
+    expect(toggleCampaignSelection(["snap-security"], "snap-security")).toEqual([]);
+    expect(selectAllCampaigns(defaultCampaignSnapshots)).toEqual([
+      "snap-newsletter",
+      "snap-security",
+      "snap-welcome",
+    ]);
+    expect(clearCampaignSelection()).toEqual([]);
+  });
+
+  it("summarizes only selected ids that exist in the current campaign list", () => {
+    const summary = summarizeCampaignSelection(defaultCampaignSnapshots, [
+      "snap-security",
+      "missing",
+    ]);
+
+    expect(summary).toEqual({
+      selectedCount: 1,
+      totalCount: 3,
+      selectedIds: ["snap-security"],
+      hasSelection: true,
+    });
+  });
+
+  it("toggles sort direction for the same key and defaults new numeric keys to desc", () => {
+    expect(nextCampaignListSort(defaultCampaignListSort, "updated")).toEqual({
+      key: "updated",
+      direction: "asc",
+    });
+    expect(nextCampaignListSort(defaultCampaignListSort, "drafts")).toEqual({
+      key: "drafts",
+      direction: "desc",
+    });
+    expect(nextCampaignListSort(defaultCampaignListSort, "name")).toEqual({
+      key: "name",
+      direction: "asc",
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/campaignListTable.ts
+++ b/src/features/demo-admin-dashboard/campaignListTable.ts
@@ -1,0 +1,118 @@
+import type { CampaignSnapshot } from "./types/campaignSnapshot";
+
+export type CampaignListSortKey = "name" | "targetAudience" | "status" | "drafts" | "updated";
+
+export type CampaignListSortDirection = "asc" | "desc";
+
+export interface CampaignListSort {
+  key: CampaignListSortKey;
+  direction: CampaignListSortDirection;
+}
+
+export interface CampaignListRow {
+  id: string;
+  name: string;
+  targetAudience: string;
+  status: NonNullable<CampaignSnapshot["status"]>;
+  tags: string[];
+  draftCount: number;
+  updatedAt: string;
+  selected: boolean;
+}
+
+export interface CampaignListSelectionSummary {
+  selectedCount: number;
+  totalCount: number;
+  selectedIds: string[];
+  hasSelection: boolean;
+}
+
+export const defaultCampaignListSort: CampaignListSort = {
+  key: "updated",
+  direction: "desc",
+};
+
+export function buildCampaignListRows(
+  campaigns: CampaignSnapshot[],
+  selectedIds: string[] = [],
+  sort: CampaignListSort = defaultCampaignListSort,
+): CampaignListRow[] {
+  const selected = new Set(selectedIds);
+  return campaigns
+    .map((campaign) => ({
+      id: campaign.id,
+      name: campaign.name,
+      targetAudience: campaign.targetAudience,
+      status: campaign.status ?? "draft",
+      tags: [...campaign.tags].sort(),
+      draftCount: campaign.drafts.length,
+      updatedAt: campaign.timestamp,
+      selected: selected.has(campaign.id),
+    }))
+    .sort((left, right) => compareCampaignRows(left, right, sort));
+}
+
+export function toggleCampaignSelection(selectedIds: string[], campaignId: string): string[] {
+  const selected = new Set(selectedIds);
+  if (selected.has(campaignId)) {
+    selected.delete(campaignId);
+  } else {
+    selected.add(campaignId);
+  }
+  return Array.from(selected).sort();
+}
+
+export function selectAllCampaigns(campaigns: CampaignSnapshot[]): string[] {
+  return campaigns.map((campaign) => campaign.id).sort();
+}
+
+export function clearCampaignSelection(): string[] {
+  return [];
+}
+
+export function summarizeCampaignSelection(
+  campaigns: CampaignSnapshot[],
+  selectedIds: string[],
+): CampaignListSelectionSummary {
+  const campaignIds = new Set(campaigns.map((campaign) => campaign.id));
+  const selected = selectedIds.filter((id) => campaignIds.has(id)).sort();
+
+  return {
+    selectedCount: selected.length,
+    totalCount: campaigns.length,
+    selectedIds: selected,
+    hasSelection: selected.length > 0,
+  };
+}
+
+export function nextCampaignListSort(
+  current: CampaignListSort,
+  key: CampaignListSortKey,
+): CampaignListSort {
+  if (current.key !== key) {
+    return { key, direction: key === "updated" || key === "drafts" ? "desc" : "asc" };
+  }
+
+  return {
+    key,
+    direction: current.direction === "asc" ? "desc" : "asc",
+  };
+}
+
+function compareCampaignRows(
+  left: CampaignListRow,
+  right: CampaignListRow,
+  sort: CampaignListSort,
+): number {
+  const multiplier = sort.direction === "asc" ? 1 : -1;
+
+  if (sort.key === "drafts") {
+    return (left.draftCount - right.draftCount || left.name.localeCompare(right.name)) * multiplier;
+  }
+
+  if (sort.key === "updated") {
+    return (Date.parse(left.updatedAt) - Date.parse(right.updatedAt)) * multiplier;
+  }
+
+  return String(left[sort.key]).localeCompare(String(right[sort.key])) * multiplier;
+}

--- a/src/features/demo-admin-dashboard/components/CampaignListTable.tsx
+++ b/src/features/demo-admin-dashboard/components/CampaignListTable.tsx
@@ -1,0 +1,148 @@
+import { ArrowDownUp, CheckSquare, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CampaignSnapshot } from "../types/campaignSnapshot";
+import {
+  buildCampaignListRows,
+  clearCampaignSelection,
+  defaultCampaignListSort,
+  nextCampaignListSort,
+  selectAllCampaigns,
+  summarizeCampaignSelection,
+  toggleCampaignSelection,
+  type CampaignListSort,
+  type CampaignListSortKey,
+} from "../campaignListTable";
+
+export interface CampaignListTableProps {
+  campaigns: CampaignSnapshot[];
+  selectedIds?: string[];
+  sort?: CampaignListSort;
+  onSelectionChange?: (selectedIds: string[]) => void;
+  onSortChange?: (sort: CampaignListSort) => void;
+  className?: string;
+}
+
+const sortableColumns: Array<{ key: CampaignListSortKey; label: string }> = [
+  { key: "name", label: "Campaign" },
+  { key: "targetAudience", label: "Audience" },
+  { key: "status", label: "Status" },
+  { key: "drafts", label: "Drafts" },
+  { key: "updated", label: "Updated" },
+];
+
+export function CampaignListTable({
+  campaigns,
+  selectedIds = [],
+  sort = defaultCampaignListSort,
+  onSelectionChange,
+  onSortChange,
+  className,
+}: CampaignListTableProps) {
+  const rows = buildCampaignListRows(campaigns, selectedIds, sort);
+  const selection = summarizeCampaignSelection(campaigns, selectedIds);
+  const allSelected = campaigns.length > 0 && selection.selectedCount === campaigns.length;
+
+  const updateSelection = (nextSelectedIds: string[]) => {
+    onSelectionChange?.(nextSelectedIds);
+  };
+
+  const updateSort = (key: CampaignListSortKey) => {
+    onSortChange?.(nextCampaignListSort(sort, key));
+  };
+
+  return (
+    <section
+      className={cn(
+        "overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]",
+        className,
+      )}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-white/[0.06] px-4 py-3">
+        <div>
+          <h3 className="text-sm font-medium">Campaign list</h3>
+          <p className="text-xs text-muted-foreground">
+            {selection.selectedCount} of {selection.totalCount} selected
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() =>
+            updateSelection(allSelected ? clearCampaignSelection() : selectAllCampaigns(campaigns))
+          }
+          className="inline-flex items-center gap-1 rounded-lg border border-white/[0.08] px-3 py-2 text-sm text-foreground hover:bg-white/[0.04]"
+        >
+          {allSelected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+          {allSelected ? "Clear all" : "Select all"}
+        </button>
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-left text-sm">
+          <thead className="border-b border-white/[0.06] text-xs text-muted-foreground">
+            <tr>
+              <th className="w-12 px-4 py-3">Select</th>
+              {sortableColumns.map((column) => (
+                <th key={column.key} className="px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={() => updateSort(column.key)}
+                    className="inline-flex items-center gap-1 hover:text-foreground"
+                  >
+                    {column.label}
+                    <ArrowDownUp className="h-3.5 w-3.5" />
+                    {sort.key === column.key ? (
+                      <span className="text-[10px] uppercase">{sort.direction}</span>
+                    ) : null}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id} className="border-b border-white/[0.04] last:border-0">
+                <td className="px-4 py-3">
+                  <button
+                    type="button"
+                    aria-label={`Toggle ${row.name}`}
+                    onClick={() => updateSelection(toggleCampaignSelection(selectedIds, row.id))}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    {row.selected ? (
+                      <CheckSquare className="h-4 w-4 text-emerald-300" />
+                    ) : (
+                      <Square className="h-4 w-4" />
+                    )}
+                  </button>
+                </td>
+                <td className="px-4 py-3">
+                  <p className="font-medium text-foreground">{row.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {row.tags.join(", ") || "untagged"}
+                  </p>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">{row.targetAudience}</td>
+                <td className="px-4 py-3">
+                  <span className="rounded-full border border-white/[0.08] px-2 py-0.5 text-xs text-muted-foreground">
+                    {row.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">{row.draftCount}</td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {new Date(row.updatedAt).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No campaign records yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -56,8 +56,26 @@ export {
 } from "./constants/displayTokens";
 
 export { CampaignTagManager } from "./components/CampaignTagManager";
+export { CampaignListTable } from "./components/CampaignListTable";
+export type { CampaignListTableProps } from "./components/CampaignListTable";
 export { MockPublishPanel } from "./components/MockPublishPanel";
 export type { MockPublishPanelProps } from "./components/MockPublishPanel";
+export {
+  buildCampaignListRows,
+  clearCampaignSelection,
+  defaultCampaignListSort,
+  nextCampaignListSort,
+  selectAllCampaigns,
+  summarizeCampaignSelection,
+  toggleCampaignSelection,
+} from "./campaignListTable";
+export type {
+  CampaignListRow,
+  CampaignListSelectionSummary,
+  CampaignListSort,
+  CampaignListSortDirection,
+  CampaignListSortKey,
+} from "./campaignListTable";
 export {
   canRetryMockPublish,
   canRollbackMockPublish,


### PR DESCRIPTION
## Summary
- add a local campaign list table for browsing fake campaign records with sortable columns and selection controls
- add pure table helpers for row building, sort cycling, select all/clear/toggle, and selection summaries
- cover default updated sorting, name sorting, deterministic selection, valid-id filtering, and sort toggling with focused tests

Closes #282

## Validation
- 
px prettier --check src/features/demo-admin-dashboard/campaignListTable.ts src/features/demo-admin-dashboard/components/CampaignListTable.tsx src/features/demo-admin-dashboard/__tests__/campaignListTable.test.ts src/features/demo-admin-dashboard/index.ts
- git diff --check
- sensitive scan for account/payment/private-key markers returned no matches
- 
px vitest run src/features/demo-admin-dashboard/__tests__/campaignListTable.test.ts could not start locally because this fresh checkout is missing the Vite config packages (@cloudflare/vite-plugin, @tailwindcss/vite, @tanstack/react-start/plugin/vite, @vitejs/plugin-react, ite, ite-tsconfig-paths)