### PR TITLE
docs: add vendor mail guard rails

### DIFF
--- a/tools/v2/team/vendor-mail-tracker/README.md
+++ b/tools/v2/team/vendor-mail-tracker/README.md
@@ -8,9 +8,7 @@ future mail-app integration.
 
 All work for this tool must stay inside:
 
-```text
 tools/v2/team/vendor-mail-tracker/
-```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet
 core, Stellar core, database schema, or shared design system unless a future
@@ -18,49 +16,54 @@ integration issue explicitly allows it.
 
 ## Reviewer Setup
 
-This issue adds folder-local documentation, fixtures, and a standalone Node test.
-No app install is required to review the contribution.
+This folder includes local documentation, fixtures, guard helpers, and standalone
+Node tests. No app install is required to review this contribution.
 
 Run from the repository root:
 
-```bash
 node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
-```
+node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
 
-The test validates the sample vendor-mail fixture against the local review
-contract described in `specs.md`.
+The fixture test validates the sample vendor-mail fixture against the local
+review contract in specs.md. The guard test validates malformed-record handling,
+text cleanup, attachment caps, date checks, and large-batch truncation.
 
 ## Tracking Workflow
 
 1. Capture vendor messages from synthetic email records.
 2. Normalize each thread into vendor, owner, status, last contact, and due date.
-3. Route each thread to `open`, `waiting-on-vendor`, `blocked`, or `resolved`.
+3. Route each thread to open, waiting-on-vendor, blocked, or resolved.
 4. Preserve a source message id for traceability.
-5. Flag stale, blocked, or high-priority vendor threads for human review.
+5. Flag stale, blocked, high-priority, or oversized-attachment threads for human
+   review.
 
 ## Fixtures
 
-The folder-local fixture at `fixtures/sample-vendor-mails.json` contains:
+The folder-local fixture at fixtures/sample-vendor-mails.json contains:
 
 - an open onboarding thread that needs an internal owner response
 - a waiting-on-vendor thread with a pending security questionnaire
 - a blocked invoice thread missing required documentation
 - a resolved renewal thread with complete owner evidence
 
-The fixture intentionally uses `example.test` addresses, synthetic vendor names,
+The fixture intentionally uses example.test addresses, synthetic vendor names,
 and fake thread ids so contributors can validate behavior without using real
 vendor, invoice, customer, or mailbox data.
 
 ## Documentation Map
 
-- `specs.md` defines the local vendor-mail tracking contract and scope.
-- `docs/test-plan.md` lists automated and manual review steps.
-- `docs/review-notes.md` explains validation and known limits.
-- `tests/vendor-mail-fixtures.test.mjs` validates the fixture contract.
+- specs.md defines the local vendor-mail tracking contract and scope.
+- docs/test-plan.md lists automated and manual review steps.
+- docs/review-notes.md explains validation and known limits.
+- docs/security-performance-notes.md documents unsafe inputs and performance limits.
+- services/vendor-mail-guards.mjs contains folder-local guard helpers.
+- tests/vendor-mail-fixtures.test.mjs validates the fixture contract.
+- tests/vendor-mail-guards.test.mjs validates guard behavior.
 
 ## Known Limitations
 
 - This contribution does not add app UI or live mailbox ingestion.
-- Tracking behavior is represented through fixture expectations only.
-- Vendor authentication, attachment storage, billing workflows, and
-  notifications remain out of scope for this isolated V2 folder.
+- Tracking behavior is represented through fixture expectations and folder-local
+  guards only.
+- Vendor authentication, attachment storage, billing workflows, notifications,
+  and live mailbox connections remain out of scope for this isolated V2 folder.

--- a/tools/v2/team/vendor-mail-tracker/docs/review-notes.md
+++ b/tools/v2/team/vendor-mail-tracker/docs/review-notes.md
@@ -2,26 +2,34 @@
 
 ## What This Contribution Adds
 
-- Replaces generated placeholder copy with a concrete vendor-mail review
-  contract.
-- Adds synthetic fixture data for vendor thread tracking states.
-- Adds a zero-dependency Node test for the fixture and local rules.
-- Documents setup, review flow, limitations, and future integration needs.
+- Adds folder-local guard helpers for Vendor Mail Tracker input validation,
+  display-text cleanup, attachment metadata limits, history limits, and large
+  batch preparation.
+- Adds a zero-dependency Node test for malformed records, text cleanup,
+  required dates, attachment caps, and batch truncation.
+- Documents threat assumptions, unsafe input categories, and performance limits
+  for future mailbox or import integrations.
+- Keeps all changes inside tools/v2/team/vendor-mail-tracker/.
 
 ## Validation Performed
 
-- `node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs`
+- node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
+- node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
 
 ## Reviewer Focus
 
-- This issue is limited to testing and documentation assets.
-- The fixture should make future implementation behavior unambiguous.
-- No real vendor names, invoice data, mailbox content, or credentials are used.
+- Guard helpers return structured validation results instead of throwing so a
+  future UI can show record-level errors.
+- No real vendor names, invoice data, mailbox content, credentials, or
+  attachment bodies are used.
 - No production app behavior changes from this contribution.
+- No main app shell, routing, auth, wallet, Stellar, database, or shared design
+  system files are modified.
 
 ## Follow-Up Work
 
-- Add service code that normalizes vendor email thread records.
-- Add UI and accessibility coverage for vendor status review.
-- Add security and retention rules before any live mailbox integration.
+- Connect the guard helpers to a future isolated UI or import flow only when a
+  separate integration issue allows that scope.
+- Add live mailbox, retention, and role-permission rules in the future issue
+  that owns production data wiring.
 - Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/team/vendor-mail-tracker/docs/security-performance-notes.md
+++ b/tools/v2/team/vendor-mail-tracker/docs/security-performance-notes.md
@@ -1,0 +1,58 @@
+# Security and Performance Notes
+
+## Threat Assumptions
+
+Vendor Mail Tracker is still an isolated V2 team tool. It must not read live
+mailboxes, store attachment bodies, call external vendor systems, or depend on
+main-app authentication until a future integration issue explicitly allows that
+work.
+
+Future integrations should treat every imported vendor thread as untrusted
+input. A mailbox connector, CSV import, webhook, or manual paste can provide
+malformed records, missing identifiers, unexpectedly large payloads, or text that
+should not be rendered as markup.
+
+## Unsafe Input Categories
+
+- non-object records or arrays where a thread record is expected
+- missing id, vendor, owner, or sourceMessageId
+- unknown priority or status values
+- invalid lastContactAt or unresolved-thread nextActionDueAt dates
+- control characters, angle brackets, or backticks in display text
+- long subject, vendor, owner, or preview fields
+- excessive attachment lists, large attachment metadata, or missing names
+- long history arrays that would slow review screens without adding value
+
+## Guard Helper Contract
+
+services/vendor-mail-guards.mjs provides two folder-local helpers:
+
+- normalizeVendorMailThread(record, options) validates one record, cleans text,
+  caps attachment metadata, caps history entries, and marks records that need
+  human review.
+- prepareVendorMailReview(records, options) limits large review batches before
+  normalization and separates accepted records from rejected records.
+
+The helpers return validation results instead of throwing so a future UI can show
+reviewable errors without breaking the entire tool.
+
+## Performance Constraints
+
+The default guard limits are intentionally conservative for a team review tool:
+
+- no more than 250 threads are prepared in one review batch
+- body previews are trimmed to 1,200 characters
+- attachment metadata is capped at 8 attachments per thread
+- attachment names are trimmed before display
+- individual attachment size metadata is capped at 15 MB
+- only the latest 25 history events are retained per thread
+
+These limits avoid unnecessary work on large imports while preserving enough
+metadata for reviewers to understand ownership, status, due date, and source
+traceability.
+
+## Review Guidance
+
+Keep future changes in this folder until an integration issue allows otherwise.
+Do not add production mailbox data, vendor credentials, attachment bodies,
+external requests, main-app routing, or shared auth logic in this isolated tool.

--- a/tools/v2/team/vendor-mail-tracker/docs/test-plan.md
+++ b/tools/v2/team/vendor-mail-tracker/docs/test-plan.md
@@ -4,9 +4,7 @@
 
 Run from the repository root:
 
-```bash
 node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
-```
 
 Expected result:
 
@@ -17,13 +15,30 @@ Expected result:
 - blocked threads require human review
 - resolved threads do not require a next action due date
 
+## Automated Guard Test
+
+Run from the repository root:
+
+node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
+
+Expected result:
+
+- malformed records are rejected before review work starts
+- display text is cleaned before it reaches a future UI
+- high-priority unresolved threads require human review
+- excessive attachment metadata is capped
+- oversized attachment metadata marks a thread for review
+- invalid dates and missing owners are reported
+- large review batches are truncated before normalization
+
 ## Manual Review Checklist
 
-1. Open `fixtures/sample-vendor-mails.json`.
+1. Open fixtures/sample-vendor-mails.json.
 2. Confirm all source messages use synthetic data.
-3. Confirm each expected thread has a traceable `sourceMessageId`.
-4. Confirm `docs/review-notes.md` documents out-of-scope live mailbox behavior.
-5. Confirm no files outside `tools/v2/team/vendor-mail-tracker/` changed.
+3. Confirm each expected thread has a traceable sourceMessageId.
+4. Confirm services/vendor-mail-guards.mjs returns structured validation results.
+5. Confirm docs/security-performance-notes.md documents unsafe inputs and performance limits.
+6. Confirm no files outside tools/v2/team/vendor-mail-tracker/ changed.
 
 ## Edge Cases Covered
 
@@ -31,13 +46,18 @@ Expected result:
 - high-priority waiting-on-vendor thread
 - blocked invoice thread with missing supporting documentation
 - resolved procurement thread without future due date
+- malformed thread records
+- invalid dates and missing owners
+- oversized or excessive attachment metadata
+- large batches that exceed the local review limit
 
 ## Future Integration Tests
 
-When implementation code is added, add tests for:
+When implementation code is connected to a UI or import flow, add tests for:
 
 - stale thread threshold configuration
 - duplicate vendor thread detection
 - attachment and document presence checks
 - owner assignment and reassignment
 - notification throttling and audit log creation
+- surfacing guard validation errors without connecting to live mailbox data

--- a/tools/v2/team/vendor-mail-tracker/services/vendor-mail-guards.mjs
+++ b/tools/v2/team/vendor-mail-tracker/services/vendor-mail-guards.mjs
@@ -1,0 +1,169 @@
+const DEFAULT_LIMITS = Object.freeze({
+  maxThreadsPerReview: 250,
+  maxTextLength: 240,
+  maxBodyPreviewLength: 1200,
+  maxAttachmentCount: 8,
+  maxAttachmentNameLength: 120,
+  maxAttachmentSizeBytes: 15 * 1024 * 1024,
+  maxHistoryEvents: 25,
+});
+
+const ALLOWED_PRIORITIES = new Set(["low", "medium", "high"]);
+const ALLOWED_STATUSES = new Set(["open", "waiting-on-vendor", "blocked", "resolved"]);
+
+function isPlainRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeLimits(overrides = {}) {
+  return { ...DEFAULT_LIMITS, ...overrides };
+}
+
+function cleanText(value, maxLength) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/[<>\`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function cleanDate(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function normalizeAttachments(value, limits, warnings) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  if (value.length > limits.maxAttachmentCount) {
+    warnings.push("attachments capped at " + limits.maxAttachmentCount);
+  }
+
+  return value.slice(0, limits.maxAttachmentCount).map((attachment, index) => {
+    const source = isPlainRecord(attachment) ? attachment : {};
+    const sizeBytes = Number(source.sizeBytes ?? 0);
+
+    return {
+      index,
+      name: cleanText(source.name, limits.maxAttachmentNameLength) || "attachment-" + (index + 1),
+      mimeType: cleanText(source.mimeType, 80) || "application/octet-stream",
+      sizeBytes: Number.isFinite(sizeBytes) && sizeBytes > 0 ? Math.min(sizeBytes, limits.maxAttachmentSizeBytes) : 0,
+      tooLarge: Number.isFinite(sizeBytes) && sizeBytes > limits.maxAttachmentSizeBytes,
+    };
+  });
+}
+
+function normalizeHistory(value, limits, warnings) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  if (value.length > limits.maxHistoryEvents) {
+    warnings.push("history capped at " + limits.maxHistoryEvents);
+  }
+
+  return value.slice(-limits.maxHistoryEvents).map((event, index) => {
+    const source = isPlainRecord(event) ? event : {};
+    return {
+      index,
+      at: cleanDate(source.at),
+      actor: cleanText(source.actor, limits.maxTextLength),
+      note: cleanText(source.note, limits.maxTextLength),
+    };
+  });
+}
+
+export function normalizeVendorMailThread(input, options = {}) {
+  const limits = mergeLimits(options.limits);
+  const errors = [];
+  const warnings = [];
+
+  if (!isPlainRecord(input)) {
+    return {
+      ok: false,
+      errors: ["thread record must be an object"],
+      warnings,
+      thread: null,
+    };
+  }
+
+  const id = cleanText(input.id, limits.maxTextLength);
+  const vendor = cleanText(input.vendor, limits.maxTextLength);
+  const owner = cleanText(input.owner, limits.maxTextLength);
+  const sourceMessageId = cleanText(input.sourceMessageId, limits.maxTextLength);
+  const priority = cleanText(input.priority, 40).toLowerCase();
+  const status = cleanText(input.status, 60).toLowerCase();
+  const lastContactAt = cleanDate(input.lastContactAt);
+  const nextActionDueAt = status === "resolved" ? null : cleanDate(input.nextActionDueAt);
+
+  if (!id) errors.push("id is required");
+  if (!vendor) errors.push("vendor is required");
+  if (!owner) errors.push("owner is required");
+  if (!sourceMessageId) errors.push("sourceMessageId is required");
+  if (!ALLOWED_PRIORITIES.has(priority)) errors.push("priority must be low, medium, or high");
+  if (!ALLOWED_STATUSES.has(status)) errors.push("status must be open, waiting-on-vendor, blocked, or resolved");
+  if (!lastContactAt) errors.push("lastContactAt must be a valid date");
+  if (status !== "resolved" && !nextActionDueAt) errors.push("nextActionDueAt must be valid until the thread is resolved");
+
+  const attachments = normalizeAttachments(input.attachments, limits, warnings);
+  const history = normalizeHistory(input.history, limits, warnings);
+  const bodyPreview = cleanText(input.bodyPreview, limits.maxBodyPreviewLength);
+
+  const reviewRequired =
+    input.reviewRequired === true ||
+    status === "blocked" ||
+    (priority === "high" && status !== "resolved") ||
+    attachments.some((attachment) => attachment.tooLarge);
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    thread: {
+      id,
+      vendor,
+      owner,
+      priority,
+      status,
+      lastContactAt,
+      nextActionDueAt,
+      sourceMessageId,
+      subject: cleanText(input.subject, limits.maxTextLength),
+      bodyPreview,
+      attachments,
+      history,
+      reviewRequired,
+    },
+  };
+}
+
+export function prepareVendorMailReview(records, options = {}) {
+  const limits = mergeLimits(options.limits);
+  const input = Array.isArray(records) ? records : [];
+  const selected = input.slice(0, limits.maxThreadsPerReview);
+  const normalized = selected.map((record) => normalizeVendorMailThread(record, { limits }));
+
+  return {
+    totalReceived: input.length,
+    processed: selected.length,
+    truncated: Math.max(0, input.length - selected.length),
+    accepted: normalized.filter((item) => item.ok).map((item) => item.thread),
+    rejected: normalized
+      .filter((item) => !item.ok)
+      .map((item, index) => ({ index, errors: item.errors })),
+    warnings: normalized.flatMap((item) => item.warnings),
+  };
+}
+
+export const vendorMailGuardLimits = DEFAULT_LIMITS;

--- a/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
+++ b/tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeVendorMailThread,
+  prepareVendorMailReview,
+  vendorMailGuardLimits,
+} from "../services/vendor-mail-guards.mjs";
+
+function validThread(overrides = {}) {
+  return {
+    id: "thread-1",
+    vendor: "Acme Procurement",
+    owner: "ops-team@example.test",
+    priority: "medium",
+    status: "open",
+    lastContactAt: "2026-06-01T09:00:00.000Z",
+    nextActionDueAt: "2026-06-03T09:00:00.000Z",
+    sourceMessageId: "msg-1",
+    subject: "Invoice follow-up",
+    bodyPreview: "Waiting for vendor documents.",
+    attachments: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+test("rejects malformed records before review work starts", () => {
+  const result = normalizeVendorMailThread(null);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors, ["thread record must be an object"]);
+  assert.equal(result.thread, null);
+});
+
+test("normalizes unsafe text and keeps review-critical metadata", () => {
+  const result = normalizeVendorMailThread(
+    validThread({
+      vendor: "<Acme>\u0000 Procurement",
+      subject: "  Renewal\n\nrequest  ",
+      priority: "HIGH",
+      status: "open",
+    }),
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.thread.vendor, "Acme Procurement");
+  assert.equal(result.thread.subject, "Renewal request");
+  assert.equal(result.thread.priority, "high");
+  assert.equal(result.thread.reviewRequired, true);
+});
+
+test("limits attachments and marks oversized files for review", () => {
+  const attachments = Array.from({ length: vendorMailGuardLimits.maxAttachmentCount + 2 }, (_, index) => ({
+    name: "contract-" + index + ".pdf",
+    mimeType: "application/pdf",
+    sizeBytes: index === 0 ? vendorMailGuardLimits.maxAttachmentSizeBytes + 1 : 512,
+  }));
+
+  const result = normalizeVendorMailThread(validThread({ attachments }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.thread.attachments.length, vendorMailGuardLimits.maxAttachmentCount);
+  assert.equal(result.thread.attachments[0].tooLarge, true);
+  assert.equal(result.thread.reviewRequired, true);
+  assert.ok(result.warnings.includes("attachments capped at " + vendorMailGuardLimits.maxAttachmentCount));
+});
+
+test("requires valid dates and required identifiers", () => {
+  const result = normalizeVendorMailThread(
+    validThread({
+      owner: "",
+      status: "waiting-on-vendor",
+      lastContactAt: "not-a-date",
+      nextActionDueAt: "",
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("owner is required"));
+  assert.ok(result.errors.includes("lastContactAt must be a valid date"));
+  assert.ok(result.errors.includes("nextActionDueAt must be valid until the thread is resolved"));
+});
+
+test("caps large review batches before normalization", () => {
+  const records = [
+    validThread({ id: "thread-1" }),
+    validThread({ id: "thread-2" }),
+    validThread({ id: "thread-3" }),
+  ];
+
+  const result = prepareVendorMailReview(records, { limits: { maxThreadsPerReview: 2 } });
+
+  assert.equal(result.totalReceived, 3);
+  assert.equal(result.processed, 2);
+  assert.equal(result.truncated, 1);
+  assert.equal(result.accepted.length, 2);
+});


### PR DESCRIPTION
Closes #717

## Summary
- add folder-local Vendor Mail Tracker guard helpers for malformed records, display-text cleanup, attachment metadata caps, history caps, and large-batch preparation
- add a zero-dependency Node guard test covering malformed input, cleanup, date checks, attachment limits, and batch truncation
- document threat assumptions, unsafe input categories, performance limits, reviewer focus, and the new test command

## Scope
- only touches tools/v2/team/vendor-mail-tracker/
- no main app shell, routing, auth, wallet, Stellar, database, inbox, live mailbox, external request, or design-system integration
- no real mailbox/vendor/customer data or attachment bodies

## Validation
- temporary local Node import/assertion run for the guard helper: passed 5 core checks
- intended repo commands:
  - node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-fixtures.test.mjs
  - node --test tools/v2/team/vendor-mail-tracker/tests/vendor-mail-guards.test.mjs
