### PR TITLE
feat: add email translator UI surface

### DIFF
--- a/tools/v2/individual/email-translator/README.md
+++ b/tools/v2/individual/email-translator/README.md
@@ -13,3 +13,9 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Local UI Surface
+
+- `components/EmailTranslatorPanel.tsx` provides the isolated translator workflow surface.
+- `docs/ui-accessibility-notes.md` documents empty, loading, error, and success states plus keyboard and screen-reader behavior.
+- The UI uses local deterministic preview text and does not call a live translation service.

--- a/tools/v2/individual/email-translator/components/EmailTranslatorPanel.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorPanel.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { FormEvent, useId, useMemo, useState } from "react";
+
+type TranslationStatus = "empty" | "loading" | "success" | "error";
+
+const languageOptions = [
+  "Auto-detect",
+  "English",
+  "Spanish",
+  "French",
+  "German",
+  "Japanese",
+  "Korean",
+  "Chinese",
+];
+
+const maxEmailChars = 12000;
+
+function buildPreview(sourceText: string, targetLanguage: string, preserveTone: boolean) {
+  const normalized = sourceText.trim().replace(/\s+/g, " ");
+  const excerpt = normalized.length > 220 ? `${normalized.slice(0, 220)}...` : normalized;
+  const toneNote = preserveTone ? "Tone preserved" : "Neutral tone";
+
+  return `[${targetLanguage}] ${excerpt}\n\n${toneNote}. Review names, dates, currency, links, and any legal or medical wording before sending.`;
+}
+
+export default function EmailTranslatorPanel() {
+  const sourceId = useId();
+  const targetId = useId();
+  const messageId = useId();
+  const statusId = useId();
+  const resultId = useId();
+  const [sourceLanguage, setSourceLanguage] = useState("Auto-detect");
+  const [targetLanguage, setTargetLanguage] = useState("Spanish");
+  const [sourceText, setSourceText] = useState("");
+  const [preserveTone, setPreserveTone] = useState(true);
+  const [status, setStatus] = useState<TranslationStatus>("empty");
+  const [translatedText, setTranslatedText] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const remainingCharacters = maxEmailChars - sourceText.length;
+  const statusCopy = useMemo(() => {
+    if (status === "loading") return "Preparing translation preview...";
+    if (status === "success") return "Translation preview ready.";
+    if (status === "error") return errorMessage;
+    return "Paste an email to prepare a translation preview.";
+  }, [errorMessage, status]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!sourceText.trim()) {
+      setStatus("error");
+      setErrorMessage("Paste an email before translating.");
+      setTranslatedText("");
+      return;
+    }
+
+    if (sourceText.length > maxEmailChars) {
+      setStatus("error");
+      setErrorMessage(`Email is ${Math.abs(remainingCharacters)} characters over the local review limit.`);
+      setTranslatedText("");
+      return;
+    }
+
+    if (sourceLanguage === targetLanguage) {
+      setStatus("error");
+      setErrorMessage("Choose a different target language.");
+      setTranslatedText("");
+      return;
+    }
+
+    setStatus("loading");
+    setErrorMessage("");
+    await Promise.resolve();
+    setTranslatedText(buildPreview(sourceText, targetLanguage, preserveTone));
+    setStatus("success");
+  }
+
+  function handleReset() {
+    setSourceText("");
+    setTranslatedText("");
+    setErrorMessage("");
+    setStatus("empty");
+  }
+
+  return (
+    <section
+      aria-labelledby={targetId}
+      className="email-translator-panel"
+      data-tool="email-translator"
+    >
+      <div className="email-translator-panel__header">
+        <p className="email-translator-panel__eyebrow">Individual email tool</p>
+        <h2 id={targetId}>Email Translator</h2>
+        <p>
+          Translate an email draft locally before a future integration connects this
+          panel to a translation service.
+        </p>
+      </div>
+
+      <form className="email-translator-panel__grid" onSubmit={handleSubmit}>
+        <div className="email-translator-panel__controls" aria-describedby={messageId}>
+          <label>
+            Source language
+            <select
+              value={sourceLanguage}
+              onChange={(event) => setSourceLanguage(event.target.value)}
+            >
+              {languageOptions.map((language) => (
+                <option key={language} value={language}>
+                  {language}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            Target language
+            <select
+              value={targetLanguage}
+              onChange={(event) => setTargetLanguage(event.target.value)}
+            >
+              {languageOptions
+                .filter((language) => language !== "Auto-detect")
+                .map((language) => (
+                  <option key={language} value={language}>
+                    {language}
+                  </option>
+                ))}
+            </select>
+          </label>
+
+          <label className="email-translator-panel__checkbox">
+            <input
+              checked={preserveTone}
+              onChange={(event) => setPreserveTone(event.target.checked)}
+              type="checkbox"
+            />
+            Preserve sender tone
+          </label>
+        </div>
+
+        <label className="email-translator-panel__source" htmlFor={sourceId}>
+          Email body
+          <textarea
+            aria-describedby={`${messageId} ${statusId}`}
+            id={sourceId}
+            maxLength={maxEmailChars + 500}
+            onChange={(event) => setSourceText(event.target.value)}
+            placeholder="Paste the email text to translate."
+            rows={10}
+            value={sourceText}
+          />
+        </label>
+
+        <p id={messageId} className="email-translator-panel__hint">
+          Maximum local preview size: {maxEmailChars.toLocaleString()} characters.
+          {remainingCharacters >= 0
+            ? ` ${remainingCharacters.toLocaleString()} remaining.`
+            : ` ${Math.abs(remainingCharacters).toLocaleString()} over the limit.`}
+        </p>
+
+        <div className="email-translator-panel__actions">
+          <button disabled={status === "loading"} type="submit">
+            {status === "loading" ? "Translating..." : "Translate email"}
+          </button>
+          <button onClick={handleReset} type="button">
+            Clear
+          </button>
+        </div>
+      </form>
+
+      <div
+        aria-live="polite"
+        className={`email-translator-panel__status email-translator-panel__status--${status}`}
+        id={statusId}
+        role={status === "error" ? "alert" : "status"}
+      >
+        {statusCopy}
+      </div>
+
+      <article
+        aria-labelledby={resultId}
+        className="email-translator-panel__result"
+        tabIndex={0}
+      >
+        <h3 id={resultId}>Translation preview</h3>
+        {translatedText ? (
+          <pre>{translatedText}</pre>
+        ) : (
+          <p>No translation preview yet.</p>
+        )}
+      </article>
+    </section>
+  );
+}

--- a/tools/v2/individual/email-translator/docs/ui-accessibility-notes.md
+++ b/tools/v2/individual/email-translator/docs/ui-accessibility-notes.md
@@ -1,0 +1,28 @@
+# Email Translator UI and Accessibility Notes
+
+## Scope
+
+This note covers the folder-local UI surface for the Email Translator tool. The
+panel is not mounted in the main app and does not call a live translation
+service.
+
+## States
+
+- Empty: prompts the user to paste an email before translation.
+- Loading: disables the submit button and announces that a preview is being prepared.
+- Error: uses `role="alert"` for missing text, same-language selection, and local size-limit failures.
+- Success: announces a completed preview and exposes the result in a focusable region.
+
+## Keyboard and Screen Reader Behavior
+
+- Native form controls are used for language selection, text entry, and the tone toggle.
+- The email textarea references both the size hint and status region with `aria-describedby`.
+- Status copy is announced through a single live region.
+- The output article is focusable so keyboard users can move directly to the generated preview.
+- Buttons keep their visible labels aligned with their state and do not rely on icon-only controls.
+
+## Review Notes
+
+- The component intentionally uses deterministic placeholder preview text instead of a network request.
+- Large emails are capped at 12,000 characters for the local preview surface.
+- Main app routes, inbox architecture, wallet code, Stellar integrations, database schema, and shared design-system files are untouched.


### PR DESCRIPTION
Closes 

## Summary
- add a folder-local `EmailTranslatorPanel` with source/target language controls, email input, tone toggle, and translation preview output
- include empty, loading, error, and success states with a live status region
- document keyboard and screen-reader behavior in `docs/ui-accessibility-notes.md` and link the local UI surface from the tool README

## Scope
- changes are limited to `tools/v2/individual/email-translator/`
- no main app shell, routing, inbox architecture, wallet code, Stellar integration, database schema, or shared design-system files are touched
- no live translation service or production data is introduced; the panel uses deterministic placeholder preview text for the isolated surface

## Validation
- local structure check confirmed the component, docs, and README files exist
- checked for empty/loading/error/success state copy, `aria-live`, `aria-describedby`, and a focusable result region
- no runtime tests were run because this is an isolated UI/docs surface and the repository toolchain was not checked out locally