### PR TITLE
test(requests): add triage regression coverage

### DIFF
--- a/src/features/requests/RequestCard.tsx
+++ b/src/features/requests/RequestCard.tsx
@@ -28,6 +28,27 @@ interface RequestCardProps {
   onInspect: (email: Email) => void;
 }
 
+export function getTriageActionFromStatus(status: CardStatus): TriageAction | null {
+  if (status.includes("approve")) return "approve";
+  if (status.includes("block")) return "block";
+  if (status.includes("refund")) return "refund";
+  return null;
+}
+
+export function formatRequestPostage(stroops?: string) {
+  if (!stroops) return "0.0 XLM";
+  try {
+    const val = BigInt(stroops);
+    const xlm = Number(val) / 10_000_000;
+    return `${xlm.toLocaleString(undefined, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 4,
+    })} XLM`;
+  } catch {
+    return `${stroops} stroops`;
+  }
+}
+
 export function RequestCard({
   email,
   status,
@@ -42,14 +63,7 @@ export function RequestCard({
   const startTimeRef = useRef<number>(0);
   const duration = 3000; // 3 seconds undo window
 
-  const getActionFromStatus = (status: CardStatus): TriageAction | null => {
-    if (status.includes("approve")) return "approve";
-    if (status.includes("block")) return "block";
-    if (status.includes("refund")) return "refund";
-    return null;
-  };
-
-  const currentAction = getActionFromStatus(status);
+  const currentAction = getTriageActionFromStatus(status);
 
   // Timer effect for the success undo countdown
   useEffect(() => {
@@ -82,21 +96,6 @@ export function RequestCard({
       }
     };
   }, [status, email.id, currentAction]);
-
-  // Handle formatting for native Stellar postage amounts (1 XLM = 10,000,000 Stroops)
-  const formatPostage = (stroops?: string) => {
-    if (!stroops) return "0.0 XLM";
-    try {
-      const val = BigInt(stroops);
-      const xlm = Number(val) / 10_000_000;
-      return `${xlm.toLocaleString(undefined, {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 4,
-      })} XLM`;
-    } catch {
-      return `${stroops} stroops`;
-    }
-  };
 
   return (
     <motion.div
@@ -162,7 +161,7 @@ export function RequestCard({
                   Postage Paid
                 </p>
                 <p className="text-xs font-semibold tabular-nums text-foreground mt-0.5">
-                  {formatPostage(email.postageAmount)}
+                  {formatRequestPostage(email.postageAmount)}
                 </p>
               </div>
             </div>

--- a/src/features/requests/RequestsTriageBoard.tsx
+++ b/src/features/requests/RequestsTriageBoard.tsx
@@ -24,6 +24,53 @@ interface RequestsTriageBoardProps {
   onShowToast: (message: string, options?: { tone: "success" | "neutral" | "danger" }) => void;
 }
 
+export function cleanRequestTriageLabels(labels?: string[], toAdd?: string) {
+  const filterOut = ["Request", "Paid", "Pending"];
+  const current = labels ? labels.filter((label) => !filterOut.includes(label)) : [];
+  return toAdd ? [...current, toAdd] : current;
+}
+
+export function resolveRequestTriageCompletion(
+  email: Pick<Email, "from" | "labels">,
+  action: TriageAction,
+): {
+  patch: Partial<Email>;
+  toast: { message: string; tone: "success" | "danger" };
+} {
+  if (action === "approve") {
+    return {
+      patch: {
+        folder: "inbox",
+        senderPolicy: "allow",
+        labels: cleanRequestTriageLabels(email.labels, "Trusted"),
+      },
+      toast: {
+        message: `${email.from} added to Trusted Contacts. Mail moved to Inbox.`,
+        tone: "success",
+      },
+    };
+  }
+
+  if (action === "block") {
+    return {
+      patch: {
+        folder: "spam",
+        senderPolicy: "block",
+        labels: cleanRequestTriageLabels(email.labels, "Blocked"),
+      },
+      toast: { message: `${email.from} blocked. Mail moved to Spam.`, tone: "danger" },
+    };
+  }
+
+  return {
+    patch: {
+      folder: "spam",
+      labels: cleanRequestTriageLabels(email.labels, "Refunded"),
+    },
+    toast: { message: `Postage refunded for message from ${email.from}.`, tone: "success" },
+  };
+}
+
 export function RequestsTriageBoard({
   emails,
   onUpdateEmail,
@@ -81,36 +128,9 @@ export function RequestsTriageBoard({
     const email = emails.find((e) => e.id === emailId);
     if (!email) return;
 
-    // Apply cleaner label updates
-    const cleanLabels = (labels?: string[], toAdd?: string) => {
-      const filterOut = ["Request", "Paid", "Pending"];
-      const current = labels ? labels.filter((l) => !filterOut.includes(l)) : [];
-      return toAdd ? [...current, toAdd] : current;
-    };
-
-    if (action === "approve") {
-      onUpdateEmail(emailId, {
-        folder: "inbox",
-        senderPolicy: "allow",
-        labels: cleanLabels(email.labels, "Trusted"),
-      });
-      onShowToast(`${email.from} added to Trusted Contacts. Mail moved to Inbox.`, {
-        tone: "success",
-      });
-    } else if (action === "block") {
-      onUpdateEmail(emailId, {
-        folder: "spam",
-        senderPolicy: "block",
-        labels: cleanLabels(email.labels, "Blocked"),
-      });
-      onShowToast(`${email.from} blocked. Mail moved to Spam.`, { tone: "danger" });
-    } else if (action === "refund") {
-      onUpdateEmail(emailId, {
-        folder: "spam",
-        labels: cleanLabels(email.labels, "Refunded"),
-      });
-      onShowToast(`Postage refunded for message from ${email.from}.`, { tone: "success" });
-    }
+    const result = resolveRequestTriageCompletion(email, action);
+    onUpdateEmail(emailId, result.patch);
+    onShowToast(result.toast.message, { tone: result.toast.tone });
 
     // Clean up local card state
     setCardStates((prev) => {

--- a/tests/unit/requests/requests.test.ts
+++ b/tests/unit/requests/requests.test.ts
@@ -1,49 +1,107 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 
-// Simple test for requests logic and formatting
-describe("Requests triage board unit helpers", () => {
-  // Test formatting for native Stellar postage amounts (1 XLM = 10,000,000 Stroops)
-  const formatPostage = (stroops?: string) => {
-    if (!stroops) return "0.0 XLM";
-    try {
-      const val = BigInt(stroops);
-      const xlm = Number(val) / 10_000_000;
-      return `${xlm.toLocaleString(undefined, {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 4,
-      })} XLM`;
-    } catch {
-      return `${stroops} stroops`;
-    }
-  };
+import type { Email } from "../../../src/components/mail/data";
+import { RequestCard, formatRequestPostage } from "../../../src/features/requests/RequestCard";
+import {
+  RequestsTriageBoard,
+  cleanRequestTriageLabels,
+  resolveRequestTriageCompletion,
+} from "../../../src/features/requests/RequestsTriageBoard";
 
-  const cleanLabels = (labels?: string[], toAdd?: string) => {
-    const filterOut = ["Request", "Paid", "Pending"];
-    const current = labels ? labels.filter((l) => !filterOut.includes(l)) : [];
-    return toAdd ? [...current, toAdd] : current;
-  };
+const requestEmail = (overrides: Partial<Email> = {}): Email => ({
+  id: "req-1",
+  from: "Avery Example",
+  email: "avery@example.test",
+  subject: "Partnership request",
+  preview: "Could we schedule a quick review?",
+  body: "Hello, I would like to discuss a small partnership.",
+  time: "10:30 AM",
+  unread: true,
+  starred: false,
+  folder: "requests",
+  labels: ["Request", "Paid", "Design"],
+  avatarColor: "bg-slate-500",
+  postageAmount: "15000000",
+  verifiedSender: false,
+  ...overrides,
+});
 
-  it("formats postage amounts from stroops to XLM native units", () => {
-    expect(formatPostage("10000000")).toBe("1.0 XLM");
-    expect(formatPostage("50000000")).toBe("5.0 XLM");
-    expect(formatPostage("15000000")).toBe("1.5 XLM");
-    expect(formatPostage("100000")).toBe("0.01 XLM");
-    expect(formatPostage(undefined)).toBe("0.0 XLM");
-    expect(formatPostage("invalid")).toBe("invalid stroops");
+describe("Request triage regressions", () => {
+  it("renders pending request details and resolves approval into inbox/trusted state", () => {
+    const email = requestEmail();
+    const boardHtml = renderToStaticMarkup(
+      createElement(RequestsTriageBoard, {
+        emails: [email],
+        onUpdateEmail: vi.fn(),
+        onShowToast: vi.fn(),
+      }),
+    );
+
+    expect(boardHtml).toContain("Request Triage Board");
+    expect(boardHtml).toContain("1 pending");
+    expect(boardHtml).toContain("Avery Example");
+    expect(boardHtml).toContain("Partnership request");
+
+    const cardHtml = renderToStaticMarkup(
+      createElement(RequestCard, {
+        email,
+        status: "idle",
+        simulateFailure: false,
+        onTriggerAction: vi.fn(),
+        onUndoAction: vi.fn(),
+        onFinalizeAction: vi.fn(),
+        onInspect: vi.fn(),
+      }),
+    );
+
+    expect(cardHtml).toContain("Unknown");
+    expect(cardHtml).toContain("1.5 XLM");
+    expect(cardHtml).toContain("Approve");
+
+    const result = resolveRequestTriageCompletion(email, "approve");
+    expect(result.patch).toEqual({
+      folder: "inbox",
+      senderPolicy: "allow",
+      labels: ["Design", "Trusted"],
+    });
+    expect(result.toast).toEqual({
+      message: "Avery Example added to Trusted Contacts. Mail moved to Inbox.",
+      tone: "success",
+    });
   });
 
-  it("cleans temporary triage labels and appends final policy badge", () => {
-    const originalLabels = ["Request", "Paid", "Design"];
-    const resultApprove = cleanLabels(originalLabels, "Trusted");
-    expect(resultApprove).toEqual(["Design", "Trusted"]);
-    expect(resultApprove).not.toContain("Request");
-    expect(resultApprove).not.toContain("Paid");
+  it("keeps the failure state visible and preserves malformed postage for retry context", () => {
+    const email = requestEmail({ postageAmount: "not-a-number" });
+    const cardHtml = renderToStaticMarkup(
+      createElement(RequestCard, {
+        email,
+        status: "failure",
+        simulateFailure: true,
+        onTriggerAction: vi.fn(),
+        onUndoAction: vi.fn(),
+        onFinalizeAction: vi.fn(),
+        onInspect: vi.fn(),
+      }),
+    );
 
-    const resultBlock = cleanLabels(originalLabels, "Blocked");
-    expect(resultBlock).toEqual(["Design", "Blocked"]);
+    expect(cardHtml).toContain("Action Failed");
+    expect(cardHtml).toContain("Could not resolve the transaction on the Stellar network");
+    expect(cardHtml).toContain("Cancel");
+    expect(cardHtml).toContain("Retry");
+    expect(formatRequestPostage("not-a-number")).toBe("not-a-number stroops");
+  });
 
-    const resultRefund = cleanLabels(originalLabels, "Refunded");
-    expect(resultRefund).toEqual(["Design", "Refunded"]);
+  it("cleans temporary triage labels without dropping unrelated badges", () => {
+    expect(cleanRequestTriageLabels(["Request", "Paid", "Design"], "Blocked")).toEqual([
+      "Design",
+      "Blocked",
+    ]);
+    expect(resolveRequestTriageCompletion(requestEmail(), "refund").patch).toEqual({
+      folder: "spam",
+      labels: ["Design", "Refunded"],
+    });
   });
 });
 

--- a/tests/unit/sender-conversion/sender-conversion.test.ts
+++ b/tests/unit/sender-conversion/sender-conversion.test.ts
@@ -1,5 +1,8 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { ConvertSenderButton } from "../../../src/features/sender-conversion/ConvertSenderButton";
 import {
   SENDER_POLICY_OPTIONS,
   getSenderPolicyOption,
@@ -30,6 +33,35 @@ describe("SENDER_POLICY_OPTIONS", () => {
     for (const choice of ["allow", "verify", "block"] as SenderPolicyChoice[]) {
       expect(getSenderPolicyOption(choice).value).toBe(choice);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConvertSenderButton
+// ---------------------------------------------------------------------------
+describe("ConvertSenderButton", () => {
+  it("renders the shared conversion CTA as a non-submit button", () => {
+    const html = renderToStaticMarkup(
+      createElement(ConvertSenderButton, { onClick: () => undefined }),
+    );
+
+    expect(html).toContain('type="button"');
+    expect(html).toContain("Convert to contact");
+  });
+
+  it("supports contextual labels and variants for request-card entry points", () => {
+    const html = renderToStaticMarkup(
+      createElement(ConvertSenderButton, {
+        onClick: () => undefined,
+        label: "Review sender",
+        variant: "ghost",
+        className: "request-card-action",
+      }),
+    );
+
+    expect(html).toContain("Review sender");
+    expect(html).toContain("text-muted-foreground");
+    expect(html).toContain("request-card-action");
   });
 });
 


### PR DESCRIPTION
## Summary
- add request triage coverage for pending board/card rendering and approval resolution
- cover failure-state UI and malformed postage fallback behavior
- cover sender-conversion CTA rendering from request-card entry points

Closes #919

## Validation
- git diff --check