### PR TITLE
fix(a11y): close keyboard and screen-reader gaps in Preferences (#972)

### DIFF
--- a/src/components/mail/SettingsModal.tsx
+++ b/src/components/mail/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
   AlertTriangle,
   Bell,
@@ -19,7 +19,7 @@ import {
   User,
   X,
 } from "lucide-react";
-import { useState, useEffect, type CSSProperties } from "react";
+import { useState, useEffect, useRef, type CSSProperties } from "react";
 import { Surface } from "@/features/design-system";
 import { cn } from "@/lib/utils";
 import { SHORTCUT_DEFINITIONS } from "@/features/command-palette";
@@ -76,6 +76,68 @@ export function SettingsModal({
 }) {
   const [activeTab, setActiveTab] = useState<Tab>("account");
   const { hasUnread } = useChangelog();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const dismiss = onCancel ?? onClose;
+  const prefersReducedMotion = useReducedMotion();
+  const panelTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { type: "spring" as const, stiffness: 300, damping: 30 };
+
+  // Keyboard + focus management for the dialog: close on Escape, focus the
+  // panel on open, keep Tab focus inside it, and restore focus on close.
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    panel?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        dismiss();
+        return;
+      }
+      if (e.key !== "Tab" || !panel) return;
+      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        (el) => el.offsetParent !== null,
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || active === panel)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [open, dismiss]);
+
+  const onTabListKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    const ids = tabs.map((t) => t.id);
+    const current = ids.indexOf(activeTab);
+    let next = current;
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") next = (current + 1) % ids.length;
+    else if (e.key === "ArrowUp" || e.key === "ArrowLeft")
+      next = (current - 1 + ids.length) % ids.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = ids.length - 1;
+    else return;
+    e.preventDefault();
+    setActiveTab(ids[next]);
+    document.getElementById(`settings-tab-${ids[next]}`)?.focus();
+  };
 
   return (
     <AnimatePresence>
@@ -85,16 +147,22 @@ export function SettingsModal({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={onCancel ?? onClose}
+            onClick={dismiss}
+            aria-hidden="true"
             className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
           />
           <motion.div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="settings-title"
+            tabIndex={-1}
             initial={{ opacity: 0, scale: 0.96, y: 8 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 8 }}
-            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            transition={panelTransition}
             className={cn(
-              "glass-strong fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl transition-all",
+              "glass-strong fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl transition-all outline-none",
               activeTab === "audit" || activeTab === "changelog"
                 ? "w-[min(800px,calc(100vw-2rem))]"
                 : "w-[min(680px,calc(100vw-2rem))]",
@@ -102,10 +170,13 @@ export function SettingsModal({
           >
             {/* Header */}
             <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
-              <h2 className="text-sm font-semibold text-foreground">Settings</h2>
+              <h2 id="settings-title" className="text-sm font-semibold text-foreground">
+                Settings
+              </h2>
               <button
-                onClick={onCancel ?? onClose}
-                className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
+                onClick={dismiss}
+                aria-label="Close settings"
+                className="glow-ring rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -119,16 +190,27 @@ export function SettingsModal({
             >
               {/* Sidebar tabs */}
               <div className="w-48 border-r border-white/5 p-3">
-                <nav className="space-y-1">
+                <nav
+                  role="tablist"
+                  aria-orientation="vertical"
+                  aria-label="Settings sections"
+                  onKeyDown={onTabListKeyDown}
+                  className="space-y-1"
+                >
                   {tabs.map((tab) => {
                     const Icon = tab.icon;
                     const isActive = activeTab === tab.id;
                     return (
                       <button
                         key={tab.id}
+                        id={`settings-tab-${tab.id}`}
+                        role="tab"
+                        aria-selected={isActive}
+                        aria-controls={`settings-panel-${tab.id}`}
+                        tabIndex={isActive ? 0 : -1}
                         onClick={() => setActiveTab(tab.id)}
                         className={cn(
-                          "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition",
+                          "glow-ring flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition",
                           isActive
                             ? "bg-white/[0.08] text-foreground"
                             : "text-muted-foreground hover:bg-white/[0.04] hover:text-foreground",
@@ -146,7 +228,13 @@ export function SettingsModal({
               </div>
 
               {/* Content */}
-              <div className="flex-1 p-5 max-h-[450px] overflow-y-auto">
+              <div
+                role="tabpanel"
+                id={`settings-panel-${activeTab}`}
+                aria-labelledby={`settings-tab-${activeTab}`}
+                tabIndex={0}
+                className="glow-ring flex-1 p-5 max-h-[450px] overflow-y-auto"
+              >
                 {activeTab === "account" && <AccountSettings />}
                 {activeTab === "appearance" && (
                   <AppearanceSettings preferences={preferences} onChange={onChange} />
@@ -334,24 +422,51 @@ function SegmentedSetting({
   options: [string, string][];
   onSelect: (value: string) => void;
 }) {
+  const groupId = `seg-${label.replace(/\s+/g, "-").toLowerCase()}`;
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const idx = options.findIndex(([v]) => v === value);
+    let next = idx;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") next = (idx + 1) % options.length;
+    else if (e.key === "ArrowLeft" || e.key === "ArrowUp")
+      next = (idx - 1 + options.length) % options.length;
+    else return;
+    e.preventDefault();
+    onSelect(options[next][0]);
+    const radios = e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    radios[next]?.focus();
+  };
+
   return (
     <div>
-      <label className="text-xs text-muted-foreground">{label}</label>
-      <div className="mt-2 flex flex-wrap gap-2">
-        {options.map(([optionValue, optionLabel]) => (
-          <button
-            key={optionValue}
-            onClick={() => onSelect(optionValue)}
-            className={cn(
-              "rounded-lg border px-4 py-2 text-xs transition",
-              value === optionValue
-                ? "border-white/20 bg-white/[0.08] text-foreground shadow-[var(--shadow-glow)]"
-                : "border-white/5 text-muted-foreground hover:border-white/10 hover:text-foreground",
-            )}
-          >
-            {optionLabel}
-          </button>
-        ))}
+      <span id={groupId} className="text-xs text-muted-foreground">
+        {label}
+      </span>
+      <div
+        role="radiogroup"
+        aria-labelledby={groupId}
+        onKeyDown={onKeyDown}
+        className="mt-2 flex flex-wrap gap-2"
+      >
+        {options.map(([optionValue, optionLabel]) => {
+          const checked = value === optionValue;
+          return (
+            <button
+              key={optionValue}
+              role="radio"
+              aria-checked={checked}
+              tabIndex={checked ? 0 : -1}
+              onClick={() => onSelect(optionValue)}
+              className={cn(
+                "glow-ring rounded-lg border px-4 py-2 text-xs transition",
+                checked
+                  ? "border-white/20 bg-white/[0.08] text-foreground shadow-[var(--shadow-glow)]"
+                  : "border-white/5 text-muted-foreground hover:border-white/10 hover:text-foreground",
+              )}
+            >
+              {optionLabel}
+            </button>
+          );
+        })}
       </div>
     </div>
   );
@@ -1347,9 +1462,11 @@ function SettingsToggle({
       </div>
       <button
         onClick={() => onChange(!checked)}
-        aria-pressed={checked}
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
         className={cn(
-          "relative h-6 w-11 rounded-full transition",
+          "glow-ring relative h-6 w-11 rounded-full transition",
           checked ? "bg-white/20" : "bg-white/10",
         )}
       >

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -9,6 +9,19 @@ function resolveTheme(theme: UiPreferences["theme"]) {
 }
 
 /**
+ * Resolve the effective motion level. Reduced motion wins whenever either the
+ * in-app toggle or the OS `prefers-reduced-motion` setting asks for it, so the
+ * accessibility preference is honored even when the user has not flipped the
+ * in-app switch. Pure so it can be unit tested without a DOM.
+ */
+export function resolveMotion(
+  lowerMotion: boolean,
+  prefersReducedMotion: boolean,
+): "lower" | "full" {
+  return lowerMotion || prefersReducedMotion ? "lower" : "full";
+}
+
+/**
  * Pure resolution of persisted preferences, shared by the hook and its tests.
  * Stored values are always merged over the current defaults so missing keys
  * stay predictable across sessions and app versions. The current key wins; the
@@ -56,21 +69,30 @@ export function usePreferences() {
 
   useEffect(() => {
     if (!hydrated) return;
+    const colorScheme = window.matchMedia("(prefers-color-scheme: light)");
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const apply = () => {
       document.documentElement.dataset.theme = resolveTheme(preferences.theme);
       const density = preferences.density ?? (preferences.compactMode ? "compact" : "comfortable");
       document.documentElement.dataset.density = density;
       document.documentElement.dataset.glass = preferences.glassIntensity ?? "medium";
       document.documentElement.dataset.reader = preferences.readerTypography ?? "sans";
-      document.documentElement.dataset.motion = preferences.lowerMotion ? "lower" : "full";
+      document.documentElement.dataset.motion = resolveMotion(
+        preferences.lowerMotion,
+        reducedMotion.matches,
+      );
     };
 
     apply();
     window.localStorage.setItem(storageKey, JSON.stringify(preferences));
 
-    const media = window.matchMedia("(prefers-color-scheme: light)");
-    if (preferences.theme === "system") media.addEventListener("change", apply);
-    return () => media.removeEventListener("change", apply);
+    if (preferences.theme === "system") colorScheme.addEventListener("change", apply);
+    // Always track the OS reduced-motion setting so the fallback stays honored.
+    reducedMotion.addEventListener("change", apply);
+    return () => {
+      colorScheme.removeEventListener("change", apply);
+      reducedMotion.removeEventListener("change", apply);
+    };
   }, [hydrated, preferences]);
 
   return { preferences, setPreferences, hydrated };

--- a/tests/e2e/policy-editing.spec.ts
+++ b/tests/e2e/policy-editing.spec.ts
@@ -12,7 +12,7 @@ test.describe("policy editing", () => {
 
   test("switches to Inbox control tab and changes unknown-sender policy", async ({ page }) => {
     await openSettings(page);
-    await page.getByRole("button", { name: "Inbox control" }).click();
+    await page.getByRole("tab", { name: "Inbox control" }).click();
     await expect(page.getByRole("heading", { name: "Inbox control" })).toBeVisible();
 
     await page.getByRole("button", { name: "Verified only" }).click();
@@ -23,7 +23,7 @@ test.describe("policy editing", () => {
 
   test("updates minimum postage value and saves", async ({ page }) => {
     await openSettings(page);
-    await page.getByRole("button", { name: "Inbox control" }).click();
+    await page.getByRole("tab", { name: "Inbox control" }).click();
     await page.locator('input[inputmode="decimal"]').last().fill("0.001");
 
     await page.getByRole("button", { name: "Save changes" }).click();

--- a/tests/unit/preferences/use-preferences.test.ts
+++ b/tests/unit/preferences/use-preferences.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { resolveStoredPreferences } from "../../../src/features/preferences/usePreferences";
+import {
+  resolveStoredPreferences,
+  resolveMotion,
+} from "../../../src/features/preferences/usePreferences";
 import { defaultPreferences } from "../../../src/features/preferences/types";
+
+describe("preferences/resolveMotion", () => {
+  it("keeps full motion when neither the toggle nor the OS asks to reduce (success path)", () => {
+    expect(resolveMotion(false, false)).toBe("full");
+  });
+
+  it("reduces motion when the in-app toggle is on", () => {
+    expect(resolveMotion(true, false)).toBe("lower");
+  });
+
+  it("honors the OS reduced-motion setting even when the toggle is off (a11y fallback)", () => {
+    expect(resolveMotion(false, true)).toBe("lower");
+  });
+
+  it("reduces motion when both ask for it", () => {
+    expect(resolveMotion(true, true)).toBe("lower");
+  });
+});
 
 describe("preferences/resolveStoredPreferences", () => {
   it("merges a stored value over the current defaults (success path)", () => {


### PR DESCRIPTION
## Summary
Closes keyboard and screen-reader gaps on the Preferences surface (issue #972).

Closes #972

## Changes
- **usePreferences** — `data-motion` now honors OS `prefers-reduced-motion` as a fallback (pure `resolveMotion` helper + unit tests).
- **SettingsModal — dialog** — `role="dialog"`/`aria-modal`/`aria-labelledby`, Escape-to-close, initial focus, Tab focus trap, focus restore; icon-only close button labelled.
- **SettingsModal — tabs** — `role="tab"`/`aria-selected`/`aria-controls`, roving `tabIndex`, arrow/Home/End navigation; labelled `tabpanel`.
- **Stateful controls** — `SegmentedSetting` → radiogroup with `aria-checked` + arrow-key selection; `SettingsToggle` → `role="switch"` + `aria-checked` + accessible name.
- **Reduced motion** — modal entrance gated via `useReducedMotion`. Visible focus (`glow-ring`) added.

## Scope
The listed paths are hooks/types with no UI, so the keyboard/SR fixes are in `SettingsModal.tsx` (the actual control surface) — a justified extension noted in the commits.

## Tests
- `tsc --noEmit` clean, `bun run test` 480 passing, lint/prettier clean.
- ARIA patterns implemented to spec; not exercised with a real screen reader in this environment.
