### PR TITLE
test(policy-editor): cover sender-admission simulation logic

### DIFF
--- a/src/routes/policy-editor/route.tsx
+++ b/src/routes/policy-editor/route.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Surface, ActionButton, useFeedback } from "@/features/design-system";
 import { Check, X, Shield, ShieldAlert, Code } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { simulateSenderAdmission } from "./simulate-sender";
 
 export const Route = createFileRoute("/policy-editor")({
   component: PolicyEditorPage,
@@ -16,29 +17,6 @@ function PolicyEditorPage() {
   const [apiError, setApiError] = useState<string | null>(null);
 
   const { notify } = useFeedback();
-
-  const simulateSender = (type: "trusted" | "blocked" | "verified" | "unverified") => {
-    if (type === "trusted") {
-      return { allowed: true, reason: "Sender is explicitly trusted in contact list." };
-    }
-    if (type === "blocked") {
-      return { allowed: false, reason: "Sender is explicitly blocked." };
-    }
-
-    if (!allowUnknown) {
-      return { allowed: false, reason: "Unknown senders are disabled completely." };
-    }
-    if (requireVerified && type === "unverified") {
-      return { allowed: false, reason: "Sender lacks verified cryptographic identity." };
-    }
-    if (minimumPostage > 0) {
-      return {
-        allowed: true,
-        reason: `Allowed if sender attaches >= ${minimumPostage.toFixed(3)} XLM postage.`,
-      };
-    }
-    return { allowed: true, reason: "Allowed freely without restrictions." };
-  };
 
   const payload = {
     allowUnknown,
@@ -173,7 +151,10 @@ function PolicyEditorPage() {
               </h2>
               <div className="space-y-3">
                 {(["trusted", "blocked", "verified", "unverified"] as const).map((type) => {
-                  const result = simulateSender(type);
+                  const result = simulateSenderAdmission(
+                    { allowUnknown, requireVerified, minimumPostage },
+                    type,
+                  );
                   return (
                     <div
                       key={type}

--- a/src/routes/policy-editor/simulate-sender.ts
+++ b/src/routes/policy-editor/simulate-sender.ts
@@ -1,0 +1,45 @@
+export type SimulatedSenderType = "trusted" | "blocked" | "verified" | "unverified";
+
+export type PolicyControls = {
+  allowUnknown: boolean;
+  requireVerified: boolean;
+  /** Minimum postage in XLM. */
+  minimumPostage: number;
+};
+
+export type SenderAdmission = {
+  allowed: boolean;
+  reason: string;
+};
+
+/**
+ * Pure preview of how the current draft policy would treat a representative
+ * sender, powering the Policy Editor's live simulator. This is an illustrative
+ * approximation for the editor UI, not the authoritative server-side admission
+ * decision. Extracted from the route so the admission logic can be regression
+ * tested without rendering the page.
+ */
+export function simulateSenderAdmission(
+  controls: PolicyControls,
+  type: SimulatedSenderType,
+): SenderAdmission {
+  if (type === "trusted") {
+    return { allowed: true, reason: "Sender is explicitly trusted in contact list." };
+  }
+  if (type === "blocked") {
+    return { allowed: false, reason: "Sender is explicitly blocked." };
+  }
+  if (!controls.allowUnknown) {
+    return { allowed: false, reason: "Unknown senders are disabled completely." };
+  }
+  if (controls.requireVerified && type === "unverified") {
+    return { allowed: false, reason: "Sender lacks verified cryptographic identity." };
+  }
+  if (controls.minimumPostage > 0) {
+    return {
+      allowed: true,
+      reason: `Allowed if sender attaches >= ${controls.minimumPostage.toFixed(3)} XLM postage.`,
+    };
+  }
+  return { allowed: true, reason: "Allowed freely without restrictions." };
+}

--- a/tests/unit/policy-editor/simulate-sender.test.ts
+++ b/tests/unit/policy-editor/simulate-sender.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  simulateSenderAdmission,
+  type PolicyControls,
+} from "../../../src/routes/policy-editor/simulate-sender";
+
+// A permissive baseline: unknown senders allowed, no verification, no postage.
+const openPolicy: PolicyControls = {
+  allowUnknown: true,
+  requireVerified: false,
+  minimumPostage: 0,
+};
+
+describe("policy-editor/simulateSenderAdmission", () => {
+  it("always allows an explicitly trusted sender (success path)", () => {
+    // Trusted wins even under the strictest policy.
+    const strict: PolicyControls = {
+      allowUnknown: false,
+      requireVerified: true,
+      minimumPostage: 1,
+    };
+    const result = simulateSenderAdmission(strict, "trusted");
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toMatch(/trusted/i);
+  });
+
+  it("always blocks an explicitly blocked sender (failure path)", () => {
+    // Blocked loses even under the most permissive policy.
+    const result = simulateSenderAdmission(openPolicy, "blocked");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/blocked/i);
+  });
+
+  it("rejects unknown senders entirely when allowUnknown is off (edge case)", () => {
+    const closed: PolicyControls = { ...openPolicy, allowUnknown: false };
+    for (const type of ["verified", "unverified"] as const) {
+      const result = simulateSenderAdmission(closed, type);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toMatch(/disabled/i);
+    }
+  });
+
+  it("rejects only unverified senders when verification is required", () => {
+    const policy: PolicyControls = { ...openPolicy, requireVerified: true };
+    expect(simulateSenderAdmission(policy, "unverified").allowed).toBe(false);
+    expect(simulateSenderAdmission(policy, "unverified").reason).toMatch(/verified/i);
+    // A verified sender still gets through under the same policy.
+    expect(simulateSenderAdmission(policy, "verified").allowed).toBe(true);
+  });
+
+  it("gates allowed unknown senders behind the postage floor when set", () => {
+    const policy: PolicyControls = { ...openPolicy, minimumPostage: 0.05 };
+    const result = simulateSenderAdmission(policy, "verified");
+    expect(result.allowed).toBe(true);
+    // The reason surfaces the exact postage floor, formatted to 3 decimals.
+    expect(result.reason).toContain("0.050 XLM");
+  });
+
+  it("allows unknown senders freely when no postage floor is set", () => {
+    const result = simulateSenderAdmission(openPolicy, "unverified");
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toMatch(/freely/i);
+  });
+
+  it("blocks unverified senders regardless of postage when verification is required", () => {
+    // requireVerified takes precedence over the postage allowance.
+    const policy: PolicyControls = {
+      allowUnknown: true,
+      requireVerified: true,
+      minimumPostage: 0.5,
+    };
+    expect(simulateSenderAdmission(policy, "unverified").allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused regression coverage for the Policy Editor's sender-admission logic (issue #939) — the rules that decide whether a representative sender would reach the inbox. Extracts the previously-inline simulator into a pure, testable helper; route behavior is unchanged.

Closes #939

## Gap addressed
The shared `mailbox-policy-templates.ts` helpers are already covered (`tests/unit/settings/mailbox-policy-templates.test.ts`) and the Settings policy flow has e2e (`tests/e2e/policy-editing.spec.ts`). The one untested piece was the standalone `/policy-editor` route's `simulateSender` — the admission-preview logic — which lived inline in the component.

## Changes
- **`src/routes/policy-editor/simulate-sender.ts`** (new) — pure `simulateSenderAdmission(controls, type)` extracted from the route (a small, justified shared helper). It's an illustrative preview, not the authoritative server-side decision.
- **`src/routes/policy-editor/route.tsx`** — imports the helper; rendering/behavior unchanged.
- **`tests/unit/policy-editor/simulate-sender.test.ts`** — 7 cases:
  - success: trusted sender always allowed (even under the strictest policy)
  - failure: blocked sender always denied (even under the most permissive policy)
  - edges: unknown senders disabled, require-verified rejecting only `unverified`, the postage floor (asserts the formatted reason), free-allow when no floor, and require-verified taking precedence over postage.
.
