### PR TITLE
Add label manager for demo messages

### DIFF
--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -406,3 +406,17 @@ export {
 } from "./types/calendarEvent";
 export { calendarEventFixtures, defaultCalendarEvent } from "./fixtures/calendarEventFixtures";
 export { validateCalendarEventEditor } from "./calendarEventValidation";
+
+// Label manager (issue #185): types, helpers, fixtures, and UI.
+export type { DemoLabel, LabeledDemoMessage, LabelUsage } from "./labels/types";
+export {
+  addLabel,
+  countLabelUsage,
+  createLabel,
+  normalizeLabelName,
+  removeLabel,
+  toLabelId,
+  unusedLabels,
+} from "./labels/labelNormalization";
+export { demoLabels, labeledDemoMessages } from "./labels/labelFixtures";
+export { LabelManager } from "./labels/LabelManager";

--- a/src/features/demo-admin-dashboard/labels/LabelManager.tsx
+++ b/src/features/demo-admin-dashboard/labels/LabelManager.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from "react";
+import { Plus, Tag, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { addLabel, countLabelUsage, removeLabel, unusedLabels } from "./labelNormalization";
+import { demoLabels, labeledDemoMessages } from "./labelFixtures";
+import type { DemoLabel, LabeledDemoMessage } from "./types";
+
+const LABEL_COLORS: Record<string, string> = {
+  amber: "bg-amber-400/10 text-amber-300 ring-amber-400/30",
+  emerald: "bg-emerald-400/10 text-emerald-300 ring-emerald-400/30",
+  sky: "bg-sky-400/10 text-sky-300 ring-sky-400/30",
+  violet: "bg-violet-400/10 text-violet-300 ring-violet-400/30",
+  rose: "bg-rose-400/10 text-rose-300 ring-rose-400/30",
+};
+
+const FALLBACK_LABEL_COLOR = "bg-white/[0.06] text-foreground/80 ring-white/15";
+
+function labelClasses(color?: string): string {
+  const mapped = color ? LABEL_COLORS[color] : undefined;
+  return mapped ?? FALLBACK_LABEL_COLOR;
+}
+
+interface LabelManagerProps {
+  /** Override the labels; defaults to the bundled demo labels. */
+  labels?: DemoLabel[];
+  /** Override the messages; defaults to the bundled labeled demo messages. */
+  messages?: LabeledDemoMessage[];
+  /** Notified after any label or message change. */
+  onChange?: (labels: DemoLabel[], messages: LabeledDemoMessage[]) => void;
+  className?: string;
+}
+
+/**
+ * Admin control for managing the labels applied to demo messages. Create new
+ * labels, apply or remove them per message, review usage counts, and clean up
+ * labels that no message uses.
+ */
+export function LabelManager({
+  labels: initialLabels = demoLabels,
+  messages: initialMessages = labeledDemoMessages,
+  onChange,
+  className,
+}: LabelManagerProps) {
+  const [labels, setLabels] = useState<DemoLabel[]>(initialLabels);
+  const [messages, setMessages] = useState<LabeledDemoMessage[]>(initialMessages);
+  const [selectedId, setSelectedId] = useState<string | null>(initialMessages[0]?.id ?? null);
+  const [newLabelName, setNewLabelName] = useState("");
+
+  const usage = useMemo(() => countLabelUsage(labels, messages), [labels, messages]);
+  const unused = useMemo(() => unusedLabels(labels, messages), [labels, messages]);
+
+  const addNewLabel = () => {
+    const next = addLabel(labels, newLabelName);
+    if (next === labels) return;
+    setLabels(next);
+    setNewLabelName("");
+    onChange?.(next, messages);
+  };
+
+  const deleteLabel = (id: string) => {
+    const result = removeLabel(labels, messages, id);
+    setLabels(result.labels);
+    setMessages(result.messages);
+    onChange?.(result.labels, result.messages);
+  };
+
+  const toggleLabel = (messageId: string, labelId: string) => {
+    const next = messages.map((message) => {
+      if (message.id !== messageId) return message;
+      const has = message.labelIds.includes(labelId);
+      return {
+        ...message,
+        labelIds: has
+          ? message.labelIds.filter((id) => id !== labelId)
+          : [...message.labelIds, labelId],
+      };
+    });
+    setMessages(next);
+    onChange?.(labels, next);
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-5 text-sm text-foreground", className)}>
+      <p className="text-xs text-foreground/60">
+        Create, apply, and clean up labels across demo messages. All data is synthetic.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="new-label" className="text-xs font-medium text-foreground/70">
+          New label
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="new-label"
+            value={newLabelName}
+            onChange={(event) => setNewLabelName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") addNewLabel();
+            }}
+            placeholder="e.g. Follow up"
+            className="flex-1 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-sm text-foreground outline-none focus:border-white/25"
+          />
+          <button
+            type="button"
+            onClick={addNewLabel}
+            disabled={!newLabelName.trim()}
+            className="flex items-center gap-1.5 rounded-lg border border-emerald-400/30 bg-emerald-400/[0.08] px-3 py-2 text-sm text-foreground transition hover:bg-emerald-400/[0.12] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Plus className="h-4 w-4" />
+            Add
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/50">Labels</h3>
+        <ul className="flex flex-col gap-1.5">
+          {usage.map(({ label, count }) => (
+            <li
+              key={label.id}
+              className="flex items-center justify-between gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+            >
+              <span className="flex items-center gap-2">
+                <span className={cn("rounded-md px-2 py-0.5 text-xs ring-1", labelClasses(label.color))}>
+                  {label.name}
+                </span>
+                <span className="text-xs text-foreground/50">
+                  {count === 0 ? "Unused" : `${count} message${count === 1 ? "" : "s"}`}
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => deleteLabel(label.id)}
+                aria-label={`Delete ${label.name}`}
+                className="rounded-md p-1 text-foreground/40 transition hover:bg-white/[0.06] hover:text-rose-300"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </li>
+          ))}
+        </ul>
+        {unused.length > 0 && (
+          <p className="text-xs text-foreground/50">
+            {unused.length} unused label{unused.length === 1 ? "" : "s"} ready to clean up.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground/50">
+          Messages
+        </h3>
+        <div className="flex flex-col gap-1.5">
+          {messages.map((message) => {
+            const active = message.id === selectedId;
+            return (
+              <div
+                key={message.id}
+                className={cn(
+                  "rounded-lg border px-3 py-2 transition",
+                  active
+                    ? "border-white/15 bg-white/[0.06]"
+                    : "border-white/[0.06] bg-white/[0.02]",
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(message.id)}
+                  className="flex w-full items-center gap-2 text-left"
+                >
+                  <Tag className="h-4 w-4 shrink-0 text-foreground/40" />
+                  <span className="flex-1 truncate text-sm text-foreground">{message.subject}</span>
+                  <span className="text-xs text-foreground/40">{message.labelIds.length}</span>
+                </button>
+                {active && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {labels.map((label) => {
+                      const checked = message.labelIds.includes(label.id);
+                      return (
+                        <button
+                          key={label.id}
+                          type="button"
+                          onClick={() => toggleLabel(message.id, label.id)}
+                          className={cn(
+                            "rounded-md px-2 py-0.5 text-xs ring-1 transition",
+                            checked
+                              ? labelClasses(label.color)
+                              : "bg-transparent text-foreground/50 ring-white/10 hover:bg-white/[0.04]",
+                          )}
+                        >
+                          {label.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+                                                                 }

--- a/src/features/demo-admin-dashboard/labels/LabelManager.tsx
+++ b/src/features/demo-admin-dashboard/labels/LabelManager.tsx
@@ -121,7 +121,9 @@ export function LabelManager({
               className="flex items-center justify-between gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2"
             >
               <span className="flex items-center gap-2">
-                <span className={cn("rounded-md px-2 py-0.5 text-xs ring-1", labelClasses(label.color))}>
+                <span
+                  className={cn("rounded-md px-2 py-0.5 text-xs ring-1", labelClasses(label.color))}
+                >
                   {label.name}
                 </span>
                 <span className="text-xs text-foreground/50">
@@ -201,4 +203,4 @@ export function LabelManager({
       </div>
     </div>
   );
-                                                                 }
+}

--- a/src/features/demo-admin-dashboard/labels/README.md
+++ b/src/features/demo-admin-dashboard/labels/README.md
@@ -1,0 +1,32 @@
+# Label manager
+
+Admin tooling for creating, applying, and cleaning up labels across demo
+messages in the Demo Admin Dashboard. Everything here is deterministic and uses
+synthetic data only — no real mail, addresses, or secrets.
+
+## What's included
+
+- `types.ts` — `DemoLabel`, `LabeledDemoMessage`, and `LabelUsage` shapes.
+- `labelNormalization.ts` — pure helpers: name normalization, id generation,
+  add/remove, usage counts, and unused-label detection.
+- `labelFixtures.ts` — deterministic demo labels and labeled messages.
+- `LabelManager.tsx` — the UI for creating labels, applying them per message,
+  reviewing usage counts, and spotting labels to clean up.
+- `labelNormalization.test.ts` — unit coverage for the helpers.
+
+## Usage
+
+Import `LabelManager` from the feature barrel and render it. It manages its own
+state and falls back to the bundled demo data when no props are passed.
+
+- `labels` — optional starting labels (defaults to the bundled demo labels).
+- `messages` — optional starting messages (defaults to the bundled demo data).
+- `onChange` — optional callback fired after any label or message change.
+- `className` — optional class names for the root element.
+
+## Conventions
+
+- Label ids are derived from names via `toLabelId`, so they stay stable and
+  case-insensitive.
+- A label is unused when no message references its id; those are surfaced for
+  cleanup.

--- a/src/features/demo-admin-dashboard/labels/labelFixtures.ts
+++ b/src/features/demo-admin-dashboard/labels/labelFixtures.ts
@@ -1,0 +1,64 @@
+import type { DemoLabel, LabeledDemoMessage } from "./types";
+
+/**
+ * Deterministic, fake labels for the demo label manager. Ids are pre-normalized
+ * (see `toLabelId`) so they stay stable across renders and tests. "archive" is
+ * intentionally unused so the cleanup view always has an example.
+ */
+export const demoLabels: DemoLabel[] = [
+  { id: "follow-up", name: "Follow up", color: "amber" },
+  { id: "invoices", name: "Invoices", color: "emerald" },
+  { id: "events", name: "Events", color: "sky" },
+  { id: "partners", name: "Partners", color: "violet" },
+  { id: "archive", name: "Archive", color: "rose" },
+];
+
+/**
+ * Deterministic, fake demo messages. Senders use the reserved `*stealth.demo`
+ * handle so nothing references real people or live addresses. Every entry in
+ * `labelIds` references an id in `demoLabels`.
+ */
+export const labeledDemoMessages: LabeledDemoMessage[] = [
+  {
+    id: "lbl-studio-visit",
+    subject: "Studio visit follow-up",
+    from: "Aria Voss",
+    email: "aria*stealth.demo",
+    labelIds: ["follow-up", "partners"],
+  },
+  {
+    id: "lbl-invoice-review",
+    subject: "Invoice review before sign-off",
+    from: "Billing System",
+    email: "billing*stealth.demo",
+    labelIds: ["invoices"],
+  },
+  {
+    id: "lbl-roundtable-prep",
+    subject: "Prep notes for the demo roundtable",
+    from: "Events Desk",
+    email: "events*stealth.demo",
+    labelIds: ["events", "follow-up"],
+  },
+  {
+    id: "lbl-quarterly-digest",
+    subject: "Quarterly product digest draft",
+    from: "Digest Bot",
+    email: "digest*stealth.demo",
+    labelIds: [],
+  },
+  {
+    id: "lbl-partner-sync",
+    subject: "Partner sync recap",
+    from: "Partnerships",
+    email: "partners*stealth.demo",
+    labelIds: ["partners"],
+  },
+  {
+    id: "lbl-invoice-reminder",
+    subject: "Second invoice reminder",
+    from: "Billing System",
+    email: "billing*stealth.demo",
+    labelIds: ["invoices", "follow-up"],
+  },
+];

--- a/src/features/demo-admin-dashboard/labels/labelNormalization.test.ts
+++ b/src/features/demo-admin-dashboard/labels/labelNormalization.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  addLabel,
+  countLabelUsage,
+  createLabel,
+  normalizeLabelName,
+  removeLabel,
+  toLabelId,
+  unusedLabels,
+} from "./labelNormalization";
+import { demoLabels, labeledDemoMessages } from "./labelFixtures";
+
+describe("normalizeLabelName", () => {
+  it("trims and collapses whitespace", () => {
+    expect(normalizeLabelName("  Follow   up  ")).toBe("Follow up");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeLabelName("   ")).toBe("");
+  });
+});
+
+describe("toLabelId", () => {
+  it("slugifies a label name", () => {
+    expect(toLabelId("Follow up")).toBe("follow-up");
+  });
+
+  it("is case-insensitive and strips stray punctuation", () => {
+    expect(toLabelId("  VIP!! Clients  ")).toBe("vip-clients");
+  });
+});
+
+describe("createLabel", () => {
+  it("builds a label from a raw name", () => {
+    expect(createLabel("Follow up")).toEqual({ id: "follow-up", name: "Follow up" });
+  });
+
+  it("keeps a provided color", () => {
+    expect(createLabel("Events", "sky")).toEqual({
+      id: "events",
+      name: "Events",
+      color: "sky",
+    });
+  });
+
+  it("returns null when the name has no usable characters", () => {
+    expect(createLabel("   ")).toBeNull();
+    expect(createLabel("!!!")).toBeNull();
+  });
+});
+
+describe("addLabel", () => {
+  it("appends a new label", () => {
+    const result = addLabel([], "Follow up");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("follow-up");
+  });
+
+  it("ignores duplicates by id", () => {
+    const labels = addLabel([], "Follow up");
+    expect(addLabel(labels, "  follow   UP ")).toBe(labels);
+  });
+
+  it("ignores invalid names", () => {
+    const labels: ReturnType<typeof addLabel> = [];
+    expect(addLabel(labels, "   ")).toBe(labels);
+  });
+});
+
+describe("countLabelUsage", () => {
+  it("counts how many messages use each label, most used first", () => {
+    const usage = countLabelUsage(demoLabels, labeledDemoMessages);
+    const counts = Object.fromEntries(usage.map((entry) => [entry.label.id, entry.count]));
+    expect(counts).toMatchObject({
+      "follow-up": 3,
+      invoices: 2,
+      partners: 2,
+      events: 1,
+      archive: 0,
+    });
+    expect(usage[0]?.label.id).toBe("follow-up");
+  });
+});
+
+describe("unusedLabels", () => {
+  it("returns only labels no message uses", () => {
+    const unused = unusedLabels(demoLabels, labeledDemoMessages);
+    expect(unused.map((label) => label.id)).toEqual(["archive"]);
+  });
+});
+
+describe("removeLabel", () => {
+  it("drops the label and strips it from messages", () => {
+    const { labels, messages } = removeLabel(demoLabels, labeledDemoMessages, "follow-up");
+    expect(labels.some((label) => label.id === "follow-up")).toBe(false);
+    expect(messages.every((message) => !message.labelIds.includes("follow-up"))).toBe(true);
+  });
+});

--- a/src/features/demo-admin-dashboard/labels/labelNormalization.ts
+++ b/src/features/demo-admin-dashboard/labels/labelNormalization.ts
@@ -1,0 +1,79 @@
+import type { DemoLabel, LabeledDemoMessage, LabelUsage } from "./types";
+
+/**
+ * Normalize a label's display name: trim the ends and collapse any run of
+ * internal whitespace down to a single space. Returns an empty string when the
+ * input is only whitespace.
+ */
+export function normalizeLabelName(name: string): string {
+  return name.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Derive a stable, case-insensitive id from a label name. Lowercases the
+ * normalized name and replaces every run of non-alphanumeric characters with a
+ * single hyphen, with no leading or trailing hyphens.
+ */
+export function toLabelId(name: string): string {
+  return normalizeLabelName(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a label from a raw name. Returns null when the name is blank or has no
+ * usable characters, so callers can reject empty input.
+ */
+export function createLabel(name: string, color?: string): DemoLabel | null {
+  const normalized = normalizeLabelName(name);
+  const id = toLabelId(normalized);
+  if (!normalized || !id) return null;
+  return color ? { id, name: normalized, color } : { id, name: normalized };
+}
+
+/**
+ * Add a label to the list unless one with the same id already exists. Returns
+ * the original list unchanged when the name is invalid or already present.
+ */
+export function addLabel(labels: DemoLabel[], name: string, color?: string): DemoLabel[] {
+  const label = createLabel(name, color);
+  if (!label || labels.some((existing) => existing.id === label.id)) return labels;
+  return [...labels, label];
+}
+
+/** Remove a label and strip its id from every message. */
+export function removeLabel(
+  labels: DemoLabel[],
+  messages: LabeledDemoMessage[],
+  id: string,
+): { labels: DemoLabel[]; messages: LabeledDemoMessage[] } {
+  return {
+    labels: labels.filter((label) => label.id !== id),
+    messages: messages.map((message) =>
+      message.labelIds.includes(id)
+        ? { ...message, labelIds: message.labelIds.filter((labelId) => labelId !== id) }
+        : message,
+    ),
+  };
+}
+
+/** Count how many demo messages use each label. */
+export function countLabelUsage(labels: DemoLabel[], messages: LabeledDemoMessage[]): LabelUsage[] {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    for (const labelId of message.labelIds) {
+      counts.set(labelId, (counts.get(labelId) ?? 0) + 1);
+    }
+  }
+  return labels
+    .map((label) => ({ label, count: counts.get(label.id) ?? 0 }))
+    .sort((a, b) => b.count - a.count || a.label.name.localeCompare(b.label.name));
+}
+
+/** Labels that no message uses; candidates for cleanup. */
+export function unusedLabels(labels: DemoLabel[], messages: LabeledDemoMessage[]): DemoLabel[] {
+  return countLabelUsage(labels, messages)
+    .filter((usage) => usage.count === 0)
+    .map((usage) => usage.label);
+}

--- a/src/features/demo-admin-dashboard/labels/types.ts
+++ b/src/features/demo-admin-dashboard/labels/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Types for the demo-admin label manager.
+ *
+ * Labels are lightweight, deterministic tags that maintainers can create,
+ * apply, and clean up across demo messages. They never reference real mail.
+ */
+
+/** A single label that can be applied to demo messages. */
+export interface DemoLabel {
+  /** Stable identifier derived from the normalized label name. */
+  id: string;
+  /** Human-readable label name as entered by the maintainer. */
+  name: string;
+  /** Optional accent color token used by the UI. */
+  color?: string;
+}
+
+/** A demo message that carries zero or more label ids. */
+export interface LabeledDemoMessage {
+  id: string;
+  subject: string;
+  from: string;
+  email: string;
+  labelIds: string[];
+}
+
+/** A label paired with how many demo messages currently use it. */
+export interface LabelUsage {
+  label: DemoLabel;
+  count: number;
+}


### PR DESCRIPTION
## Summary

Adds a label manager for the Demo Admin Dashboard so maintainers can create, apply, and clean up labels across demo messages. It lives in a self-contained `labels/` module under `src/features/demo-admin-dashboard/`, following the same structure as the existing `snooze/` and `templates/` features.

## What's included

- `labels/types.ts` — `DemoLabel`, `LabeledDemoMessage`, and `LabelUsage` types.
- `labels/labelNormalization.ts` — pure helpers for name normalization, stable id generation, add/remove, usage counts, and unused-label detection.
- `labels/labelFixtures.ts` — deterministic demo labels and labeled messages using the reserved demo sender handles.
- `labels/LabelManager.tsx` — UI for creating labels, applying or removing them per message, reviewing usage counts, and surfacing unused labels for cleanup.
- `labels/labelNormalization.test.ts` — unit coverage for the helpers.
- `labels/README.md` — short overview of the module.
- Exposed the public API from the feature `index.ts`.

## Notes

- All data is deterministic and synthetic; nothing references real mail, addresses, or secrets.
- Label ids are derived from names, so they stay stable and case-insensitive.

Closes #185