### PR TITLE
docs: add collision detection review assets

### DIFF
--- a/tools/v1/team/collision-detection/README.md
+++ b/tools/v1/team/collision-detection/README.md
@@ -1,15 +1,44 @@
 # Collision Detection
 
-This folder is the isolated workspace for the Collision Detection tool.
+This folder is the isolated workspace for the Collision Detection tool. The
+tool helps a team review outbound mail candidates and spot responses that look
+like duplicates before they are sent.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\team\collision-detection\
-`
+```text
+tools/v1/team/collision-detection/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Setup
+
+This issue does not add a production integration. Review it as a folder-local
+test and documentation surface:
+
+1. Read `fixtures/collision-cases.json` for the sample duplicate-response cases.
+2. Read `tests/collision-detection-test-plan.md` for expected outcomes and edge
+   cases.
+3. Read `docs/validation-notes.md` for independent review guidance and known
+   limitations.
+
+## Expected Behavior
+
+- Exact duplicate draft bodies should be detected even when whitespace differs.
+- Near duplicate drafts should be marked for human review instead of auto-send.
+- Distinct drafts for different recipients should stay unblocked.
+- Empty or missing draft content should be handled as invalid input in a future
+  implementation.
+
+## Files
+
+- `specs.md` describes the isolated product scope and acceptance criteria.
+- `fixtures/collision-cases.json` gives deterministic review inputs.
+- `tests/collision-detection-test-plan.md` documents the folder-local cases.
+- `docs/validation-notes.md` explains how maintainers can validate the change.
+- `REVIEW_NOTES.md` summarizes the contribution for OSS review.

--- a/tools/v1/team/collision-detection/REVIEW_NOTES.md
+++ b/tools/v1/team/collision-detection/REVIEW_NOTES.md
@@ -1,0 +1,32 @@
+# Review Notes
+
+## Summary
+
+This change prepares the isolated Collision Detection tool for review by adding
+synthetic fixtures, a folder-local test plan, validation notes, and cleaned scope
+documentation.
+
+## What Changed
+
+- Rewrote the README so contributors can review the folder independently.
+- Cleaned `specs.md` to remove generated placeholder artifacts and describe the
+  V1 team scope.
+- Added deterministic synthetic fixture cases for duplicate, possible duplicate,
+  distinct, and invalid draft outcomes.
+- Added a manual test plan that can later be converted into an automated
+  folder-local test.
+- Added validation notes and explicit safety boundaries.
+
+## Out of Scope
+
+- No production detector service.
+- No app integration.
+- No live mailbox data.
+- No wallet, Stellar, database, routing, auth, or shared design-system changes.
+
+## Suggested Reviewer Checks
+
+1. Confirm every changed file is under `tools/v1/team/collision-detection/`.
+2. Confirm the fixture recipients use `.test` addresses.
+3. Confirm the test plan maps every fixture to an expected result.
+4. Confirm the README and specs describe an isolated review surface.

--- a/tools/v1/team/collision-detection/docs/validation-notes.md
+++ b/tools/v1/team/collision-detection/docs/validation-notes.md
@@ -1,0 +1,29 @@
+# Validation Notes
+
+## Independent Review
+
+This contribution is intentionally limited to the Collision Detection folder.
+It can be reviewed without running the main application.
+
+Reviewers can validate it by checking:
+
+- The README points to all folder-local review assets.
+- The fixture file uses synthetic `.test` recipients only.
+- The test plan covers duplicate, possible duplicate, distinct, and invalid
+  cases.
+- The specs no longer contain generated placeholder text.
+- No files outside `tools/v1/team/collision-detection/` are changed.
+
+## Known Limitations
+
+- There is no production detector service in this PR.
+- Near-duplicate scoring is documented as expected behavior, not implemented.
+- Future implementation should define a deterministic normalization function
+  before adding automated tests.
+
+## Safety Boundaries
+
+- No live email content is included.
+- No external services are contacted.
+- No authentication, wallet, Stellar, routing, database, or design-system code is
+  touched.

--- a/tools/v1/team/collision-detection/fixtures/collision-cases.json
+++ b/tools/v1/team/collision-detection/fixtures/collision-cases.json
@@ -1,0 +1,78 @@
+{
+  "tool": "collision-detection",
+  "version": "v1",
+  "cases": [
+    {
+      "id": "exact-whitespace-duplicate",
+      "description": "Same recipient, subject, and body with extra whitespace.",
+      "existingDraft": {
+        "recipient": "ops@example.test",
+        "subject": "Invoice follow-up",
+        "body": "Thanks for the update. We will review the invoice today."
+      },
+      "candidateDraft": {
+        "recipient": "ops@example.test",
+        "subject": "Invoice follow-up",
+        "body": "Thanks for the update.   We will review the invoice today."
+      },
+      "expected": {
+        "classification": "duplicate",
+        "action": "block"
+      }
+    },
+    {
+      "id": "near-duplicate-summary",
+      "description": "Same intent with shorter wording should require human review.",
+      "existingDraft": {
+        "recipient": "partner@example.test",
+        "subject": "Launch checklist",
+        "body": "The launch checklist is ready. Please confirm the final owner by Friday."
+      },
+      "candidateDraft": {
+        "recipient": "partner@example.test",
+        "subject": "Launch checklist",
+        "body": "Checklist is ready. Please confirm the owner by Friday."
+      },
+      "expected": {
+        "classification": "possible_duplicate",
+        "action": "review"
+      }
+    },
+    {
+      "id": "different-recipient-distinct-body",
+      "description": "Same subject but different recipient and content should remain available.",
+      "existingDraft": {
+        "recipient": "ops@example.test",
+        "subject": "Weekly status",
+        "body": "We shipped the first analytics milestone."
+      },
+      "candidateDraft": {
+        "recipient": "finance@example.test",
+        "subject": "Weekly status",
+        "body": "The invoice export is ready for finance review."
+      },
+      "expected": {
+        "classification": "distinct",
+        "action": "allow"
+      }
+    },
+    {
+      "id": "missing-candidate-body",
+      "description": "A blank candidate body should not be treated as safe output.",
+      "existingDraft": {
+        "recipient": "support@example.test",
+        "subject": "Support reply",
+        "body": "We can help troubleshoot the issue today."
+      },
+      "candidateDraft": {
+        "recipient": "support@example.test",
+        "subject": "Support reply",
+        "body": ""
+      },
+      "expected": {
+        "classification": "invalid",
+        "action": "block"
+      }
+    }
+  ]
+}

--- a/tools/v1/team/collision-detection/specs.md
+++ b/tools/v1/team/collision-detection/specs.md
@@ -1,41 +1,47 @@
-# Collision Detection
-
-Prevent duplicate responses.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/collision-detection/README.md"
-  @"
-
 # Collision Detection Specs
 
 ## Purpose
 
-Prevent duplicate responses.
+Prevent duplicate team responses by identifying outbound draft candidates that
+match or closely resemble an existing draft in the same review batch.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V1
+- Audience: team
+- Folder ownership: `tools/v1/team/collision-detection/`
 
-$dir/
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system unless a future integration issue explicitly allows it.
 
-## Required issue categories
+## Primary Review Flow
+
+1. A reviewer opens a batch of candidate outbound replies.
+2. The tool compares normalized subject, recipient, and body signals.
+3. The tool flags exact duplicates as blocked.
+4. The tool flags near duplicates for human review.
+5. The tool leaves distinct replies available for normal review.
+
+## Testable Cases
+
+- Exact body duplicate with extra whitespace.
+- Near duplicate with a shortened sentence.
+- Same subject but different recipient and different body.
+- Missing body content.
+- Same recipient with a distinct follow-up message.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Non-Goals
+
+- No production email sending.
+- No mailbox ingestion.
+- No wallet, Stellar, database, route, or design-system changes.
+- No cross-folder imports.

--- a/tools/v1/team/collision-detection/tests/collision-detection-test-plan.md
+++ b/tools/v1/team/collision-detection/tests/collision-detection-test-plan.md
@@ -1,0 +1,44 @@
+# Collision Detection Test Plan
+
+## Goal
+
+Give reviewers deterministic cases for the isolated Collision Detection tool
+before a production implementation is connected.
+
+## Fixture Contract
+
+Use `fixtures/collision-cases.json`. Each case includes:
+
+- `existingDraft`: the current reply already present in the review batch.
+- `candidateDraft`: the reply being evaluated.
+- `expected.classification`: `duplicate`, `possible_duplicate`, `distinct`, or
+  `invalid`.
+- `expected.action`: `block`, `review`, or `allow`.
+
+## Manual Review Cases
+
+| Case | Expected classification | Expected action | Why it matters |
+| --- | --- | --- | --- |
+| `exact-whitespace-duplicate` | `duplicate` | `block` | Normalization should avoid repeated sends caused by spacing changes. |
+| `near-duplicate-summary` | `possible_duplicate` | `review` | The tool should avoid overblocking shortened but similar team replies. |
+| `different-recipient-distinct-body` | `distinct` | `allow` | Same subject alone is not enough to block a draft. |
+| `missing-candidate-body` | `invalid` | `block` | Empty content should not be treated as a valid outgoing response. |
+
+## Future Automated Test Shape
+
+When a service module exists, add a folder-local test such as:
+
+```text
+tests/collision-detection.test.ts
+```
+
+The test should load the fixture cases, run the detector, and compare each
+result to `expected.classification` and `expected.action`.
+
+## Acceptance Notes
+
+- Tests must stay inside this folder.
+- Fixtures must not contain live mailbox data.
+- The tool should not contact external services during local validation.
+- Any future integration with the main mail app should be handled in a separate
+  issue.


### PR DESCRIPTION
Closes 

## Summary
- clean the isolated Collision Detection README/specs so contributors can review the tool without generated placeholder artifacts
- add synthetic duplicate-response fixture cases covering duplicate, possible_duplicate, distinct, and invalid outcomes
- add a folder-local test plan, validation notes, and review notes for independent OSS review

## Scope
- changes are limited to `tools/v1/team/collision-detection/`
- no app shell, routing, inbox architecture, authentication, wallet code, Stellar integration, database schema, or shared design-system files are touched
- no live mailbox data, external service calls, or production detector integration are introduced

## Validation
- confirmed the compare against upstream main contains only six files inside `tools/v1/team/collision-detection/`
- validated `fixtures/collision-cases.json` as JSON locally
- static checks confirmed README/test-plan/review/validation docs link the folder-local review assets and use synthetic `.test` recipients only
