### PR TITLE
Email to Todo Converter - architecture + folder contract (#354)

### DIFF
--- a/tools/v1/individual/email-to-todo-converter/README.md
+++ b/tools/v1/individual/email-to-todo-converter/README.md
@@ -1,15 +1,34 @@
 # Email-to-Todo Converter
 
-This folder is the isolated workspace for the Email-to-Todo Converter tool.
+Email-to-Todo Converter is an isolated V1 individual tool for proposing todos from email metadata and message content. It is not wired into the main mail app yet; this folder captures the review surface for the tool until a future integration issue connects it.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\email-to-todo-converter\
-`
+```text
+tools/v1/individual/email-to-todo-converter/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not modify the main application shell, routing, inbox architecture, wallet core, Stellar integration, database schema, or shared design system from this issue.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `specs.md` defines the expected input, output, decision rules, and open questions.
+- `fixtures/email-todo-cases.json` provides representative emails and expected todos.
+- `tests/test-plan.md` lists the folder-local validation scenarios for future code.
+- `docs/review-notes.md` gives maintainers a short checklist for reviewing this tool independently from the main application.
+
+## Intended Behavior
+
+The tool inspects an email (subject, sender, snippet, body preview) and proposes one or more candidate todos with task text, confidence, and evidence.
+
+Extraction method (manual selection, automatic background parse, or LLM-assisted) is explicitly UNDECIDED.
+
+## Known Limitations
+
+- No production model, service, hook, or UI component is implemented in this issue.
+- Extraction strategy is undecided.
+- Storage destination is undecided (see specs.md open questions).
+- The test plan is fixture-backed documentation because the tool has no executable implementation yet.
+- Future implementation work must avoid sending message content outside the user-controlled execution boundary.

--- a/tools/v1/individual/email-to-todo-converter/docs/review-notes.md
+++ b/tools/v1/individual/email-to-todo-converter/docs/review-notes.md
@@ -1,0 +1,26 @@
+# Review Notes
+
+This contribution prepares the Email-to-Todo Converter tool for independent review before implementation work starts.
+
+## What To Review
+
+- The tool boundary is explicit and limited to this folder.
+- Fixtures include clear-action, meeting, multi-item, no-action, and ambiguous examples.
+- The test plan documents privacy, confidence, and cardinality rules.
+- Open questions are explicitly listed and left unresolved.
+
+## What Is Intentionally Not Included
+
+- No app route, navigation item, database migration, wallet integration, or shared design system change.
+- No extraction strategy decided (manual, automatic, or LLM-assisted).
+- No storage integration.
+- No model call or external API.
+- No executable test harness until the first service/hook implementation is introduced.
+
+## Follow-Up Implementation Shape
+
+A future implementation can add:
+
+- `services/extractTodos.ts` for deterministic todo extraction.
+- `tests/extractTodos.test.ts` using the fixture file in this folder.
+- A local demo component only if a future UI issue asks for it.

--- a/tools/v1/individual/email-to-todo-converter/fixtures/email-todo-cases.json
+++ b/tools/v1/individual/email-to-todo-converter/fixtures/email-todo-cases.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "budget-review-deadline",
+    "from": "finance@example-corp.com",
+    "subject": "Q3 budget draft needs your review",
+    "snippet": "Please review the attached Q3 budget draft and reply with comments by end of week.",
+    "bodyPreview": "The draft is due for consolidation Friday. Let me know if any line items need adjustment.",
+    "receivedAt": "2026-06-18T10:00:00Z",
+    "expectedTodos": [
+      {
+        "id": "todo-budget-1",
+        "sourceEmailId": "budget-review-deadline",
+        "task": "Review Q3 budget draft and send comments",
+        "confidence": "high",
+        "evidence": "Please review the attached Q3 budget draft and reply with comments by end of week.",
+        "dueDate": "2026-06-20",
+        "priority": "high"
+      }
+    ]
+  },
+  {
+    "id": "team-sync-reschedule",
+    "from": "alice@example-team.com",
+    "subject": "Reschedule team sync",
+    "snippet": "Can we move tomorrow's sync to 3pm? Need to confirm attendees.",
+    "bodyPreview": "Please reply by noon so I can update the calendar invite.",
+    "receivedAt": "2026-06-18T11:30:00Z",
+    "expectedTodos": [
+      {
+        "id": "todo-sync-1",
+        "sourceEmailId": "team-sync-reschedule",
+        "task": "Confirm new time for team sync and reply",
+        "confidence": "high",
+        "evidence": "Can we move tomorrow's sync to 3pm? Need to confirm attendees.",
+        "priority": "medium"
+      }
+    ]
+  },
+  {
+    "id": "project-kickoff-actions",
+    "from": "pm@example-project.com",
+    "subject": "Project kickoff next steps",
+    "snippet": "Please prepare the requirements doc, schedule kickoff call, and assign owners for the three workstreams.",
+    "bodyPreview": "Draft doc by Monday, call on Tuesday, owners by Wednesday.",
+    "receivedAt": "2026-06-18T09:00:00Z",
+    "expectedTodos": [
+      {
+        "id": "todo-kick-1",
+        "sourceEmailId": "project-kickoff-actions",
+        "task": "Prepare requirements doc",
+        "confidence": "high",
+        "evidence": "Please prepare the requirements doc",
+        "dueDate": "2026-06-22",
+        "priority": "high"
+      },
+      {
+        "id": "todo-kick-2",
+        "sourceEmailId": "project-kickoff-actions",
+        "task": "Schedule kickoff call for next week",
+        "confidence": "high",
+        "evidence": "schedule kickoff call",
+        "priority": "medium"
+      },
+      {
+        "id": "todo-kick-3",
+        "sourceEmailId": "project-kickoff-actions",
+        "task": "Assign owners for the three workstreams",
+        "confidence": "high",
+        "evidence": "assign owners for the three workstreams",
+        "priority": "medium"
+      }
+    ]
+  },
+  {
+    "id": "newsletter-june-update",
+    "from": "news@example-product.com",
+    "subject": "June product newsletter",
+    "snippet": "This month we shipped search improvements and a new dashboard widget.",
+    "bodyPreview": "Read the full changelog and join our webinar next week if interested.",
+    "receivedAt": "2026-06-18T08:00:00Z",
+    "expectedTodos": []
+  },
+  {
+    "id": "catch-up-sometime",
+    "from": "bob@example-colleague.com",
+    "subject": "Quick catch up?",
+    "snippet": "We should grab coffee sometime soon to talk about the old project.",
+    "bodyPreview": "No rush, just wanted to reconnect.",
+    "receivedAt": "2026-06-18T14:00:00Z",
+    "expectedTodos": [
+      {
+        "id": "todo-catch-1",
+        "sourceEmailId": "catch-up-sometime",
+        "task": "Follow up with Bob about catching up",
+        "confidence": "low",
+        "evidence": "We should grab coffee sometime soon to talk about the old project.",
+        "priority": "low"
+      }
+    ]
+  }
+]

--- a/tools/v1/individual/email-to-todo-converter/specs.md
+++ b/tools/v1/individual/email-to-todo-converter/specs.md
@@ -1,41 +1,61 @@
-# Email-to-Todo Converter
-
-Convert emails into tasks.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/email-to-todo-converter/README.md"
-  @"
-
 # Email-to-Todo Converter Specs
 
 ## Purpose
 
-Convert emails into tasks.
+Extract actionable todos from individual inbox emails so users can capture follow-up tasks without re-reading threads.
 
-## Contributor boundary
+## Input Contract
 
-All work for this tool should stay in:
+```ts
+type EmailToTodoInput = {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  bodyPreview?: string;
+  receivedAt?: string;
+};
+```
 
-$dir/
+## Output Contract
 
-## Required issue categories
+```ts
+type ExtractedTodo = {
+  id: string;
+  sourceEmailId: string;
+  task: string;
+  confidence: "high" | "medium" | "low";
+  evidence: string;
+  dueDate?: string;
+  priority?: "high" | "medium" | "low";
+};
+```
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Open Questions
+
+- Extraction strategy: manual selection vs automatic full-inbox parse vs LLM-assisted extraction. Architecture should not preclude any of the three.
+- Storage destination: where does an ExtractedTodo persist once created? No local store, fixture-only store, or real task-store integration has been decided.
+- Due date / priority inference: whether these are derived automatically or left for manual user input is undecided.
+
+## Decision Rules
+
+- Never send raw message content to any destination outside the user-controlled execution boundary without explicit consent.
+- A todo's evidence field must quote only the minimal text needed to justify it.
+- Suggestions must be deterministic for the same input fixture.
+- At most five candidate todos returned per email.
+
+## Test Fixtures
+
+Use `fixtures/email-todo-cases.json` as the baseline fixture set for future unit tests.
+
+## Module Boundaries
+
+- `components/` — future folder-local UI only (e.g. todo review/approval list). No implementation yet.
+- `services/` — future folder-local extraction + mapping logic (e.g. extractTodos.ts). Must not import from src/components/mail or any core app module. No implementation yet.
+- `hooks/` — future folder-local React hooks wrapping services/ for local UI state. No implementation yet.
+- `tests/` — fixture-backed test plan now; executable unit tests once services/ exists.
+- `docs/` — architecture and review notes, folder-local only.
+
+## Review Expectations
+
+Until executable code exists, reviewers can validate this tool by checking that the fixtures and the test plan cover the decision rules, edge cases, and privacy boundaries without modifying the main app.

--- a/tools/v1/individual/email-to-todo-converter/tests/test-plan.md
+++ b/tools/v1/individual/email-to-todo-converter/tests/test-plan.md
@@ -17,13 +17,13 @@ dueDate/priority.
 
 ## Scenarios
 
-| Scenario              | Fixture                     | Expected result                                                                 |
-| --------------------- | --------------------------- | ------------------------------------------------------------------------------- |
-| Clear deadline        | `budget-review-deadline`    | One high-confidence todo; task mentions review and comments; dueDate present.   |
-| Meeting follow-up     | `team-sync-reschedule`      | One high-confidence todo; task captures confirm action; no dueDate required.    |
-| Multiple actions      | `project-kickoff-actions`   | Three distinct todos; respects at-most-five rule; all high confidence.          |
-| No actionable content | `newsletter-june-update`    | Empty array; no forced todo created.                                            |
-| Ambiguous request     | `catch-up-sometime`         | One low-confidence todo; evidence is minimal and quoted.                        |
+| Scenario              | Fixture                   | Expected result                                                               |
+| --------------------- | ------------------------- | ----------------------------------------------------------------------------- |
+| Clear deadline        | `budget-review-deadline`  | One high-confidence todo; task mentions review and comments; dueDate present. |
+| Meeting follow-up     | `team-sync-reschedule`    | One high-confidence todo; task captures confirm action; no dueDate required.  |
+| Multiple actions      | `project-kickoff-actions` | Three distinct todos; respects at-most-five rule; all high confidence.        |
+| No actionable content | `newsletter-june-update`  | Empty array; no forced todo created.                                          |
+| Ambiguous request     | `catch-up-sometime`       | One low-confidence todo; evidence is minimal and quoted.                      |
 
 ## Negative Checks
 

--- a/tools/v1/individual/email-to-todo-converter/tests/test-plan.md
+++ b/tools/v1/individual/email-to-todo-converter/tests/test-plan.md
@@ -1,0 +1,42 @@
+# Email-to-Todo Converter Test Plan
+
+This test plan is folder-local because the tool is not integrated with the app shell yet.
+It should become executable unit coverage when the first implementation lands.
+
+## Fixture Setup
+
+Use:
+
+```text
+tools/v1/individual/email-to-todo-converter/fixtures/email-todo-cases.json
+```
+
+Each fixture contains the normalized email input and the expected todos. Future tests
+should assert the returned task text first, then validate confidence, evidence, and optional
+dueDate/priority.
+
+## Scenarios
+
+| Scenario              | Fixture                     | Expected result                                                                 |
+| --------------------- | --------------------------- | ------------------------------------------------------------------------------- |
+| Clear deadline        | `budget-review-deadline`    | One high-confidence todo; task mentions review and comments; dueDate present.   |
+| Meeting follow-up     | `team-sync-reschedule`      | One high-confidence todo; task captures confirm action; no dueDate required.    |
+| Multiple actions      | `project-kickoff-actions`   | Three distinct todos; respects at-most-five rule; all high confidence.          |
+| No actionable content | `newsletter-june-update`    | Empty array; no forced todo created.                                            |
+| Ambiguous request     | `catch-up-sometime`         | One low-confidence todo; evidence is minimal and quoted.                        |
+
+## Negative Checks
+
+- Empty subject and snippet should return empty array, not a fallback todo.
+- Ambiguous input must stay `low` confidence; must not upgrade without clear signals.
+- Re-running the same input fixture must not create duplicate todos.
+- Evidence must quote only the minimal text needed; must not include full body.
+
+## Manual Review
+
+1. Confirm all changed files stay under `tools/v1/individual/email-to-todo-converter/`.
+2. Confirm fixture examples avoid real personal data, secrets, access tokens, and live
+   wallet addresses.
+3. Confirm the README documents setup, usage, fixtures, and limitations.
+4. Confirm future executable tests can be written from this plan without touching the
+   main application.


### PR DESCRIPTION
Closes #354

Folder-local arch contract for the email-to-todo tool, scoped entirely to
tools/v1/individual/email-to-todo-converter/.

Heads up: README.md and specs.md in this folder were actually broken
before this PR. They had unexecuted PowerShell template output committed
into them (stuff like $(System.Collections.Hashtable.Tier.ToUpperInvariant())
and a stray here-string block) from the original scaffold commit 6f15f57.
Rewrote both from scratch.

Followed auto-label-suggestion's folder pattern since it's the one sibling
tool that actually has a real architecture doc done right.

specs.md defines the input/output contracts (EmailToTodoInput to
ExtractedTodo), and leaves extraction strategy and storage destination as
open questions on purpose. Manual selection, full-inbox auto-parse, and
LLM-assisted extraction are all still on the table, didn't want to lock
that in here. Decision rules that hold no matter which way that goes are
in there too (no raw message content leaving the boundary, max 5 todos
per email, deterministic output).

Also added fixtures (5 cases: clear deadline, scheduling follow-up,
multi-item, no-action, ambiguous), a test plan, and review notes.

No actual code in this PR, just docs/fixtures. components/services/hooks
are documented as the future shape, not built yet.

Side note: the same PowerShell corruption is sitting in 27 other tool
folders from the same scaffold commit. Didn't touch those, out of scope
here, filing it as a separate issue so it doesn't get lost.