### PR TITLE
Email to Todo Converter - fix broken fences, remove scaffold residue, keep extraction strategy open (#354)

### DIFF
--- a/tools/v1/individual/email-to-todo-converter/README.md
+++ b/tools/v1/individual/email-to-todo-converter/README.md
@@ -6,9 +6,9 @@ This folder is the isolated workspace for the Email-to-Todo Converter tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\email-to-todo-converter\
-`
+```text
+tools/v1/individual/email-to-todo-converter/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 

--- a/tools/v1/individual/email-to-todo-converter/specs.md
+++ b/tools/v1/individual/email-to-todo-converter/specs.md
@@ -10,14 +10,6 @@ Convert emails into tasks.
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- tests/
-- docs/
-
 # Email-to-Todo Converter Specs
 
 ## Purpose
@@ -29,7 +21,9 @@ review before saving to a future task system.
 
 All work for this tool should stay in:
 
-`tools/v1/individual/email-to-todo-converter/`
+```text
+tools/v1/individual/email-to-todo-converter/
+```
 
 Do not add imports from the main inbox, routing, wallet, Stellar, database, or
 design-system layers until a later integration issue explicitly allows it.
@@ -48,12 +42,20 @@ The future implementation should:
 
 - accept a normalized email input with `subject`, `sender`, `receivedAt`, plain
   text body, and optional labels;
-- detect actionable language such as "please send", "follow up", "schedule",
-  "review", and "due";
+- detect actionable content in the email (the specific extraction method —
+  keyword matching, automatic parsing, or LLM-assisted - is an open
+  implementation decision, not fixed by this spec);
 - produce a task draft with title, notes, source email metadata, suggested due
   date, and suggested priority;
 - keep extraction deterministic for the same input;
 - preserve user review before any task is saved or synced.
+
+## Open Questions
+
+- Extraction strategy: keyword/pattern matching, automatic full-body parsing,
+  or LLM-assisted extraction are all viable; this spec does not mandate one.
+- Storage destination: where a reviewed task draft persists once approved is
+  not yet decided.
 
 ## Out of Scope
 


### PR DESCRIPTION
Closes #354

Errordog2 already merged docs here (3d1d778) before I pushed mine, we
both branched off the same broken scaffold independently. This sits on
top of their work instead of overwriting it.

Fixed:
- broken code fences in README.md and specs.md (scaffold leftover)
- orphaned bullet list in specs.md with no heading (same leftover)
- specs.md locked in keyword matching as the extraction method, which
  decides implementation too early. Reframed to leave the method open,
  added an Open Questions section for extraction strategy + storage.

Left docs/test-plan.md alone, it references #358 not #354, flagging for
a maintainer to confirm rather than guessing.

Only README.md and specs.md touched.