### PR TITLE
feat: guard deadline detector inputs

### DIFF
--- a/tools/v2/individual/deadline-detector/README.md
+++ b/tools/v2/individual/deadline-detector/README.md
@@ -33,12 +33,23 @@ The test validates synthetic sample messages and expected deadline states.
 ## Tool Workflow
 
 1. Accept message-like input through local `DeadlineMessage` objects.
-2. Detect ISO dates, US dates, relative phrases such as today/tomorrow/next
+2. Normalize and cap source messages before date or time matching starts.
+3. Detect ISO dates, US dates, relative phrases such as today/tomorrow/next
    week, and simple 24-hour times.
-3. Classify each result as `detected`, `needs-review`, `missed`, or `ignored`.
-4. Rank urgent results first while preserving ambiguous rows for manual review.
-5. Offer UI actions for review or reminder creation without creating reminders
+4. Classify each result as `detected`, `needs-review`, `missed`, or `ignored`.
+5. Rank urgent results first while preserving ambiguous rows for manual review.
+6. Offer UI actions for review or reminder creation without creating reminders
    automatically.
+
+## Safety and Performance Guard Rails
+
+`services/input-guards.ts` is the folder-local input boundary. It caps message
+batches, cleans text fields, normalizes malformed message objects, defaults
+unknown source types to `email`, and prevents large bodies from reaching the
+date-matching step unchanged.
+
+`docs/SAFETY_PERFORMANCE.md` documents unsafe input categories, limits, and
+review checks for the guard layer.
 
 ## UI Surface
 
@@ -71,6 +82,8 @@ No real sender, mailbox, or personal data is used.
 - `specs.md` defines scope, status rules, and the local detection contract.
 - `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
 - `docs/VISUAL_STYLE.md` documents the local visual treatment.
+- `docs/SAFETY_PERFORMANCE.md` documents the input guard limits and review
+  checks.
 - `docs/TEST_PLAN.md` lists automated and manual review checks.
 - `tests/deadline-fixtures.test.mjs` validates the fixture contract.
 

--- a/tools/v2/individual/deadline-detector/docs/SAFETY_PERFORMANCE.md
+++ b/tools/v2/individual/deadline-detector/docs/SAFETY_PERFORMANCE.md
@@ -1,0 +1,52 @@
+# Safety and Performance Notes
+
+## Scope
+
+These notes apply only to `tools/v2/individual/deadline-detector/`. The tool
+stays isolated from app routing, mailbox ingestion, reminder writes, calendar
+writes, wallet code, Stellar integration, database state, and the shared design
+system.
+
+## Input guard behavior
+
+`services/input-guards.ts` normalizes source messages before deadline detection
+starts. It:
+
+- accepts only array input and falls back to an empty list for non-arrays;
+- caps message batches before running date or time matching;
+- removes control characters and normalizes line endings;
+- trims noisy whitespace while preserving paragraph boundaries;
+- caps message ids, senders, subjects, bodies, and time zone labels;
+- supplies stable fallback ids for malformed message objects;
+- defaults unknown source types to `email`;
+- keeps the original `containsPersonalData` flag only when explicitly true.
+
+## Current limits
+
+- Messages per run: 50.
+- Message id: 80 characters.
+- Sender: 160 characters.
+- Subject: 240 characters.
+- Body: 12,000 characters.
+- Time zone label: 80 characters.
+
+The service options can lower or raise the message, subject, and body limits for
+future folder-local tests without changing the main app.
+
+## Unsafe input categories
+
+- Non-array source payloads.
+- Missing or non-string ids, subjects, bodies, senders, or time zones.
+- Very large message batches.
+- Very large message bodies.
+- Control characters or inconsistent line endings.
+- Unknown source type values.
+
+## Review checklist
+
+- Confirm all changes stay in the Deadline Detector folder.
+- Confirm normalization runs before date matching.
+- Confirm malformed message objects do not crash title or evidence creation.
+- Confirm large batches are capped before mapping.
+- Confirm no live mailbox, reminder, calendar, database, or network writes are
+  introduced.

--- a/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
+++ b/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
@@ -6,6 +6,7 @@ import type {
   DeadlineUrgency,
   DetectedDeadline,
 } from "../types";
+import { normalizeDeadlineMessages } from "./input-guards";
 
 const ISO_DATE_PATTERN = /\b(20\d{2})-(\d{2})-(\d{2})\b/;
 const US_DATE_PATTERN = /\b(\d{1,2})\/(\d{1,2})\/(20\d{2})\b/;
@@ -133,8 +134,14 @@ export function detectDeadlines(
 ): DeadlineDetectionResult {
   const now = new Date(options.now ?? new Date().toISOString());
   const defaultTimezone = options.defaultTimezone ?? "UTC";
+  const normalizedMessages = normalizeDeadlineMessages(messages, {
+    defaultTimezone,
+    maxBodyChars: options.maxBodyChars,
+    maxMessages: options.maxMessages,
+    maxSubjectChars: options.maxSubjectChars,
+  });
 
-  const deadlines = messages.map((message): DetectedDeadline => {
+  const deadlines = normalizedMessages.map((message): DetectedDeadline => {
     const combinedText = `${message.subject}\n${message.body}`;
     const dueDate = normalizeDateFromText(combinedText, now);
     const dueTime = normalizeTimeFromText(combinedText);
@@ -182,7 +189,7 @@ export function detectDeadlines(
       return acc;
     },
     {
-      totalMessages: messages.length,
+      totalMessages: normalizedMessages.length,
       totalDeadlines: 0,
       detected: 0,
       needsReview: 0,

--- a/tools/v2/individual/deadline-detector/services/index.ts
+++ b/tools/v2/individual/deadline-detector/services/index.ts
@@ -1,1 +1,7 @@
 export { detectDeadlines, sortDetectedDeadlines } from "./deadline-detector.service";
+export {
+  DEADLINE_INPUT_LIMITS,
+  cleanDeadlineText,
+  normalizeDeadlineMessages,
+} from "./input-guards";
+export type { DeadlineInputGuardOptions, DeadlineInputLimits } from "./input-guards";

--- a/tools/v2/individual/deadline-detector/services/input-guards.ts
+++ b/tools/v2/individual/deadline-detector/services/input-guards.ts
@@ -1,0 +1,93 @@
+import type { DeadlineMessage, DeadlineSourceType } from "../types";
+
+export interface DeadlineInputLimits {
+  maxMessages: number;
+  maxIdChars: number;
+  maxSenderChars: number;
+  maxSubjectChars: number;
+  maxBodyChars: number;
+  maxTimezoneChars: number;
+}
+
+export interface DeadlineInputGuardOptions extends Partial<DeadlineInputLimits> {
+  defaultTimezone?: string;
+}
+
+export const DEADLINE_INPUT_LIMITS: DeadlineInputLimits = Object.freeze({
+  maxMessages: 50,
+  maxIdChars: 80,
+  maxSenderChars: 160,
+  maxSubjectChars: 240,
+  maxBodyChars: 12000,
+  maxTimezoneChars: 80,
+});
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const WHITESPACE_PATTERN = /[ \t]+/g;
+const SOURCE_TYPES: ReadonlySet<DeadlineSourceType> = new Set([
+  "calendar-forward",
+  "email",
+  "invoice",
+  "project-update",
+]);
+
+function resolveLimits(options: DeadlineInputGuardOptions): DeadlineInputLimits {
+  return {
+    maxMessages: options.maxMessages ?? DEADLINE_INPUT_LIMITS.maxMessages,
+    maxIdChars: options.maxIdChars ?? DEADLINE_INPUT_LIMITS.maxIdChars,
+    maxSenderChars: options.maxSenderChars ?? DEADLINE_INPUT_LIMITS.maxSenderChars,
+    maxSubjectChars: options.maxSubjectChars ?? DEADLINE_INPUT_LIMITS.maxSubjectChars,
+    maxBodyChars: options.maxBodyChars ?? DEADLINE_INPUT_LIMITS.maxBodyChars,
+    maxTimezoneChars: options.maxTimezoneChars ?? DEADLINE_INPUT_LIMITS.maxTimezoneChars,
+  };
+}
+
+export function cleanDeadlineText(value: unknown, maxChars: number): string {
+  return typeof value === "string"
+    ? value
+        .replace(CONTROL_CHAR_PATTERN, "")
+        .replace(/\r\n?/g, "\n")
+        .split("\n")
+        .map((line) => line.replace(WHITESPACE_PATTERN, " ").trim())
+        .join("\n")
+        .trim()
+        .slice(0, maxChars)
+    : "";
+}
+
+function normalizeSourceType(value: unknown): DeadlineSourceType {
+  return SOURCE_TYPES.has(value as DeadlineSourceType)
+    ? (value as DeadlineSourceType)
+    : "email";
+}
+
+export function normalizeDeadlineMessages(
+  messages: DeadlineMessage[],
+  options: DeadlineInputGuardOptions = {},
+): DeadlineMessage[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  const limits = resolveLimits(options);
+  const defaultTimezone = cleanDeadlineText(options.defaultTimezone, limits.maxTimezoneChars) || "UTC";
+
+  return messages.slice(0, limits.maxMessages).map((message, index) => {
+    const source =
+      message && typeof message === "object" && !Array.isArray(message)
+        ? (message as Partial<DeadlineMessage>)
+        : {};
+
+    return {
+      id: cleanDeadlineText(source.id, limits.maxIdChars) || `message-${index + 1}`,
+      type: normalizeSourceType(source.type),
+      sender: cleanDeadlineText(source.sender, limits.maxSenderChars),
+      subject: cleanDeadlineText(source.subject, limits.maxSubjectChars),
+      body: cleanDeadlineText(source.body, limits.maxBodyChars),
+      receivedAt: cleanDeadlineText(source.receivedAt, 40),
+      containsPersonalData: source.containsPersonalData === true,
+      userTimezone:
+        cleanDeadlineText(source.userTimezone, limits.maxTimezoneChars) || defaultTimezone,
+    };
+  });
+}

--- a/tools/v2/individual/deadline-detector/types/deadline.ts
+++ b/tools/v2/individual/deadline-detector/types/deadline.ts
@@ -48,4 +48,7 @@ export interface DeadlineDetectionResult {
 export interface DeadlineDetectorServiceOptions {
   now?: string;
   defaultTimezone?: string;
+  maxMessages?: number;
+  maxSubjectChars?: number;
+  maxBodyChars?: number;
 }


### PR DESCRIPTION
Closes 

## Summary
- add a folder-local Deadline Detector input guard module for malformed message objects, unknown source types, noisy text, large batches, and large body text
- run the existing detector through normalized messages before date/time matching and expose limit options for folder-local tests
- document the guard limits, unsafe input categories, and review checklist in the README and safety notes

## Scope
- only touches `tools/v2/individual/deadline-detector/`
- no main app shell, routing, auth, wallet, Stellar, database, live mailbox, reminder write, calendar write, external request, or design-system integration
- no real sender, mailbox, or personal data is introduced

## Validation
- compare against upstream main: 6 changed files, all inside the Deadline Detector folder
- static review of the TypeScript guard flow and existing detector call site
- not run locally: this desktop does not expose the repository TypeScript/Node toolchain on PATH

## Suggested reviewer command
- `node --test tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs