### PR TITLE
Add postage service regression coverage

### DIFF
--- a/tests/unit/api/postage-service.regression.test.ts
+++ b/tests/unit/api/postage-service.regression.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { getPostage, quotePostage, submitPostage } from "../../../src/server/api/postage-service";
+
+const recipient = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+
+describe("postage service regression coverage", () => {
+  it("quotes the mailbox minimum for unknown senders", async () => {
+    const repository = new MemoryApiRepository();
+    await repository.setPolicy(recipient, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
+
+    await expect(quotePostage(repository, { recipient, sender })).resolves.toMatchObject({
+      amount: "100",
+      eligible: true,
+      reason: "mailbox_minimum",
+      trusted: false,
+    });
+  });
+
+  it("rejects submissions from blocked senders", async () => {
+    const repository = new MemoryApiRepository();
+    await repository.setSenderRule(recipient, sender, "block");
+
+    await expect(
+      submitPostage(repository, {
+        amount: "100",
+        messageId: "a".repeat(64),
+        paymentHash: "b".repeat(64),
+        recipient,
+        sender,
+      }),
+    ).rejects.toMatchObject({ status: 403, code: "forbidden" });
+  });
+
+  it("returns not found for unknown postage", async () => {
+    const repository = new MemoryApiRepository();
+
+    await expect(getPostage(repository, "a".repeat(64))).rejects.toMatchObject({
+      status: 404,
+      code: "not_found",
+    });
+  });
+});


### PR DESCRIPTION
Adds focused regression coverage for existing Postage API behavior that was previously untested:

- quotePostage returns the mailbox-minimum quote for unknown senders (not trusted, not blocked).
- submitPostage rejects submissions from blocked senders with a 403.
- getPostage returns a 404 when no postage exists for a message.

These complement the existing tests/unit/api/postage-service.test.ts and do not change any app code. Fixtures are fake and deterministic.

Note: the test runner could not start locally in this environment (vite.config.ts fails to load a native Tailwind binding), so the change was validated with tsc --noEmit, ESLint, and Prettier. CI runs the full unit suite under tests/unit.

Closes #949