### PR TITLE
test(mail): add regression coverage for mobile navigation 

### DIFF
--- a/src/components/mail/BottomNavigation.tsx
+++ b/src/components/mail/BottomNavigation.tsx
@@ -1,7 +1,20 @@
 import { motion } from "framer-motion";
-import { Pencil, Search, Inbox, Calendar, ReceiptText, Settings } from "lucide-react";
+import {
+  Pencil,
+  Search,
+  Inbox,
+  Calendar,
+  ReceiptText,
+  Settings,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { MailFolder } from "./data";
+import {
+  BOTTOM_NAV_ITEMS,
+  isBottomNavItemActive,
+  type BottomNavItemId,
+} from "./bottom-navigation-items";
 
 interface BottomNavigationProps {
   active: MailFolder;
@@ -12,6 +25,15 @@ interface BottomNavigationProps {
   onSelectFolder: (folder: MailFolder) => void;
 }
 
+const ICONS: Record<BottomNavItemId, LucideIcon> = {
+  compose: Pencil,
+  search: Search,
+  inbox: Inbox,
+  calendar: Calendar,
+  proofs: ReceiptText,
+  settings: Settings,
+};
+
 export function BottomNavigation({
   active,
   onCompose,
@@ -20,80 +42,49 @@ export function BottomNavigation({
   onOpenSettings,
   onSelectFolder,
 }: BottomNavigationProps) {
-  const items = [
-    {
-      id: "compose",
-      icon: Pencil,
-      label: "Compose",
-      onClick: onCompose,
-      isActive: false,
-    },
-    {
-      id: "search",
-      icon: Search,
-      label: "Search",
-      onClick: onOpenPalette,
-      isActive: false,
-    },
-    {
-      id: "inbox",
-      icon: Inbox,
-      label: "Inbox",
-      onClick: () => onSelectFolder("inbox"),
-      isActive: active === "inbox",
-    },
-    {
-      id: "calendar",
-      icon: Calendar,
-      label: "Calendar",
-      onClick: onOpenCalendar,
-      isActive: false,
-    },
-    {
-      id: "proofs",
-      icon: ReceiptText,
-      label: "Proofs",
-      onClick: () => onSelectFolder("pending"),
-      isActive: active === "pending",
-    },
-    {
-      id: "settings",
-      icon: Settings,
-      label: "Settings",
-      onClick: onOpenSettings,
-      isActive: false,
-    },
-  ];
+  const handlers: Record<BottomNavItemId, () => void> = {
+    compose: onCompose,
+    search: onOpenPalette,
+    inbox: () => onSelectFolder("inbox"),
+    calendar: onOpenCalendar,
+    proofs: () => onSelectFolder("pending"),
+    settings: onOpenSettings,
+  };
 
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 glass border-t border-white/10 safe-area-inset-bottom">
+    <nav
+      aria-label="Bottom navigation"
+      className="md:hidden fixed bottom-0 left-0 right-0 z-40 glass border-t border-white/10 safe-area-inset-bottom"
+    >
       <div className="flex items-center justify-around py-2 px-1">
-        {items.map((item) => {
-          const Icon = item.icon;
+        {BOTTOM_NAV_ITEMS.map((item) => {
+          const Icon = ICONS[item.id];
+          const isActive = isBottomNavItemActive(item, active);
           return (
             <button
               key={item.id}
-              onClick={item.onClick}
+              onClick={handlers[item.id]}
               className="relative flex flex-col items-center justify-center px-2 py-1.5 rounded-lg transition-all"
               aria-label={item.label}
+              aria-current={isActive ? "page" : undefined}
             >
               <div className="relative z-10 flex flex-col items-center gap-0.5">
                 <Icon
                   className={cn(
                     "h-6 w-6 transition-colors",
-                    item.isActive ? "text-foreground" : "text-muted-foreground",
+                    isActive ? "text-foreground" : "text-muted-foreground",
                   )}
                 />
                 <span
                   className={cn(
                     "text-[10px] font-medium transition-colors",
-                    item.isActive ? "text-foreground" : "text-muted-foreground",
+                    isActive ? "text-foreground" : "text-muted-foreground",
                   )}
                 >
                   {item.label}
                 </span>
               </div>
-              {item.isActive && (
+              {isActive && (
                 <motion.div
                   layoutId="bottom-nav-active"
                   className="absolute inset-0 rounded-lg bg-white/5"

--- a/src/components/mail/bottom-navigation-items.ts
+++ b/src/components/mail/bottom-navigation-items.ts
@@ -1,0 +1,39 @@
+import type { MailFolder } from "./data";
+
+export type BottomNavItemId = "compose" | "search" | "inbox" | "calendar" | "proofs" | "settings";
+
+export interface BottomNavItemConfig {
+  id: BottomNavItemId;
+  label: string;
+  /**
+   * The folder this tab selects, when the tab represents a folder destination.
+   * Action-only tabs (compose, search, calendar, settings) leave this undefined
+   * and never render as the active tab.
+   */
+  folder?: MailFolder;
+}
+
+/**
+ * Static descriptor for the mobile bottom navigation, in left-to-right display
+ * order. Icons and click handlers are bound in the component; this module owns
+ * only the stable, presentation-free contract so it can be unit tested.
+ */
+export const BOTTOM_NAV_ITEMS: readonly BottomNavItemConfig[] = [
+  { id: "compose", label: "Compose" },
+  { id: "search", label: "Search" },
+  { id: "inbox", label: "Inbox", folder: "inbox" },
+  { id: "calendar", label: "Calendar" },
+  { id: "proofs", label: "Proofs", folder: "pending" },
+  { id: "settings", label: "Settings" },
+];
+
+/**
+ * A bottom-nav tab is highlighted only when it maps to a folder and that folder
+ * is the one currently being viewed. Action-only tabs are never active.
+ */
+export function isBottomNavItemActive(
+  item: BottomNavItemConfig,
+  activeFolder: MailFolder,
+): boolean {
+  return item.folder !== undefined && item.folder === activeFolder;
+}

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,6 +1,16 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+export const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Pure breakpoint predicate shared by the hook and its tests. A viewport counts
+ * as "mobile" when its width is below the `md` breakpoint (768px), which keeps
+ * this in lockstep with the Tailwind `md:` utilities used across the navigation
+ * surface (e.g. the bottom bar's `md:hidden` and the sidebar's `hidden md:flex`).
+ */
+export function isMobileViewport(width: number): boolean {
+  return width < MOBILE_BREAKPOINT;
+}
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
@@ -8,10 +18,10 @@ export function useIsMobile() {
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileViewport(window.innerWidth));
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(isMobileViewport(window.innerWidth));
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/tests/e2e/mobile-navigation.spec.ts
+++ b/tests/e2e/mobile-navigation.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, openDemoMailbox } from "./fixtures";
+
+// Drive the navigation surface at a phone-sized viewport so the mobile bottom
+// bar is the active navigation affordance and the desktop sidebar is collapsed
+// out of the layout by its `hidden md:flex` class.
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.describe("mobile navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await openDemoMailbox(page);
+  });
+
+  test("shows the bottom bar and hides the desktop sidebar on small screens", async ({ page }) => {
+    const bottomNav = page.getByRole("navigation", { name: "Bottom navigation" });
+    await expect(bottomNav).toBeVisible();
+    await expect(bottomNav.getByRole("button", { name: "Inbox" })).toBeVisible();
+
+    // The desktop sidebar's Compose button (labelled with its Ctrl+N hint) is
+    // part of the `hidden md:flex` sidebar, so it must not be visible on mobile.
+    await expect(page.getByRole("button", { name: "Compose Ctrl+N" })).toBeHidden();
+  });
+
+  test("tapping a folder tab switches the mailbox folder (success path)", async ({ page }) => {
+    const bottomNav = page.getByRole("navigation", { name: "Bottom navigation" });
+
+    await bottomNav.getByRole("button", { name: "Proofs" }).click();
+    await expect(page.getByRole("heading", { name: "Pending Proof" })).toBeVisible();
+    await expect(bottomNav.getByRole("button", { name: "Proofs" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    await bottomNav.getByRole("button", { name: "Inbox" }).click();
+    await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+    await expect(bottomNav.getByRole("button", { name: "Inbox" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  test("action-only tabs never mark themselves active (edge path)", async ({ page }) => {
+    const bottomNav = page.getByRole("navigation", { name: "Bottom navigation" });
+
+    // Compose opens the composer but must not become an active folder tab.
+    await bottomNav.getByRole("button", { name: "Compose" }).click();
+    await expect(page.getByText("New message")).toBeVisible();
+    await expect(bottomNav.getByRole("button", { name: "Compose" })).not.toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});

--- a/tests/unit/mobile-navigation/bottom-navigation-items.test.ts
+++ b/tests/unit/mobile-navigation/bottom-navigation-items.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOTTOM_NAV_ITEMS,
+  isBottomNavItemActive,
+  type BottomNavItemConfig,
+} from "../../../src/components/mail/bottom-navigation-items";
+import type { MailFolder } from "../../../src/components/mail/data";
+
+const itemsById = Object.fromEntries(BOTTOM_NAV_ITEMS.map((item) => [item.id, item])) as Record<
+  string,
+  BottomNavItemConfig
+>;
+
+describe("mobile-navigation/BOTTOM_NAV_ITEMS", () => {
+  it("exposes the six tabs in display order", () => {
+    expect(BOTTOM_NAV_ITEMS.map((item) => item.id)).toEqual([
+      "compose",
+      "search",
+      "inbox",
+      "calendar",
+      "proofs",
+      "settings",
+    ]);
+  });
+
+  it("maps only the folder tabs to a destination folder", () => {
+    expect(itemsById.inbox.folder).toBe("inbox");
+    expect(itemsById.proofs.folder).toBe("pending");
+    // Action-only tabs are not folder destinations.
+    for (const id of ["compose", "search", "calendar", "settings"]) {
+      expect(itemsById[id].folder).toBeUndefined();
+    }
+  });
+});
+
+describe("mobile-navigation/isBottomNavItemActive", () => {
+  it("highlights a folder tab when its folder is the current folder (success path)", () => {
+    expect(isBottomNavItemActive(itemsById.inbox, "inbox")).toBe(true);
+    expect(isBottomNavItemActive(itemsById.proofs, "pending")).toBe(true);
+  });
+
+  it("does not highlight a folder tab for a different folder (edge case)", () => {
+    expect(isBottomNavItemActive(itemsById.inbox, "pending")).toBe(false);
+    expect(isBottomNavItemActive(itemsById.proofs, "inbox")).toBe(false);
+    expect(isBottomNavItemActive(itemsById.inbox, "sent")).toBe(false);
+  });
+
+  it("never highlights action-only tabs regardless of folder (failure path)", () => {
+    const everyFolder: MailFolder[] = [
+      "all",
+      "inbox",
+      "priority",
+      "snoozed",
+      "verified",
+      "pending",
+      "requests",
+      "encrypted",
+      "receipts",
+      "starred",
+      "sent",
+      "outbox",
+      "drafts",
+      "scheduled",
+      "archive",
+      "spam",
+      "trash",
+    ];
+    for (const id of ["compose", "search", "calendar", "settings"]) {
+      for (const folder of everyFolder) {
+        expect(isBottomNavItemActive(itemsById[id], folder)).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/unit/mobile-navigation/use-mobile.test.ts
+++ b/tests/unit/mobile-navigation/use-mobile.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { MOBILE_BREAKPOINT, isMobileViewport } from "../../../src/hooks/use-mobile";
+
+describe("mobile-navigation/isMobileViewport", () => {
+  it("treats typical phone and tablet widths as mobile (success path)", () => {
+    expect(isMobileViewport(320)).toBe(true); // small phone
+    expect(isMobileViewport(390)).toBe(true); // modern phone
+    expect(isMobileViewport(767)).toBe(true); // largest mobile width
+  });
+
+  it("treats tablet-landscape and desktop widths as not mobile", () => {
+    expect(isMobileViewport(768)).toBe(false); // md breakpoint -> desktop
+    expect(isMobileViewport(1024)).toBe(false);
+    expect(isMobileViewport(1440)).toBe(false);
+  });
+
+  it("switches exactly at the Tailwind md breakpoint (edge case)", () => {
+    // The boundary must align with Tailwind's `md` (min-width: 768px) so the JS
+    // layout switch matches the `md:` utilities on the nav surface.
+    expect(MOBILE_BREAKPOINT).toBe(768);
+    expect(isMobileViewport(MOBILE_BREAKPOINT - 1)).toBe(true);
+    expect(isMobileViewport(MOBILE_BREAKPOINT)).toBe(false);
+  });
+
+  it("handles degenerate widths without flipping the contract (failure path)", () => {
+    expect(isMobileViewport(0)).toBe(true);
+    expect(isMobileViewport(-100)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused regression coverage for the existing Mobile Navigation surface (issue #979) — bottom navigation, sidebar collapse boundary, and the responsive switch. Scoped to existing app paths; no new tool or feature. Two small pure helpers were extracted so the behavior is testable without a DOM, and the bottom bar gained minor accessibility attributes.

Closes #979

## Changes
- **Mobile breakpoint helper** — extracted pure `isMobileViewport(width)` + `MOBILE_BREAKPOINT` in `src/hooks/use-mobile.tsx`; the hook now delegates to it (behavior unchanged). Boundary aligns with Tailwind's `md` (768px).
- **Bottom-nav contract** — new `src/components/mail/bottom-navigation-items.ts` with `BOTTOM_NAV_ITEMS` descriptors and a pure `isBottomNavItemActive()` so the active-tab logic is a stable, testable contract.
- **BottomNavigation** — consumes the descriptors (rendering identical); adds `aria-current="page"` on the active tab and an accessible `aria-label="Bottom navigation"` on the nav.
- **Unit tests — breakpoint** — success (phone/desktop widths), edge (exact 768px boundary), failure (degenerate widths).
- **Unit tests — bottom nav** — success (folder tabs highlight), edge (wrong folder), failure (action-only tabs never active); plus order/folder-mapping assertions.
- **Playwright spec** — mobile-viewport flow: bottom bar shown / desktop sidebar hidden, tapping a folder tab switches the mailbox, action-only tabs stay inactive.

