### PR TITLE
feat: add email tone rewriter core service

### DIFF
--- a/tools/v1/individual/email-tone-rewriter/README.md
+++ b/tools/v1/individual/email-tone-rewriter/README.md
@@ -14,13 +14,16 @@ Do not wire this tool into the main app, routing, inbox architecture, wallet cor
 
 ## Contributor Setup
 
-This folder does not contain executable tool code yet. Until a feature issue
-adds the implementation, contributors should use these local documents as the
-launch contract:
+The folder now includes a reviewable, folder-local core service for the V1
+feature issue:
 
+- `services.ts` exposes the pure rewrite API, validation helpers, and preserved
+  key-point extraction.
+- `services.test.ts` covers supported tones, validation errors, key-point
+  preservation, disabled send/save flags, and length constraints.
 - `specs.md` defines the behavior and ownership boundary.
-- `docs/test-plan.md` lists the acceptance scenarios future unit and component
-  tests should cover.
+- `docs/test-plan.md` lists the acceptance scenarios future component tests
+  should cover.
 - `docs/fixtures.md` describes synthetic rewrite requests and expected outputs.
 - `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
 
@@ -33,7 +36,8 @@ reviewable rewrite without sending or saving anything automatically.
 
 ## Known Limitations
 
-- No production code is present in this folder yet.
-- The documented tests are a plan, not an executable suite.
-- Main app routing, inbox integration, send actions, and persistence are
-  intentionally out of scope until a future integration issue allows them.
+- This issue adds the pure core service only; UI, integration, send actions, and
+  persistence are intentionally out of scope until a future integration issue
+  allows them.
+- The rewrite is deterministic and local. It does not call external AI providers,
+  production APIs, or mailbox data.

--- a/tools/v1/individual/email-tone-rewriter/services.test.ts
+++ b/tools/v1/individual/email-tone-rewriter/services.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPreservedKeyPoints,
+  rewriteEmailTone,
+  SUPPORTED_TONES,
+  validateRewriteInput,
+} from "./services";
+
+describe("Email Tone Rewriter core service", () => {
+  it("supports the documented V1 tones", () => {
+    expect(SUPPORTED_TONES).toEqual(["concise", "friendly", "formal", "apologetic"]);
+  });
+
+  it("rewrites a draft into a selected tone without enabling send or save actions", () => {
+    const result = rewriteEmailTone({
+      subject: "Follow up",
+      bodyText:
+        "Hi Maya, please review the invoice for $240 by June 22. I need approval before the 6/24 client call.",
+      tone: "formal",
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.rewrittenBody).toContain("Hello,");
+    expect(result.rewrittenBody).toContain("Maya");
+    expect(result.rewrittenBody).toContain("$240");
+    expect(result.rewrittenBody).toContain("June 22");
+    expect(result.rewrittenBody).toContain("6/24");
+    expect(result.sendDisabled).toBe(true);
+    expect(result.saveDisabled).toBe(true);
+  });
+
+  it("preserves key names, dates, amounts, links, and request sentences for review", () => {
+    const keyPoints = extractPreservedKeyPoints(
+      "Alex, please confirm the $99 refund by 12/15. Reference https://example.test/refund for the ticket.",
+    );
+
+    expect(keyPoints).toContain("Alex");
+    expect(keyPoints).toContain("$99");
+    expect(keyPoints).toContain("12/15");
+    expect(keyPoints).toContain("https://example.test/refund");
+    expect(keyPoints.some((point) => point.includes("please confirm"))).toBe(true);
+  });
+
+  it("returns deterministic validation errors for empty drafts and unsupported tones", () => {
+    expect(validateRewriteInput({ bodyText: "", tone: "friendly" })).toContain(
+      "Draft body is required.",
+    );
+    expect(validateRewriteInput({ bodyText: "hello", tone: "angry" as never })).toContain(
+      "Tone must be one of: concise, friendly, formal, apologetic.",
+    );
+  });
+
+  it("applies maxSentences without dropping the extracted preserved key points", () => {
+    const result = rewriteEmailTone({
+      subject: "Launch note",
+      bodyText:
+        "Priya, please send the launch note today. The preview link is https://example.test/launch. The budget is $500. Reply after review.",
+      tone: "concise",
+      maxSentences: 1,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.rewrittenBody).not.toContain("The budget is $500");
+    expect(result.preservedKeyPoints).toContain("Priya");
+    expect(result.preservedKeyPoints).toContain("https://example.test/launch");
+    expect(result.preservedKeyPoints).toContain("$500");
+  });
+});

--- a/tools/v1/individual/email-tone-rewriter/services.ts
+++ b/tools/v1/individual/email-tone-rewriter/services.ts
@@ -1,0 +1,164 @@
+export const SUPPORTED_TONES = ["concise", "friendly", "formal", "apologetic"] as const;
+
+export type SupportedTone = (typeof SUPPORTED_TONES)[number];
+
+export type RewriteStatus = "idle" | "loading" | "success" | "error";
+
+export interface ToneRewriteDraft {
+  subject?: string;
+  bodyText: string;
+  tone: SupportedTone;
+  maxSentences?: number;
+}
+
+export interface ToneRewriteResult {
+  status: RewriteStatus;
+  subject: string;
+  tone: SupportedTone;
+  rewrittenBody: string;
+  preservedKeyPoints: string[];
+  sendDisabled: true;
+  saveDisabled: true;
+  validationErrors: string[];
+}
+
+export interface ToneRewriteErrorResult {
+  status: "error";
+  rewrittenBody: "";
+  preservedKeyPoints: string[];
+  sendDisabled: true;
+  saveDisabled: true;
+  validationErrors: string[];
+}
+
+export const DEFAULT_MAX_SENTENCES = 4;
+
+const toneOpeners: Record<SupportedTone, string> = {
+  concise: "Hi,",
+  friendly: "Hi there,",
+  formal: "Hello,",
+  apologetic: "Hi, and thank you for your patience.",
+};
+
+const toneClosers: Record<SupportedTone, string> = {
+  concise: "Thanks.",
+  friendly: "Thanks so much!",
+  formal: "Thank you for your time.",
+  apologetic: "Sorry again for the inconvenience, and thank you for understanding.",
+};
+
+const factPattern =
+  /(?:https?:\/\/\S+|\$\d+(?:\.\d{1,2})?|\b\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?\b|\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:,\s*\d{4})?\b|\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b)/g;
+
+export function validateRewriteInput(input: Partial<ToneRewriteDraft>): string[] {
+  const errors: string[] = [];
+
+  if (!input.bodyText || input.bodyText.trim().length === 0) {
+    errors.push("Draft body is required.");
+  }
+
+  if (!input.tone || !SUPPORTED_TONES.includes(input.tone as SupportedTone)) {
+    errors.push(`Tone must be one of: ${SUPPORTED_TONES.join(", ")}.`);
+  }
+
+  if (
+    input.maxSentences !== undefined &&
+    (!Number.isInteger(input.maxSentences) || input.maxSentences < 1)
+  ) {
+    errors.push("maxSentences must be a positive integer when provided.");
+  }
+
+  return errors;
+}
+
+export function extractPreservedKeyPoints(bodyText: string): string[] {
+  const facts = new Set<string>();
+  for (const match of bodyText.matchAll(factPattern)) {
+    const value = match[0].replace(/[.,;:!?)]$/, "");
+    if (value.length > 1 && !["Hi", "Hello", "Thanks", "Thank"].includes(value)) {
+      facts.add(value);
+    }
+  }
+
+  const actionSentences = splitSentences(bodyText).filter((sentence) =>
+    /\b(please|need|needs|review|send|confirm|schedule|approve|update|reply|call)\b/i.test(
+      sentence,
+    ),
+  );
+
+  return [...facts, ...actionSentences.map((sentence) => sentence.trim())]
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+export function rewriteEmailTone(
+  input: ToneRewriteDraft,
+): ToneRewriteResult | ToneRewriteErrorResult {
+  const validationErrors = validateRewriteInput(input);
+  const preservedKeyPoints = input.bodyText ? extractPreservedKeyPoints(input.bodyText) : [];
+
+  if (validationErrors.length > 0) {
+    return {
+      status: "error",
+      rewrittenBody: "",
+      preservedKeyPoints,
+      sendDisabled: true,
+      saveDisabled: true,
+      validationErrors,
+    };
+  }
+
+  const subject = normalizeWhitespace(input.subject || "");
+  const sentences = splitSentences(input.bodyText);
+  const maxSentences = input.maxSentences ?? DEFAULT_MAX_SENTENCES;
+  const body = sentences.slice(0, maxSentences).map((sentence) => applyTone(sentence, input.tone));
+
+  const rewrittenBody = [toneOpeners[input.tone], ...body, toneClosers[input.tone]]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return {
+    status: "success",
+    subject,
+    tone: input.tone,
+    rewrittenBody,
+    preservedKeyPoints,
+    sendDisabled: true,
+    saveDisabled: true,
+    validationErrors: [],
+  };
+}
+
+function splitSentences(text: string): string[] {
+  return normalizeWhitespace(text)
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function applyTone(sentence: string, tone: SupportedTone): string {
+  const clean = normalizeWhitespace(sentence).replace(/!+/g, ".");
+
+  if (tone === "concise") {
+    return clean.replace(/\b(just|really|very|actually|basically)\b\s*/gi, "");
+  }
+
+  if (tone === "formal") {
+    return clean
+      .replace(/\bcan't\b/gi, "cannot")
+      .replace(/\bwon't\b/gi, "will not")
+      .replace(/\bASAP\b/g, "as soon as possible");
+  }
+
+  if (tone === "apologetic") {
+    return /\b(sorry|apologize|apology)\b/i.test(clean)
+      ? clean
+      : `I apologize for the friction here. ${clean}`;
+  }
+
+  return clean.replace(/\.$/, "") + ".";
+}


### PR DESCRIPTION
## Summary
- Add a folder-local Email Tone Rewriter core service for issue #350
- Support documented tones, deterministic validation errors, preserved key-point extraction, and disabled send/save flags
- Add Vitest coverage and update the tool README to point at the executable service

Closes #350

## Validation
- npm ci
- npm test -- tools/v1/individual/email-tone-rewriter/services.test.ts (51 files / 540 tests passed; existing recipientResolver test logs an expected handled DB error to stderr)
- npm run lint -- tools/v1/individual/email-tone-rewriter (0 errors; existing repo warnings outside this folder remain)
- git diff --check