### PR TITLE
docs: add draft improver test plan and fixtures

### DIFF
--- a/tools/v2/individual/draft-improver/README.md
+++ b/tools/v2/individual/draft-improver/README.md
@@ -13,3 +13,16 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Review Assets
+
+- [docs/TEST_PLAN.md](docs/TEST_PLAN.md) explains the folder-local review flow, fixture checks, and future test coverage expected for the tool.
+- [docs/REVIEW_NOTES.md](docs/REVIEW_NOTES.md) maps issue #488 acceptance criteria to the files in this folder.
+- [fixtures/sample-drafts.json](fixtures/sample-drafts.json) contains deterministic draft-improvement examples for reviewers and future automated tests.
+- [tests/draft-improver-fixtures.test.mjs](tests/draft-improver-fixtures.test.mjs) validates the fixture contract without app-wide dependencies.
+
+Run the local fixture check from the repository root:
+
+```bash
+node --test tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs
+```

--- a/tools/v2/individual/draft-improver/docs/REVIEW_NOTES.md
+++ b/tools/v2/individual/draft-improver/docs/REVIEW_NOTES.md
@@ -1,0 +1,38 @@
+# Draft Improver Review Notes
+
+## Issue
+
+Addresses issue #488: Draft Improver - Testing and documentation.
+
+## What Changed
+
+- Added deterministic sample draft fixtures for support, sales, and internal-review scenarios.
+- Added a folder-local Node test that validates the fixture shape and reviewability contract.
+- Added a test plan that documents current fixture coverage and future service-level tests.
+- Linked the review assets from the folder README.
+
+## Acceptance Criteria Mapping
+
+| Acceptance Criteria | Evidence |
+| --- | --- |
+| Tests or test plans live inside the tool folder. | `tests/draft-improver-fixtures.test.mjs` and `docs/TEST_PLAN.md` are both under `tools/v2/individual/draft-improver/`. |
+| Documentation explains independent review. | `docs/TEST_PLAN.md` describes scope, manual review, and future coverage without app-wide integration. |
+| Issue remains isolated from app-wide tests. | No files outside the Draft Improver folder are required for the fixture test. |
+| Files changed are limited to the implementation folder. | All changed files stay under `tools/v2/individual/draft-improver/`. |
+| Contribution is a self-contained mini-product change. | Reviewers can inspect fixtures and run the local Node test without wiring the tool into the app. |
+
+## Validation
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs
+```
+
+Expected result: one passing test confirming the fixture contract.
+
+## Known Limitations
+
+- This does not implement the final Draft Improver engine or UI.
+- The fixtures are synthetic and contain no real user email data.
+- App-wide integration, shared navigation, authentication, and inbox wiring remain out of scope for this issue.

--- a/tools/v2/individual/draft-improver/docs/TEST_PLAN.md
+++ b/tools/v2/individual/draft-improver/docs/TEST_PLAN.md
@@ -1,0 +1,55 @@
+# Draft Improver Test Plan
+
+## Scope
+
+This test plan covers only the isolated Draft Improver workspace:
+
+```text
+tools/v2/individual/draft-improver/
+```
+
+It does not require the main app shell, routing, wallet logic, Stellar integration, database schema, or shared design system.
+
+## Current Coverage
+
+The current folder has review fixtures and a local Node test that verifies the fixture contract:
+
+```bash
+node --test tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs
+```
+
+The test checks that each sample draft has:
+
+- a stable kebab-case id;
+- a scenario reviewers can understand;
+- an input draft and a changed suggested draft;
+- at least two improvement goals;
+- at least two concrete review checks.
+
+## Fixture Review Matrix
+
+| Fixture | Main Behavior | Review Focus |
+| --- | --- | --- |
+| `support-refund-follow-up` | Rewrites a terse support reply into a warmer customer update. | Preserves refund uncertainty and avoids promising an outcome. |
+| `sales-demo-reschedule` | Shortens a vague sales note into a clear scheduling request. | Keeps the next action concrete without inventing calendar details. |
+| `security-review-summary` | Clarifies an internal status update. | Avoids leaking implementation details while asking for review. |
+
+## Manual Review Checklist
+
+- Confirm every fixture stays inside the Draft Improver folder.
+- Confirm suggested drafts preserve the factual meaning of the input draft.
+- Confirm the tool does not add promises, dates, approvals, recipients, or private details that were not present in the input.
+- Confirm known limitations are clear enough for future implementation work.
+- Confirm future UI work can reuse the fixtures without touching app-wide routes or shared mail state.
+
+## Future Automated Coverage
+
+When the core service is implemented, add folder-local tests for:
+
+- preserving original intent and key facts;
+- rejecting empty or whitespace-only drafts;
+- keeping suggested drafts within an expected length range;
+- returning review notes for risky or ambiguous input;
+- avoiding private-data exposure in preview fixtures and logs.
+
+These tests should remain under this folder unless a future integration issue explicitly allows app-wide coverage.

--- a/tools/v2/individual/draft-improver/fixtures/sample-drafts.json
+++ b/tools/v2/individual/draft-improver/fixtures/sample-drafts.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "support-refund-follow-up",
+    "scenario": "Customer support follow-up that needs a warmer tone without changing the refund status.",
+    "inputDraft": "We got your request. The refund is still being checked. Wait for another email.",
+    "improvementGoals": ["warmer_tone", "clear_next_step", "preserve_facts"],
+    "suggestedDraft": "Thanks for reaching out. Your refund request is still under review, and we will send you an update by email as soon as the check is complete.",
+    "reviewChecks": [
+      "Does not promise a refund before review is complete.",
+      "Adds a clear update channel.",
+      "Keeps the message concise and professional."
+    ]
+  },
+  {
+    "id": "sales-demo-reschedule",
+    "scenario": "Sales reply that should be shorter and easier to act on.",
+    "inputDraft": "Hello, I think maybe we need to move the demo because the team is busy and there may be a better time later this week if that works for you.",
+    "improvementGoals": ["shorten", "actionable_question", "professional_tone"],
+    "suggestedDraft": "Could we move the demo to later this week? Please send two times that work for you, and I will confirm the best slot with our team.",
+    "reviewChecks": [
+      "Keeps the reschedule request intact.",
+      "Asks for a concrete next action.",
+      "Avoids adding unavailable calendar details."
+    ]
+  },
+  {
+    "id": "security-review-summary",
+    "scenario": "Internal update that should be clearer without leaking private implementation details.",
+    "inputDraft": "The review is mostly done. There were some risky parts but I fixed a few things and still need someone to check it.",
+    "improvementGoals": ["clarity", "safe_summary", "review_request"],
+    "suggestedDraft": "The review is nearly complete. I resolved the main risky items I found and need a second reviewer to verify the remaining changes before release.",
+    "reviewChecks": [
+      "Does not disclose sensitive implementation details.",
+      "States current status and remaining action.",
+      "Keeps the tone appropriate for internal stakeholders."
+    ]
+  }
+]

--- a/tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs
+++ b/tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const fixturePath = new URL("../fixtures/sample-drafts.json", import.meta.url);
+
+test("sample draft fixtures document reviewable improvement cases", async () => {
+  const fixtures = JSON.parse(await readFile(fixturePath, "utf8"));
+
+  assert.ok(Array.isArray(fixtures), "fixtures must be an array");
+  assert.ok(fixtures.length >= 3, "include at least three review scenarios");
+
+  const ids = new Set();
+
+  for (const item of fixtures) {
+    assert.equal(typeof item.id, "string");
+    assert.match(item.id, /^[a-z0-9-]+$/);
+    assert.ok(!ids.has(item.id), `duplicate fixture id: ${item.id}`);
+    ids.add(item.id);
+
+    assert.equal(typeof item.scenario, "string");
+    assert.ok(item.scenario.length > 20);
+    assert.equal(typeof item.inputDraft, "string");
+    assert.equal(typeof item.suggestedDraft, "string");
+    assert.notEqual(item.inputDraft, item.suggestedDraft);
+
+    assert.ok(Array.isArray(item.improvementGoals));
+    assert.ok(item.improvementGoals.length >= 2);
+    assert.ok(item.improvementGoals.every((goal) => /^[a-z_]+$/.test(goal)));
+
+    assert.ok(Array.isArray(item.reviewChecks));
+    assert.ok(item.reviewChecks.length >= 2);
+    assert.ok(item.reviewChecks.every((check) => typeof check === "string" && check.length > 10));
+  }
+});


### PR DESCRIPTION
Closes #488

## Summary
- add a folder-local Draft Improver test plan and review notes
- add deterministic synthetic draft fixtures for support, sales, and internal-review scenarios
- add a Node fixture contract test that runs without app-wide dependencies
- link the review assets from the tool README

## Scope
- only touches `tools/v2/individual/draft-improver/`
- no app shell, routing, auth, wallet, Stellar, database, inbox, or design-system integration
- no real user email data or network calls

## Validation
- `node --test tools/v2/individual/draft-improver/tests/draft-improver-fixtures.test.mjs`