### PR TITLE
Add audit log reducer for demo admin dashboard

### DIFF
--- a/src/features/demo-admin-dashboard/reducers/auditLogReducer.test.ts
+++ b/src/features/demo-admin-dashboard/reducers/auditLogReducer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  auditLogReducer,
+  initialAuditLogState,
+  selectRecentAuditEntries,
+  type AuditLogState,
+} from "./auditLogReducer";
+import type { AuditLogEntry } from "../auditLog";
+
+const baseEntryInput: Omit<AuditLogEntry, "id"> = {
+  timestamp: "2026-01-01T10:00:00.000Z",
+  actor: { id: "user-1", name: "Admin User" },
+  action: "create",
+  target: { type: "Campaign", id: "camp-1", name: "Welcome Campaign" },
+};
+
+describe("auditLogReducer", () => {
+  it("starts with no entries", () => {
+    expect(initialAuditLogState.entries).toEqual([]);
+  });
+
+  it("records a new entry with a generated id at the front", () => {
+    const state = auditLogReducer(initialAuditLogState, {
+      type: "record",
+      payload: baseEntryInput,
+    });
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0].id).toMatch(/^audit-\d+/);
+    expect(state.entries[0].action).toBe("create");
+  });
+
+  it("adds a prebuilt entry to the front (newest first)", () => {
+    const existing: AuditLogEntry = { id: "audit-1", ...baseEntryInput };
+    const newer: AuditLogEntry = { id: "audit-2", ...baseEntryInput, action: "publish" };
+    const state = auditLogReducer({ entries: [existing] }, { type: "add", payload: newer });
+    expect(state.entries.map((entry) => entry.id)).toEqual(["audit-2", "audit-1"]);
+  });
+
+  it("clears all entries", () => {
+    const populated: AuditLogState = { entries: [{ id: "audit-1", ...baseEntryInput }] };
+    expect(auditLogReducer(populated, { type: "clear" }).entries).toEqual([]);
+  });
+
+  it("resets entries to a provided list", () => {
+    const entries: AuditLogEntry[] = [
+      { id: "audit-1", ...baseEntryInput },
+      { id: "audit-2", ...baseEntryInput, action: "publish" },
+    ];
+    const state = auditLogReducer(initialAuditLogState, { type: "reset", payload: entries });
+    expect(state.entries).toHaveLength(2);
+  });
+
+  it("selects only the most recent entries up to the limit", () => {
+    const entries: AuditLogEntry[] = [
+      { id: "audit-3", ...baseEntryInput },
+      { id: "audit-2", ...baseEntryInput },
+      { id: "audit-1", ...baseEntryInput },
+    ];
+    const state: AuditLogState = { entries };
+    expect(selectRecentAuditEntries(state, 2).map((entry) => entry.id)).toEqual([
+      "audit-3",
+      "audit-2",
+    ]);
+    expect(selectRecentAuditEntries(state, 0)).toEqual([]);
+  });
+});

--- a/src/features/demo-admin-dashboard/reducers/auditLogReducer.ts
+++ b/src/features/demo-admin-dashboard/reducers/auditLogReducer.ts
@@ -1,0 +1,49 @@
+import { createAuditEntry, type AuditLogEntry } from "../auditLog";
+
+export interface AuditLogState {
+  entries: AuditLogEntry[];
+}
+
+export type AuditLogAction =
+  | { type: "record"; payload: Omit<AuditLogEntry, "id"> }
+  | { type: "add"; payload: AuditLogEntry }
+  | { type: "clear" }
+  | { type: "reset"; payload: AuditLogEntry[] };
+
+export const initialAuditLogState: AuditLogState = {
+  entries: [],
+};
+
+/**
+ * Reducer for the demo admin audit log. Keeps entries newest-first so the
+ * AuditLogPanel can render the most recent activity at the top.
+ */
+export function auditLogReducer(
+  state: AuditLogState = initialAuditLogState,
+  action: AuditLogAction,
+): AuditLogState {
+  switch (action.type) {
+    case "record": {
+      const entry = createAuditEntry(action.payload);
+      return { entries: [entry, ...state.entries] };
+    }
+    case "add":
+      return { entries: [action.payload, ...state.entries] };
+    case "clear":
+      return { entries: [] };
+    case "reset":
+      return { entries: [...action.payload] };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Returns the most recent entries, up to the provided limit.
+ */
+export function selectRecentAuditEntries(state: AuditLogState, limit: number): AuditLogEntry[] {
+  if (limit <= 0) {
+    return [];
+  }
+  return state.entries.slice(0, limit);
+}


### PR DESCRIPTION
Closes #193

Adds a local audit log reducer for the demo admin dashboard. All changes stay inside src/features/demo-admin-dashboard/.

What's included:
- reducers/auditLogReducer.ts - records, adds, clears, and resets AuditLogEntry items (newest-first), building on the existing auditLog helpers, plus a selector for the most recent entries.
- reducers/auditLogReducer.test.ts - unit tests covering the initial state, every action, and the selector.

Notes:
- Builds on the existing AuditLogEntry type, createAuditEntry helper, and AuditLogPanel component already in the folder.
- No files outside the folder are changed; pure state logic with no app wiring or network calls.
- All sample data in tests is fake, deterministic, and safe for public review.