### PR TITLE
feat(mail-to-ticket): add security and performance guardrails

### DIFF
--- a/tools/v2/team/mail-to-ticket-converter/README.md
+++ b/tools/v2/team/mail-to-ticket-converter/README.md
@@ -1,15 +1,48 @@
 # Mail-to-Ticket Converter
 
-This folder is the isolated workspace for the Mail-to-Ticket Converter tool.
+Isolated V2 team tool workspace for converting inbound mail into reviewable ticket drafts.
 
-## Ownership Boundary
+## Ownership boundary
 
-All work for this tool must stay inside:
+All work for this tool stays inside:
 
-`text
-.\tools\v2\team\mail-to-ticket-converter\
-`
+```text
+tools/v2/team/mail-to-ticket-converter/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+This folder does **not** wire into the main app shell, dashboard routing, authentication, wallet core, mail renderer, Stellar integration, database schema, or shared design system. A future integration issue must explicitly authorize any mounting or persistence.
 
-See specs.md for the issue categories and contributor expectations.
+## Security and performance hardening
+
+This contribution adds a folder-local `MailToTicketSecurityGuard` that future core/UI work can reuse before creating a ticket draft:
+
+- validates sender/recipient email shapes and opaque team ids;
+- rejects header-injection-like input such as newline-delimited `Bcc:` fields;
+- strips control characters and active markup (`script`, `iframe`, `object`, `embed`, `link`, `meta`);
+- normalizes attachment names so paths cannot escape the tool boundary;
+- truncates oversized subject/body/attachment-name fields with warnings;
+- rejects too many recipients or attachments for immediate conversion;
+- estimates processing cost so future integration can defer expensive conversions to a worker.
+
+## Local API surface
+
+```ts
+import { MailToTicketSecurityGuard } from "./services/security-guard.service";
+
+const guard = new MailToTicketSecurityGuard();
+const result = guard.sanitize(mailInput);
+
+if (result.ok && !guard.shouldDefer(mailInput)) {
+  // Safe to pass result.value to future folder-local ticket draft logic.
+}
+```
+
+No live network calls, secrets, production data, or app-level side effects are introduced.
+
+## Validation
+
+Run the isolated tests with:
+
+```bash
+npm test -- tools/v2/team/mail-to-ticket-converter/tests/security-guard.test.ts
+```

--- a/tools/v2/team/mail-to-ticket-converter/docs/security-and-performance.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/security-and-performance.md
@@ -1,0 +1,28 @@
+# Security and performance notes
+
+## Threat assumptions
+
+The converter may eventually receive user-controlled mail content from external senders, team inboxes, forwarded threads, or pasted examples. Treat every field as hostile until validated inside this folder.
+
+Primary risks handled by the local guard:
+
+1. **Header injection** — newline-delimited `To:`, `Cc:`, `Bcc:`, `From:`, `Reply-To:`, or `Subject:` fragments are rejected before ticket generation.
+2. **Active markup** — script-like tags are replaced with inert text before summaries or previews render them.
+3. **Control characters** — invisible control bytes are stripped to avoid parser and reviewer confusion.
+4. **Path-like attachments** — slash and backslash characters in attachment names are normalized so future file handling cannot accidentally treat names as paths.
+5. **Oversized input** — subject, body, recipient, and attachment limits bound synchronous work and keep future UI previews responsive.
+
+## Performance posture
+
+`MailToTicketSecurityGuard.estimateProcessingCost()` assigns a simple deterministic cost from body length, recipient count, and attachment count. `shouldDefer()` returns true when the conversion should be queued or chunked instead of handled in an immediate UI path.
+
+Future integration should keep these rules:
+
+- Run the guard before any model, parser, or ticket API call.
+- Defer high-cost conversions to a worker with progress state rather than blocking the page.
+- Preserve `warnings` on the ticket draft so reviewers know what was normalized or truncated.
+- Do not fetch remote attachments, remote images, or linked resources from this isolated tool without a separate issue and sandbox policy.
+
+## Non-goals
+
+This folder does not implement production mail ingestion, ticket persistence, authentication, authorization, webhook delivery, or app routing. Those remain out of scope until an explicit integration issue links this tool to the main application.

--- a/tools/v2/team/mail-to-ticket-converter/index.ts
+++ b/tools/v2/team/mail-to-ticket-converter/index.ts
@@ -1,0 +1,8 @@
+export { MailToTicketSecurityGuard } from "./services/security-guard.service";
+export type {
+  MailToTicketGuardOptions,
+  MailToTicketGuardResult,
+  MailToTicketInput,
+  SanitizedMailToTicketInput,
+  TicketPriority,
+} from "./types";

--- a/tools/v2/team/mail-to-ticket-converter/services/security-guard.service.ts
+++ b/tools/v2/team/mail-to-ticket-converter/services/security-guard.service.ts
@@ -1,0 +1,202 @@
+/* eslint-disable no-control-regex -- guard intentionally strips unsafe control bytes from hostile mail input. */
+
+import type {
+  MailToTicketGuardOptions,
+  MailToTicketGuardResult,
+  MailToTicketInput,
+  SanitizedMailToTicketInput,
+  TicketPriority,
+} from "../types";
+
+const DEFAULT_OPTIONS: MailToTicketGuardOptions = {
+  maxSubjectLength: 180,
+  maxBodyLength: 24_000,
+  maxRecipients: 25,
+  maxAttachments: 10,
+  maxAttachmentNameLength: 160,
+};
+
+const VALID_PRIORITIES = new Set<TicketPriority>(["low", "normal", "high", "urgent"]);
+
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const HEADER_INJECTION = /(?:\r|\n)\s*(?:bcc|cc|to|from|reply-to|subject):/i;
+const SCRIPT_LIKE_CONTENT = /<\/?(?:script|iframe|object|embed|link|meta)\b[^>]*>/gi;
+
+export class MailToTicketSecurityGuard {
+  private readonly options: MailToTicketGuardOptions;
+
+  constructor(options: Partial<MailToTicketGuardOptions> = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  sanitize(input: MailToTicketInput): MailToTicketGuardResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const subject = this.cleanText(
+      input.subject,
+      this.options.maxSubjectLength,
+      "subject",
+      errors,
+      warnings,
+    );
+    const body = this.cleanText(input.body, this.options.maxBodyLength, "body", errors, warnings);
+    const from = this.cleanEmail(input.from, "from", errors);
+    const to = this.cleanEmailList(input.to ?? [], "to", errors);
+    const cc = this.cleanEmailList(input.cc ?? [], "cc", errors);
+    const attachmentNames = this.cleanAttachmentNames(
+      input.attachmentNames ?? [],
+      errors,
+      warnings,
+    );
+    const teamId = this.cleanTeamId(input.teamId, errors);
+    const requestedPriority = this.cleanPriority(input.requestedPriority, warnings);
+
+    if (!subject.trim()) {
+      errors.push("subject is required");
+    }
+
+    if (!body.trim()) {
+      errors.push("body is required");
+    }
+
+    if (HEADER_INJECTION.test(input.subject) || HEADER_INJECTION.test(input.body)) {
+      errors.push("input contains header-injection-like content");
+    }
+
+    if (errors.length > 0) {
+      return { ok: false, errors };
+    }
+
+    const value: SanitizedMailToTicketInput = {
+      subject,
+      body,
+      from,
+      to,
+      cc,
+      attachmentNames,
+      teamId,
+      requestedPriority,
+      warnings,
+    };
+
+    return { ok: true, value, errors: [] };
+  }
+
+  estimateProcessingCost(input: MailToTicketInput): number {
+    const bodyUnits = Math.ceil((input.body?.length ?? 0) / 1_000);
+    const recipientUnits = (input.to?.length ?? 0) + (input.cc?.length ?? 0);
+    const attachmentUnits = (input.attachmentNames?.length ?? 0) * 2;
+    return bodyUnits + recipientUnits + attachmentUnits;
+  }
+
+  shouldDefer(input: MailToTicketInput, maxImmediateCost = 40): boolean {
+    return this.estimateProcessingCost(input) > maxImmediateCost;
+  }
+
+  private cleanText(
+    value: string,
+    maxLength: number,
+    field: string,
+    errors: string[],
+    warnings: string[],
+  ): string {
+    if (typeof value !== "string") {
+      errors.push(`${field} must be a string`);
+      return "";
+    }
+
+    const withoutControls = value.replace(CONTROL_CHARACTERS, "");
+    const withoutActiveMarkup = withoutControls.replace(
+      SCRIPT_LIKE_CONTENT,
+      "[removed unsafe markup]",
+    );
+    const normalized = withoutActiveMarkup.replace(/\s+$/gm, "").trim();
+
+    if (normalized.length > maxLength) {
+      warnings.push(`${field} was truncated to ${maxLength} characters`);
+      return normalized.slice(0, maxLength).trimEnd();
+    }
+
+    if (normalized !== value) {
+      warnings.push(`${field} was normalized for safe ticket creation`);
+    }
+
+    return normalized;
+  }
+
+  private cleanEmail(value: string, field: string, errors: string[]): string {
+    const normalized = String(value ?? "")
+      .trim()
+      .toLowerCase();
+    if (!/^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(normalized)) {
+      errors.push(`${field} must be a valid email address`);
+      return "";
+    }
+    return normalized;
+  }
+
+  private cleanEmailList(values: string[], field: string, errors: string[]): string[] {
+    if (values.length > this.options.maxRecipients) {
+      errors.push(`${field} has too many recipients`);
+      return [];
+    }
+
+    return values.map((value, index) => this.cleanEmail(value, `${field}[${index}]`, errors));
+  }
+
+  private cleanAttachmentNames(names: string[], errors: string[], warnings: string[]): string[] {
+    if (names.length > this.options.maxAttachments) {
+      errors.push("too many attachments for immediate ticket conversion");
+      return [];
+    }
+
+    return names.map((name, index) => {
+      const cleaned = String(name ?? "")
+        .replace(CONTROL_CHARACTERS, "")
+        .replace(/[\\/]/g, "_")
+        .trim();
+
+      if (!cleaned) {
+        errors.push(`attachmentNames[${index}] is empty after sanitization`);
+        return "";
+      }
+
+      if (cleaned.length > this.options.maxAttachmentNameLength) {
+        warnings.push(`attachmentNames[${index}] was truncated`);
+        return cleaned.slice(0, this.options.maxAttachmentNameLength).trimEnd();
+      }
+
+      return cleaned;
+    });
+  }
+
+  private cleanTeamId(value: string | undefined, errors: string[]): string | null {
+    if (!value) {
+      return null;
+    }
+
+    const normalized = value.trim();
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(normalized)) {
+      errors.push(
+        "teamId must be an opaque id containing only letters, numbers, dash, or underscore",
+      );
+      return null;
+    }
+
+    return normalized;
+  }
+
+  private cleanPriority(value: TicketPriority | undefined, warnings: string[]): TicketPriority {
+    if (!value) {
+      return "normal";
+    }
+
+    if (!VALID_PRIORITIES.has(value)) {
+      warnings.push("requestedPriority was not recognized and defaulted to normal");
+      return "normal";
+    }
+
+    return value;
+  }
+}

--- a/tools/v2/team/mail-to-ticket-converter/tests/security-guard.test.ts
+++ b/tools/v2/team/mail-to-ticket-converter/tests/security-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { MailToTicketSecurityGuard } from "../services/security-guard.service";
+
+const baseInput = {
+  subject: "Invoice follow-up",
+  body: "Can support convert this customer email into a ticket?",
+  from: "Customer@Example.com",
+  to: ["Support@example.com"],
+  cc: [],
+  attachmentNames: ["invoice.pdf"],
+  teamId: "team_support",
+  requestedPriority: "normal" as const,
+};
+
+describe("MailToTicketSecurityGuard", () => {
+  it("sanitizes safe mail input without touching main app state", () => {
+    const guard = new MailToTicketSecurityGuard();
+
+    const result = guard.sanitize(baseInput);
+
+    expect(result.ok).toBe(true);
+    expect(result.value?.from).toBe("customer@example.com");
+    expect(result.value?.to).toEqual(["support@example.com"]);
+    expect(result.value?.teamId).toBe("team_support");
+    expect(result.value?.requestedPriority).toBe("normal");
+  });
+
+  it("rejects header injection and invalid sender input", () => {
+    const guard = new MailToTicketSecurityGuard();
+
+    const result = guard.sanitize({
+      ...baseInput,
+      subject: "Need help\nBcc: victim@example.com",
+      from: "not an email",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("from must be a valid email address");
+    expect(result.errors).toContain("input contains header-injection-like content");
+  });
+
+  it("removes active markup and control characters from ticket text", () => {
+    const guard = new MailToTicketSecurityGuard();
+
+    const result = guard.sanitize({
+      ...baseInput,
+      body: "hello\u0000<script>alert('x')</script>world",
+      attachmentNames: ["../evidence\\thread.txt"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.value?.body).toContain("[removed unsafe markup]");
+    expect(result.value?.body).not.toContain("<script>");
+    expect(result.value?.attachmentNames).toEqual([".._evidence_thread.txt"]);
+  });
+
+  it("bounds large messages and many attachments for predictable performance", () => {
+    const guard = new MailToTicketSecurityGuard({
+      maxBodyLength: 20,
+      maxAttachments: 2,
+    });
+
+    const result = guard.sanitize({
+      ...baseInput,
+      body: "x".repeat(200),
+      attachmentNames: ["a.txt", "b.txt", "c.txt"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("too many attachments for immediate ticket conversion");
+  });
+
+  it("flags high-cost conversions so future integration can defer them", () => {
+    const guard = new MailToTicketSecurityGuard();
+
+    const shouldDefer = guard.shouldDefer({
+      ...baseInput,
+      body: "long body ".repeat(10_000),
+      to: Array.from({ length: 20 }, (_, index) => `user${index}@example.com`),
+      attachmentNames: Array.from({ length: 8 }, (_, index) => `evidence-${index}.txt`),
+    });
+
+    expect(shouldDefer).toBe(true);
+  });
+});

--- a/tools/v2/team/mail-to-ticket-converter/types/index.ts
+++ b/tools/v2/team/mail-to-ticket-converter/types/index.ts
@@ -1,0 +1,38 @@
+export type TicketPriority = "low" | "normal" | "high" | "urgent";
+
+export interface MailToTicketInput {
+  subject: string;
+  body: string;
+  from: string;
+  to?: string[];
+  cc?: string[];
+  attachmentNames?: string[];
+  teamId?: string;
+  requestedPriority?: TicketPriority;
+}
+
+export interface SanitizedMailToTicketInput {
+  subject: string;
+  body: string;
+  from: string;
+  to: string[];
+  cc: string[];
+  attachmentNames: string[];
+  teamId: string | null;
+  requestedPriority: TicketPriority;
+  warnings: string[];
+}
+
+export interface MailToTicketGuardOptions {
+  maxSubjectLength: number;
+  maxBodyLength: number;
+  maxRecipients: number;
+  maxAttachments: number;
+  maxAttachmentNameLength: number;
+}
+
+export interface MailToTicketGuardResult {
+  ok: boolean;
+  value?: SanitizedMailToTicketInput;
+  errors: string[];
+}


### PR DESCRIPTION
## Summary
- Adds a folder-local `MailToTicketSecurityGuard` for the isolated V2 team Mail-to-Ticket Converter tool.
- Validates/sanitizes hostile mail fields: email shapes, header-injection-like content, active markup, control characters, attachment names, team ids, and priority defaults.
- Adds deterministic processing-cost/defer helpers plus docs describing threat assumptions, performance boundaries, and non-goals.
- Keeps all changes under `tools/v2/team/mail-to-ticket-converter/` with no main app, routing, auth, wallet, database, or Stellar integration changes.

Closes #622

## Validation
- `npm install`
- `npm test -- tools/v2/team/mail-to-ticket-converter/tests/security-guard.test.ts` — passed (52 files / 584 tests; includes 5 new Mail-to-Ticket guard tests)
- `npx eslint tools/v2/team/mail-to-ticket-converter` — passed
- `git diff --check` and `git diff --cached --check` — passed

## Notes
The repository test script currently also includes `tests/unit` when a tool test path is provided, so the validation run covered the full unit suite in addition to the new isolated test file.