### PR TITLE
Polish calendar workspace interaction states

### DIFF
--- a/src/features/calendar/components/CalendarWorkspace.tsx
+++ b/src/features/calendar/components/CalendarWorkspace.tsx
@@ -124,6 +124,25 @@ export function CalendarWorkspace({
     });
   }, [month, selectedDate, view, visibleEvents]);
   const eventDates = visibleEvents.map((event) => parseISO(event.date));
+  const visibleCalendarCount = visibleIds.size;
+  const emptyState =
+    visibleCalendarCount === 0
+      ? {
+          title: "All calendars are hidden",
+          description: "Turn on a calendar in the sidebar to restore scheduled mail events.",
+          action: "Create event",
+        }
+      : view === "agenda"
+        ? {
+            title: "No events on this day",
+            description: "Create a schedule from this mailbox context or choose another day.",
+            action: "Create event",
+          }
+        : {
+            title: "No visible events this month",
+            description: "Try another month or create a new schedule from the selected date.",
+            action: "Create event",
+          };
 
   const openNewEvent = () => {
     setEditorEvent(null);
@@ -252,7 +271,11 @@ export function CalendarWorkspace({
                       <button
                         key={calendar.id}
                         onClick={() => onToggleCalendar(calendar.id)}
-                        className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs transition hover:bg-white/[0.05]"
+                        aria-pressed={calendar.visible}
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
+                          !calendar.visible && "text-muted-foreground",
+                        )}
                       >
                         <span
                           className={cn(
@@ -310,7 +333,7 @@ export function CalendarWorkspace({
                       disabled={!calendarName.trim()}
                       className="ml-auto rounded-md border border-white/10 px-2 py-1 text-[10px] transition hover:bg-white/[0.06] disabled:opacity-40"
                     >
-                      Add
+                      {calendarName.trim() ? "Add" : "Name required"}
                     </button>
                   </div>
                 </form>
@@ -365,12 +388,12 @@ export function CalendarWorkspace({
                     <div className="grid min-h-56 place-items-center rounded-2xl border border-dashed border-white/10 bg-white/[0.02] text-center">
                       <div>
                         <CalendarDays className="mx-auto h-6 w-6 text-muted-foreground" />
-                        <p className="mt-3 text-sm font-medium">No events here</p>
+                        <p className="mt-3 text-sm font-medium">{emptyState.title}</p>
                         <p className="mt-1 text-xs text-muted-foreground">
-                          Create an event or choose another day.
+                          {emptyState.description}
                         </p>
                         <button onClick={openNewEvent} className="calendar-primary-button mt-4">
-                          <Plus className="h-3.5 w-3.5" /> Create event
+                          <Plus className="h-3.5 w-3.5" /> {emptyState.action}
                         </button>
                       </div>
                     </div>
@@ -383,6 +406,7 @@ export function CalendarWorkspace({
                           onClick={() => setSelectedId(event.id)}
                           className={cn(
                             "calendar-event-row group grid w-full grid-cols-[64px_5px_1fr_auto] items-center gap-3 rounded-xl border p-3 text-left transition",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
                             selectedId === event.id
                               ? "border-white/20 bg-white/[0.08]"
                               : "border-white/8 bg-white/[0.025] hover:border-white/14 hover:bg-white/[0.05]",
@@ -498,6 +522,22 @@ function EventDetails({
   onReminderChange: (reminder: string) => void;
   onShowToast: (message: string) => void;
 }) {
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copying" | "copied">("idle");
+
+  const copyDetails = async () => {
+    setCopyStatus("copying");
+    try {
+      await navigator.clipboard?.writeText(`${event.title} - ${event.date} ${event.time}`);
+      setCopyStatus("copied");
+      onShowToast("Event details copied");
+    } catch {
+      setCopyStatus("idle");
+      onShowToast("Copy failed");
+      return;
+    }
+    window.setTimeout(() => setCopyStatus("idle"), 1200);
+  };
+
   return (
     <div>
       <div className="flex items-start justify-between gap-3">
@@ -584,13 +624,16 @@ function EventDetails({
           </button>
         )}
         <button
-          onClick={() => {
-            navigator.clipboard?.writeText(`${event.title} - ${event.date} ${event.time}`);
-            onShowToast("Event details copied");
-          }}
+          onClick={copyDetails}
+          disabled={copyStatus === "copying"}
           className="calendar-control"
         >
-          <Copy className="h-3.5 w-3.5" /> Copy details
+          <Copy className="h-3.5 w-3.5" />{" "}
+          {copyStatus === "copying"
+            ? "Copying"
+            : copyStatus === "copied"
+              ? "Copied"
+              : "Copy details"}
         </button>
       </div>
 
@@ -683,7 +726,12 @@ function EventEditor({
             </p>
             <h3 className="mt-1 text-xl font-semibold">{event ? "Edit event" : "Create event"}</h3>
           </div>
-          <button type="button" onClick={onClose} className="calendar-icon-button">
+          <button
+            type="button"
+            onClick={onClose}
+            className="calendar-icon-button"
+            aria-label="Close event editor"
+          >
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -780,7 +828,7 @@ function EventEditor({
             Cancel
           </button>
           <button type="submit" disabled={!draft.title.trim()} className="calendar-primary-button">
-            {event ? "Save changes" : "Create event"}
+            {draft.title.trim() ? (event ? "Save changes" : "Create event") : "Add title first"}
           </button>
         </div>
       </motion.form>

--- a/src/features/calendar/styles.css
+++ b/src/features/calendar/styles.css
@@ -116,6 +116,20 @@
   background: oklch(1 0 0 / 0.075);
 }
 
+.calendar-control:focus-visible,
+.calendar-primary-button:focus-visible,
+.calendar-icon-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px oklch(1 0 0 / 0.1);
+}
+
+.calendar-control:disabled,
+.calendar-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+}
+
 .calendar-primary-button {
   color: oklch(0.16 0.006 270);
   background: oklch(0.94 0.005 270);


### PR DESCRIPTION
## Summary
- Polish the existing Calendar Workspace empty states so hidden calendars, empty agenda days, and empty months explain the next action clearly.
- Add pressed/focus treatment for calendar toggles, visible disabled copy for missing custom-calendar names, and a short copying/copied state with failure handling for event details.
- Keep the work inside the existing calendar module and preserve the existing event/calendar behavior.

Closes #921

## Before/after note
- Before: empty calendar views reused generic copy, invisible calendars were harder to distinguish, and the copy-details action had no transient feedback.
- After: the workspace explains why the view is empty, toggles expose pressed/focus states, disabled actions tell users what is missing, and copy details reports copying/copied/failure states.

## Validation
- `npx prettier --check src/features/calendar/components/CalendarWorkspace.tsx src/features/calendar/styles.css`
- `git diff --check`
- sensitive scan for account/payment/private-key markers returned no matches
- `npx tsc --noEmit` could not run locally because this checkout has no installed TypeScript compiler and npm attempted to fetch the deprecated `tsc` package
- `npm run lint -- src/features/calendar/components/CalendarWorkspace.tsx src/features/calendar/styles.css` could not start locally because `eslint` is not installed in this checkout