### PR TITLE
docs: add email translator test and review plan

### DIFF
--- a/tools/v2/individual/email-translator/README.md
+++ b/tools/v2/individual/email-translator/README.md
@@ -1,15 +1,51 @@
 # Email Translator
 
-This folder is the isolated workspace for the Email Translator tool.
+Email Translator is an isolated V2 individual tool workspace for translating
+email content between languages. It is not wired into the main mail app yet; the
+folder documents the local review contract and test plan until future issues add
+the core engine or user interface.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\email-translator\
-`
+```text
+tools/v2/individual/email-translator/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not modify the main application shell, dashboard layout, routing, inbox
+architecture, wallet core, Stellar integration, database schema, or shared
+design system from this issue.
 
-See specs.md for the issue categories and contributor expectations.
+## Current Scope
+
+This contribution focuses on contributor-friendly testing and documentation. It
+does not add a translation provider, network calls, persistence, React
+components, hooks, or app integration.
+
+## Review Map
+
+- `specs.md` defines the tool contract, loading states, error states, fixtures,
+  and known limitations.
+- `tests/test-plan.md` gives a folder-local manual and future automated test
+  plan.
+- `docs/review-notes.md` gives maintainers a self-contained review checklist.
+- `fixtures/translation-cases.json` provides deterministic fake email samples
+  that future tests can reuse.
+
+## Setup
+
+No app-wide setup is required for this documentation-only contribution.
+
+Future code contributions should keep tests local to this folder and use the
+fixture cases in `fixtures/translation-cases.json` instead of live email data or
+external translation services.
+
+## Known Limitations
+
+- No translation engine is implemented in this issue.
+- No live network calls or third-party translation provider are used.
+- No production email, account, wallet, or contact data is included.
+- No UI is mounted in the main application.
+- Automated tests should be added by a later implementation issue once core
+  behavior exists.

--- a/tools/v2/individual/email-translator/docs/review-notes.md
+++ b/tools/v2/individual/email-translator/docs/review-notes.md
@@ -1,0 +1,46 @@
+# Email Translator Review Notes
+
+## Scope Confirmation
+
+This change is intentionally limited to documentation, test planning, and local
+fixtures for:
+
+```text
+tools/v2/individual/email-translator/
+```
+
+It does not mount UI, call a translation provider, touch the inbox architecture,
+change routing, modify wallet or Stellar code, or add production data.
+
+## What To Review
+
+1. `README.md` gives setup, scope, and limitation notes.
+2. `specs.md` defines the future input/output contract and state model.
+3. `tests/test-plan.md` provides manual checks and future automated cases.
+4. `fixtures/translation-cases.json` gives deterministic synthetic inputs.
+
+## Why This Helps Future Work
+
+- Contributors can validate future core behavior against stable examples.
+- Maintainers can review later code against documented boundaries.
+- UI work can rely on documented idle, loading, success, and error states.
+- The tool remains isolated until a future integration issue explicitly connects
+  it to the main app.
+
+## Known Non-Goals
+
+- Implementing translation logic.
+- Selecting a translation provider.
+- Adding React components or hooks.
+- Connecting to real email data.
+- Adding global state or app-wide tests.
+
+## Acceptance Mapping
+
+| Issue requirement | Covered by |
+| --- | --- |
+| Tests or test plans live inside the tool folder | `tests/test-plan.md` |
+| Documentation explains independent review | `README.md`, `docs/review-notes.md` |
+| Work remains isolated from app-wide tests | Scope notes in all docs |
+| Files are limited to the tool folder | All paths in this change |
+| Self-contained mini-product review | Review map, fixtures, and test plan |

--- a/tools/v2/individual/email-translator/fixtures/translation-cases.json
+++ b/tools/v2/individual/email-translator/fixtures/translation-cases.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "support-reply-es-en",
+    "subject": "Actualizacion sobre su solicitud",
+    "body": "Hola,\n\nRecibimos su mensaje y estamos revisando los detalles. Le enviaremos una respuesta antes del viernes.\n\nGracias.",
+    "sourceLanguage": "es",
+    "targetLanguage": "en",
+    "preserveFormatting": true,
+    "expectedWarnings": []
+  },
+  {
+    "id": "project-update-fr-en",
+    "subject": "Resume du projet",
+    "body": "Bonjour,\n\n- La maquette est prete.\n- Les tests de contenu continuent.\n- La revision finale est prevue demain.\n\nCordialement.",
+    "sourceLanguage": "fr",
+    "targetLanguage": "en",
+    "preserveFormatting": true,
+    "expectedWarnings": []
+  },
+  {
+    "id": "oversized-draft-de-en",
+    "subject": "Langer Entwurf",
+    "body": "Dies ist ein synthetischer langer E-Mail-Entwurf, der in zukunftigen Tests mehrfach wiederholt werden kann, um Groessenbegrenzungen und Aufteilung zu pruefen.",
+    "sourceLanguage": "de",
+    "targetLanguage": "en",
+    "preserveFormatting": false,
+    "expectedWarnings": ["content-size-limit"]
+  },
+  {
+    "id": "missing-target-language",
+    "subject": "Missing target language",
+    "body": "This fixture should fail validation because the target language is empty.",
+    "sourceLanguage": "en",
+    "targetLanguage": "",
+    "preserveFormatting": true,
+    "expectedWarnings": ["validation-target-language"]
+  }
+]

--- a/tools/v2/individual/email-translator/specs.md
+++ b/tools/v2/individual/email-translator/specs.md
@@ -1,41 +1,113 @@
-# Email Translator
-
-Translate emails between languages.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/email-translator/README.md"
-  @"
-
 # Email Translator Specs
 
 ## Purpose
 
-Translate emails between languages.
+Email Translator helps an individual convert email content from a source
+language to a target language while preserving sender intent, subject context,
+and important action items.
 
-## Contributor boundary
+## Contributor Boundary
 
 All work for this tool should stay in:
 
-$dir/
+```text
+tools/v2/individual/email-translator/
+```
 
-## Required issue categories
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database schema, or
+shared design system unless a future integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Input Contract
+
+Future implementation work should treat translation requests as plain local
+objects:
+
+```ts
+type TranslationRequest = {
+  id: string;
+  subject: string;
+  body: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  preserveFormatting: boolean;
+};
+```
+
+## Output Contract
+
+```ts
+type TranslationResult = {
+  requestId: string;
+  translatedSubject: string;
+  translatedBody: string;
+  detectedLanguage: string;
+  warnings: string[];
+};
+```
+
+## Loading States
+
+- **Idle**: No translation has been requested.
+- **Loading**: A translation request is being processed.
+- **Success**: Translated subject/body are available with any non-blocking
+  warnings.
+- **Error**: Input validation fails or translation cannot be completed.
+
+Because this tool is isolated, loading state should be represented by local
+state or a folder-local helper in a future implementation. Do not introduce
+global app state for this tool.
+
+## Error States
+
+Validation should reject:
+
+- Empty subject and empty body.
+- Missing or unsupported target language.
+- Matching source and target languages when no translation is needed.
+- Bodies that exceed the documented size limit.
+- Messages that contain unsupported binary attachment placeholders.
+
+Expected error shape for future code:
+
+```ts
+type TranslationValidationError = {
+  field: string;
+  message: string;
+};
+```
+
+## Fixture Expectations
+
+Use `fixtures/translation-cases.json` for deterministic review data. The fixture
+set includes:
+
+- A short support reply.
+- A formatted project update.
+- A long message that should trigger size-limit handling.
+- A malformed request with an empty target language.
+
+Fixtures must stay synthetic and must not contain real email addresses, real
+customer names, account identifiers, wallet addresses, or production data.
+
+## Test Categories
+
+Future automated tests should cover:
+
+1. Valid translation request mapping.
+2. Input validation errors.
+3. Loading and error-state transitions.
+4. Formatting preservation.
+5. Warning generation for long or partially unsupported content.
+6. Deterministic fixture behavior.
+
+## Review Expectations
+
+Reviewers should verify:
+
+1. All files changed by this issue stay inside the tool folder.
+2. The docs explain how to review the tool independently.
+3. The test plan is usable before a translation engine exists.
+4. Fixtures are deterministic and synthetic.
+5. The contribution does not introduce live network calls, secrets, production
+   data, or app-wide integration.

--- a/tools/v2/individual/email-translator/tests/test-plan.md
+++ b/tools/v2/individual/email-translator/tests/test-plan.md
@@ -1,0 +1,82 @@
+# Email Translator Test Plan
+
+## Goal
+
+This plan defines how contributors can review the Email Translator tool before
+the core translation engine is implemented. It keeps testing local to
+`tools/v2/individual/email-translator/`.
+
+## Manual Review Checklist
+
+- Confirm all changed files are inside this folder.
+- Confirm no live translation provider, network request, secret, wallet value,
+  or production email data is introduced.
+- Confirm `fixtures/translation-cases.json` contains only synthetic examples.
+- Confirm `README.md` explains the current limitation: documentation and test
+  planning only.
+- Confirm `specs.md` documents input, output, loading, error, fixture, and
+  review expectations.
+
+## Future Automated Test Cases
+
+### 1. Valid request mapping
+
+Use the `support-reply-es-en` fixture.
+
+Expected checks:
+
+- Request id is preserved in the result.
+- Source and target languages are different.
+- Subject and body are both present.
+- No warning is required for a short supported message.
+
+### 2. Formatting preservation
+
+Use the `project-update-fr-en` fixture.
+
+Expected checks:
+
+- Bullet-like line breaks remain line-based.
+- Greeting and sign-off positions are preserved.
+- `preserveFormatting: true` is passed through the local API.
+
+### 3. Size-limit handling
+
+Use the `oversized-draft-de-en` fixture.
+
+Expected checks:
+
+- The request is rejected or split by a future local helper.
+- A warning or validation error explains the size limit.
+- No live provider call is attempted for over-limit input.
+
+### 4. Validation failure
+
+Use the `missing-target-language` fixture.
+
+Expected checks:
+
+- Validation reports `targetLanguage`.
+- Translation does not continue after validation fails.
+- Error output is deterministic.
+
+### 5. Empty message protection
+
+Create a local case with empty `subject` and empty `body`.
+
+Expected checks:
+
+- Validation rejects the request.
+- Error output includes a clear message.
+- No network or provider code is reached.
+
+## Review Command Placeholder
+
+When a future implementation adds local tests, the expected command should stay
+folder-local, for example:
+
+```bash
+npm run test -- --run tools/v2/individual/email-translator
+```
+
+No command is required for this documentation-only contribution.


### PR DESCRIPTION
## Summary
- Clean up the Email Translator folder docs for issue #498.
- Add a folder-local test plan, review notes, and deterministic synthetic fixtures.
- Document setup, usage boundaries, loading/error states, and known limitations.

## Scope
- Only touches `tools/v2/individual/email-translator/`.
- No main app, routing, inbox, auth, wallet, Stellar, database, or design-system integration.
- No live network calls, secrets, production email, wallet data, or real user data.

## Validation
- Compared the branch against `main`: 5 changed files, all inside the Email Translator tool folder.
- Documentation-only/test-plan contribution, so no app-wide tests were run locally.

Closes #498