### PR TITLE
perf(proof-inspector): trim render work and loading latency

### DIFF
--- a/src/components/mail/provenance.ts
+++ b/src/components/mail/provenance.ts
@@ -156,36 +156,38 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
           : "N/A",
       },
     ],
-    rawJson: JSON.stringify(
-      {
-        identifier: rawIdentity,
-        resolved_public_key: resolvedKey,
-        protocol: senderProvider,
-        verification_status: isVerified ? "SUCCESS" : "UNRESOLVED_SIGNATURE",
-        federation_metadata: rawIdentity.includes("*")
-          ? {
-              domain: rawIdentity.split("*")[1],
-              memo_type: "id",
-              stellar_address: resolvedKey,
-            }
-          : null,
-        verification_trace: [
-          {
-            step: 1,
-            action: "Lookup domain stellar.toml",
-            status: rawIdentity.includes("*") ? "OK" : "SKIP",
-          },
-          { step: 2, action: "Resolve account alias", status: "OK", result: resolvedKey },
-          {
-            step: 3,
-            action: "Validate cryptographic envelope signature",
-            status: isVerified ? "VALID" : "MISSING",
-          },
-        ],
-      },
-      null,
-      2,
-    ),
+    get rawJson() {
+      return JSON.stringify(
+        {
+          identifier: rawIdentity,
+          resolved_public_key: resolvedKey,
+          protocol: senderProvider,
+          verification_status: isVerified ? "SUCCESS" : "UNRESOLVED_SIGNATURE",
+          federation_metadata: rawIdentity.includes("*")
+            ? {
+                domain: rawIdentity.split("*")[1],
+                memo_type: "id",
+                stellar_address: resolvedKey,
+              }
+            : null,
+          verification_trace: [
+            {
+              step: 1,
+              action: "Lookup domain stellar.toml",
+              status: rawIdentity.includes("*") ? "OK" : "SKIP",
+            },
+            { step: 2, action: "Resolve account alias", status: "OK", result: resolvedKey },
+            {
+              step: 3,
+              action: "Validate cryptographic envelope signature",
+              status: isVerified ? "VALID" : "MISSING",
+            },
+          ],
+        },
+        null,
+        2,
+      );
+    },
   };
 
   // 2. Relay Source
@@ -210,22 +212,24 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
       { label: "Operator Signature", value: relaySignature, isCode: true },
       { label: "Processing Time", value: relayTimestamp },
     ],
-    rawJson: JSON.stringify(
-      {
-        relay_node_id: relayNodeId,
-        routing_domain: relayDomain,
-        node_signing_key: relayPubkey,
-        routing_signature: relaySignature,
-        timestamp: relayTimestamp,
-        relayed_metadata: {
-          latency_ms: 242,
-          ip_anonymized: "127.0.0.1 (VPN Loopback)",
-          protocol_version: "stealth-v1.4.2",
+    get rawJson() {
+      return JSON.stringify(
+        {
+          relay_node_id: relayNodeId,
+          routing_domain: relayDomain,
+          node_signing_key: relayPubkey,
+          routing_signature: relaySignature,
+          timestamp: relayTimestamp,
+          relayed_metadata: {
+            latency_ms: 242,
+            ip_anonymized: "127.0.0.1 (VPN Loopback)",
+            protocol_version: "stealth-v1.4.2",
+          },
         },
-      },
-      null,
-      2,
-    ),
+        null,
+        2,
+      );
+    },
   };
 
   // 3. Message Hash
@@ -241,24 +245,26 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
       { label: "Plaintext Hash Digest", value: rawMessageHash, isCode: true },
       { label: "Payload Size", value: `${sizeBytes} bytes` },
     ],
-    rawJson: JSON.stringify(
-      {
-        hash_algorithm: "SHA-256",
-        digest: rawMessageHash,
-        message_properties: {
-          length: email.body.length,
-          size_bytes: sizeBytes,
-          encoding: "UTF-8",
-          has_attachments: !!email.attachments?.length,
+    get rawJson() {
+      return JSON.stringify(
+        {
+          hash_algorithm: "SHA-256",
+          digest: rawMessageHash,
+          message_properties: {
+            length: email.body.length,
+            size_bytes: sizeBytes,
+            encoding: "UTF-8",
+            has_attachments: !!email.attachments?.length,
+          },
+          verification: {
+            recalculated_hash: rawMessageHash,
+            integrity_match: true,
+          },
         },
-        verification: {
-          recalculated_hash: rawMessageHash,
-          integrity_match: true,
-        },
-      },
-      null,
-      2,
-    ),
+        null,
+        2,
+      );
+    },
   };
 
   // 4. Payload Commitment
@@ -274,22 +280,24 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
       { label: "Commitment Hash", value: rawPayloadCommitment, isCode: true },
       { label: "Ephemeral Session Key", value: ephemeralKey, isCode: true },
     ],
-    rawJson: JSON.stringify(
-      {
-        envelope_type: "X25519-XSalsa20-Poly1305",
-        commitment_hash: rawPayloadCommitment,
-        session_keys: {
-          ephemeral_public_key: ephemeralKey,
-          recipient_identity_key: resolvedKey,
+    get rawJson() {
+      return JSON.stringify(
+        {
+          envelope_type: "X25519-XSalsa20-Poly1305",
+          commitment_hash: rawPayloadCommitment,
+          session_keys: {
+            ephemeral_public_key: ephemeralKey,
+            recipient_identity_key: resolvedKey,
+          },
+          sealed_box: {
+            nonce: getDeterministicHash(seed, "nonce", 48),
+            mac: getDeterministicHash(seed, "mac", 32),
+          },
         },
-        sealed_box: {
-          nonce: getDeterministicHash(seed, "nonce", 48),
-          mac: getDeterministicHash(seed, "mac", 32),
-        },
-      },
-      null,
-      2,
-    ),
+        null,
+        2,
+      );
+    },
   };
 
   // 5. Postage Record
@@ -316,22 +324,24 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
       { label: "Stellar Tx Hash", value: postageTxHash, isCode: true },
       { label: "Escrow Contract", value: postageEscrow, isCode: true },
     ],
-    rawJson: JSON.stringify(
-      {
-        ledger_entry_type: "postage_escrow",
-        postage_fee: postageAmount,
-        currency: "XLM",
-        status: postageStatus,
-        stellar_transaction: {
-          hash: postageTxHash,
-          ledger_sequence: 61200000 + (parseInt(seed) || 123),
-          source_account: resolvedKey,
-          escrow_contract_id: postageEscrow,
+    get rawJson() {
+      return JSON.stringify(
+        {
+          ledger_entry_type: "postage_escrow",
+          postage_fee: postageAmount,
+          currency: "XLM",
+          status: postageStatus,
+          stellar_transaction: {
+            hash: postageTxHash,
+            ledger_sequence: 61200000 + (parseInt(seed) || 123),
+            source_account: resolvedKey,
+            escrow_contract_id: postageEscrow,
+          },
         },
-      },
-      null,
-      2,
-    ),
+        null,
+        2,
+      );
+    },
   };
 
   // 6. Receipt Record
@@ -350,28 +360,30 @@ export function getEmailProvenance(email: Email): ProvenanceDetails {
       { label: "Soroban Resource Cost", value: "14,820 CPU Instructions" },
       { label: "Settlement Status", value: receiptStatus },
     ],
-    rawJson: JSON.stringify(
-      {
-        smart_contract: {
-          contract_id: receiptContract,
-          standard: "SRC-14 (Delivery Receipt)",
-          function: "verify_and_settle",
+    get rawJson() {
+      return JSON.stringify(
+        {
+          smart_contract: {
+            contract_id: receiptContract,
+            standard: "SRC-14 (Delivery Receipt)",
+            function: "verify_and_settle",
+          },
+          settlement_tx: receiptTxHash,
+          event: {
+            topic: "read_proof",
+            receipt_commitment: getDeterministicHash(seed, "receipt_commitment", 64),
+            recipient_signature: `sig_${getDeterministicHash(seed, "recipient_sig", 64)}`,
+          },
+          execution_cost: {
+            cpu_instructions: 14820,
+            rent_bump_fee_xlm: "0.00002",
+          },
+          status: receiptStatus,
         },
-        settlement_tx: receiptTxHash,
-        event: {
-          topic: "read_proof",
-          receipt_commitment: getDeterministicHash(seed, "receipt_commitment", 64),
-          recipient_signature: `sig_${getDeterministicHash(seed, "recipient_sig", 64)}`,
-        },
-        execution_cost: {
-          cpu_instructions: 14820,
-          rent_bump_fee_xlm: "0.00002",
-        },
-        status: receiptStatus,
-      },
-      null,
-      2,
-    ),
+        null,
+        2,
+      );
+    },
   };
 
   const receiptTimestamp = isSmtpBridge ? "Not requested" : "2026-06-16 14:58:22 UTC";

--- a/src/features/proof-inspector/ProofInspectorModal.tsx
+++ b/src/features/proof-inspector/ProofInspectorModal.tsx
@@ -46,6 +46,36 @@ interface MockProofRecord {
   email: Email;
 }
 
+const generateMockProofRecord = (email: Email): MockProofRecord => {
+  // Message ID SHA-256 mock
+  const messageHash = `0x${email.id.repeat(16).padEnd(64, "a")}d8c7e9`;
+  // Payment Preimage Hash mock
+  const paymentHash = `0x${(email.id + "pay").repeat(12).padEnd(64, "b")}f12a3d`;
+  // Relay diagnostic ID UUID
+  const diagnosticId = `d1f038c7-4b1d-44a6-8968-3e5f492305${email.id.padStart(2, "0")}`;
+  // Contract address
+  const contractAddress = `CB${email.id.repeat(10).toUpperCase().padEnd(54, "9")}`;
+
+  return {
+    emailId: email.id,
+    messageHash,
+    paymentHash,
+    diagnosticId,
+    contractAddress,
+    relayNode: "relay-us-east-1.stealth.network",
+    latency: `${20 + (email.from.length % 5) * 6}ms`,
+    signature: `Ed25519 [0x${email.id.repeat(8).padEnd(32, "7")}f31b]`,
+    deliveredAt:
+      email.time.includes("AM") || email.time.includes("PM") ? "Today, " + email.time : email.time,
+    readAt: email.unread ? null : "Delivered + Read",
+    postageAmount: email.postageAmount ?? "10000000",
+    postageStatus:
+      email.folder === "requests" ? "pending" : email.folder === "spam" ? "refunded" : "settled",
+    senderRule: email.senderPolicy === "verify" ? "default" : (email.senderPolicy ?? "default"),
+    email,
+  };
+};
+
 export function ProofInspectorModal({
   open,
   onClose,
@@ -56,6 +86,7 @@ export function ProofInspectorModal({
 }: ProofInspectorModalProps) {
   const [query, setQuery] = useState(initialQuery);
   const [hasSearched, setHasSearched] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
   const [validationMsg, setValidationMsg] = useState<{
     text: string;
     type: "success" | "warning" | "error" | null;
@@ -66,50 +97,18 @@ export function ProofInspectorModal({
     if (open) {
       setQuery(initialQuery);
       setHasSearched(!!initialQuery);
+      setIsSearching(false);
     } else {
       setQuery("");
       setHasSearched(false);
+      setIsSearching(false);
       setValidationMsg({ text: "", type: null });
     }
   }, [open, initialQuery]);
 
-  // Generate deterministic mock proof records for emails
-  const proofRecords = useMemo<MockProofRecord[]>(() => {
-    return emails.map((email) => {
-      // Message ID SHA-256 mock
-      const messageHash = `0x${email.id.repeat(16).padEnd(64, "a")}d8c7e9`;
-      // Payment Preimage Hash mock
-      const paymentHash = `0x${(email.id + "pay").repeat(12).padEnd(64, "b")}f12a3d`;
-      // Relay diagnostic ID UUID
-      const diagnosticId = `d1f038c7-4b1d-44a6-8968-3e5f492305${email.id.padStart(2, "0")}`;
-      // Contract address
-      const contractAddress = `CB${email.id.repeat(10).toUpperCase().padEnd(54, "9")}`;
-
-      return {
-        emailId: email.id,
-        messageHash,
-        paymentHash,
-        diagnosticId,
-        contractAddress,
-        relayNode: "relay-us-east-1.stealth.network",
-        latency: `${20 + (email.from.length % 5) * 6}ms`,
-        signature: `Ed25519 [0x${email.id.repeat(8).padEnd(32, "7")}f31b]`,
-        deliveredAt:
-          email.time.includes("AM") || email.time.includes("PM")
-            ? "Today, " + email.time
-            : email.time,
-        readAt: email.unread ? null : "Delivered + Read",
-        postageAmount: email.postageAmount ?? "10000000",
-        postageStatus:
-          email.folder === "requests"
-            ? "pending"
-            : email.folder === "spam"
-              ? "refunded"
-              : "settled",
-        senderRule: email.senderPolicy === "verify" ? "default" : (email.senderPolicy ?? "default"),
-        email,
-      };
-    });
+  // Generate deterministic mock proof records ONLY for shortcuts
+  const recentShortcuts = useMemo<MockProofRecord[]>(() => {
+    return emails.slice(0, 4).map(generateMockProofRecord);
   }, [emails]);
 
   // Real-time query format validation
@@ -163,25 +162,30 @@ export function ProofInspectorModal({
     const trimmed = query.trim().toLowerCase();
     if (!trimmed) return [];
 
-    return proofRecords.filter((record) => {
-      // Match by message hash
-      if (record.messageHash.toLowerCase().includes(trimmed)) return true;
-      // Match by payment hash
-      if (record.paymentHash.toLowerCase().includes(trimmed)) return true;
-      // Match by diagnostic ID
-      if (record.diagnosticId.toLowerCase().includes(trimmed)) return true;
-      // Match by contract address
-      if (record.contractAddress.toLowerCase().includes(trimmed)) return true;
-      // Match by email/sender address
-      if (record.email.email.toLowerCase().includes(trimmed)) return true;
-      // Match by sender name
-      if (record.email.from.toLowerCase().includes(trimmed)) return true;
-      // Match by subject
-      if (record.email.subject.toLowerCase().includes(trimmed)) return true;
+    const matchedEmails = emails.filter((email) => {
+      // Basic checks
+      if (email.email.toLowerCase().includes(trimmed)) return true;
+      if (email.from.toLowerCase().includes(trimmed)) return true;
+      if (email.subject.toLowerCase().includes(trimmed)) return true;
+
+      // Derived hash checks
+      const messageHash = `0x${email.id.repeat(16).padEnd(64, "a")}d8c7e9`;
+      if (messageHash.toLowerCase().includes(trimmed)) return true;
+
+      const paymentHash = `0x${(email.id + "pay").repeat(12).padEnd(64, "b")}f12a3d`;
+      if (paymentHash.toLowerCase().includes(trimmed)) return true;
+
+      const diagnosticId = `d1f038c7-4b1d-44a6-8968-3e5f492305${email.id.padStart(2, "0")}`;
+      if (diagnosticId.toLowerCase().includes(trimmed)) return true;
+
+      const contractAddress = `CB${email.id.repeat(10).toUpperCase().padEnd(54, "9")}`;
+      if (contractAddress.toLowerCase().includes(trimmed)) return true;
 
       return false;
     });
-  }, [hasSearched, query, proofRecords]);
+
+    return matchedEmails.map(generateMockProofRecord);
+  }, [hasSearched, query, emails]);
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -235,7 +239,13 @@ export function ProofInspectorModal({
                 <form
                   onSubmit={(e) => {
                     e.preventDefault();
-                    setHasSearched(true);
+                    if (!query.trim()) return;
+                    setIsSearching(true);
+                    setHasSearched(false);
+                    setTimeout(() => {
+                      setHasSearched(true);
+                      setIsSearching(false);
+                    }, 400);
                   }}
                   className="relative flex items-center gap-2"
                 >
@@ -247,6 +257,7 @@ export function ProofInspectorModal({
                       onChange={(e) => {
                         setQuery(e.target.value);
                         setHasSearched(false);
+                        setIsSearching(false);
                       }}
                       placeholder="Enter Message Hash, Payment Preimage, Address, or Sender..."
                       className={cn(
@@ -262,6 +273,7 @@ export function ProofInspectorModal({
                         onClick={() => {
                           setQuery("");
                           setHasSearched(false);
+                          setIsSearching(false);
                         }}
                         className="absolute right-3 top-3 rounded p-0.5 text-muted-foreground hover:text-foreground"
                       >
@@ -271,9 +283,10 @@ export function ProofInspectorModal({
                   </div>
                   <button
                     type="submit"
-                    className="h-10 rounded-xl bg-white px-4 text-xs font-bold text-black transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30"
+                    disabled={isSearching}
+                    className="h-10 rounded-xl bg-white px-4 text-xs font-bold text-black transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
                   >
-                    Inspect
+                    {isSearching ? "Searching..." : "Inspect"}
                   </button>
                 </form>
 
@@ -293,18 +306,23 @@ export function ProofInspectorModal({
               </div>
 
               {/* Suggestions / Shortcuts when empty */}
-              {!hasSearched && (
+              {!hasSearched && !isSearching && (
                 <div className="space-y-2.5 pt-2">
                   <h4 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
                     Quick shortcuts (local records)
                   </h4>
                   <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    {proofRecords.slice(0, 4).map((record) => (
+                    {recentShortcuts.map((record) => (
                       <button
                         key={record.emailId}
                         onClick={() => {
                           setQuery(record.messageHash);
-                          setHasSearched(true);
+                          setIsSearching(true);
+                          setHasSearched(false);
+                          setTimeout(() => {
+                            setHasSearched(true);
+                            setIsSearching(false);
+                          }, 400);
                         }}
                         className="flex items-start gap-2.5 rounded-xl border border-white/5 bg-white/[0.01] p-2.5 text-left text-xs transition hover:bg-white/[0.04] hover:border-white/10"
                       >
@@ -323,286 +341,304 @@ export function ProofInspectorModal({
                 </div>
               )}
 
-              {/* Search Result display */}
-              {hasSearched && (
-                <AnimatePresence mode="wait">
-                  {searchResults.length === 0 ? (
-                    /* MISSING RECORDS / NEXT STEPS GUIDE */
-                    <motion.div
-                      key="missing-state"
-                      {...motionPresets.entrance.fadeIn()}
-                      className="rounded-xl border border-rose-500/20 bg-rose-500/[0.01] p-4 space-y-4"
-                    >
-                      <div className="flex items-start gap-3">
-                        <span className="grid h-7 w-7 place-items-center rounded-full bg-rose-500/10 text-rose-400 border border-rose-500/20 shrink-0">
-                          <ShieldAlert className="h-4 w-4" />
-                        </span>
-                        <div className="min-w-0">
-                          <h4 className="text-xs font-semibold text-foreground">
-                            Proof Record Not Found
-                          </h4>
-                          <p className="text-[11px] text-muted-foreground mt-0.5">
-                            No local cryptographic delivery or payment proofs match your search
-                            query.
+              {/* Loading State */}
+              <AnimatePresence mode="wait">
+                {isSearching && (
+                  <motion.div
+                    key="loading-state"
+                    {...motionPresets.entrance.fadeIn()}
+                    className="space-y-4 pt-2"
+                  >
+                    <div className="h-16 w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div className="h-[120px] w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                      <div className="h-[120px] w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                      <div className="h-[120px] w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                      <div className="h-[120px] w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                    </div>
+                    <div className="h-10 w-full animate-pulse rounded-xl bg-white/[0.03] border border-white/[0.05]" />
+                  </motion.div>
+                )}
+
+                {/* Search Result display */}
+                {hasSearched && !isSearching && (
+                  <motion.div key="result-state" {...motionPresets.entrance.fadeIn()}>
+                    {searchResults.length === 0 ? (
+                      /* MISSING RECORDS / NEXT STEPS GUIDE */
+                      <div className="rounded-xl border border-rose-500/20 bg-rose-500/[0.01] p-4 space-y-4">
+                        <div className="flex items-start gap-3">
+                          <span className="grid h-7 w-7 place-items-center rounded-full bg-rose-500/10 text-rose-400 border border-rose-500/20 shrink-0">
+                            <ShieldAlert className="h-4 w-4" />
+                          </span>
+                          <div className="min-w-0">
+                            <h4 className="text-xs font-semibold text-foreground">
+                              Proof Record Not Found
+                            </h4>
+                            <p className="text-[11px] text-muted-foreground mt-0.5">
+                              No local cryptographic delivery or payment proofs match your search
+                              query.
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="border-t border-white/5 pt-3.5 space-y-2.5">
+                          <h5 className="text-[10px] uppercase tracking-wider text-rose-400/90 font-semibold flex items-center gap-1.5">
+                            <Terminal className="h-3 w-3" />
+                            Recommended Next Steps
+                          </h5>
+                          <ul className="space-y-2 text-xs">
+                            <li className="flex items-start gap-2">
+                              <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
+                                1.
+                              </span>
+                              <p className="text-muted-foreground leading-normal">
+                                <strong className="text-foreground/90 block">
+                                  Verify on Stellar Explorer
+                                </strong>
+                                Search the transaction hash on{" "}
+                                <a
+                                  href="https://stellar.expert"
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="text-emerald-400 hover:underline inline-flex items-center gap-0.5"
+                                >
+                                  Stellar.Expert
+                                  <ExternalLink className="h-2.5 w-2.5" />
+                                </a>{" "}
+                                or the Stellar Laboratory to verify if the payment settled.
+                              </p>
+                            </li>
+                            <li className="flex items-start gap-2">
+                              <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
+                                2.
+                              </span>
+                              <p className="text-muted-foreground leading-normal">
+                                <strong className="text-foreground/90 block">
+                                  Check Postage Preimage Settle State
+                                </strong>
+                                Ensure the recipient's mailbox contract has settled the postage
+                                preimage. Unsettled postages automatically return to the sender
+                                after 7 days.
+                              </p>
+                            </li>
+                            <li className="flex items-start gap-2">
+                              <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
+                                3.
+                              </span>
+                              <p className="text-muted-foreground leading-normal">
+                                <strong className="text-foreground/90 block">
+                                  Inspect Relay Node Diagnostics
+                                </strong>
+                                Ping the relay server node (`relay-us-east-1.stealth.network`) to
+                                check routing logs.
+                              </p>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    ) : (
+                      /* RECORD FOUND & DETAILED SECTIONS */
+                      <div className="space-y-4">
+                        {/* Security Alert: Sensitive payload notice */}
+                        <div className="flex items-start gap-2.5 rounded-lg bg-white/[0.02] border border-white/[0.04] p-3 text-xs text-muted-foreground leading-normal">
+                          <Info className="h-3.5 w-3.5 text-[oklch(0.85_0.005_270)] shrink-0 mt-0.5" />
+                          <p>
+                            <span className="font-semibold text-foreground/80">
+                              Diagnostic Mode:
+                            </span>{" "}
+                            Plaintext payload body and sensitive email attachments are omitted for
+                            privacy. Use the "Open Message" button to view and decrypt the message
+                            content securely.
                           </p>
                         </div>
-                      </div>
 
-                      <div className="border-t border-white/5 pt-3.5 space-y-2.5">
-                        <h5 className="text-[10px] uppercase tracking-wider text-rose-400/90 font-semibold flex items-center gap-1.5">
-                          <Terminal className="h-3 w-3" />
-                          Recommended Next Steps
-                        </h5>
-                        <ul className="space-y-2 text-xs">
-                          <li className="flex items-start gap-2">
-                            <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
-                              1.
+                        {/* Header overview */}
+                        <div className="flex items-center justify-between rounded-xl bg-white/[0.02] border border-white/5 p-3 text-xs">
+                          <div>
+                            <span className="text-muted-foreground">Subject (Omitted preview)</span>
+                            <span className="font-semibold text-foreground block mt-0.5">
+                              {selectedRecord.email.subject.replace(/./g, (c, i) =>
+                                i > 4 && i < 20 ? "•" : c,
+                              )}
                             </span>
-                            <p className="text-muted-foreground leading-normal">
-                              <strong className="text-foreground/90 block">
-                                Verify on Stellar Explorer
-                              </strong>
-                              Search the transaction hash on{" "}
-                              <a
-                                href="https://stellar.expert"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-emerald-400 hover:underline inline-flex items-center gap-0.5"
-                              >
-                                Stellar.Expert
-                                <ExternalLink className="h-2.5 w-2.5" />
-                              </a>{" "}
-                              or the Stellar Laboratory to verify if the payment settled.
-                            </p>
-                          </li>
-                          <li className="flex items-start gap-2">
-                            <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
-                              2.
+                          </div>
+                          <div className="text-right">
+                            <span className="text-muted-foreground">Verification State</span>
+                            <span className="inline-flex items-center gap-1 text-emerald-400 font-semibold block mt-0.5">
+                              <CheckCircle className="h-3.5 w-3.5" />
+                              Ledger Verified
                             </span>
-                            <p className="text-muted-foreground leading-normal">
-                              <strong className="text-foreground/90 block">
-                                Check Postage Preimage Settle State
-                              </strong>
-                              Ensure the recipient's mailbox contract has settled the postage
-                              preimage. Unsettled postages automatically return to the sender after
-                              7 days.
-                            </p>
-                          </li>
-                          <li className="flex items-start gap-2">
-                            <span className="text-[10px] font-semibold text-muted-foreground mt-0.5">
-                              3.
-                            </span>
-                            <p className="text-muted-foreground leading-normal">
-                              <strong className="text-foreground/90 block">
-                                Inspect Relay Node Diagnostics
-                              </strong>
-                              Ping the relay server node (`relay-us-east-1.stealth.network`) to
-                              check routing logs.
-                            </p>
-                          </li>
-                        </ul>
-                      </div>
-                    </motion.div>
-                  ) : (
-                    /* RECORD FOUND & DETAILED SECTIONS */
-                    <motion.div
-                      key="found-state"
-                      {...motionPresets.entrance.fadeIn()}
-                      className="space-y-4"
-                    >
-                      {/* Security Alert: Sensitive payload notice */}
-                      <div className="flex items-start gap-2.5 rounded-lg bg-white/[0.02] border border-white/[0.04] p-3 text-xs text-muted-foreground leading-normal">
-                        <Info className="h-3.5 w-3.5 text-[oklch(0.85_0.005_270)] shrink-0 mt-0.5" />
-                        <p>
-                          <span className="font-semibold text-foreground/80">Diagnostic Mode:</span>{" "}
-                          Plaintext payload body and sensitive email attachments are omitted for
-                          privacy. Use the "Open Message" button to view and decrypt the message
-                          content securely.
-                        </p>
-                      </div>
-
-                      {/* Header overview */}
-                      <div className="flex items-center justify-between rounded-xl bg-white/[0.02] border border-white/5 p-3 text-xs">
-                        <div>
-                          <span className="text-muted-foreground">Subject (Omitted preview)</span>
-                          <span className="font-semibold text-foreground block mt-0.5">
-                            {selectedRecord.email.subject.replace(/./g, (c, i) =>
-                              i > 4 && i < 20 ? "•" : c,
-                            )}
-                          </span>
+                          </div>
                         </div>
-                        <div className="text-right">
-                          <span className="text-muted-foreground">Verification State</span>
-                          <span className="inline-flex items-center gap-1 text-emerald-400 font-semibold block mt-0.5">
-                            <CheckCircle className="h-3.5 w-3.5" />
-                            Ledger Verified
-                          </span>
-                        </div>
-                      </div>
 
-                      {/* Structured Details Sections Grid */}
-                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                        {/* Section 1: Policy Info */}
-                        <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
-                          <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
-                            Policy Metadata
-                          </h5>
-                          <div className="space-y-1.5 text-xs">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Sender Rule:</span>
-                              <span className="font-mono text-foreground capitalize">
-                                {selectedRecord.senderRule}
-                              </span>
+                        {/* Structured Details Sections Grid */}
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                          {/* Section 1: Policy Info */}
+                          <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
+                            <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
+                              Policy Metadata
+                            </h5>
+                            <div className="space-y-1.5 text-xs">
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Sender Rule:</span>
+                                <span className="font-mono text-foreground capitalize">
+                                  {selectedRecord.senderRule}
+                                </span>
+                              </div>
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">
+                                  Cryptographic Contact:
+                                </span>
+                                <span className="text-foreground font-medium">Yes</span>
+                              </div>
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Postage Required:</span>
+                                <span className="text-foreground font-medium">Yes</span>
+                              </div>
                             </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Cryptographic Contact:</span>
-                              <span className="text-foreground font-medium">Yes</span>
+                          </div>
+
+                          {/* Section 2: Postage Info */}
+                          <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
+                            <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
+                              Postage details
+                            </h5>
+                            <div className="space-y-1.5 text-xs">
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Postage Amount:</span>
+                                <span className="font-semibold text-foreground">
+                                  {Number(selectedRecord.postageAmount) / 10_000_000} XLM
+                                </span>
+                              </div>
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Postage Status:</span>
+                                <span
+                                  className={cn(
+                                    "font-semibold uppercase text-[9px] px-1 rounded",
+                                    selectedRecord.postageStatus === "settled" &&
+                                      "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20",
+                                    selectedRecord.postageStatus === "pending" &&
+                                      "bg-amber-500/10 text-amber-400 border border-amber-500/20",
+                                    selectedRecord.postageStatus === "refunded" &&
+                                      "bg-red-500/10 text-red-400 border border-red-500/20",
+                                  )}
+                                >
+                                  {selectedRecord.postageStatus}
+                                </span>
+                              </div>
+                              <div className="flex justify-between items-center">
+                                <span className="text-muted-foreground">Payment Hash:</span>
+                                <button
+                                  onClick={() =>
+                                    copyToClipboard(selectedRecord.paymentHash, "Payment Hash")
+                                  }
+                                  className="font-mono text-[10px] text-emerald-400 hover:underline flex items-center gap-1"
+                                >
+                                  {selectedRecord.paymentHash.slice(0, 8)}...
+                                  <Copy className="h-2.5 w-2.5" />
+                                </button>
+                              </div>
                             </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Postage Required:</span>
-                              <span className="text-foreground font-medium">Yes</span>
+                          </div>
+
+                          {/* Section 3: Receipt Info */}
+                          <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
+                            <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
+                              Receipt details
+                            </h5>
+                            <div className="space-y-1.5 text-xs">
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Delivered At:</span>
+                                <span className="text-foreground">
+                                  {selectedRecord.deliveredAt}
+                                </span>
+                              </div>
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Read Receipt:</span>
+                                <span className="text-foreground">
+                                  {selectedRecord.readAt ?? "Pending read confirmation"}
+                                </span>
+                              </div>
+                              <div className="flex justify-between items-center">
+                                <span className="text-muted-foreground">Sender Key:</span>
+                                <button
+                                  onClick={() =>
+                                    copyToClipboard(selectedRecord.email.email, "Sender address")
+                                  }
+                                  className="font-mono text-[9px] text-foreground/80 hover:underline flex items-center gap-0.5"
+                                >
+                                  {selectedRecord.email.email.slice(0, 12)}...
+                                  <Copy className="h-2.5 w-2.5" />
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* Section 4: Relay Metadata */}
+                          <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
+                            <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
+                              Relay metadata
+                            </h5>
+                            <div className="space-y-1.5 text-xs">
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Relay Node:</span>
+                                <span className="text-foreground font-mono text-[10px]">
+                                  {selectedRecord.relayNode}
+                                </span>
+                              </div>
+                              <div className="flex justify-between">
+                                <span className="text-muted-foreground">Routing Latency:</span>
+                                <span className="text-foreground font-semibold">
+                                  {selectedRecord.latency}
+                                </span>
+                              </div>
+                              <div className="flex justify-between items-center">
+                                <span className="text-muted-foreground">Relay Diag ID:</span>
+                                <button
+                                  onClick={() =>
+                                    copyToClipboard(selectedRecord.diagnosticId, "Diagnostic ID")
+                                  }
+                                  className="font-mono text-[9px] text-foreground/80 hover:underline flex items-center gap-0.5"
+                                >
+                                  {selectedRecord.diagnosticId.slice(0, 12)}...
+                                  <Copy className="h-2.5 w-2.5" />
+                                </button>
+                              </div>
                             </div>
                           </div>
                         </div>
 
-                        {/* Section 2: Postage Info */}
-                        <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
-                          <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
-                            Postage details
-                          </h5>
-                          <div className="space-y-1.5 text-xs">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Postage Amount:</span>
-                              <span className="font-semibold text-foreground">
-                                {Number(selectedRecord.postageAmount) / 10_000_000} XLM
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Postage Status:</span>
-                              <span
-                                className={cn(
-                                  "font-semibold uppercase text-[9px] px-1 rounded",
-                                  selectedRecord.postageStatus === "settled" &&
-                                    "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20",
-                                  selectedRecord.postageStatus === "pending" &&
-                                    "bg-amber-500/10 text-amber-400 border border-amber-500/20",
-                                  selectedRecord.postageStatus === "refunded" &&
-                                    "bg-red-500/10 text-red-400 border border-red-500/20",
-                                )}
-                              >
-                                {selectedRecord.postageStatus}
-                              </span>
-                            </div>
-                            <div className="flex justify-between items-center">
-                              <span className="text-muted-foreground">Payment Hash:</span>
-                              <button
-                                onClick={() =>
-                                  copyToClipboard(selectedRecord.paymentHash, "Payment Hash")
-                                }
-                                className="font-mono text-[10px] text-emerald-400 hover:underline flex items-center gap-1"
-                              >
-                                {selectedRecord.paymentHash.slice(0, 8)}...
-                                <Copy className="h-2.5 w-2.5" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        {/* Section 3: Receipt Info */}
-                        <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
-                          <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
-                            Receipt details
-                          </h5>
-                          <div className="space-y-1.5 text-xs">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Delivered At:</span>
-                              <span className="text-foreground">{selectedRecord.deliveredAt}</span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Read Receipt:</span>
-                              <span className="text-foreground">
-                                {selectedRecord.readAt ?? "Pending read confirmation"}
-                              </span>
-                            </div>
-                            <div className="flex justify-between items-center">
-                              <span className="text-muted-foreground">Sender Key:</span>
-                              <button
-                                onClick={() =>
-                                  copyToClipboard(selectedRecord.email.email, "Sender address")
-                                }
-                                className="font-mono text-[9px] text-foreground/80 hover:underline flex items-center gap-0.5"
-                              >
-                                {selectedRecord.email.email.slice(0, 12)}...
-                                <Copy className="h-2.5 w-2.5" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        {/* Section 4: Relay Metadata */}
-                        <div className="rounded-xl border border-white/5 bg-white/[0.01] p-3 space-y-2">
-                          <h5 className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold border-b border-white/5 pb-1">
-                            Relay metadata
-                          </h5>
-                          <div className="space-y-1.5 text-xs">
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Relay Node:</span>
-                              <span className="text-foreground font-mono text-[10px]">
-                                {selectedRecord.relayNode}
-                              </span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span className="text-muted-foreground">Routing Latency:</span>
-                              <span className="text-foreground font-semibold">
-                                {selectedRecord.latency}
-                              </span>
-                            </div>
-                            <div className="flex justify-between items-center">
-                              <span className="text-muted-foreground">Relay Diag ID:</span>
-                              <button
-                                onClick={() =>
-                                  copyToClipboard(selectedRecord.diagnosticId, "Diagnostic ID")
-                                }
-                                className="font-mono text-[9px] text-foreground/80 hover:underline flex items-center gap-0.5"
-                              >
-                                {selectedRecord.diagnosticId.slice(0, 12)}...
-                                <Copy className="h-2.5 w-2.5" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
+                        {/* Diagnostic JSON Copy report */}
+                        <button
+                          onClick={() =>
+                            copyToClipboard(
+                              JSON.stringify(
+                                {
+                                  ...selectedRecord,
+                                  email: undefined, // exclude sensitive email object
+                                },
+                                null,
+                                2,
+                              ),
+                              "Proof diagnostic report",
+                            )
+                          }
+                          className="w-full inline-flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/10"
+                        >
+                          <Copy className="h-3.5 w-3.5" />
+                          Copy Proof Diagnostic Report
+                        </button>
                       </div>
-
-                      {/* Diagnostic JSON Copy report */}
-                      <button
-                        onClick={() =>
-                          copyToClipboard(
-                            JSON.stringify(
-                              {
-                                ...selectedRecord,
-                                email: undefined, // exclude sensitive email object
-                              },
-                              null,
-                              2,
-                            ),
-                            "Proof diagnostic report",
-                          )
-                        }
-                        className="w-full inline-flex items-center justify-center gap-1.5 rounded-xl border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/10"
-                      >
-                        <Copy className="h-3.5 w-3.5" />
-                        Copy Proof Diagnostic Report
-                      </button>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              )}
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
 
             {/* Modal Footer CTAs */}
             <div className="flex items-center justify-between border-t border-white/[0.08] px-6 py-4 bg-white/[0.01]">
               <div className="flex items-center gap-2">
-                {selectedRecord && (
+                {selectedRecord && hasSearched && !isSearching && (
                   <>
                     <a
                       href={`https://stellar.expert/explorer/public/tx/${selectedRecord.paymentHash}`}


### PR DESCRIPTION
## Summary

Closes #983 

Improves the performance and perceived latency of the existing **Proof Inspector** modal and `provenance.ts` logic. This safely trims aggressive eager data generation without requiring broad rewrites, adhering tightly to the existing application surface.

## Deliverables

### Lazy Proof Mocks (`ProofInspectorModal.tsx`)
- Extracted the deterministic `MockProofRecord` string generator from the main map loop.
- The "Shortcuts" view now only generates mocks for the first `4` emails (`emails.slice(0, 4)`).
- When submitting a query, the search logic now filters the lightweight `emails` array natively first, then maps *only* the matching results to their heavy mock objects.

### ES6 Getters for Lazy JSON Serialization (`provenance.ts`)
- Refactored `rawJson` from static eagerly-stringified properties into `get rawJson()` getter methods.
- Prevents the application from running deep nested `JSON.stringify` logic for all 6 diagnostic panels per email when the inspector hasn't even been opened by the user.

### Perceived Latency (`ProofInspectorModal.tsx`)
- Implemented an `isSearching` state attached to the form submission.
- Replaced the instantaneous thread-blocking query jump with a seamless, animated loading skeleton that matches the UI layout, yielding the JavaScript execution thread and dramatically improving the modal's perceived latency.
