### PR TITLE
Harden Email Translator input guards

### DIFF
--- a/tools/v2/individual/email-translator/README.md
+++ b/tools/v2/individual/email-translator/README.md
@@ -2,6 +2,19 @@
 
 This folder is the isolated workspace for the Email Translator tool.
 
+## Current Hardening Surface
+
+- `services/email-translator-guards.mjs` validates translation requests before any future model or UI integration.
+- `fixtures/sample-translation-requests.json` keeps deterministic synthetic review cases for safe, malformed, hostile, and large messages.
+- `tests/email-translator-guards.test.mjs` verifies the local security and performance contract with Node's built-in test runner.
+- `docs/SECURITY_AND_PERFORMANCE.md` documents threat assumptions, unsafe inputs, and workload limits.
+
+Run the local checks from the repository root:
+
+```bash
+node --test tools/v2/individual/email-translator/tests/email-translator-guards.test.mjs
+```
+
 ## Ownership Boundary
 
 All work for this tool must stay inside:

--- a/tools/v2/individual/email-translator/docs/SECURITY_AND_PERFORMANCE.md
+++ b/tools/v2/individual/email-translator/docs/SECURITY_AND_PERFORMANCE.md
@@ -1,0 +1,48 @@
+# Email Translator Security and Performance Notes
+
+## Threat Assumptions
+
+The isolated Email Translator accepts user-controlled email text and metadata. Until a future issue wires it into the main mail app, this folder must treat all message bodies, subjects, recipients, URLs, HTML, and attachment metadata as untrusted local input.
+
+The tool must not:
+
+- fetch external URLs, images, tracking pixels, or attachment links;
+- render HTML directly into the DOM;
+- process credentials, recovery codes, private keys, passwords, OTPs, or seed phrases;
+- store production mail, wallet, or account data in fixtures;
+- modify the main app shell, inbox, wallet, Stellar, routing, database, or shared design-system files.
+
+## Unsafe Input Handling
+
+`services/email-translator-guards.mjs` rejects or clips inputs before any future translation service receives them.
+
+- Active markup such as `script`, `iframe`, `object`, `embed`, `link`, `meta`, or `style` is rejected.
+- Credential-looking content is rejected with a review-blocking error.
+- HTML tags are stripped into plain text for safe local processing.
+- Tracking pixels and external URLs are retained only as inert warning signals; they are never fetched.
+- Control characters are removed.
+- Recipients are retained only when they are synthetic `.test` addresses in local fixtures.
+- Attachment handling keeps bounded metadata only and never opens files.
+
+## Performance Constraints
+
+The guard layer keeps processing bounded:
+
+- subjects are clipped at 280 characters;
+- bodies are clipped at 20,000 characters;
+- recipient metadata is clipped at 50 rows;
+- attachment metadata is clipped at 20 rows;
+- estimated translation work is split into 4,000-character segments;
+- messages above 12,000 normalized characters are marked for chunked processing.
+
+These limits prevent a future UI or model bridge from attempting unbounded translation on large threads, forwarded histories, or attachment-heavy emails.
+
+## Local Validation
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/email-translator/tests/email-translator-guards.test.mjs
+```
+
+The test suite validates safe input, hostile markup, secret-looking content, unsupported languages, malformed metadata, and large-body clipping without using network calls or production data.

--- a/tools/v2/individual/email-translator/fixtures/sample-translation-requests.json
+++ b/tools/v2/individual/email-translator/fixtures/sample-translation-requests.json
@@ -1,0 +1,60 @@
+{
+  "tool": "email-translator",
+  "sourceRequests": [
+    {
+      "id": "safe-fr-en",
+      "sourceLanguage": "fr",
+      "targetLanguage": "en",
+      "subject": "Rendez-vous demain",
+      "body": "Bonjour, pouvez-vous confirmer le rendez-vous de demain matin ?",
+      "recipients": ["buyer@example.test"],
+      "attachments": [],
+      "expectedOk": true,
+      "expectedMode": "inline"
+    },
+    {
+      "id": "html-tracking-warning",
+      "sourceLanguage": "en",
+      "targetLanguage": "es",
+      "subject": "Welcome",
+      "body": "<p>Welcome to the project.</p><img src=\"https://tracker.example.test/pixel\" width=\"1\" height=\"1\">",
+      "recipients": ["member@example.test"],
+      "attachments": [{ "name": "overview.pdf", "bytes": 42000 }],
+      "expectedOk": true,
+      "expectedWarning": "content:tracking-pixel"
+    },
+    {
+      "id": "hostile-active-markup",
+      "sourceLanguage": "en",
+      "targetLanguage": "de",
+      "subject": "Security update",
+      "body": "<script>alert('x')</script>Please translate this message.",
+      "recipients": ["reviewer@example.test"],
+      "attachments": [],
+      "expectedOk": false,
+      "expectedError": "content:active-markup"
+    },
+    {
+      "id": "secret-looking-body",
+      "sourceLanguage": "en",
+      "targetLanguage": "pt",
+      "subject": "Credentials",
+      "body": "The password is in the private key backup. Do not translate until reviewed.",
+      "recipients": ["security@example.test"],
+      "attachments": [],
+      "expectedOk": false,
+      "expectedError": "content:possible-secret"
+    },
+    {
+      "id": "unsupported-language",
+      "sourceLanguage": "en",
+      "targetLanguage": "klingon",
+      "subject": "Unsupported target",
+      "body": "This should be rejected before work starts.",
+      "recipients": ["qa@example.test"],
+      "attachments": [],
+      "expectedOk": false,
+      "expectedError": "targetLanguage:unsupported"
+    }
+  ]
+}

--- a/tools/v2/individual/email-translator/services/email-translator-guards.mjs
+++ b/tools/v2/individual/email-translator/services/email-translator-guards.mjs
@@ -1,0 +1,267 @@
+const SUPPORTED_LANGUAGE_CODES = new Set([
+  "en",
+  "es",
+  "fr",
+  "de",
+  "it",
+  "pt",
+  "zh",
+  "ja",
+  "ko",
+]);
+
+export const TRANSLATION_LIMITS = Object.freeze({
+  maxSubjectChars: 280,
+  maxBodyChars: 20_000,
+  maxRecipients: 50,
+  maxAttachmentMetadata: 20,
+  chunkSizeChars: 4_000,
+  chunkedModeThresholdChars: 12_000,
+});
+
+const CONTROL_CHARS_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const UNSAFE_MARKUP_PATTERN = /<\s*(script|iframe|object|embed|link|meta|style)\b/i;
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+const TRACKING_PIXEL_PATTERN = /<img[^>]+(?:width=["']?1|height=["']?1|tracking|pixel)/i;
+const SECRET_PATTERN =
+  /\b(seed phrase|private key|api[_ -]?key|password|one[- ]time code|otp|recovery code)\b/i;
+const EXTERNAL_URL_PATTERN = /https?:\/\/[^\s<>"']+/gi;
+
+function makeIssue(code, message) {
+  return { code, message };
+}
+
+function normalizeLanguageCode(value, fieldName, errors) {
+  if (typeof value !== "string" || value.trim() === "") {
+    errors.push(makeIssue(`${fieldName}:missing`, `${fieldName} is required.`));
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!SUPPORTED_LANGUAGE_CODES.has(normalized)) {
+    errors.push(
+      makeIssue(
+        `${fieldName}:unsupported`,
+        `${fieldName} must be one of: ${Array.from(SUPPORTED_LANGUAGE_CODES).join(", ")}.`,
+      ),
+    );
+    return null;
+  }
+
+  return normalized;
+}
+
+function toBoundedString(value, limit, fieldName, errors, warnings) {
+  if (value == null) {
+    return { text: "", originalLength: 0, truncated: false };
+  }
+
+  if (typeof value !== "string") {
+    errors.push(makeIssue(`${fieldName}:invalid-type`, `${fieldName} must be a string.`));
+    return { text: "", originalLength: 0, truncated: false };
+  }
+
+  const withoutControls = value.replace(CONTROL_CHARS_PATTERN, "");
+  const truncated = withoutControls.length > limit;
+  if (truncated) {
+    warnings.push(
+      makeIssue(
+        `${fieldName}:truncated`,
+        `${fieldName} exceeded ${limit} characters and was clipped for local processing.`,
+      ),
+    );
+  }
+
+  return {
+    text: truncated ? withoutControls.slice(0, limit) : withoutControls,
+    originalLength: withoutControls.length,
+    truncated,
+  };
+}
+
+export function sanitizeTextForTranslation(text) {
+  return String(text)
+    .replace(CONTROL_CHARS_PATTERN, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(HTML_TAG_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function inspectUnsafeSignals(subject, body, errors, warnings) {
+  const combined = `${subject}\n${body}`;
+
+  if (UNSAFE_MARKUP_PATTERN.test(combined)) {
+    errors.push(
+      makeIssue(
+        "content:active-markup",
+        "Active or executable markup is not accepted by the isolated translator.",
+      ),
+    );
+  }
+
+  if (SECRET_PATTERN.test(combined)) {
+    errors.push(
+      makeIssue(
+        "content:possible-secret",
+        "Message appears to contain credentials, recovery codes, or other secrets.",
+      ),
+    );
+  }
+
+  if (TRACKING_PIXEL_PATTERN.test(combined)) {
+    warnings.push(
+      makeIssue(
+        "content:tracking-pixel",
+        "Tracking-pixel markup was detected and must not be fetched or rendered.",
+      ),
+    );
+  }
+
+  const externalUrls = combined.match(EXTERNAL_URL_PATTERN) ?? [];
+  if (externalUrls.length > 0) {
+    warnings.push(
+      makeIssue(
+        "content:external-urls",
+        "External URLs are treated as inert text and must not be fetched by this tool.",
+      ),
+    );
+  }
+}
+
+function normalizeRecipients(value, errors, warnings) {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push(makeIssue("recipients:invalid-type", "recipients must be an array when present."));
+    return [];
+  }
+
+  if (value.length > TRANSLATION_LIMITS.maxRecipients) {
+    warnings.push(
+      makeIssue(
+        "recipients:clipped",
+        `Only the first ${TRANSLATION_LIMITS.maxRecipients} recipients are retained locally.`,
+      ),
+    );
+  }
+
+  return value
+    .slice(0, TRANSLATION_LIMITS.maxRecipients)
+    .filter((recipient) => typeof recipient === "string" && recipient.endsWith(".test"));
+}
+
+function summarizeAttachments(value, errors, warnings) {
+  if (value == null) {
+    return { count: 0, retainedMetadata: [] };
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push(makeIssue("attachments:invalid-type", "attachments must be an array when present."));
+    return { count: 0, retainedMetadata: [] };
+  }
+
+  if (value.length > TRANSLATION_LIMITS.maxAttachmentMetadata) {
+    warnings.push(
+      makeIssue(
+        "attachments:metadata-clipped",
+        `Only ${TRANSLATION_LIMITS.maxAttachmentMetadata} attachment metadata entries are retained.`,
+      ),
+    );
+  }
+
+  return {
+    count: value.length,
+    retainedMetadata: value.slice(0, TRANSLATION_LIMITS.maxAttachmentMetadata).map((item) => ({
+      name: typeof item?.name === "string" ? item.name.slice(0, 120) : "unnamed",
+      bytes: Number.isFinite(item?.bytes) && item.bytes >= 0 ? item.bytes : null,
+    })),
+  };
+}
+
+export function estimateTranslationWorkload(subject, body) {
+  const totalCharacters = subject.length + body.length;
+  const estimatedSegments = Math.max(
+    1,
+    Math.ceil(totalCharacters / TRANSLATION_LIMITS.chunkSizeChars),
+  );
+
+  return {
+    totalCharacters,
+    estimatedSegments,
+    recommendedMode:
+      totalCharacters > TRANSLATION_LIMITS.chunkedModeThresholdChars ? "chunked" : "inline",
+  };
+}
+
+export function normalizeEmailTranslationRequest(input) {
+  const errors = [];
+  const warnings = [];
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: [makeIssue("request:invalid-type", "request must be an object.")],
+      warnings,
+      request: null,
+    };
+  }
+
+  const sourceLanguage = normalizeLanguageCode(input.sourceLanguage, "sourceLanguage", errors);
+  const targetLanguage = normalizeLanguageCode(input.targetLanguage, "targetLanguage", errors);
+
+  if (sourceLanguage && targetLanguage && sourceLanguage === targetLanguage) {
+    errors.push(makeIssue("languages:same", "sourceLanguage and targetLanguage must differ."));
+  }
+
+  const subject = toBoundedString(
+    input.subject,
+    TRANSLATION_LIMITS.maxSubjectChars,
+    "subject",
+    errors,
+    warnings,
+  );
+  const body = toBoundedString(
+    input.body,
+    TRANSLATION_LIMITS.maxBodyChars,
+    "body",
+    errors,
+    warnings,
+  );
+
+  if (!subject.text.trim() && !body.text.trim()) {
+    errors.push(makeIssue("content:empty", "subject or body must contain text."));
+  }
+
+  inspectUnsafeSignals(subject.text, body.text, errors, warnings);
+
+  const sanitizedSubject = sanitizeTextForTranslation(subject.text);
+  const sanitizedBody = sanitizeTextForTranslation(body.text);
+  const recipients = normalizeRecipients(input.recipients, errors, warnings);
+  const attachments = summarizeAttachments(input.attachments, errors, warnings);
+  const performance = estimateTranslationWorkload(sanitizedSubject, sanitizedBody);
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    request:
+      errors.length === 0
+        ? {
+            id: typeof input.id === "string" && input.id ? input.id : "email-translation-request",
+            sourceLanguage,
+            targetLanguage,
+            subject: sanitizedSubject,
+            body: sanitizedBody,
+            recipients,
+            attachments,
+            bodyTruncated: body.truncated,
+            subjectTruncated: subject.truncated,
+            performance,
+          }
+        : null,
+  };
+}

--- a/tools/v2/individual/email-translator/tests/email-translator-guards.test.mjs
+++ b/tools/v2/individual/email-translator/tests/email-translator-guards.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  TRANSLATION_LIMITS,
+  normalizeEmailTranslationRequest,
+  sanitizeTextForTranslation,
+} from "../services/email-translator-guards.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-translation-requests.json");
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+function issueCodes(issues) {
+  return new Set(issues.map((issue) => issue.code));
+}
+
+test("sample translation requests follow the local security contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "email-translator");
+  assert.ok(Array.isArray(fixture.sourceRequests), "sourceRequests must be an array");
+
+  for (const source of fixture.sourceRequests) {
+    const result = normalizeEmailTranslationRequest(source);
+
+    assert.equal(result.ok, source.expectedOk, `${source.id} ok status mismatch`);
+
+    if (source.expectedError) {
+      assert.ok(issueCodes(result.errors).has(source.expectedError), `${source.id} missing error`);
+      assert.equal(result.request, null, `${source.id} must not return a normalized request`);
+    }
+
+    if (source.expectedWarning) {
+      assert.ok(
+        issueCodes(result.warnings).has(source.expectedWarning),
+        `${source.id} missing warning`,
+      );
+    }
+
+    if (result.ok) {
+      assert.equal(result.request.id, source.id);
+      assert.equal(result.request.performance.recommendedMode, source.expectedMode ?? "inline");
+      assert.ok(
+        result.request.recipients.every((recipient) => recipient.endsWith(".test")),
+        `${source.id} must retain only synthetic recipient data`,
+      );
+      assert.doesNotMatch(result.request.body, /<[^>]*>/, `${source.id} body must be plain text`);
+    }
+  }
+});
+
+test("large bodies are clipped and assigned chunked processing", () => {
+  const body = "Please translate this sentence. ".repeat(900);
+  const result = normalizeEmailTranslationRequest({
+    id: "large-body",
+    sourceLanguage: "en",
+    targetLanguage: "fr",
+    subject: "Large body",
+    body,
+    recipients: ["reviewer@example.test"],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.request.bodyTruncated, true);
+  assert.ok(result.request.body.length <= TRANSLATION_LIMITS.maxBodyChars);
+  assert.equal(result.request.performance.recommendedMode, "chunked");
+  assert.ok(issueCodes(result.warnings).has("body:truncated"));
+});
+
+test("sanitizer strips controls and active markup from safe display text", () => {
+  const sanitized = sanitizeTextForTranslation("Hello\u0000 <b>team</b> <script>x()</script>");
+
+  assert.equal(sanitized, "Hello team");
+  assert.doesNotMatch(sanitized, /script|<|>/i);
+});
+
+test("malformed requests fail before doing translation work", () => {
+  const result = normalizeEmailTranslationRequest({
+    id: "bad-request",
+    sourceLanguage: "en",
+    targetLanguage: "en",
+    subject: "",
+    body: "",
+    recipients: "not-an-array",
+    attachments: "not-an-array",
+  });
+
+  const codes = issueCodes(result.errors);
+
+  assert.equal(result.ok, false);
+  assert.ok(codes.has("languages:same"));
+  assert.ok(codes.has("content:empty"));
+  assert.ok(codes.has("recipients:invalid-type"));
+  assert.ok(codes.has("attachments:invalid-type"));
+  assert.equal(result.request, null);
+});


### PR DESCRIPTION
## Summary

Closes 

Adds a folder-local security and performance hardening surface for the isolated Email Translator tool. The change stays entirely inside `tools/v2/individual/email-translator/` and does not wire the tool into the main app.

## Changes

- Added `services/email-translator-guards.mjs` with request normalization, language checks, unsafe markup detection, secret-looking content blocking, bounded metadata handling, and translation workload estimation.
- Added deterministic synthetic fixtures covering safe input, tracking-pixel warnings, active markup rejection, secret-looking content, and unsupported language rejection.
- Added Node built-in tests for the local guard contract, large-body clipping, sanitizer behavior, and malformed metadata.
- Added `docs/SECURITY_AND_PERFORMANCE.md` documenting threat assumptions, unsafe inputs, and performance limits.
- Updated the tool README with the local validation command.

## Validation

- `node --test tools/v2/individual/email-translator/tests/email-translator-guards.test.mjs` - 4 passing
- `git diff --check`

## Boundary check

- Only files under `tools/v2/individual/email-translator/` changed.
- No live network calls, secrets, production data, app shell, routing, inbox, wallet, Stellar, database, or shared design system changes.