### PR TITLE
feat: add email translator core engine

### DIFF
--- a/tools/v2/individual/email-translator/docs/core-engine-notes.md
+++ b/tools/v2/individual/email-translator/docs/core-engine-notes.md
@@ -1,0 +1,42 @@
+# Email Translator Core Engine Notes
+
+## Scope
+
+This folder-local engine models the core translation workflow without integrating
+with the main app or calling a live translation provider.
+
+## Inputs
+
+- `sourceText`: required email body, normalized for whitespace and capped at
+  12,000 characters.
+- `sourceLanguage`: optional, defaults to `auto`.
+- `targetLanguage`: optional, defaults to `english`.
+- `preserveTone`: optional, defaults to `true`.
+
+## Outputs
+
+- `normalizeTranslatorInput` returns either a normalized value or a structured
+  validation error.
+- `createTranslationJob` returns a deterministic job id, language settings,
+  preview text, warning categories, and requested translation steps.
+- `buildTranslationDraft` returns translated text plus a review checklist for
+  names, dates, links, amounts, sensitive wording, and tone.
+
+## Deterministic Fixtures
+
+The local Node test file covers:
+
+- valid normalization,
+- empty text rejection,
+- oversized input rejection,
+- same-language rejection,
+- stable job ids,
+- warning categories for links, dates, currency, and numbers,
+- success and empty draft results.
+
+## Integration Boundary
+
+No network calls, secrets, production data, inbox routing, wallet behavior,
+Stellar integration, database schema, or shared design-system files are used.
+Future integration work can call this engine from a UI or provider adapter
+without changing its validation contract.

--- a/tools/v2/individual/email-translator/services/email-translator-engine.mjs
+++ b/tools/v2/individual/email-translator/services/email-translator-engine.mjs
@@ -1,0 +1,146 @@
+export const EMAIL_TRANSLATOR_LANGUAGES = Object.freeze([
+  "auto",
+  "english",
+  "spanish",
+  "french",
+  "german",
+  "japanese",
+  "korean",
+  "chinese",
+]);
+
+export const EMAIL_TRANSLATOR_MAX_CHARS = 12000;
+
+const warningPatterns = [
+  ["links", /https?:\/\/|www\./i],
+  ["dates", /\b(?:\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{4}-\d{2}-\d{2})\b/],
+  ["currency", /[$€£¥]\s?\d|\b(?:usd|eur|gbp|jpy|cny|xlm|usdc)\b/i],
+  ["numbers", /\b\d+(?:[.,]\d+)?\b/],
+];
+
+function cleanText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function normalizeLanguage(value, fallback) {
+  const normalized = cleanText(value || fallback).toLowerCase();
+  return EMAIL_TRANSLATOR_LANGUAGES.includes(normalized) ? normalized : fallback;
+}
+
+function stableJobId(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `email-translation-${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+export function detectTranslationWarnings(sourceText) {
+  const text = cleanText(sourceText);
+  return warningPatterns
+    .filter(([, pattern]) => pattern.test(text))
+    .map(([warning]) => warning);
+}
+
+export function normalizeTranslatorInput(input = {}) {
+  const sourceText = cleanText(input.sourceText);
+  const sourceLanguage = normalizeLanguage(input.sourceLanguage, "auto");
+  const targetLanguage = normalizeLanguage(input.targetLanguage, "english");
+  const preserveTone = input.preserveTone !== false;
+
+  if (!sourceText) {
+    return {
+      ok: false,
+      error: "empty_source",
+      message: "Email text is required before creating a translation job.",
+    };
+  }
+
+  if (sourceText.length > EMAIL_TRANSLATOR_MAX_CHARS) {
+    return {
+      ok: false,
+      error: "source_too_large",
+      message: `Email text must be ${EMAIL_TRANSLATOR_MAX_CHARS} characters or fewer.`,
+    };
+  }
+
+  if (sourceLanguage !== "auto" && sourceLanguage === targetLanguage) {
+    return {
+      ok: false,
+      error: "same_language",
+      message: "Source and target languages must be different.",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      sourceText,
+      sourceLanguage,
+      targetLanguage,
+      preserveTone,
+    },
+  };
+}
+
+export function createTranslationJob(input = {}) {
+  const normalized = normalizeTranslatorInput(input);
+
+  if (!normalized.ok) {
+    return {
+      status: "error",
+      error: normalized.error,
+      message: normalized.message,
+    };
+  }
+
+  const { sourceText, sourceLanguage, targetLanguage, preserveTone } = normalized.value;
+  const warnings = detectTranslationWarnings(sourceText);
+  const sourcePreview =
+    sourceText.length > 180 ? `${sourceText.slice(0, 180).trim()}...` : sourceText;
+
+  return {
+    status: "ready",
+    job: {
+      id: stableJobId(`${sourceLanguage}:${targetLanguage}:${preserveTone}:${sourceText}`),
+      sourceLanguage,
+      targetLanguage,
+      preserveTone,
+      sourcePreview,
+      characterCount: sourceText.length,
+      warnings,
+      requestedSteps: [
+        "detect source language when set to auto",
+        "translate body copy only",
+        "preserve names, dates, links, amounts, and signatures",
+        preserveTone ? "preserve sender tone" : "use neutral tone",
+      ],
+    },
+  };
+}
+
+export function buildTranslationDraft(job, translatedText) {
+  if (!job || typeof job !== "object") {
+    throw new TypeError("A translation job is required.");
+  }
+
+  const cleanTranslation = cleanText(translatedText);
+
+  return {
+    status: cleanTranslation ? "success" : "empty",
+    jobId: job.id,
+    targetLanguage: job.targetLanguage,
+    translatedText: cleanTranslation,
+    reviewChecklist: [
+      "verify recipient name and greeting",
+      "verify dates, amounts, links, and product names",
+      "review legal, medical, or financial language before sending",
+      job.preserveTone ? "confirm translated tone matches the source" : "confirm neutral tone is acceptable",
+    ],
+  };
+}

--- a/tools/v2/individual/email-translator/tests/email-translator-engine.test.mjs
+++ b/tools/v2/individual/email-translator/tests/email-translator-engine.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EMAIL_TRANSLATOR_MAX_CHARS,
+  buildTranslationDraft,
+  createTranslationJob,
+  detectTranslationWarnings,
+  normalizeTranslatorInput,
+} from "../services/email-translator-engine.mjs";
+
+test("normalizes valid translation input", () => {
+  const result = normalizeTranslatorInput({
+    sourceLanguage: "Auto",
+    targetLanguage: "Spanish",
+    sourceText: " Hello team,\n\nPlease review the contract. ",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.sourceLanguage, "auto");
+  assert.equal(result.value.targetLanguage, "spanish");
+  assert.equal(result.value.preserveTone, true);
+  assert.equal(result.value.sourceText, "Hello team,\n\nPlease review the contract.");
+});
+
+test("rejects empty, oversized, and same-language requests", () => {
+  assert.equal(normalizeTranslatorInput({ sourceText: " " }).error, "empty_source");
+  assert.equal(
+    normalizeTranslatorInput({
+      sourceText: "x".repeat(EMAIL_TRANSLATOR_MAX_CHARS + 1),
+      targetLanguage: "French",
+    }).error,
+    "source_too_large"
+  );
+  assert.equal(
+    normalizeTranslatorInput({
+      sourceText: "Bonjour",
+      sourceLanguage: "French",
+      targetLanguage: "French",
+    }).error,
+    "same_language"
+  );
+});
+
+test("creates a deterministic translation job with review warnings", () => {
+  const input = {
+    sourceText: "Invoice total is $150 due on 2026-07-01. Details: https://example.com",
+    targetLanguage: "German",
+    preserveTone: false,
+  };
+
+  const first = createTranslationJob(input);
+  const second = createTranslationJob(input);
+
+  assert.equal(first.status, "ready");
+  assert.equal(first.job.id, second.job.id);
+  assert.deepEqual(first.job.warnings, ["links", "dates", "currency", "numbers"]);
+  assert.equal(first.job.targetLanguage, "german");
+  assert.equal(first.job.preserveTone, false);
+});
+
+test("detects translation review warning categories", () => {
+  assert.deepEqual(detectTranslationWarnings("Meet on 2026-08-12 with 3 links"), [
+    "dates",
+    "numbers",
+  ]);
+});
+
+test("builds a draft result with a review checklist", () => {
+  const job = createTranslationJob({
+    sourceText: "Hello, please confirm delivery.",
+    targetLanguage: "Spanish",
+  }).job;
+
+  const draft = buildTranslationDraft(job, " Hola, confirme la entrega. ");
+
+  assert.equal(draft.status, "success");
+  assert.equal(draft.jobId, job.id);
+  assert.equal(draft.targetLanguage, "spanish");
+  assert.equal(draft.translatedText, "Hola, confirme la entrega.");
+  assert.ok(draft.reviewChecklist.some((item) => item.includes("dates")));
+});
+
+test("marks an empty translated draft as incomplete", () => {
+  const job = createTranslationJob({
+    sourceText: "Hello",
+    targetLanguage: "Spanish",
+  }).job;
+
+  const draft = buildTranslationDraft(job, "");
+
+  assert.equal(draft.status, "empty");
+  assert.equal(draft.translatedText, "");
+});


### PR DESCRIPTION
Closes 

## Summary
- add folder-local Email Translator core helpers for input normalization, language validation, deterministic job creation, warning detection, and draft output
- add deterministic Node tests for valid input, empty/oversized/same-language errors, stable job ids, warning categories, and draft states
- document the engine inputs, outputs, fixture coverage, and no-integration boundary

## Scope
- changes are limited to `tools/v2/individual/email-translator/`
- no main app shell, routing, inbox architecture, wallet code, Stellar integration, database schema, or shared design-system files are touched
- no live network calls, secrets, or production data are introduced

## Validation
- local JavaScript assertion run passed 9 checks for normalization, validation errors, deterministic job ids, warning detection, and draft output
- standalone `node --test` was not available on this desktop PATH, so the equivalent assertions were run through the available JavaScript runtime
