### PR TITLE
Add Follow-up Reminder core feature engine

### DIFF
--- a/tools/v1/individual/follow-up-reminder/docs/engine.md
+++ b/tools/v1/individual/follow-up-reminder/docs/engine.md
@@ -1,0 +1,79 @@
+# Follow-up Reminder -- core feature engine
+
+This document describes the folder-local core engine for the Follow-up Reminder
+tool. The engine is self-contained and is not wired into the main app, routing,
+inbox, wallet, Stellar core, database, or design system.
+
+## What the engine does
+
+`buildFollowUpReminder(input, options?)` turns one normalized email into a
+single reminder review model. It is the only behavior a future UI needs to call.
+The engine is pure and deterministic: the same input always yields the same
+output.
+
+## Inputs
+
+`NormalizedEmailInput`:
+
+- `messageId` -- synthetic source message id.
+- `subject` and `body` -- email text.
+- `senderAddress`, optional `senderName`.
+- `receivedAt` -- ISO-8601 timestamp, used as the base for relative dates.
+- optional `timeZone` -- IANA timezone for relative-date confirmation.
+- optional `threadHint` -- caller-supplied sender or thread hint.
+
+`BuildReminderOptions`:
+
+- `now` -- optional base timestamp override for relative-date resolution.
+- `existingReminders` -- known reminder keys, used to avoid duplicates.
+
+## Output
+
+`ReminderReviewModel` with `state`, `confidence`, `title`, `dueAt`,
+`sourceMessageId`, `signals`, and `warnings`.
+
+- `state` is `draft` for a suggested reminder, or `no_action` when nothing should
+  be suggested. Suggested reminders always start as `draft` until a user
+  confirms them; the engine never schedules or confirms.
+- `confidence` is `high`, `medium`, or `low`.
+- `dueAt` is an ISO date or datetime, or `null` when no clear date is available.
+
+## States, loading, and errors
+
+- The engine is synchronous and performs no IO, so it has no async loading state
+  of its own. A host UI owns any loading indicator while it gathers email input.
+- Errors are surfaced as data, not exceptions. Malformed or missing dates,
+  ambiguous dates, low-confidence contexts, and missing signals produce
+  `warnings` and a safe `no_action` or null `dueAt` result instead of throwing.
+- Ambiguous due dates always return a `draft` with a warning rather than a
+  scheduled reminder.
+
+## Signals
+
+- Explicit request terms (for example follow up, remind me, reply by, deadline).
+- Absolute dates and datetimes in ISO form (YYYY-MM-DD and YYYY-MM-DDTHH:mm).
+- Relative dates: tomorrow, next week, and in N days (digits or one through
+  ten), resolved from the base timestamp.
+- Sender or thread hints supplied by the caller.
+- Low-confidence contexts such as newsletters, receipts, and FYI-only messages.
+
+## Duplicate avoidance
+
+When `options.existingReminders` already contains the same `sourceMessageId` and
+`dueAt`, the engine returns `no_action` with a warning so duplicate reminders are
+not suggested.
+
+## Security and performance
+
+- No network calls, secrets, or production data are used.
+- The engine never sends email, creates calendar events, changes labels, marks
+  messages read, archives, or deletes messages.
+- Date and keyword scanning is bounded to the first 4000 characters so long
+  messages stay fast.
+- Fixtures use synthetic senders, message ids, and dates only.
+
+## API surface
+
+The tool's public surface is exported from `index.ts`: `buildFollowUpReminder`,
+`isReminderDuplicate`, `summarizeReminder`, the related types, and the synthetic
+`sampleEmails` fixtures.

--- a/tools/v1/individual/follow-up-reminder/index.ts
+++ b/tools/v1/individual/follow-up-reminder/index.ts
@@ -1,0 +1,21 @@
+export {
+  buildFollowUpReminder,
+  isReminderDuplicate,
+  summarizeReminder,
+  EXPLICIT_REQUEST_TERMS,
+  LOW_CONFIDENCE_TERMS,
+  MAX_SCAN_LENGTH,
+  MILLISECONDS_PER_DAY,
+  NUMBER_WORDS,
+} from "./services/followUpReminder";
+export type {
+  BuildReminderOptions,
+  ExistingReminderKey,
+  NormalizedEmailInput,
+  ReminderConfidence,
+  ReminderReviewModel,
+  ReminderSignal,
+  ReminderState,
+  SignalType,
+} from "./services/followUpReminder";
+export { sampleEmails, sampleEmailList } from "./services/fixtures";

--- a/tools/v1/individual/follow-up-reminder/services/fixtures.ts
+++ b/tools/v1/individual/follow-up-reminder/services/fixtures.ts
@@ -1,0 +1,56 @@
+import type { NormalizedEmailInput } from "./followUpReminder";
+
+// Synthetic fixtures only. No real senders, message ids, or data.
+export const sampleEmails: Record<string, NormalizedEmailInput> = {
+  explicitWithDate: {
+    messageId: "msg-1001",
+    subject: "Reply by 2026-02-10 about the contract",
+    body: "Please follow up and reply by 2026-02-10 with the signed contract.",
+    senderName: "Dana Vendor",
+    senderAddress: "dana@vendor.example",
+    receivedAt: "2026-02-01T09:00:00.000Z",
+    timeZone: "America/New_York",
+  },
+  relativeNextWeek: {
+    messageId: "msg-1002",
+    subject: "Check back next week",
+    body: "Let us reconnect next week to finalize the plan.",
+    senderName: "Sam Lead",
+    senderAddress: "sam@team.example",
+    receivedAt: "2026-02-01T09:00:00.000Z",
+    timeZone: "America/New_York",
+  },
+  ambiguousDates: {
+    messageId: "msg-1003",
+    subject: "Deadline questions",
+    body: "The deadline might be 2026-03-01 or 2026-03-15, please confirm.",
+    senderName: "Pat Client",
+    senderAddress: "pat@client.example",
+    receivedAt: "2026-02-20T09:00:00.000Z",
+  },
+  newsletter: {
+    messageId: "msg-1004",
+    subject: "Weekly newsletter: product updates",
+    body: "This is our FYI newsletter. To stop receiving it, unsubscribe here.",
+    senderName: "Updates",
+    senderAddress: "updates@news.example",
+    receivedAt: "2026-02-02T09:00:00.000Z",
+  },
+  noSignal: {
+    messageId: "msg-1005",
+    subject: "Photos from the trip",
+    body: "Sharing some pictures from our vacation. Hope you like them.",
+    senderName: "Jordan Friend",
+    senderAddress: "jordan@friend.example",
+    receivedAt: "2026-02-03T09:00:00.000Z",
+  },
+  explicitNoDate: {
+    messageId: "msg-1006",
+    subject: "Please follow up",
+    body: "Remind me to follow up on this when you can.",
+    senderAddress: "lee@team.example",
+    receivedAt: "2026-02-04T09:00:00.000Z",
+  },
+};
+
+export const sampleEmailList: NormalizedEmailInput[] = Object.values(sampleEmails);

--- a/tools/v1/individual/follow-up-reminder/services/followUpReminder.ts
+++ b/tools/v1/individual/follow-up-reminder/services/followUpReminder.ts
@@ -1,0 +1,320 @@
+// Follow-up Reminder -- core feature engine.
+//
+// Self-contained and deterministic. No imports from the main inbox, routing,
+// wallet, Stellar, database, or design-system layers, as required by the tool
+// spec. The engine performs no IO: it never sends email, touches the mailbox,
+// creates calendar events, or calls external services. It only turns a
+// normalized email into a single reminder review model.
+
+export type ReminderState = "draft" | "no_action";
+
+export type ReminderConfidence = "high" | "medium" | "low";
+
+export type SignalType =
+  | "explicit_request"
+  | "absolute_date"
+  | "relative_date"
+  | "sender_hint"
+  | "low_confidence_context";
+
+export interface ReminderSignal {
+  type: SignalType;
+  detail: string;
+}
+
+export interface NormalizedEmailInput {
+  messageId: string;
+  subject: string;
+  body: string;
+  senderAddress: string;
+  senderName?: string;
+  receivedAt: string; // ISO-8601 timestamp
+  timeZone?: string; // IANA timezone, optional
+  threadHint?: string;
+}
+
+export interface ReminderReviewModel {
+  state: ReminderState;
+  confidence: ReminderConfidence;
+  title: string;
+  dueAt: string | null; // ISO-8601 date or datetime; null when ambiguous or no action
+  sourceMessageId: string;
+  signals: ReminderSignal[];
+  warnings: string[];
+}
+
+export interface ExistingReminderKey {
+  sourceMessageId: string;
+  dueAt: string | null;
+}
+
+export interface BuildReminderOptions {
+  now?: string; // base timestamp for relative-date resolution; defaults to receivedAt
+  existingReminders?: ExistingReminderKey[];
+}
+
+export const EXPLICIT_REQUEST_TERMS = [
+  "follow up",
+  "follow-up",
+  "remind me",
+  "check back",
+  "reply by",
+  "respond by",
+  "due",
+  "deadline",
+  "waiting on response",
+  "waiting for response",
+];
+
+export const LOW_CONFIDENCE_TERMS = [
+  "newsletter",
+  "unsubscribe",
+  "receipt",
+  "order confirmation",
+  "do not reply",
+  "fyi",
+  "no action needed",
+  "no action required",
+];
+
+export const NUMBER_WORDS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+};
+
+export const MAX_SCAN_LENGTH = 4000;
+export const MILLISECONDS_PER_DAY = 86400000;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function boundedText(input: NormalizedEmailInput): string {
+  const combined = input.subject + "\n" + input.body;
+  return combined.slice(0, MAX_SCAN_LENGTH).toLowerCase();
+}
+
+function addDaysIso(baseIso: string, days: number): string | null {
+  const base = new Date(baseIso);
+  if (Number.isNaN(base.getTime())) {
+    return null;
+  }
+  const next = new Date(base.getTime() + days * MILLISECONDS_PER_DAY);
+  return next.toISOString().slice(0, 10);
+}
+
+function detectExplicitRequests(text: string): ReminderSignal[] {
+  const found: ReminderSignal[] = [];
+  for (const term of EXPLICIT_REQUEST_TERMS) {
+    if (text.includes(term)) {
+      found.push({ type: "explicit_request", detail: term });
+    }
+  }
+  return found;
+}
+
+function detectLowConfidence(text: string): ReminderSignal[] {
+  const found: ReminderSignal[] = [];
+  for (const term of LOW_CONFIDENCE_TERMS) {
+    if (text.includes(term)) {
+      found.push({ type: "low_confidence_context", detail: term });
+    }
+  }
+  return found;
+}
+
+function detectDateCandidates(text: string): {
+  signals: ReminderSignal[];
+  candidates: string[];
+} {
+  const signals: ReminderSignal[] = [];
+  const candidates: string[] = [];
+
+  const datetimeMatches = Array.from(text.matchAll(/\b(\d{4}-\d{2}-\d{2})[t ](\d{2}:\d{2})\b/g));
+  for (const match of datetimeMatches) {
+    const value = match[1] + "T" + match[2];
+    signals.push({ type: "absolute_date", detail: value });
+    candidates.push(value);
+  }
+
+  const withoutDatetimes = text.replace(/\b(\d{4}-\d{2}-\d{2})[t ](\d{2}:\d{2})\b/g, " ");
+  const dateMatches = Array.from(withoutDatetimes.matchAll(/\b(\d{4}-\d{2}-\d{2})\b/g));
+  for (const match of dateMatches) {
+    signals.push({ type: "absolute_date", detail: match[1] });
+    candidates.push(match[1]);
+  }
+
+  return { signals, candidates };
+}
+
+function detectRelativeDates(
+  text: string,
+  baseIso: string,
+): { signals: ReminderSignal[]; candidates: string[] } {
+  const signals: ReminderSignal[] = [];
+  const candidates: string[] = [];
+
+  if (/\btomorrow\b/.test(text)) {
+    signals.push({ type: "relative_date", detail: "tomorrow" });
+    const resolved = addDaysIso(baseIso, 1);
+    if (resolved) {
+      candidates.push(resolved);
+    }
+  }
+  if (/\bnext week\b/.test(text)) {
+    signals.push({ type: "relative_date", detail: "next week" });
+    const resolved = addDaysIso(baseIso, 7);
+    if (resolved) {
+      candidates.push(resolved);
+    }
+  }
+  const inDays = text.match(
+    /\bin (\d{1,3}|one|two|three|four|five|six|seven|eight|nine|ten) days?\b/,
+  );
+  if (inDays) {
+    const raw = inDays[1];
+    const amount = /^\d+$/.test(raw) ? parseInt(raw, 10) : (NUMBER_WORDS[raw] ?? 0);
+    if (amount > 0) {
+      signals.push({ type: "relative_date", detail: inDays[0] });
+      const resolved = addDaysIso(baseIso, amount);
+      if (resolved) {
+        candidates.push(resolved);
+      }
+    }
+  }
+
+  return { signals, candidates };
+}
+
+function buildTitle(input: NormalizedEmailInput): string {
+  const subject = normalizeWhitespace(input.subject);
+  if (subject.length > 0) {
+    return "Follow up: " + subject;
+  }
+  return "Follow up on email";
+}
+
+export function buildFollowUpReminder(
+  input: NormalizedEmailInput,
+  options: BuildReminderOptions = {},
+): ReminderReviewModel {
+  const baseIso = options.now ?? input.receivedAt;
+  const text = boundedText(input);
+
+  const explicitSignals = detectExplicitRequests(text);
+  const lowConfidenceSignals = detectLowConfidence(text);
+  const absolute = detectDateCandidates(text);
+  const relative = detectRelativeDates(text, baseIso);
+
+  const hasThreadHint = Boolean(
+    input.threadHint && normalizeWhitespace(input.threadHint).length > 0,
+  );
+
+  const signals: ReminderSignal[] = [
+    ...explicitSignals,
+    ...absolute.signals,
+    ...relative.signals,
+    ...lowConfidenceSignals,
+  ];
+  if (hasThreadHint) {
+    signals.push({ type: "sender_hint", detail: normalizeWhitespace(input.threadHint as string) });
+  }
+
+  const warnings: string[] = [];
+  const uniqueCandidates = Array.from(new Set([...absolute.candidates, ...relative.candidates]));
+
+  const hasExplicit = explicitSignals.length > 0;
+  const isLowContext = lowConfidenceSignals.length > 0;
+
+  let dueAt: string | null = null;
+  if (uniqueCandidates.length === 1) {
+    dueAt = uniqueCandidates[0];
+  } else if (uniqueCandidates.length > 1) {
+    warnings.push(
+      "Ambiguous due date: found " +
+        uniqueCandidates.join(", ") +
+        ". Confirm one before scheduling.",
+    );
+  }
+
+  if (relative.signals.length > 0 && !input.timeZone && dueAt !== null) {
+    warnings.push("Relative date resolved without a timezone; confirm the due time.");
+  }
+
+  const title = buildTitle(input);
+
+  let state: ReminderState;
+  if (!hasExplicit && isLowContext) {
+    state = "no_action";
+    warnings.push("Low-confidence context detected; no reminder suggested.");
+  } else if (!hasExplicit && uniqueCandidates.length === 0 && !hasThreadHint) {
+    state = "no_action";
+    warnings.push("No actionable follow-up signal detected.");
+  } else {
+    state = "draft";
+    if (dueAt === null && uniqueCandidates.length === 0) {
+      warnings.push("No due date detected; add one before scheduling.");
+    }
+  }
+
+  const hasUnambiguousDate = uniqueCandidates.length === 1;
+  let confidence: ReminderConfidence;
+  if (state === "no_action") {
+    confidence = "low";
+  } else if (hasExplicit && hasUnambiguousDate && !isLowContext) {
+    confidence = "high";
+  } else if ((hasExplicit || hasUnambiguousDate) && !isLowContext) {
+    confidence = "medium";
+  } else {
+    confidence = "low";
+  }
+
+  const existing = options.existingReminders ?? [];
+  if (
+    state === "draft" &&
+    dueAt !== null &&
+    existing.some((item) => item.sourceMessageId === input.messageId && item.dueAt === dueAt)
+  ) {
+    state = "no_action";
+    confidence = "low";
+    warnings.push("A reminder for this message and due date already exists.");
+  }
+
+  return {
+    state,
+    confidence,
+    title,
+    dueAt,
+    sourceMessageId: input.messageId,
+    signals,
+    warnings,
+  };
+}
+
+export function isReminderDuplicate(
+  model: ReminderReviewModel,
+  existing: ExistingReminderKey[],
+): boolean {
+  if (model.dueAt === null) {
+    return false;
+  }
+  return existing.some(
+    (item) => item.sourceMessageId === model.sourceMessageId && item.dueAt === model.dueAt,
+  );
+}
+
+export function summarizeReminder(model: ReminderReviewModel): string {
+  if (model.state === "no_action") {
+    return "No reminder suggested (" + model.confidence + " confidence).";
+  }
+  const due = model.dueAt ?? "no due date yet";
+  return model.title + " -- due " + due + " (" + model.confidence + " confidence).";
+}

--- a/tools/v1/individual/follow-up-reminder/tests/followUpReminder.test.ts
+++ b/tools/v1/individual/follow-up-reminder/tests/followUpReminder.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFollowUpReminder,
+  isReminderDuplicate,
+  summarizeReminder,
+  MAX_SCAN_LENGTH,
+  type NormalizedEmailInput,
+} from "../services/followUpReminder";
+import { sampleEmails } from "../services/fixtures";
+
+function emailInput(overrides: Partial<NormalizedEmailInput> = {}): NormalizedEmailInput {
+  return {
+    messageId: "msg-test",
+    subject: "Sync",
+    body: "Hello there.",
+    senderAddress: "person@example.com",
+    receivedAt: "2026-05-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildFollowUpReminder", () => {
+  it("creates a high-confidence draft from an explicit request with a clear date", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitWithDate);
+    expect(model.state).toBe("draft");
+    expect(model.confidence).toBe("high");
+    expect(model.dueAt).toBe("2026-02-10");
+    expect(model.sourceMessageId).toBe("msg-1001");
+    expect(model.signals.some((s) => s.type === "explicit_request")).toBe(true);
+    expect(model.signals.some((s) => s.type === "absolute_date")).toBe(true);
+  });
+
+  it("resolves a relative date using the received time as the base", () => {
+    const model = buildFollowUpReminder(sampleEmails.relativeNextWeek);
+    expect(model.dueAt).toBe("2026-02-08");
+    expect(model.state).toBe("draft");
+    expect(model.signals.some((s) => s.type === "relative_date")).toBe(true);
+  });
+
+  it("returns a draft with a warning when the due date is ambiguous", () => {
+    const model = buildFollowUpReminder(sampleEmails.ambiguousDates);
+    expect(model.state).toBe("draft");
+    expect(model.dueAt).toBeNull();
+    expect(model.confidence).toBe("medium");
+    expect(model.warnings.some((w) => w.toLowerCase().includes("ambiguous"))).toBe(true);
+  });
+
+  it("suggests no reminder for low-confidence contexts", () => {
+    const model = buildFollowUpReminder(sampleEmails.newsletter);
+    expect(model.state).toBe("no_action");
+    expect(model.confidence).toBe("low");
+  });
+
+  it("suggests no reminder when there is no actionable signal", () => {
+    const model = buildFollowUpReminder(sampleEmails.noSignal);
+    expect(model.state).toBe("no_action");
+    expect(model.warnings.some((w) => w.toLowerCase().includes("no actionable"))).toBe(true);
+  });
+
+  it("keeps an explicit request as a draft but flags the missing due date", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitNoDate);
+    expect(model.state).toBe("draft");
+    expect(model.dueAt).toBeNull();
+    expect(model.confidence).toBe("medium");
+    expect(model.warnings.some((w) => w.toLowerCase().includes("no due date"))).toBe(true);
+  });
+
+  it("warns when a relative date is resolved without a timezone", () => {
+    const model = buildFollowUpReminder(
+      emailInput({
+        messageId: "msg-2001",
+        subject: "Please reply by tomorrow",
+        body: "Remind me to follow up tomorrow.",
+      }),
+    );
+    expect(model.dueAt).toBe("2026-05-02");
+    expect(model.warnings.some((w) => w.toLowerCase().includes("timezone"))).toBe(true);
+  });
+
+  it("resolves word-based relative dates such as in two days", () => {
+    const model = buildFollowUpReminder(
+      emailInput({
+        body: "Let us follow up in two days about the launch.",
+        timeZone: "UTC",
+      }),
+    );
+    expect(model.dueAt).toBe("2026-05-03");
+  });
+
+  it("avoids duplicate reminders for the same message and due date", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitWithDate, {
+      existingReminders: [{ sourceMessageId: "msg-1001", dueAt: "2026-02-10" }],
+    });
+    expect(model.state).toBe("no_action");
+    expect(model.warnings.some((w) => w.toLowerCase().includes("already exists"))).toBe(true);
+  });
+
+  it("is deterministic for the same input", () => {
+    const first = buildFollowUpReminder(sampleEmails.explicitWithDate);
+    const second = buildFollowUpReminder(sampleEmails.explicitWithDate);
+    expect(first).toEqual(second);
+  });
+
+  it("bounds date scanning for very long messages", () => {
+    const model = buildFollowUpReminder(
+      emailInput({
+        subject: "Notes",
+        body: "a".repeat(MAX_SCAN_LENGTH) + " 2026-09-09",
+      }),
+    );
+    expect(model.dueAt).toBeNull();
+  });
+});
+
+describe("isReminderDuplicate", () => {
+  it("detects an existing reminder with the same message and due date", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitWithDate);
+    expect(isReminderDuplicate(model, [{ sourceMessageId: "msg-1001", dueAt: "2026-02-10" }])).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the due date is null", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitNoDate);
+    expect(isReminderDuplicate(model, [{ sourceMessageId: "msg-1006", dueAt: null }])).toBe(false);
+  });
+});
+
+describe("summarizeReminder", () => {
+  it("summarizes a draft with its due date", () => {
+    const model = buildFollowUpReminder(sampleEmails.explicitWithDate);
+    expect(summarizeReminder(model)).toContain("2026-02-10");
+  });
+
+  it("summarizes a no-action result", () => {
+    const model = buildFollowUpReminder(sampleEmails.newsletter);
+    expect(summarizeReminder(model)).toContain("No reminder suggested");
+  });
+});


### PR DESCRIPTION
Adds the folder-local core engine for the Follow-up Reminder tool, scoped entirely to tools/v1/individual/follow-up-reminder/.

What is included:
- A pure, deterministic buildFollowUpReminder engine that turns one normalized email into a single reminder review model (state, confidence, title, dueAt, sourceMessageId, signals, warnings).
- Signal detection for explicit request terms, absolute ISO dates/datetimes, relative dates (tomorrow, next week, in N days), sender/thread hints, and low-confidence contexts.
- Ambiguous dates return a draft with a warning instead of a scheduled reminder, and duplicate reminders for the same message and due date are avoided.
- Synthetic fixtures, unit tests, and documentation covering inputs, outputs, states, loading, and error behavior.

Safety and scope:
- Suggested reminders start as draft; the engine never confirms or schedules.
- No network calls, secrets, or production data; no email send, calendar events, label changes, read/archive/delete, or mailbox mutation.
- Date and keyword scanning is bounded for long messages; fixtures are synthetic only.
- Only a folder-local API surface is exposed (index.ts) for future UI work; nothing is wired into the main app.

Closes #360