### PR TITLE
feat: add grammar cleaner UI surface

### DIFF
--- a/tools/v1/individual/grammar-cleaner/README.md
+++ b/tools/v1/individual/grammar-cleaner/README.md
@@ -6,10 +6,32 @@ This folder is the isolated workspace for the Grammar Cleaner tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\grammar-cleaner\
-`
+`tools/v1/individual/grammar-cleaner/`
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Local UI Surface
+
+- `components/GrammarCleanerPanel.tsx` provides the isolated grammar-cleaning
+  workflow surface.
+- `docs/ui-accessibility-notes.md` documents empty, loading, error, and success
+  states plus keyboard, focus, labeling, and screen-reader behavior.
+- `REVIEW_NOTES.md` gives reviewers a short checklist for this issue.
+
+The panel uses deterministic local preview text and does not call a live grammar
+service, save drafts, send email, or mount into the application shell.
+
+## Intended Usage
+
+The tool helps an individual user paste an email draft, choose how much cleanup
+to apply, and review a grammar-cleaned preview before a future integration issue
+connects it to production mail flows.
+
+## Known Limitations
+
+- The UI is folder-local and not mounted in the main app.
+- The cleaned preview is deterministic placeholder behavior for review.
+- Main app routing, inbox integration, send actions, persistence, and shared
+  design-system files remain out of scope.

--- a/tools/v1/individual/grammar-cleaner/REVIEW_NOTES.md
+++ b/tools/v1/individual/grammar-cleaner/REVIEW_NOTES.md
@@ -1,0 +1,25 @@
+# Review Notes
+
+This issue adds a folder-local UI and accessibility surface for the isolated
+Grammar Cleaner tool.
+
+## What Changed
+
+- Added `components/GrammarCleanerPanel.tsx` with empty, loading, error, and
+  success states.
+- Added accessible labels, `aria-describedby`, a status live region, and a
+  focusable cleaned-preview output.
+- Updated `README.md` and `specs.md` so the tool folder has a clean launch
+  contract.
+- Added `docs/ui-accessibility-notes.md` for visual style, keyboard, focus, and
+  screen-reader review notes.
+
+## Review Checklist
+
+- All files remain inside `tools/v1/individual/grammar-cleaner/`.
+- No main app, routing, inbox, wallet, database, compose, Stellar, or shared
+  design-system integration is introduced.
+- The UI exposes labeled controls and keyboard-accessible actions.
+- Empty, loading, error, and success states are represented.
+- The preview behavior is deterministic and does not send, save, or persist
+  draft content.

--- a/tools/v1/individual/grammar-cleaner/components/GrammarCleanerPanel.tsx
+++ b/tools/v1/individual/grammar-cleaner/components/GrammarCleanerPanel.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { FormEvent, useId, useMemo, useState } from "react";
+
+type CleanerStatus = "empty" | "loading" | "success" | "error";
+type CleanupMode = "light" | "standard" | "concise";
+
+const maxDraftChars = 10000;
+
+const cleanupModes: Array<{ label: string; value: CleanupMode }> = [
+  { label: "Light grammar pass", value: "light" },
+  { label: "Standard cleanup", value: "standard" },
+  { label: "Concise rewrite", value: "concise" },
+];
+
+const commonCorrections: Array<[RegExp, string]> = [
+  [/\bteh\b/gi, "the"],
+  [/\brecieve\b/gi, "receive"],
+  [/\badress\b/gi, "address"],
+  [/\bseperate\b/gi, "separate"],
+  [/\boccured\b/gi, "occurred"],
+];
+
+function sentenceCase(text: string) {
+  return text.replace(/(^|[.!?]\s+)([a-z])/g, (_, prefix: string, letter: string) =>
+    `${prefix}${letter.toUpperCase()}`,
+  );
+}
+
+function ensureTerminalPunctuation(text: string) {
+  if (!text) return text;
+  return /[.!?]$/.test(text) ? text : `${text}.`;
+}
+
+function buildGrammarPreview(
+  draftText: string,
+  cleanupMode: CleanupMode,
+  preserveTone: boolean,
+) {
+  let cleaned = draftText.trim().replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n");
+
+  for (const [pattern, replacement] of commonCorrections) {
+    cleaned = cleaned.replace(pattern, replacement);
+  }
+
+  cleaned = sentenceCase(cleaned);
+
+  if (cleanupMode !== "light") {
+    cleaned = cleaned
+      .replace(/\bkindly please\b/gi, "please")
+      .replace(/\bas soon as possible\b/gi, "soon")
+      .replace(/\bin order to\b/gi, "to");
+  }
+
+  if (cleanupMode === "concise") {
+    cleaned = cleaned
+      .split(/\n+/)
+      .map((line) => ensureTerminalPunctuation(line.trim()))
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  const toneNote = preserveTone
+    ? "Tone preserved; review names, deadlines, numbers, and commitments before sending."
+    : "Neutral tone applied; review relationship-sensitive wording before sending.";
+
+  return `${cleaned}\n\n${toneNote}`;
+}
+
+export default function GrammarCleanerPanel() {
+  const titleId = useId();
+  const draftId = useId();
+  const modeId = useId();
+  const hintId = useId();
+  const statusId = useId();
+  const resultId = useId();
+
+  const [draftText, setDraftText] = useState("");
+  const [cleanupMode, setCleanupMode] = useState<CleanupMode>("standard");
+  const [preserveTone, setPreserveTone] = useState(true);
+  const [status, setStatus] = useState<CleanerStatus>("empty");
+  const [resultText, setResultText] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const remainingCharacters = maxDraftChars - draftText.length;
+  const statusCopy = useMemo(() => {
+    if (status === "loading") return "Preparing grammar-cleaned preview...";
+    if (status === "success") return "Grammar-cleaned preview ready.";
+    if (status === "error") return errorMessage;
+    return "Paste a draft to prepare a grammar-cleaned preview.";
+  }, [errorMessage, status]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!draftText.trim()) {
+      setStatus("error");
+      setErrorMessage("Paste an email draft before cleaning grammar.");
+      setResultText("");
+      return;
+    }
+
+    if (draftText.length > maxDraftChars) {
+      setStatus("error");
+      setErrorMessage(
+        `Draft is ${Math.abs(remainingCharacters).toLocaleString()} characters over the local review limit.`,
+      );
+      setResultText("");
+      return;
+    }
+
+    setStatus("loading");
+    setErrorMessage("");
+    await Promise.resolve();
+    setResultText(buildGrammarPreview(draftText, cleanupMode, preserveTone));
+    setStatus("success");
+  }
+
+  function handleReset() {
+    setDraftText("");
+    setResultText("");
+    setErrorMessage("");
+    setStatus("empty");
+  }
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="grammar-cleaner-panel"
+      data-tool="grammar-cleaner"
+    >
+      <div className="grammar-cleaner-panel__header">
+        <p className="grammar-cleaner-panel__eyebrow">Individual email tool</p>
+        <h2 id={titleId}>Grammar Cleaner</h2>
+        <p>
+          Clean grammar, punctuation, and clarity issues in a draft before a
+          future integration connects this panel to live mail data.
+        </p>
+      </div>
+
+      <form className="grammar-cleaner-panel__grid" onSubmit={handleSubmit}>
+        <label className="grammar-cleaner-panel__source" htmlFor={draftId}>
+          Email draft
+          <textarea
+            aria-describedby={`${hintId} ${statusId}`}
+            id={draftId}
+            maxLength={maxDraftChars + 500}
+            onChange={(event) => setDraftText(event.target.value)}
+            placeholder="Paste the email draft to clean."
+            rows={10}
+            value={draftText}
+          />
+        </label>
+
+        <div className="grammar-cleaner-panel__controls">
+          <label htmlFor={modeId}>
+            Cleanup level
+            <select
+              id={modeId}
+              onChange={(event) => setCleanupMode(event.target.value as CleanupMode)}
+              value={cleanupMode}
+            >
+              {cleanupModes.map((mode) => (
+                <option key={mode.value} value={mode.value}>
+                  {mode.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grammar-cleaner-panel__checkbox">
+            <input
+              checked={preserveTone}
+              onChange={(event) => setPreserveTone(event.target.checked)}
+              type="checkbox"
+            />
+            Preserve the sender's tone
+          </label>
+        </div>
+
+        <p className="grammar-cleaner-panel__hint" id={hintId}>
+          Maximum local preview size: {maxDraftChars.toLocaleString()} characters.
+          {remainingCharacters >= 0
+            ? ` ${remainingCharacters.toLocaleString()} remaining.`
+            : ` ${Math.abs(remainingCharacters).toLocaleString()} over the limit.`}
+        </p>
+
+        <div className="grammar-cleaner-panel__actions">
+          <button disabled={status === "loading"} type="submit">
+            {status === "loading" ? "Cleaning..." : "Clean grammar"}
+          </button>
+          <button onClick={handleReset} type="button">
+            Clear
+          </button>
+        </div>
+      </form>
+
+      <div
+        aria-live="polite"
+        className={`grammar-cleaner-panel__status grammar-cleaner-panel__status--${status}`}
+        id={statusId}
+        role={status === "error" ? "alert" : "status"}
+      >
+        {statusCopy}
+      </div>
+
+      <article
+        aria-labelledby={resultId}
+        className="grammar-cleaner-panel__result"
+        tabIndex={0}
+      >
+        <h3 id={resultId}>Cleaned preview</h3>
+        {resultText ? <pre>{resultText}</pre> : <p>No cleaned preview yet.</p>}
+      </article>
+    </section>
+  );
+}

--- a/tools/v1/individual/grammar-cleaner/docs/ui-accessibility-notes.md
+++ b/tools/v1/individual/grammar-cleaner/docs/ui-accessibility-notes.md
@@ -1,0 +1,42 @@
+# Grammar Cleaner UI and Accessibility Notes
+
+## Scope
+
+This note covers the folder-local UI surface for the Grammar Cleaner tool. The
+panel is not mounted in the main app and does not call a live grammar service.
+
+## States
+
+- Empty: prompts the user to paste a draft before running cleanup.
+- Loading: disables the submit button and announces that a preview is being prepared.
+- Error: uses `role="alert"` for missing text and local size-limit failures.
+- Success: announces a completed preview and exposes the result in a focusable region.
+
+## Keyboard and Screen Reader Behavior
+
+- Native form controls are used for the draft textarea, cleanup-level select,
+  tone-preservation checkbox, and action buttons.
+- The draft textarea references both the size hint and status region with
+  `aria-describedby`.
+- Status copy is announced through a single live region.
+- The cleaned preview article is focusable so keyboard users can move directly
+  to the generated result.
+- Buttons keep visible labels aligned with their current state and do not rely
+  on icon-only controls.
+
+## Visual Style Notes
+
+- The component uses local class names prefixed with `grammar-cleaner-panel__`
+  so future styling can remain isolated to this tool folder.
+- The intended layout is a simple two-part workflow: draft input and controls
+  first, then status and preview output.
+- Empty and error states should remain visibly distinct from the success state,
+  but the shared design system is intentionally untouched in this issue.
+
+## Review Notes
+
+- The component intentionally uses deterministic placeholder preview text
+  instead of a network request.
+- Drafts are capped at 10,000 characters for the local review surface.
+- Main app routes, inbox architecture, wallet code, Stellar integrations,
+  database schema, and shared design-system files are untouched.

--- a/tools/v1/individual/grammar-cleaner/specs.md
+++ b/tools/v1/individual/grammar-cleaner/specs.md
@@ -1,41 +1,41 @@
-# Grammar Cleaner
-
-Correct grammar and writing issues.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/individual/grammar-cleaner/README.md"
-  @"
-
 # Grammar Cleaner Specs
 
 ## Purpose
 
-Correct grammar and writing issues.
+Correct grammar and writing issues in individual email drafts while preserving
+the original meaning and leaving the user in control before anything is sent.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay in:
 
-$dir/
+`tools/v1/individual/grammar-cleaner/`
 
-## Required issue categories
+The tool is a self-contained V1 workspace. Do not wire it into the main app,
+routing, inbox architecture, wallet core, Stellar core, database schema, or
+shared design system unless a future integration issue explicitly allows it.
+
+## Recommended Internal Structure
+
+- `components/`
+- `services/`
+- `hooks/`
+- `tests/`
+- `docs/`
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## UI Expectations
+
+- Accept a draft email body and show an empty state before input.
+- Expose a local preview flow with loading, error, and success states.
+- Label every interactive control.
+- Use native keyboard-accessible controls.
+- Announce status changes through a single live region.
+- Keep the result reviewable and focusable before any future send integration.


### PR DESCRIPTION
Closes #366

## Summary
- add a folder-local `GrammarCleanerPanel` with draft input, cleanup-level control, tone toggle, and cleaned-preview output
- include empty, loading, error, and success states with a live status region and focusable result panel
- document keyboard, focus, screen-reader, and visual style expectations in local docs and review notes

## Scope
- changes are limited to `tools/v1/individual/grammar-cleaner/`
- no main app shell, routing, inbox architecture, wallet code, Stellar integration, database schema, or shared design-system files are touched
- no live grammar service or production data is introduced; the panel uses deterministic local preview behavior for the isolated surface

## Validation
- confirmed the compare against upstream main contains only five files inside `tools/v1/individual/grammar-cleaner/`
- local static checks confirmed empty/loading/error/success state coverage, `aria-live`, `aria-describedby`, native labeled controls, and a focusable preview region
- no wallet addresses, payout details, or production data were added
