### PR TITLE
docs: add test plan and documentation for response time tracker

### DIFF
--- a/src/tools/v2/team/response-time-tracker/README.md
+++ b/src/tools/v2/team/response-time-tracker/README.md
@@ -1,0 +1,39 @@
+# Response Time Tracker (V2)
+
+## Goal
+
+The Response Time Tracker is a contributor-friendly, isolated tool for measuring and displaying metrics related to team email response speeds. This is a V2 later-release tool designed specifically for the team audience.
+
+**Note:** This tool is built as complete, isolated work. It is not yet linked to the main app, main application shell, dashboard layout, existing routing, or the existing inbox architecture.
+
+## Setup
+
+To work on this tool independently:
+
+1. Ensure you have the standard repository dependencies installed (`npm install` / `bun install`).
+2. Run tests and verify the UI strictly within this directory boundary (`$rel/`).
+3. Use the localized mock fixtures provided in `test-plan.md` or local subdirectories to emulate the main application context.
+
+## Usage
+
+Currently, this module serves as an isolated feature package. When reviewing or working on the `Response Time Tracker`:
+
+- Keep all modifications inside `src/tools/v2/team/response-time-tracker/`.
+- Do not modify existing routing, the Stellar integration core, database schemas, or the design system unless explicitly stated in a follow-up integration issue.
+
+## Fixtures
+
+For development and testing, use strictly folder-local fixtures (e.g., mock email threads, fake response timestamps, dummy SLA policies). These fixtures should emulate the larger app environment without actually importing main app services that require complex setup.
+
+## Known Limitations
+
+- Not currently integrated with the main routing or navigation system.
+- Not connected to the real production database schema or live tracking dispatchers.
+- Lacks main app authentication wrappers.
+
+## OSS Contributor Notes
+
+- **Scope:** Keep your work small, reviewable, and limited to this specific folder (`$rel/`).
+- **Dependencies:** Prefer folder-local components, services, and hooks over global shared utilities to minimize breaking changes.
+- **Reviewability:** The contribution should be reviewable as a self-contained mini-product change. If this tool requires a future connection to the main mail app or metric service, that will be addressed in a follow-up issue rather than adding integration complexity here.
+- **Testing:** Add test coverage locally or follow the guidelines in `test-plan.md`. The issue must remain isolated from app-wide tests.

--- a/src/tools/v2/team/response-time-tracker/test-plan.md
+++ b/src/tools/v2/team/response-time-tracker/test-plan.md
@@ -1,0 +1,42 @@
+# Test Plan: Response Time Tracker
+
+This document outlines the testing strategy for the Response Time Tracker tool. Because this tool is built as an isolated V2 component and is not yet linked to the main app, tests should strictly remain localized within `src/tools/v2/team/response-time-tracker/`.
+
+## 1. Unit Testing Strategy
+
+Once the core logic is implemented, the following unit tests must be added:
+
+- **Metric Calculation:** Ensure that core utility functions accurately calculate response times between initial receipt and the first recorded team reply.
+- **SLA Validation:** Test functions that validate whether a response time meets, exceeds, or breaches predefined Service Level Agreement (SLA) thresholds.
+- **Data Aggregation:** Verify that functions responsible for aggregating daily, weekly, or team-wide averages return accurate deterministic results based on mock payloads.
+
+## 2. Component Testing (UI)
+
+If frontend components are developed, they should be tested using isolated rendering (e.g., via React Testing Library):
+
+- **Metric Dashboards:** Render the tracking visualizer UI using local fixture data and verify that response charts or KPI badges display correctly without relying on the main app shell.
+- **Filtering Controls:** Simulate user interactions like changing date ranges or selecting specific team members, and assert that the localized state updates accordingly.
+
+## 3. Fixtures and Mocks
+
+To maintain isolation from the rest of the application, contributors must create and use local mock data:
+
+- **`__fixtures__/mockMetrics.ts`**: Sample JSON payloads containing complex and simple arrays of response time data points.
+- **`__fixtures__/mockSLAConfigs.ts`**: Snapshot configurations defining different response time targets for various priorities.
+- **Service Mocks**: If the module requires external triggers (like mocking an incoming mail webhook), stub these interfaces directly inside the test files.
+
+## 4. Acceptance Criteria for Tests
+
+Before considering a PR complete for this tool:
+
+- [ ] Test files exist strictly inside the `response-time-tracker` folder.
+- [ ] No tests depend on global `stealth` testing configurations or app-wide test suites unless explicitly provided by the framework (e.g., standard Playwright/Vitest config).
+- [ ] Tests execute successfully using standard test commands (e.g., `bun test` or equivalent) on the specific folder path.
+
+## 5. Review Guidelines for OSS Contributors
+
+When validating test coverage:
+
+1. Ensure the scope of tests does not exceed the `$rel/` directory boundaries.
+2. Confirm that mock data accurately reflects what would be expected from the real metrics engine, without actually importing it.
+3. Validate that adding or running tests here does not break existing app-wide continuous integration pipelines.


### PR DESCRIPTION
## What was done
- Initialized the isolated directory structure for the team V2 `Response Time Tracker` tool.
- Added a `README.md` defining the setup, usage, limitations, and specific review guidelines for OSS contributors working within this scope.
- Added a `test-plan.md` outlining the future testing strategy (metric calculation, SLA validation, data aggregation), fixture constraints, and requirements to ensure tests remain strictly folder-local.

## Why it was done
This establishes the foundational isolation boundaries and context for the Response Time Tracker. It enables open-source contributors to independently build and test the SLA and metrics visualization logic without risking regressions in the main `stealth` repository's routing, dashboard architecture, or primary mail event indexers. 

## How it was verified
- Verified that all documentation files are correctly placed in `src/tools/v2/team/response-time-tracker/`.
- Confirmed that no global dependencies, app-wide tests, routing systems, or core authentication wrappers were modified.
- Verified that all documentation adheres to the project's Prettier formatting standards.

closes #648 
