### PR TITLE
Authenticate before loading postage in settle and refund routes

### DIFF
--- a/src/routes/api/v1/postage/$messageId/refund.ts
+++ b/src/routes/api/v1/postage/$messageId/refund.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { requireActorMatches } from "@/server/api/actor";
+import { requireActor, requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema } from "@/server/api/domain";
 import { getPostage, resolvePostage } from "@/server/api/postage-service";
@@ -12,6 +12,9 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/refund")({
       POST: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const repository = getApiContext().repository;
+          // Authenticate before loading so unauthenticated callers cannot
+          // probe whether a message id exists.
+          requireActor(request);
           const messageId = hash32Schema.parse(params.messageId);
           const current = await getPostage(repository, messageId);
           requireActorMatches(request, current.recipient);

--- a/src/routes/api/v1/postage/$messageId/settle.ts
+++ b/src/routes/api/v1/postage/$messageId/settle.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { requireActorMatches } from "@/server/api/actor";
+import { requireActor, requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema } from "@/server/api/domain";
 import { getPostage, resolvePostage } from "@/server/api/postage-service";
@@ -12,6 +12,9 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/settle")({
       POST: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const repository = getApiContext().repository;
+          // Authenticate before loading so unauthenticated callers cannot
+          // probe whether a message id exists.
+          requireActor(request);
           const messageId = hash32Schema.parse(params.messageId);
           const current = await getPostage(repository, messageId);
           requireActorMatches(request, current.recipient);


### PR DESCRIPTION
The settle and refund routes looked up the postage record before authenticating the caller. An unauthenticated request could therefore tell whether a message id existed from the response it got back (404 not found versus 401 unauthorized).

This change authenticates the caller first, matching the existing read route, so unauthenticated callers get a consistent 401 and cannot probe for valid message ids.

Before: getPostage runs, then requireActorMatches.
After: requireActor runs, then getPostage, then requireActorMatches.

Recipient-only authorization and all success behavior are unchanged. Existing unit and e2e coverage for quote, submit, settle, and refund still applies.

Validation: prettier, tsc, and eslint pass locally. The Vitest and Playwright suites could not run in the Codespace due to an unrelated Tailwind native-binding issue, so CI covers those.

Closes #946