### PR TITLE
Add Email Summarizer core feature engine

### DIFF
--- a/tools/v1/individual/email-summarizer/docs/engine.md
+++ b/tools/v1/individual/email-summarizer/docs/engine.md
@@ -1,0 +1,65 @@
+# Email Summarizer Engine
+
+Core feature engine for the Email Summarizer tool. Pure, deterministic, and
+fully isolated inside this folder.
+
+## Public API
+
+Imported from the folder-local entry point (index.ts):
+
+- summarizeEmail(input, options?) - main entry point.
+- extractActionItems(body) - pull action items from an email body.
+- splitSentences(text) - deterministic sentence splitter.
+- toReadyState(result) - map a result into a UI-friendly state.
+- DEFAULT_SUMMARIZER_OPTIONS - default sentence/character limits.
+- SAMPLE_EMAILS, EMPTY_BODY_EMAIL - deterministic fixtures.
+
+## Inputs
+
+NormalizedEmail:
+
+- subject - string
+- sender - string
+- receivedAt - ISO timestamp string
+- body - plain-text email body
+
+SummarizerOptions (optional):
+
+- maxSentences - narrative sentence cap (default 3)
+- maxCharacters - narrative character cap (default 280)
+
+## Outputs
+
+On success, summarizeEmail returns { status: "ok", summary } where summary has:
+
+- summary - concise narrative within the configured limits
+- actionItems - action items extracted separately from the narrative
+- sentenceCount - number of sentences kept in the summary
+- truncated - whether the summary was shortened
+- source - preserved subject, sender, and receivedAt for traceability
+
+## Loading states
+
+The engine is synchronous and pure. For async UI usage, SummarizerState models
+the lifecycle a component can render:
+
+- idle - nothing requested yet
+- loading - a summarize call is in flight
+- ready - summary available
+- error - summarize failed
+
+toReadyState converts a SummarizerResult into ready/error for the UI.
+
+## Error states
+
+summarizeEmail never throws. It returns { status: "error", code, message }:
+
+- empty-body - the email body is empty or whitespace only
+- unsupported-input - the input is not a valid normalized email
+
+## Guarantees
+
+- No live network calls, secrets, or production data.
+- No mailbox mutation and no persistence outside this folder.
+- Deterministic: the same input always produces the same output.
+- The summary is extracted from the email body and does not invent facts.

--- a/tools/v1/individual/email-summarizer/index.ts
+++ b/tools/v1/individual/email-summarizer/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Folder-local public API surface for the Email Summarizer tool.
+ * Future UI work should import from here only.
+ */
+
+export * from "./services/emailSummarizer";
+export * from "./services/fixtures";

--- a/tools/v1/individual/email-summarizer/services/emailSummarizer.ts
+++ b/tools/v1/individual/email-summarizer/services/emailSummarizer.ts
@@ -1,0 +1,191 @@
+/**
+ * Email Summarizer — core feature engine.
+ *
+ * Pure, deterministic logic that turns a single normalized email into a concise
+ * summary plus a separate list of action items. No network calls, no mailbox
+ * mutations, and no external AI providers: everything is derived locally from
+ * the email body so the tool stays isolated and safe to review.
+ */
+
+export interface NormalizedEmail {
+  subject: string;
+  sender: string;
+  receivedAt: string;
+  body: string;
+}
+
+export interface SummarizerOptions {
+  /** Maximum number of sentences kept in the narrative summary. */
+  maxSentences?: number;
+  /** Hard character cap for the narrative summary. */
+  maxCharacters?: number;
+}
+
+export interface EmailSummarySource {
+  subject: string;
+  sender: string;
+  receivedAt: string;
+}
+
+export interface EmailSummary {
+  summary: string;
+  actionItems: string[];
+  sentenceCount: number;
+  truncated: boolean;
+  source: EmailSummarySource;
+}
+
+export type SummarizerErrorCode = "empty-body" | "unsupported-input";
+
+export type SummarizerResult =
+  | { status: "ok"; summary: EmailSummary }
+  | { status: "error"; code: SummarizerErrorCode; message: string };
+
+/** Lifecycle states a UI can render for an async summarize call. */
+export type SummarizerState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; summary: EmailSummary }
+  | { status: "error"; code: SummarizerErrorCode; message: string };
+
+export const DEFAULT_SUMMARIZER_OPTIONS: Required<SummarizerOptions> = {
+  maxSentences: 3,
+  maxCharacters: 280,
+};
+
+const ACTION_ITEM_MARKERS = [
+  "please",
+  "could you",
+  "can you",
+  "let me know",
+  "make sure",
+  "don't forget",
+  "remember to",
+  "need you to",
+  "action required",
+  "by tomorrow",
+  "by end of day",
+  "asap",
+  "deadline",
+];
+
+function isNormalizedEmail(value: unknown): value is NormalizedEmail {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.subject === "string" &&
+    typeof candidate.sender === "string" &&
+    typeof candidate.receivedAt === "string" &&
+    typeof candidate.body === "string"
+  );
+}
+
+/** Deterministic sentence splitter. */
+export function splitSentences(text: string): string[] {
+  return text
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 0);
+}
+
+/** Extracts action-item sentences separately from the narrative summary. */
+export function extractActionItems(body: string): string[] {
+  const items: string[] = [];
+  for (const sentence of splitSentences(body)) {
+    const normalized = sentence.toLowerCase();
+    const isActionItem = ACTION_ITEM_MARKERS.some((marker) => normalized.includes(marker));
+    if (isActionItem && !items.includes(sentence)) {
+      items.push(sentence);
+    }
+  }
+  return items;
+}
+
+function buildSummaryText(
+  sentences: string[],
+  options: Required<SummarizerOptions>,
+): { summary: string; sentenceCount: number; truncated: boolean } {
+  const selected = sentences.slice(0, options.maxSentences);
+  let summary = selected.join(" ");
+  let truncated = sentences.length > selected.length;
+
+  if (summary.length > options.maxCharacters) {
+    summary = `${summary.slice(0, Math.max(0, options.maxCharacters - 1)).trimEnd()}\u2026`;
+    truncated = true;
+  }
+
+  return { summary, sentenceCount: selected.length, truncated };
+}
+
+function resolveOptions(options: SummarizerOptions): Required<SummarizerOptions> {
+  return {
+    maxSentences:
+      options.maxSentences && options.maxSentences > 0
+        ? Math.floor(options.maxSentences)
+        : DEFAULT_SUMMARIZER_OPTIONS.maxSentences,
+    maxCharacters:
+      options.maxCharacters && options.maxCharacters > 0
+        ? Math.floor(options.maxCharacters)
+        : DEFAULT_SUMMARIZER_OPTIONS.maxCharacters,
+  };
+}
+
+/**
+ * Summarizes a single normalized email. Never throws: invalid input is reported
+ * through a typed error result instead.
+ */
+export function summarizeEmail(
+  input: NormalizedEmail,
+  options: SummarizerOptions = {},
+): SummarizerResult {
+  if (!isNormalizedEmail(input)) {
+    return {
+      status: "error",
+      code: "unsupported-input",
+      message: "Expected a normalized email with subject, sender, receivedAt, and body.",
+    };
+  }
+
+  const body = input.body.trim();
+  if (body.length === 0) {
+    return {
+      status: "error",
+      code: "empty-body",
+      message: "Cannot summarize an email with an empty body.",
+    };
+  }
+
+  const resolved = resolveOptions(options);
+  const sentences = splitSentences(body);
+  const actionItems = extractActionItems(body);
+  const narrative = sentences.filter((sentence) => !actionItems.includes(sentence));
+  const summarySource = narrative.length > 0 ? narrative : sentences;
+  const { summary, sentenceCount, truncated } = buildSummaryText(summarySource, resolved);
+
+  return {
+    status: "ok",
+    summary: {
+      summary,
+      actionItems,
+      sentenceCount,
+      truncated,
+      source: {
+        subject: input.subject,
+        sender: input.sender,
+        receivedAt: input.receivedAt,
+      },
+    },
+  };
+}
+
+/** Maps a summarizer result into a UI-friendly ready/error state. */
+export function toReadyState(result: SummarizerResult): SummarizerState {
+  if (result.status === "error") {
+    return { status: "error", code: result.code, message: result.message };
+  }
+  return { status: "ready", summary: result.summary };
+}

--- a/tools/v1/individual/email-summarizer/services/fixtures.ts
+++ b/tools/v1/individual/email-summarizer/services/fixtures.ts
@@ -1,0 +1,41 @@
+import type { NormalizedEmail } from "./emailSummarizer";
+
+export interface SummarizerFixture {
+  id: string;
+  description: string;
+  email: NormalizedEmail;
+}
+
+/**
+ * Deterministic, synthetic emails used for tests, docs, and future UI previews.
+ * None of these contain real personal data.
+ */
+export const SAMPLE_EMAILS: SummarizerFixture[] = [
+  {
+    id: "project-update",
+    description: "Status update with a single clear action item.",
+    email: {
+      subject: "Weekly project update",
+      sender: "alex@example.com",
+      receivedAt: "2026-01-02T10:00:00.000Z",
+      body: "The release is on track for Friday. The team finished the API work yesterday. Please review the changelog before the demo. We also fixed three importer bugs.",
+    },
+  },
+  {
+    id: "invoice-reminder",
+    description: "Reminder email with multiple action items.",
+    email: {
+      subject: "Invoice 1042 reminder",
+      sender: "billing@example.com",
+      receivedAt: "2026-01-05T08:30:00.000Z",
+      body: "Your invoice is due next week. Please confirm the billing address on file. Can you send the updated purchase order by end of day? Thanks for your continued partnership.",
+    },
+  },
+];
+
+export const EMPTY_BODY_EMAIL: NormalizedEmail = {
+  subject: "No content",
+  sender: "noreply@example.com",
+  receivedAt: "2026-01-06T12:00:00.000Z",
+  body: "   ",
+};

--- a/tools/v1/individual/email-summarizer/tests/emailSummarizer.test.ts
+++ b/tools/v1/individual/email-summarizer/tests/emailSummarizer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SUMMARIZER_OPTIONS,
+  extractActionItems,
+  splitSentences,
+  summarizeEmail,
+  toReadyState,
+  type NormalizedEmail,
+} from "../services/emailSummarizer";
+import { EMPTY_BODY_EMAIL, SAMPLE_EMAILS } from "../services/fixtures";
+
+const longEmail: NormalizedEmail = SAMPLE_EMAILS[0].email;
+
+describe("summarizeEmail", () => {
+  it("summarizes a valid email within the default limits", () => {
+    const result = summarizeEmail(longEmail);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.summary.sentenceCount).toBeLessThanOrEqual(
+      DEFAULT_SUMMARIZER_OPTIONS.maxSentences,
+    );
+    expect(result.summary.summary.length).toBeGreaterThan(0);
+    expect(result.summary.source.sender).toBe("alex@example.com");
+  });
+
+  it("extracts action items separately from the narrative summary", () => {
+    const result = summarizeEmail(longEmail);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.summary.actionItems).toContain("Please review the changelog before the demo.");
+    expect(result.summary.summary).not.toContain("Please review the changelog");
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(summarizeEmail(longEmail)).toEqual(summarizeEmail(longEmail));
+  });
+
+  it("truncates summaries that exceed the character limit", () => {
+    const result = summarizeEmail(longEmail, { maxCharacters: 40 });
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.summary.length).toBeLessThanOrEqual(40);
+  });
+
+  it("returns an error for an empty body", () => {
+    const result = summarizeEmail(EMPTY_BODY_EMAIL);
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.code).toBe("empty-body");
+  });
+
+  it("returns an error for unsupported input", () => {
+    const result = summarizeEmail({ subject: "x" } as unknown as NormalizedEmail);
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.code).toBe("unsupported-input");
+  });
+});
+
+describe("helpers", () => {
+  it("splits text into sentences", () => {
+    expect(splitSentences("Hello world. Second one!")).toEqual(["Hello world.", "Second one!"]);
+  });
+
+  it("extracts only action-item sentences", () => {
+    expect(extractActionItems("Please do this. Nothing here.")).toEqual(["Please do this."]);
+  });
+
+  it("maps results into UI states", () => {
+    expect(toReadyState(summarizeEmail(longEmail)).status).toBe("ready");
+    expect(toReadyState(summarizeEmail(EMPTY_BODY_EMAIL)).status).toBe("error");
+  });
+
+  it("summarizes every sample fixture", () => {
+    for (const fixture of SAMPLE_EMAILS) {
+      expect(summarizeEmail(fixture.email).status).toBe("ok");
+    }
+  });
+});


### PR DESCRIPTION
This implements the Email Summarizer core feature engine inside its isolated tool folder, following the launch contract in specs.md.

New files, all under tools/v1/individual/email-summarizer/:
- services/emailSummarizer.ts: pure, deterministic engine. summarizeEmail() turns a normalized email (subject, sender, receivedAt, body) into a concise narrative summary within configurable sentence/character limits, extracts action items separately, preserves source metadata for traceability, and returns typed validation errors for empty or unsupported input. Includes a SummarizerState type and toReadyState() helper for future async UI usage.
- services/fixtures.ts: deterministic synthetic email fixtures (no real data).
- index.ts: the folder-local public API surface.
- tests/emailSummarizer.test.ts: unit tests for summaries, action-item extraction, determinism, truncation, validation errors, and UI-state mapping.
- docs/engine.md: documents inputs, outputs, loading states, and error states.

No live network calls, secrets, or production data are introduced, and nothing outside the tool folder is touched. The tool stays isolated from the main app, routing, inbox, wallet, Stellar, database, and design-system layers.

Note: this tool folder is intentionally not wired into the app tsconfig include or the tests/unit CI run yet, so it is validated with prettier and eslint and kept pure and deterministic. A future integration issue can connect it to the app.

Closes #345