### PR TITLE
feat(demo-admin-dashboard): add scenario registry and loader

### DIFF
--- a/src/features/demo-admin-dashboard/docs/SCENARIO_REGISTRY.md
+++ b/src/features/demo-admin-dashboard/docs/SCENARIO_REGISTRY.md
@@ -1,0 +1,34 @@
+# Scenario Registry and Loader
+
+This module lets the demo admin dashboard load individual demo scenarios into
+the compose draft state. It is part of the Demo Admin Dashboard initiative
+(issue #216) and stays fully inside `src/features/demo-admin-dashboard/`.
+
+## Concepts
+
+- `DemoScenario` — a self-contained, fake, deterministic scenario that carries
+  a ready-to-load `Draft` (`id`, `subject`, `body`, `recipients`).
+- `ScenarioRegistry` — a read-only lookup created from a list of scenarios,
+  exposing `list()`, `get(id)`, and `has(id)`.
+- `ScenarioLoadMode` — `replace` or `merge`.
+
+## Usage
+
+Create a registry with the built-in `demoScenarios` or your own list:
+
+- `createScenarioRegistry()` returns a registry over the built-in scenarios.
+- `createScenarioRegistry(custom)` returns a registry over `custom`. When two
+  scenarios share an id, the later entry wins, keeping the result deterministic.
+
+Load a scenario into the current draft with `loadScenarioIntoDraft`:
+
+- replace — returns a fresh copy of the scenario draft and ignores the current
+  draft. This is also used automatically when there is no current draft.
+- merge — keeps the current draft `id`, overlays the scenario `subject` and
+  `body` when they are non-empty, and unions `recipients` without duplicates.
+
+## Safety
+
+All scenario data must remain fake and safe for public review. Email addresses
+use `@example.com`, `@example.org`, or `*.stealth.demo`. No real PII, secrets,
+or live network calls are included.

--- a/src/features/demo-admin-dashboard/helpers/scenarioRegistry.test.ts
+++ b/src/features/demo-admin-dashboard/helpers/scenarioRegistry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { Draft } from "../types/draft";
+import { createScenarioRegistry, demoScenarios, loadScenarioIntoDraft } from "./scenarioRegistry";
+
+describe("createScenarioRegistry", () => {
+  it("lists all provided scenarios", () => {
+    const registry = createScenarioRegistry();
+    expect(registry.list()).toHaveLength(demoScenarios.length);
+  });
+
+  it("looks up scenarios by id", () => {
+    const registry = createScenarioRegistry();
+    const first = demoScenarios[0];
+    expect(registry.get(first.id)?.name).toBe(first.name);
+    expect(registry.has(first.id)).toBe(true);
+    expect(registry.has("missing")).toBe(false);
+  });
+
+  it("keeps the last entry when ids are duplicated", () => {
+    const registry = createScenarioRegistry([
+      {
+        id: "dup",
+        name: "First",
+        description: "first",
+        draft: { id: "d1", subject: "s1", body: "b1", recipients: [] },
+      },
+      {
+        id: "dup",
+        name: "Second",
+        description: "second",
+        draft: { id: "d2", subject: "s2", body: "b2", recipients: [] },
+      },
+    ]);
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.get("dup")?.name).toBe("Second");
+  });
+});
+
+describe("loadScenarioIntoDraft", () => {
+  const scenario = {
+    id: "scenario-test",
+    name: "Test",
+    description: "test",
+    draft: {
+      id: "draft-test",
+      subject: "Scenario subject",
+      body: "Scenario body",
+      recipients: ["new@example.com"],
+    },
+  };
+
+  it("replaces the current draft when mode is replace", () => {
+    const current: Draft = {
+      id: "existing",
+      subject: "Old",
+      body: "Old body",
+      recipients: ["old@example.com"],
+    };
+    const result = loadScenarioIntoDraft(current, scenario, "replace");
+    expect(result.id).toBe("draft-test");
+    expect(result.recipients).toEqual(["new@example.com"]);
+  });
+
+  it("replaces when there is no current draft, even in merge mode", () => {
+    const result = loadScenarioIntoDraft(null, scenario, "merge");
+    expect(result.id).toBe("draft-test");
+  });
+
+  it("merges recipients without duplicates and keeps the current id", () => {
+    const current: Draft = {
+      id: "existing",
+      subject: "Old",
+      body: "Old body",
+      recipients: ["old@example.com", "new@example.com"],
+    };
+    const result = loadScenarioIntoDraft(current, scenario, "merge");
+    expect(result.id).toBe("existing");
+    expect(result.subject).toBe("Scenario subject");
+    expect(result.recipients).toEqual(["old@example.com", "new@example.com"]);
+  });
+});

--- a/src/features/demo-admin-dashboard/helpers/scenarioRegistry.ts
+++ b/src/features/demo-admin-dashboard/helpers/scenarioRegistry.ts
@@ -1,0 +1,87 @@
+import type { Draft } from "../types/draft";
+import type { DemoScenario, ScenarioLoadMode, ScenarioRegistry } from "../types/scenario";
+
+/**
+ * Built-in demo scenarios. All data is fake, deterministic, and safe for
+ * public repository review (addresses use example.com / *.stealth.demo).
+ */
+export const demoScenarios: DemoScenario[] = [
+  {
+    id: "scenario-welcome",
+    name: "Welcome announcement",
+    description: "A short welcome message for the demo community list.",
+    draft: {
+      id: "draft-scenario-welcome",
+      subject: "Welcome to the Stellar Mail demo",
+      body: "Thanks for trying the demo. Explore the dashboard to populate sample data.",
+      recipients: ["community@example.com"],
+    },
+  },
+  {
+    id: "scenario-protocol-update",
+    name: "Protocol update notice",
+    description: "Notifies demo recipients about an upcoming protocol change.",
+    draft: {
+      id: "draft-scenario-protocol-update",
+      subject: "Upcoming protocol update",
+      body: "A demo protocol upgrade is scheduled. No action is required for this sample.",
+      recipients: ["ops@example.org", "updates@stealth.demo"],
+    },
+  },
+];
+
+/**
+ * Creates a read-only scenario registry from the provided scenarios.
+ * Later entries with a duplicate id override earlier ones, keeping the
+ * registry deterministic.
+ */
+export function createScenarioRegistry(
+  scenarios: DemoScenario[] = demoScenarios,
+): ScenarioRegistry {
+  const byId = new Map<string, DemoScenario>();
+  for (const scenario of scenarios) {
+    byId.set(scenario.id, scenario);
+  }
+
+  return {
+    list: () => Array.from(byId.values()),
+    get: (id: string) => byId.get(id),
+    has: (id: string) => byId.has(id),
+  };
+}
+
+/**
+ * Loads a scenario's draft into the current draft state.
+ *
+ * - "replace" returns a copy of the scenario draft, ignoring the current draft.
+ * - "merge" keeps the current draft id and overlays the scenario's non-empty
+ *   fields, unioning recipients without duplicates.
+ */
+export function loadScenarioIntoDraft(
+  current: Draft | null,
+  scenario: DemoScenario,
+  mode: ScenarioLoadMode = "replace",
+): Draft {
+  if (mode === "replace" || current === null) {
+    return {
+      id: scenario.draft.id,
+      subject: scenario.draft.subject,
+      body: scenario.draft.body,
+      recipients: [...scenario.draft.recipients],
+    };
+  }
+
+  const mergedRecipients = [...current.recipients];
+  for (const recipient of scenario.draft.recipients) {
+    if (!mergedRecipients.includes(recipient)) {
+      mergedRecipients.push(recipient);
+    }
+  }
+
+  return {
+    id: current.id,
+    subject: scenario.draft.subject || current.subject,
+    body: scenario.draft.body || current.body,
+    recipients: mergedRecipients,
+  };
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -476,3 +476,11 @@ export { LabelManager } from "./labels/LabelManager";
 // Draft dataset JSON import (issue #272): JSON -> safe drafts mapper with error output.
 export { mapImportedDataset, parseDatasetImport } from "./helpers/datasetImport";
 export type { DatasetImportIssue, DatasetImportResult } from "./types/datasetImport";
+
+// Scenario registry and loader (issue #216): load demo scenarios into draft state.
+export {
+  createScenarioRegistry,
+  demoScenarios,
+  loadScenarioIntoDraft,
+} from "./helpers/scenarioRegistry";
+export type { DemoScenario, ScenarioLoadMode, ScenarioRegistry } from "./types/scenario";

--- a/src/features/demo-admin-dashboard/types/scenario.ts
+++ b/src/features/demo-admin-dashboard/types/scenario.ts
@@ -1,0 +1,28 @@
+import type { Draft } from "./draft";
+
+/**
+ * Controls how a scenario's draft is applied to the current draft state.
+ * - "replace": discard the current draft and load the scenario draft as-is.
+ * - "merge": keep the current draft and overlay the scenario's fields.
+ */
+export type ScenarioLoadMode = "replace" | "merge";
+
+/**
+ * A self-contained demo scenario that can be loaded into the compose draft.
+ * All scenario data must stay fake, deterministic, and safe for public review.
+ */
+export interface DemoScenario {
+  id: string;
+  name: string;
+  description: string;
+  draft: Draft;
+}
+
+/**
+ * Read-only registry of demo scenarios keyed by id.
+ */
+export interface ScenarioRegistry {
+  list(): DemoScenario[];
+  get(id: string): DemoScenario | undefined;
+  has(id: string): boolean;
+}


### PR DESCRIPTION
Adds a read-only scenario registry and a loader that applies demo scenarios to the compose draft state, supporting replace and merge modes. All changes are scoped to src/features/demo-admin-dashboard/.

Closes #216