### PR TITLE
docs: add email tone rewrite guard rails

### DIFF
--- a/tools/v1/individual/email-tone-rewriter/README.md
+++ b/tools/v1/individual/email-tone-rewriter/README.md
@@ -10,7 +10,9 @@ All work for this tool must stay inside:
 .\tools\v1\individual\email-tone-rewriter\
 `
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
 ## Contributor Setup
 
@@ -30,6 +32,23 @@ The tool helps an individual user rewrite a draft email into a selected tone,
 such as concise, friendly, formal, or apologetic. A future implementation should
 accept a draft, requested tone, and optional constraints, then return a
 reviewable rewrite without sending or saving anything automatically.
+
+## Safety and Performance Guard Rails
+
+This folder now includes a local guard helper for future tone rewrite work:
+
+- `services/tone-guards.mjs` normalizes draft input, validates supported tones,
+  caps large fields, keeps only attachment metadata, and returns deterministic
+  success or error results.
+- `tests/tone-guards.test.mjs` covers valid requests, malformed drafts,
+  unsupported tones, large input truncation, attachment metadata limits, and
+  history caps.
+- `docs/security-performance-notes.md` documents unsafe inputs, assumptions,
+  and performance limits.
+
+Suggested local check:
+
+`node --test tools/v1/individual/email-tone-rewriter/tests/tone-guards.test.mjs`
 
 ## Known Limitations
 

--- a/tools/v1/individual/email-tone-rewriter/docs/review-notes.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/review-notes.md
@@ -1,0 +1,37 @@
+# Review Notes
+
+## Issue coverage
+
+Issue #352 asks for safety and performance constraints before future
+integration. This change adds those constraints inside the isolated tool
+folder only.
+
+## Files added or updated
+
+- `services/tone-guards.mjs` adds local normalization, validation, and request
+  capping helpers.
+- `tests/tone-guards.test.mjs` covers valid requests, invalid drafts,
+  unsupported tones, large body truncation, attachment metadata limits, history
+  limits, and helper determinism.
+- `docs/security-performance-notes.md` documents assumptions, unsafe inputs,
+  limits, and reviewer checks.
+- `docs/review-notes.md` maps the change back to the issue.
+- `README.md` links the new helper and test command.
+
+## Acceptance criteria mapping
+
+- Explicit handling for malformed input: empty drafts and unsupported tones
+  return deterministic errors.
+- Avoid unnecessary large-request work: body, constraints, attachments, and
+  history are capped before rewrite logic would run.
+- No sensitive app code modified: all files remain under the local tool folder.
+- Self-contained mini-product review: helper, tests, docs, and README links are
+  in one folder.
+
+## Suggested validation
+
+Run:
+
+`node --test tools/v1/individual/email-tone-rewriter/tests/tone-guards.test.mjs`
+
+The test suite uses only Node built-ins and does not require app wiring.

--- a/tools/v1/individual/email-tone-rewriter/docs/security-performance-notes.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/security-performance-notes.md
@@ -1,0 +1,66 @@
+# Email Tone Rewriter Safety and Performance Notes
+
+## Scope
+
+These notes apply only to `tools/v1/individual/email-tone-rewriter/`.
+The tool remains isolated from the main app shell, routing, wallet code,
+Stellar integration, database, inbox rendering, and the shared design system.
+
+## Input assumptions
+
+- Requests are treated as untrusted draft data until normalized.
+- `bodyText` is required and must be a string after cleanup.
+- `tone` must be one of the supported local values: apologetic, concise,
+  formal, friendly, or neutral.
+- Attachment bodies are not accepted by the guard helper. Only bounded metadata
+  such as filename, MIME type, and byte size is kept.
+- Conversation history is optional and capped before any future rewrite work
+  starts.
+
+## Unsafe input categories
+
+- Empty or whitespace-only drafts.
+- Unsupported tone names.
+- Drafts containing control characters or inconsistent newline formats.
+- Very large drafts, attachment lists, or history arrays.
+- Attachment objects that include raw body content.
+- Constraint notes that are too large to review comfortably.
+
+## Guard helper behavior
+
+`services/tone-guards.mjs` exposes `prepareToneRewriteInput()`. It returns a
+deterministic success or error object so a future UI can show validation errors
+without guessing.
+
+The helper:
+
+- removes control characters and normalizes line endings;
+- trims noisy whitespace while preserving paragraph boundaries;
+- caps subject, body, constraint, attachment, and history sizes;
+- keeps only attachment metadata;
+- records whether large fields were truncated;
+- rejects unsupported tones and empty drafts before rewrite work begins.
+
+## Performance limits
+
+The current local limits are intentionally small enough for a V1 individual
+tool:
+
+- subject: 240 characters;
+- body text: 12,000 characters;
+- constraint notes: 240 characters;
+- attachments: 8 metadata entries;
+- attachment names: 120 characters;
+- history: 6 entries;
+- history text: 1,600 characters per entry.
+
+These caps prevent unnecessary work on large requests while preserving enough
+context for a reviewable tone rewrite.
+
+## Reviewer checklist
+
+- Confirm all changed files stay inside the Email Tone Rewriter folder.
+- Confirm the helper does not call external services.
+- Confirm raw attachment body content is not forwarded.
+- Confirm validation errors are deterministic.
+- Confirm large inputs are capped before future rewrite logic would run.

--- a/tools/v1/individual/email-tone-rewriter/services/tone-guards.mjs
+++ b/tools/v1/individual/email-tone-rewriter/services/tone-guards.mjs
@@ -1,0 +1,159 @@
+export const SUPPORTED_TONES = Object.freeze([
+  "apologetic",
+  "concise",
+  "formal",
+  "friendly",
+  "neutral",
+]);
+
+export const TONE_REWRITE_LIMITS = Object.freeze({
+  maxSubjectChars: 240,
+  maxBodyChars: 12000,
+  maxConstraintChars: 240,
+  maxAttachmentCount: 8,
+  maxAttachmentNameChars: 120,
+  maxHistoryItems: 6,
+  maxHistoryChars: 1600,
+});
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const WHITESPACE_PATTERN = /[ \t]+/g;
+
+function coerceString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+export function cleanToneText(value, maxChars) {
+  return coerceString(value)
+    .replace(CONTROL_CHAR_PATTERN, "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(WHITESPACE_PATTERN, " ").trim())
+    .join("\n")
+    .trim()
+    .slice(0, maxChars);
+}
+
+export function normalizeTone(value) {
+  const tone = coerceString(value).trim().toLowerCase();
+  return SUPPORTED_TONES.includes(tone) ? tone : "";
+}
+
+function normalizeConstraints(constraints, limits) {
+  const source =
+    constraints && typeof constraints === "object" && !Array.isArray(constraints)
+      ? constraints
+      : {};
+
+  return {
+    maxWords:
+      Number.isInteger(source.maxWords) && source.maxWords > 0
+        ? Math.min(source.maxWords, 500)
+        : null,
+    keepGreeting: source.keepGreeting === true,
+    keepSignature: source.keepSignature !== false,
+    notes: cleanToneText(source.notes, limits.maxConstraintChars),
+  };
+}
+
+function normalizeAttachments(attachments, limits) {
+  if (!Array.isArray(attachments)) {
+    return [];
+  }
+
+  return attachments.slice(0, limits.maxAttachmentCount).map((attachment) => {
+    const source =
+      attachment && typeof attachment === "object" && !Array.isArray(attachment)
+        ? attachment
+        : {};
+
+    return {
+      name: cleanToneText(source.name, limits.maxAttachmentNameChars),
+      mimeType: cleanToneText(source.mimeType, 80),
+      sizeBytes:
+        Number.isFinite(source.sizeBytes) && source.sizeBytes >= 0
+          ? Math.floor(source.sizeBytes)
+          : null,
+    };
+  });
+}
+
+function normalizeHistory(history, limits) {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history.slice(0, limits.maxHistoryItems).map((entry) => {
+    const source =
+      entry && typeof entry === "object" && !Array.isArray(entry) ? entry : {};
+
+    return {
+      role: cleanToneText(source.role, 40),
+      text: cleanToneText(source.text, limits.maxHistoryChars),
+    };
+  });
+}
+
+function buildError(field, code, message) {
+  return { field, code, message };
+}
+
+export function prepareToneRewriteInput(input, options = {}) {
+  const limits = { ...TONE_REWRITE_LIMITS, ...options };
+  const errors = [];
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: [
+        buildError("request", "invalid_request", "Expected a tone rewrite request object."),
+      ],
+    };
+  }
+
+  const subject = cleanToneText(input.subject, limits.maxSubjectChars);
+  const bodyText = cleanToneText(input.bodyText, limits.maxBodyChars);
+  const tone = normalizeTone(input.tone);
+  const constraints = normalizeConstraints(input.constraints, limits);
+  const attachments = normalizeAttachments(input.attachments, limits);
+  const history = normalizeHistory(input.history, limits);
+
+  if (!bodyText) {
+    errors.push(
+      buildError("bodyText", "empty_body", "Draft body text is required before rewriting."),
+    );
+  }
+
+  if (!tone) {
+    errors.push(
+      buildError(
+        "tone",
+        "unsupported_tone",
+        `Tone must be one of: ${SUPPORTED_TONES.join(", ")}.`,
+      ),
+    );
+  }
+
+  if (errors.length) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      subject,
+      bodyText,
+      tone,
+      constraints,
+      attachments,
+      history,
+      truncated: {
+        bodyText: coerceString(input.bodyText).length > bodyText.length,
+        attachments:
+          Array.isArray(input.attachments) &&
+          input.attachments.length > attachments.length,
+        history: Array.isArray(input.history) && input.history.length > history.length,
+      },
+    },
+  };
+}

--- a/tools/v1/individual/email-tone-rewriter/tests/tone-guards.test.mjs
+++ b/tools/v1/individual/email-tone-rewriter/tests/tone-guards.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  TONE_REWRITE_LIMITS,
+  cleanToneText,
+  normalizeTone,
+  prepareToneRewriteInput,
+} from "../services/tone-guards.mjs";
+
+test("normalizes a valid tone rewrite request", () => {
+  const result = prepareToneRewriteInput({
+    subject: "  Quarterly update  ",
+    bodyText: "Hello team,\r\n\r\n  Please review the updated launch plan.  ",
+    tone: "Friendly",
+    constraints: {
+      maxWords: 120,
+      keepGreeting: true,
+      notes: " preserve dates ",
+    },
+    attachments: [{ name: "brief.pdf", mimeType: "application/pdf", sizeBytes: 2048 }],
+    history: [{ role: "user", text: "Make it warmer." }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.subject, "Quarterly update");
+  assert.equal(result.value.bodyText, "Hello team,\n\nPlease review the updated launch plan.");
+  assert.equal(result.value.tone, "friendly");
+  assert.equal(result.value.constraints.keepGreeting, true);
+  assert.equal(result.value.constraints.notes, "preserve dates");
+  assert.deepEqual(result.value.attachments[0], {
+    name: "brief.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2048,
+  });
+});
+
+test("rejects empty bodies and unsupported tones", () => {
+  const result = prepareToneRewriteInput({ bodyText: "  ", tone: "salesy" });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(
+    result.errors.map((error) => error.code),
+    ["empty_body", "unsupported_tone"],
+  );
+});
+
+test("removes control characters and caps large body text", () => {
+  const longBody = `${"A".repeat(TONE_REWRITE_LIMITS.maxBodyChars + 40)}\u0000`;
+  const result = prepareToneRewriteInput({ bodyText: longBody, tone: "concise" });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.bodyText.length, TONE_REWRITE_LIMITS.maxBodyChars);
+  assert.equal(result.value.bodyText.includes("\u0000"), false);
+  assert.equal(result.value.truncated.bodyText, true);
+});
+
+test("limits attachment metadata and never returns attachment bodies", () => {
+  const result = prepareToneRewriteInput({
+    bodyText: "Please rewrite this draft.",
+    tone: "formal",
+    attachments: Array.from({ length: 12 }, (_, index) => ({
+      name: `attachment-${index}.txt`,
+      mimeType: "text/plain",
+      sizeBytes: index,
+      body: "raw attachment content that should not be forwarded",
+    })),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.attachments.length, TONE_REWRITE_LIMITS.maxAttachmentCount);
+  assert.equal(result.value.attachments[0].body, undefined);
+  assert.equal(result.value.truncated.attachments, true);
+});
+
+test("caps history and constraint notes before rewrite work starts", () => {
+  const result = prepareToneRewriteInput({
+    bodyText: "Need a cleaner version.",
+    tone: "neutral",
+    constraints: { notes: "x".repeat(TONE_REWRITE_LIMITS.maxConstraintChars + 20) },
+    history: Array.from({ length: 10 }, (_, index) => ({
+      role: "assistant",
+      text: `previous answer ${index} ${"y".repeat(TONE_REWRITE_LIMITS.maxHistoryChars + 20)}`,
+    })),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.constraints.notes.length, TONE_REWRITE_LIMITS.maxConstraintChars);
+  assert.equal(result.value.history.length, TONE_REWRITE_LIMITS.maxHistoryItems);
+  assert.equal(result.value.history[0].text.length, TONE_REWRITE_LIMITS.maxHistoryChars);
+  assert.equal(result.value.truncated.history, true);
+});
+
+test("exposes deterministic text and tone helpers", () => {
+  assert.equal(cleanToneText(" a\t\tb\u0000c ", 10), "a bc");
+  assert.equal(normalizeTone("APOLOGETIC"), "apologetic");
+  assert.equal(normalizeTone("urgent"), "");
+});


### PR DESCRIPTION
Closes #352

## Summary
- add folder-local Email Tone Rewriter guard helpers for malformed drafts, supported tone validation, attachment metadata limits, history caps, and large-input truncation
- add a zero-dependency Node guard test covering valid requests, invalid drafts, unsupported tones, large bodies, attachment metadata, and history limits
- document safety assumptions, unsafe input categories, performance caps, reviewer checks, and the local test command

## Scope
- only touches `tools/v1/individual/email-tone-rewriter/`
- no main app shell, routing, auth, wallet, Stellar, database, inbox, live mailbox, external request, or design-system integration
- no real mailbox/customer data or attachment bodies

## Validation
- temporary local Node import/assertion run for the guard helper: passed 4 core checks
- intended repo command:
  - `node --test tools/v1/individual/email-tone-rewriter/tests/tone-guards.test.mjs`