### PR TITLE
test(calendar): add workspace regression coverage

### DIFF
--- a/src/features/calendar/components/CalendarWorkspace.tsx
+++ b/src/features/calendar/components/CalendarWorkspace.tsx
@@ -28,6 +28,8 @@ import type {
   CalendarResponse,
 } from "../types";
 
+export type CalendarWorkspaceView = "agenda" | "month";
+
 type CalendarWorkspaceProps = {
   open: boolean;
   onClose: () => void;
@@ -64,7 +66,7 @@ export function CalendarWorkspace({
   const [month, setMonth] = useState(getAppToday());
   const [selectedDate, setSelectedDate] = useState(getAppToday());
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [view, setView] = useState<"agenda" | "month">("agenda");
+  const [view, setView] = useState<CalendarWorkspaceView>("agenda");
   const [editorEvent, setEditorEvent] = useState<CalendarEvent | null | undefined>(undefined);
   const [calendarName, setCalendarName] = useState("");
   const [calendarColor, setCalendarColor] = useState(calendarColors[3]);
@@ -106,23 +108,14 @@ export function CalendarWorkspace({
   }, [editorEvent, onClose, open]);
 
   const selectedEvent = events.find((event) => event.id === selectedId) ?? null;
-  const visibleIds = useMemo(
-    () => new Set(calendars.filter((calendar) => calendar.visible).map((calendar) => calendar.id)),
-    [calendars],
-  );
   const visibleEvents = useMemo(
-    () => events.filter((event) => visibleIds.has(event.calendarId)),
-    [events, visibleIds],
+    () => filterVisibleCalendarEvents(calendars, events),
+    [calendars, events],
   );
-  const displayedEvents = useMemo(() => {
-    if (view === "agenda") {
-      return visibleEvents.filter((event) => isSameDay(parseISO(event.date), selectedDate));
-    }
-    return visibleEvents.filter((event) => {
-      const date = parseISO(event.date);
-      return date.getMonth() === month.getMonth() && date.getFullYear() === month.getFullYear();
-    });
-  }, [month, selectedDate, view, visibleEvents]);
+  const displayedEvents = useMemo(
+    () => getDisplayedCalendarEvents({ calendars, events, selectedDate, month, view }),
+    [calendars, events, month, selectedDate, view],
+  );
   const eventDates = visibleEvents.map((event) => parseISO(event.date));
 
   const openNewEvent = () => {
@@ -477,6 +470,39 @@ export function CalendarWorkspace({
       )}
     </AnimatePresence>
   );
+}
+
+export function filterVisibleCalendarEvents(
+  calendars: CalendarDefinition[],
+  events: CalendarEvent[],
+): CalendarEvent[] {
+  const visibleIds = new Set(
+    calendars.filter((calendar) => calendar.visible).map((calendar) => calendar.id),
+  );
+  return events.filter((event) => visibleIds.has(event.calendarId));
+}
+
+export function getDisplayedCalendarEvents({
+  calendars,
+  events,
+  selectedDate,
+  month,
+  view,
+}: {
+  calendars: CalendarDefinition[];
+  events: CalendarEvent[];
+  selectedDate: Date;
+  month: Date;
+  view: CalendarWorkspaceView;
+}): CalendarEvent[] {
+  const visibleEvents = filterVisibleCalendarEvents(calendars, events);
+  if (view === "agenda") {
+    return visibleEvents.filter((event) => isSameDay(parseISO(event.date), selectedDate));
+  }
+  return visibleEvents.filter((event) => {
+    const date = parseISO(event.date);
+    return date.getMonth() === month.getMonth() && date.getFullYear() === month.getFullYear();
+  });
 }
 
 function EventDetails({

--- a/src/features/calendar/components/EventMailCard.tsx
+++ b/src/features/calendar/components/EventMailCard.tsx
@@ -30,6 +30,7 @@ export function EventMailCard({
   const [view, setView] = useState<"event" | "monthly">("event");
   const [addedEvent, setAddedEvent] = useState<CalendarEvent | null>(calendarEvent ?? null);
   const savedEvent = calendarEvent ?? addedEvent;
+  const statusLabel = getEventMailCardStatusLabel(savedEvent);
 
   const addEvent = () => {
     const saved = onAdd?.(event);
@@ -185,10 +186,10 @@ export function EventMailCard({
         <span className="rounded-md border border-white/[0.1] bg-white/[0.04] px-2.5 py-1 backdrop-blur-xl">
           {savedEvent ? (
             <span className="inline-flex items-center gap-1">
-              <Check className="h-3 w-3 text-emerald-300" /> Added to calendar
+              <Check className="h-3 w-3 text-emerald-300" /> {statusLabel}
             </span>
           ) : (
-            "Upcoming event"
+            statusLabel
           )}
         </span>
         <button
@@ -204,4 +205,8 @@ export function EventMailCard({
       </div>
     </div>
   );
+}
+
+export function getEventMailCardStatusLabel(calendarEvent?: CalendarEvent | null): string {
+  return calendarEvent ? "Added to calendar" : "Upcoming event";
 }

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -72,21 +72,7 @@ export function useCalendar() {
     const existing = snapshot.events.find((event) => event.sourceEmailId === sourceEmailId);
     if (existing) return existing;
 
-    return saveEvent({
-      title: mailEvent.title,
-      date: mailEvent.date ?? "2026-06-13",
-      time: to24HourTime(mailEvent.time),
-      endTime: mailEvent.endTime ?? addOneHour(to24HourTime(mailEvent.time)),
-      location: mailEvent.location,
-      note: mailEvent.note,
-      calendarId: mailEvent.calendar ?? "personal",
-      cadence: mailEvent.cadence,
-      organizer: mailEvent.organizer,
-      meetingUrl: mailEvent.meetingUrl,
-      sourceEmailId,
-      response: "going",
-      reminder: "15 minutes",
-    });
+    return saveEvent(mailEventToCalendarDraft(mailEvent, sourceEmailId));
   };
 
   const deleteEvent = (id: string) => {
@@ -152,6 +138,28 @@ export function useCalendar() {
     updateReminder,
     toggleCalendar,
     addCalendar,
+  };
+}
+
+export function mailEventToCalendarDraft(
+  mailEvent: MailEvent,
+  sourceEmailId: string,
+): CalendarEventDraft {
+  const startTime = to24HourTime(mailEvent.time);
+  return {
+    title: mailEvent.title,
+    date: mailEvent.date ?? "2026-06-13",
+    time: startTime,
+    endTime: mailEvent.endTime ?? addOneHour(startTime),
+    location: mailEvent.location,
+    note: mailEvent.note,
+    calendarId: mailEvent.calendar ?? "personal",
+    cadence: mailEvent.cadence,
+    organizer: mailEvent.organizer,
+    meetingUrl: mailEvent.meetingUrl,
+    sourceEmailId,
+    response: "going",
+    reminder: "15 minutes",
   };
 }
 

--- a/tests/unit/calendar/calendar-workspace.test.ts
+++ b/tests/unit/calendar/calendar-workspace.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterVisibleCalendarEvents,
+  getDisplayedCalendarEvents,
+} from "../../../src/features/calendar/components/CalendarWorkspace";
+import { getEventMailCardStatusLabel } from "../../../src/features/calendar/components/EventMailCard";
+import { getAppToday, getReferenceNow } from "../../../src/features/calendar/dateUtils";
+import type {
+  CalendarDefinition,
+  CalendarEvent,
+  MailEvent,
+} from "../../../src/features/calendar/types";
+import { mailEventToCalendarDraft } from "../../../src/features/calendar/useCalendar";
+
+const calendars: CalendarDefinition[] = [
+  { id: "work", name: "Work", color: "#8fa8ff", visible: true },
+  { id: "personal", name: "Personal", color: "#d5d7dc", visible: true },
+  { id: "hidden", name: "Hidden", color: "#f2b880", visible: false },
+];
+
+const calendarEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  id: "event-work-review",
+  title: "Design review",
+  date: "2026-06-13",
+  time: "10:00",
+  endTime: "10:45",
+  location: "Vantage studio",
+  note: "Approve final identity direction.",
+  calendarId: "work",
+  cadence: "One time",
+  response: "going",
+  reminder: "15 minutes",
+  ...overrides,
+});
+
+const mailEvent = (overrides: Partial<MailEvent> = {}): MailEvent => ({
+  id: "mail-investor-sync",
+  title: "Investor sync",
+  month: "Jun",
+  day: "16",
+  cadence: "Monthly",
+  date: "2026-06-16",
+  time: "1:15 PM",
+  location: "Lumos Capital",
+  note: "Join briefing",
+  calendar: "protocol",
+  organizer: "Uthaimin Lawal",
+  meetingUrl: "https://meet.stealth.local/investor-sync",
+  days: [
+    { label: "Mon", date: "15" },
+    { label: "Tue", date: "16", active: true },
+  ],
+  ...overrides,
+});
+
+describe("calendar reference clock", () => {
+  it("uses the deterministic seed timestamp and day boundary", () => {
+    const now = getReferenceNow();
+    expect([
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      now.getHours(),
+      now.getMinutes(),
+    ]).toEqual([2026, 5, 13, 9, 41]);
+
+    const today = getAppToday();
+    expect([today.getFullYear(), today.getMonth(), today.getDate()]).toEqual([2026, 5, 13]);
+    expect([today.getHours(), today.getMinutes(), today.getSeconds()]).toEqual([0, 0, 0]);
+  });
+});
+
+describe("mailEventToCalendarDraft", () => {
+  it("builds a saved calendar draft from a mail event", () => {
+    const draft = mailEventToCalendarDraft(mailEvent(), "email-investor-sync");
+
+    expect(draft).toMatchObject({
+      title: "Investor sync",
+      date: "2026-06-16",
+      time: "13:15",
+      endTime: "14:15",
+      location: "Lumos Capital",
+      calendarId: "protocol",
+      organizer: "Uthaimin Lawal",
+      meetingUrl: "https://meet.stealth.local/investor-sync",
+      sourceEmailId: "email-investor-sync",
+      response: "going",
+      reminder: "15 minutes",
+    });
+    expect(draft.id).toBeUndefined();
+  });
+
+  it("falls back to deterministic defaults for missing date, calendar, and malformed time", () => {
+    const draft = mailEventToCalendarDraft(
+      mailEvent({ date: undefined, time: "after lunch", calendar: undefined }),
+      "email-missing-time",
+    );
+
+    expect(draft.date).toBe("2026-06-13");
+    expect(draft.time).toBe("09:00");
+    expect(draft.endTime).toBe("10:00");
+    expect(draft.calendarId).toBe("personal");
+  });
+});
+
+describe("CalendarWorkspace event filtering", () => {
+  const events: CalendarEvent[] = [
+    calendarEvent({ id: "work-today", calendarId: "work", date: "2026-06-13" }),
+    calendarEvent({ id: "hidden-today", calendarId: "hidden", date: "2026-06-13" }),
+    calendarEvent({ id: "personal-next-day", calendarId: "personal", date: "2026-06-14" }),
+    calendarEvent({ id: "work-next-month", calendarId: "work", date: "2026-07-01" }),
+  ];
+
+  it("shows visible-calendar events for the selected agenda day", () => {
+    const displayed = getDisplayedCalendarEvents({
+      calendars,
+      events,
+      selectedDate: new Date(2026, 5, 13),
+      month: new Date(2026, 5, 1),
+      view: "agenda",
+    });
+
+    expect(displayed.map((event) => event.id)).toEqual(["work-today"]);
+  });
+
+  it("excludes hidden calendars from month and visible event collections", () => {
+    expect(filterVisibleCalendarEvents(calendars, events).map((event) => event.id)).toEqual([
+      "work-today",
+      "personal-next-day",
+      "work-next-month",
+    ]);
+
+    const displayed = getDisplayedCalendarEvents({
+      calendars,
+      events,
+      selectedDate: new Date(2026, 5, 13),
+      month: new Date(2026, 5, 1),
+      view: "month",
+    });
+
+    expect(displayed.map((event) => event.id)).toEqual(["work-today", "personal-next-day"]);
+  });
+});
+
+describe("EventMailCard status label", () => {
+  it("returns the user-visible label for unsaved and saved event cards", () => {
+    expect(getEventMailCardStatusLabel(null)).toBe("Upcoming event");
+    expect(getEventMailCardStatusLabel(calendarEvent())).toBe("Added to calendar");
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic coverage for mail events converted into calendar drafts
- cover fallback date, calendar, and malformed-time behavior
- cover visible-calendar filtering for agenda/month views and event-card status labels

Closes #924

## Validation
- git diff --check