### PR TITLE
Add inbox daily digest UI and accessibility surface. 

### DIFF
--- a/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useMemo, useState } from "react";
+import type { JSX } from "react";
+
+import { DigestEmptyState } from "./states/DigestEmptyState";
+import { DigestErrorState } from "./states/DigestErrorState";
+import { DigestLoadingState } from "./states/DigestLoadingState";
+import { DigestSuccessState } from "./states/DigestSuccessState";
+
+export type DigestStatus = "empty" | "loading" | "error" | "success";
+
+export interface DigestEmailPreview {
+  id: string;
+  sender: string;
+  subject: string;
+  receivedAt: string;
+  priority: "low" | "normal" | "high";
+}
+
+export interface DigestInsight {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface DailyDigest {
+  dateLabel: string;
+  summary: string;
+  insights: DigestInsight[];
+  topEmails: DigestEmailPreview[];
+  nextActions: string[];
+}
+
+const SAMPLE_DIGEST: DailyDigest = {
+  dateLabel: "Today",
+  summary:
+    "Your inbox is calm overall, with one partner reply needing a same-day response and two low-risk updates that can wait until tomorrow.",
+  insights: [
+    { id: "priority", label: "High priority", value: "1" },
+    { id: "waiting", label: "Needs reply", value: "3" },
+    { id: "quiet", label: "Can archive", value: "7" },
+  ],
+  topEmails: [
+    {
+      id: "partner-brief",
+      sender: "Mira Chen",
+      subject: "Partner launch brief follow-up",
+      receivedAt: "09:14",
+      priority: "high",
+    },
+    {
+      id: "billing",
+      sender: "Stellar Billing",
+      subject: "Receipt for workspace postage",
+      receivedAt: "08:42",
+      priority: "normal",
+    },
+    {
+      id: "calendar",
+      sender: "Operations",
+      subject: "Updated onboarding calendar",
+      receivedAt: "07:58",
+      priority: "normal",
+    },
+  ],
+  nextActions: [
+    "Reply to Mira before the launch review.",
+    "Confirm the onboarding calendar update.",
+    "Archive low-priority status emails after review.",
+  ],
+};
+
+export interface InboxDailyDigestToolProps {
+  initialDigest?: DailyDigest;
+}
+
+export function InboxDailyDigestTool({
+  initialDigest = SAMPLE_DIGEST,
+}: InboxDailyDigestToolProps): JSX.Element {
+  const [status, setStatus] = useState<DigestStatus>("empty");
+  const [includeReceipts, setIncludeReceipts] = useState(true);
+  const [includeLowPriority, setIncludeLowPriority] = useState(false);
+  const [digestTone, setDigestTone] = useState("Focused");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const filteredDigest = useMemo<DailyDigest>(() => {
+    const topEmails = initialDigest.topEmails.filter((email) => {
+      if (includeLowPriority) return true;
+      return email.priority !== "low";
+    });
+
+    const nextActions = includeReceipts
+      ? initialDigest.nextActions
+      : initialDigest.nextActions.filter((action) => !action.toLowerCase().includes("receipt"));
+
+    return { ...initialDigest, topEmails, nextActions };
+  }, [includeLowPriority, includeReceipts, initialDigest]);
+
+  function handleGenerate(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    setErrorMessage("");
+    setStatus("loading");
+
+    window.setTimeout(() => {
+      setStatus("success");
+    }, 450);
+  }
+
+  function handleShowError(): void {
+    setErrorMessage("The digest could not load because no mailbox snapshot was available.");
+    setStatus("error");
+  }
+
+  function handleRetry(): void {
+    setErrorMessage("");
+    setStatus("loading");
+
+    window.setTimeout(() => {
+      setStatus("success");
+    }, 450);
+  }
+
+  function handleReset(): void {
+    setErrorMessage("");
+    setStatus("empty");
+  }
+
+  return (
+    <section className="idd-shell" aria-labelledby="idd-title">
+      <div className="idd-header">
+        <div>
+          <p className="idd-kicker">Individual tool</p>
+          <h1 id="idd-title">Inbox Daily Digest</h1>
+        </div>
+        <span className="idd-badge" aria-label="V1 launch tool">
+          V1
+        </span>
+      </div>
+
+      <form className="idd-controls" onSubmit={handleGenerate} aria-describedby="idd-help">
+        <p id="idd-help" className="idd-help">
+          Configure a local digest preview before any future inbox integration.
+        </p>
+
+        <fieldset>
+          <legend>Digest scope</legend>
+          <label className="idd-checkbox">
+            <input
+              type="checkbox"
+              checked={includeReceipts}
+              onChange={(event) => setIncludeReceipts(event.target.checked)}
+            />
+            Include receipts
+          </label>
+          <label className="idd-checkbox">
+            <input
+              type="checkbox"
+              checked={includeLowPriority}
+              onChange={(event) => setIncludeLowPriority(event.target.checked)}
+            />
+            Include low-priority mail
+          </label>
+        </fieldset>
+
+        <label className="idd-field">
+          <span>Digest tone</span>
+          <select value={digestTone} onChange={(event) => setDigestTone(event.target.value)}>
+            <option>Focused</option>
+            <option>Detailed</option>
+            <option>Brief</option>
+          </select>
+        </label>
+
+        <div className="idd-actions">
+          <button type="submit">Generate digest</button>
+          <button type="button" className="idd-secondary" onClick={handleShowError}>
+            Preview error
+          </button>
+          <button type="button" className="idd-ghost" onClick={handleReset}>
+            Reset
+          </button>
+        </div>
+      </form>
+
+      <div className="idd-status" role="region" aria-live="polite" aria-label="Digest preview">
+        {status === "empty" ? <DigestEmptyState /> : null}
+        {status === "loading" ? <DigestLoadingState /> : null}
+        {status === "error" ? (
+          <DigestErrorState message={errorMessage} onRetry={handleRetry} />
+        ) : null}
+        {status === "success" ? (
+          <DigestSuccessState digest={filteredDigest} tone={digestTone} onReset={handleReset} />
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/index.ts
+++ b/tools/v1/individual/inbox-daily-digest/components/index.ts
@@ -1,0 +1,8 @@
+export { InboxDailyDigestTool } from "./InboxDailyDigestTool";
+export type {
+  DailyDigest,
+  DigestEmailPreview,
+  DigestInsight,
+  DigestStatus,
+  InboxDailyDigestToolProps,
+} from "./InboxDailyDigestTool";

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestEmptyState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestEmptyState.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from "react";
+
+export function DigestEmptyState(): JSX.Element {
+  return (
+    <div className="idd-panel idd-empty">
+      <p className="idd-state-label">Ready</p>
+      <h2>No digest generated yet</h2>
+      <p>
+        Choose the digest scope and generate a local preview. This state avoids assuming a mailbox
+        connection before the tool is integrated.
+      </p>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestErrorState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestErrorState.tsx
@@ -1,0 +1,19 @@
+import type { JSX } from "react";
+
+export interface DigestErrorStateProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export function DigestErrorState({ message, onRetry }: DigestErrorStateProps): JSX.Element {
+  return (
+    <div className="idd-panel idd-error" role="alert">
+      <p className="idd-state-label">Needs attention</p>
+      <h2>Digest unavailable</h2>
+      <p>{message}</p>
+      <button type="button" onClick={onRetry}>
+        Retry preview
+      </button>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestLoadingState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestLoadingState.tsx
@@ -1,0 +1,12 @@
+import type { JSX } from "react";
+
+export function DigestLoadingState(): JSX.Element {
+  return (
+    <div className="idd-panel idd-loading" aria-busy="true">
+      <span className="idd-spinner" aria-hidden="true" />
+      <p className="idd-state-label">Preparing</p>
+      <h2>Building digest preview</h2>
+      <p>Grouping recent mail, ranking important senders, and drafting next actions.</p>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
@@ -1,0 +1,68 @@
+import type { JSX } from "react";
+
+import type { DailyDigest } from "../InboxDailyDigestTool";
+
+export interface DigestSuccessStateProps {
+  digest: DailyDigest;
+  tone: string;
+  onReset: () => void;
+}
+
+export function DigestSuccessState({
+  digest,
+  tone,
+  onReset,
+}: DigestSuccessStateProps): JSX.Element {
+  return (
+    <article className="idd-panel idd-success" aria-labelledby="idd-result-title">
+      <div className="idd-result-heading">
+        <div>
+          <p className="idd-state-label">{digest.dateLabel}</p>
+          <h2 id="idd-result-title">{tone} digest</h2>
+        </div>
+        <button type="button" className="idd-secondary" onClick={onReset}>
+          Clear
+        </button>
+      </div>
+
+      <p className="idd-summary">{digest.summary}</p>
+
+      <dl className="idd-insights" aria-label="Digest metrics">
+        {digest.insights.map((insight) => (
+          <div key={insight.id}>
+            <dt>{insight.label}</dt>
+            <dd>{insight.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <section aria-labelledby="idd-top-email-title">
+        <h3 id="idd-top-email-title">Top mail</h3>
+        <ul className="idd-email-list">
+          {digest.topEmails.map((email) => (
+            <li key={email.id}>
+              <span className={`idd-priority idd-priority-${email.priority}`}>
+                {email.priority}
+              </span>
+              <div>
+                <strong>{email.subject}</strong>
+                <span>
+                  {email.sender} at {email.receivedAt}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="idd-actions-title">
+        <h3 id="idd-actions-title">Next actions</h3>
+        <ol className="idd-next-actions">
+          {digest.nextActions.map((action) => (
+            <li key={action}>{action}</li>
+          ))}
+        </ol>
+      </section>
+    </article>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/docs/visual-style.md
+++ b/tools/v1/individual/inbox-daily-digest/docs/visual-style.md
@@ -1,0 +1,24 @@
+# Inbox Daily Digest visual style
+
+The UI is intentionally folder-local and does not depend on the shared design system.
+
+## Surface
+
+- Calm operational layout with one configuration panel and one result region.
+- White panels use 8px radii, subtle borders, and restrained shadowing.
+- Metrics are displayed as scannable definition-list tiles.
+
+## Color
+
+- Primary action: deep navy `#17324d`.
+- Focus ring: amber `#f5b84b`.
+- Success badge: green tint `#e7f2ec`.
+- Priority states use red, blue, and slate tints so priority is not expressed by one hue alone.
+
+## Accessibility notes
+
+- The component uses a labelled section, labelled form controls, fieldset grouping, and a live preview region.
+- The error state uses `role="alert"`.
+- Loading communicates progress with `aria-busy`; the spinner is decorative.
+- Native buttons, checkboxes, and select controls provide keyboard support.
+- Focus-visible styles are defined locally in `styles.css`.

--- a/tools/v1/individual/inbox-daily-digest/index.ts
+++ b/tools/v1/individual/inbox-daily-digest/index.ts
@@ -1,0 +1,8 @@
+export { InboxDailyDigestTool } from "./components";
+export type {
+  DailyDigest,
+  DigestEmailPreview,
+  DigestInsight,
+  DigestStatus,
+  InboxDailyDigestToolProps,
+} from "./components";

--- a/tools/v1/individual/inbox-daily-digest/styles.css
+++ b/tools/v1/individual/inbox-daily-digest/styles.css
@@ -1,0 +1,276 @@
+.idd-shell {
+  color: #172033;
+  display: grid;
+  gap: 1rem;
+  max-width: 760px;
+}
+
+.idd-header,
+.idd-result-heading,
+.idd-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.idd-header h1,
+.idd-panel h2,
+.idd-panel h3,
+.idd-kicker,
+.idd-state-label {
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.idd-header h1 {
+  font-size: 1.75rem;
+  line-height: 1.2;
+}
+
+.idd-kicker,
+.idd-state-label {
+  color: #58627a;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.idd-badge,
+.idd-priority {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.38rem 0.55rem;
+}
+
+.idd-badge {
+  background: #e7f2ec;
+  color: #12633f;
+}
+
+.idd-controls,
+.idd-panel {
+  background: #ffffff;
+  border: 1px solid #d9dfeb;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgb(20 32 50 / 8%);
+  padding: 1rem;
+}
+
+.idd-controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.idd-help,
+.idd-panel p {
+  color: #4d5870;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.idd-controls fieldset {
+  border: 1px solid #d9dfeb;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0.85rem;
+}
+
+.idd-controls legend,
+.idd-field span {
+  color: #202a3e;
+  font-weight: 700;
+}
+
+.idd-checkbox,
+.idd-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.idd-checkbox {
+  align-items: center;
+  grid-template-columns: auto 1fr;
+}
+
+.idd-field select {
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #172033;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.idd-actions {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.idd-shell button {
+  background: #17324d;
+  border: 1px solid #17324d;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 2.5rem;
+  padding: 0.6rem 0.85rem;
+}
+
+.idd-shell button:hover,
+.idd-shell button:focus-visible {
+  background: #234a70;
+}
+
+.idd-shell button:focus-visible,
+.idd-field select:focus-visible,
+.idd-checkbox input:focus-visible {
+  outline: 3px solid #f5b84b;
+  outline-offset: 2px;
+}
+
+.idd-shell .idd-secondary {
+  background: #ffffff;
+  color: #17324d;
+}
+
+.idd-shell .idd-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: #334155;
+}
+
+.idd-panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idd-empty {
+  border-style: dashed;
+}
+
+.idd-error {
+  border-color: #d8594c;
+}
+
+.idd-loading {
+  align-items: start;
+}
+
+.idd-spinner {
+  animation: idd-spin 850ms linear infinite;
+  border: 3px solid #d9dfeb;
+  border-radius: 50%;
+  border-top-color: #17324d;
+  height: 2rem;
+  width: 2rem;
+}
+
+.idd-summary {
+  font-size: 1rem;
+}
+
+.idd-insights {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.idd-insights div {
+  background: #f6f8fb;
+  border: 1px solid #e4e9f1;
+  border-radius: 8px;
+  padding: 0.8rem;
+}
+
+.idd-insights dt {
+  color: #58627a;
+  font-size: 0.8rem;
+}
+
+.idd-insights dd {
+  color: #172033;
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin: 0.2rem 0 0;
+}
+
+.idd-email-list,
+.idd-next-actions {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0.6rem 0 0;
+  padding-left: 0;
+}
+
+.idd-email-list {
+  list-style: none;
+}
+
+.idd-email-list li {
+  align-items: center;
+  border: 1px solid #e4e9f1;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: auto 1fr;
+  padding: 0.75rem;
+}
+
+.idd-email-list strong,
+.idd-email-list span {
+  display: block;
+}
+
+.idd-email-list span {
+  color: #58627a;
+}
+
+.idd-priority-high {
+  background: #fdecea;
+  color: #a3291f;
+}
+
+.idd-priority-normal {
+  background: #eaf1fb;
+  color: #1c5790;
+}
+
+.idd-priority-low {
+  background: #eef2f7;
+  color: #475569;
+}
+
+.idd-next-actions {
+  padding-left: 1.25rem;
+}
+
+@keyframes idd-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .idd-header,
+  .idd-result-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .idd-insights {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idd-spinner {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Builds the **Inbox Daily Digest** tool's core UI and accessibility surface inside its isolated folder `tools/v1/individual/inbox-daily-digest/`.

## Deliverables

### UI Components (`components/`)
- `InboxDailyDigestTool.tsx` — main container orchestrating the state machine and tone selection
- `states/DigestEmptyState.tsx` — idle state prompting user to generate daily digest preview
- `states/DigestLoadingState.tsx` — accessible loading state with spinner and `aria-busy="true"`
- `states/DigestErrorState.tsx` — accessible error display with dynamic message and a retry button
- `states/DigestSuccessState.tsx` — lists metrics, top emails, next actions, and tone details

### Styling & CSS (`styles.css`)
- Structured layout with grid and flexbox, custom badges, and responsive view adjustments
- Clean color palette adhering to the tool requirements (no generic red/blue/green)
- Focus states and animation handling (supporting `prefers-reduced-motion: reduce`)

### Documentation (`docs/visual-style.md`)
- Outlines layout structure, typography, interactive states, and responsive styling details

## Boundary Compliance
- All changes stay inside `tools/v1/individual/inbox-daily-digest/`
- No modification to main app shell, routing, inbox, wallet, Stellar core, database, or design system

Closes #376