### PR TITLE
test(preferences): add regression coverage for persistence behavior

### DIFF
--- a/src/features/preferences/useLayoutPreferences.ts
+++ b/src/features/preferences/useLayoutPreferences.ts
@@ -7,7 +7,7 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
-function clampPreferences(prefs: LayoutPreferences): LayoutPreferences {
+export function clampLayoutPreferences(prefs: LayoutPreferences): LayoutPreferences {
   return {
     ...prefs,
     sidebarWidth: clamp(prefs.sidebarWidth, 5, 40),
@@ -25,7 +25,7 @@ export function useLayoutPreferences() {
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
-        setLayout(clampPreferences({ ...defaultLayoutPreferences, ...parsed }));
+        setLayout(clampLayoutPreferences({ ...defaultLayoutPreferences, ...parsed }));
       } catch {
         window.localStorage.removeItem(storageKey);
       }
@@ -40,7 +40,7 @@ export function useLayoutPreferences() {
 
   const setLayoutPreference = useCallback((patch: Partial<LayoutPreferences>) => {
     setLayout((prev: LayoutPreferences) => {
-      const next = clampPreferences({ ...prev, ...patch });
+      const next = clampLayoutPreferences({ ...prev, ...patch });
       // Only create a new object when at least one value actually changed.
       const changed = (Object.keys(next) as Array<keyof LayoutPreferences>).some(
         (k) => prev[k] !== next[k],

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -8,29 +8,48 @@ function resolveTheme(theme: UiPreferences["theme"]) {
   return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
 }
 
+/**
+ * Pure resolution of persisted preferences, shared by the hook and its tests.
+ * Stored values are always merged over the current defaults so missing keys
+ * stay predictable across sessions and app versions. The current key wins; the
+ * legacy `stealth-preferences` key is migrated only when the current one is
+ * absent. `corrupt` is true when the current key is present but unparseable, so
+ * the caller can clear it.
+ */
+export function resolveStoredPreferences(
+  current: string | null,
+  legacy: string | null,
+): { preferences: UiPreferences; corrupt: boolean } {
+  if (current) {
+    try {
+      return { preferences: { ...defaultPreferences, ...JSON.parse(current) }, corrupt: false };
+    } catch {
+      return { preferences: defaultPreferences, corrupt: true };
+    }
+  }
+  if (legacy) {
+    try {
+      return { preferences: { ...defaultPreferences, ...JSON.parse(legacy) }, corrupt: false };
+    } catch {
+      return { preferences: defaultPreferences, corrupt: false };
+    }
+  }
+  return { preferences: defaultPreferences, corrupt: false };
+}
+
 export function usePreferences() {
   const [preferences, setPreferences] = useState<UiPreferences>(defaultPreferences);
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    let stored = window.localStorage.getItem(storageKey);
-    if (!stored) {
-      const legacyStored = window.localStorage.getItem("stealth-preferences");
-      if (legacyStored) {
-        try {
-          const parsed = JSON.parse(legacyStored);
-          stored = JSON.stringify({ ...defaultPreferences, ...parsed });
-        } catch {
-          // ignore
-        }
-      }
-    }
-    if (stored) {
-      try {
-        setPreferences({ ...defaultPreferences, ...JSON.parse(stored) });
-      } catch {
-        window.localStorage.removeItem(storageKey);
-      }
+    const { preferences: resolved, corrupt } = resolveStoredPreferences(
+      window.localStorage.getItem(storageKey),
+      window.localStorage.getItem("stealth-preferences"),
+    );
+    if (corrupt) {
+      window.localStorage.removeItem(storageKey);
+    } else {
+      setPreferences(resolved);
     }
     setHydrated(true);
   }, []);

--- a/tests/unit/preferences/use-layout-preferences.test.ts
+++ b/tests/unit/preferences/use-layout-preferences.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { clampLayoutPreferences } from "../../../src/features/preferences/useLayoutPreferences";
+import {
+  defaultLayoutPreferences,
+  type LayoutPreferences,
+} from "../../../src/features/preferences/layout-types";
+
+describe("preferences/clampLayoutPreferences", () => {
+  it("leaves in-range layout widths untouched (success path)", () => {
+    const inRange: LayoutPreferences = {
+      ...defaultLayoutPreferences,
+      sidebarWidth: 15,
+      listWidth: 30,
+      readerWidth: 35,
+    };
+    expect(clampLayoutPreferences(inRange)).toEqual(inRange);
+  });
+
+  it("clamps out-of-range widths back into the usable bounds (edge case)", () => {
+    const tooWide: LayoutPreferences = {
+      ...defaultLayoutPreferences,
+      sidebarWidth: 95,
+      listWidth: 95,
+      readerWidth: 95,
+    };
+    expect(clampLayoutPreferences(tooWide)).toMatchObject({
+      sidebarWidth: 40,
+      listWidth: 60,
+      readerWidth: 80,
+    });
+
+    const tooNarrow: LayoutPreferences = {
+      ...defaultLayoutPreferences,
+      sidebarWidth: 0,
+      listWidth: 1,
+      readerWidth: 2,
+    };
+    expect(clampLayoutPreferences(tooNarrow)).toMatchObject({
+      sidebarWidth: 5,
+      listWidth: 10,
+      readerWidth: 15,
+    });
+  });
+
+  it("preserves the exact min and max bounds (boundary values)", () => {
+    const atBounds: LayoutPreferences = {
+      ...defaultLayoutPreferences,
+      sidebarWidth: 40,
+      listWidth: 10,
+      readerWidth: 80,
+    };
+    expect(clampLayoutPreferences(atBounds)).toMatchObject({
+      sidebarWidth: 40,
+      listWidth: 10,
+      readerWidth: 80,
+    });
+  });
+
+  it("does not mutate the input object (failure-safety)", () => {
+    const input: LayoutPreferences = { ...defaultLayoutPreferences, sidebarWidth: 100 };
+    const snapshot = { ...input };
+    clampLayoutPreferences(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("carries non-width fields through unchanged", () => {
+    const input: LayoutPreferences = {
+      ...defaultLayoutPreferences,
+      sidebarCollapsed: true,
+      rightPanelCollapsed: true,
+      compactMode: true,
+      sidebarWidth: 999,
+    };
+    const result = clampLayoutPreferences(input);
+    expect(result.sidebarCollapsed).toBe(true);
+    expect(result.rightPanelCollapsed).toBe(true);
+    expect(result.compactMode).toBe(true);
+  });
+});

--- a/tests/unit/preferences/use-preferences.test.ts
+++ b/tests/unit/preferences/use-preferences.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveStoredPreferences } from "../../../src/features/preferences/usePreferences";
+import { defaultPreferences } from "../../../src/features/preferences/types";
+
+describe("preferences/resolveStoredPreferences", () => {
+  it("merges a stored value over the current defaults (success path)", () => {
+    const stored = JSON.stringify({ theme: "light", sound: true });
+    const { preferences, corrupt } = resolveStoredPreferences(stored, null);
+
+    expect(corrupt).toBe(false);
+    expect(preferences.theme).toBe("light");
+    expect(preferences.sound).toBe(true);
+    // Untouched keys fall back to defaults, keeping shape stable across versions.
+    expect(preferences.density).toBe(defaultPreferences.density);
+    expect(preferences.receipts).toEqual(defaultPreferences.receipts);
+  });
+
+  it("returns defaults when nothing is stored", () => {
+    const { preferences, corrupt } = resolveStoredPreferences(null, null);
+    expect(corrupt).toBe(false);
+    expect(preferences).toEqual(defaultPreferences);
+  });
+
+  it("migrates the legacy key only when the current key is absent (edge case)", () => {
+    const legacy = JSON.stringify({ theme: "light" });
+    const { preferences, corrupt } = resolveStoredPreferences(null, legacy);
+    expect(corrupt).toBe(false);
+    expect(preferences.theme).toBe("light");
+  });
+
+  it("prefers the current key over the legacy key when both exist", () => {
+    const current = JSON.stringify({ theme: "dark" });
+    const legacy = JSON.stringify({ theme: "light" });
+    const { preferences } = resolveStoredPreferences(current, legacy);
+    expect(preferences.theme).toBe("dark");
+  });
+
+  it("flags a corrupt current key for cleanup and falls back to defaults (failure path)", () => {
+    const { preferences, corrupt } = resolveStoredPreferences("{not valid json", null);
+    expect(corrupt).toBe(true);
+    expect(preferences).toEqual(defaultPreferences);
+  });
+
+  it("ignores a corrupt legacy key without flagging cleanup", () => {
+    const { preferences, corrupt } = resolveStoredPreferences(null, "{bad");
+    expect(corrupt).toBe(false);
+    expect(preferences).toEqual(defaultPreferences);
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused regression coverage for the existing Preferences surface (issue #974) — layout width clamping and preference persistence/migration. Two small pure helpers were exported/extracted so the persistence rules are testable without a DOM; hook behavior is unchanged.

Closes #974

## Changes
- **clampLayoutPreferences** — exported the existing pure clamp helper from `useLayoutPreferences.ts` (hook delegates to it).
- **resolveStoredPreferences** — extracted a pure helper from `usePreferences.ts` covering merge-over-defaults, legacy `stealth-preferences` migration, and corrupt-JSON recovery.
- **Unit tests — layout** — in-range preserved (success), out-of-range clamped + boundary values (edge), no mutation, non-width passthrough.
- **Unit tests — preferences** — stored merges over defaults (success), legacy migration only when current absent, current-wins, corrupt current flagged for cleanup + defaults fallback (failure), corrupt legacy ignored.

