### PR TITLE
Internal Comment Thread - architecture and folder contract (#439)

### DIFF
--- a/tools/v1/team/internal-comment-thread/DATA_OWNERSHIP.md
+++ b/tools/v1/team/internal-comment-thread/DATA_OWNERSHIP.md
@@ -1,0 +1,67 @@
+# Internal Comment Thread - Data Ownership & Flow
+
+This document describes the data structures, storage boundaries, state lifecycle, and mutation rules inside the Internal Comment Thread tool.
+
+## 1. Domain entities and data model
+
+The core structures are declared in `types/index.ts`:
+
+    export type CommentTarget =
+      | { kind: "message"; id: string }
+      | { kind: "thread"; id: string };
+
+    export interface InternalComment {
+      id: string;
+      target: CommentTarget;
+      author: string;        // Stealth address of team member
+      body: string;
+      createdAt: string;
+      updatedAt?: string;
+    }
+
+    export interface CommentResult {
+      comment: InternalComment;
+    }
+
+    export interface ListCommentsResult {
+      comments: InternalComment[];
+    }
+
+## 2. Data lifecycle
+
+- A team member opens a message (or thread) inside a shared inbox context.
+- The `useInternalComments` hook requests existing comments for the target.
+- The comment service returns the list filtered to the current team (enforced at storage layer).
+- A new comment is created with author = current team member's Stealth address, body, and timestamp.
+- The hook stores the updated list in React state; the comment list re-renders.
+- Edit and delete operations are restricted to the original author.
+
+Validation checkpoint: every comment body is stored exactly as provided by the author; no transformation that would allow leakage to external paths is permitted. The `target` reference must resolve to a message or thread that the team is authorized to see.
+
+## 3. Data storage boundaries
+
+- Local in-memory state only (default): no database, blockchain sync, or cookie caching.
+- Seed fixtures: sample comments come from deterministic mock data in `fixtures/`.
+- No persistence: durable storage, if ever required, must be added through a new adapter layer in a follow-up issue.
+- Team roster is provided at tool startup and used to gate all comment operations.
+
+## 4. Mutability and mutation constraints
+
+Immutable:
+
+- Fixture vectors: the mock targets and comments in `fixtures/` are read-only at runtime.
+- Comment `id` and `author`: once created, these fields never change.
+- Target reference: the `target` of an existing comment cannot be altered.
+
+Mutable:
+
+- Comment body: only the original author may update the body (via `updateComment`).
+- Result collection: adding or deleting a comment produces a new list; the previous list object is not mutated.
+- Component visual state: local draft text in the composer.
+
+## 5. Security and privacy safeguards
+
+- Team-only visibility (firm rule): comment bodies are never included in any payload, header, log, or delivery mechanism that could reach an external sender address. This invariant is enforced in services, hooks, and any future storage adapters.
+- Fake demo data only: all sample authors, targets, and comment bodies are fake, deterministic, and safe for public repository review.
+- No real recipients or secrets: no real Stealth addresses (outside the declared team roster), private keys, or live network calls are ever included in fixtures or default state.
+- Safe authoring: the service rejects any attempt to create a comment for a target the current author is not authorized to see.

--- a/tools/v1/team/internal-comment-thread/INTEGRATION_CONSTRAINTS.md
+++ b/tools/v1/team/internal-comment-thread/INTEGRATION_CONSTRAINTS.md
@@ -1,0 +1,29 @@
+# Internal Comment Thread - Integration Constraints
+
+This document records the boundaries that keep the Internal Comment Thread tool isolated from the main application during V1 development.
+
+## 1. Isolation rules
+
+- All implementation stays inside `tools/v1/team/internal-comment-thread/`.
+- The tool must not modify the main application shell, dashboard layout, navigation system, authentication, wallet core, mail rendering engine, existing inbox architecture, existing routing, Stellar integration core, database schema, or the shared design system.
+- The tool does not register routes, navigation entries, or global providers in this phase.
+- **Firm rule**: no implementation may create any code path that would make internal comment content visible to or deliverable to an external sender, even accidentally.
+
+## 2. Dependency constraints
+
+- Only folder-local imports are allowed: no file outside this folder may be imported, and the main app must not import this folder yet.
+- Allowed external dependencies are limited to the existing project runtime (React and TypeScript) and presentational asset libraries already used in the repository.
+- No new runtime services, network clients, or persistence layers are introduced.
+- The tool may reference the Stealth protocol for team identity concepts but must not depend on any core mail engine or inbox state.
+
+## 3. Data and safety constraints
+
+- All fixtures and samples remain fake, deterministic, and safe for public review.
+- No real user data, secrets, private keys, or live network calls.
+- Comment bodies must be treated as strictly team-internal data at all times.
+
+## 4. Future integration
+
+- A connection to the main mail app (for example, reading the selected shared message or saving comments to a team store) is intentionally out of scope for V1.
+- Any such integration must be proposed as a separate follow-up issue that explicitly links this tool so it can be reviewed on its own.
+- When integration occurs, the team-only visibility rule must remain an enforceable invariant in every new code path.

--- a/tools/v1/team/internal-comment-thread/MODULE_BOUNDARIES.md
+++ b/tools/v1/team/internal-comment-thread/MODULE_BOUNDARIES.md
@@ -1,0 +1,120 @@
+# Internal Comment Thread - Module Boundaries
+
+This document defines the internal contracts, public interfaces, and dependency rules for each module inside the Internal Comment Thread tool. The tool is a V1, team-audience mini-product that allows team members to leave internal annotations on shared inbox messages. Comments are visible only inside the team and must never reach an external sender. It is built in isolation and is not wired into the main application yet.
+
+## 1. Module: Types (shared contracts)
+
+Location: `types/` (for example, `types/index.ts`).
+
+Responsibility: declares the shared TypeScript interfaces used across the tool. Owns no logic and imports nothing.
+
+Public API:
+
+    export type CommentTarget =
+      | { kind: "message"; id: string }
+      | { kind: "thread"; id: string };
+
+    export interface InternalComment {
+      id: string;
+      target: CommentTarget;
+      author: string;        // Stealth address of team member
+      body: string;
+      createdAt: string;
+      updatedAt?: string;
+    }
+
+    export interface CommentResult {
+      comment: InternalComment;
+    }
+
+    export interface ListCommentsResult {
+      comments: InternalComment[];
+    }
+
+Dependencies: no imports from `components/`, `services/`, `hooks/`, or the main application.
+
+## 2. Module: Services (business logic)
+
+Location: `services/` (for example, `services/comment.service.ts`).
+
+Responsibility: encapsulates all framework-free logic — target resolution, comment creation, ownership checks, and list filtering. Services never import React and never reach outside this folder. They must enforce the team-only visibility rule in every operation.
+
+Public API:
+
+    export function createCommentService(): {
+      addComment: (
+        target: CommentTarget,
+        body: string,
+        author: string,
+      ) => InternalComment;
+      listComments: (target: CommentTarget) => InternalComment[];
+      updateComment: (
+        id: string,
+        newBody: string,
+        author: string,
+      ) => InternalComment;
+      deleteComment: (id: string, author: string) => void;
+    };
+
+Dependencies:
+
+- Allowed to import: TypeScript types from `../types/`.
+- Forbidden: React or hooks, presentational components, main app stores or APIs, and any code that could serialize comment body for external delivery.
+
+## 3. Module: Hooks (React integration)
+
+Location: `hooks/` (for example, `hooks/use-internal-comments.ts`).
+
+Responsibility: synchronizes the service with React components, managing the current target, the list of comments, authoring state, and error/loading state. Hooks must never allow comment data to escape into any external rendering or delivery path.
+
+Public API:
+
+    export function useInternalComments(target: CommentTarget): {
+      comments: InternalComment[];
+      add: (body: string) => void;
+      update: (id: string, newBody: string) => void;
+      remove: (id: string) => void;
+      isLoading: boolean;
+      error: string | null;
+    };
+
+Dependencies:
+
+- Allowed to import: React hooks, the service factory from `../services/`, and types from `../types/`.
+- Forbidden: presentational components and core app state contexts.
+
+## 4. Module: Components (user interface)
+
+Location: `components/`.
+
+Responsibility: renders the visual elements of the tool (comment list, composer, edit/delete controls). Components stay presentational and delegate all actions to the hook. They must never render or log comment content in a way that could be captured by external sender flows.
+
+Public API:
+
+    // InternalCommentList.tsx
+    export const InternalCommentList: React.FC<{
+      target: CommentTarget;
+    }>;
+
+    // InternalCommentComposer.tsx
+    export const InternalCommentComposer: React.FC<{
+      onSubmit: (body: string) => void;
+    }>;
+
+    // InternalCommentThread.tsx
+    export const InternalCommentThread: React.FC<{
+      target: CommentTarget;
+    }>;
+
+Dependencies:
+
+- Allowed to import: hooks from `../hooks/`, types from `../types/`, and external presentational assets such as icons.
+- Forbidden: core app features, layout navigation, or importing service functions directly.
+
+## Import rules checklist
+
+- [ ] Only import from files inside `tools/v1/team/internal-comment-thread/`.
+- [ ] Maintain a one-way dependency flow: components -> hooks -> services -> types.
+- [ ] No circular dependencies.
+- [ ] All shared interfaces are imported from `types/`.
+- [ ] No path may ever allow comment body text to be included in any output intended for an external sender.

--- a/tools/v1/team/internal-comment-thread/README.md
+++ b/tools/v1/team/internal-comment-thread/README.md
@@ -1,15 +1,77 @@
 # Internal Comment Thread
 
-This folder is the isolated workspace for the Internal Comment Thread tool.
+Team-only internal annotations attached to messages in a shared inbox. Comments are visible exclusively to authorized team members and are never exposed to or delivered to the external sender under any circumstances.
 
-## Ownership Boundary
+---
 
-All work for this tool must stay inside:
+## Purpose
 
-`text
-.\tools\v1\team\internal-comment-thread\
-`
+Support and operations teams need a private channel to discuss context, next steps, known issues, and internal decisions about incoming messages without leaking any of that information back to the customer or external sender. This tool provides that isolated comment surface on top of Stealth's shared inbox primitives.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+## Audience
 
-See specs.md for the issue categories and contributor expectations.
+- Teams operating shared support, ops, or community inboxes.
+- OSS contributors implementing team collaboration features on the Stealth protocol.
+- Maintainers who need audit trails of internal discussion that never leaves the team boundary.
+
+## Setup
+
+See [docs/setup.md](./docs/setup.md) for full instructions.
+
+Quick start:
+
+```bash
+cd tools/v1/team/internal-comment-thread
+bun install
+bun dev
+```
+
+Configuration is through environment variables or a `.env` file in the tool root (see `docs/setup.md`).
+
+## Usage
+
+### Core workflows
+
+1. **View message context** — Open a shared inbox message.
+2. **Add internal comment** — Write a note visible only to the team.
+3. **Browse team comments** — See all prior internal discussion on the same message/thread.
+4. **Edit or delete own comments** — Subject to team policy (future).
+5. **Never leak to sender** — No code path may include comment content in any reply, forward, or external notification.
+
+### Example workflow
+
+```
+1. customer@example.com sends a message to support@stealth.xyz
+2. The shared inbox surfaces the message for the team
+3. Alice (team) adds internal comment: "Customer is on the old plan, see ticket #3192"
+4. Bob (team) sees the comment, replies to customer using the shared identity
+5. The external sender never sees Alice's or Bob's internal note
+```
+
+## Fixture Expectations
+
+When testing, fixtures should cover:
+
+- **Messages** — Sender address, subject, body, timestamp, delivery proof.
+- **Internal comments** — Author (Stealth address), body, timestamp, reference to source (message or thread).
+- **Visibility enforcement** — Every generated artifact must prove that comment text cannot reach an external address.
+- **Team roster** — List of authorized team Stealth addresses.
+
+## Known Limitations
+
+- Attachment scope (single message vs. whole thread) is undecided.
+- Reply structure (nested threads vs. flat list) is undecided.
+- No editing of other members' comments yet.
+- No @mentions or notifications inside the team.
+- No attachment of files or images to comments.
+- No search or filtering over comment history.
+- Ephemeral state by default (in-memory storage; restart loses data unless a durable adapter is connected).
+
+## OSS Review Notes
+
+- All work stays inside `tools/v1/team/internal-comment-thread/`.
+- Follow Stealth conventions: TypeScript, React (JSX), Prettier (100-char width, trailing commas).
+- Every feature change must update the test plan in `tests/README.md`.
+- Do not import from `src/` or from other tool folders.
+- **Firm rule**: comment content must never appear in any payload, header, or log that could be delivered to an external sender. This rule is non-negotiable for this tool.
+- Use Stealth protocol concepts (Stealth address, delivery proof) where applicable.

--- a/tools/v1/team/internal-comment-thread/components/.gitkeep
+++ b/tools/v1/team/internal-comment-thread/components/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/tools/v1/team/internal-comment-thread/docs/setup.md
+++ b/tools/v1/team/internal-comment-thread/docs/setup.md
@@ -23,13 +23,13 @@ cp .env.example .env
 
 ## Configuration
 
-| Variable                | Required | Description                                                |
-| ----------------------- | -------- | ---------------------------------------------------------- |
-| `STEALTH_API_URL`       | Yes      | Stealth relay API base URL (e.g., `http://localhost:8080`) |
-| `TEAM_ROSTER`           | Yes      | Comma-separated Stealth addresses of authorized team members |
-| `INTERNAL_COMMENT_STORAGE` | No    | Storage backend: `memory` (default) or `file`              |
-| `INTERNAL_COMMENT_DATA_DIR` | No  | Directory for file-based storage (defaults to `./data/`)   |
-| `LOG_LEVEL`             | No       | `debug`, `info`, `warn`, `error` (defaults to `info`)      |
+| Variable                    | Required | Description                                                  |
+| --------------------------- | -------- | ------------------------------------------------------------ |
+| `STEALTH_API_URL`           | Yes      | Stealth relay API base URL (e.g., `http://localhost:8080`)   |
+| `TEAM_ROSTER`               | Yes      | Comma-separated Stealth addresses of authorized team members |
+| `INTERNAL_COMMENT_STORAGE`  | No       | Storage backend: `memory` (default) or `file`                |
+| `INTERNAL_COMMENT_DATA_DIR` | No       | Directory for file-based storage (defaults to `./data/`)     |
+| `LOG_LEVEL`                 | No       | `debug`, `info`, `warn`, `error` (defaults to `info`)        |
 
 ## Running Locally
 
@@ -43,9 +43,9 @@ bun run lint     # Lint
 
 ## Troubleshooting
 
-| Problem                                    | Likely cause                                        | Fix                                                       |
-| ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------- |
-| Relay connection refused                   | Stealth dev server not running                      | Start from repo root: `bun run dev`                       |
-| No comments visible                        | Wrong team roster or no authorized members          | Verify `TEAM_ROSTER` contains the current test address    |
-| Identity resolution fails                  | Member addresses not registered with relay          | Confirm addresses in `TEAM_ROSTER`                        |
-| Changes not reflected after editing `.env` | Values read at startup                              | Restart the dev server                                    |
+| Problem                                    | Likely cause                               | Fix                                                    |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------ |
+| Relay connection refused                   | Stealth dev server not running             | Start from repo root: `bun run dev`                    |
+| No comments visible                        | Wrong team roster or no authorized members | Verify `TEAM_ROSTER` contains the current test address |
+| Identity resolution fails                  | Member addresses not registered with relay | Confirm addresses in `TEAM_ROSTER`                     |
+| Changes not reflected after editing `.env` | Values read at startup                     | Restart the dev server                                 |

--- a/tools/v1/team/internal-comment-thread/docs/setup.md
+++ b/tools/v1/team/internal-comment-thread/docs/setup.md
@@ -1,0 +1,51 @@
+# Setup Guide
+
+## Prerequisites
+
+| Tool                    | Version | Purpose                           |
+| ----------------------- | ------- | --------------------------------- |
+| Node.js                 | 20+     | JavaScript runtime                |
+| Bun                     | 1.1+    | Package manager and dev server    |
+| Stealth dev environment | latest  | Relay API, Stellar testnet access |
+
+## Local Setup
+
+```bash
+cd tools/v1/team/internal-comment-thread
+bun install
+```
+
+Copy and edit the environment file:
+
+```bash
+cp .env.example .env
+```
+
+## Configuration
+
+| Variable                | Required | Description                                                |
+| ----------------------- | -------- | ---------------------------------------------------------- |
+| `STEALTH_API_URL`       | Yes      | Stealth relay API base URL (e.g., `http://localhost:8080`) |
+| `TEAM_ROSTER`           | Yes      | Comma-separated Stealth addresses of authorized team members |
+| `INTERNAL_COMMENT_STORAGE` | No    | Storage backend: `memory` (default) or `file`              |
+| `INTERNAL_COMMENT_DATA_DIR` | No  | Directory for file-based storage (defaults to `./data/`)   |
+| `LOG_LEVEL`             | No       | `debug`, `info`, `warn`, `error` (defaults to `info`)      |
+
+## Running Locally
+
+```bash
+bun dev          # Development server with hot reload
+bun run build    # Production build
+bun run preview  # Preview production build
+bun test         # Run tests
+bun run lint     # Lint
+```
+
+## Troubleshooting
+
+| Problem                                    | Likely cause                                        | Fix                                                       |
+| ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------- |
+| Relay connection refused                   | Stealth dev server not running                      | Start from repo root: `bun run dev`                       |
+| No comments visible                        | Wrong team roster or no authorized members          | Verify `TEAM_ROSTER` contains the current test address    |
+| Identity resolution fails                  | Member addresses not registered with relay          | Confirm addresses in `TEAM_ROSTER`                        |
+| Changes not reflected after editing `.env` | Values read at startup                              | Restart the dev server                                    |

--- a/tools/v1/team/internal-comment-thread/hooks/.gitkeep
+++ b/tools/v1/team/internal-comment-thread/hooks/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/tools/v1/team/internal-comment-thread/services/.gitkeep
+++ b/tools/v1/team/internal-comment-thread/services/.gitkeep
@@ -1,0 +1,1 @@
+# gitkeep

--- a/tools/v1/team/internal-comment-thread/specs.md
+++ b/tools/v1/team/internal-comment-thread/specs.md
@@ -49,14 +49,12 @@ Do not import from `src/`, `tools/v2/`, or sibling tool folders. Do not modify t
 
 ```ts
 // Message or thread reference (exact shape undecided — see Open Questions)
-type CommentTarget =
-  | { kind: "message"; id: string }
-  | { kind: "thread"; id: string };
+type CommentTarget = { kind: "message"; id: string } | { kind: "thread"; id: string };
 
 interface InternalComment {
   id: string;
   target: CommentTarget;
-  author: string;           // Stealth address of team member
+  author: string; // Stealth address of team member
   body: string;
   createdAt: string;
   updatedAt?: string;

--- a/tools/v1/team/internal-comment-thread/specs.md
+++ b/tools/v1/team/internal-comment-thread/specs.md
@@ -1,41 +1,83 @@
-# Internal Comment Thread
+# Internal Comment Thread — Specification
 
-Internal collaboration notes.
+Team-only internal annotations for shared inbox messages. Comments are never visible to or delivered to the external sender.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Accept a reference to a message (or thread) in a shared inbox.
+- Allow an authorized team member to attach a text comment that is stored with author identity, timestamp, and visibility flag.
+- Surface all comments on that reference exclusively to other members of the same team.
+- Enforce at every layer that comment content cannot leak into any reply, forward, notification, or external delivery path.
+- Support basic CRUD for comments owned by the current team member (create, read own, update own, delete own).
+- Persist state via a swappable storage adapter (in-memory reference implementation).
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+## Non-goals
 
-Recommended internal structure:
+- Exposing comments to external senders under any code path.
+- Attaching comments to external messages or non-shared inboxes.
+- Rich formatting, attachments, or embeds inside comments.
+- @mentions or push notifications inside the team (future).
+- Role-based permissions beyond flat team membership.
+- Search or full-text indexing over comment history.
+- Editing or deleting other members' comments.
 
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/internal-comment-thread/README.md"
-  @"
+## Architecture Overview
 
-# Internal Comment Thread Specs
+The tool follows a layered pattern: UI components call hooks that delegate to services, which use a storage adapter (interface-based, swappable). The storage layer defaults to in-memory. The tool depends on the Stealth protocol for team identity and message reference but does not depend on the main application's routing, mail rendering engine, wallet core, or design system.
 
-## Purpose
+**Firm rule (non-negotiable):** No code path may ever include comment body text in any payload, header, log, or delivery that could reach an external sender address.
 
-Internal collaboration notes.
+## Ownership Boundary
 
-## Contributor boundary
+All source code, tests, documentation, fixtures, and configuration live under:
 
-All work for this tool should stay in:
+```
+tools/v1/team/internal-comment-thread/
+```
 
-$dir/
+Do not import from `src/`, `tools/v2/`, or sibling tool folders. Do not modify the main application's router, mail engine, or design system. Do not add dependencies to the root `package.json` — use a local `package.json` if needed.
 
-## Required issue categories
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Core Contracts (to be implemented)
+
+```ts
+// Message or thread reference (exact shape undecided — see Open Questions)
+type CommentTarget =
+  | { kind: "message"; id: string }
+  | { kind: "thread"; id: string };
+
+interface InternalComment {
+  id: string;
+  target: CommentTarget;
+  author: string;           // Stealth address of team member
+  body: string;
+  createdAt: string;
+  updatedAt?: string;
+  // visibility is implicitly team-only; never serialized for external delivery
+}
+
+interface CommentService {
+  addComment(target: CommentTarget, body: string, author: string): InternalComment;
+  listComments(target: CommentTarget): InternalComment[];
+  updateComment(id: string, newBody: string, author: string): InternalComment;
+  deleteComment(id: string, author: string): void;
+}
+```
+
+## Open Questions
+
+- **Attachment scope**: Should a comment attach to a single message or to an entire thread? The architecture must not preclude either model.
+- **Reply structure**: Should comments support nested replies (tree) or remain a flat list per target? The data model and UI contracts should remain flexible until this is decided.
+
+## Out of Scope (until future integration issues)
+
+- Wiring into the main mail app shell or shared inbox UI.
+- Persisting comments to a durable team store (current default is in-memory only).
+- Any delivery or rendering path that could make comment text visible outside the team boundary.

--- a/tools/v1/team/internal-comment-thread/tests/README.md
+++ b/tools/v1/team/internal-comment-thread/tests/README.md
@@ -8,11 +8,11 @@ Folder-local test strategy for the Internal Comment Thread tool.
 
 ## Test Strategy
 
-| Layer           | Scope                                                           | Framework        |
-| --------------- | --------------------------------------------------------------- | ---------------- |
-| **Unit**        | Services, storage adapters, and utility functions in isolation  | Vitest           |
+| Layer           | Scope                                                            | Framework        |
+| --------------- | ---------------------------------------------------------------- | ---------------- |
+| **Unit**        | Services, storage adapters, and utility functions in isolation   | Vitest           |
 | **Integration** | Multi-step comment workflows using the in-memory storage adapter | Vitest           |
-| **Manual**      | UI behavior, visual regression, accessibility, end-to-end flows | Review checklist |
+| **Manual**      | UI behavior, visual regression, accessibility, end-to-end flows  | Review checklist |
 
 ---
 

--- a/tools/v1/team/internal-comment-thread/tests/README.md
+++ b/tools/v1/team/internal-comment-thread/tests/README.md
@@ -1,0 +1,151 @@
+# Test Plan
+
+Folder-local test strategy for the Internal Comment Thread tool.
+
+> Tests will be written as `.test.ts` files alongside the source implementation. This document defines the plan and coverage expectations.
+
+---
+
+## Test Strategy
+
+| Layer           | Scope                                                           | Framework        |
+| --------------- | --------------------------------------------------------------- | ---------------- |
+| **Unit**        | Services, storage adapters, and utility functions in isolation  | Vitest           |
+| **Integration** | Multi-step comment workflows using the in-memory storage adapter | Vitest           |
+| **Manual**      | UI behavior, visual regression, accessibility, end-to-end flows | Review checklist |
+
+---
+
+## Unit Test Scenarios
+
+### Comment creation
+
+- Valid team member can add a comment on a valid target.
+- Comment is stored with correct author, body, createdAt, and target reference.
+- Adding a comment with empty body is rejected.
+- Adding a comment for a target the author is not authorized to see is rejected.
+
+### Listing comments
+
+- `listComments` returns only comments for the requested target.
+- Comments from different targets are never mixed.
+- Deleted comments are excluded from the list (or clearly marked).
+
+### Ownership and mutation
+
+- Author can update their own comment body.
+- Update by a different author is rejected.
+- Author can delete their own comment.
+- Delete by a different author is rejected.
+- Non-existent comment id returns appropriate error.
+
+### Target handling (supports both models until decided)
+
+- Comments can be created and listed using a `message` target.
+- Comments can be created and listed using a `thread` target.
+- Same author can have comments on both a message and its containing thread without collision.
+
+### Storage adapter
+
+- Round-trip: create a comment, retrieve it by target.
+- Get for unknown target returns empty list.
+- Delete removes the entry; subsequent list no longer contains it.
+- Fresh store returns empty list for any target.
+
+### Team-only visibility enforcement (firm rule)
+
+- No serialization path includes comment body in any structure intended for external delivery.
+- Attempting to construct an external-facing payload containing a comment body fails the test.
+
+---
+
+## Integration Test Scenarios
+
+### Add-and-list workflow
+
+1. Alice (authorized team member) adds a comment on message M1.
+2. Bob (authorized) lists comments for M1.
+3. Verify: both see Alice's comment; comment contains correct author and body.
+4. Verify: the comment body never appears in any simulated external reply payload.
+
+### Multi-author thread
+
+1. Alice adds comment C1 on thread T1.
+2. Bob adds comment C2 on the same thread T1.
+3. Carol lists comments for T1.
+4. Verify: list contains both C1 and C2 in creation order; each has correct author.
+
+### Update and delete
+
+1. Alice adds a comment.
+2. Alice updates the body.
+3. Verify: list shows the updated body and updatedAt timestamp.
+4. Alice deletes the comment.
+5. Verify: list no longer contains the comment.
+
+### Cross-target isolation
+
+1. Alice comments on message M1.
+2. Alice comments on thread T1 (that contains M1).
+3. List for M1 returns only the message-level comment.
+4. List for T1 returns only the thread-level comment.
+
+### Unauthorized access
+
+1. Eve (not in team roster) attempts to add a comment.
+2. Verify: operation is rejected at service level.
+3. Verify: no comment record is created.
+
+---
+
+## Manual Review Checklist
+
+### Comment list
+
+- [ ] Comments appear in chronological order (or reverse, per spec).
+- [ ] Each comment displays author (Stealth address or display name), body, and timestamp.
+- [ ] Only the current user's comments show edit/delete controls.
+
+### Composer
+
+- [ ] Composer accepts multi-line input.
+- [ ] Submit (Enter / button) creates the comment and clears the input.
+- [ ] Empty body is rejected with clear feedback.
+- [ ] Comment appears immediately in the list after submit.
+
+### Ownership
+
+- [ ] Editing own comment updates the list in place.
+- [ ] Deleting own comment removes it from the list (or marks as deleted).
+- [ ] Attempting to edit/delete another user's comment is not possible in UI.
+
+### Target scope (flexible for open question)
+
+- [ ] UI can render comments for a message target.
+- [ ] UI can render comments for a thread target.
+- [ ] Switching targets shows the correct isolated comment set.
+
+### Team-only visibility (firm rule — must pass)
+
+- [ ] No comment body text is rendered, logged, or exported in any simulated external-sender view.
+- [ ] Review of any generated payload or log for external paths shows zero comment content.
+- [ ] All fixtures and test data remain strictly internal.
+
+### Accessibility
+
+- [ ] Comment list is keyboard navigable.
+- [ ] Composer has proper labels and ARIA attributes.
+- [ ] Delete actions have confirmation and are not the only way to understand state.
+
+---
+
+## Validation Steps for OSS Contributors
+
+Before opening a pull request:
+
+1. **`bun test`** — all tests pass.
+2. **`bun run tsc --noEmit`** — zero type errors.
+3. **`bun run lint`** — zero warnings.
+4. **All new files under `tools/v1/team/internal-comment-thread/`** — verify with `git diff --name-only`.
+5. **Test plan updated** — new features add or update scenarios in this file.
+6. **Firm rule validation** — manual inspection confirms no comment body can reach an external sender path in any new code.


### PR DESCRIPTION
Closes #439

Folder-local architecture contract for the Internal Comment Thread tool,
scoped entirely to tools/v1/team/internal-comment-thread/.

README.md and specs.md were broken before this PR, same PowerShell
template leftover bug as the other scaffolded folders. Rewrote both.

Followed shared-team-inbox's structure since it's the closest tier match
(V1 team tool). Also added MODULE_BOUNDARIES.md, DATA_OWNERSHIP.md, and
INTEGRATION_CONSTRAINTS.md following contact-extractor's three-file split,
with real TypeScript contracts for CommentTarget, InternalComment, and
the comment service shape.

Two things are left as open questions in specs.md on purpose: whether
comments attach to a single message or a whole thread, and whether
replies are nested or flat. Didn't want to lock either in at the
architecture stage.

One thing is locked in as a firm rule everywhere: comment content can
never reach an external sender, under any code path. That rule shows up
in every doc and the test plan is written to validate it regardless of
how the two open questions get resolved later.

No code, just docs and folder structure. components/services/hooks have
.gitkeep placeholders for the future implementation.