### PR TITLE
perf(mail): cut unnecessary render/listener work in mobile nav

### DIFF
--- a/src/components/mail/Sidebar.tsx
+++ b/src/components/mail/Sidebar.tsx
@@ -106,22 +106,11 @@ export function Sidebar({
 }) {
   const [folders, setFolders] = useState(defaultFolders);
   const [isAddingFolder, setIsAddingFolder] = useState(false);
-  const [newFolderName, setNewFolderName] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (isAddingFolder && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [isAddingFolder]);
-
-  const handleAddFolder = () => {
-    if (newFolderName.trim()) {
-      const color = folderColors[folders.length % folderColors.length];
-      setFolders([...folders, { name: newFolderName.trim(), color }]);
-      setNewFolderName("");
-      setIsAddingFolder(false);
-    }
+  const handleAddFolder = (name: string) => {
+    const color = folderColors[folders.length % folderColors.length];
+    setFolders([...folders, { name, color }]);
+    setIsAddingFolder(false);
   };
   return (
     <motion.aside
@@ -239,39 +228,7 @@ export function Sidebar({
             {/* Add folder input */}
             <AnimatePresence>
               {isAddingFolder && (
-                <motion.div
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: 0 }}
-                  className="mb-2 overflow-hidden px-3"
-                >
-                  <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-2 py-1.5">
-                    <Hash className="h-3.5 w-3.5 text-muted-foreground" />
-                    <input
-                      ref={inputRef}
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleAddFolder();
-                        if (e.key === "Escape") {
-                          setIsAddingFolder(false);
-                          setNewFolderName("");
-                        }
-                      }}
-                      placeholder="Folder name"
-                      className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
-                    />
-                    <button
-                      onClick={() => {
-                        setIsAddingFolder(false);
-                        setNewFolderName("");
-                      }}
-                      className="rounded p-0.5 text-muted-foreground transition hover:text-foreground"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
-                </motion.div>
+                <AddFolderInput onAdd={handleAddFolder} onCancel={() => setIsAddingFolder(false)} />
               )}
             </AnimatePresence>
 
@@ -325,6 +282,58 @@ export function Sidebar({
         )}
       </div>
     </motion.aside>
+  );
+}
+
+// Owns its own input state so typing a new folder name does not re-render the
+// sidebar nav (all section items and FolderButtons) on every keystroke.
+function AddFolderInput({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const submit = () => {
+    const trimmed = name.trim();
+    if (trimmed) onAdd(trimmed);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: "auto" }}
+      exit={{ opacity: 0, height: 0 }}
+      className="mb-2 overflow-hidden px-3"
+    >
+      <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-2 py-1.5">
+        <Hash className="h-3.5 w-3.5 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+            if (e.key === "Escape") onCancel();
+          }}
+          placeholder="Folder name"
+          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+        />
+        <button
+          onClick={onCancel}
+          className="rounded p-0.5 text-muted-foreground transition hover:text-foreground"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+    </motion.div>
   );
 }
 

--- a/src/components/mail/Topbar.tsx
+++ b/src/components/mail/Topbar.tsx
@@ -94,7 +94,14 @@ export function Topbar({
   }, [notificationsOpen]);
 
   useEffect(() => {
-    const onResize = () => {
+    // Only subscribe to global scroll/resize while a dropdown is actually open.
+    // The scroll listener uses capture, so without this gate it would fire on
+    // every scroll anywhere in the app (e.g. the email list and reader panes)
+    // even when there is no open panel to reposition.
+    const anyOpen = filterOpen || accountOpen || helpOpen || notificationsOpen;
+    if (!anyOpen) return;
+
+    const onReposition = () => {
       if (filterOpen && filterRef.current) setFilterRect(filterRef.current.getBoundingClientRect());
       if (accountOpen && accountRef.current)
         setAccountRect(accountRef.current.getBoundingClientRect());
@@ -102,11 +109,11 @@ export function Topbar({
       if (notificationsOpen && notificationsRef.current)
         setNotifRect(notificationsRef.current.getBoundingClientRect());
     };
-    window.addEventListener("resize", onResize);
-    window.addEventListener("scroll", onResize, true);
+    window.addEventListener("resize", onReposition);
+    window.addEventListener("scroll", onReposition, true);
     return () => {
-      window.removeEventListener("resize", onResize);
-      window.removeEventListener("scroll", onResize, true);
+      window.removeEventListener("resize", onReposition);
+      window.removeEventListener("scroll", onReposition, true);
     };
   }, [filterOpen, accountOpen, helpOpen, notificationsOpen]);
 


### PR DESCRIPTION
## Summary
Scoped performance pass on the existing Mobile Navigation surface (issue #978). Reduces unnecessary global listeners and per-keystroke re-renders. No behavior, copy, or visual change — strictly fewer wasted renders/listeners.

Closes #978

## Hotspots identified (before changing code)
- **Topbar** attached a global `scroll` listener in **capture** phase that stayed mounted at all times, so it fired on every scroll anywhere in the app (email list, reader panes) even when no dropdown was open and there was nothing to reposition.
- **Sidebar** held the new-folder input text in its own state, so typing a folder name re-rendered the entire sidebar nav — every section item and every `FolderButton` (each a `motion.button`) — on every keystroke.

## Changes
- **Topbar — gate global listeners** — `scroll`/`resize` now subscribe only while a dropdown is open (`if (!anyOpen) return`). In the common all-closed state, no global listener runs. Reposition-on-open and reposition-on-scroll-while-open behavior is unchanged.
- **Sidebar — isolate add-folder input** — extracted `AddFolderInput`, which owns its own text state. Typing is now scoped to the input; the folder list no longer re-renders per keystroke. Markup, animation, Enter/Escape/cancel behavior all preserved.

## Performance note (reasoned)
- Topbar: eliminates a capture-phase scroll handler during normal scrolling whenever no dropdown is open (i.e. almost always).
- Sidebar: per-keystroke work in the add-folder flow drops from "re-render the whole sidebar subtree" to "re-render one input".

## Scope
2 files, both within the issue's listed paths. No new tool/feature, no real data, no broad refactor.
