### PR TITLE
docs: add email template library review assets

### DIFF
--- a/tools/v2/individual/email-template-library/README.md
+++ b/tools/v2/individual/email-template-library/README.md
@@ -13,3 +13,9 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Review Assets
+
+- `TEST_PLAN.md` covers the folder-local checks for template listing, filtering, rendering, variable validation, and empty/error states.
+- `REVIEW_NOTES.md` maps the issue acceptance criteria to files a reviewer can inspect without running the full app.
+- `fixtures/template-library-fixtures.json` provides deterministic synthetic templates and preview values for manual or future automated tests.

--- a/tools/v2/individual/email-template-library/REVIEW_NOTES.md
+++ b/tools/v2/individual/email-template-library/REVIEW_NOTES.md
@@ -1,0 +1,31 @@
+# Email Template Library Review Notes
+
+## Issue Mapping
+
+This contribution supports issue #493 by adding reviewable test and documentation assets for the isolated Email Template Library tool.
+
+## Files Added or Updated
+
+- `README.md`: links the local review assets from the tool entry point.
+- `TEST_PLAN.md`: defines manual and future automated checks for template behavior.
+- `REVIEW_NOTES.md`: maps the contribution to the issue acceptance criteria.
+- `fixtures/template-library-fixtures.json`: provides deterministic synthetic data for review.
+
+## Acceptance Criteria Coverage
+
+- Tests or test plans live inside the tool folder: covered by `TEST_PLAN.md`.
+- Documentation explains independent review: covered by this file and the README links.
+- No app-wide integration: all guidance keeps the tool isolated from app routing, auth, wallet, mail engine, and Stellar code.
+- Files limited to the tool folder: all changes are under `tools/v2/individual/email-template-library/`.
+- Self-contained contribution: fixtures and review steps allow validation without external services.
+
+## Reviewer Checklist
+
+- [ ] Confirm no file outside `tools/v2/individual/email-template-library/` changed.
+- [ ] Confirm fixture data is synthetic and safe to commit.
+- [ ] Confirm the test plan covers happy path, missing variables, validation, empty states, and future automation targets.
+- [ ] Confirm no live network, wallet, auth, or production email dependency was introduced.
+
+## Known Limitations
+
+This PR does not implement runtime components or services. It documents the expected review surface and provides fixtures so a later implementation can add folder-local tests without changing the main application.

--- a/tools/v2/individual/email-template-library/TEST_PLAN.md
+++ b/tools/v2/individual/email-template-library/TEST_PLAN.md
@@ -1,0 +1,40 @@
+# Email Template Library Test Plan
+
+This plan covers the isolated Email Template Library tool in `tools/v2/individual/email-template-library/`. It does not require wiring the tool into the main mail app.
+
+## Scope
+
+Use the synthetic fixtures in `fixtures/template-library-fixtures.json` to validate the expected behavior for template browsing, searching, rendering, and variable handling. Do not use live email, wallet, Stellar, authentication, or production user data.
+
+## Fixture Coverage
+
+The fixture file includes:
+
+- three templates across work, recruiting, and billing categories;
+- variable placeholders such as `{{firstName}}`, `{{companyName}}`, and `{{invoiceNumber}}`;
+- preview values for a complete render path;
+- intentionally missing preview values for negative-state checks.
+
+## Manual Review Checks
+
+1. Confirm all files changed by this issue stay under `tools/v2/individual/email-template-library/`.
+2. Confirm the fixture data is synthetic and contains no real addresses, private keys, payment data, or production identifiers.
+3. Confirm a template list can be reviewed by category, name, subject, and body text from the fixture data.
+4. Confirm rendering replaces all variables when complete preview values are supplied.
+5. Confirm missing variables are reported by key when a preview value is absent.
+6. Confirm duplicate template names, blank subjects, and blank bodies are treated as validation errors in future implementation work.
+7. Confirm empty search results and no-template states have explicit reviewer expectations.
+
+## Suggested Future Automated Tests
+
+When the service layer exists, add folder-local tests for:
+
+- `searchTemplates(query)` returning templates by name, category, subject, or body text;
+- `renderTemplate(id, values)` replacing known variables and returning missing variable keys;
+- `validateTemplate(template)` rejecting empty names, duplicate names, empty subjects, and empty bodies;
+- category filtering preserving stable ordering;
+- fixture import remaining deterministic.
+
+## Out-of-Scope Checks
+
+Do not test the main app router, inbox, authentication, wallet state, Stellar calls, database persistence, or shared design system here. Those integrations need a separate issue.

--- a/tools/v2/individual/email-template-library/fixtures/template-library-fixtures.json
+++ b/tools/v2/individual/email-template-library/fixtures/template-library-fixtures.json
@@ -1,0 +1,76 @@
+{
+  "categories": [
+    {
+      "id": "work",
+      "name": "Work"
+    },
+    {
+      "id": "recruiting",
+      "name": "Recruiting"
+    },
+    {
+      "id": "billing",
+      "name": "Billing"
+    }
+  ],
+  "templates": [
+    {
+      "id": "welcome-client",
+      "name": "Welcome Client",
+      "categoryId": "work",
+      "subject": "Welcome, {{firstName}}",
+      "body": "Hi {{firstName}}, welcome to {{companyName}}. I will follow up with the onboarding notes by {{dueDate}}.",
+      "variables": [
+        "firstName",
+        "companyName",
+        "dueDate"
+      ]
+    },
+    {
+      "id": "interview-follow-up",
+      "name": "Interview Follow Up",
+      "categoryId": "recruiting",
+      "subject": "Next steps for {{roleName}}",
+      "body": "Hello {{candidateName}}, thank you for discussing the {{roleName}} role. The team will share feedback by {{followUpDate}}.",
+      "variables": [
+        "candidateName",
+        "roleName",
+        "followUpDate"
+      ]
+    },
+    {
+      "id": "invoice-reminder",
+      "name": "Invoice Reminder",
+      "categoryId": "billing",
+      "subject": "Invoice {{invoiceNumber}} reminder",
+      "body": "Hi {{firstName}}, invoice {{invoiceNumber}} for {{amountDue}} is due on {{dueDate}}.",
+      "variables": [
+        "firstName",
+        "invoiceNumber",
+        "amountDue",
+        "dueDate"
+      ]
+    }
+  ],
+  "previewValues": {
+    "firstName": "Alex",
+    "companyName": "Example Studio",
+    "dueDate": "Friday",
+    "candidateName": "Jordan",
+    "roleName": "Product Designer",
+    "followUpDate": "June 30",
+    "invoiceNumber": "INV-1001",
+    "amountDue": "125 USDC"
+  },
+  "missingValueScenario": {
+    "templateId": "invoice-reminder",
+    "suppliedValues": {
+      "firstName": "Alex",
+      "invoiceNumber": "INV-1001"
+    },
+    "expectedMissingVariables": [
+      "amountDue",
+      "dueDate"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a folder-local Email Template Library test plan
- add deterministic synthetic template/category fixtures for review and future automated tests
- add review notes that map issue #493 acceptance criteria to the changed files
- link the review assets from the tool README

Closes #493

## Validation
- Confirmed #493 had no comments and no open PR before submission.
- Confirmed all changed files stay under `tools/v2/individual/email-template-library/`.
- Documentation and fixture-only change; no runtime tests were run locally.