### PR TITLE
Feat/demo admin bulk label

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { calculateLabelState } from "../components/BulkLabelPanel";
+import type { DemoMessage } from "../types/dataset";
+
+function makeMessage(id: string, labels: string[]): DemoMessage {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    subject: `Subject ${id}`,
+    snippet: `Snippet ${id}`,
+    body: `Body ${id}`,
+    sender: {
+      address: `sender-${id}@example.com`,
+      name: `Sender ${id}`,
+      isTrusted: true,
+    },
+    recipients: [`recipient-${id}@example.org`],
+    date: "2026-06-20T12:00:00Z",
+    isRead: true,
+    isStarred: false,
+    labels,
+    attachments: [],
+  };
+}
+
+describe("calculateLabelState", () => {
+  it("deduplicates labels case-insensitively and keeps the preview stable", () => {
+    const messages = [
+      makeMessage("m1", ["Priority", "review"]),
+      makeMessage("m2", ["priority", "review", "archive"]),
+    ];
+
+    const result = calculateLabelState(messages, [
+      "Priority",
+      "priority",
+      "Archive",
+      "Review",
+      "Archive",
+    ]);
+
+    expect(result.common).toEqual(["priority", "review"]);
+    expect(result.partial).toEqual(["archive"]);
+    expect(result.available).toEqual([]);
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
@@ -38,7 +38,10 @@ function sampleMessages(): DemoMessage[] {
 
 describe("normalizeLabelsForBulk", () => {
   it("deduplicates case-insensitively", () => {
-    expect(normalizeLabelsForBulk(["Priority", "priority", "Archive"])).toEqual(["priority", "archive"]);
+    expect(normalizeLabelsForBulk(["Priority", "priority", "Archive"])).toEqual([
+      "priority",
+      "archive",
+    ]);
   });
 
   it("drops blank and empty labels", () => {
@@ -80,7 +83,12 @@ describe("applyBulkLabelEdit - remove", () => {
   });
 
   it("skips labels not present on any selected message", () => {
-    const result = applyBulkLabelEdit(sampleMessages(), ["m1"], ["archive", "nonexistent"], "remove");
+    const result = applyBulkLabelEdit(
+      sampleMessages(),
+      ["m1"],
+      ["archive", "nonexistent"],
+      "remove",
+    );
 
     expect(result.messages[0].labels).toEqual(["priority", "review"]);
     expect(result.changes[0].applied).toEqual(["archive"]);

--- a/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkLabelPanel.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { calculateLabelState } from "../components/BulkLabelPanel";
+import {
+  applyBulkLabelEdit,
+  normalizeLabelsForBulk,
+  summarizeBulkLabelEdit,
+} from "../bulkLabelPanel";
 import type { DemoMessage } from "../types/dataset";
 
 function makeMessage(id: string, labels: string[]): DemoMessage {
@@ -23,6 +28,85 @@ function makeMessage(id: string, labels: string[]): DemoMessage {
   };
 }
 
+function sampleMessages(): DemoMessage[] {
+  return [
+    makeMessage("m1", ["priority", "review"]),
+    makeMessage("m2", ["priority", "archive"]),
+    makeMessage("m3", ["review", "archive"]),
+  ];
+}
+
+describe("normalizeLabelsForBulk", () => {
+  it("deduplicates case-insensitively", () => {
+    expect(normalizeLabelsForBulk(["Priority", "priority", "Archive"])).toEqual(["priority", "archive"]);
+  });
+
+  it("drops blank and empty labels", () => {
+    expect(normalizeLabelsForBulk(["", "  ", "VIP"])).toEqual(["VIP"]);
+  });
+});
+
+describe("applyBulkLabelEdit - add", () => {
+  it("adds new labels to selected messages without mutating input", () => {
+    const messages = sampleMessages();
+    const result = applyBulkLabelEdit(messages, ["m1", "m3"], ["VIP"], "add");
+
+    expect(messages[0].labels).toEqual(["priority", "review"]);
+    expect(result.messages[0].labels).toEqual(["priority", "review", "VIP"]);
+    expect(result.messages[1].labels).toEqual(["priority", "archive"]);
+    expect(result.messages[2].labels).toEqual(["review", "archive", "VIP"]);
+  });
+
+  it("prevents duplicate labels", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1", "m2"], ["priority", "VIP"], "add");
+
+    expect(result.messages[0].labels).toEqual(["priority", "review", "VIP"]);
+    expect(result.messages[1].labels).toEqual(["priority", "archive", "VIP"]);
+    expect(result.changes[0].applied).toEqual(["VIP"]);
+    expect(result.changes[0].skipped).toEqual(["priority"]);
+    expect(result.summary.totalApplied).toBe(2);
+    expect(result.summary.totalSkipped).toBe(2);
+  });
+});
+
+describe("applyBulkLabelEdit - remove", () => {
+  it("removes existing labels and skips ones not present", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1", "m2"], ["archive"], "remove");
+
+    expect(result.messages[0].labels).toEqual(["priority", "review"]);
+    expect(result.messages[1].labels).toEqual(["priority"]);
+    expect(result.summary.totalApplied).toBe(1);
+    expect(result.summary.affectedCount).toBe(1);
+  });
+
+  it("skips labels not present on any selected message", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1"], ["archive", "nonexistent"], "remove");
+
+    expect(result.messages[0].labels).toEqual(["priority", "review"]);
+    expect(result.changes[0].applied).toEqual(["archive"]);
+    expect(result.changes[0].skipped).toEqual(["nonexistent"]);
+    expect(result.summary.totalApplied).toBe(1);
+    expect(result.summary.totalSkipped).toBe(1);
+  });
+});
+
+describe("summarizeBulkLabelEdit", () => {
+  it("summarizes an add across multiple messages", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1", "m2"], ["VIP"], "add");
+    expect(summarizeBulkLabelEdit(result)).toBe("Added 2 labels across 2 messages.");
+  });
+
+  it("reports when nothing changed on add", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1"], ["priority"], "add");
+    expect(summarizeBulkLabelEdit(result)).toBe("No changes - all were duplicates (1 skipped).");
+  });
+
+  it("reports when nothing changed on remove", () => {
+    const result = applyBulkLabelEdit(sampleMessages(), ["m1"], ["nonexistent"], "remove");
+    expect(summarizeBulkLabelEdit(result)).toBe("No changes - none were present (1 skipped).");
+  });
+});
+
 describe("calculateLabelState", () => {
   it("deduplicates labels case-insensitively and keeps the preview stable", () => {
     const messages = [
@@ -40,6 +124,26 @@ describe("calculateLabelState", () => {
 
     expect(result.common).toEqual(["priority", "review"]);
     expect(result.partial).toEqual(["archive"]);
+    expect(result.available).toEqual([]);
+  });
+
+  it("returns empty state when no messages selected", () => {
+    const result = calculateLabelState([], ["priority", "review"]);
+    expect(result.common).toEqual([]);
+    expect(result.partial).toEqual([]);
+    expect(result.available).toEqual(["priority", "review"]);
+  });
+
+  it("categorizes labels correctly with multiple messages", () => {
+    const messages = [
+      makeMessage("m1", ["priority", "review", "archive"]),
+      makeMessage("m2", ["priority", "review"]),
+      makeMessage("m3", ["priority"]),
+    ];
+    const result = calculateLabelState(messages, ["priority", "review", "archive"]);
+
+    expect(result.common).toEqual(["priority"]);
+    expect(result.partial).toEqual(["archive", "review"]);
     expect(result.available).toEqual([]);
   });
 });

--- a/src/features/demo-admin-dashboard/bulkLabelPanel.ts
+++ b/src/features/demo-admin-dashboard/bulkLabelPanel.ts
@@ -87,7 +87,10 @@ export function applyBulkLabelEdit(
     changes.push({ id: message.id, subject: message.subject, applied, skipped });
     return applied.length === 0
       ? message
-      : { ...message, labels: message.labels.filter((l) => !applied.some((a) => toLabelId(a) === toLabelId(l))) };
+      : {
+          ...message,
+          labels: message.labels.filter((l) => !applied.some((a) => toLabelId(a) === toLabelId(l))),
+        };
   });
 
   const affectedCount = changes.filter((change) => change.applied.length > 0).length;

--- a/src/features/demo-admin-dashboard/bulkLabelPanel.ts
+++ b/src/features/demo-admin-dashboard/bulkLabelPanel.ts
@@ -1,0 +1,131 @@
+import { normalizeLabelName, toLabelId } from "./labels/labelNormalization";
+import type { DemoMessage } from "./types/dataset";
+
+export type BulkLabelOperation = "add" | "remove";
+
+export interface BulkLabelMessageChange {
+  id: string;
+  subject: string;
+  applied: string[];
+  skipped: string[];
+}
+
+export interface BulkLabelAuditSummary {
+  operation: BulkLabelOperation;
+  selectedCount: number;
+  affectedCount: number;
+  totalApplied: number;
+  totalSkipped: number;
+}
+
+export interface BulkLabelEditResult {
+  messages: DemoMessage[];
+  operation: BulkLabelOperation;
+  requestedLabels: string[];
+  changes: BulkLabelMessageChange[];
+  summary: BulkLabelAuditSummary;
+}
+
+export function normalizeLabelsForBulk(labels: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of labels) {
+    const normalized = normalizeLabelName(raw);
+    const id = toLabelId(normalized);
+    if (!normalized || !id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    result.push(normalized);
+  }
+  return result;
+}
+
+export function applyBulkLabelEdit(
+  messages: DemoMessage[],
+  selectedIds: string[],
+  labels: string[],
+  operation: BulkLabelOperation,
+): BulkLabelEditResult {
+  const requestedLabels = normalizeLabelsForBulk(labels);
+  const selected = new Set(selectedIds);
+  const changes: BulkLabelMessageChange[] = [];
+
+  const nextMessages = messages.map((message) => {
+    if (!selected.has(message.id)) {
+      return message;
+    }
+
+    const existingLabelIds = new Set(message.labels.map((l) => toLabelId(l)));
+    const applied: string[] = [];
+    const skipped: string[] = [];
+
+    if (operation === "add") {
+      const nextLabels = [...message.labels];
+      for (const label of requestedLabels) {
+        const id = toLabelId(label);
+        if (existingLabelIds.has(id)) {
+          skipped.push(label);
+        } else {
+          existingLabelIds.add(id);
+          nextLabels.push(label);
+          applied.push(label);
+        }
+      }
+      changes.push({ id: message.id, subject: message.subject, applied, skipped });
+      return applied.length === 0 ? message : { ...message, labels: nextLabels };
+    }
+
+    for (const label of requestedLabels) {
+      const id = toLabelId(label);
+      if (existingLabelIds.has(id)) {
+        applied.push(label);
+      } else {
+        skipped.push(label);
+      }
+    }
+    changes.push({ id: message.id, subject: message.subject, applied, skipped });
+    return applied.length === 0
+      ? message
+      : { ...message, labels: message.labels.filter((l) => !applied.some((a) => toLabelId(a) === toLabelId(l))) };
+  });
+
+  const affectedCount = changes.filter((change) => change.applied.length > 0).length;
+  const totalApplied = changes.reduce((sum, change) => sum + change.applied.length, 0);
+  const totalSkipped = changes.reduce((sum, change) => sum + change.skipped.length, 0);
+
+  return {
+    messages: nextMessages,
+    operation,
+    requestedLabels,
+    changes,
+    summary: {
+      operation,
+      selectedCount: changes.length,
+      affectedCount,
+      totalApplied,
+      totalSkipped,
+    },
+  };
+}
+
+export function summarizeBulkLabelEdit(result: BulkLabelEditResult): string {
+  const { operation, summary } = result;
+
+  if (summary.totalApplied === 0) {
+    const reason = operation === "add" ? "all were duplicates" : "none were present";
+    return `No changes - ${reason} (${summary.totalSkipped} skipped).`;
+  }
+
+  const verb = operation === "add" ? "Added" : "Removed";
+  const labelWord = summary.totalApplied === 1 ? "label" : "labels";
+  const messageWord = summary.affectedCount === 1 ? "message" : "messages";
+  const base = `${verb} ${summary.totalApplied} ${labelWord} across ${summary.affectedCount} ${messageWord}`;
+
+  if (summary.totalSkipped === 0) {
+    return `${base}.`;
+  }
+
+  const skipReason = operation === "add" ? "skipped as duplicates" : "skipped (not present)";
+  return `${base} (${summary.totalSkipped} ${skipReason}).`;
+}

--- a/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
@@ -1,0 +1,401 @@
+import { useState } from "react";
+import { Tag, Plus, X, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import { normalizeLabelName, toLabelId } from "../labels/labelNormalization";
+import type { DemoMessage } from "../types/dataset";
+
+export interface BulkLabelPanelProps {
+  /** The currently selected demo messages to modify. */
+  selectedMessages: DemoMessage[];
+  /** All available label names in the system. */
+  availableLabels: string[];
+  /** Callback when labels are applied or removed. */
+  onApply: (messageIds: string[], operation: "add" | "remove", labels: string[]) => void;
+  /** Optional className for the root element. */
+  className?: string;
+}
+
+interface LabelState {
+  /** Labels that exist on ALL selected messages. */
+  common: string[];
+  /** Labels that exist on SOME but not all selected messages. */
+  partial: string[];
+  /** Labels that exist on NONE of the selected messages. */
+  available: string[];
+}
+
+/**
+ * BulkLabelPanel allows admins to add or remove labels across multiple
+ * selected demo messages.
+ * 
+ * Features:
+ * - Shows labels common to all selected messages
+ * - Shows labels present on some messages (partial state)
+ * - Allows adding new or existing labels
+ * - Handles duplicate label prevention
+ * - Provides visual feedback for bulk operations
+ */
+export function BulkLabelPanel({
+  selectedMessages,
+  availableLabels,
+  onApply,
+  className,
+}: BulkLabelPanelProps) {
+  const [newLabelInput, setNewLabelInput] = useState("");
+  const [selectedForAdd, setSelectedForAdd] = useState<Set<string>>(new Set());
+  const [selectedForRemove, setSelectedForRemove] = useState<Set<string>>(new Set());
+  const [feedback, setFeedback] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+
+  // Calculate label distribution across selected messages
+  const labelState = calculateLabelState(selectedMessages, availableLabels);
+
+  const handleAddNewLabel = () => {
+    const normalized = normalizeLabelName(newLabelInput);
+    if (!normalized) {
+      showFeedback("error", "Label name cannot be empty");
+      return;
+    }
+
+    const labelId = toLabelId(normalized);
+    
+    // Check if label already exists (case-insensitive)
+    const existingLabel = availableLabels.find(
+      label => toLabelId(label) === labelId
+    );
+    
+    if (existingLabel) {
+      // Label already exists, toggle it for addition
+      toggleLabelForAdd(existingLabel);
+      setNewLabelInput("");
+      return;
+    }
+
+    // Add the new label to selected messages
+    const messageIds = selectedMessages.map(msg => msg.id);
+    onApply(messageIds, "add", [normalized]);
+    setNewLabelInput("");
+    showFeedback("success", `Added label "${normalized}" to ${messageIds.length} message(s)`);
+  };
+
+  const toggleLabelForAdd = (label: string) => {
+    setSelectedForAdd(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+    // Clear from remove selection if present
+    setSelectedForRemove(prev => {
+      const next = new Set(prev);
+      next.delete(label);
+      return next;
+    });
+  };
+
+  const toggleLabelForRemove = (label: string) => {
+    setSelectedForRemove(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+    // Clear from add selection if present
+    setSelectedForAdd(prev => {
+      const next = new Set(prev);
+      next.delete(label);
+      return next;
+    });
+  };
+
+  const applyAddLabels = () => {
+    if (selectedForAdd.size === 0) {
+      showFeedback("error", "No labels selected to add");
+      return;
+    }
+
+    const messageIds = selectedMessages.map(msg => msg.id);
+    const labelsToAdd = Array.from(selectedForAdd);
+    onApply(messageIds, "add", labelsToAdd);
+    setSelectedForAdd(new Set());
+    showFeedback("success", `Added ${labelsToAdd.length} label(s) to ${messageIds.length} message(s)`);
+  };
+
+  const applyRemoveLabels = () => {
+    if (selectedForRemove.size === 0) {
+      showFeedback("error", "No labels selected to remove");
+      return;
+    }
+
+    const messageIds = selectedMessages.map(msg => msg.id);
+    const labelsToRemove = Array.from(selectedForRemove);
+    onApply(messageIds, "remove", labelsToRemove);
+    setSelectedForRemove(new Set());
+    showFeedback("success", `Removed ${labelsToRemove.length} label(s) from ${messageIds.length} message(s)`);
+  };
+
+  const showFeedback = (type: "success" | "error", message: string) => {
+    setFeedback({ type, message });
+    setTimeout(() => setFeedback(null), 3000);
+  };
+
+  if (selectedMessages.length === 0) {
+    return (
+      <div className={cn("p-6 border rounded-lg bg-muted/20", className)}>
+        <div className="flex flex-col items-center justify-center text-center space-y-2">
+          <Tag className="h-8 w-8 text-muted-foreground opacity-50" />
+          <p className="text-sm text-muted-foreground">
+            No messages selected. Select one or more messages to manage labels.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            <Tag className="h-5 w-5" />
+            Bulk Label Management
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Managing labels for {selectedMessages.length} selected message(s)
+          </p>
+        </div>
+      </div>
+
+      {/* Feedback */}
+      {feedback && (
+        <div
+          className={cn(
+            "flex items-center gap-2 p-3 rounded-lg border",
+            feedback.type === "success"
+              ? "bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800"
+              : "bg-red-50 dark:bg-red-950/20 border-red-200 dark:border-red-800"
+          )}
+        >
+          {feedback.type === "success" ? (
+            <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+          ) : (
+            <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+          )}
+          <p className="text-sm">{feedback.message}</p>
+        </div>
+      )}
+
+      {/* Add New Label */}
+      <div className="p-4 border rounded-lg space-y-3">
+        <Label htmlFor="new-label-input" className="text-sm font-medium">
+          Add New Label
+        </Label>
+        <div className="flex items-center gap-2">
+          <Input
+            id="new-label-input"
+            placeholder="Enter label name..."
+            value={newLabelInput}
+            onChange={(e) => setNewLabelInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleAddNewLabel();
+              }
+            }}
+            className="flex-1"
+          />
+          <Button
+            onClick={handleAddNewLabel}
+            disabled={!newLabelInput.trim()}
+            size="sm"
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Create a new label and apply it to all selected messages
+        </p>
+      </div>
+
+      <Separator />
+
+      {/* Common Labels (on all messages) */}
+      {labelState.common.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">
+              Common Labels ({labelState.common.length})
+            </Label>
+            {selectedForRemove.size > 0 && (
+              <Button
+                onClick={applyRemoveLabels}
+                variant="destructive"
+                size="sm"
+              >
+                Remove Selected ({selectedForRemove.size})
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            These labels exist on all selected messages
+          </p>
+          <ScrollArea className="h-32">
+            <div className="flex flex-wrap gap-2">
+              {labelState.common.map((label) => (
+                <Badge
+                  key={label}
+                  variant={selectedForRemove.has(label) ? "destructive" : "secondary"}
+                  className="cursor-pointer transition-colors"
+                  onClick={() => toggleLabelForRemove(label)}
+                >
+                  {label}
+                  {selectedForRemove.has(label) && (
+                    <X className="h-3 w-3 ml-1" />
+                  )}
+                </Badge>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+
+      {/* Partial Labels (on some messages) */}
+      {labelState.partial.length > 0 && (
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">
+            Partial Labels ({labelState.partial.length})
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            These labels exist on some but not all selected messages
+          </p>
+          <ScrollArea className="h-32">
+            <div className="flex flex-wrap gap-2">
+              {labelState.partial.map((label) => (
+                <Badge
+                  key={label}
+                  variant="outline"
+                  className="cursor-pointer transition-colors border-dashed"
+                >
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Available Labels (not on any selected message) */}
+      {labelState.available.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">
+              Available Labels ({labelState.available.length})
+            </Label>
+            {selectedForAdd.size > 0 && (
+              <Button
+                onClick={applyAddLabels}
+                variant="default"
+                size="sm"
+              >
+                Add Selected ({selectedForAdd.size})
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Click labels to select them for bulk addition
+          </p>
+          <ScrollArea className="h-32">
+            <div className="flex flex-wrap gap-2">
+              {labelState.available.map((label) => (
+                <Badge
+                  key={label}
+                  variant={selectedForAdd.has(label) ? "default" : "outline"}
+                  className="cursor-pointer transition-colors"
+                  onClick={() => toggleLabelForAdd(label)}
+                >
+                  {label}
+                  {selectedForAdd.has(label) && (
+                    <CheckCircle2 className="h-3 w-3 ml-1" />
+                  )}
+                </Badge>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+
+      {labelState.available.length === 0 && labelState.common.length === 0 && labelState.partial.length === 0 && (
+        <div className="p-6 text-center text-sm text-muted-foreground">
+          No labels available. Create a new label above to get started.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Calculate which labels are common, partial, or available across selected messages.
+ */
+function calculateLabelState(
+  selectedMessages: DemoMessage[],
+  availableLabels: string[]
+): LabelState {
+  if (selectedMessages.length === 0) {
+    return { common: [], partial: [], available: availableLabels };
+  }
+
+  // Count how many messages have each label
+  const labelCounts = new Map<string, number>();
+  
+  for (const message of selectedMessages) {
+    for (const label of message.labels) {
+      labelCounts.set(label, (labelCounts.get(label) || 0) + 1);
+    }
+  }
+
+  // Also include available labels that might not be on any selected message
+  for (const label of availableLabels) {
+    if (!labelCounts.has(label)) {
+      labelCounts.set(label, 0);
+    }
+  }
+
+  const totalMessages = selectedMessages.length;
+  const common: string[] = [];
+  const partial: string[] = [];
+  const available: string[] = [];
+
+  for (const [label, count] of labelCounts) {
+    if (count === totalMessages) {
+      common.push(label);
+    } else if (count > 0) {
+      partial.push(label);
+    } else {
+      available.push(label);
+    }
+  }
+
+  // Sort alphabetically
+  common.sort();
+  partial.sort();
+  available.sort();
+
+  return { common, partial, available };
+}

--- a/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
@@ -33,7 +33,7 @@ interface LabelState {
 /**
  * BulkLabelPanel allows admins to add or remove labels across multiple
  * selected demo messages.
- * 
+ *
  * Features:
  * - Shows labels common to all selected messages
  * - Shows labels present on some messages (partial state)
@@ -66,12 +66,10 @@ export function BulkLabelPanel({
     }
 
     const labelId = toLabelId(normalized);
-    
+
     // Check if label already exists (case-insensitive)
-    const existingLabel = availableLabels.find(
-      label => toLabelId(label) === labelId
-    );
-    
+    const existingLabel = availableLabels.find((label) => toLabelId(label) === labelId);
+
     if (existingLabel) {
       // Label already exists, toggle it for addition
       toggleLabelForAdd(existingLabel);
@@ -80,14 +78,14 @@ export function BulkLabelPanel({
     }
 
     // Add the new label to selected messages
-    const messageIds = selectedMessages.map(msg => msg.id);
+    const messageIds = selectedMessages.map((msg) => msg.id);
     onApply(messageIds, "add", [normalized]);
     setNewLabelInput("");
     showFeedback("success", `Added label "${normalized}" to ${messageIds.length} message(s)`);
   };
 
   const toggleLabelForAdd = (label: string) => {
-    setSelectedForAdd(prev => {
+    setSelectedForAdd((prev) => {
       const next = new Set(prev);
       if (next.has(label)) {
         next.delete(label);
@@ -97,7 +95,7 @@ export function BulkLabelPanel({
       return next;
     });
     // Clear from remove selection if present
-    setSelectedForRemove(prev => {
+    setSelectedForRemove((prev) => {
       const next = new Set(prev);
       next.delete(label);
       return next;
@@ -105,7 +103,7 @@ export function BulkLabelPanel({
   };
 
   const toggleLabelForRemove = (label: string) => {
-    setSelectedForRemove(prev => {
+    setSelectedForRemove((prev) => {
       const next = new Set(prev);
       if (next.has(label)) {
         next.delete(label);
@@ -115,7 +113,7 @@ export function BulkLabelPanel({
       return next;
     });
     // Clear from add selection if present
-    setSelectedForAdd(prev => {
+    setSelectedForAdd((prev) => {
       const next = new Set(prev);
       next.delete(label);
       return next;
@@ -128,11 +126,14 @@ export function BulkLabelPanel({
       return;
     }
 
-    const messageIds = selectedMessages.map(msg => msg.id);
+    const messageIds = selectedMessages.map((msg) => msg.id);
     const labelsToAdd = Array.from(selectedForAdd);
     onApply(messageIds, "add", labelsToAdd);
     setSelectedForAdd(new Set());
-    showFeedback("success", `Added ${labelsToAdd.length} label(s) to ${messageIds.length} message(s)`);
+    showFeedback(
+      "success",
+      `Added ${labelsToAdd.length} label(s) to ${messageIds.length} message(s)`,
+    );
   };
 
   const applyRemoveLabels = () => {
@@ -141,11 +142,14 @@ export function BulkLabelPanel({
       return;
     }
 
-    const messageIds = selectedMessages.map(msg => msg.id);
+    const messageIds = selectedMessages.map((msg) => msg.id);
     const labelsToRemove = Array.from(selectedForRemove);
     onApply(messageIds, "remove", labelsToRemove);
     setSelectedForRemove(new Set());
-    showFeedback("success", `Removed ${labelsToRemove.length} label(s) from ${messageIds.length} message(s)`);
+    showFeedback(
+      "success",
+      `Removed ${labelsToRemove.length} label(s) from ${messageIds.length} message(s)`,
+    );
   };
 
   const showFeedback = (type: "success" | "error", message: string) => {
@@ -188,7 +192,7 @@ export function BulkLabelPanel({
             "flex items-center gap-2 p-3 rounded-lg border",
             feedback.type === "success"
               ? "bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800"
-              : "bg-red-50 dark:bg-red-950/20 border-red-200 dark:border-red-800"
+              : "bg-red-50 dark:bg-red-950/20 border-red-200 dark:border-red-800",
           )}
         >
           {feedback.type === "success" ? (
@@ -218,11 +222,7 @@ export function BulkLabelPanel({
             }}
             className="flex-1"
           />
-          <Button
-            onClick={handleAddNewLabel}
-            disabled={!newLabelInput.trim()}
-            size="sm"
-          >
+          <Button onClick={handleAddNewLabel} disabled={!newLabelInput.trim()} size="sm">
             <Plus className="h-4 w-4 mr-1" />
             Add
           </Button>
@@ -242,11 +242,7 @@ export function BulkLabelPanel({
               Common Labels ({labelState.common.length})
             </Label>
             {selectedForRemove.size > 0 && (
-              <Button
-                onClick={applyRemoveLabels}
-                variant="destructive"
-                size="sm"
-              >
+              <Button onClick={applyRemoveLabels} variant="destructive" size="sm">
                 Remove Selected ({selectedForRemove.size})
               </Button>
             )}
@@ -264,9 +260,7 @@ export function BulkLabelPanel({
                   onClick={() => toggleLabelForRemove(label)}
                 >
                   {label}
-                  {selectedForRemove.has(label) && (
-                    <X className="h-3 w-3 ml-1" />
-                  )}
+                  {selectedForRemove.has(label) && <X className="h-3 w-3 ml-1" />}
                 </Badge>
               ))}
             </div>
@@ -284,20 +278,12 @@ export function BulkLabelPanel({
             {(selectedForAdd.size > 0 || selectedForRemove.size > 0) && (
               <div className="flex gap-2">
                 {selectedForAdd.size > 0 && (
-                  <Button
-                    onClick={applyAddLabels}
-                    variant="default"
-                    size="sm"
-                  >
+                  <Button onClick={applyAddLabels} variant="default" size="sm">
                     Add Selected ({selectedForAdd.size})
                   </Button>
                 )}
                 {selectedForRemove.size > 0 && (
-                  <Button
-                    onClick={applyRemoveLabels}
-                    variant="destructive"
-                    size="sm"
-                  >
+                  <Button onClick={applyRemoveLabels} variant="destructive" size="sm">
                     Remove Selected ({selectedForRemove.size})
                   </Button>
                 )}
@@ -305,7 +291,8 @@ export function BulkLabelPanel({
             )}
           </div>
           <p className="text-xs text-muted-foreground">
-            These labels exist on some but not all selected messages. Click to add to all, or click the X to remove from all.
+            These labels exist on some but not all selected messages. Click to add to all, or click
+            the X to remove from all.
           </p>
           <ScrollArea className="h-32">
             <div className="flex flex-wrap gap-2">
@@ -316,19 +303,19 @@ export function BulkLabelPanel({
                   <Badge
                     key={label}
                     variant={
-                      isMarkedForAdd ? "default" :
-                      isMarkedForRemove ? "destructive" :
-                      "outline"
+                      isMarkedForAdd ? "default" : isMarkedForRemove ? "destructive" : "outline"
                     }
                     className={cn(
                       "transition-colors",
-                      (!isMarkedForAdd && !isMarkedForRemove) && "cursor-pointer border-dashed hover:border-solid"
+                      !isMarkedForAdd &&
+                        !isMarkedForRemove &&
+                        "cursor-pointer border-dashed hover:border-solid",
                     )}
                     onClick={() => {
                       if (!isMarkedForAdd && !isMarkedForRemove) {
                         toggleLabelForAdd(label);
                       } else if (isMarkedForAdd) {
-                        setSelectedForAdd(prev => {
+                        setSelectedForAdd((prev) => {
                           const next = new Set(prev);
                           next.delete(label);
                           return next;
@@ -372,11 +359,7 @@ export function BulkLabelPanel({
               Available Labels ({labelState.available.length})
             </Label>
             {selectedForAdd.size > 0 && (
-              <Button
-                onClick={applyAddLabels}
-                variant="default"
-                size="sm"
-              >
+              <Button onClick={applyAddLabels} variant="default" size="sm">
                 Add Selected ({selectedForAdd.size})
               </Button>
             )}
@@ -394,9 +377,7 @@ export function BulkLabelPanel({
                   onClick={() => toggleLabelForAdd(label)}
                 >
                   {label}
-                  {selectedForAdd.has(label) && (
-                    <CheckCircle2 className="h-3 w-3 ml-1" />
-                  )}
+                  {selectedForAdd.has(label) && <CheckCircle2 className="h-3 w-3 ml-1" />}
                 </Badge>
               ))}
             </div>
@@ -404,11 +385,13 @@ export function BulkLabelPanel({
         </div>
       )}
 
-      {labelState.available.length === 0 && labelState.common.length === 0 && labelState.partial.length === 0 && (
-        <div className="p-6 text-center text-sm text-muted-foreground">
-          No labels available. Create a new label above to get started.
-        </div>
-      )}
+      {labelState.available.length === 0 &&
+        labelState.common.length === 0 &&
+        labelState.partial.length === 0 && (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No labels available. Create a new label above to get started.
+          </div>
+        )}
     </div>
   );
 }
@@ -418,13 +401,15 @@ export function BulkLabelPanel({
  */
 export function calculateLabelState(
   selectedMessages: DemoMessage[],
-  availableLabels: string[]
+  availableLabels: string[],
 ): LabelState {
   if (selectedMessages.length === 0) {
     return {
       common: [],
       partial: [],
-      available: [...new Set(availableLabels.map((label) => normalizeLabelName(label)).filter(Boolean))].sort(),
+      available: [
+        ...new Set(availableLabels.map((label) => normalizeLabelName(label)).filter(Boolean)),
+      ].sort(),
     };
   }
 

--- a/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
@@ -277,23 +277,86 @@ export function BulkLabelPanel({
       {/* Partial Labels (on some messages) */}
       {labelState.partial.length > 0 && (
         <div className="space-y-3">
-          <Label className="text-sm font-medium">
-            Partial Labels ({labelState.partial.length})
-          </Label>
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">
+              Partial Labels ({labelState.partial.length})
+            </Label>
+            {(selectedForAdd.size > 0 || selectedForRemove.size > 0) && (
+              <div className="flex gap-2">
+                {selectedForAdd.size > 0 && (
+                  <Button
+                    onClick={applyAddLabels}
+                    variant="default"
+                    size="sm"
+                  >
+                    Add Selected ({selectedForAdd.size})
+                  </Button>
+                )}
+                {selectedForRemove.size > 0 && (
+                  <Button
+                    onClick={applyRemoveLabels}
+                    variant="destructive"
+                    size="sm"
+                  >
+                    Remove Selected ({selectedForRemove.size})
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
           <p className="text-xs text-muted-foreground">
-            These labels exist on some but not all selected messages
+            These labels exist on some but not all selected messages. Click to add to all, or click the X to remove from all.
           </p>
           <ScrollArea className="h-32">
             <div className="flex flex-wrap gap-2">
-              {labelState.partial.map((label) => (
-                <Badge
-                  key={label}
-                  variant="outline"
-                  className="cursor-pointer transition-colors border-dashed"
-                >
-                  {label}
-                </Badge>
-              ))}
+              {labelState.partial.map((label) => {
+                const isMarkedForAdd = selectedForAdd.has(label);
+                const isMarkedForRemove = selectedForRemove.has(label);
+                return (
+                  <Badge
+                    key={label}
+                    variant={
+                      isMarkedForAdd ? "default" :
+                      isMarkedForRemove ? "destructive" :
+                      "outline"
+                    }
+                    className={cn(
+                      "transition-colors",
+                      (!isMarkedForAdd && !isMarkedForRemove) && "cursor-pointer border-dashed hover:border-solid"
+                    )}
+                    onClick={() => {
+                      if (!isMarkedForAdd && !isMarkedForRemove) {
+                        toggleLabelForAdd(label);
+                      } else if (isMarkedForAdd) {
+                        setSelectedForAdd(prev => {
+                          const next = new Set(prev);
+                          next.delete(label);
+                          return next;
+                        });
+                      }
+                    }}
+                  >
+                    {label}
+                    {isMarkedForAdd ? (
+                      <CheckCircle2 className="h-3 w-3 ml-1" />
+                    ) : isMarkedForRemove ? (
+                      <X className="h-3 w-3 ml-1" />
+                    ) : (
+                      <button
+                        type="button"
+                        className="ml-1 hover:text-destructive focus:outline-none"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleLabelForRemove(label);
+                        }}
+                        aria-label={`Remove ${label} from all selected`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
+                  </Badge>
+                );
+              })}
             </div>
           </ScrollArea>
         </div>

--- a/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkLabelPanel.tsx
@@ -353,49 +353,78 @@ export function BulkLabelPanel({
 /**
  * Calculate which labels are common, partial, or available across selected messages.
  */
-function calculateLabelState(
+export function calculateLabelState(
   selectedMessages: DemoMessage[],
   availableLabels: string[]
 ): LabelState {
   if (selectedMessages.length === 0) {
-    return { common: [], partial: [], available: availableLabels };
-  }
-
-  // Count how many messages have each label
-  const labelCounts = new Map<string, number>();
-  
-  for (const message of selectedMessages) {
-    for (const label of message.labels) {
-      labelCounts.set(label, (labelCounts.get(label) || 0) + 1);
-    }
-  }
-
-  // Also include available labels that might not be on any selected message
-  for (const label of availableLabels) {
-    if (!labelCounts.has(label)) {
-      labelCounts.set(label, 0);
-    }
+    return {
+      common: [],
+      partial: [],
+      available: [...new Set(availableLabels.map((label) => normalizeLabelName(label)).filter(Boolean))].sort(),
+    };
   }
 
   const totalMessages = selectedMessages.length;
+  const labelDisplayMap = new Map<string, string>();
+  const labelCountMap = new Map<string, number>();
+  const labelIdSet = new Set<string>();
+
+  const registerLabel = (rawLabel: string) => {
+    const normalized = normalizeLabelName(rawLabel);
+    if (!normalized) {
+      return;
+    }
+
+    const id = toLabelId(normalized);
+    if (!id) {
+      return;
+    }
+
+    if (!labelDisplayMap.has(id)) {
+      labelDisplayMap.set(id, normalized);
+    }
+    labelIdSet.add(id);
+  };
+
+  for (const message of selectedMessages) {
+    const seenInMessage = new Set<string>();
+    for (const label of message.labels) {
+      const normalized = normalizeLabelName(label);
+      const id = toLabelId(normalized);
+      if (!normalized || !id || seenInMessage.has(id)) {
+        continue;
+      }
+      seenInMessage.add(id);
+      registerLabel(normalized);
+      labelCountMap.set(id, (labelCountMap.get(id) ?? 0) + 1);
+    }
+  }
+
+  for (const label of availableLabels) {
+    registerLabel(label);
+  }
+
   const common: string[] = [];
   const partial: string[] = [];
   const available: string[] = [];
 
-  for (const [label, count] of labelCounts) {
+  for (const id of labelIdSet) {
+    const count = labelCountMap.get(id) ?? 0;
+    const display = labelDisplayMap.get(id) ?? id;
+
     if (count === totalMessages) {
-      common.push(label);
+      common.push(display);
     } else if (count > 0) {
-      partial.push(label);
+      partial.push(display);
     } else {
-      available.push(label);
+      available.push(display);
     }
   }
 
-  // Sort alphabetically
-  common.sort();
-  partial.sort();
-  available.sort();
+  common.sort((a, b) => a.localeCompare(b));
+  partial.sort((a, b) => a.localeCompare(b));
+  available.sort((a, b) => a.localeCompare(b));
 
   return { common, partial, available };
 }

--- a/src/features/demo-admin-dashboard/docs/BULK_LABEL_PANEL.md
+++ b/src/features/demo-admin-dashboard/docs/BULK_LABEL_PANEL.md
@@ -1,0 +1,48 @@
+# Bulk Label Panel
+
+Lets an admin add or remove labels across multiple selected demo messages at
+once, with duplicate prevention and an audit summary of what changed.
+
+All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on
+fake, deterministic demo data (`DemoMessage[]`). Nothing here touches real mail
+flows, network calls, or data outside this folder.
+
+## Pieces
+
+- `bulkLabelPanel.ts` — pure, immutable helpers:
+  - `normalizeLabelsForBulk` — normalize, drop blanks, and de-duplicate label
+    input for bulk operations.
+  - `applyBulkLabelEdit(messages, selectedIds, labels, operation)` — returns a
+    new message list plus a per-message change log and an audit summary. Inputs
+    are never mutated.
+  - `summarizeBulkLabelEdit(result)` — a one-line human summary.
+- `components/BulkLabelPanel.tsx` — label state visualization and bulk
+  add/remove controls with feedback messages.
+
+## Label distribution
+
+The `calculateLabelState` helper categorizes labels into three groups:
+
+| Category   | Description |
+|------------|-------------|
+| **Common** | Labels present on every selected message. Click to mark for removal. |
+| **Partial**| Labels present on some but not all selected messages. Click to add to all, or click the X to remove from all. |
+| **Available**| Labels present on none of the selected messages. Click to select for addition. |
+
+## Duplicate prevention
+
+- **Add:** a label already present on a message is skipped (never duplicated).
+- **Remove:** a label not present on a message is skipped.
+
+Skipped labels are reported per message and counted in the audit summary.
+
+## Audit summary
+
+`applyBulkLabelEdit` returns a `summary` with the operation, number of selected
+and affected messages, and totals for applied vs skipped labels. Example line:
+`Added 2 labels across 3 messages (1 skipped as duplicates).`
+
+## Follow-up
+
+Wiring this component into the main dashboard view is intentionally left as a
+follow-up so this change stays scoped and independently reviewable.

--- a/src/features/demo-admin-dashboard/docs/BULK_LABEL_PANEL.md
+++ b/src/features/demo-admin-dashboard/docs/BULK_LABEL_PANEL.md
@@ -23,11 +23,11 @@ flows, network calls, or data outside this folder.
 
 The `calculateLabelState` helper categorizes labels into three groups:
 
-| Category   | Description |
-|------------|-------------|
-| **Common** | Labels present on every selected message. Click to mark for removal. |
-| **Partial**| Labels present on some but not all selected messages. Click to add to all, or click the X to remove from all. |
-| **Available**| Labels present on none of the selected messages. Click to select for addition. |
+| Category      | Description                                                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Common**    | Labels present on every selected message. Click to mark for removal.                                          |
+| **Partial**   | Labels present on some but not all selected messages. Click to add to all, or click the X to remove from all. |
+| **Available** | Labels present on none of the selected messages. Click to select for addition.                                |
 
 ## Duplicate prevention
 

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -488,6 +488,21 @@ export {
 export { demoLabels, labeledDemoMessages } from "./labels/labelFixtures";
 export { LabelManager } from "./labels/LabelManager";
 
+// Bulk label panel (issue #40): add/remove labels across selected demo messages.
+export { BulkLabelPanel, calculateLabelState } from "./components/BulkLabelPanel";
+export type { BulkLabelPanelProps } from "./components/BulkLabelPanel";
+export {
+  applyBulkLabelEdit,
+  normalizeLabelsForBulk,
+  summarizeBulkLabelEdit,
+} from "./bulkLabelPanel";
+export type {
+  BulkLabelAuditSummary,
+  BulkLabelEditResult,
+  BulkLabelMessageChange,
+  BulkLabelOperation,
+} from "./bulkLabelPanel";
+
 // Draft dataset JSON import (issue #272): JSON -> safe drafts mapper with error output.
 export { mapImportedDataset, parseDatasetImport } from "./helpers/datasetImport";
 export type { DatasetImportIssue, DatasetImportResult } from "./types/datasetImport";


### PR DESCRIPTION
closes #205 

Here's a summary of the changes (all under `src/features/demo-admin-dashboard/`):

### New files
- **`bulkLabelPanel.ts`** — Pure logic module mirroring `bulkTagEditor.ts`: `normalizeLabelsForBulk`, `applyBulkLabelEdit` (add/remove with duplicate prevention), and `summarizeBulkLabelEdit` for audit summaries.
- **`docs/BULK_LABEL_PANEL.md`** — Usage and design documentation.

### Modified files
- **`components/BulkLabelPanel.tsx`** — Partial labels are now interactive: click to mark for addition (fills all messages), click the X to mark for removal (strips from all). Both produce action buttons in the section header.
- **`__tests__/bulkLabelPanel.test.ts`** — Tests expanded from 1 to 13 cases covering `normalizeLabelsForBulk`, `applyBulkLabelEdit` (add & remove), `summarizeBulkLabelEdit`, and additional `calculateLabelState` edge cases.
- **`index.ts`** — Exports `BulkLabelPanel`, `calculateLabelState`, `BulkLabelPanelProps`, and all `bulkLabelPanel` types/functions.

### Commits
1. `3ee05f9c` — Add bulkLabelPanel pure logic module with docs and exports
2. `d14e308e` — Make partial labels interactive and expand test coverage