### PR TITLE
docs: add confidential mode guard rails

### DIFF
--- a/tools/v2/individual/confidential-mode-suggestion/README.md
+++ b/tools/v2/individual/confidential-mode-suggestion/README.md
@@ -6,10 +6,39 @@ This folder is the isolated workspace for the Confidential Mode Suggestion tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\confidential-mode-suggestion\
-`
+```text
+tools/v2/individual/confidential-mode-suggestion/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Safety and Performance Guard Rails
+
+This folder includes a local guard helper for future confidential-mode
+suggestions:
+
+- `services/confidential-mode-guards.mjs` normalizes subject, body, recipient,
+  attachment, and context input before scoring.
+- `tests/confidential-mode-guards.test.mjs` covers valid input, empty input,
+  large input caps, attachment metadata handling, high-signal recommendations,
+  and low-signal review behavior.
+- `docs/SECURITY_AND_PERFORMANCE.md` documents unsafe input categories, limits,
+  and review checks.
+- `docs/REVIEW_NOTES.md` maps the implementation to issue #477.
+
+Suggested local check:
+
+```bash
+node --test tools/v2/individual/confidential-mode-suggestion/tests/confidential-mode-guards.test.mjs
+```
+
+## Known Limitations
+
+- This contribution does not mount the tool in the main app.
+- The recommendation helper is deterministic and conservative.
+- Live email ingestion, sending, persistence, wallet flows, and database writes
+  remain out of scope.
+
+See `specs.md` for the issue categories and contributor expectations.

--- a/tools/v2/individual/confidential-mode-suggestion/docs/REVIEW_NOTES.md
+++ b/tools/v2/individual/confidential-mode-suggestion/docs/REVIEW_NOTES.md
@@ -1,0 +1,35 @@
+# Review Notes
+
+## Issue coverage
+
+Issue #477 asks for safety and performance constraints before future
+integration. This change adds that boundary inside the isolated tool folder.
+
+## Files added or updated
+
+- `services/confidential-mode-guards.mjs` adds request normalization, input
+  caps, privacy-signal scoring, and recommendation output.
+- `tests/confidential-mode-guards.test.mjs` covers valid input, empty input,
+  large input caps, attachment metadata handling, high-signal recommendations,
+  and low-signal review behavior.
+- `docs/SECURITY_AND_PERFORMANCE.md` documents assumptions, limits, unsafe input
+  categories, and reviewer checks.
+- `docs/REVIEW_NOTES.md` maps the change to issue #477.
+- `README.md` links the guard helper and local test command.
+
+## Acceptance criteria mapping
+
+- Explicit handling for malformed or hostile input: empty requests return
+  deterministic errors, and noisy strings are cleaned before scoring.
+- Avoid unnecessary work on large datasets: body, recipients, attachments, and
+  context are capped before recommendation scoring.
+- No existing sensitive app code modified: all files stay inside the local tool
+  folder.
+- Self-contained mini-product review: helper, tests, docs, and README links are
+  colocated.
+
+## Suggested validation
+
+Run:
+
+`node --test tools/v2/individual/confidential-mode-suggestion/tests/confidential-mode-guards.test.mjs`

--- a/tools/v2/individual/confidential-mode-suggestion/docs/SECURITY_AND_PERFORMANCE.md
+++ b/tools/v2/individual/confidential-mode-suggestion/docs/SECURITY_AND_PERFORMANCE.md
@@ -1,0 +1,48 @@
+# Safety and Performance Notes
+
+## Scope
+
+These notes apply only to
+`tools/v2/individual/confidential-mode-suggestion/`. The tool remains isolated
+from app routing, inbox architecture, wallet code, Stellar integration,
+database state, live mailboxes, and the shared design system.
+
+## Guard behavior
+
+`services/confidential-mode-guards.mjs` provides a folder-local boundary for
+future confidential-mode suggestions. It:
+
+- normalizes subject, body, recipient, attachment, and context input;
+- removes control characters and normalizes line endings;
+- caps message body, recipient list, and attachment metadata before scoring;
+- keeps only attachment metadata and never returns attachment bodies;
+- returns deterministic errors for empty requests;
+- records whether large input collections were truncated;
+- produces a reviewable recommendation with reasons and suggested safeguards.
+
+## Current limits
+
+- Subject: 240 characters.
+- Body text: 12,000 characters.
+- Recipients: 25 entries, 160 characters each.
+- Attachments: 10 metadata entries, 120 characters per name.
+- Context notes: 600 characters.
+
+## Unsafe input categories
+
+- Empty messages that do not have a subject or body.
+- Very large message bodies.
+- Broad recipient lists.
+- Attachment objects carrying raw body content.
+- Text with control characters or inconsistent newline formats.
+- Context notes that are too large to review quickly.
+
+## Review checklist
+
+- Confirm all changed files stay inside the Confidential Mode Suggestion folder.
+- Confirm no live mailbox, send, route, wallet, Stellar, database, or network
+  integration is added.
+- Confirm attachment bodies are not forwarded.
+- Confirm large inputs are capped before recommendation scoring.
+- Confirm low-signal messages remain review-required instead of being treated as
+  automatic privacy decisions.

--- a/tools/v2/individual/confidential-mode-suggestion/services/confidential-mode-guards.mjs
+++ b/tools/v2/individual/confidential-mode-suggestion/services/confidential-mode-guards.mjs
@@ -1,0 +1,199 @@
+export const CONFIDENTIAL_MODE_LIMITS = Object.freeze({
+  maxSubjectChars: 240,
+  maxBodyChars: 12000,
+  maxRecipientCount: 25,
+  maxRecipientChars: 160,
+  maxAttachmentCount: 10,
+  maxAttachmentNameChars: 120,
+  maxContextChars: 600,
+});
+
+export const PRIVACY_SIGNAL_GROUPS = Object.freeze({
+  personal: ["passport", "tax id", "national id", "home address", "phone number"],
+  financial: ["bank account", "invoice", "payroll", "wire", "routing number"],
+  account: ["password", "recovery code", "one-time code", "api key", "private key"],
+  legal: ["nda", "contract", "settlement", "legal review", "confidential"],
+});
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const WHITESPACE_PATTERN = /[ \t]+/g;
+
+function coerceString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+export function cleanConfidentialText(value, maxChars) {
+  return coerceString(value)
+    .replace(CONTROL_CHAR_PATTERN, "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(WHITESPACE_PATTERN, " ").trim())
+    .join("\n")
+    .trim()
+    .slice(0, maxChars);
+}
+
+function normalizeRecipients(recipients, limits) {
+  if (!Array.isArray(recipients)) {
+    return [];
+  }
+
+  return recipients
+    .slice(0, limits.maxRecipientCount)
+    .map((recipient) => cleanConfidentialText(recipient, limits.maxRecipientChars))
+    .filter(Boolean);
+}
+
+function normalizeAttachments(attachments, limits) {
+  if (!Array.isArray(attachments)) {
+    return [];
+  }
+
+  return attachments.slice(0, limits.maxAttachmentCount).map((attachment) => {
+    const source =
+      attachment && typeof attachment === "object" && !Array.isArray(attachment)
+        ? attachment
+        : {};
+
+    return {
+      name: cleanConfidentialText(source.name, limits.maxAttachmentNameChars),
+      mimeType: cleanConfidentialText(source.mimeType, 80),
+      sizeBytes:
+        Number.isFinite(source.sizeBytes) && source.sizeBytes >= 0
+          ? Math.floor(source.sizeBytes)
+          : null,
+    };
+  });
+}
+
+function findPrivacySignals(text) {
+  const lowered = text.toLowerCase();
+  const signals = [];
+
+  for (const [group, words] of Object.entries(PRIVACY_SIGNAL_GROUPS)) {
+    for (const word of words) {
+      if (lowered.includes(word)) {
+        signals.push({ group, word });
+      }
+    }
+  }
+
+  return signals;
+}
+
+function scoreRecommendation(normalized, signals) {
+  let score = signals.length * 2;
+
+  if (normalized.attachments.length > 0) {
+    score += 1;
+  }
+  if (normalized.recipients.length > 5) {
+    score += 1;
+  }
+  if (normalized.bodyText.length > 3000) {
+    score += 1;
+  }
+
+  if (score >= 4) {
+    return {
+      recommendation: "enable-confidential-mode",
+      confidence: 0.92,
+      reviewRequired: false,
+    };
+  }
+
+  if (score >= 2) {
+    return {
+      recommendation: "review-before-sending",
+      confidence: 0.72,
+      reviewRequired: true,
+    };
+  }
+
+  return {
+    recommendation: "no-confidential-mode-needed",
+    confidence: 0.58,
+    reviewRequired: true,
+  };
+}
+
+export function prepareConfidentialModeInput(input, options = {}) {
+  const limits = { ...CONFIDENTIAL_MODE_LIMITS, ...options };
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          field: "request",
+          code: "invalid_request",
+          message: "Expected a confidential mode suggestion request object.",
+        },
+      ],
+    };
+  }
+
+  const subject = cleanConfidentialText(input.subject, limits.maxSubjectChars);
+  const bodyText = cleanConfidentialText(input.bodyText, limits.maxBodyChars);
+  const recipients = normalizeRecipients(input.recipients, limits);
+  const attachments = normalizeAttachments(input.attachments, limits);
+  const context = cleanConfidentialText(input.context, limits.maxContextChars);
+
+  if (!subject && !bodyText) {
+    return {
+      ok: false,
+      errors: [
+        {
+          field: "bodyText",
+          code: "empty_message",
+          message: "Subject or body text is required before suggesting privacy protections.",
+        },
+      ],
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      subject,
+      bodyText,
+      recipients,
+      attachments,
+      context,
+      truncated: {
+        bodyText: coerceString(input.bodyText).length > bodyText.length,
+        recipients:
+          Array.isArray(input.recipients) && input.recipients.length > recipients.length,
+        attachments:
+          Array.isArray(input.attachments) &&
+          input.attachments.length > attachments.length,
+      },
+    },
+  };
+}
+
+export function suggestConfidentialMode(input, options = {}) {
+  const prepared = prepareConfidentialModeInput(input, options);
+  if (!prepared.ok) {
+    return prepared;
+  }
+
+  const normalized = prepared.value;
+  const signals = findPrivacySignals(
+    `${normalized.subject}\n${normalized.bodyText}\n${normalized.context}`,
+  );
+  const scoring = scoreRecommendation(normalized, signals);
+
+  return {
+    ok: true,
+    value: {
+      ...normalized,
+      signals,
+      ...scoring,
+      safeguards:
+        scoring.recommendation === "enable-confidential-mode"
+          ? ["limit forwarding", "set an expiration", "avoid broad recipient lists"]
+          : ["review recipients", "confirm attachment names"],
+    },
+  };
+}

--- a/tools/v2/individual/confidential-mode-suggestion/tests/confidential-mode-guards.test.mjs
+++ b/tools/v2/individual/confidential-mode-suggestion/tests/confidential-mode-guards.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONFIDENTIAL_MODE_LIMITS,
+  cleanConfidentialText,
+  prepareConfidentialModeInput,
+  suggestConfidentialMode,
+} from "../services/confidential-mode-guards.mjs";
+
+test("normalizes a valid confidential-mode request", () => {
+  const result = prepareConfidentialModeInput({
+    subject: "  Contract follow-up  ",
+    bodyText: "Please review the settlement draft.\r\nThanks.",
+    recipients: [" legal@example.test ", " finance@example.test "],
+    attachments: [{ name: "contract.pdf", mimeType: "application/pdf", sizeBytes: 4096 }],
+    context: " external counsel ",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.subject, "Contract follow-up");
+  assert.equal(result.value.bodyText, "Please review the settlement draft.\nThanks.");
+  assert.deepEqual(result.value.recipients, ["legal@example.test", "finance@example.test"]);
+  assert.deepEqual(result.value.attachments[0], {
+    name: "contract.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 4096,
+  });
+  assert.equal(result.value.context, "external counsel");
+});
+
+test("rejects empty request content with deterministic errors", () => {
+  const result = prepareConfidentialModeInput({ subject: " ", bodyText: "" });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors.map((error) => error.code), ["empty_message"]);
+});
+
+test("caps large bodies, recipients, and attachments before scoring", () => {
+  const result = prepareConfidentialModeInput({
+    bodyText: "A".repeat(CONFIDENTIAL_MODE_LIMITS.maxBodyChars + 100),
+    recipients: Array.from({ length: 40 }, (_, index) => `person-${index}@example.test`),
+    attachments: Array.from({ length: 20 }, (_, index) => ({
+      name: `file-${index}.pdf`,
+      mimeType: "application/pdf",
+      sizeBytes: index,
+      body: "raw file content should not be forwarded",
+    })),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.bodyText.length, CONFIDENTIAL_MODE_LIMITS.maxBodyChars);
+  assert.equal(result.value.recipients.length, CONFIDENTIAL_MODE_LIMITS.maxRecipientCount);
+  assert.equal(result.value.attachments.length, CONFIDENTIAL_MODE_LIMITS.maxAttachmentCount);
+  assert.equal(result.value.attachments[0].body, undefined);
+  assert.equal(result.value.truncated.bodyText, true);
+  assert.equal(result.value.truncated.recipients, true);
+  assert.equal(result.value.truncated.attachments, true);
+});
+
+test("recommends confidential mode when multiple privacy signals are present", () => {
+  const result = suggestConfidentialMode({
+    subject: "Confidential contract and payroll update",
+    bodyText: "The attachment includes payroll details and bank account instructions.",
+    recipients: ["owner@example.test", "finance@example.test"],
+    attachments: [{ name: "payroll-instructions.pdf", mimeType: "application/pdf" }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.recommendation, "enable-confidential-mode");
+  assert.equal(result.value.reviewRequired, false);
+  assert.ok(result.value.signals.length >= 2);
+  assert.ok(result.value.safeguards.includes("set an expiration"));
+});
+
+test("keeps low-signal drafts reviewable without auto-enabling", () => {
+  const result = suggestConfidentialMode({
+    subject: "Lunch plan",
+    bodyText: "Can we move lunch to tomorrow?",
+    recipients: ["friend@example.test"],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.recommendation, "no-confidential-mode-needed");
+  assert.equal(result.value.reviewRequired, true);
+});
+
+test("exposes deterministic text cleanup", () => {
+  assert.equal(cleanConfidentialText(" a\t\tb\u0000c ", 20), "a bc");
+});


### PR DESCRIPTION
Closes #477

## Summary
- add folder-local Confidential Mode Suggestion guard helpers for malformed requests, text cleanup, recipient caps, attachment metadata caps, and privacy-signal scoring
- add a zero-dependency Node guard test covering valid input, empty input, large input caps, attachment metadata handling, high-signal recommendations, and low-signal review behavior
- document safety assumptions, unsafe input categories, performance limits, reviewer checks, and the local test command

## Scope
- only touches `tools/v2/individual/confidential-mode-suggestion/`
- no main app shell, routing, auth, wallet, Stellar, database, inbox, live mailbox, send action, external request, or design-system integration
- no real mailbox/customer data or attachment bodies

## Validation
- temporary local Node import/assertion run for the guard helper: passed 5 core checks
- intended repo command:
  - `node --test tools/v2/individual/confidential-mode-suggestion/tests/confidential-mode-guards.test.mjs`
