### PR TITLE
feat: add meeting assignment guard rails

### DIFF
--- a/tools/v2/team/meeting-assignment-tool/README.md
+++ b/tools/v2/team/meeting-assignment-tool/README.md
@@ -10,15 +10,17 @@ All work for this tool must stay inside:
 tools/v2/team/meeting-assignment-tool/
 ```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
 ## Structure
 
 ```
 fixtures/           Deterministic local data (team members, sample meetings)
-services/           Core pure-function logic + async service factory
+services/           Core pure-function logic, guard helpers, async service factory
 tests/              node:test suite (no external runner required)
-docs/               Review notes and contributor context
+docs/               Review notes, safety notes, and contributor context
 types.ts            All domain types
 index.ts            Folder-local public API
 ```
@@ -27,9 +29,29 @@ index.ts            Folder-local public API
 
 ```bash
 node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment.test.mjs
+node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment-guards.test.mjs
 ```
 
-17 tests, no external dependencies.
+The existing assignment suite covers 17 tests. The guard suite covers request
+normalization, malformed inputs, duplicate ids, invalid effort, batch caps, work
+estimation, and text cleanup.
+
+## Safety and Performance Guard Rails
+
+This folder includes a local guard helper for future meeting assignment input:
+
+- `services/meeting-assignment-guards.mjs` normalizes team member and meeting
+  input before assignment work.
+- `tests/meeting-assignment-guards.test.mjs` covers valid normalization,
+  malformed requests, duplicate ids, invalid effort, large-batch caps, work
+  estimation, and control-character cleanup.
+- `docs/SAFETY_AND_PERFORMANCE.md` documents unsafe input categories, limits,
+  and review checks.
+- `docs/SECURITY_REVIEW_NOTES.md` maps the guard helper to issue #632.
+
+The guard helper does not call live calendars, inboxes, wallets, Stellar
+services, databases, or external APIs. It is a deterministic boundary for future
+integration work.
 
 ## Public API
 
@@ -50,7 +72,7 @@ const data = await svc.assign();
 
 1. Sort meetings by priority (desc), then effort (asc).
 2. Find members whose skill set covers all `requiredSkills`.
-3. Filter by remaining capacity (`weeklyCapacity − currentLoad ≥ effort`).
+3. Filter by remaining capacity (`weeklyCapacity - currentLoad >= effort`).
 4. Pick the least-loaded eligible member; ties broken by higher capacity.
 5. Unassigned reason is one of: `"matched"` / `"capacity"` / `"skill_mismatch"`.
 
@@ -77,10 +99,11 @@ const data = await svc.assign();
 
 **Output — `MeetingAssignment`**
 
-| Field        | Type                                          | Description                 |
-| ------------ | --------------------------------------------- | --------------------------- |
+| Field        | Type                                      | Description                 |
+| ------------ | ----------------------------------------- | --------------------------- |
 | `assigneeId` | `string \| null`                              | Assigned member id, or null |
-| `status`     | `"assigned" \| "unassigned"`                  |                             |
+| `status`     | `"assigned" \| "unassigned"`                  | Assignment state            |
 | `reason`     | `"matched" \| "capacity" \| "skill_mismatch"` | Why assigned or not         |
 
-See `types.ts` for full type definitions and `docs/review-notes.md` for contributor notes.
+See `types.ts` for full type definitions and `docs/review-notes.md` for
+contributor notes.

--- a/tools/v2/team/meeting-assignment-tool/docs/SAFETY_AND_PERFORMANCE.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/SAFETY_AND_PERFORMANCE.md
@@ -1,0 +1,54 @@
+# Safety and Performance Notes
+
+## Scope
+
+These notes apply only to `tools/v2/team/meeting-assignment-tool/`. The tool
+remains isolated from the main app shell, routing, wallet code, Stellar
+integration, inbox architecture, database state, live calendars, and live
+customer data.
+
+## Guard helper
+
+`services/meeting-assignment-guards.mjs` adds a folder-local review boundary for
+future meeting assignment requests. It:
+
+- normalizes team member ids, names, roles, skills, meeting titles, and required
+  skills;
+- removes control characters and normalizes whitespace before any assignment
+  work;
+- rejects malformed members, malformed meetings, duplicate ids, invalid
+  scheduled times, and invalid effort values;
+- caps team member and meeting batch sizes before expensive pairwise work;
+- records truncation warnings so a future UI can explain why only part of a
+  batch was reviewed;
+- exposes a small work estimator for routing large batches to async review.
+
+## Current limits
+
+- Team members per batch: 100.
+- Meetings per batch: 250.
+- Skills per item: 20.
+- Meeting duration: 1 to 480 minutes.
+- Effort: 1, 2, or 3.
+- Priority: 0 to 100.
+- Weekly capacity and current load: 0 to 80.
+
+## Unsafe input categories
+
+- Missing or non-array `teamMembers` or `meetings`.
+- Team members without both `id` and `name`.
+- Meetings without both `id` and `title`.
+- Duplicate member or meeting ids inside one batch.
+- Meetings with unparseable scheduled times.
+- Effort values outside the existing 1 to 3 assignment model.
+- Very large batches that would multiply team members by meetings.
+- Skill and text values containing control characters or excessive whitespace.
+
+## Review checklist
+
+- Confirm all changed files stay inside the Meeting Assignment Tool folder.
+- Confirm the existing `assignMeetings` algorithm remains deterministic.
+- Confirm the guard helper does not call live APIs, calendars, inboxes, wallets,
+  Stellar services, databases, or network resources.
+- Confirm large batches are capped before assignment work is estimated.
+- Confirm rejected input returns deterministic error codes reviewers can test.

--- a/tools/v2/team/meeting-assignment-tool/docs/SECURITY_REVIEW_NOTES.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/SECURITY_REVIEW_NOTES.md
@@ -1,0 +1,37 @@
+# Review Notes
+
+## Issue coverage
+
+Issue #632 asks for safety and performance constraints before future
+integration. This change adds that boundary beside the existing Meeting
+Assignment Tool engine without wiring it into the app.
+
+## Files added or updated
+
+- `services/meeting-assignment-guards.mjs` adds request normalization, duplicate
+  checks, size caps, effort/date validation, and work estimation.
+- `tests/meeting-assignment-guards.test.mjs` covers valid normalization,
+  malformed requests, duplicate ids, invalid effort, batch caps, work
+  estimation, and text cleanup.
+- `docs/SAFETY_AND_PERFORMANCE.md` documents assumptions, limits, unsafe input
+  categories, and reviewer checks.
+- `docs/SECURITY_REVIEW_NOTES.md` maps the implementation to issue #632.
+- `README.md` links the guard helper and test command.
+
+## Acceptance criteria mapping
+
+- Explicit handling for malformed or hostile input: invalid top-level payloads,
+  malformed members, malformed meetings, duplicate ids, invalid dates, and
+  invalid effort values return deterministic errors.
+- Avoid unnecessary work on large datasets: team member and meeting arrays are
+  capped before pairwise work is estimated.
+- No existing sensitive app code modified: all files stay in the isolated tool
+  folder.
+- Self-contained mini-product review: helper, tests, docs, and README links are
+  colocated with the existing Meeting Assignment Tool.
+
+## Suggested validation
+
+Run:
+
+`node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment-guards.test.mjs`

--- a/tools/v2/team/meeting-assignment-tool/services/meeting-assignment-guards.mjs
+++ b/tools/v2/team/meeting-assignment-tool/services/meeting-assignment-guards.mjs
@@ -1,0 +1,313 @@
+export const MEETING_ASSIGNMENT_GUARD_LIMITS = Object.freeze({
+  maxTeamMembers: 100,
+  maxMeetings: 250,
+  maxSkillsPerItem: 20,
+  maxSkillChars: 80,
+  maxIdChars: 80,
+  maxNameChars: 120,
+  maxRoleChars: 80,
+  maxTitleChars: 180,
+  maxDurationMinutes: 480,
+  maxPriority: 100,
+  maxWeeklyCapacity: 80,
+  maxCurrentMeetingLoad: 80,
+});
+
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const WHITESPACE_PATTERN = /[ \t]+/g;
+const VALID_EFFORT = new Set([1, 2, 3]);
+
+function coerceString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+export function cleanMeetingAssignmentText(value, maxChars) {
+  return coerceString(value)
+    .replace(CONTROL_CHAR_PATTERN, "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(WHITESPACE_PATTERN, " ").trim())
+    .join("\n")
+    .trim()
+    .slice(0, maxChars);
+}
+
+function boundedInteger(value, min, max, fallback) {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function normalizeSkills(skills, limits) {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+
+  const normalized = [];
+  const seen = new Set();
+
+  for (const skill of skills.slice(0, limits.maxSkillsPerItem)) {
+    const cleaned = cleanMeetingAssignmentText(skill, limits.maxSkillChars).toLowerCase();
+    if (cleaned && !seen.has(cleaned)) {
+      seen.add(cleaned);
+      normalized.push(cleaned);
+    }
+  }
+
+  return normalized;
+}
+
+function hasValidScheduledAt(value) {
+  const cleaned = cleanMeetingAssignmentText(value, 80);
+  return cleaned.length > 0 && !Number.isNaN(Date.parse(cleaned));
+}
+
+function normalizeTeamMember(member, index, limits) {
+  if (!member || typeof member !== "object" || Array.isArray(member)) {
+    return {
+      error: {
+        field: `teamMembers[${index}]`,
+        code: "invalid_member",
+        message: "Expected a team member object.",
+      },
+    };
+  }
+
+  const id = cleanMeetingAssignmentText(member.id, limits.maxIdChars);
+  const name = cleanMeetingAssignmentText(member.name, limits.maxNameChars);
+  const role = cleanMeetingAssignmentText(member.role, limits.maxRoleChars);
+  const skills = normalizeSkills(member.skills, limits);
+
+  if (!id || !name) {
+    return {
+      error: {
+        field: `teamMembers[${index}]`,
+        code: "missing_member_identity",
+        message: "Team members need both id and name before assignment.",
+      },
+    };
+  }
+
+  return {
+    value: {
+      id,
+      name,
+      role,
+      skills,
+      currentMeetingLoad: boundedInteger(
+        member.currentMeetingLoad,
+        0,
+        limits.maxCurrentMeetingLoad,
+        0,
+      ),
+      weeklyCapacity: boundedInteger(member.weeklyCapacity, 0, limits.maxWeeklyCapacity, 0),
+    },
+  };
+}
+
+function normalizeMeeting(meeting, index, limits) {
+  if (!meeting || typeof meeting !== "object" || Array.isArray(meeting)) {
+    return {
+      error: {
+        field: `meetings[${index}]`,
+        code: "invalid_meeting",
+        message: "Expected a meeting object.",
+      },
+    };
+  }
+
+  const id = cleanMeetingAssignmentText(meeting.id, limits.maxIdChars);
+  const title = cleanMeetingAssignmentText(meeting.title, limits.maxTitleChars);
+  const scheduledAt = cleanMeetingAssignmentText(meeting.scheduledAt, 80);
+
+  if (!id || !title) {
+    return {
+      error: {
+        field: `meetings[${index}]`,
+        code: "missing_meeting_identity",
+        message: "Meetings need both id and title before assignment.",
+      },
+    };
+  }
+
+  if (!hasValidScheduledAt(scheduledAt)) {
+    return {
+      error: {
+        field: `meetings[${index}].scheduledAt`,
+        code: "invalid_scheduled_at",
+        message: "Meeting scheduledAt must be a parseable ISO-like datetime string.",
+      },
+    };
+  }
+
+  const effort = Number(meeting.effort);
+  if (!VALID_EFFORT.has(effort)) {
+    return {
+      error: {
+        field: `meetings[${index}].effort`,
+        code: "invalid_effort",
+        message: "Meeting effort must be 1, 2, or 3.",
+      },
+    };
+  }
+
+  return {
+    value: {
+      id,
+      title,
+      scheduledAt,
+      durationMinutes: boundedInteger(
+        meeting.durationMinutes,
+        1,
+        limits.maxDurationMinutes,
+        30,
+      ),
+      requiredSkills: normalizeSkills(meeting.requiredSkills, limits),
+      effort,
+      priority: boundedInteger(meeting.priority, 0, limits.maxPriority, 0),
+    },
+  };
+}
+
+export function prepareMeetingAssignmentInput(input, options = {}) {
+  const limits = { ...MEETING_ASSIGNMENT_GUARD_LIMITS, ...options };
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          field: "request",
+          code: "invalid_request",
+          message: "Expected a meeting assignment request object.",
+        },
+      ],
+    };
+  }
+
+  const errors = [];
+  const warnings = [];
+
+  if (!Array.isArray(input.teamMembers)) {
+    errors.push({
+      field: "teamMembers",
+      code: "invalid_team_members",
+      message: "teamMembers must be an array.",
+    });
+  }
+
+  if (!Array.isArray(input.meetings)) {
+    errors.push({
+      field: "meetings",
+      code: "invalid_meetings",
+      message: "meetings must be an array.",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const rawMembers = input.teamMembers.slice(0, limits.maxTeamMembers);
+  const rawMeetings = input.meetings.slice(0, limits.maxMeetings);
+
+  if (input.teamMembers.length > rawMembers.length) {
+    warnings.push({
+      field: "teamMembers",
+      code: "team_members_truncated",
+      message: `Only the first ${limits.maxTeamMembers} team members are reviewed.`,
+    });
+  }
+
+  if (input.meetings.length > rawMeetings.length) {
+    warnings.push({
+      field: "meetings",
+      code: "meetings_truncated",
+      message: `Only the first ${limits.maxMeetings} meetings are reviewed.`,
+    });
+  }
+
+  const teamMembers = [];
+  const seenMembers = new Set();
+  for (const [index, member] of rawMembers.entries()) {
+    const normalized = normalizeTeamMember(member, index, limits);
+    if (normalized.error) {
+      errors.push(normalized.error);
+      continue;
+    }
+    if (seenMembers.has(normalized.value.id)) {
+      errors.push({
+        field: `teamMembers[${index}].id`,
+        code: "duplicate_member_id",
+        message: "Team member ids must be unique in a single assignment request.",
+      });
+      continue;
+    }
+    seenMembers.add(normalized.value.id);
+    teamMembers.push(normalized.value);
+  }
+
+  const meetings = [];
+  const seenMeetings = new Set();
+  for (const [index, meeting] of rawMeetings.entries()) {
+    const normalized = normalizeMeeting(meeting, index, limits);
+    if (normalized.error) {
+      errors.push(normalized.error);
+      continue;
+    }
+    if (seenMeetings.has(normalized.value.id)) {
+      errors.push({
+        field: `meetings[${index}].id`,
+        code: "duplicate_meeting_id",
+        message: "Meeting ids must be unique in a single assignment request.",
+      });
+      continue;
+    }
+    seenMeetings.add(normalized.value.id);
+    meetings.push(normalized.value);
+  }
+
+  if (teamMembers.length === 0) {
+    errors.push({
+      field: "teamMembers",
+      code: "empty_team",
+      message: "At least one valid team member is required before assignment.",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, warnings };
+  }
+
+  return {
+    ok: true,
+    value: {
+      teamMembers,
+      meetings,
+      warnings,
+      truncated: {
+        teamMembers: input.teamMembers.length > rawMembers.length,
+        meetings: input.meetings.length > rawMeetings.length,
+      },
+    },
+  };
+}
+
+export function estimateMeetingAssignmentWork(input, options = {}) {
+  const limits = { ...MEETING_ASSIGNMENT_GUARD_LIMITS, ...options };
+  const memberCount = Array.isArray(input?.teamMembers)
+    ? Math.min(input.teamMembers.length, limits.maxTeamMembers)
+    : 0;
+  const meetingCount = Array.isArray(input?.meetings)
+    ? Math.min(input.meetings.length, limits.maxMeetings)
+    : 0;
+
+  return {
+    memberCount,
+    meetingCount,
+    skillComparisons: memberCount * meetingCount,
+    shouldDefer: memberCount * meetingCount > limits.maxTeamMembers * 50,
+  };
+}

--- a/tools/v2/team/meeting-assignment-tool/tests/meeting-assignment-guards.test.mjs
+++ b/tools/v2/team/meeting-assignment-tool/tests/meeting-assignment-guards.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MEETING_ASSIGNMENT_GUARD_LIMITS,
+  cleanMeetingAssignmentText,
+  estimateMeetingAssignmentWork,
+  prepareMeetingAssignmentInput,
+} from "../services/meeting-assignment-guards.mjs";
+
+const validMember = {
+  id: " alice ",
+  name: " Alice ",
+  role: " Facilitator ",
+  skills: ["Planning", "planning", "UX"],
+  currentMeetingLoad: 1,
+  weeklyCapacity: 6,
+};
+
+const validMeeting = {
+  id: " mtg-1 ",
+  title: " Sprint planning ",
+  scheduledAt: "2026-06-30T10:00:00Z",
+  durationMinutes: 45,
+  requiredSkills: ["planning", "UX"],
+  effort: 2,
+  priority: 5,
+};
+
+test("normalizes valid team members and meetings", () => {
+  const result = prepareMeetingAssignmentInput({
+    teamMembers: [validMember],
+    meetings: [validMeeting],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.teamMembers[0].id, "alice");
+  assert.equal(result.value.teamMembers[0].name, "Alice");
+  assert.deepEqual(result.value.teamMembers[0].skills, ["planning", "ux"]);
+  assert.equal(result.value.meetings[0].title, "Sprint planning");
+  assert.deepEqual(result.value.meetings[0].requiredSkills, ["planning", "ux"]);
+});
+
+test("rejects malformed top-level requests with deterministic errors", () => {
+  assert.deepEqual(prepareMeetingAssignmentInput(null).errors.map((error) => error.code), [
+    "invalid_request",
+  ]);
+
+  const result = prepareMeetingAssignmentInput({ teamMembers: "nope", meetings: null });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors.map((error) => error.code), [
+    "invalid_team_members",
+    "invalid_meetings",
+  ]);
+});
+
+test("rejects duplicate ids and invalid meeting effort", () => {
+  const result = prepareMeetingAssignmentInput({
+    teamMembers: [validMember, { ...validMember, name: "Alice Copy" }],
+    meetings: [validMeeting, { ...validMeeting, id: "mtg-2", effort: 4 }],
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors.map((error) => error.code), [
+    "duplicate_member_id",
+    "invalid_effort",
+  ]);
+});
+
+test("caps large batches before assignment work is estimated", () => {
+  const result = prepareMeetingAssignmentInput({
+    teamMembers: Array.from({ length: 120 }, (_, index) => ({
+      ...validMember,
+      id: `member-${index}`,
+      name: `Member ${index}`,
+    })),
+    meetings: Array.from({ length: 300 }, (_, index) => ({
+      ...validMeeting,
+      id: `meeting-${index}`,
+      title: `Planning ${index}`,
+    })),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.teamMembers.length, MEETING_ASSIGNMENT_GUARD_LIMITS.maxTeamMembers);
+  assert.equal(result.value.meetings.length, MEETING_ASSIGNMENT_GUARD_LIMITS.maxMeetings);
+  assert.equal(result.value.truncated.teamMembers, true);
+  assert.equal(result.value.truncated.meetings, true);
+  assert.deepEqual(result.value.warnings.map((warning) => warning.code), [
+    "team_members_truncated",
+    "meetings_truncated",
+  ]);
+});
+
+test("estimates large assignment work for review routing", () => {
+  const estimate = estimateMeetingAssignmentWork({
+    teamMembers: Array.from({ length: 100 }),
+    meetings: Array.from({ length: 250 }),
+  });
+
+  assert.equal(estimate.memberCount, 100);
+  assert.equal(estimate.meetingCount, 250);
+  assert.equal(estimate.skillComparisons, 25000);
+  assert.equal(estimate.shouldDefer, true);
+});
+
+test("removes control characters while preserving readable text", () => {
+  assert.equal(cleanMeetingAssignmentText(" sprint\t\tplanning\u0000 ", 80), "sprint planning");
+});


### PR DESCRIPTION
Closes #632

## Summary
- add folder-local Meeting Assignment guard helpers for malformed requests, duplicate ids, text cleanup, effort/date validation, batch caps, and work estimation
- add a zero-dependency Node guard test covering valid normalization, malformed input, duplicate ids, invalid effort, large input caps, work estimation, and control-character cleanup
- document safety assumptions, unsafe input categories, performance limits, reviewer checks, and the local test command

## Scope
- only touches `tools/v2/team/meeting-assignment-tool/`
- no main app shell, routing, auth, wallet, Stellar, database, inbox, live calendar, external request, or design-system integration
- no real mailbox/customer data

## Validation
- temporary local Node import/assertion run for the guard helper: passed 8 core checks
- intended repo command:
  - `node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment-guards.test.mjs`
