### PR TITLE
Add architecture and folder contract docs for Contact Extractor

### DIFF
--- a/tools/v1/individual/contact-extractor/DATA_OWNERSHIP.md
+++ b/tools/v1/individual/contact-extractor/DATA_OWNERSHIP.md
@@ -1,0 +1,54 @@
+# Contact Extractor - Data Ownership & Flow
+
+This document describes the data structures, storage boundaries, state lifecycle, and mutation rules inside the Contact Extractor tool.
+
+## 1. Domain entities and data model
+
+The core structures are declared in `types/index.ts`:
+
+    export interface ExtractedContact {
+      id: string;
+      name: string | null;
+      email: string | null;
+      phone: string | null;
+      organization: string | null;
+      source: "header" | "signature" | "body";
+    }
+
+    export interface ContactExtractionResult {
+      contacts: ExtractedContact[];
+      skipped: string[];
+    }
+
+## 2. Data lifecycle
+
+- Raw email text is entered in the input panel.
+- The `useContactExtractor` hook forwards it to the service.
+- `ContactExtractorService.extract()` parses the text and returns a `ContactExtractionResult`.
+- The hook stores the result in React state, and the contact list re-renders.
+
+Validation checkpoint: each candidate contact is normalized and validated (well-formed email, trimmed name, recognized source) before it is added to `contacts`; anything rejected is recorded in `skipped`.
+
+## 3. Data storage boundaries
+
+- Local in-memory state only: no database, blockchain sync, or cookie caching.
+- Seed fixtures: sample emails come from deterministic mock data in `fixtures/`.
+- No persistence: durable storage, if ever required, must be added through a new adapter layer in a follow-up issue.
+
+## 4. Mutability and mutation constraints
+
+Immutable:
+
+- Fixture vectors: the mock emails in `fixtures/` are read-only at runtime.
+- Contact `id`: once assigned, a contact's `id` never changes.
+
+Mutable:
+
+- Result collection: re-running extraction produces a new result object instead of mutating the previous one in place.
+- Component visual state: local indicators such as the current input buffer.
+
+## 5. Security and privacy safeguards
+
+- Fake demo data only: all sample emails, names, and addresses are fake, deterministic, and safe for public repository review.
+- No real recipients or secrets: no real email addresses, private keys, secrets, or live network calls are ever included.
+- Safe parsing: extraction only reads the provided text and never performs network lookups or enrichment.

--- a/tools/v1/individual/contact-extractor/INTEGRATION_CONSTRAINTS.md
+++ b/tools/v1/individual/contact-extractor/INTEGRATION_CONSTRAINTS.md
@@ -1,0 +1,25 @@
+# Contact Extractor - Integration Constraints
+
+This document records the boundaries that keep the Contact Extractor tool isolated from the main application during V1 development.
+
+## 1. Isolation rules
+
+- All implementation stays inside `tools/v1/individual/contact-extractor/`.
+- The tool must not modify the main application shell, dashboard layout, navigation system, authentication, wallet core, mail rendering engine, existing inbox architecture, existing routing, Stellar integration core, database schema, or the shared design system.
+- The tool does not register routes, navigation entries, or global providers in this phase.
+
+## 2. Dependency constraints
+
+- Only folder-local imports are allowed: no file outside this folder may be imported, and the main app must not import this folder yet.
+- Allowed external dependencies are limited to the existing project runtime (React and TypeScript) and presentational asset libraries already used in the repository.
+- No new runtime services, network clients, or persistence layers are introduced.
+
+## 3. Data and safety constraints
+
+- All fixtures and samples remain fake, deterministic, and safe for public review.
+- No real user data, secrets, private keys, or live network calls.
+
+## 4. Future integration
+
+- A connection to the main mail app (for example, reading the selected message or saving extracted contacts) is intentionally out of scope for V1.
+- Any such integration must be proposed as a separate follow-up issue that explicitly links this tool so it can be reviewed on its own.

--- a/tools/v1/individual/contact-extractor/MODULE_BOUNDARIES.md
+++ b/tools/v1/individual/contact-extractor/MODULE_BOUNDARIES.md
@@ -1,0 +1,105 @@
+# Contact Extractor - Module Boundaries
+
+This document defines the internal contracts, public interfaces, and dependency rules for each module inside the Contact Extractor tool. The tool is a V1, individual-audience mini-product that extracts structured contact details from a single email message. It is built in isolation and is not wired into the main application yet.
+
+## 1. Module: Types (shared contracts)
+
+Location: `types/` (for example, `types/index.ts`).
+
+Responsibility: declares the shared TypeScript interfaces used across the tool. Owns no logic and imports nothing.
+
+Public API:
+
+    export interface ExtractedContact {
+      id: string;
+      name: string | null;
+      email: string | null;
+      phone: string | null;
+      organization: string | null;
+      source: "header" | "signature" | "body";
+    }
+
+    export interface ContactExtractionResult {
+      contacts: ExtractedContact[];
+      skipped: string[];
+    }
+
+    export interface ExtractionOptions {
+      includeBody: boolean;
+      dedupe: boolean;
+    }
+
+Dependencies: no imports from `components/`, `services/`, `hooks/`, or the main application.
+
+## 2. Module: Services (business logic)
+
+Location: `services/` (for example, `services/contact-extractor.service.ts`).
+
+Responsibility: encapsulates all framework-free logic - header parsing, signature and body scanning, normalization, and de-duplication. Services never import React and never reach outside this folder.
+
+Public API:
+
+    export function createContactExtractorService(): {
+      extract: (
+        rawEmail: string,
+        options?: ExtractionOptions,
+      ) => ContactExtractionResult;
+      dedupe: (contacts: ExtractedContact[]) => ExtractedContact[];
+    };
+
+Dependencies:
+
+- Allowed to import: TypeScript types from `../types/`.
+- Forbidden: React or hooks, presentational components, and main app stores or APIs.
+
+## 3. Module: Hooks (React integration)
+
+Location: `hooks/` (for example, `hooks/use-contact-extractor.ts`).
+
+Responsibility: synchronizes the service with React components, managing the current input, the extraction result, and loading or error state.
+
+Public API:
+
+    export function useContactExtractor(): {
+      result: ContactExtractionResult | null;
+      extract: (rawEmail: string, options?: ExtractionOptions) => void;
+      reset: () => void;
+    };
+
+Dependencies:
+
+- Allowed to import: React hooks, the service factory from `../services/`, and types from `../types/`.
+- Forbidden: presentational components and core app state contexts.
+
+## 4. Module: Components (user interface)
+
+Location: `components/`.
+
+Responsibility: renders the visual elements of the tool (raw email input, the extract action, and the extracted contact list). Components stay presentational and delegate all actions to the hook.
+
+Public API:
+
+    // ContactInputPanel.tsx
+    export const ContactInputPanel: React.FC<{
+      onExtract: (rawEmail: string) => void;
+    }>;
+
+    // ExtractedContactList.tsx
+    export const ExtractedContactList: React.FC<{
+      result: ContactExtractionResult;
+    }>;
+
+    // ContactExtractorConsole.tsx
+    export const ContactExtractorConsole: React.FC;
+
+Dependencies:
+
+- Allowed to import: hooks from `../hooks/`, types from `../types/`, and external presentational assets such as icons.
+- Forbidden: core app features, layout navigation, or importing service functions directly.
+
+## Import rules checklist
+
+- [ ] Only import from files inside `tools/v1/individual/contact-extractor/`.
+- [ ] Maintain a one-way dependency flow: components -> hooks -> services -> types.
+- [ ] No circular dependencies.
+- [ ] All shared interfaces are imported from `types/`.


### PR DESCRIPTION
Closes #334

Adds the architecture and folder contract for the Contact Extractor tool (V1, individual). This is documentation only and stays fully inside tools/v1/individual/contact-extractor/.

What's included:
- MODULE_BOUNDARIES.md - internal module contracts and the one-way dependency flow (components -> hooks -> services -> types).
- DATA_OWNERSHIP.md - data model, lifecycle, storage boundaries, and mutation rules.
- INTEGRATION_CONSTRAINTS.md - isolation rules, dependency limits, and future-integration boundaries.

Notes:
- No files outside the tool folder are changed.
- No runtime code, routes, or app wiring are added; all guidance is folder-local.
- All sample data described is fake, deterministic, and safe for public review.