### PR TITLE
perf: trim unnecessary EventRow re-renders in Audit Log (#963)

### DIFF
--- a/src/features/audit-log/AuditLog.tsx
+++ b/src/features/audit-log/AuditLog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import {
   BadgeDollarSign,
   ClipboardCopy,
@@ -74,7 +74,7 @@ function formatActor(event: AuditEvent): string {
 
 // ─── Row ─────────────────────────────────────────────────────────────────────
 
-function EventRow({ event }: { event: AuditEvent }) {
+const EventRow = memo(function EventRow({ event }: { event: AuditEvent }) {
   const Icon = CATEGORY_ICON[event.category];
   const context = event.context;
 
@@ -117,10 +117,9 @@ function EventRow({ event }: { event: AuditEvent }) {
       >
         {formatTs(event.ts)}
       </time>
-    </article>
+</article>
   );
-}
-
+});
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function AuditLog() {


### PR DESCRIPTION
closes #963 
EventRow re-rendered on every AuditLog state change (copy/export
     loading-state transitions) even when the filtered event list was
     unchanged, since filterAuditEvents already preserves object identity
     for surviving items. Wrapping EventRow in React.memo lets unaffected
     rows skip re-render entirely when only copyState/exportState change.

     No data-flow or filtering logic changed.