### PR TITLE
Add email-to-todo converter UI, tests, and docs

### DIFF
--- a/tools/v1/individual/email-to-todo-converter/docs/ui.md
+++ b/tools/v1/individual/email-to-todo-converter/docs/ui.md
@@ -1,0 +1,60 @@
+# Email-to-Todo Converter -- UI and accessibility
+
+This document describes the folder-local user interface for the Email-to-Todo
+Converter tool. The UI is isolated to this tool folder and is not mounted into
+the main application, routing, navigation, or design system.
+
+## Components
+
+- `ui/EmailToTodoConverter.tsx` -- the primary, self-contained workflow
+  component. It renders the selected email, a convert action, and the resulting
+  task draft for review.
+- `ui/emailToTodoView.ts` -- pure, deterministic view-model helpers used by the
+  component (priority detection, due-date suggestion, draft building, status
+  messaging). Keeping logic here lets the UI stay thin and testable without a
+  DOM.
+- `ui/index.ts` -- the local public surface for the tool's UI.
+
+## Workflow and states
+
+The component always reflects one of four explicit states:
+
+- Empty -- no email is selected. The convert action is disabled and guidance is
+  shown.
+- Loading -- a conversion is in flight. The container sets `aria-busy` and a
+  polite status message is announced. Conversion is deterministic today, but the
+  loading affordance is kept for the spec's future async extraction option.
+- Success -- a task draft is shown for review (title, notes, suggested due date,
+  suggested priority). Nothing is saved or synced; user review is preserved.
+- Error -- conversion could not run. An alert is shown and focus moves to it.
+
+## Accessibility decisions
+
+- Labeling -- the section is labelled by its heading via `aria-labelledby`, and
+  every field uses an explicit `label` bound with `htmlFor`.
+- Live regions -- the status line uses `role=status` with `aria-live=polite` so
+  state changes are announced without stealing focus. Errors use `role=alert`.
+- Focus management -- when a draft appears, focus moves to the draft heading;
+  when an error appears, focus moves to the alert. Both targets are
+  programmatically focusable but kept out of the normal tab order.
+- Keyboard support -- all controls are native `button`, `input`, and `textarea`
+  elements, so they are reachable and operable with the keyboard by default.
+- Convert button state -- it is disabled when there is no convertible email or
+  while a conversion is in flight, and it is described by the status line via
+  `aria-describedby`.
+
+## Visual style
+
+Styling is expressed only through local, namespaced class names under the
+`email-to-todo-converter` prefix (for example `email-to-todo-converter__title`).
+No shared design-system tokens, themes, or global styles are modified. A host
+application that later integrates this tool can map these class names to its own
+styles. Until an explicit integration issue exists, the component ships without
+global styles so it stays isolated.
+
+## Isolation
+
+This UI imports nothing from the main inbox, routing, wallet, Stellar, database,
+or design-system layers. It is not registered in any route or navigation
+surface, and it is intended to be reviewed as a self-contained mini-product
+change.

--- a/tools/v1/individual/email-to-todo-converter/tests/emailToTodoView.test.ts
+++ b/tools/v1/individual/email-to-todo-converter/tests/emailToTodoView.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTaskDraft,
+  describeConverter,
+  detectPriority,
+  hasConvertibleContent,
+  resolveStatusMessage,
+  suggestDueDate,
+  DEFAULT_DUE_DATE_OFFSET_DAYS,
+  HIGH_PRIORITY_DUE_DATE_OFFSET_DAYS,
+  type NormalizedEmail,
+} from "../ui/emailToTodoView";
+
+function baseEmail(overrides: Partial<NormalizedEmail> = {}): NormalizedEmail {
+  return {
+    subject: "Project kickoff notes",
+    sender: "alex@example.com",
+    receivedAt: "2026-01-10T09:00:00.000Z",
+    body: "Please review the attached plan and reply with feedback.",
+    labels: ["work"],
+    ...overrides,
+  };
+}
+
+describe("detectPriority", () => {
+  it("returns high when an urgent keyword is present", () => {
+    expect(detectPriority(baseEmail({ subject: "URGENT: sign the contract" }))).toBe("high");
+  });
+
+  it("returns medium when a soft keyword is present", () => {
+    expect(detectPriority(baseEmail({ subject: "Reminder: timesheet" }))).toBe("medium");
+  });
+
+  it("returns low when no priority keywords are present", () => {
+    expect(detectPriority(baseEmail({ subject: "Lunch menu", body: "Soup and salad." }))).toBe(
+      "low",
+    );
+  });
+});
+
+describe("suggestDueDate", () => {
+  it("uses the high-priority offset for high-priority emails", () => {
+    expect(suggestDueDate(baseEmail(), "high")).toBe("2026-01-11");
+    expect(HIGH_PRIORITY_DUE_DATE_OFFSET_DAYS).toBe(1);
+  });
+
+  it("uses the default offset for lower priorities", () => {
+    expect(suggestDueDate(baseEmail(), "low")).toBe("2026-01-13");
+    expect(DEFAULT_DUE_DATE_OFFSET_DAYS).toBe(3);
+  });
+
+  it("returns an empty string for an unparseable timestamp", () => {
+    expect(suggestDueDate(baseEmail({ receivedAt: "not-a-date" }), "low")).toBe("");
+  });
+});
+
+describe("buildTaskDraft", () => {
+  it("builds a deterministic draft from a normalized email", () => {
+    const email = baseEmail();
+    expect(buildTaskDraft(email)).toEqual(buildTaskDraft(email));
+    const draft = buildTaskDraft(email);
+    expect(draft.title).toBe("Project kickoff notes");
+    expect(draft.sourceSender).toBe("alex@example.com");
+    expect(draft.suggestedPriority).toBe("low");
+  });
+
+  it("falls back to the first body line when the subject is empty", () => {
+    const draft = buildTaskDraft(
+      baseEmail({ subject: "   ", body: "Call the bank about the invoice." }),
+    );
+    expect(draft.title).toBe("Call the bank about the invoice.");
+  });
+
+  it("falls back to a placeholder when subject and body are empty", () => {
+    expect(buildTaskDraft(baseEmail({ subject: "", body: "" })).title).toBe("Untitled task");
+  });
+});
+
+describe("hasConvertibleContent", () => {
+  it("is false for null", () => {
+    expect(hasConvertibleContent(null)).toBe(false);
+  });
+
+  it("is false when subject and body are blank", () => {
+    expect(hasConvertibleContent(baseEmail({ subject: "  ", body: "  " }))).toBe(false);
+  });
+
+  it("is true when there is a subject", () => {
+    expect(hasConvertibleContent(baseEmail({ body: "" }))).toBe(true);
+  });
+});
+
+describe("describeConverter", () => {
+  it("shows the empty state when there is no email", () => {
+    const view = describeConverter({ status: "empty", hasEmail: false });
+    expect(view.showEmptyState).toBe(true);
+    expect(view.canConvert).toBe(false);
+  });
+
+  it("allows converting when an email is ready", () => {
+    const view = describeConverter({ status: "ready", hasEmail: true });
+    expect(view.canConvert).toBe(true);
+    expect(view.isBusy).toBe(false);
+  });
+
+  it("marks busy while loading", () => {
+    const view = describeConverter({ status: "loading", hasEmail: true });
+    expect(view.isBusy).toBe(true);
+    expect(view.canConvert).toBe(false);
+  });
+
+  it("shows the draft on success and the error on failure", () => {
+    expect(describeConverter({ status: "success", hasEmail: true }).showDraft).toBe(true);
+    expect(describeConverter({ status: "error", hasEmail: true }).showError).toBe(true);
+  });
+});
+
+describe("resolveStatusMessage", () => {
+  it("returns a distinct message for each status", () => {
+    const statuses = ["empty", "ready", "loading", "success", "error"] as const;
+    const messages = statuses.map((status) => resolveStatusMessage(status));
+    expect(new Set(messages).size).toBe(statuses.length);
+  });
+});

--- a/tools/v1/individual/email-to-todo-converter/ui/EmailToTodoConverter.tsx
+++ b/tools/v1/individual/email-to-todo-converter/ui/EmailToTodoConverter.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import {
+  buildTaskDraft,
+  describeConverter,
+  hasConvertibleContent,
+  type ConverterStatus,
+  type EmailToTodoConverterProps,
+  type TaskDraft,
+} from "./emailToTodoView";
+
+interface ConverterState {
+  status: ConverterStatus;
+  draft: TaskDraft | null;
+  errorMessage: string;
+}
+
+type ConverterAction =
+  | { type: "reset"; hasEmail: boolean }
+  | { type: "convert-start" }
+  | { type: "convert-success"; draft: TaskDraft }
+  | { type: "convert-error"; message: string };
+
+function converterReducer(state: ConverterState, action: ConverterAction): ConverterState {
+  switch (action.type) {
+    case "reset":
+      return { status: action.hasEmail ? "ready" : "empty", draft: null, errorMessage: "" };
+    case "convert-start":
+      return { status: "loading", draft: null, errorMessage: "" };
+    case "convert-success":
+      return { status: "success", draft: action.draft, errorMessage: "" };
+    case "convert-error":
+      return { status: "error", draft: null, errorMessage: action.message };
+    default:
+      return state;
+  }
+}
+
+export function EmailToTodoConverter(props: EmailToTodoConverterProps) {
+  const { email, onSaveDraft, idPrefix = "email-to-todo" } = props;
+  const hasEmail = hasConvertibleContent(email);
+
+  const [state, dispatch] = useReducer(converterReducer, {
+    status: hasConvertibleContent(email) ? "ready" : "empty",
+    draft: null,
+    errorMessage: "",
+  });
+
+  const draftHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const errorRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset the converter whenever a different email is selected.
+  useEffect(() => {
+    dispatch({ type: "reset", hasEmail: hasConvertibleContent(email) });
+  }, [email]);
+
+  // Move focus to the most relevant region after a state change.
+  useEffect(() => {
+    if (state.status === "success") {
+      draftHeadingRef.current?.focus();
+    } else if (state.status === "error") {
+      errorRef.current?.focus();
+    }
+  }, [state.status]);
+
+  const handleConvert = useCallback(() => {
+    if (!hasConvertibleContent(email)) {
+      dispatch({ type: "convert-error", message: "Select an email with a subject or body first." });
+      return;
+    }
+    dispatch({ type: "convert-start" });
+    try {
+      dispatch({ type: "convert-success", draft: buildTaskDraft(email) });
+    } catch {
+      dispatch({ type: "convert-error", message: "Conversion failed. Please try another email." });
+    }
+  }, [email]);
+
+  const handleSave = useCallback(() => {
+    if (state.draft && onSaveDraft) {
+      onSaveDraft(state.draft);
+    }
+  }, [state.draft, onSaveDraft]);
+
+  const view = describeConverter({ status: state.status, hasEmail });
+  const statusRegionId = idPrefix + "-status";
+
+  return (
+    <section
+      className="email-to-todo-converter"
+      aria-labelledby={idPrefix + "-heading"}
+      aria-busy={view.isBusy}
+    >
+      <h2 id={idPrefix + "-heading"} className="email-to-todo-converter__title">
+        Email to task converter
+      </h2>
+
+      <p
+        id={statusRegionId}
+        className="email-to-todo-converter__status"
+        role="status"
+        aria-live="polite"
+      >
+        {view.statusMessage}
+      </p>
+
+      {email ? (
+        <dl className="email-to-todo-converter__source">
+          <div className="email-to-todo-converter__source-row">
+            <dt>Subject</dt>
+            <dd>{email.subject || "(no subject)"}</dd>
+          </div>
+          <div className="email-to-todo-converter__source-row">
+            <dt>From</dt>
+            <dd>{email.sender || "(unknown sender)"}</dd>
+          </div>
+          <div className="email-to-todo-converter__source-row">
+            <dt>Received</dt>
+            <dd>{email.receivedAt || "(unknown)"}</dd>
+          </div>
+        </dl>
+      ) : null}
+
+      {view.showEmptyState ? (
+        <p className="email-to-todo-converter__empty">
+          No email is selected yet. Choose an email to begin.
+        </p>
+      ) : null}
+
+      <div className="email-to-todo-converter__actions">
+        <button
+          type="button"
+          className="email-to-todo-converter__convert"
+          onClick={handleConvert}
+          disabled={!view.canConvert}
+          aria-describedby={statusRegionId}
+        >
+          Convert to task draft
+        </button>
+      </div>
+
+      {view.isBusy ? (
+        <p className="email-to-todo-converter__loading" role="status" aria-live="polite">
+          Converting...
+        </p>
+      ) : null}
+
+      {view.showError ? (
+        <div className="email-to-todo-converter__error" role="alert" tabIndex={-1} ref={errorRef}>
+          {state.errorMessage}
+        </div>
+      ) : null}
+
+      {view.showDraft && state.draft ? (
+        <article
+          className="email-to-todo-converter__draft"
+          aria-labelledby={idPrefix + "-draft-heading"}
+        >
+          <h3
+            id={idPrefix + "-draft-heading"}
+            className="email-to-todo-converter__draft-heading"
+            tabIndex={-1}
+            ref={draftHeadingRef}
+          >
+            Review task draft
+          </h3>
+
+          <div className="email-to-todo-converter__field">
+            <label htmlFor={idPrefix + "-title"}>Title</label>
+            <input id={idPrefix + "-title"} type="text" defaultValue={state.draft.title} readOnly />
+          </div>
+
+          <div className="email-to-todo-converter__field">
+            <label htmlFor={idPrefix + "-notes"}>Notes</label>
+            <textarea id={idPrefix + "-notes"} defaultValue={state.draft.notes} readOnly />
+          </div>
+
+          <div className="email-to-todo-converter__field">
+            <label htmlFor={idPrefix + "-due"}>Suggested due date</label>
+            <input
+              id={idPrefix + "-due"}
+              type="text"
+              defaultValue={state.draft.suggestedDueDate}
+              readOnly
+            />
+          </div>
+
+          <div className="email-to-todo-converter__field">
+            <label htmlFor={idPrefix + "-priority"}>Suggested priority</label>
+            <input
+              id={idPrefix + "-priority"}
+              type="text"
+              defaultValue={state.draft.suggestedPriority}
+              readOnly
+            />
+          </div>
+
+          <p className="email-to-todo-converter__hint">
+            Review the draft above. Saving is intentionally not wired up in this isolated tool.
+          </p>
+
+          <div className="email-to-todo-converter__actions">
+            <button
+              type="button"
+              className="email-to-todo-converter__save"
+              onClick={handleSave}
+              disabled={!onSaveDraft}
+            >
+              Save task draft
+            </button>
+          </div>
+        </article>
+      ) : null}
+    </section>
+  );
+}

--- a/tools/v1/individual/email-to-todo-converter/ui/emailToTodoView.ts
+++ b/tools/v1/individual/email-to-todo-converter/ui/emailToTodoView.ts
@@ -1,0 +1,162 @@
+// Email-to-Todo Converter -- UI view-model and deterministic helpers.
+//
+// This module is intentionally self-contained and free of imports from the
+// main inbox, routing, wallet, Stellar, database, or design-system layers, as
+// required by the tool spec. Everything here is pure and deterministic so the
+// UI layer can stay thin and testable without a DOM.
+
+export type TaskPriority = "low" | "medium" | "high";
+
+export type ConverterStatus = "empty" | "ready" | "loading" | "success" | "error";
+
+export interface NormalizedEmail {
+  subject: string;
+  sender: string;
+  receivedAt: string; // ISO-8601 timestamp
+  body: string;
+  labels?: string[];
+}
+
+export interface TaskDraft {
+  title: string;
+  notes: string;
+  sourceSubject: string;
+  sourceSender: string;
+  sourceReceivedAt: string;
+  suggestedDueDate: string; // ISO-8601 date (YYYY-MM-DD)
+  suggestedPriority: TaskPriority;
+}
+
+export interface ConverterViewModel {
+  statusMessage: string;
+  isBusy: boolean;
+  showEmptyState: boolean;
+  showDraft: boolean;
+  showError: boolean;
+  canConvert: boolean;
+}
+
+export interface EmailToTodoConverterProps {
+  email: NormalizedEmail | null;
+  onSaveDraft?: (draft: TaskDraft) => void;
+  idPrefix?: string;
+}
+
+export const HIGH_PRIORITY_KEYWORDS = ["urgent", "asap", "immediately", "critical"];
+export const MEDIUM_PRIORITY_KEYWORDS = ["soon", "today", "reminder", "follow up", "follow-up"];
+
+export const DEFAULT_DUE_DATE_OFFSET_DAYS = 3;
+export const HIGH_PRIORITY_DUE_DATE_OFFSET_DAYS = 1;
+export const MAX_NOTES_LENGTH = 280;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function firstNonEmptyLine(body: string): string {
+  const lines = body.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return "";
+}
+
+export function detectPriority(email: NormalizedEmail): TaskPriority {
+  const haystack = (email.subject + " " + email.body).toLowerCase();
+  if (HIGH_PRIORITY_KEYWORDS.some((word) => haystack.includes(word))) {
+    return "high";
+  }
+  if (MEDIUM_PRIORITY_KEYWORDS.some((word) => haystack.includes(word))) {
+    return "medium";
+  }
+  return "low";
+}
+
+function addDays(isoTimestamp: string, days: number): string {
+  const parsed = new Date(isoTimestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return "";
+  }
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+export function suggestDueDate(email: NormalizedEmail, priority: TaskPriority): string {
+  const offset =
+    priority === "high" ? HIGH_PRIORITY_DUE_DATE_OFFSET_DAYS : DEFAULT_DUE_DATE_OFFSET_DAYS;
+  return addDays(email.receivedAt, offset);
+}
+
+export function buildTaskTitle(email: NormalizedEmail): string {
+  const subject = normalizeWhitespace(email.subject);
+  if (subject.length > 0) {
+    return subject;
+  }
+  const fallback = normalizeWhitespace(firstNonEmptyLine(email.body));
+  return fallback.length > 0 ? fallback : "Untitled task";
+}
+
+export function buildTaskNotes(email: NormalizedEmail): string {
+  const summary = normalizeWhitespace(firstNonEmptyLine(email.body));
+  if (summary.length <= MAX_NOTES_LENGTH) {
+    return summary;
+  }
+  return summary.slice(0, MAX_NOTES_LENGTH - 1).trimEnd() + "...";
+}
+
+export function buildTaskDraft(email: NormalizedEmail): TaskDraft {
+  const priority = detectPriority(email);
+  return {
+    title: buildTaskTitle(email),
+    notes: buildTaskNotes(email),
+    sourceSubject: normalizeWhitespace(email.subject),
+    sourceSender: normalizeWhitespace(email.sender),
+    sourceReceivedAt: email.receivedAt,
+    suggestedDueDate: suggestDueDate(email, priority),
+    suggestedPriority: priority,
+  };
+}
+
+export function hasConvertibleContent(email: NormalizedEmail | null): email is NormalizedEmail {
+  if (!email) {
+    return false;
+  }
+  return (
+    normalizeWhitespace(email.subject).length > 0 || normalizeWhitespace(email.body).length > 0
+  );
+}
+
+export function resolveStatusMessage(status: ConverterStatus): string {
+  switch (status) {
+    case "empty":
+      return "No email selected. Choose an email to convert into a task draft.";
+    case "ready":
+      return "Ready to convert the selected email into a task draft.";
+    case "loading":
+      return "Converting email into a task draft...";
+    case "success":
+      return "Task draft ready for review. Nothing has been saved yet.";
+    case "error":
+      return "The selected email could not be converted into a task draft.";
+    default:
+      return "";
+  }
+}
+
+export function describeConverter(args: {
+  status: ConverterStatus;
+  hasEmail: boolean;
+}): ConverterViewModel {
+  const { status, hasEmail } = args;
+  return {
+    statusMessage: resolveStatusMessage(status),
+    isBusy: status === "loading",
+    showEmptyState: status === "empty" || !hasEmail,
+    showDraft: status === "success",
+    showError: status === "error",
+    canConvert: hasEmail && status !== "loading",
+  };
+}

--- a/tools/v1/individual/email-to-todo-converter/ui/index.ts
+++ b/tools/v1/individual/email-to-todo-converter/ui/index.ts
@@ -1,0 +1,24 @@
+export { EmailToTodoConverter } from "./EmailToTodoConverter";
+export {
+  buildTaskDraft,
+  buildTaskNotes,
+  buildTaskTitle,
+  describeConverter,
+  detectPriority,
+  hasConvertibleContent,
+  resolveStatusMessage,
+  suggestDueDate,
+  DEFAULT_DUE_DATE_OFFSET_DAYS,
+  HIGH_PRIORITY_DUE_DATE_OFFSET_DAYS,
+  HIGH_PRIORITY_KEYWORDS,
+  MAX_NOTES_LENGTH,
+  MEDIUM_PRIORITY_KEYWORDS,
+} from "./emailToTodoView";
+export type {
+  ConverterStatus,
+  ConverterViewModel,
+  EmailToTodoConverterProps,
+  NormalizedEmail,
+  TaskDraft,
+  TaskPriority,
+} from "./emailToTodoView";


### PR DESCRIPTION
Implements the isolated UI, view-model helpers, tests, and docs for the email-to-todo converter. Closes #356