### PR TITLE
[codex] Harden email ownership tracker

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -1,15 +1,53 @@
 # Email Ownership Tracker
 
-This folder is the isolated workspace for the Email Ownership Tracker tool.
+A self-contained V1 team tool for tracking who currently owns an email thread
+and preserving a bounded ownership history for review.
 
-## Ownership Boundary
+**Release tier:** V1
+**Audience:** Team
+**Isolation boundary:** `tools/v1/team/email-ownership-tracker/`
 
-All work for this tool must stay inside:
+## Purpose
 
-`text
-.\tools\v1\team\email-ownership-tracker\
-`
+Team inboxes need a clear handoff trail. This tool provides folder-local
+business logic for:
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+- validating ownership events before they are stored
+- normalizing owner, thread, and actor identifiers
+- sanitizing notes and reasons used in history rows
+- appending events without mutating existing histories
+- reading current ownership and compact thread histories
+- bounding large histories so the future UI does not process unlimited input
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```text
+email-ownership-tracker/
+├── docs/
+│   ├── REVIEW_NOTES.md
+│   └── SETUP.md
+├── fixtures/
+│   └── ownership.fixture.ts
+├── services/
+│   └── ownership.service.ts
+├── tests/
+│   ├── TEST_PLAN.md
+│   └── ownership.service.test.ts
+├── README.md
+├── specs.md
+└── vitest.config.ts
+```
+
+## Running Tests
+
+From the repository root:
+
+```bash
+npx vitest run --config tools/v1/team/email-ownership-tracker/vitest.config.ts
+```
+
+## Boundary
+
+This contribution is intentionally isolated. It does not import from the main
+app, mutate shared app state, add routes, touch auth, change the inbox
+architecture, or connect to external services.

--- a/tools/v1/team/email-ownership-tracker/docs/REVIEW_NOTES.md
+++ b/tools/v1/team/email-ownership-tracker/docs/REVIEW_NOTES.md
@@ -1,0 +1,41 @@
+# Email Ownership Tracker Review Notes
+
+## What This Adds
+
+| Deliverable | Location |
+| --- | --- |
+| Pure service logic | `services/ownership.service.ts` |
+| Local fixtures | `fixtures/ownership.fixture.ts` |
+| Unit tests | `tests/ownership.service.test.ts` |
+| Test plan | `tests/TEST_PLAN.md` |
+| Setup notes | `docs/SETUP.md` |
+| Specs cleanup | `specs.md` |
+
+No files outside `tools/v1/team/email-ownership-tracker/` should be modified by
+this contribution.
+
+## Security Notes
+
+- Identifiers are normalized and restricted to safe characters.
+- Free-text reason and note fields remove control characters and collapse
+  whitespace.
+- Text fields are bounded before storage.
+- Malformed ownership events throw instead of entering history.
+
+## Performance Notes
+
+- History reads are bounded with `MAX_HISTORY_LIMIT`.
+- Functions are pure and do not mutate caller-provided arrays.
+- There are no network calls, timers, storage adapters, or app imports.
+
+## Verification
+
+```bash
+npx vitest run --config tools/v1/team/email-ownership-tracker/vitest.config.ts
+```
+
+Optional boundary check:
+
+```bash
+git diff --name-only | grep -v '^tools/v1/team/email-ownership-tracker/'
+```

--- a/tools/v1/team/email-ownership-tracker/docs/SETUP.md
+++ b/tools/v1/team/email-ownership-tracker/docs/SETUP.md
@@ -1,0 +1,17 @@
+# Email Ownership Tracker Setup
+
+No tool-specific dependencies are required. Use the repository root toolchain.
+
+```bash
+npm install
+npx vitest run --config tools/v1/team/email-ownership-tracker/vitest.config.ts
+```
+
+All implementation files for this issue are intentionally scoped to:
+
+```text
+tools/v1/team/email-ownership-tracker/
+```
+
+The tool is pure TypeScript and does not require a browser, localStorage,
+network access, or database setup.

--- a/tools/v1/team/email-ownership-tracker/fixtures/ownership.fixture.ts
+++ b/tools/v1/team/email-ownership-tracker/fixtures/ownership.fixture.ts
@@ -1,0 +1,34 @@
+import type { OwnershipEvent } from "../services/ownership.service";
+
+export const FIXTURE_OWNERSHIP_EVENTS: OwnershipEvent[] = [
+  {
+    id: "ownership_thread-100_2026-06-20T09:00:00.000Z",
+    threadId: "thread-100",
+    ownerId: "agent-alice",
+    actorId: "lead-marta",
+    action: "assigned",
+    reason: "Initial triage",
+    note: "Customer asks about account recovery.",
+    createdAt: "2026-06-20T09:00:00.000Z",
+  },
+  {
+    id: "ownership_thread-100_2026-06-20T10:00:00.000Z",
+    threadId: "thread-100",
+    ownerId: "agent-bob",
+    actorId: "agent-alice",
+    action: "transferred",
+    reason: "Escalation",
+    note: "Needs billing specialist follow-up.",
+    createdAt: "2026-06-20T10:00:00.000Z",
+  },
+  {
+    id: "ownership_thread-200_2026-06-20T11:00:00.000Z",
+    threadId: "thread-200",
+    ownerId: "agent-carol",
+    actorId: "agent-carol",
+    action: "claimed",
+    reason: "Queue pickup",
+    note: "New inbound enterprise question.",
+    createdAt: "2026-06-20T11:00:00.000Z",
+  },
+];

--- a/tools/v1/team/email-ownership-tracker/services/ownership.service.ts
+++ b/tools/v1/team/email-ownership-tracker/services/ownership.service.ts
@@ -1,0 +1,195 @@
+/**
+ * Email Ownership Tracker — Core Service
+ *
+ * Pure business logic for validating and reading ownership history.
+ * Isolation contract: this module must not import from the main app.
+ */
+
+export type OwnershipAction = "assigned" | "claimed" | "released" | "transferred";
+
+export interface OwnershipEvent {
+  id: string;
+  threadId: string;
+  ownerId: string;
+  actorId: string;
+  action: OwnershipAction;
+  reason: string;
+  note: string;
+  createdAt: string;
+}
+
+export interface OwnershipEventInput {
+  threadId: string;
+  ownerId: string;
+  actorId: string;
+  action: OwnershipAction;
+  reason?: string;
+  note?: string;
+  createdAt?: string;
+}
+
+export interface OwnershipValidationError {
+  field: "threadId" | "ownerId" | "actorId" | "action" | "reason" | "note" | "createdAt";
+  message: string;
+}
+
+export interface OwnershipSummary {
+  threadId: string;
+  currentOwnerId: string | null;
+  eventCount: number;
+  latestAction: OwnershipAction | null;
+  latestAt: string | null;
+}
+
+export const MAX_REASON_LENGTH = 120;
+export const MAX_NOTE_LENGTH = 500;
+export const MAX_HISTORY_LIMIT = 200;
+
+const VALID_ACTIONS: OwnershipAction[] = ["assigned", "claimed", "released", "transferred"];
+const ID_PATTERN = /^[a-z0-9][a-z0-9._:-]{1,79}$/;
+
+export function now(): string {
+  return new Date().toISOString();
+}
+
+export function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function sanitizeText(value: string, maxLength: number): string {
+  return [...value]
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || code === 127 ? " " : char;
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function isValidIdentifier(value: string): boolean {
+  return ID_PATTERN.test(normalizeIdentifier(value));
+}
+
+export function isValidIsoTimestamp(value: string): boolean {
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString() === value;
+}
+
+export function validateOwnershipEventInput(
+  input: Partial<OwnershipEventInput>,
+): OwnershipValidationError[] {
+  const errors: OwnershipValidationError[] = [];
+
+  if (!input.threadId || !isValidIdentifier(input.threadId)) {
+    errors.push({
+      field: "threadId",
+      message: "Thread id must be 2-80 safe identifier characters.",
+    });
+  }
+
+  if (!input.ownerId || !isValidIdentifier(input.ownerId)) {
+    errors.push({
+      field: "ownerId",
+      message: "Owner id must be 2-80 safe identifier characters.",
+    });
+  }
+
+  if (!input.actorId || !isValidIdentifier(input.actorId)) {
+    errors.push({
+      field: "actorId",
+      message: "Actor id must be 2-80 safe identifier characters.",
+    });
+  }
+
+  if (!input.action || !VALID_ACTIONS.includes(input.action)) {
+    errors.push({ field: "action", message: "Action is not supported." });
+  }
+
+  if (input.reason && sanitizeText(input.reason, MAX_REASON_LENGTH).length === 0) {
+    errors.push({ field: "reason", message: "Reason must contain visible text." });
+  }
+
+  if (input.note && sanitizeText(input.note, MAX_NOTE_LENGTH).length === 0) {
+    errors.push({ field: "note", message: "Note must contain visible text." });
+  }
+
+  if (input.createdAt && !isValidIsoTimestamp(input.createdAt)) {
+    errors.push({ field: "createdAt", message: "createdAt must be an ISO-8601 timestamp." });
+  }
+
+  return errors;
+}
+
+export function createOwnershipEvent(input: OwnershipEventInput): OwnershipEvent {
+  const errors = validateOwnershipEventInput(input);
+  if (errors.length > 0) {
+    throw new Error(errors.map((error) => `${error.field}: ${error.message}`).join("; "));
+  }
+
+  const createdAt = input.createdAt ?? now();
+  const threadId = normalizeIdentifier(input.threadId);
+  const ownerId = normalizeIdentifier(input.ownerId);
+  const actorId = normalizeIdentifier(input.actorId);
+
+  return {
+    id: `ownership_${threadId}_${createdAt}`,
+    threadId,
+    ownerId,
+    actorId,
+    action: input.action,
+    reason: sanitizeText(input.reason ?? "", MAX_REASON_LENGTH),
+    note: sanitizeText(input.note ?? "", MAX_NOTE_LENGTH),
+    createdAt,
+  };
+}
+
+export function appendOwnershipEvent(
+  events: OwnershipEvent[],
+  input: OwnershipEventInput,
+): OwnershipEvent[] {
+  return [...events, createOwnershipEvent(input)].sort(compareEventsAscending);
+}
+
+export function getOwnershipHistoryForThread(
+  events: OwnershipEvent[],
+  threadId: string,
+  limit = MAX_HISTORY_LIMIT,
+): OwnershipEvent[] {
+  const normalizedThreadId = normalizeIdentifier(threadId);
+  const safeLimit = Math.max(0, Math.min(Math.floor(limit), MAX_HISTORY_LIMIT));
+
+  return events
+    .filter((event) => event.threadId === normalizedThreadId)
+    .sort(compareEventsDescending)
+    .slice(0, safeLimit);
+}
+
+export function getCurrentOwnerId(events: OwnershipEvent[], threadId: string): string | null {
+  const [latest] = getOwnershipHistoryForThread(events, threadId, 1);
+  if (!latest || latest.action === "released") return null;
+  return latest.ownerId;
+}
+
+export function summarizeOwnership(events: OwnershipEvent[], threadId: string): OwnershipSummary {
+  const history = getOwnershipHistoryForThread(events, threadId);
+  const [latest] = history;
+  const normalizedThreadId = normalizeIdentifier(threadId);
+
+  return {
+    threadId: normalizedThreadId,
+    currentOwnerId: getCurrentOwnerId(events, normalizedThreadId),
+    eventCount: history.length,
+    latestAction: latest?.action ?? null,
+    latestAt: latest?.createdAt ?? null,
+  };
+}
+
+function compareEventsAscending(a: OwnershipEvent, b: OwnershipEvent): number {
+  return a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id);
+}
+
+function compareEventsDescending(a: OwnershipEvent, b: OwnershipEvent): number {
+  return compareEventsAscending(b, a);
+}

--- a/tools/v1/team/email-ownership-tracker/specs.md
+++ b/tools/v1/team/email-ownership-tracker/specs.md
@@ -1,41 +1,61 @@
-# Email Ownership Tracker
-
-Track ownership history.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/email-ownership-tracker/README.md"
-  @"
-
 # Email Ownership Tracker Specs
 
 ## Purpose
 
-Track ownership history.
+Track ownership history for team inbox threads before this tool is integrated
+with the main mail product.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- **Release tier:** V1
+- **Audience:** Team
+- **Folder ownership:** `tools/v1/team/email-ownership-tracker/`
 
-$dir/
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system unless a future integration issue explicitly allows it.
 
-## Required issue categories
+## Required Issue Categories
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+| Category | Status |
+| --- | --- |
+| Architecture | Addressed with pure service functions and folder-local types |
+| Feature | Addressed with ownership event creation, append, history, and summary helpers |
+| UI and accessibility | Deferred to a separate UI issue |
+| Security and performance | Addressed with validation, sanitization, and bounded history reads |
+| Testing and documentation | Addressed with fixtures, unit tests, setup notes, and review notes |
+
+## Data Model
+
+Ownership events are append-only records. Each event includes:
+
+- `threadId`
+- `ownerId`
+- `actorId`
+- `action`
+- `reason`
+- `note`
+- `createdAt`
+
+Current ownership is derived from the newest valid event for a thread.
+
+## Security and Performance Requirements
+
+- Reject empty or malformed thread, owner, and actor identifiers.
+- Normalize identifiers to lowercase trimmed strings.
+- Sanitize free-text fields by removing control characters and collapsing
+  whitespace.
+- Bound reason and note lengths before storing.
+- Bound history reads with explicit limits.
+- Avoid mutating caller-provided event arrays.
+
+## Contributor Boundary
+
+All work for this tool stays in:
+
+```text
+tools/v1/team/email-ownership-tracker/
+```
+
+Pull requests that modify files outside this folder should be rejected unless a
+future integration issue explicitly grants expanded scope.

--- a/tools/v1/team/email-ownership-tracker/tests/TEST_PLAN.md
+++ b/tools/v1/team/email-ownership-tracker/tests/TEST_PLAN.md
@@ -1,0 +1,25 @@
+# Email Ownership Tracker Test Plan
+
+Run from the repository root:
+
+```bash
+npx vitest run --config tools/v1/team/email-ownership-tracker/vitest.config.ts
+```
+
+## Coverage
+
+- Identifier validation rejects empty, short, path-like, and markup-like input.
+- Free-text sanitization removes control characters, collapses whitespace, and
+  bounds stored text lengths.
+- Ownership event creation normalizes identifiers and refuses malformed input.
+- Append operations return new arrays and do not mutate caller-owned history.
+- History reads are newest-first and bounded by explicit and maximum limits.
+- Released threads report no current owner.
+- Summary output is deterministic for review and future UI use.
+
+## Non-Goals
+
+- No React or DOM testing.
+- No integration with the main app, inbox, routing, auth, wallet, Stellar, or
+  database layers.
+- No network or external service calls.

--- a/tools/v1/team/email-ownership-tracker/tests/ownership.service.test.ts
+++ b/tools/v1/team/email-ownership-tracker/tests/ownership.service.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { FIXTURE_OWNERSHIP_EVENTS } from "../fixtures/ownership.fixture";
+import {
+  MAX_HISTORY_LIMIT,
+  MAX_NOTE_LENGTH,
+  MAX_REASON_LENGTH,
+  appendOwnershipEvent,
+  createOwnershipEvent,
+  getCurrentOwnerId,
+  getOwnershipHistoryForThread,
+  isValidIdentifier,
+  sanitizeText,
+  summarizeOwnership,
+  validateOwnershipEventInput,
+} from "../services/ownership.service";
+
+describe("identifier validation", () => {
+  it("accepts normalized safe identifiers", () => {
+    expect(isValidIdentifier("Thread-100")).toBe(true);
+    expect(isValidIdentifier("agent.alice")).toBe(true);
+  });
+
+  it("rejects empty, single-character, and hostile identifiers", () => {
+    expect(isValidIdentifier("")).toBe(false);
+    expect(isValidIdentifier("a")).toBe(false);
+    expect(isValidIdentifier("../thread")).toBe(false);
+    expect(isValidIdentifier("<script>")).toBe(false);
+  });
+});
+
+describe("sanitizeText", () => {
+  it("removes control characters and collapses whitespace", () => {
+    expect(sanitizeText("  transfer\u0000\n\nbecause\turgent  ", MAX_REASON_LENGTH)).toBe(
+      "transfer because urgent",
+    );
+  });
+
+  it("bounds text to the requested length", () => {
+    expect(sanitizeText("x".repeat(MAX_NOTE_LENGTH + 20), MAX_NOTE_LENGTH)).toHaveLength(
+      MAX_NOTE_LENGTH,
+    );
+  });
+});
+
+describe("validateOwnershipEventInput", () => {
+  it("returns no errors for a valid event", () => {
+    expect(
+      validateOwnershipEventInput({
+        threadId: "thread-300",
+        ownerId: "agent-dana",
+        actorId: "lead-marta",
+        action: "assigned",
+        createdAt: "2026-06-20T12:00:00.000Z",
+      }),
+    ).toEqual([]);
+  });
+
+  it("reports malformed identifiers and unsupported actions", () => {
+    const errors = validateOwnershipEventInput({
+      threadId: "<bad>",
+      ownerId: "",
+      actorId: "../actor",
+      action: "assigned",
+    });
+    expect(errors.map((error) => error.field)).toEqual(["threadId", "ownerId", "actorId"]);
+  });
+
+  it("rejects non-ISO timestamps", () => {
+    const errors = validateOwnershipEventInput({
+      threadId: "thread-300",
+      ownerId: "agent-dana",
+      actorId: "lead-marta",
+      action: "assigned",
+      createdAt: "20 June 2026",
+    });
+    expect(errors).toContainEqual({
+      field: "createdAt",
+      message: "createdAt must be an ISO-8601 timestamp.",
+    });
+  });
+});
+
+describe("createOwnershipEvent", () => {
+  it("normalizes ids and sanitizes reason and note", () => {
+    const event = createOwnershipEvent({
+      threadId: " Thread-300 ",
+      ownerId: " Agent-Dana ",
+      actorId: " Lead-Marta ",
+      action: "assigned",
+      reason: "  Queue\u0000pickup ",
+      note: "  Needs\nreview ",
+      createdAt: "2026-06-20T12:00:00.000Z",
+    });
+
+    expect(event.threadId).toBe("thread-300");
+    expect(event.ownerId).toBe("agent-dana");
+    expect(event.actorId).toBe("lead-marta");
+    expect(event.reason).toBe("Queue pickup");
+    expect(event.note).toBe("Needs review");
+  });
+
+  it("throws on invalid input instead of storing malformed events", () => {
+    expect(() =>
+      createOwnershipEvent({
+        threadId: "x",
+        ownerId: "agent-dana",
+        actorId: "lead-marta",
+        action: "claimed",
+      }),
+    ).toThrow("threadId");
+  });
+
+  it("bounds reason length", () => {
+    const event = createOwnershipEvent({
+      threadId: "thread-300",
+      ownerId: "agent-dana",
+      actorId: "lead-marta",
+      action: "claimed",
+      reason: "r".repeat(MAX_REASON_LENGTH + 25),
+      createdAt: "2026-06-20T12:00:00.000Z",
+    });
+    expect(event.reason).toHaveLength(MAX_REASON_LENGTH);
+  });
+});
+
+describe("ownership history", () => {
+  it("appends without mutating caller-provided arrays", () => {
+    const before = [...FIXTURE_OWNERSHIP_EVENTS];
+    const next = appendOwnershipEvent(FIXTURE_OWNERSHIP_EVENTS, {
+      threadId: "thread-100",
+      ownerId: "agent-dana",
+      actorId: "lead-marta",
+      action: "transferred",
+      createdAt: "2026-06-20T12:00:00.000Z",
+    });
+
+    expect(FIXTURE_OWNERSHIP_EVENTS).toEqual(before);
+    expect(next).toHaveLength(FIXTURE_OWNERSHIP_EVENTS.length + 1);
+  });
+
+  it("returns newest events first for a thread", () => {
+    const history = getOwnershipHistoryForThread(FIXTURE_OWNERSHIP_EVENTS, "THREAD-100");
+    expect(history.map((event) => event.ownerId)).toEqual(["agent-bob", "agent-alice"]);
+  });
+
+  it("respects explicit and maximum history limits", () => {
+    const manyEvents = Array.from({ length: MAX_HISTORY_LIMIT + 10 }, (_, index) =>
+      createOwnershipEvent({
+        threadId: "thread-big",
+        ownerId: `agent-${index}`,
+        actorId: "lead-marta",
+        action: "assigned",
+        createdAt: new Date(Date.UTC(2026, 5, 20, 12, 0, index)).toISOString(),
+      }),
+    );
+
+    expect(getOwnershipHistoryForThread(manyEvents, "thread-big", 3)).toHaveLength(3);
+    expect(getOwnershipHistoryForThread(manyEvents, "thread-big", 9999)).toHaveLength(
+      MAX_HISTORY_LIMIT,
+    );
+  });
+
+  it("returns null current owner when latest action releases ownership", () => {
+    const events = appendOwnershipEvent(FIXTURE_OWNERSHIP_EVENTS, {
+      threadId: "thread-100",
+      ownerId: "agent-bob",
+      actorId: "agent-bob",
+      action: "released",
+      createdAt: "2026-06-20T13:00:00.000Z",
+    });
+
+    expect(getCurrentOwnerId(events, "thread-100")).toBeNull();
+  });
+
+  it("summarizes ownership for a thread", () => {
+    expect(summarizeOwnership(FIXTURE_OWNERSHIP_EVENTS, "thread-100")).toEqual({
+      threadId: "thread-100",
+      currentOwnerId: "agent-bob",
+      eventCount: 2,
+      latestAction: "transferred",
+      latestAt: "2026-06-20T10:00:00.000Z",
+    });
+  });
+});

--- a/tools/v1/team/email-ownership-tracker/vitest.config.ts
+++ b/tools/v1/team/email-ownership-tracker/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "email-ownership-tracker",
+    include: ["tools/v1/team/email-ownership-tracker/tests/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+    environment: "node",
+    globals: false,
+    reporters: ["verbose"],
+  },
+});


### PR DESCRIPTION
## Summary

- replace generated README/spec leftovers for the Email Ownership Tracker with
  reviewable tool documentation
- add a pure folder-local ownership history service with validation,
  sanitization, bounded history reads, current-owner derivation, and immutable
  append behavior
- add fixtures, unit tests, setup notes, review notes, a test plan, and a
  tool-local Vitest config

## Why

Issue #437 asks for security and performance hardening before future
integration. The tool folder existed, but it only contained starter
documentation and generated leftovers. This PR keeps the work isolated inside
`tools/v1/team/email-ownership-tracker/` and adds the small core layer needed
to safely handle malformed ownership inputs and large histories.

## Testing

- `npx vitest run --config tools/v1/team/email-ownership-tracker/vitest.config.ts`
- `npx eslint tools/v1/team/email-ownership-tracker/services/ownership.service.ts tools/v1/team/email-ownership-tracker/fixtures/ownership.fixture.ts tools/v1/team/email-ownership-tracker/tests/ownership.service.test.ts tools/v1/team/email-ownership-tracker/vitest.config.ts`
- `git diff --check HEAD~1..HEAD`

Closes #
