### PR TITLE
feat(demo-admin-dashboard): add validation quick-fix framework

### DIFF
--- a/src/features/demo-admin-dashboard/docs/QUICK_FIX_FRAMEWORK.md
+++ b/src/features/demo-admin-dashboard/docs/QUICK_FIX_FRAMEWORK.md
@@ -1,0 +1,37 @@
+# Validation Quick-Fix Framework
+
+This module provides safe, one-click fixes for the most common demo-data
+validation issues produced by `validateCampaignDrafts`. It is part of the Demo
+Admin Dashboard initiative (issue #221) and stays fully inside
+`src/features/demo-admin-dashboard/`.
+
+## Concepts
+
+- `QuickFix` — a safe, deterministic repair with a `kind`, a button `label`,
+  and an `apply(draft, issue)` function that returns a new `Draft`.
+- `QuickFixRegistry` — a read-only lookup exposing `list()`, `get(kind)`, and
+  `resolve(issue)`.
+- `QuickFixApplication` — the result of `applyQuickFix`: whether a fix was
+  applied, the resulting drafts, and the fix that ran.
+
+## Supported fixes
+
+- `fill-subject` — sets a placeholder subject when the subject is empty.
+- `fill-body` — sets a placeholder body when the body is empty.
+- `add-recipient` — adds a safe demo recipient when the list is empty.
+- `replace-unsafe-recipient` — rewrites an invalid or unsafe recipient to a
+  safe example.com address, keeping the local part where possible.
+
+## Usage
+
+- `quickFixKindForIssue(issue)` maps a `ValidationIssue` id to a fix kind.
+- `createQuickFixRegistry()` builds a registry from the built-in fixes;
+  `defaultQuickFixRegistry` is a ready-made instance.
+- `applyQuickFix(drafts, issue, registry?)` resolves the matching fix, applies
+  it to the draft named by `issue.recordId`, and returns a new drafts array.
+  The input is never mutated.
+
+## Safety
+
+All fixes produce fake, deterministic, review-safe values. Addresses always use
+example.com. No real PII, secrets, or live network calls are introduced.

--- a/src/features/demo-admin-dashboard/helpers/quickFixRegistry.test.ts
+++ b/src/features/demo-admin-dashboard/helpers/quickFixRegistry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { Draft } from "../types/draft";
+import type { ValidationIssue } from "../validation-types";
+import {
+  SAFE_BODY,
+  SAFE_RECIPIENT,
+  SAFE_SUBJECT,
+  applyQuickFix,
+  createQuickFixRegistry,
+  quickFixKindForIssue,
+  toSafeRecipient,
+} from "./quickFixRegistry";
+
+function issue(overrides: Partial<ValidationIssue>): ValidationIssue {
+  return {
+    id: "draft-d1-subject-empty",
+    severity: "error",
+    fieldPath: "drafts[0].subject",
+    message: "Subject is required for draft message.",
+    datasetId: "campaign-drafts",
+    recordId: "d1",
+    ...overrides,
+  };
+}
+
+const baseDraft: Draft = {
+  id: "d1",
+  subject: "",
+  body: "",
+  recipients: [],
+};
+
+describe("quickFixKindForIssue", () => {
+  it("maps issue ids to fix kinds", () => {
+    expect(quickFixKindForIssue(issue({ id: "draft-d1-subject-empty" }))).toBe("fill-subject");
+    expect(quickFixKindForIssue(issue({ id: "draft-d1-body-empty" }))).toBe("fill-body");
+    expect(quickFixKindForIssue(issue({ id: "draft-d1-recipients-empty" }))).toBe("add-recipient");
+    expect(quickFixKindForIssue(issue({ id: "draft-d1-recipient-0-unsafe-domain" }))).toBe(
+      "replace-unsafe-recipient",
+    );
+  });
+
+  it("returns undefined for unknown issues", () => {
+    expect(quickFixKindForIssue(issue({ id: "draft-d1-unknown" }))).toBeUndefined();
+  });
+});
+
+describe("toSafeRecipient", () => {
+  it("rewrites any address to a safe example.com address", () => {
+    expect(toSafeRecipient("alice@evil.com")).toBe("alice@example.com");
+    expect(toSafeRecipient("bob*federation")).toBe("bob@example.com");
+    expect(toSafeRecipient("   ")).toBe("demo@example.com");
+  });
+});
+
+describe("applyQuickFix", () => {
+  const registry = createQuickFixRegistry();
+
+  it("fills an empty subject without mutating the input", () => {
+    const result = applyQuickFix([baseDraft], issue({ id: "draft-d1-subject-empty" }), registry);
+    expect(result.applied).toBe(true);
+    expect(result.drafts[0].subject).toBe(SAFE_SUBJECT);
+    expect(baseDraft.subject).toBe("");
+  });
+
+  it("fills an empty body", () => {
+    const result = applyQuickFix([baseDraft], issue({ id: "draft-d1-body-empty" }), registry);
+    expect(result.drafts[0].body).toBe(SAFE_BODY);
+  });
+
+  it("adds a safe recipient when none exist", () => {
+    const result = applyQuickFix(
+      [baseDraft],
+      issue({
+        id: "draft-d1-recipients-empty",
+        fieldPath: "drafts[0].recipients",
+      }),
+      registry,
+    );
+    expect(result.drafts[0].recipients).toEqual([SAFE_RECIPIENT]);
+  });
+
+  it("replaces an unsafe recipient by index", () => {
+    const draft: Draft = {
+      id: "d1",
+      subject: "Hi",
+      body: "Body",
+      recipients: ["ok@example.com", "bad@evil.com"],
+    };
+    const result = applyQuickFix(
+      [draft],
+      issue({
+        id: "draft-d1-recipient-1-unsafe-domain",
+        fieldPath: "drafts[0].recipients[1]",
+        severity: "warning",
+      }),
+      registry,
+    );
+    expect(result.drafts[0].recipients).toEqual(["ok@example.com", "bad@example.com"]);
+  });
+
+  it("does nothing when no fix matches", () => {
+    const drafts = [baseDraft];
+    const result = applyQuickFix(drafts, issue({ id: "draft-d1-unknown" }), registry);
+    expect(result.applied).toBe(false);
+    expect(result.drafts).toBe(drafts);
+  });
+});

--- a/src/features/demo-admin-dashboard/helpers/quickFixRegistry.ts
+++ b/src/features/demo-admin-dashboard/helpers/quickFixRegistry.ts
@@ -1,0 +1,129 @@
+import type { Draft } from "../types/draft";
+import type {
+  QuickFix,
+  QuickFixApplication,
+  QuickFixKind,
+  QuickFixRegistry,
+} from "../types/quickFix";
+import type { ValidationIssue } from "../validation-types";
+
+/** Safe, deterministic placeholders used by the quick fixes. */
+export const SAFE_SUBJECT = "Untitled demo draft";
+export const SAFE_BODY = "Draft content pending review.";
+export const SAFE_RECIPIENT = "demo@example.com";
+
+/** Rewrite any address into a safe demo address on example.com. */
+export function toSafeRecipient(value: string): string {
+  const [rawLocal = ""] = value.trim().split(/[@*]/);
+  const localPart = rawLocal.replace(/[^a-zA-Z0-9._-]/g, "");
+  const safeLocal = localPart.length > 0 ? localPart : "demo";
+  return `${safeLocal.toLowerCase()}@example.com`;
+}
+
+function recipientIndexFromPath(fieldPath: string): number | null {
+  const match = fieldPath.match(/recipients\[(\d+)\]/);
+  if (!match) {
+    return null;
+  }
+  const raw = match[1];
+  if (raw === undefined) {
+    return null;
+  }
+  return Number(raw);
+}
+
+const QUICK_FIXES: QuickFix[] = [
+  {
+    kind: "fill-subject",
+    label: "Add placeholder subject",
+    apply: (draft) => ({ ...draft, subject: SAFE_SUBJECT }),
+  },
+  {
+    kind: "fill-body",
+    label: "Add placeholder body",
+    apply: (draft) => ({ ...draft, body: SAFE_BODY }),
+  },
+  {
+    kind: "add-recipient",
+    label: "Add safe demo recipient",
+    apply: (draft) =>
+      draft.recipients.length > 0 ? draft : { ...draft, recipients: [SAFE_RECIPIENT] },
+  },
+  {
+    kind: "replace-unsafe-recipient",
+    label: "Replace with safe demo address",
+    apply: (draft, issue) => {
+      const index = recipientIndexFromPath(issue.fieldPath);
+      if (index === null || index < 0 || index >= draft.recipients.length) {
+        return draft;
+      }
+      const recipients = draft.recipients.map((recipient, i) =>
+        i === index ? toSafeRecipient(recipient) : recipient,
+      );
+      return { ...draft, recipients };
+    },
+  },
+];
+
+/** Map a validation issue to the quick-fix kind that resolves it, if any. */
+export function quickFixKindForIssue(issue: ValidationIssue): QuickFixKind | undefined {
+  if (issue.id.endsWith("-subject-empty")) {
+    return "fill-subject";
+  }
+  if (issue.id.endsWith("-body-empty")) {
+    return "fill-body";
+  }
+  if (issue.id.endsWith("-recipients-empty")) {
+    return "add-recipient";
+  }
+  if (issue.id.includes("-unsafe-domain") || issue.id.includes("-invalid-format")) {
+    return "replace-unsafe-recipient";
+  }
+  return undefined;
+}
+
+/** Create a read-only quick-fix registry from the provided fixes. */
+export function createQuickFixRegistry(fixes: QuickFix[] = QUICK_FIXES): QuickFixRegistry {
+  const byKind = new Map<QuickFixKind, QuickFix>();
+  for (const fix of fixes) {
+    byKind.set(fix.kind, fix);
+  }
+
+  return {
+    list: () => Array.from(byKind.values()),
+    get: (kind) => byKind.get(kind),
+    resolve: (issue) => {
+      const kind = quickFixKindForIssue(issue);
+      return kind ? byKind.get(kind) : undefined;
+    },
+  };
+}
+
+/** The default registry built from the common fixes. */
+export const defaultQuickFixRegistry: QuickFixRegistry = createQuickFixRegistry();
+
+/**
+ * Apply the quick fix that matches `issue` to the matching draft in `drafts`.
+ * Returns a new drafts array and whether a fix was applied; never mutates input.
+ */
+export function applyQuickFix(
+  drafts: Draft[],
+  issue: ValidationIssue,
+  registry: QuickFixRegistry = defaultQuickFixRegistry,
+): QuickFixApplication {
+  const fix = registry.resolve(issue);
+  if (!fix || issue.recordId === undefined) {
+    return { applied: false, drafts };
+  }
+
+  let applied = false;
+  const next = drafts.map((draft) => {
+    if (draft.id !== issue.recordId) {
+      return draft;
+    }
+    applied = true;
+    return fix.apply(draft, issue);
+  });
+
+  return applied ? { applied, drafts: next, fix } : { applied: false, drafts };
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -476,3 +476,21 @@ export { LabelManager } from "./labels/LabelManager";
 // Draft dataset JSON import (issue #272): JSON -> safe drafts mapper with error output.
 export { mapImportedDataset, parseDatasetImport } from "./helpers/datasetImport";
 export type { DatasetImportIssue, DatasetImportResult } from "./types/datasetImport";
+
+// Validation quick-fix framework (issue #221): one-click fixes for demo-data validation issues.
+export {
+  applyQuickFix,
+  createQuickFixRegistry,
+  defaultQuickFixRegistry,
+  quickFixKindForIssue,
+  toSafeRecipient,
+  SAFE_BODY,
+  SAFE_RECIPIENT,
+  SAFE_SUBJECT,
+} from "./helpers/quickFixRegistry";
+export type {
+  QuickFix,
+  QuickFixApplication,
+  QuickFixKind,
+  QuickFixRegistry,
+} from "./types/quickFix";

--- a/src/features/demo-admin-dashboard/types/quickFix.ts
+++ b/src/features/demo-admin-dashboard/types/quickFix.ts
@@ -1,0 +1,35 @@
+import type { Draft } from "./draft";
+import type { ValidationIssue } from "../validation-types";
+
+/** The kinds of safe, one-click fixes the framework can apply. */
+export type QuickFixKind =
+  | "fill-subject"
+  | "fill-body"
+  | "add-recipient"
+  | "replace-unsafe-recipient";
+
+/**
+ * A safe, deterministic repair for a common demo-data validation issue.
+ * Each fix returns a new Draft and never mutates its input.
+ */
+export interface QuickFix {
+  kind: QuickFixKind;
+  /** Short label for the action button shown in the dashboard. */
+  label: string;
+  apply(draft: Draft, issue: ValidationIssue): Draft;
+}
+
+/** Read-only registry of quick fixes keyed by kind. */
+export interface QuickFixRegistry {
+  list(): QuickFix[];
+  get(kind: QuickFixKind): QuickFix | undefined;
+  /** Resolve the fix that matches a validation issue, if any. */
+  resolve(issue: ValidationIssue): QuickFix | undefined;
+}
+
+/** Outcome of attempting to apply a quick fix to a set of drafts. */
+export interface QuickFixApplication {
+  applied: boolean;
+  drafts: Draft[];
+  fix?: QuickFix;
+}


### PR DESCRIPTION
Adds a framework for safe, one-click fixes on common demo-data validation issues (empty subject, empty body, empty recipients, and unsafe recipient domains). Includes a QuickFix type, a registry, issue-to-fix mapping, and an applyQuickFix helper. All changes are scoped to src/features/demo-admin-dashboard/.

Closes #221 