### PR TITLE
Fix/377 inbox daily digest hardening

### DIFF
--- a/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
@@ -5,6 +5,7 @@ import { DigestEmptyState } from "./states/DigestEmptyState";
 import { DigestErrorState } from "./states/DigestErrorState";
 import { DigestLoadingState } from "./states/DigestLoadingState";
 import { DigestSuccessState } from "./states/DigestSuccessState";
+import { guardDigestEmails } from "../services";
 
 export type DigestStatus = "empty" | "loading" | "error" | "success";
 
@@ -69,39 +70,146 @@ const SAMPLE_DIGEST: DailyDigest = {
   ],
 };
 
+function generateDigest(
+  emails: { id: string; sender: string; subject: string; receivedAt: string; body: string }[],
+): DailyDigest {
+  const topEmails: DigestEmailPreview[] = emails.map((email) => {
+    let priority: "low" | "normal" | "high" = "normal";
+    const text = (email.subject + " " + email.body).toLowerCase();
+    if (
+      text.includes("urgent") ||
+      text.includes("asap") ||
+      text.includes("deadline") ||
+      text.includes("launch")
+    ) {
+      priority = "high";
+    } else if (text.includes("receipt") || text.includes("newsletter") || email.body.length < 50) {
+      priority = "low";
+    }
+    return {
+      id: email.id,
+      sender: email.sender,
+      subject: email.subject,
+      receivedAt: email.receivedAt || "00:00",
+      priority,
+    };
+  });
+
+  const highCount = topEmails.filter((e) => e.priority === "high").length;
+  const lowCount = topEmails.filter((e) => e.priority === "low").length;
+
+  const nextActions: string[] = [];
+  const actionMarkers = ["please", "could you", "can you", "need you to", "make sure", "confirm"];
+
+  emails.forEach((email) => {
+    const sentences = email.body.split(/(?<=[.!?])\s+/);
+    sentences.forEach((sentence) => {
+      const lower = sentence.toLowerCase();
+      if (actionMarkers.some((marker) => lower.includes(marker))) {
+        const cleaned = sentence.trim();
+        if (cleaned.length > 0 && !nextActions.includes(cleaned)) {
+          nextActions.push(cleaned);
+        }
+      }
+    });
+  });
+
+  if (nextActions.length === 0) {
+    topEmails.forEach((email) => {
+      if (email.priority === "high") {
+        nextActions.push(`Review urgent update: "${email.subject}" from ${email.sender}.`);
+      }
+    });
+  }
+  if (nextActions.length === 0 && topEmails.length > 0) {
+    nextActions.push(`Go through ${topEmails.length} recent messages in your inbox.`);
+  }
+
+  const insights = [
+    { id: "priority", label: "High priority", value: String(highCount) },
+    { id: "waiting", label: "Needs reply", value: String(nextActions.length) },
+    { id: "quiet", label: "Can archive", value: String(lowCount) },
+  ];
+
+  const summary =
+    emails.length === 0
+      ? "Your inbox is completely empty. Nothing needs your attention."
+      : `Your inbox has ${emails.length} message${emails.length > 1 ? "s" : ""} requiring review. ` +
+        (highCount > 0
+          ? `There are ${highCount} high-priority thread${highCount > 1 ? "s" : ""} to address.`
+          : "No urgent actions are pending today.");
+
+  return {
+    dateLabel: "Today",
+    summary,
+    insights,
+    topEmails,
+    nextActions,
+  };
+}
+
 export interface InboxDailyDigestToolProps {
   initialDigest?: DailyDigest;
+  rawEmails?: unknown;
 }
 
 export function InboxDailyDigestTool({
   initialDigest = SAMPLE_DIGEST,
+  rawEmails,
 }: InboxDailyDigestToolProps): JSX.Element {
   const [status, setStatus] = useState<DigestStatus>("empty");
   const [includeReceipts, setIncludeReceipts] = useState(true);
   const [includeLowPriority, setIncludeLowPriority] = useState(false);
   const [digestTone, setDigestTone] = useState("Focused");
   const [errorMessage, setErrorMessage] = useState("");
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const guardedEmails = useMemo(() => {
+    if (rawEmails === undefined) return null;
+    return guardDigestEmails(rawEmails, {
+      maxEmails: 50,
+    });
+  }, [rawEmails]);
+
+  const activeDigest = useMemo<DailyDigest>(() => {
+    if (guardedEmails && guardedEmails.emails) {
+      return generateDigest(guardedEmails.emails);
+    }
+    return initialDigest;
+  }, [guardedEmails, initialDigest]);
 
   const filteredDigest = useMemo<DailyDigest>(() => {
-    const topEmails = initialDigest.topEmails.filter((email) => {
+    const topEmails = activeDigest.topEmails.filter((email) => {
       if (includeLowPriority) return true;
       return email.priority !== "low";
     });
 
     const nextActions = includeReceipts
-      ? initialDigest.nextActions
-      : initialDigest.nextActions.filter((action) => !action.toLowerCase().includes("receipt"));
+      ? activeDigest.nextActions
+      : activeDigest.nextActions.filter((action) => !action.toLowerCase().includes("receipt"));
 
-    return { ...initialDigest, topEmails, nextActions };
-  }, [includeLowPriority, includeReceipts, initialDigest]);
+    return { ...activeDigest, topEmails, nextActions };
+  }, [includeLowPriority, includeReceipts, activeDigest]);
 
   function handleGenerate(event: FormEvent<HTMLFormElement>): void {
     event.preventDefault();
     setErrorMessage("");
+    setWarnings([]);
     setStatus("loading");
 
     window.setTimeout(() => {
-      setStatus("success");
+      if (guardedEmails) {
+        const rejectionWarning = guardedEmails.report.warnings.find((w) => w.includes("rejected"));
+        if (rejectionWarning) {
+          setErrorMessage(rejectionWarning);
+          setStatus("error");
+        } else {
+          setWarnings(guardedEmails.report.warnings);
+          setStatus("success");
+        }
+      } else {
+        setStatus("success");
+      }
     }, 450);
   }
 
@@ -112,15 +220,28 @@ export function InboxDailyDigestTool({
 
   function handleRetry(): void {
     setErrorMessage("");
+    setWarnings([]);
     setStatus("loading");
 
     window.setTimeout(() => {
-      setStatus("success");
+      if (guardedEmails) {
+        const rejectionWarning = guardedEmails.report.warnings.find((w) => w.includes("rejected"));
+        if (rejectionWarning) {
+          setErrorMessage(rejectionWarning);
+          setStatus("error");
+        } else {
+          setWarnings(guardedEmails.report.warnings);
+          setStatus("success");
+        }
+      } else {
+        setStatus("success");
+      }
     }, 450);
   }
 
   function handleReset(): void {
     setErrorMessage("");
+    setWarnings([]);
     setStatus("empty");
   }
 
@@ -188,7 +309,12 @@ export function InboxDailyDigestTool({
           <DigestErrorState message={errorMessage} onRetry={handleRetry} />
         ) : null}
         {status === "success" ? (
-          <DigestSuccessState digest={filteredDigest} tone={digestTone} onReset={handleReset} />
+          <DigestSuccessState
+            digest={filteredDigest}
+            tone={digestTone}
+            onReset={handleReset}
+            warnings={warnings}
+          />
         ) : null}
       </div>
     </section>

--- a/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/InboxDailyDigestTool.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useMemo, useState } from "react";
+import type { JSX } from "react";
+
+import { DigestEmptyState } from "./states/DigestEmptyState";
+import { DigestErrorState } from "./states/DigestErrorState";
+import { DigestLoadingState } from "./states/DigestLoadingState";
+import { DigestSuccessState } from "./states/DigestSuccessState";
+
+export type DigestStatus = "empty" | "loading" | "error" | "success";
+
+export interface DigestEmailPreview {
+  id: string;
+  sender: string;
+  subject: string;
+  receivedAt: string;
+  priority: "low" | "normal" | "high";
+}
+
+export interface DigestInsight {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface DailyDigest {
+  dateLabel: string;
+  summary: string;
+  insights: DigestInsight[];
+  topEmails: DigestEmailPreview[];
+  nextActions: string[];
+}
+
+const SAMPLE_DIGEST: DailyDigest = {
+  dateLabel: "Today",
+  summary:
+    "Your inbox is calm overall, with one partner reply needing a same-day response and two low-risk updates that can wait until tomorrow.",
+  insights: [
+    { id: "priority", label: "High priority", value: "1" },
+    { id: "waiting", label: "Needs reply", value: "3" },
+    { id: "quiet", label: "Can archive", value: "7" },
+  ],
+  topEmails: [
+    {
+      id: "partner-brief",
+      sender: "Mira Chen",
+      subject: "Partner launch brief follow-up",
+      receivedAt: "09:14",
+      priority: "high",
+    },
+    {
+      id: "billing",
+      sender: "Stellar Billing",
+      subject: "Receipt for workspace postage",
+      receivedAt: "08:42",
+      priority: "normal",
+    },
+    {
+      id: "calendar",
+      sender: "Operations",
+      subject: "Updated onboarding calendar",
+      receivedAt: "07:58",
+      priority: "normal",
+    },
+  ],
+  nextActions: [
+    "Reply to Mira before the launch review.",
+    "Confirm the onboarding calendar update.",
+    "Archive low-priority status emails after review.",
+  ],
+};
+
+export interface InboxDailyDigestToolProps {
+  initialDigest?: DailyDigest;
+}
+
+export function InboxDailyDigestTool({
+  initialDigest = SAMPLE_DIGEST,
+}: InboxDailyDigestToolProps): JSX.Element {
+  const [status, setStatus] = useState<DigestStatus>("empty");
+  const [includeReceipts, setIncludeReceipts] = useState(true);
+  const [includeLowPriority, setIncludeLowPriority] = useState(false);
+  const [digestTone, setDigestTone] = useState("Focused");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const filteredDigest = useMemo<DailyDigest>(() => {
+    const topEmails = initialDigest.topEmails.filter((email) => {
+      if (includeLowPriority) return true;
+      return email.priority !== "low";
+    });
+
+    const nextActions = includeReceipts
+      ? initialDigest.nextActions
+      : initialDigest.nextActions.filter((action) => !action.toLowerCase().includes("receipt"));
+
+    return { ...initialDigest, topEmails, nextActions };
+  }, [includeLowPriority, includeReceipts, initialDigest]);
+
+  function handleGenerate(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    setErrorMessage("");
+    setStatus("loading");
+
+    window.setTimeout(() => {
+      setStatus("success");
+    }, 450);
+  }
+
+  function handleShowError(): void {
+    setErrorMessage("The digest could not load because no mailbox snapshot was available.");
+    setStatus("error");
+  }
+
+  function handleRetry(): void {
+    setErrorMessage("");
+    setStatus("loading");
+
+    window.setTimeout(() => {
+      setStatus("success");
+    }, 450);
+  }
+
+  function handleReset(): void {
+    setErrorMessage("");
+    setStatus("empty");
+  }
+
+  return (
+    <section className="idd-shell" aria-labelledby="idd-title">
+      <div className="idd-header">
+        <div>
+          <p className="idd-kicker">Individual tool</p>
+          <h1 id="idd-title">Inbox Daily Digest</h1>
+        </div>
+        <span className="idd-badge" aria-label="V1 launch tool">
+          V1
+        </span>
+      </div>
+
+      <form className="idd-controls" onSubmit={handleGenerate} aria-describedby="idd-help">
+        <p id="idd-help" className="idd-help">
+          Configure a local digest preview before any future inbox integration.
+        </p>
+
+        <fieldset>
+          <legend>Digest scope</legend>
+          <label className="idd-checkbox">
+            <input
+              type="checkbox"
+              checked={includeReceipts}
+              onChange={(event) => setIncludeReceipts(event.target.checked)}
+            />
+            Include receipts
+          </label>
+          <label className="idd-checkbox">
+            <input
+              type="checkbox"
+              checked={includeLowPriority}
+              onChange={(event) => setIncludeLowPriority(event.target.checked)}
+            />
+            Include low-priority mail
+          </label>
+        </fieldset>
+
+        <label className="idd-field">
+          <span>Digest tone</span>
+          <select value={digestTone} onChange={(event) => setDigestTone(event.target.value)}>
+            <option>Focused</option>
+            <option>Detailed</option>
+            <option>Brief</option>
+          </select>
+        </label>
+
+        <div className="idd-actions">
+          <button type="submit">Generate digest</button>
+          <button type="button" className="idd-secondary" onClick={handleShowError}>
+            Preview error
+          </button>
+          <button type="button" className="idd-ghost" onClick={handleReset}>
+            Reset
+          </button>
+        </div>
+      </form>
+
+      <div className="idd-status" role="region" aria-live="polite" aria-label="Digest preview">
+        {status === "empty" ? <DigestEmptyState /> : null}
+        {status === "loading" ? <DigestLoadingState /> : null}
+        {status === "error" ? (
+          <DigestErrorState message={errorMessage} onRetry={handleRetry} />
+        ) : null}
+        {status === "success" ? (
+          <DigestSuccessState digest={filteredDigest} tone={digestTone} onReset={handleReset} />
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/index.ts
+++ b/tools/v1/individual/inbox-daily-digest/components/index.ts
@@ -1,0 +1,8 @@
+export { InboxDailyDigestTool } from "./InboxDailyDigestTool";
+export type {
+  DailyDigest,
+  DigestEmailPreview,
+  DigestInsight,
+  DigestStatus,
+  InboxDailyDigestToolProps,
+} from "./InboxDailyDigestTool";

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestEmptyState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestEmptyState.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from "react";
+
+export function DigestEmptyState(): JSX.Element {
+  return (
+    <div className="idd-panel idd-empty">
+      <p className="idd-state-label">Ready</p>
+      <h2>No digest generated yet</h2>
+      <p>
+        Choose the digest scope and generate a local preview. This state avoids assuming a mailbox
+        connection before the tool is integrated.
+      </p>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestErrorState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestErrorState.tsx
@@ -1,0 +1,19 @@
+import type { JSX } from "react";
+
+export interface DigestErrorStateProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export function DigestErrorState({ message, onRetry }: DigestErrorStateProps): JSX.Element {
+  return (
+    <div className="idd-panel idd-error" role="alert">
+      <p className="idd-state-label">Needs attention</p>
+      <h2>Digest unavailable</h2>
+      <p>{message}</p>
+      <button type="button" onClick={onRetry}>
+        Retry preview
+      </button>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestLoadingState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestLoadingState.tsx
@@ -1,0 +1,12 @@
+import type { JSX } from "react";
+
+export function DigestLoadingState(): JSX.Element {
+  return (
+    <div className="idd-panel idd-loading" aria-busy="true">
+      <span className="idd-spinner" aria-hidden="true" />
+      <p className="idd-state-label">Preparing</p>
+      <h2>Building digest preview</h2>
+      <p>Grouping recent mail, ranking important senders, and drafting next actions.</p>
+    </div>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
@@ -6,12 +6,14 @@ export interface DigestSuccessStateProps {
   digest: DailyDigest;
   tone: string;
   onReset: () => void;
+  warnings?: string[];
 }
 
 export function DigestSuccessState({
   digest,
   tone,
   onReset,
+  warnings,
 }: DigestSuccessStateProps): JSX.Element {
   return (
     <article className="idd-panel idd-success" aria-labelledby="idd-result-title">
@@ -26,6 +28,29 @@ export function DigestSuccessState({
       </div>
 
       <p className="idd-summary">{digest.summary}</p>
+
+      {warnings && warnings.length > 0 && (
+        <div
+          className="idd-warnings-box"
+          style={{
+            background: "#fffaf0",
+            border: "1px solid #feebc8",
+            borderRadius: "6px",
+            padding: "0.75rem",
+            color: "#c05621",
+            fontSize: "0.85rem",
+          }}
+        >
+          <span style={{ fontWeight: 700, display: "block", marginBottom: "0.25rem" }}>
+            Processing Notes ({warnings.length})
+          </span>
+          <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+            {warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <dl className="idd-insights" aria-label="Digest metrics">
         {digest.insights.map((insight) => (

--- a/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
+++ b/tools/v1/individual/inbox-daily-digest/components/states/DigestSuccessState.tsx
@@ -1,0 +1,68 @@
+import type { JSX } from "react";
+
+import type { DailyDigest } from "../InboxDailyDigestTool";
+
+export interface DigestSuccessStateProps {
+  digest: DailyDigest;
+  tone: string;
+  onReset: () => void;
+}
+
+export function DigestSuccessState({
+  digest,
+  tone,
+  onReset,
+}: DigestSuccessStateProps): JSX.Element {
+  return (
+    <article className="idd-panel idd-success" aria-labelledby="idd-result-title">
+      <div className="idd-result-heading">
+        <div>
+          <p className="idd-state-label">{digest.dateLabel}</p>
+          <h2 id="idd-result-title">{tone} digest</h2>
+        </div>
+        <button type="button" className="idd-secondary" onClick={onReset}>
+          Clear
+        </button>
+      </div>
+
+      <p className="idd-summary">{digest.summary}</p>
+
+      <dl className="idd-insights" aria-label="Digest metrics">
+        {digest.insights.map((insight) => (
+          <div key={insight.id}>
+            <dt>{insight.label}</dt>
+            <dd>{insight.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <section aria-labelledby="idd-top-email-title">
+        <h3 id="idd-top-email-title">Top mail</h3>
+        <ul className="idd-email-list">
+          {digest.topEmails.map((email) => (
+            <li key={email.id}>
+              <span className={`idd-priority idd-priority-${email.priority}`}>
+                {email.priority}
+              </span>
+              <div>
+                <strong>{email.subject}</strong>
+                <span>
+                  {email.sender} at {email.receivedAt}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="idd-actions-title">
+        <h3 id="idd-actions-title">Next actions</h3>
+        <ol className="idd-next-actions">
+          {digest.nextActions.map((action) => (
+            <li key={action}>{action}</li>
+          ))}
+        </ol>
+      </section>
+    </article>
+  );
+}

--- a/tools/v1/individual/inbox-daily-digest/docs/security-performance.md
+++ b/tools/v1/individual/inbox-daily-digest/docs/security-performance.md
@@ -1,0 +1,51 @@
+# Inbox Daily Digest security and performance notes
+
+This tool is still isolated from the mail app. The guard helpers in `services/digestGuards.ts`
+define the input contract expected by future integration work.
+
+## Threat assumptions
+
+- Mail content is untrusted, even when it came from a user's own mailbox.
+- Sender names, subjects, labels, attachment names, and bodies may contain markup, control
+  characters, extremely long text, duplicated values, or unexpected non-string values.
+- The tool must not fetch remote content, render raw HTML, execute mailbox-provided scripts, or
+  mutate messages while building a digest.
+- Attachments are represented only by sanitized names in this isolated tool. File bytes are out of
+  scope until a future integration issue explicitly permits them.
+
+## Unsafe input handling
+
+`guardDigestEmails` accepts `unknown` input and returns a typed result. It never throws for malformed
+mailbox snapshots.
+
+The guard layer:
+
+- rejects non-array snapshots;
+- rejects email entries that are not objects;
+- requires sanitized `sender`, `subject`, and `body` fields;
+- strips HTML tags and ASCII control characters;
+- normalizes repeated whitespace;
+- caps body length, field length, label count, attachment count, and email count;
+- reports accepted, rejected, and truncated counts for review.
+
+## Performance limits
+
+Defaults are intentionally small for a daily preview:
+
+- `maxEmails`: 50
+- `maxBodyCharacters`: 8,000
+- `maxTextFieldCharacters`: 180
+- `maxLabels`: 12
+- `maxAttachments`: 10
+
+Future integration work should preserve these caps or justify higher limits with local benchmark
+data. Digest generation should process the capped snapshot once, avoid repeated full-body scans,
+and avoid loading attachment bytes.
+
+## Review checklist
+
+- Pass hostile fixtures as `unknown` and verify the function returns warnings instead of throwing.
+- Confirm rejected records do not appear in the returned email list.
+- Confirm long bodies and long lists are truncated before any summarization or rendering layer sees
+  them.
+- Confirm no security-sensitive application code outside this folder is modified.

--- a/tools/v1/individual/inbox-daily-digest/docs/visual-style.md
+++ b/tools/v1/individual/inbox-daily-digest/docs/visual-style.md
@@ -1,0 +1,24 @@
+# Inbox Daily Digest visual style
+
+The UI is intentionally folder-local and does not depend on the shared design system.
+
+## Surface
+
+- Calm operational layout with one configuration panel and one result region.
+- White panels use 8px radii, subtle borders, and restrained shadowing.
+- Metrics are displayed as scannable definition-list tiles.
+
+## Color
+
+- Primary action: deep navy `#17324d`.
+- Focus ring: amber `#f5b84b`.
+- Success badge: green tint `#e7f2ec`.
+- Priority states use red, blue, and slate tints so priority is not expressed by one hue alone.
+
+## Accessibility notes
+
+- The component uses a labelled section, labelled form controls, fieldset grouping, and a live preview region.
+- The error state uses `role="alert"`.
+- Loading communicates progress with `aria-busy`; the spinner is decorative.
+- Native buttons, checkboxes, and select controls provide keyboard support.
+- Focus-visible styles are defined locally in `styles.css`.

--- a/tools/v1/individual/inbox-daily-digest/index.ts
+++ b/tools/v1/individual/inbox-daily-digest/index.ts
@@ -1,0 +1,8 @@
+export { InboxDailyDigestTool } from "./components";
+export type {
+  DailyDigest,
+  DigestEmailPreview,
+  DigestInsight,
+  DigestStatus,
+  InboxDailyDigestToolProps,
+} from "./components";

--- a/tools/v1/individual/inbox-daily-digest/services/digestGuards.ts
+++ b/tools/v1/individual/inbox-daily-digest/services/digestGuards.ts
@@ -1,0 +1,252 @@
+export interface RawDigestEmail {
+  id?: unknown;
+  sender?: unknown;
+  subject?: unknown;
+  receivedAt?: unknown;
+  body?: unknown;
+  labels?: unknown;
+  attachments?: unknown;
+}
+
+export interface GuardedDigestEmail {
+  id: string;
+  sender: string;
+  subject: string;
+  receivedAt: string;
+  body: string;
+  labels: string[];
+  attachments: string[];
+  wasTruncated: boolean;
+}
+
+export interface DigestGuardOptions {
+  maxEmails?: number;
+  maxBodyCharacters?: number;
+  maxTextFieldCharacters?: number;
+  maxLabels?: number;
+  maxAttachments?: number;
+}
+
+export interface DigestGuardReport {
+  acceptedCount: number;
+  rejectedCount: number;
+  truncatedCount: number;
+  warnings: string[];
+}
+
+export interface DigestGuardResult {
+  emails: GuardedDigestEmail[];
+  report: DigestGuardReport;
+}
+
+export const DEFAULT_DIGEST_GUARD_OPTIONS: Required<DigestGuardOptions> = {
+  maxEmails: 50,
+  maxBodyCharacters: 8_000,
+  maxTextFieldCharacters: 180,
+  maxLabels: 12,
+  maxAttachments: 10,
+};
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const HTML_TAG_PATTERN = /<[^>]*>/g;
+const WHITESPACE_PATTERN = /\s+/g;
+
+function resolveOptions(options: DigestGuardOptions): Required<DigestGuardOptions> {
+  return {
+    maxEmails: resolvePositiveInteger(options.maxEmails, DEFAULT_DIGEST_GUARD_OPTIONS.maxEmails),
+    maxBodyCharacters: resolvePositiveInteger(
+      options.maxBodyCharacters,
+      DEFAULT_DIGEST_GUARD_OPTIONS.maxBodyCharacters,
+    ),
+    maxTextFieldCharacters: resolvePositiveInteger(
+      options.maxTextFieldCharacters,
+      DEFAULT_DIGEST_GUARD_OPTIONS.maxTextFieldCharacters,
+    ),
+    maxLabels: resolvePositiveInteger(options.maxLabels, DEFAULT_DIGEST_GUARD_OPTIONS.maxLabels),
+    maxAttachments: resolvePositiveInteger(
+      options.maxAttachments,
+      DEFAULT_DIGEST_GUARD_OPTIONS.maxAttachments,
+    ),
+  };
+}
+
+function resolvePositiveInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cleanText(value: unknown, maxCharacters: number): { value: string; truncated: boolean } {
+  if (typeof value !== "string") {
+    return { value: "", truncated: false };
+  }
+
+  const cleaned = value
+    .replace(CONTROL_CHARACTER_PATTERN, "")
+    .replace(HTML_TAG_PATTERN, " ")
+    .replace(WHITESPACE_PATTERN, " ")
+    .trim();
+
+  if (cleaned.length <= maxCharacters) {
+    return { value: cleaned, truncated: false };
+  }
+
+  return {
+    value: cleaned.slice(0, maxCharacters).trimEnd(),
+    truncated: true,
+  };
+}
+
+function cleanStringList(
+  value: unknown,
+  maxItems: number,
+  maxCharacters: number,
+): { values: string[]; truncated: boolean } {
+  if (!Array.isArray(value)) {
+    return { values: [], truncated: false };
+  }
+
+  const values: string[] = [];
+  let truncated = value.length > maxItems;
+
+  for (const item of value.slice(0, maxItems)) {
+    const cleaned = cleanText(item, maxCharacters);
+    if (cleaned.value.length > 0 && !values.includes(cleaned.value)) {
+      values.push(cleaned.value);
+    }
+    truncated = truncated || cleaned.truncated;
+  }
+
+  return { values, truncated };
+}
+
+function buildStableId(index: number, sender: string, subject: string): string {
+  const source = `${sender}-${subject}-${index}`.toLowerCase();
+  const slug = source.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return slug.length > 0 ? slug.slice(0, 80) : `digest-email-${index + 1}`;
+}
+
+function guardEmail(
+  rawEmail: unknown,
+  index: number,
+  options: Required<DigestGuardOptions>,
+): { email: GuardedDigestEmail | null; warnings: string[] } {
+  const warnings: string[] = [];
+
+  if (!isRecord(rawEmail)) {
+    return {
+      email: null,
+      warnings: [`Email ${index + 1} was rejected because it is not an object.`],
+    };
+  }
+
+  const sender = cleanText(rawEmail.sender, options.maxTextFieldCharacters);
+  const subject = cleanText(rawEmail.subject, options.maxTextFieldCharacters);
+  const receivedAt = cleanText(rawEmail.receivedAt, options.maxTextFieldCharacters);
+  const body = cleanText(rawEmail.body, options.maxBodyCharacters);
+  const id = cleanText(rawEmail.id, options.maxTextFieldCharacters);
+  const labels = cleanStringList(
+    rawEmail.labels,
+    options.maxLabels,
+    options.maxTextFieldCharacters,
+  );
+  const attachments = cleanStringList(
+    rawEmail.attachments,
+    options.maxAttachments,
+    options.maxTextFieldCharacters,
+  );
+
+  if (sender.value.length === 0 || subject.value.length === 0 || body.value.length === 0) {
+    return {
+      email: null,
+      warnings: [`Email ${index + 1} was rejected because sender, subject, and body are required.`],
+    };
+  }
+
+  const wasTruncated =
+    sender.truncated ||
+    subject.truncated ||
+    receivedAt.truncated ||
+    body.truncated ||
+    id.truncated ||
+    labels.truncated ||
+    attachments.truncated;
+
+  if (wasTruncated) {
+    warnings.push(`Email ${index + 1} exceeded one or more local processing limits.`);
+  }
+
+  return {
+    email: {
+      id: id.value || buildStableId(index, sender.value, subject.value),
+      sender: sender.value,
+      subject: subject.value,
+      receivedAt: receivedAt.value,
+      body: body.value,
+      labels: labels.values,
+      attachments: attachments.values,
+      wasTruncated,
+    },
+    warnings,
+  };
+}
+
+export function guardDigestEmails(
+  input: unknown,
+  guardOptions: DigestGuardOptions = {},
+): DigestGuardResult {
+  const options = resolveOptions(guardOptions);
+  const warnings: string[] = [];
+
+  if (!Array.isArray(input)) {
+    return {
+      emails: [],
+      report: {
+        acceptedCount: 0,
+        rejectedCount: 0,
+        truncatedCount: 0,
+        warnings: ["Mailbox snapshot was rejected because it is not an array."],
+      },
+    };
+  }
+
+  const emails: GuardedDigestEmail[] = [];
+  let rejectedCount = 0;
+  let truncatedCount = 0;
+
+  if (input.length > options.maxEmails) {
+    warnings.push(`Mailbox snapshot was capped at ${options.maxEmails} emails.`);
+  }
+
+  for (const [index, rawEmail] of input.slice(0, options.maxEmails).entries()) {
+    const guarded = guardEmail(rawEmail, index, options);
+    warnings.push(...guarded.warnings);
+
+    if (guarded.email === null) {
+      rejectedCount += 1;
+      continue;
+    }
+
+    if (guarded.email.wasTruncated) {
+      truncatedCount += 1;
+    }
+
+    emails.push(guarded.email);
+  }
+
+  return {
+    emails,
+    report: {
+      acceptedCount: emails.length,
+      rejectedCount,
+      truncatedCount,
+      warnings,
+    },
+  };
+}

--- a/tools/v1/individual/inbox-daily-digest/services/index.ts
+++ b/tools/v1/individual/inbox-daily-digest/services/index.ts
@@ -1,0 +1,9 @@
+export {
+  DEFAULT_DIGEST_GUARD_OPTIONS,
+  guardDigestEmails,
+  type DigestGuardOptions,
+  type DigestGuardReport,
+  type DigestGuardResult,
+  type GuardedDigestEmail,
+  type RawDigestEmail,
+} from "./digestGuards";

--- a/tools/v1/individual/inbox-daily-digest/styles.css
+++ b/tools/v1/individual/inbox-daily-digest/styles.css
@@ -1,0 +1,276 @@
+.idd-shell {
+  color: #172033;
+  display: grid;
+  gap: 1rem;
+  max-width: 760px;
+}
+
+.idd-header,
+.idd-result-heading,
+.idd-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.idd-header h1,
+.idd-panel h2,
+.idd-panel h3,
+.idd-kicker,
+.idd-state-label {
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.idd-header h1 {
+  font-size: 1.75rem;
+  line-height: 1.2;
+}
+
+.idd-kicker,
+.idd-state-label {
+  color: #58627a;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.idd-badge,
+.idd-priority {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.38rem 0.55rem;
+}
+
+.idd-badge {
+  background: #e7f2ec;
+  color: #12633f;
+}
+
+.idd-controls,
+.idd-panel {
+  background: #ffffff;
+  border: 1px solid #d9dfeb;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgb(20 32 50 / 8%);
+  padding: 1rem;
+}
+
+.idd-controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.idd-help,
+.idd-panel p {
+  color: #4d5870;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.idd-controls fieldset {
+  border: 1px solid #d9dfeb;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0.85rem;
+}
+
+.idd-controls legend,
+.idd-field span {
+  color: #202a3e;
+  font-weight: 700;
+}
+
+.idd-checkbox,
+.idd-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.idd-checkbox {
+  align-items: center;
+  grid-template-columns: auto 1fr;
+}
+
+.idd-field select {
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #172033;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.idd-actions {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.idd-shell button {
+  background: #17324d;
+  border: 1px solid #17324d;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 2.5rem;
+  padding: 0.6rem 0.85rem;
+}
+
+.idd-shell button:hover,
+.idd-shell button:focus-visible {
+  background: #234a70;
+}
+
+.idd-shell button:focus-visible,
+.idd-field select:focus-visible,
+.idd-checkbox input:focus-visible {
+  outline: 3px solid #f5b84b;
+  outline-offset: 2px;
+}
+
+.idd-shell .idd-secondary {
+  background: #ffffff;
+  color: #17324d;
+}
+
+.idd-shell .idd-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: #334155;
+}
+
+.idd-panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.idd-empty {
+  border-style: dashed;
+}
+
+.idd-error {
+  border-color: #d8594c;
+}
+
+.idd-loading {
+  align-items: start;
+}
+
+.idd-spinner {
+  animation: idd-spin 850ms linear infinite;
+  border: 3px solid #d9dfeb;
+  border-radius: 50%;
+  border-top-color: #17324d;
+  height: 2rem;
+  width: 2rem;
+}
+
+.idd-summary {
+  font-size: 1rem;
+}
+
+.idd-insights {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.idd-insights div {
+  background: #f6f8fb;
+  border: 1px solid #e4e9f1;
+  border-radius: 8px;
+  padding: 0.8rem;
+}
+
+.idd-insights dt {
+  color: #58627a;
+  font-size: 0.8rem;
+}
+
+.idd-insights dd {
+  color: #172033;
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin: 0.2rem 0 0;
+}
+
+.idd-email-list,
+.idd-next-actions {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0.6rem 0 0;
+  padding-left: 0;
+}
+
+.idd-email-list {
+  list-style: none;
+}
+
+.idd-email-list li {
+  align-items: center;
+  border: 1px solid #e4e9f1;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: auto 1fr;
+  padding: 0.75rem;
+}
+
+.idd-email-list strong,
+.idd-email-list span {
+  display: block;
+}
+
+.idd-email-list span {
+  color: #58627a;
+}
+
+.idd-priority-high {
+  background: #fdecea;
+  color: #a3291f;
+}
+
+.idd-priority-normal {
+  background: #eaf1fb;
+  color: #1c5790;
+}
+
+.idd-priority-low {
+  background: #eef2f7;
+  color: #475569;
+}
+
+.idd-next-actions {
+  padding-left: 1.25rem;
+}
+
+@keyframes idd-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .idd-header,
+  .idd-result-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .idd-insights {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .idd-spinner {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Add safety and performance constraints for daily digest. Closes https://github.com/Stellar-Mail/stealth/issues/377
Adds safety, input validation, and performance constraints to the **Inbox Daily Digest** tool inside `tools/v1/individual/inbox-daily-digest/`.

## Deliverables

### Safety Guards (`services/digestGuards.ts`)
- `guardDigestEmails(input, options)` — sanitizes, validates, and caps raw mailbox entries
- Normalizes whitespaces, strips control characters and HTML tags, and truncates overly long strings (e.g. sender, subject, body fields)
- Rejects non-array snapshots and non-object elements gracefully, returning warnings instead of throwing errors

### UI Integration
- Integrates the input sanitization guard inside `InboxDailyDigestTool.tsx` generator callbacks
- Added an alert box in `DigestSuccessState.tsx` to render any processing and truncation notes returned by the guard report

### Documentation (`docs/security-performance.md`)
- Documents threat assumptions, unsafe input handling, performance caps, and reviewer validation guidelines

## Boundary Compliance
- Confined to `tools/v1/individual/inbox-daily-digest/`
- Zero changes to main app or existing security-sensitive shared code
- Memory and processing limits are enforced to protect against denial-of-service from hostile mail payloads