### PR TITLE
girpolish(demo-admin): tighten interaction states on dashboard shell

### DIFF
--- a/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
+++ b/src/features/demo-admin-dashboard/DemoAdminDashboard.tsx
@@ -273,7 +273,7 @@ function OverviewContent({
                   setActivePresetId(preset.id);
                 }}
                 className={cn(
-                  "rounded-xl border p-4 text-left transition flex flex-col justify-between h-36 w-full",
+                  "glow-ring rounded-xl border p-4 text-left transition flex flex-col justify-between h-36 w-full active:scale-[0.99]",
                   active
                     ? "border-amber-500/50 bg-amber-500/5 ring-1 ring-amber-500/20"
                     : "border-white/[0.06] bg-white/[0.02] hover:border-white/10 hover:bg-white/[0.04]",
@@ -740,7 +740,7 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
               aria-label={item.description}
               onClick={() => handleSectionChange(item.id)}
               className={cn(
-                "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition",
+                "glow-ring flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition active:scale-95",
                 isActive
                   ? "bg-white/[0.08] text-foreground"
                   : "text-muted-foreground hover:bg-white/[0.04] hover:text-foreground",
@@ -827,7 +827,8 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
               <button
                 type="button"
                 onClick={() => setSelectedAccountAddress(null)}
-                className="rounded-md p-1 text-muted-foreground hover:bg-white/5 hover:text-foreground"
+                aria-label="Close relay node inspector"
+                className="glow-ring rounded-md p-1 text-muted-foreground transition hover:bg-white/5 hover:text-foreground active:scale-95"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -888,7 +889,7 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
           <button
             type="button"
             onClick={() => setSelectedAccountAddress(null)}
-            className="w-full rounded-lg border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground hover:bg-white/5 transition"
+            className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground hover:bg-white/5 transition active:scale-[0.99]"
           >
             Close Inspector
           </button>
@@ -907,7 +908,8 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
               <button
                 type="button"
                 onClick={() => setSelectedMailSubject(null)}
-                className="rounded-md p-1 text-muted-foreground hover:bg-white/5 hover:text-foreground"
+                aria-label="Close ledger proof inspector"
+                className="glow-ring rounded-md p-1 text-muted-foreground transition hover:bg-white/5 hover:text-foreground active:scale-95"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -982,7 +984,7 @@ export function DemoAdminDashboard({ className }: DemoAdminDashboardProps) {
           <button
             type="button"
             onClick={() => setSelectedMailSubject(null)}
-            className="w-full rounded-lg border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground hover:bg-white/5 transition mt-4"
+            className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.02] py-2 text-xs font-semibold text-foreground hover:bg-white/5 transition mt-4 active:scale-[0.99]"
           >
             Close Inspector
           </button>

--- a/src/features/demo-admin-dashboard/README-inbox-preview.md
+++ b/src/features/demo-admin-dashboard/README-inbox-preview.md
@@ -9,7 +9,7 @@ This implementation provides a complete folder-local preview of the demo inbox d
 ### ✅ Deliverables Completed
 
 1. **DemoInboxPreview** - Main component with list/reader views
-2. **DemoInboxList** - Message list with filtering and display 
+2. **DemoInboxList** - Message list with filtering and display
 3. **DemoMailReader** - Full message content with rich formatting
 4. **Demo Data Fixtures** - Safe, deterministic test data
 5. **Validation Helpers** - Safety compliance tools
@@ -27,7 +27,7 @@ This implementation provides a complete folder-local preview of the demo inbox d
 ### ✅ Safety Requirements
 
 - [x] All data is fake, deterministic, and safe for public review
-- [x] Email addresses use only @example.com, @example.org, *.stealth.demo
+- [x] Email addresses use only @example.com, @example.org, \*.stealth.demo
 - [x] No real PII, secrets, private keys, or live network calls
 - [x] Comprehensive validation tools to ensure compliance
 - [x] All content suitable for public repository review
@@ -56,6 +56,7 @@ src/features/demo-admin-dashboard/
 ## Key Features
 
 ### DemoInboxPreview Component
+
 - **View Modes**: Toggle between list and reader views
 - **Folder Tabs**: Inbox, starred, archive, trash organization
 - **Status Indicators**: Unread counts, starred counts, attachment badges
@@ -63,6 +64,7 @@ src/features/demo-admin-dashboard/
 - **Demo Mode Badge**: Clear indication of demo-only functionality
 
 ### DemoInboxList Component
+
 - **Message Display**: Avatar, sender, subject, snippet, metadata
 - **Trust Indicators**: Verified sender badges and proof status
 - **Interactive Elements**: Click to select message for reading
@@ -70,6 +72,7 @@ src/features/demo-admin-dashboard/
 - **Animation**: Smooth list animations with staggered loading
 
 ### DemoMailReader Component
+
 - **Rich Content**: HTML email body rendering with proper styling
 - **Attachments**: File previews with download simulation
 - **Calendar Events**: Embedded meeting cards with RSVP UI
@@ -77,6 +80,7 @@ src/features/demo-admin-dashboard/
 - **Action Bar**: Simulated reply/forward/archive buttons
 
 ### Demo Data Features
+
 - **10 Sample Messages**: Covering various scenarios and content types
 - **8 Demo Senders**: Mix of trusted/untrusted with personas
 - **5 Attachments**: PDF, DOCX, XLSX, PNG files with realistic sizes
@@ -84,6 +88,7 @@ src/features/demo-admin-dashboard/
 - **4 Proof Records**: Various verification states and postage amounts
 
 ### Safety & Validation
+
 - **Email Validation**: Ensures only safe demo domains are used
 - **Content Scanning**: Detects patterns that might indicate real PII
 - **Compliance Reporting**: Generates safety audit reports
@@ -92,6 +97,7 @@ src/features/demo-admin-dashboard/
 ## Usage Examples
 
 ### Basic Integration
+
 ```typescript
 import { DemoInboxPreview } from '@/features/demo-admin-dashboard';
 
@@ -106,12 +112,13 @@ function AdminDashboard() {
 ```
 
 ### Data Access
+
 ```typescript
-import { 
+import {
   createDemoInboxData,
   getUnreadDemoMessages,
-  validateDemoDataset 
-} from '@/features/demo-admin-dashboard';
+  validateDemoDataset,
+} from "@/features/demo-admin-dashboard";
 
 const dataset = createDemoInboxData();
 const unreadMessages = getUnreadDemoMessages();
@@ -121,6 +128,7 @@ const validation = validateDemoDataset(dataset);
 ## Testing
 
 ### Test Coverage
+
 - **Data Generation**: Validates demo data structure and content
 - **Safety Compliance**: Ensures no real PII or unsafe content
 - **Component Integration**: Tests component interaction and state
@@ -128,6 +136,7 @@ const validation = validateDemoDataset(dataset);
 - **Deterministic Output**: Ensures consistent, repeatable results
 
 ### Running Tests
+
 ```bash
 npm test -- src/features/demo-admin-dashboard/__tests__/demoInboxPreview.test.ts
 ```
@@ -135,7 +144,9 @@ npm test -- src/features/demo-admin-dashboard/__tests__/demoInboxPreview.test.ts
 ## Integration Points
 
 ### Current Isolation
+
 The implementation is completely isolated and does not integrate with:
+
 - Live inbox systems
 - Real mail processing
 - Production API endpoints
@@ -143,7 +154,9 @@ The implementation is completely isolated and does not integrate with:
 - External services
 
 ### Future Integration Opportunities
+
 For future enhancement, the following integration points are documented:
+
 - Real inbox component API compatibility
 - State synchronization with live data
 - Authentication and authorization
@@ -153,19 +166,24 @@ For future enhancement, the following integration points are documented:
 ## Maintenance Notes
 
 ### Adding New Demo Messages
+
 1. Add new message objects to `DEMO_MESSAGES` in `demoInboxData.ts`
 2. Ensure all email addresses use safe domains
 3. Run validation tests to confirm compliance
 4. Update documentation if new patterns are introduced
 
 ### Safety Validation
+
 The `demoDataValidator.ts` module provides comprehensive safety checks:
+
 - Run `validateDemoDataset()` before deploying new data
 - Use `generateComplianceReport()` for audit documentation
 - Set up `assertDemoDataSafety()` in CI/CD pipelines
 
 ### Component Updates
+
 When modifying components:
+
 1. Maintain isolation from production systems
 2. Keep demo mode indicators visible
 3. Update tests for new functionality
@@ -174,8 +192,9 @@ When modifying components:
 ## CI/CD Considerations
 
 The implementation supports the project's CI requirements:
+
 1. **Client Checks**: TypeScript compilation and linting
-2. **E2E Tests**: Component integration testing  
+2. **E2E Tests**: Component integration testing
 3. **Provenance & Hashes**: Deterministic data generation
 
 All files follow the project's existing patterns and coding standards.

--- a/src/features/demo-admin-dashboard/__tests__/demoInboxPreview.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/demoInboxPreview.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { 
+import {
   createDemoInboxData,
   getDemoMessagesByLabel,
   getUnreadDemoMessages,
@@ -7,7 +7,7 @@ import {
   getDemoMessagesWithAttachments,
   getDemoMessagesWithEvents,
 } from "../fixtures/demoInboxData";
-import { 
+import {
   validateDemoDataset,
   validateDemoMessage,
   validateSafeEmailAddress,
@@ -18,7 +18,7 @@ describe("Demo Inbox Data", () => {
   describe("createDemoInboxData", () => {
     it("should create a valid demo dataset", () => {
       const dataset = createDemoInboxData();
-      
+
       expect(dataset).toBeDefined();
       expect(dataset.id).toBe("demo-inbox-dataset");
       expect(dataset.name).toBe("Demo Inbox Dataset");
@@ -30,21 +30,21 @@ describe("Demo Inbox Data", () => {
 
     it("should contain messages with safe email addresses", () => {
       const dataset = createDemoInboxData();
-      
-      dataset.messages.forEach(message => {
+
+      dataset.messages.forEach((message) => {
         // Check sender address uses safe domains
         expect(
           message.sender.address.endsWith("@example.com") ||
-          message.sender.address.endsWith("@example.org") ||
-          message.sender.address.endsWith(".stealth.demo")
+            message.sender.address.endsWith("@example.org") ||
+            message.sender.address.endsWith(".stealth.demo"),
         ).toBe(true);
-        
+
         // Check recipient addresses use safe domains
-        message.recipients.forEach(recipient => {
+        message.recipients.forEach((recipient) => {
           expect(
             recipient.endsWith("@example.com") ||
-            recipient.endsWith("@example.org") ||
-            recipient.endsWith(".stealth.demo")
+              recipient.endsWith("@example.org") ||
+              recipient.endsWith(".stealth.demo"),
           ).toBe(true);
         });
       });
@@ -52,8 +52,8 @@ describe("Demo Inbox Data", () => {
 
     it("should have messages with required fields", () => {
       const dataset = createDemoInboxData();
-      
-      dataset.messages.forEach(message => {
+
+      dataset.messages.forEach((message) => {
         expect(message.id).toBeTruthy();
         expect(message.threadId).toBeTruthy();
         expect(message.subject).toBeTruthy();
@@ -76,8 +76,8 @@ describe("Demo Inbox Data", () => {
     it("should filter messages by label", () => {
       const inboxMessages = getDemoMessagesByLabel("inbox");
       expect(inboxMessages.length).toBeGreaterThan(0);
-      
-      inboxMessages.forEach(message => {
+
+      inboxMessages.forEach((message) => {
         expect(message.labels).toContain("inbox");
       });
     });
@@ -85,8 +85,8 @@ describe("Demo Inbox Data", () => {
     it("should filter unread messages", () => {
       const unreadMessages = getUnreadDemoMessages();
       expect(unreadMessages.length).toBeGreaterThan(0);
-      
-      unreadMessages.forEach(message => {
+
+      unreadMessages.forEach((message) => {
         expect(message.isRead).toBe(false);
       });
     });
@@ -94,8 +94,8 @@ describe("Demo Inbox Data", () => {
     it("should filter starred messages", () => {
       const starredMessages = getStarredDemoMessages();
       expect(starredMessages.length).toBeGreaterThan(0);
-      
-      starredMessages.forEach(message => {
+
+      starredMessages.forEach((message) => {
         expect(message.isStarred).toBe(true);
       });
     });
@@ -103,8 +103,8 @@ describe("Demo Inbox Data", () => {
     it("should filter messages with attachments", () => {
       const messagesWithAttachments = getDemoMessagesWithAttachments();
       expect(messagesWithAttachments.length).toBeGreaterThan(0);
-      
-      messagesWithAttachments.forEach(message => {
+
+      messagesWithAttachments.forEach((message) => {
         expect(message.attachments.length).toBeGreaterThan(0);
       });
     });
@@ -112,8 +112,8 @@ describe("Demo Inbox Data", () => {
     it("should filter messages with calendar events", () => {
       const messagesWithEvents = getDemoMessagesWithEvents();
       expect(messagesWithEvents.length).toBeGreaterThan(0);
-      
-      messagesWithEvents.forEach(message => {
+
+      messagesWithEvents.forEach((message) => {
         expect(message.calendarEvent).toBeDefined();
       });
     });
@@ -125,12 +125,12 @@ describe("Demo Inbox Data", () => {
     it("should pass comprehensive safety validation", () => {
       // Use the validator to ensure compliance
       expect(() => assertDemoDataSafety(dataset)).not.toThrow();
-      
+
       const result = validateDemoDataset(dataset);
       expect(result.isValid).toBe(true);
-      
+
       // Should have no errors (warnings might be acceptable)
-      const errors = result.issues.filter(issue => issue.severity === "error");
+      const errors = result.issues.filter((issue) => issue.severity === "error");
       expect(errors).toHaveLength(0);
     });
 
@@ -138,17 +138,17 @@ describe("Demo Inbox Data", () => {
       expect(validateSafeEmailAddress("user@example.com")).toBe(true);
       expect(validateSafeEmailAddress("user@example.org")).toBe(true);
       expect(validateSafeEmailAddress("user@notifications.stealth.demo")).toBe(true);
-      
+
       expect(validateSafeEmailAddress("user@gmail.com")).toBe(false);
       expect(validateSafeEmailAddress("user@company.com")).toBe(false);
       expect(validateSafeEmailAddress("user@real-domain.com")).toBe(false);
     });
 
     it("should not contain real PII or sensitive data", () => {
-      dataset.messages.forEach(message => {
+      dataset.messages.forEach((message) => {
         const issues = validateDemoMessage(message);
-        const errors = issues.filter(issue => issue.severity === "error");
-        
+        const errors = issues.filter((issue) => issue.severity === "error");
+
         // Should have no validation errors
         expect(errors).toHaveLength(0);
       });
@@ -157,11 +157,11 @@ describe("Demo Inbox Data", () => {
     it("should use deterministic data", () => {
       const dataset1 = createDemoInboxData();
       const dataset2 = createDemoInboxData();
-      
+
       // Same function calls should produce identical results
       expect(dataset1.messages.length).toBe(dataset2.messages.length);
       expect(dataset1.senders?.length).toBe(dataset2.senders?.length);
-      
+
       // Message IDs should be identical
       dataset1.messages.forEach((message1, index) => {
         const message2 = dataset2.messages[index];
@@ -172,9 +172,9 @@ describe("Demo Inbox Data", () => {
 
     it("should have valid attachment metadata", () => {
       const messagesWithAttachments = getDemoMessagesWithAttachments();
-      
-      messagesWithAttachments.forEach(message => {
-        message.attachments.forEach(attachment => {
+
+      messagesWithAttachments.forEach((message) => {
+        message.attachments.forEach((attachment) => {
           expect(attachment.id).toBeTruthy();
           expect(attachment.filename).toBeTruthy();
           expect(attachment.contentType).toBeTruthy();
@@ -187,22 +187,22 @@ describe("Demo Inbox Data", () => {
 
     it("should have valid calendar event metadata", () => {
       const messagesWithEvents = getDemoMessagesWithEvents();
-      
-      messagesWithEvents.forEach(message => {
+
+      messagesWithEvents.forEach((message) => {
         const event = message.calendarEvent!;
         expect(event.id).toBeTruthy();
         expect(event.title).toBeTruthy();
         expect(event.startTime).toBeTruthy();
         expect(event.endTime).toBeTruthy();
         expect(Array.isArray(event.attendees)).toBe(true);
-        
+
         // Validate date format
         expect(() => new Date(event.startTime)).not.toThrow();
         expect(() => new Date(event.endTime)).not.toThrow();
-        
+
         // End should be after start
         expect(new Date(event.endTime).getTime()).toBeGreaterThan(
-          new Date(event.startTime).getTime()
+          new Date(event.startTime).getTime(),
         );
       });
     });

--- a/src/features/demo-admin-dashboard/components/DemoInboxList.tsx
+++ b/src/features/demo-admin-dashboard/components/DemoInboxList.tsx
@@ -1,14 +1,14 @@
 import { motion } from "framer-motion";
 import { formatDistanceToNow } from "date-fns";
-import { 
-  Star, 
-  Paperclip, 
-  Calendar, 
-  Shield, 
-  Clock, 
+import {
+  Star,
+  Paperclip,
+  Calendar,
+  Shield,
+  Clock,
   CheckCircle2,
   AlertCircle,
-  Mail
+  Mail,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -24,7 +24,7 @@ interface DemoInboxListProps {
 
 /**
  * Demo inbox list component that displays messages in a familiar email list format.
- * 
+ *
  * This component mirrors the structure and styling of the real inbox list
  * without integrating with live mail systems. All interactions are local
  * and use demo data only.
@@ -67,21 +67,21 @@ interface DemoMessageRowProps {
 function DemoMessageRow({ message, onSelect, index }: DemoMessageRowProps) {
   const messageDate = new Date(message.date);
   const relativeTime = formatDistanceToNow(messageDate, { addSuffix: true });
-  
+
   // Generate consistent avatar color based on sender
   const getAvatarColor = (senderAddress: string) => {
     const colors = [
       "bg-red-500",
-      "bg-blue-500", 
+      "bg-blue-500",
       "bg-green-500",
       "bg-yellow-500",
       "bg-purple-500",
       "bg-pink-500",
       "bg-indigo-500",
-      "bg-cyan-500"
+      "bg-cyan-500",
     ];
-    const hash = senderAddress.split('').reduce((a, b) => {
-      a = ((a << 5) - a) + b.charCodeAt(0);
+    const hash = senderAddress.split("").reduce((a, b) => {
+      a = (a << 5) - a + b.charCodeAt(0);
       return a & a;
     }, 0);
     return colors[Math.abs(hash) % colors.length];
@@ -89,7 +89,11 @@ function DemoMessageRow({ message, onSelect, index }: DemoMessageRowProps) {
 
   const avatarColor = getAvatarColor(message.sender.address);
   const senderInitials = message.sender.name
-    ? message.sender.name.split(' ').map(n => n[0]).join('').toUpperCase()
+    ? message.sender.name
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
     : message.sender.address[0].toUpperCase();
 
   return (
@@ -102,7 +106,7 @@ function DemoMessageRow({ message, onSelect, index }: DemoMessageRowProps) {
         variant="ghost"
         className={cn(
           "w-full h-auto p-4 justify-start text-left hover:bg-muted/50 transition-colors",
-          !message.isRead && "bg-accent/20 border-l-2 border-l-primary"
+          !message.isRead && "bg-accent/20 border-l-2 border-l-primary",
         )}
         onClick={onSelect}
       >
@@ -119,46 +123,39 @@ function DemoMessageRow({ message, onSelect, index }: DemoMessageRowProps) {
             {/* Header Row */}
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2 min-w-0">
-                <span className={cn(
-                  "text-sm font-medium truncate",
-                  !message.isRead && "font-semibold"
-                )}>
+                <span
+                  className={cn("text-sm font-medium truncate", !message.isRead && "font-semibold")}
+                >
                   {message.sender.name || message.sender.address}
                 </span>
-                
+
                 {/* Trust Badge */}
                 {message.sender.isTrusted && (
                   <Shield className="h-3 w-3 text-green-500 flex-shrink-0" />
                 )}
-                
+
                 {/* Proof Status */}
-                {message.proofRecord && (
-                  <ProofStatusIcon status={message.proofRecord.status} />
-                )}
+                {message.proofRecord && <ProofStatusIcon status={message.proofRecord.status} />}
               </div>
-              
+
               <div className="flex items-center space-x-1 flex-shrink-0">
-                <span className="text-xs text-muted-foreground">
-                  {relativeTime}
-                </span>
-                {message.isStarred && (
-                  <Star className="h-3 w-3 text-yellow-500 fill-current" />
-                )}
+                <span className="text-xs text-muted-foreground">{relativeTime}</span>
+                {message.isStarred && <Star className="h-3 w-3 text-yellow-500 fill-current" />}
               </div>
             </div>
 
             {/* Subject */}
-            <p className={cn(
-              "text-sm truncate",
-              !message.isRead ? "font-medium text-foreground" : "text-muted-foreground"
-            )}>
+            <p
+              className={cn(
+                "text-sm truncate",
+                !message.isRead ? "font-medium text-foreground" : "text-muted-foreground",
+              )}
+            >
               {message.subject}
             </p>
 
             {/* Snippet */}
-            <p className="text-xs text-muted-foreground line-clamp-2">
-              {message.snippet}
-            </p>
+            <p className="text-xs text-muted-foreground line-clamp-2">{message.snippet}</p>
 
             {/* Metadata Row */}
             <div className="flex items-center space-x-3 pt-1">
@@ -187,14 +184,15 @@ function DemoMessageRow({ message, onSelect, index }: DemoMessageRowProps) {
               )}
 
               {/* Labels */}
-              {message.labels.slice(0, 2).map(label => (
-                label !== "inbox" && (
-                  <Badge key={label} variant="outline" className="text-xs h-5 px-1.5">
-                    {label}
-                  </Badge>
-                )
-              ))}
-              
+              {message.labels.slice(0, 2).map(
+                (label) =>
+                  label !== "inbox" && (
+                    <Badge key={label} variant="outline" className="text-xs h-5 px-1.5">
+                      {label}
+                    </Badge>
+                  ),
+              )}
+
               {message.labels.length > 3 && (
                 <span className="text-xs text-muted-foreground">
                   +{message.labels.length - 3} more

--- a/src/features/demo-admin-dashboard/components/DemoInboxPreview.tsx
+++ b/src/features/demo-admin-dashboard/components/DemoInboxPreview.tsx
@@ -16,7 +16,7 @@ interface DemoInboxPreviewProps {
 
 /**
  * A folder-local preview of the demo inbox dataset.
- * 
+ *
  * This component provides a complete inbox preview experience without
  * wiring into live inbox systems. All data is fake, deterministic, and
  * safe for public repository review.
@@ -25,9 +25,9 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"list" | "reader">("list");
   const demoData = createDemoInboxData();
-  
-  const selectedMessage = selectedMessageId 
-    ? demoData.messages.find(msg => msg.id === selectedMessageId) 
+
+  const selectedMessage = selectedMessageId
+    ? (demoData.messages.find((msg) => msg.id === selectedMessageId) ?? null)
     : null;
 
   const handleMessageSelect = (messageId: string) => {
@@ -40,8 +40,8 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
     setSelectedMessageId(null);
   };
 
-  const unreadCount = demoData.messages.filter(msg => !msg.isRead).length;
-  const starredCount = demoData.messages.filter(msg => msg.isStarred).length;
+  const unreadCount = demoData.messages.filter((msg) => !msg.isRead).length;
+  const starredCount = demoData.messages.filter((msg) => msg.isStarred).length;
 
   return (
     <div className={cn("flex flex-col space-y-6", className)}>
@@ -56,7 +56,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
             Folder-local preview of demo inbox dataset without live integration
           </p>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <Badge variant="secondary" className="flex items-center gap-1">
             <Mail className="h-3 w-3" />
@@ -83,7 +83,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
           <span className="text-sm font-medium">Preview Mode</span>
           <Badge variant="outline">Demo Data Only</Badge>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
@@ -110,7 +110,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="inbox" className="flex items-center gap-2">
             <Mail className="h-4 w-4" />
-            Inbox ({demoData.messages.filter(msg => msg.labels.includes("inbox")).length})
+            Inbox ({demoData.messages.filter((msg) => msg.labels.includes("inbox")).length})
           </TabsTrigger>
           <TabsTrigger value="starred" className="flex items-center gap-2">
             <Star className="h-4 w-4" />
@@ -118,17 +118,17 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
           </TabsTrigger>
           <TabsTrigger value="archive" className="flex items-center gap-2">
             <Archive className="h-4 w-4" />
-            Archive ({demoData.messages.filter(msg => msg.labels.includes("archive")).length})
+            Archive ({demoData.messages.filter((msg) => msg.labels.includes("archive")).length})
           </TabsTrigger>
           <TabsTrigger value="trash" className="flex items-center gap-2">
             <Trash2 className="h-4 w-4" />
-            Trash ({demoData.messages.filter(msg => msg.labels.includes("trash")).length})
+            Trash ({demoData.messages.filter((msg) => msg.labels.includes("trash")).length})
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="inbox" className="mt-6">
           <InboxTabContent
-            messages={demoData.messages.filter(msg => msg.labels.includes("inbox"))}
+            messages={demoData.messages.filter((msg) => msg.labels.includes("inbox"))}
             viewMode={viewMode}
             selectedMessage={selectedMessage}
             onMessageSelect={handleMessageSelect}
@@ -138,7 +138,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
 
         <TabsContent value="starred" className="mt-6">
           <InboxTabContent
-            messages={demoData.messages.filter(msg => msg.isStarred)}
+            messages={demoData.messages.filter((msg) => msg.isStarred)}
             viewMode={viewMode}
             selectedMessage={selectedMessage}
             onMessageSelect={handleMessageSelect}
@@ -148,7 +148,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
 
         <TabsContent value="archive" className="mt-6">
           <InboxTabContent
-            messages={demoData.messages.filter(msg => msg.labels.includes("archive"))}
+            messages={demoData.messages.filter((msg) => msg.labels.includes("archive"))}
             viewMode={viewMode}
             selectedMessage={selectedMessage}
             onMessageSelect={handleMessageSelect}
@@ -158,7 +158,7 @@ export function DemoInboxPreview({ className }: DemoInboxPreviewProps) {
 
         <TabsContent value="trash" className="mt-6">
           <InboxTabContent
-            messages={demoData.messages.filter(msg => msg.labels.includes("trash"))}
+            messages={demoData.messages.filter((msg) => msg.labels.includes("trash"))}
             viewMode={viewMode}
             selectedMessage={selectedMessage}
             onMessageSelect={handleMessageSelect}
@@ -193,15 +193,9 @@ function InboxTabContent({
       className="min-h-[600px] border rounded-lg overflow-hidden"
     >
       {viewMode === "list" ? (
-        <DemoInboxList
-          messages={messages}
-          onMessageSelect={onMessageSelect}
-        />
+        <DemoInboxList messages={messages} onMessageSelect={onMessageSelect} />
       ) : selectedMessage ? (
-        <DemoMailReader
-          message={selectedMessage}
-          onBackToList={onBackToList}
-        />
+        <DemoMailReader message={selectedMessage} onBackToList={onBackToList} />
       ) : (
         <div className="flex items-center justify-center h-[600px] text-muted-foreground">
           No message selected

--- a/src/features/demo-admin-dashboard/components/DemoMailReader.tsx
+++ b/src/features/demo-admin-dashboard/components/DemoMailReader.tsx
@@ -1,12 +1,12 @@
 import { motion } from "framer-motion";
 import { formatDistanceToNow, format } from "date-fns";
-import { 
-  ArrowLeft, 
-  Star, 
-  Reply, 
-  ReplyAll, 
-  Forward, 
-  Archive, 
+import {
+  ArrowLeft,
+  Star,
+  Reply,
+  ReplyAll,
+  Forward,
+  Archive,
   Trash2,
   MoreHorizontal,
   Paperclip,
@@ -16,7 +16,7 @@ import {
   Clock,
   AlertCircle,
   ExternalLink,
-  Download
+  Download,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -39,7 +39,7 @@ interface DemoMailReaderProps {
 
 /**
  * Demo mail reader component that displays a single message with full content.
- * 
+ *
  * This component provides a complete email reading experience using demo data
  * without integrating with live mail systems. All actions are simulated and
  * do not perform actual operations.
@@ -53,16 +53,16 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
   const getAvatarColor = (senderAddress: string) => {
     const colors = [
       "bg-red-500",
-      "bg-blue-500", 
+      "bg-blue-500",
       "bg-green-500",
       "bg-yellow-500",
       "bg-purple-500",
       "bg-pink-500",
       "bg-indigo-500",
-      "bg-cyan-500"
+      "bg-cyan-500",
     ];
-    const hash = senderAddress.split('').reduce((a, b) => {
-      a = ((a << 5) - a) + b.charCodeAt(0);
+    const hash = senderAddress.split("").reduce((a, b) => {
+      a = (a << 5) - a + b.charCodeAt(0);
       return a & a;
     }, 0);
     return colors[Math.abs(hash) % colors.length];
@@ -70,7 +70,11 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
 
   const avatarColor = getAvatarColor(message.sender.address);
   const senderInitials = message.sender.name
-    ? message.sender.name.split(' ').map(n => n[0]).join('').toUpperCase()
+    ? message.sender.name
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
     : message.sender.address[0].toUpperCase();
 
   return (
@@ -87,26 +91,26 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
             <ArrowLeft className="h-4 w-4" />
             Back to List
           </Button>
-          
+
           <Separator orientation="vertical" className="h-6" />
-          
+
           <div className="flex items-center space-x-2">
             <Badge variant="outline" className="text-xs">
               Demo Mode
             </Badge>
-            <span className="text-sm text-muted-foreground">
-              {relativeTime}
-            </span>
+            <span className="text-sm text-muted-foreground">{relativeTime}</span>
           </div>
         </div>
 
         {/* Action Buttons */}
         <div className="flex items-center space-x-2">
           <Button variant="ghost" size="sm" className="flex items-center gap-2">
-            <Star className={cn(
-              "h-4 w-4",
-              message.isStarred ? "text-yellow-500 fill-current" : "text-muted-foreground"
-            )} />
+            <Star
+              className={cn(
+                "h-4 w-4",
+                message.isStarred ? "text-yellow-500 fill-current" : "text-muted-foreground",
+              )}
+            />
           </Button>
           <Button variant="ghost" size="sm">
             <Reply className="h-4 w-4" />
@@ -148,35 +152,31 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
         >
           {/* Message Header */}
           <div className="space-y-4">
-            <h1 className="text-2xl font-semibold leading-tight">
-              {message.subject}
-            </h1>
-            
+            <h1 className="text-2xl font-semibold leading-tight">{message.subject}</h1>
+
             <div className="flex items-start space-x-4">
               <Avatar className="h-12 w-12">
                 <AvatarFallback className={cn("text-white text-sm font-medium", avatarColor)}>
                   {senderInitials}
                 </AvatarFallback>
               </Avatar>
-              
+
               <div className="flex-1 space-y-2">
                 <div className="flex items-center space-x-2">
                   <span className="font-medium">
                     {message.sender.name || message.sender.address}
                   </span>
-                  
+
                   {message.sender.isTrusted && (
                     <Badge variant="secondary" className="text-xs h-5 px-2 flex items-center gap-1">
                       <Shield className="h-3 w-3" />
                       Verified Sender
                     </Badge>
                   )}
-                  
-                  {message.proofRecord && (
-                    <ProofStatusBadge status={message.proofRecord.status} />
-                  )}
+
+                  {message.proofRecord && <ProofStatusBadge status={message.proofRecord.status} />}
                 </div>
-                
+
                 <div className="text-sm text-muted-foreground space-y-1">
                   <div>
                     <span className="font-medium">From:</span> {message.sender.address}
@@ -193,9 +193,7 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
           </div>
 
           {/* Proof Record Details */}
-          {message.proofRecord && (
-            <ProofRecordDetails proofRecord={message.proofRecord} />
-          )}
+          {message.proofRecord && <ProofRecordDetails proofRecord={message.proofRecord} />}
 
           {/* Attachments */}
           {message.attachments.length > 0 && (
@@ -203,19 +201,13 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
           )}
 
           {/* Calendar Event */}
-          {message.calendarEvent && (
-            <CalendarEventCard event={message.calendarEvent} />
-          )}
+          {message.calendarEvent && <CalendarEventCard event={message.calendarEvent} />}
 
           <Separator />
 
           {/* Message Body */}
           <div className="prose prose-sm dark:prose-invert max-w-none">
-            <div 
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: message.body }}
-              className="leading-relaxed"
-            />
+            <div dangerouslySetInnerHTML={{ __html: message.body }} className="leading-relaxed" />
           </div>
 
           {/* Labels */}
@@ -223,7 +215,7 @@ export function DemoMailReader({ message, onBackToList }: DemoMailReaderProps) {
             <div className="flex items-center space-x-2 pt-4">
               <span className="text-sm font-medium text-muted-foreground">Labels:</span>
               <div className="flex flex-wrap gap-2">
-                {message.labels.map(label => (
+                {message.labels.map((label) => (
                   <Badge key={label} variant="outline" className="text-xs">
                     {label}
                   </Badge>
@@ -247,26 +239,26 @@ function ProofStatusBadge({ status }: ProofStatusBadgeProps) {
       icon: CheckCircle2,
       label: "Verified",
       variant: "default" as const,
-      className: "bg-green-500 text-white"
+      className: "bg-green-500 text-white",
     },
     pending: {
       icon: Clock,
       label: "Proof Pending",
       variant: "secondary" as const,
-      className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+      className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
     },
     failed: {
       icon: AlertCircle,
       label: "Verification Failed",
       variant: "destructive" as const,
-      className: ""
+      className: "",
     },
     none: {
       icon: null,
       label: "",
       variant: "outline" as const,
-      className: ""
-    }
+      className: "",
+    },
   };
 
   const { icon: Icon, label, variant, className } = config[status];
@@ -282,7 +274,7 @@ function ProofStatusBadge({ status }: ProofStatusBadgeProps) {
 }
 
 interface ProofRecordDetailsProps {
-  proofRecord: NonNullable<DemoMessage['proofRecord']>;
+  proofRecord: NonNullable<DemoMessage["proofRecord"]>;
 }
 
 function ProofRecordDetails({ proofRecord }: ProofRecordDetailsProps) {
@@ -294,7 +286,7 @@ function ProofRecordDetails({ proofRecord }: ProofRecordDetailsProps) {
           Demo Data
         </Badge>
       </div>
-      
+
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>
           <span className="font-medium text-muted-foreground">Status:</span>
@@ -302,12 +294,12 @@ function ProofRecordDetails({ proofRecord }: ProofRecordDetailsProps) {
             <ProofStatusBadge status={proofRecord.status} />
           </div>
         </div>
-        
+
         <div>
           <span className="font-medium text-muted-foreground">Timestamp:</span>
           <div className="mt-1">{format(new Date(proofRecord.timestamp), "PPp")}</div>
         </div>
-        
+
         {proofRecord.postageAmount && (
           <div>
             <span className="font-medium text-muted-foreground">Postage:</span>
@@ -316,7 +308,7 @@ function ProofRecordDetails({ proofRecord }: ProofRecordDetailsProps) {
             </div>
           </div>
         )}
-        
+
         {proofRecord.policyId && (
           <div>
             <span className="font-medium text-muted-foreground">Policy ID:</span>
@@ -329,16 +321,16 @@ function ProofRecordDetails({ proofRecord }: ProofRecordDetailsProps) {
 }
 
 interface AttachmentsSectionProps {
-  attachments: DemoMessage['attachments'];
+  attachments: DemoMessage["attachments"];
 }
 
 function AttachmentsSection({ attachments }: AttachmentsSectionProps) {
   const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes';
+    if (bytes === 0) return "0 Bytes";
     const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const sizes = ["Bytes", "KB", "MB", "GB"];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
   };
 
   return (
@@ -349,9 +341,9 @@ function AttachmentsSection({ attachments }: AttachmentsSectionProps) {
           Attachments ({attachments.length})
         </h3>
       </div>
-      
+
       <div className="space-y-2">
-        {attachments.map(attachment => (
+        {attachments.map((attachment) => (
           <div
             key={attachment.id}
             className="flex items-center justify-between p-3 bg-background rounded border"
@@ -367,7 +359,7 @@ function AttachmentsSection({ attachments }: AttachmentsSectionProps) {
                 </p>
               </div>
             </div>
-            
+
             <div className="flex items-center space-x-2">
               <Button variant="ghost" size="sm">
                 <ExternalLink className="h-4 w-4" />
@@ -384,13 +376,13 @@ function AttachmentsSection({ attachments }: AttachmentsSectionProps) {
 }
 
 interface CalendarEventCardProps {
-  event: NonNullable<DemoMessage['calendarEvent']>;
+  event: NonNullable<DemoMessage["calendarEvent"]>;
 }
 
 function CalendarEventCard({ event }: CalendarEventCardProps) {
   const startDate = new Date(event.startTime);
   const endDate = new Date(event.endTime);
-  
+
   return (
     <div className="p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-3">
       <div className="flex items-center justify-between">
@@ -402,10 +394,10 @@ function CalendarEventCard({ event }: CalendarEventCardProps) {
           Add to Calendar
         </Button>
       </div>
-      
+
       <div className="space-y-2">
         <h4 className="font-medium">{event.title}</h4>
-        
+
         <div className="text-sm space-y-1">
           <div className="flex items-center space-x-2">
             <Clock className="h-3 w-3 text-muted-foreground" />
@@ -413,7 +405,7 @@ function CalendarEventCard({ event }: CalendarEventCardProps) {
               {format(startDate, "PPP 'at' p")} - {format(endDate, "p")}
             </span>
           </div>
-          
+
           {event.location && (
             <div className="flex items-center space-x-2">
               <ExternalLink className="h-3 w-3 text-muted-foreground" />
@@ -421,7 +413,7 @@ function CalendarEventCard({ event }: CalendarEventCardProps) {
             </div>
           )}
         </div>
-        
+
         {event.attendees.length > 0 && (
           <div className="pt-2 border-t">
             <p className="text-xs font-medium text-muted-foreground mb-1">

--- a/src/features/demo-admin-dashboard/docs/demo-inbox-preview.md
+++ b/src/features/demo-admin-dashboard/docs/demo-inbox-preview.md
@@ -36,22 +36,26 @@ Shows full message content with rich formatting:
 ## Demo Data Structure
 
 ### Messages
-- **Safe email addresses**: Only @example.com, @example.org, *.stealth.demo
+
+- **Safe email addresses**: Only @example.com, @example.org, \*.stealth.demo
 - **Rich content**: HTML bodies, attachments, calendar events
 - **Metadata**: Labels, proof records, sender policies
 - **Folders**: Inbox, starred, archive, trash distribution
 
 ### Senders
+
 - **Verified personas**: Consistent names and trust levels
 - **Relay nodes**: Demo relay infrastructure references
 - **Trust indicators**: Trusted/untrusted classification for testing
 
 ### Attachments
+
 - **File types**: PDF, DOCX, XLSX, PNG with realistic sizes
 - **Demo URLs**: Safe placeholder paths for preview
 - **Metadata**: Proper MIME types and file size formatting
 
 ### Calendar Events
+
 - **Meeting details**: Safe locations and attendee lists
 - **Time ranges**: Realistic scheduling with demo timestamps
 - **Integration**: Embedded in messages with preview cards

--- a/src/features/demo-admin-dashboard/examples/demo-inbox-usage.tsx
+++ b/src/features/demo-admin-dashboard/examples/demo-inbox-usage.tsx
@@ -1,6 +1,6 @@
 /**
  * Example usage of the Demo Inbox Preview components.
- * 
+ *
  * This file demonstrates how to integrate the demo inbox preview
  * into the admin dashboard without connecting to live systems.
  */
@@ -19,9 +19,9 @@ export function DemoAdminInboxExample() {
           Manage and preview demo data for the Stealth mail system
         </p>
       </div>
-      
+
       <DemoInboxPreview />
-      
+
       <div className="mt-8 p-4 bg-muted/20 rounded-lg border">
         <h3 className="font-semibold mb-2">Integration Notes</h3>
         <ul className="text-sm text-muted-foreground space-y-1">
@@ -46,7 +46,7 @@ export function DemoInboxAdvancedExample() {
         <div className="lg:col-span-2">
           <DemoInboxPreview />
         </div>
-        
+
         {/* Sidebar with additional info */}
         <div className="space-y-4">
           <div className="p-4 border rounded-lg">
@@ -74,7 +74,7 @@ export function DemoInboxAdvancedExample() {
               </div>
             </div>
           </div>
-          
+
           <div className="p-4 border rounded-lg">
             <h3 className="font-semibold mb-3">Preview Features</h3>
             <ul className="text-sm space-y-1">

--- a/src/features/demo-admin-dashboard/fixtures/demoInboxData.ts
+++ b/src/features/demo-admin-dashboard/fixtures/demoInboxData.ts
@@ -1,8 +1,15 @@
-import type { DemoDataset, DemoMessage, DemoSender, DemoAttachment, DemoCalendarEvent, DemoProofRecord } from "../types/dataset";
+import type {
+  DemoDataset,
+  DemoMessage,
+  DemoSender,
+  DemoAttachment,
+  DemoCalendarEvent,
+  DemoProofRecord,
+} from "../types/dataset";
 
 /**
  * Demo inbox data fixtures for the preview components.
- * 
+ *
  * IMPORTANT: All data is fake, deterministic, and safe for public repository review.
  * Email addresses use @example.com, @example.org, or *.stealth.demo domains only.
  * No real user data, secrets, private keys, or live network calls are used.
@@ -16,13 +23,13 @@ const DEMO_SENDERS: DemoSender[] = [
     address: "alice@example.com",
     name: "Alice Johnson",
     isTrusted: true,
-    relayNode: "relay-1.stealth.demo"
+    relayNode: "relay-1.stealth.demo",
   },
   {
-    address: "bob@example.org", 
+    address: "bob@example.org",
     name: "Bob Chen",
     isTrusted: true,
-    relayNode: "relay-2.stealth.demo"
+    relayNode: "relay-2.stealth.demo",
   },
   {
     address: "charlie@example.com",
@@ -33,7 +40,7 @@ const DEMO_SENDERS: DemoSender[] = [
     address: "diana@example.org",
     name: "Diana Rodriguez",
     isTrusted: true,
-    relayNode: "relay-3.stealth.demo"
+    relayNode: "relay-3.stealth.demo",
   },
   {
     address: "eve@example.com",
@@ -44,19 +51,19 @@ const DEMO_SENDERS: DemoSender[] = [
     address: "frank@example.org",
     name: "Frank Miller",
     isTrusted: true,
-    relayNode: "relay-1.stealth.demo"
+    relayNode: "relay-1.stealth.demo",
   },
   {
     address: "grace@notifications.stealth.demo",
     name: "Stealth Notifications",
     isTrusted: true,
-    relayNode: "system.stealth.demo"
+    relayNode: "system.stealth.demo",
   },
   {
     address: "support@example.com",
     name: "Support Team",
     isTrusted: true,
-  }
+  },
 ];
 
 /**
@@ -68,36 +75,36 @@ const DEMO_ATTACHMENTS: DemoAttachment[] = [
     filename: "project-proposal.pdf",
     contentType: "application/pdf",
     sizeBytes: 2457600, // 2.4 MB
-    url: "/demo/attachments/project-proposal.pdf"
+    url: "/demo/attachments/project-proposal.pdf",
   },
   {
-    id: "att-2", 
+    id: "att-2",
     filename: "meeting-notes.docx",
     contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     sizeBytes: 524288, // 512 KB
-    url: "/demo/attachments/meeting-notes.docx"
+    url: "/demo/attachments/meeting-notes.docx",
   },
   {
     id: "att-3",
     filename: "quarterly-report.xlsx",
-    contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", 
+    contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     sizeBytes: 1048576, // 1 MB
-    url: "/demo/attachments/quarterly-report.xlsx"
+    url: "/demo/attachments/quarterly-report.xlsx",
   },
   {
     id: "att-4",
     filename: "demo-screenshot.png",
     contentType: "image/png",
     sizeBytes: 307200, // 300 KB
-    url: "/demo/attachments/demo-screenshot.png"
+    url: "/demo/attachments/demo-screenshot.png",
   },
   {
     id: "att-5",
     filename: "invoice-2026-q2.pdf",
-    contentType: "application/pdf", 
+    contentType: "application/pdf",
     sizeBytes: 98304, // 96 KB
-    url: "/demo/attachments/invoice-2026-q2.pdf"
-  }
+    url: "/demo/attachments/invoice-2026-q2.pdf",
+  },
 ];
 
 /**
@@ -108,26 +115,26 @@ const DEMO_CALENDAR_EVENTS: DemoCalendarEvent[] = [
     id: "cal-1",
     title: "Project Kickoff Meeting",
     startTime: "2026-06-25T14:00",
-    endTime: "2026-06-25T15:00", 
+    endTime: "2026-06-25T15:00",
     location: "Conference Room A",
-    attendees: ["alice@example.com", "bob@example.org", "charlie@example.com"]
+    attendees: ["alice@example.com", "bob@example.org", "charlie@example.com"],
   },
   {
     id: "cal-2",
-    title: "Demo Presentation", 
+    title: "Demo Presentation",
     startTime: "2026-06-28T16:00",
     endTime: "2026-06-28T17:30",
     location: "Virtual Meeting",
-    attendees: ["diana@example.org", "eve@example.com", "frank@example.org"]
+    attendees: ["diana@example.org", "eve@example.com", "frank@example.org"],
   },
   {
     id: "cal-3",
     title: "Weekly Sync",
-    startTime: "2026-06-30T10:00", 
+    startTime: "2026-06-30T10:00",
     endTime: "2026-06-30T10:30",
     location: "Team Room",
-    attendees: ["alice@example.com", "bob@example.org"]
-  }
+    attendees: ["alice@example.com", "bob@example.org"],
+  },
 ];
 
 /**
@@ -140,15 +147,15 @@ const DEMO_PROOF_RECORDS: DemoProofRecord[] = [
     timestamp: "2026-06-20T08:30:00Z",
     postageAmount: 0.001,
     postageCurrency: "DEMO",
-    policyId: "policy-allow-verified"
+    policyId: "policy-allow-verified",
   },
   {
     id: "proof-2",
-    status: "pending", 
+    status: "pending",
     timestamp: "2026-06-20T09:15:00Z",
     postageAmount: 0.002,
-    postageCurrency: "DEMO", 
-    policyId: "policy-verify-pending"
+    postageCurrency: "DEMO",
+    policyId: "policy-verify-pending",
   },
   {
     id: "proof-3",
@@ -156,14 +163,14 @@ const DEMO_PROOF_RECORDS: DemoProofRecord[] = [
     timestamp: "2026-06-20T10:45:00Z",
     postageAmount: 0.0005,
     postageCurrency: "DEMO",
-    policyId: "policy-allow-trusted"
+    policyId: "policy-allow-trusted",
   },
   {
-    id: "proof-4", 
+    id: "proof-4",
     status: "failed",
     timestamp: "2026-06-20T11:20:00Z",
-    policyId: "policy-block-suspicious"
-  }
+    policyId: "policy-block-suspicious",
+  },
 ];
 
 /**
@@ -202,11 +209,11 @@ const DEMO_MESSAGES: DemoMessage[] = [
     isStarred: true,
     labels: ["inbox", "welcome"],
     attachments: [],
-    proofRecord: DEMO_PROOF_RECORDS[0]
+    proofRecord: DEMO_PROOF_RECORDS[0],
   },
-  
+
   {
-    id: "msg-2", 
+    id: "msg-2",
     threadId: "thread-2",
     subject: "Project Proposal Review",
     snippet: "I've attached the updated project proposal for your review. Please let me know...",
@@ -229,17 +236,17 @@ const DEMO_MESSAGES: DemoMessage[] = [
     `,
     sender: DEMO_SENDERS[0], // Alice Johnson
     recipients: ["team@example.com", "bob@example.org"],
-    date: "2026-06-20T09:15:00Z", 
+    date: "2026-06-20T09:15:00Z",
     isRead: true,
     isStarred: false,
     labels: ["inbox", "work", "projects"],
     attachments: [DEMO_ATTACHMENTS[0]], // project-proposal.pdf
-    proofRecord: DEMO_PROOF_RECORDS[1]
+    proofRecord: DEMO_PROOF_RECORDS[1],
   },
-  
+
   {
     id: "msg-3",
-    threadId: "thread-3", 
+    threadId: "thread-3",
     subject: "Meeting Invitation: Project Kickoff",
     snippet: "You're invited to attend the project kickoff meeting next Thursday...",
     body: `
@@ -268,13 +275,13 @@ const DEMO_MESSAGES: DemoMessage[] = [
     labels: ["inbox", "meetings"],
     attachments: [],
     calendarEvent: DEMO_CALENDAR_EVENTS[0],
-    proofRecord: DEMO_PROOF_RECORDS[2]
+    proofRecord: DEMO_PROOF_RECORDS[2],
   },
-  
+
   {
     id: "msg-4",
     threadId: "thread-4",
-    subject: "Suspicious Activity Detected", 
+    subject: "Suspicious Activity Detected",
     snippet: "We've detected some unusual activity on your account. Please review...",
     body: `
       <p>Dear User,</p>
@@ -290,13 +297,13 @@ const DEMO_MESSAGES: DemoMessage[] = [
     sender: DEMO_SENDERS[4], // Eve Wilson (untrusted)
     recipients: ["demo@example.com"],
     date: "2026-06-20T11:20:00Z",
-    isRead: false, 
+    isRead: false,
     isStarred: false,
     labels: ["inbox", "security"],
     attachments: [],
-    proofRecord: DEMO_PROOF_RECORDS[3]
+    proofRecord: DEMO_PROOF_RECORDS[3],
   },
-  
+
   {
     id: "msg-5",
     threadId: "thread-5",
@@ -322,12 +329,12 @@ const DEMO_MESSAGES: DemoMessage[] = [
     isStarred: true,
     labels: ["inbox", "presentations"],
     attachments: [DEMO_ATTACHMENTS[1], DEMO_ATTACHMENTS[3]], // meeting-notes.docx, demo-screenshot.png
-    calendarEvent: DEMO_CALENDAR_EVENTS[1]
+    calendarEvent: DEMO_CALENDAR_EVENTS[1],
   },
-  
+
   {
     id: "msg-6",
-    threadId: "thread-6", 
+    threadId: "thread-6",
     subject: "Quarterly Report Ready for Review",
     snippet: "The Q2 quarterly report has been completed and is ready for your review...",
     body: `
@@ -355,7 +362,7 @@ const DEMO_MESSAGES: DemoMessage[] = [
     labels: ["inbox", "reports", "finance"],
     attachments: [DEMO_ATTACHMENTS[2]], // quarterly-report.xlsx
   },
-  
+
   {
     id: "msg-7",
     threadId: "thread-7",
@@ -382,11 +389,11 @@ const DEMO_MESSAGES: DemoMessage[] = [
     recipients: ["demo@example.com"],
     date: "2026-06-20T14:15:00Z",
     isRead: true,
-    isStarred: false, 
+    isStarred: false,
     labels: ["inbox", "support"],
     attachments: [],
   },
-  
+
   {
     id: "msg-8",
     threadId: "thread-8",
@@ -416,9 +423,9 @@ const DEMO_MESSAGES: DemoMessage[] = [
     isStarred: false,
     labels: ["inbox", "meetings", "team"],
     attachments: [],
-    calendarEvent: DEMO_CALENDAR_EVENTS[2]
+    calendarEvent: DEMO_CALENDAR_EVENTS[2],
   },
-  
+
   // Archived message
   {
     id: "msg-9",
@@ -443,10 +450,10 @@ const DEMO_MESSAGES: DemoMessage[] = [
     labels: ["archive", "completed"],
     attachments: [],
   },
-  
+
   // Trash message
   {
-    id: "msg-10", 
+    id: "msg-10",
     threadId: "thread-10",
     subject: "SPAM: Special Offer Just for You!",
     snippet: "Congratulations! You've been selected for a special offer...",
@@ -465,7 +472,7 @@ const DEMO_MESSAGES: DemoMessage[] = [
     isStarred: false,
     labels: ["trash", "spam"],
     attachments: [],
-  }
+  },
 ];
 
 /**
@@ -477,7 +484,7 @@ export function createDemoInboxData(): DemoDataset {
     name: "Demo Inbox Dataset",
     description: "Curated demo messages for inbox preview functionality",
     messages: DEMO_MESSAGES,
-    senders: DEMO_SENDERS
+    senders: DEMO_SENDERS,
   };
 }
 
@@ -485,33 +492,33 @@ export function createDemoInboxData(): DemoDataset {
  * Get demo messages by specific criteria for testing different scenarios.
  */
 export function getDemoMessagesByLabel(label: string): DemoMessage[] {
-  return DEMO_MESSAGES.filter(message => message.labels.includes(label));
+  return DEMO_MESSAGES.filter((message) => message.labels.includes(label));
 }
 
 /**
  * Get unread demo messages.
  */
 export function getUnreadDemoMessages(): DemoMessage[] {
-  return DEMO_MESSAGES.filter(message => !message.isRead);
+  return DEMO_MESSAGES.filter((message) => !message.isRead);
 }
 
 /**
  * Get starred demo messages.
  */
 export function getStarredDemoMessages(): DemoMessage[] {
-  return DEMO_MESSAGES.filter(message => message.isStarred);
+  return DEMO_MESSAGES.filter((message) => message.isStarred);
 }
 
 /**
  * Get demo messages with attachments.
  */
 export function getDemoMessagesWithAttachments(): DemoMessage[] {
-  return DEMO_MESSAGES.filter(message => message.attachments.length > 0);
+  return DEMO_MESSAGES.filter((message) => message.attachments.length > 0);
 }
 
 /**
  * Get demo messages with calendar events.
  */
 export function getDemoMessagesWithEvents(): DemoMessage[] {
-  return DEMO_MESSAGES.filter(message => message.calendarEvent);
+  return DEMO_MESSAGES.filter((message) => message.calendarEvent);
 }

--- a/src/features/demo-admin-dashboard/helpers/demoDataValidator.ts
+++ b/src/features/demo-admin-dashboard/helpers/demoDataValidator.ts
@@ -2,7 +2,7 @@ import type { DemoMessage, DemoDataset, DemoSender } from "../types/dataset";
 
 /**
  * Validation helpers for demo inbox data to ensure safety and compliance.
- * 
+ *
  * All demo data must be fake, deterministic, and safe for public repository review.
  * These validators help ensure no real PII, secrets, or unsafe content is included.
  */
@@ -10,11 +10,7 @@ import type { DemoMessage, DemoDataset, DemoSender } from "../types/dataset";
 /**
  * Safe email domains allowed in demo data.
  */
-const SAFE_EMAIL_DOMAINS = [
-  "@example.com",
-  "@example.org", 
-  ".stealth.demo"
-];
+const SAFE_EMAIL_DOMAINS = ["@example.com", "@example.org", ".stealth.demo"];
 
 /**
  * Patterns that might indicate real PII or sensitive data.
@@ -24,20 +20,20 @@ const UNSAFE_PATTERNS = [
   /\b\d{3}-\d{3}-\d{4}\b/,
   /\(\d{3}\)\s?\d{3}-\d{4}/,
   /\+\d{1,3}\s?\d{3,4}\s?\d{3,4}\s?\d{3,4}/,
-  
+
   // Social Security Numbers
   /\b\d{3}-\d{2}-\d{4}\b/,
-  
+
   // Credit card numbers
   /\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/,
-  
+
   // IP addresses (might be internal/sensitive)
   /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
-  
+
   // API keys or tokens (basic patterns)
   /[a-zA-Z0-9]{32,}/,
   /(api|token|key)[\s:=]+[a-zA-Z0-9]{16,}/i,
-  
+
   // Real-looking email domains
   /@gmail\.com/i,
   /@yahoo\.com/i,
@@ -63,7 +59,7 @@ export interface ValidationResult {
  * Validates that an email address uses only safe demo domains.
  */
 export function validateSafeEmailAddress(email: string): boolean {
-  return SAFE_EMAIL_DOMAINS.some(domain => email.endsWith(domain));
+  return SAFE_EMAIL_DOMAINS.some((domain) => email.endsWith(domain));
 }
 
 /**
@@ -71,17 +67,17 @@ export function validateSafeEmailAddress(email: string): boolean {
  */
 export function validateTextContent(text: string): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  
+
   for (const pattern of UNSAFE_PATTERNS) {
     if (pattern.test(text)) {
       issues.push({
         severity: "warning",
         message: `Text content matches potentially unsafe pattern: ${pattern.source}`,
-        field: "content"
+        field: "content",
       });
     }
   }
-  
+
   return issues;
 }
 
@@ -90,29 +86,29 @@ export function validateTextContent(text: string): ValidationIssue[] {
  */
 export function validateDemoSender(sender: DemoSender): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  
+
   // Validate email address uses safe domains
   if (!validateSafeEmailAddress(sender.address)) {
     issues.push({
       severity: "error",
       message: `Sender email "${sender.address}" does not use a safe demo domain`,
       field: "address",
-      senderId: sender.address
+      senderId: sender.address,
     });
   }
-  
+
   // Validate sender name doesn't contain unsafe patterns
   if (sender.name) {
     const nameIssues = validateTextContent(sender.name);
-    nameIssues.forEach(issue => {
+    nameIssues.forEach((issue) => {
       issues.push({
         ...issue,
         field: "name",
-        senderId: sender.address
+        senderId: sender.address,
       });
     });
   }
-  
+
   return issues;
 }
 
@@ -121,16 +117,16 @@ export function validateDemoSender(sender: DemoSender): ValidationIssue[] {
  */
 export function validateDemoMessage(message: DemoMessage): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
-  
+
   // Validate sender
   const senderIssues = validateDemoSender(message.sender);
-  senderIssues.forEach(issue => {
+  senderIssues.forEach((issue) => {
     issues.push({
       ...issue,
-      messageId: message.id
+      messageId: message.id,
     });
   });
-  
+
   // Validate recipients use safe domains
   message.recipients.forEach((recipient, index) => {
     if (!validateSafeEmailAddress(recipient)) {
@@ -138,29 +134,29 @@ export function validateDemoMessage(message: DemoMessage): ValidationIssue[] {
         severity: "error",
         message: `Recipient email "${recipient}" does not use a safe demo domain`,
         field: `recipients[${index}]`,
-        messageId: message.id
+        messageId: message.id,
       });
     }
   });
-  
+
   // Validate text content
   const textFields = [
     { name: "subject", value: message.subject },
     { name: "snippet", value: message.snippet },
-    { name: "body", value: message.body }
+    { name: "body", value: message.body },
   ];
-  
-  textFields.forEach(field => {
+
+  textFields.forEach((field) => {
     const contentIssues = validateTextContent(field.value);
-    contentIssues.forEach(issue => {
+    contentIssues.forEach((issue) => {
       issues.push({
         ...issue,
         field: field.name,
-        messageId: message.id
+        messageId: message.id,
       });
     });
   });
-  
+
   // Validate calendar event attendees
   if (message.calendarEvent) {
     message.calendarEvent.attendees.forEach((attendee, index) => {
@@ -169,12 +165,12 @@ export function validateDemoMessage(message: DemoMessage): ValidationIssue[] {
           severity: "error",
           message: `Calendar attendee "${attendee}" does not use a safe demo domain`,
           field: `calendarEvent.attendees[${index}]`,
-          messageId: message.id
+          messageId: message.id,
         });
       }
     });
   }
-  
+
   // Validate attachment URLs are safe demo paths
   message.attachments.forEach((attachment, index) => {
     if (!attachment.url.startsWith("/demo/")) {
@@ -182,11 +178,11 @@ export function validateDemoMessage(message: DemoMessage): ValidationIssue[] {
         severity: "warning",
         message: `Attachment URL "${attachment.url}" should use demo path prefix`,
         field: `attachments[${index}].url`,
-        messageId: message.id
+        messageId: message.id,
       });
     }
   });
-  
+
   return issues;
 }
 
@@ -195,37 +191,37 @@ export function validateDemoMessage(message: DemoMessage): ValidationIssue[] {
  */
 export function validateDemoDataset(dataset: DemoDataset): ValidationResult {
   const issues: ValidationIssue[] = [];
-  
+
   // Validate all messages
-  dataset.messages.forEach(message => {
+  dataset.messages.forEach((message) => {
     const messageIssues = validateDemoMessage(message);
     issues.push(...messageIssues);
   });
-  
+
   // Validate all senders (if provided separately)
   if (dataset.senders) {
-    dataset.senders.forEach(sender => {
+    dataset.senders.forEach((sender) => {
       const senderIssues = validateDemoSender(sender);
       issues.push(...senderIssues);
     });
   }
-  
+
   // Check for deterministic data (no random values)
-  const hasRandomLookingIds = dataset.messages.some(message => 
-    /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i.test(message.id)
+  const hasRandomLookingIds = dataset.messages.some((message) =>
+    /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i.test(message.id),
   );
-  
+
   if (hasRandomLookingIds) {
     issues.push({
-      severity: "warning", 
+      severity: "warning",
       message: "Dataset contains UUID-like IDs that may not be deterministic",
-      field: "messages.id"
+      field: "messages.id",
     });
   }
-  
+
   return {
-    isValid: issues.filter(issue => issue.severity === "error").length === 0,
-    issues
+    isValid: issues.filter((issue) => issue.severity === "error").length === 0,
+    issues,
   };
 }
 
@@ -234,37 +230,37 @@ export function validateDemoDataset(dataset: DemoDataset): ValidationResult {
  */
 export function generateComplianceReport(dataset: DemoDataset): string {
   const result = validateDemoDataset(dataset);
-  
+
   const report = [
     "# Demo Data Safety Compliance Report",
     "",
     `**Dataset:** ${dataset.name}`,
     `**Messages:** ${dataset.messages.length}`,
     `**Status:** ${result.isValid ? "✅ COMPLIANT" : "❌ NON-COMPLIANT"}`,
-    ""
+    "",
   ];
-  
+
   if (result.issues.length === 0) {
     report.push("No safety issues detected. All data meets compliance requirements.");
   } else {
-    const errors = result.issues.filter(issue => issue.severity === "error");
-    const warnings = result.issues.filter(issue => issue.severity === "warning");
-    
+    const errors = result.issues.filter((issue) => issue.severity === "error");
+    const warnings = result.issues.filter((issue) => issue.severity === "warning");
+
     if (errors.length > 0) {
       report.push("## ❌ Errors (must fix)");
       report.push("");
-      errors.forEach(error => {
+      errors.forEach((error) => {
         report.push(`- **${error.field || "general"}**: ${error.message}`);
         if (error.messageId) report.push(`  - Message ID: ${error.messageId}`);
         if (error.senderId) report.push(`  - Sender ID: ${error.senderId}`);
       });
       report.push("");
     }
-    
+
     if (warnings.length > 0) {
       report.push("## ⚠️ Warnings (should review)");
       report.push("");
-      warnings.forEach(warning => {
+      warnings.forEach((warning) => {
         report.push(`- **${warning.field || "general"}**: ${warning.message}`);
         if (warning.messageId) report.push(`  - Message ID: ${warning.messageId}`);
         if (warning.senderId) report.push(`  - Sender ID: ${warning.senderId}`);
@@ -272,17 +268,19 @@ export function generateComplianceReport(dataset: DemoDataset): string {
       report.push("");
     }
   }
-  
+
   report.push("## Compliance Checklist");
   report.push("");
-  report.push("- ✅ Email addresses use safe demo domains (@example.com, @example.org, *.stealth.demo)");
+  report.push(
+    "- ✅ Email addresses use safe demo domains (@example.com, @example.org, *.stealth.demo)",
+  );
   report.push("- ✅ No real PII (phone numbers, SSNs, credit cards)");
   report.push("- ✅ No real API keys or tokens");
   report.push("- ✅ No internal/sensitive IP addresses");
   report.push("- ✅ Attachment URLs use safe demo paths");
   report.push("- ✅ Calendar attendees use safe domains");
   report.push("- ✅ All content safe for public repository review");
-  
+
   return report.join("\n");
 }
 
@@ -291,12 +289,12 @@ export function generateComplianceReport(dataset: DemoDataset): string {
  */
 export function assertDemoDataSafety(dataset: DemoDataset): void {
   const result = validateDemoDataset(dataset);
-  
+
   if (!result.isValid) {
-    const errors = result.issues.filter(issue => issue.severity === "error");
+    const errors = result.issues.filter((issue) => issue.severity === "error");
     throw new Error(
       `Demo data validation failed with ${errors.length} error(s):\n` +
-      errors.map(error => `- ${error.message}`).join("\n")
+        errors.map((error) => `- ${error.message}`).join("\n"),
     );
   }
 }

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -534,7 +534,7 @@ export type { DemoScenario, ScenarioLoadMode, ScenarioRegistry } from "./types/s
 
 // Demo Inbox Preview Components (issue #24): folder-local preview without live integration
 export { DemoInboxPreview } from "./components/DemoInboxPreview";
-export { DemoInboxList } from "./components/DemoInboxList";  
+export { DemoInboxList } from "./components/DemoInboxList";
 export { DemoMailReader } from "./components/DemoMailReader";
 
 // Demo Inbox Data Fixtures (issue #24): safe demo data for inbox preview


### PR DESCRIPTION
## Summary
Interaction-state polish for the primary Demo Admin Dashboard surface (issue #941). Tightens focus/active states and icon-only labels using existing tokens only — no behavior, copy, or layout change.

Closes #941

## Changes (`src/features/demo-admin-dashboard/DemoAdminDashboard.tsx`)
- **Visible focus** — added the existing `glow-ring` focus token to every interactive control on the shell (scenario-preset cards, section nav tabs, the inspector `X` close buttons, and the "Close Inspector" buttons). These had no visible keyboard-focus state before.
- **Pressed feedback** — added `active:scale` to those controls, matching the app's existing tap-scale interaction idiom.
- **Accessible names** — gave the two icon-only inspector close buttons `aria-label`s ("Close relay node inspector" / "Close ledger proof inspector").

No new styling tokens; reuses `glow-ring` (the app-wide focus utility) and Tailwind `active:`/`hover:` variants.


