### PR TITLE
Feat/v1 follow up reminder UI

### DIFF
--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminder.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminder.tsx
@@ -1,0 +1,240 @@
+import React, { useState, useCallback } from "react";
+import type { ReminderReviewModel } from "../services/followUpReminder";
+import { buildFollowUpReminder } from "../services/followUpReminder";
+import { sampleEmailList } from "../services/fixtures";
+import { FollowUpReminderCard } from "./FollowUpReminderCard";
+import { FollowUpReminderEmptyState } from "./FollowUpReminderEmptyState";
+import { FollowUpReminderErrorState } from "./FollowUpReminderErrorState";
+import { FollowUpReminderLoadingState } from "./FollowUpReminderLoadingState";
+
+type ToolState = "idle" | "loading" | "success" | "error" | "empty";
+
+export const FollowUpReminder: React.FC = () => {
+  const [state, setState] = useState<ToolState>("idle");
+  const [reminders, setReminders] = useState<ReminderReviewModel[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLoad = useCallback(() => {
+    setState("loading");
+    setError(null);
+    setTimeout(() => {
+      try {
+        const results = sampleEmailList.map((email) => buildFollowUpReminder(email));
+        const actionable = results.filter((r) => r.state === "draft");
+        if (actionable.length === 0) {
+          setState("empty");
+          setReminders([]);
+        } else {
+          setState("success");
+          setReminders(actionable);
+        }
+      } catch {
+        setState("error");
+        setError("An unexpected error occurred while processing email content.");
+      }
+    }, 1200);
+  }, []);
+
+  const handleSimulateEmpty = useCallback(() => {
+    setState("empty");
+    setReminders([]);
+    setError(null);
+  }, []);
+
+  const handleSimulateError = useCallback(() => {
+    setState("error");
+    setReminders([]);
+    setError("Connection lost. Unable to reach the email analysis service.");
+  }, []);
+
+  const handleSimulateSuccess = useCallback(() => {
+    const results = sampleEmailList.map((email) => buildFollowUpReminder(email));
+    const actionable = results.filter((r) => r.state === "draft");
+    setState("success");
+    setReminders(actionable);
+    setError(null);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    handleLoad();
+  }, [handleLoad]);
+
+  const handleConfirm = useCallback((id: string) => {
+    setReminders((prev) =>
+      prev.map((r) =>
+        r.sourceMessageId === id ? { ...r, warnings: [...r.warnings, "Reminder confirmed."] } : r,
+      ),
+    );
+  }, []);
+
+  const handleSnooze = useCallback((id: string) => {
+    setReminders((prev) =>
+      prev.map((r) =>
+        r.sourceMessageId === id
+          ? { ...r, warnings: [...r.warnings, "Snoozed until tomorrow."] }
+          : r,
+      ),
+    );
+  }, []);
+
+  const handleComplete = useCallback((id: string) => {
+    setReminders((prev) => {
+      const filtered = prev.filter((r) => r.sourceMessageId !== id);
+      if (filtered.length === 0) {
+        setState("empty");
+      }
+      return filtered;
+    });
+  }, []);
+
+  const handleDismiss = useCallback((id: string) => {
+    setReminders((prev) => {
+      const filtered = prev.filter((r) => r.sourceMessageId !== id);
+      if (filtered.length === 0) {
+        setState("empty");
+      }
+      return filtered;
+    });
+  }, []);
+
+  const handleEditDueDate = useCallback((id: string, newDate: string) => {
+    setReminders((prev) =>
+      prev.map((r) =>
+        r.sourceMessageId === id ? { ...r, dueAt: newDate } : r,
+      ),
+    );
+  }, []);
+
+  const activeCount = reminders.length;
+
+  return (
+    <div
+      className="p-6 border rounded-xl max-w-3xl mx-auto bg-white shadow-sm"
+      role="region"
+      aria-labelledby="follow-up-reminder-heading"
+    >
+      <header className="mb-6 border-b pb-4">
+        <div className="flex items-center gap-3 mb-1">
+          <svg
+            className="w-6 h-6 text-indigo-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+            />
+          </svg>
+          <h2 className="text-2xl font-semibold text-gray-800" id="follow-up-reminder-heading">
+            Follow-up Reminder
+          </h2>
+        </div>
+        <p className="text-sm text-gray-500 ml-9">
+          Detect follow-up requests, deadlines, and action items from email content.
+        </p>
+      </header>
+
+      <div
+        className="flex flex-wrap gap-2 mb-6"
+        role="group"
+        aria-label="Demo state controls"
+      >
+        <button
+          onClick={handleLoad}
+          className="px-4 py-2 bg-indigo-50 text-indigo-700 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors font-medium text-sm"
+          aria-pressed={state === "loading"}
+        >
+          Analyze Emails
+        </button>
+        <button
+          onClick={handleSimulateEmpty}
+          className="px-4 py-2 bg-gray-50 text-gray-700 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors font-medium text-sm"
+          aria-pressed={state === "empty"}
+        >
+          No Reminders Found
+        </button>
+        <button
+          onClick={handleSimulateError}
+          className="px-4 py-2 bg-red-50 text-red-700 rounded-md hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors font-medium text-sm"
+          aria-pressed={state === "error"}
+        >
+          Simulate Error
+        </button>
+        <button
+          onClick={handleSimulateSuccess}
+          className="px-4 py-2 bg-green-50 text-green-700 rounded-md hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors font-medium text-sm"
+          aria-pressed={state === "success"}
+        >
+          Show Success
+        </button>
+      </div>
+
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="min-h-[300px] bg-gray-50 rounded-lg border border-gray-100 p-4"
+      >
+        {state === "idle" && (
+          <div className="flex items-center justify-center h-full min-h-[250px]">
+            <div className="text-center">
+              <svg
+                className="w-12 h-12 text-gray-300 mx-auto mb-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                />
+              </svg>
+              <p className="text-gray-500 text-center">
+                Select <span className="font-medium">Analyze Emails</span> to detect follow-up
+                reminders.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {state === "loading" && <FollowUpReminderLoadingState />}
+
+        {state === "empty" && <FollowUpReminderEmptyState />}
+
+        {state === "error" && (
+          <FollowUpReminderErrorState error={error ?? undefined} onRetry={handleRetry} />
+        )}
+
+        {state === "success" && (
+          <div className="space-y-4">
+            <div className="flex justify-between items-center mb-2 px-2">
+              <span className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+                {activeCount} {activeCount === 1 ? "Reminder" : "Reminders"} Found
+              </span>
+            </div>
+            <ul className="space-y-3" aria-label="Follow-up reminder list">
+              {reminders.map((reminder) => (
+                <li key={reminder.sourceMessageId}>
+                  <FollowUpReminderCard
+                    reminder={reminder}
+                    onConfirm={handleConfirm}
+                    onSnooze={handleSnooze}
+                    onComplete={handleComplete}
+                    onDismiss={handleDismiss}
+                    onEditDueDate={handleEditDueDate}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminder.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminder.tsx
@@ -99,9 +99,7 @@ export const FollowUpReminder: React.FC = () => {
 
   const handleEditDueDate = useCallback((id: string, newDate: string) => {
     setReminders((prev) =>
-      prev.map((r) =>
-        r.sourceMessageId === id ? { ...r, dueAt: newDate } : r,
-      ),
+      prev.map((r) => (r.sourceMessageId === id ? { ...r, dueAt: newDate } : r)),
     );
   }, []);
 
@@ -138,11 +136,7 @@ export const FollowUpReminder: React.FC = () => {
         </p>
       </header>
 
-      <div
-        className="flex flex-wrap gap-2 mb-6"
-        role="group"
-        aria-label="Demo state controls"
-      >
+      <div className="flex flex-wrap gap-2 mb-6" role="group" aria-label="Demo state controls">
         <button
           onClick={handleLoad}
           className="px-4 py-2 bg-indigo-50 text-indigo-700 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors font-medium text-sm"

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminderCard.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminderCard.tsx
@@ -1,0 +1,249 @@
+import React, { useState } from "react";
+import type {
+  ReminderReviewModel,
+  ReminderConfidence,
+  ReminderState,
+} from "../services/followUpReminder";
+
+const CONFIDENCE_META: Record<
+  ReminderConfidence,
+  { label: string; bg: string; text: string; dot: string }
+> = {
+  high: { label: "High", bg: "bg-green-50", text: "text-green-800", dot: "bg-green-500" },
+  medium: { label: "Medium", bg: "bg-amber-50", text: "text-amber-800", dot: "bg-amber-500" },
+  low: { label: "Low", bg: "bg-gray-50", text: "text-gray-700", dot: "bg-gray-400" },
+};
+
+const SIGNAL_LABELS: Record<string, string> = {
+  explicit_request: "Explicit Request",
+  absolute_date: "Absolute Date",
+  relative_date: "Relative Date",
+  sender_hint: "Sender Hint",
+  low_confidence_context: "Low Confidence",
+};
+
+function formatDueDate(iso: string | null): string {
+  if (!iso) return "No due date set";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface FollowUpReminderCardProps {
+  reminder: ReminderReviewModel;
+  onConfirm?: (id: string) => void;
+  onSnooze?: (id: string) => void;
+  onComplete?: (id: string) => void;
+  onDismiss?: (id: string) => void;
+  onEditDueDate?: (id: string, newDate: string) => void;
+}
+
+export const FollowUpReminderCard: React.FC<FollowUpReminderCardProps> = ({
+  reminder,
+  onConfirm,
+  onSnooze,
+  onComplete,
+  onDismiss,
+  onEditDueDate,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [editDate, setEditDate] = useState(reminder.dueAt ?? "");
+
+  const meta = CONFIDENCE_META[reminder.confidence];
+
+  const handleEditSave = () => {
+    if (onEditDueDate && editDate) {
+      onEditDueDate(reminder.sourceMessageId, editDate);
+    }
+    setEditing(false);
+  };
+
+  const handleEditKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleEditSave();
+    } else if (e.key === "Escape") {
+      setEditing(false);
+      setEditDate(reminder.dueAt ?? "");
+    }
+  };
+
+  return (
+    <div
+      className="p-5 border border-indigo-200 rounded-lg bg-white shadow-sm hover:border-indigo-300 focus-within:ring-2 focus-within:ring-indigo-500 focus-within:border-indigo-500 outline-none transition-all"
+      tabIndex={0}
+      aria-label={`Reminder: ${reminder.title}`}
+    >
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-semibold ${meta.bg} ${meta.text}`}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} aria-hidden="true" />
+              {meta.label}
+            </span>
+            <span className="text-xs text-gray-400 font-mono">
+              {reminder.state === "draft" ? "Draft" : "No Action"}
+            </span>
+          </div>
+          <h3 className="font-semibold text-gray-900 text-base truncate">{reminder.title}</h3>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 mb-3 text-sm">
+        <div className="flex items-center gap-1.5 text-gray-600">
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          {editing ? (
+            <div className="flex items-center gap-1">
+              <input
+                type="date"
+                value={editDate}
+                onChange={(e) => setEditDate(e.target.value)}
+                onKeyDown={handleEditKeyDown}
+                className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                aria-label="Edit due date"
+                autoFocus
+              />
+              <button
+                onClick={handleEditSave}
+                className="px-2 py-1 text-xs font-medium text-white bg-indigo-600 rounded hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                aria-label="Save due date"
+              >
+                Save
+              </button>
+              <button
+                onClick={() => {
+                  setEditing(false);
+                  setEditDate(reminder.dueAt ?? "");
+                }}
+                className="px-2 py-1 text-xs font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500"
+                aria-label="Cancel editing due date"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <span>
+              Due {formatDueDate(reminder.dueAt)}
+              {reminder.dueAt && (
+                <span className="ml-1 text-gray-400 text-xs">
+                  ({new Date(reminder.dueAt).toLocaleDateString("en-CA")})
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {reminder.signals.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3" role="list" aria-label="Detected signals">
+          {reminder.signals.map((signal, idx) => (
+            <span
+              key={idx}
+              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-50 text-indigo-700"
+              role="listitem"
+            >
+              {SIGNAL_LABELS[signal.type] ?? signal.type}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {reminder.warnings.length > 0 && (
+        <div className="mb-3 space-y-1">
+          {reminder.warnings.map((warning, idx) => (
+            <p
+              key={idx}
+              className="flex items-start gap-1.5 text-xs text-amber-700 bg-amber-50 px-2.5 py-1.5 rounded"
+              role="alert"
+            >
+              <svg
+                className="w-3.5 h-3.5 mt-0.5 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              {warning}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div
+        className="flex flex-wrap gap-2 pt-2 border-t border-gray-100"
+        role="group"
+        aria-label="Reminder actions"
+      >
+        {reminder.state === "draft" && onConfirm && (
+          <button
+            onClick={() => onConfirm(reminder.sourceMessageId)}
+            className="px-3 py-1.5 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+            aria-label="Confirm reminder"
+          >
+            Confirm
+          </button>
+        )}
+        {reminder.state === "draft" && onSnooze && (
+          <button
+            onClick={() => onSnooze(reminder.sourceMessageId)}
+            className="px-3 py-1.5 bg-white border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+            aria-label="Snooze reminder"
+          >
+            Snooze
+          </button>
+        )}
+        <button
+          onClick={() => setEditing(true)}
+          className="px-3 py-1.5 bg-white border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+          aria-label="Edit reminder due date"
+        >
+          Edit
+        </button>
+        {onComplete && (
+          <button
+            onClick={() => onComplete(reminder.sourceMessageId)}
+            className="px-3 py-1.5 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+            aria-label="Mark reminder complete"
+          >
+            Complete
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            onClick={() => onDismiss(reminder.sourceMessageId)}
+            className="px-3 py-1.5 bg-white border border-gray-300 text-gray-500 rounded-md text-sm font-medium hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+            aria-label="Dismiss reminder"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminderEmptyState.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminderEmptyState.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export const FollowUpReminderEmptyState: React.FC = () => {
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[300px] text-center px-4"
+      role="status"
+      aria-live="polite"
+      aria-label="No follow-up reminders"
+    >
+      <div className="w-16 h-16 bg-green-50 text-green-500 rounded-full flex items-center justify-center mb-3">
+        <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+      <h3 className="text-lg font-medium text-gray-900">No Follow-Ups Needed</h3>
+      <p className="text-gray-500 mt-1 max-w-sm">
+        No actionable follow-up requests, deadlines, or reminders were found in the
+        selected email.
+      </p>
+    </div>
+  );
+};

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminderEmptyState.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminderEmptyState.tsx
@@ -9,14 +9,19 @@ export const FollowUpReminderEmptyState: React.FC = () => {
       aria-label="No follow-up reminders"
     >
       <div className="w-16 h-16 bg-green-50 text-green-500 rounded-full flex items-center justify-center mb-3">
-        <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          className="w-8 h-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
         </svg>
       </div>
       <h3 className="text-lg font-medium text-gray-900">No Follow-Ups Needed</h3>
       <p className="text-gray-500 mt-1 max-w-sm">
-        No actionable follow-up requests, deadlines, or reminders were found in the
-        selected email.
+        No actionable follow-up requests, deadlines, or reminders were found in the selected email.
       </p>
     </div>
   );

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminderErrorState.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminderErrorState.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+interface FollowUpReminderErrorStateProps {
+  error?: string;
+  onRetry?: () => void;
+}
+
+export const FollowUpReminderErrorState: React.FC<FollowUpReminderErrorStateProps> = ({
+  error = "Unable to analyze email content. Please verify the email is selected and try again.",
+  onRetry,
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[300px] px-4">
+      <div
+        className="bg-red-50 border border-red-200 p-5 rounded-lg max-w-md w-full"
+        role="alert"
+        aria-label="Error loading reminders"
+      >
+        <div className="flex items-start">
+          <div className="flex-shrink-0 mt-0.5">
+            <svg
+              className="w-5 h-5 text-red-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+          </div>
+          <div className="ml-3 w-full">
+            <h3 className="text-red-800 font-medium text-base">Analysis Failed</h3>
+            <p className="text-red-600 mt-1 text-sm">{error}</p>
+            {onRetry && (
+              <div className="mt-4">
+                <button
+                  onClick={onRetry}
+                  className="px-3 py-1.5 bg-red-100 text-red-800 rounded-md text-sm font-medium hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
+                  aria-label="Retry email analysis"
+                >
+                  Retry Analysis
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/tools/v1/individual/follow-up-reminder/components/FollowUpReminderLoadingState.tsx
+++ b/tools/v1/individual/follow-up-reminder/components/FollowUpReminderLoadingState.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export const FollowUpReminderLoadingState: React.FC = () => {
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[300px]"
+      role="status"
+      aria-busy="true"
+      aria-label="Analyzing email for follow-up reminders"
+    >
+      <div
+        className="w-10 h-10 border-4 border-indigo-200 border-t-indigo-600 rounded-full animate-spin mb-4"
+        role="presentation"
+      />
+      <span className="text-indigo-600 font-medium">Analyzing email content...</span>
+      <p className="text-sm text-gray-500 mt-2">Scanning for follow-up requests and due dates.</p>
+    </div>
+  );
+};

--- a/tools/v1/individual/follow-up-reminder/components/index.ts
+++ b/tools/v1/individual/follow-up-reminder/components/index.ts
@@ -1,0 +1,5 @@
+export { FollowUpReminder } from "./FollowUpReminder";
+export { FollowUpReminderCard } from "./FollowUpReminderCard";
+export { FollowUpReminderEmptyState } from "./FollowUpReminderEmptyState";
+export { FollowUpReminderErrorState } from "./FollowUpReminderErrorState";
+export { FollowUpReminderLoadingState } from "./FollowUpReminderLoadingState";

--- a/tools/v1/individual/follow-up-reminder/docs/style-guide.md
+++ b/tools/v1/individual/follow-up-reminder/docs/style-guide.md
@@ -1,0 +1,105 @@
+# Follow-up Reminder -- UI Style Guide
+
+This document describes the visual style and accessibility conventions used by
+the folder-local UI components. It does not modify or depend on the shared
+design system in `src/features/design-system/`.
+
+## Colour Palette
+
+All colours are applied via Tailwind utility classes.
+
+| Token              | Usage                            | Tailwind Class               |
+|--------------------|----------------------------------|------------------------------|
+| Background         | Card / surface backgrounds       | `bg-white`, `bg-gray-50`     |
+| Foreground         | Primary text                     | `text-gray-800`, `text-gray-900` |
+| Muted              | Secondary / description text     | `text-gray-500`              |
+| Border             | Card borders                     | `border-gray-100`, `border-indigo-200` |
+| Primary (indigo)   | Interactive controls, branding   | `text-indigo-600`, `bg-indigo-600` |
+| Success (green)    | Complete, positive state         | `text-green-500`, `bg-green-50`, `bg-green-600` |
+| Warning (amber)    | Alerts, warnings, medium confidence | `text-amber-700`, `bg-amber-50`, `bg-amber-500` |
+| Error (red)        | Errors, destructive actions      | `text-red-500`, `bg-red-50`, `bg-red-600` |
+| Neutral (gray)     | Low confidence, secondary actions | `text-gray-400`, `bg-gray-50` |
+
+## Typography
+
+- **Headings:** `text-2xl font-semibold` (`h2`), `text-lg font-medium` (`h3`)
+- **Body:** `text-sm` (`p`), `text-xs` (metadata, secondary info)
+- **Labels/Badges:** `text-xs font-semibold`
+- **Monospace:** `font-mono text-xs` for state labels
+
+Font family is inherited from the host environment (no local override).
+
+## Component Sizing
+
+- **Card container:** `p-6 border rounded-xl max-w-3xl mx-auto`
+- **Content area:** `min-h-[300px]` with `p-4`
+- **Reminder cards:** `p-5 border rounded-lg`
+- **Buttons:** `px-4 py-2` (toolbar), `px-3 py-1.5` (card actions)
+- **Badges / tags:** `px-2.5 py-0.5 rounded-full` (confidence), `px-2 py-0.5 rounded` (signal tags)
+
+## Spacing
+
+- **Section gap:** `mb-6` (between header/content), `mb-4` (between card sections)
+- **Button gap:** `gap-2` (toolbar), `gap-2` (action groups)
+- **List gap:** `space-y-3` (reminder list), `space-y-4` (card content)
+
+## Focus & Keyboard
+
+All interactive elements follow these conventions:
+
+| Element           | Focus Style                                      |
+|-------------------|--------------------------------------------------|
+| Toolbar buttons   | `focus:outline-none focus:ring-2 focus:ring-{color}-500 focus:ring-offset-2` |
+| Card actions      | Same as above, with `focus:ring-offset-1`        |
+| Card container    | `focus-within:ring-2 focus-within:ring-indigo-500` |
+| Date input        | `focus:outline-none focus:ring-2 focus:ring-indigo-500` |
+| Tab order         | Native DOM order (left-to-right, top-to-bottom) |
+
+### Keyboard interactions
+
+- **Enter / Space:** Activates buttons (native browser behavior)
+- **Escape:** Cancels inline date editing
+- **Tab:** Moves focus through interactive controls in document order
+
+## Accessibility Patterns
+
+| Pattern               | Implementation                                              |
+|-----------------------|-------------------------------------------------------------|
+| Landmark region       | `role="region"` + `aria-labelledby` on root container       |
+| Live region           | `aria-live="polite"` + `aria-atomic="true"` on content area |
+| Loading indicator     | `role="status"` + `aria-busy="true"` + `aria-label`        |
+| Error announcement    | `role="alert"` on error container                           |
+| Empty state           | `role="status"` with `aria-live="polite"`                  |
+| Button groups         | `role="group"` + `aria-label` for action clusters           |
+| Toggle buttons        | `aria-pressed` for state control buttons                    |
+| Icon decoration       | `aria-hidden="true"` on all decorative SVGs                 |
+| List semantics        | `<ul>` + `aria-label` + `<li>` for reminder list            |
+| Signal list           | `role="list"` + `aria-label` + `role="listitem"`            |
+| Inline editing        | `autoFocus` on input, Escape to cancel, Enter to save       |
+| Screen-reader labels  | `aria-label` on all icon-only or ambiguous controls         |
+
+## Animation & Transition
+
+- **Spinner:** `animate-spin` (CSS rotation, 1s linear infinite)
+- **State transitions:** No animations -- content updates immediately. The
+  `aria-live` region handles screen-reader announcement.
+- **Button hover:** `transition-colors` for smooth colour transitions
+- **Card hover:** `hover:border-{color}-300` with `transition-all`
+
+## Responsive Behaviour
+
+- **Max width:** `max-w-3xl` (768px) for readability
+- **Flex wrapping:** `flex-wrap` on button groups to handle narrow viewports
+- **Cards:** Full width within the container; no multi-column layout
+
+## Icons
+
+All icons are inline SVGs with `aria-hidden="true"`. No external icon library
+is imported. Icons used:
+
+- **Bell (reminder):** General tool and idle state icon
+- **Checkmark:** Empty state success indicator
+- **Alert triangle:** Error and warning states
+- **Calendar:** Due date display
+- **Info circle:** Warning details
+- **Spinner:** Loading indicator (`border-* + animate-spin`)

--- a/tools/v1/individual/follow-up-reminder/docs/style-guide.md
+++ b/tools/v1/individual/follow-up-reminder/docs/style-guide.md
@@ -8,17 +8,17 @@ design system in `src/features/design-system/`.
 
 All colours are applied via Tailwind utility classes.
 
-| Token              | Usage                            | Tailwind Class               |
-|--------------------|----------------------------------|------------------------------|
-| Background         | Card / surface backgrounds       | `bg-white`, `bg-gray-50`     |
-| Foreground         | Primary text                     | `text-gray-800`, `text-gray-900` |
-| Muted              | Secondary / description text     | `text-gray-500`              |
-| Border             | Card borders                     | `border-gray-100`, `border-indigo-200` |
-| Primary (indigo)   | Interactive controls, branding   | `text-indigo-600`, `bg-indigo-600` |
-| Success (green)    | Complete, positive state         | `text-green-500`, `bg-green-50`, `bg-green-600` |
-| Warning (amber)    | Alerts, warnings, medium confidence | `text-amber-700`, `bg-amber-50`, `bg-amber-500` |
-| Error (red)        | Errors, destructive actions      | `text-red-500`, `bg-red-50`, `bg-red-600` |
-| Neutral (gray)     | Low confidence, secondary actions | `text-gray-400`, `bg-gray-50` |
+| Token            | Usage                               | Tailwind Class                                  |
+| ---------------- | ----------------------------------- | ----------------------------------------------- |
+| Background       | Card / surface backgrounds          | `bg-white`, `bg-gray-50`                        |
+| Foreground       | Primary text                        | `text-gray-800`, `text-gray-900`                |
+| Muted            | Secondary / description text        | `text-gray-500`                                 |
+| Border           | Card borders                        | `border-gray-100`, `border-indigo-200`          |
+| Primary (indigo) | Interactive controls, branding      | `text-indigo-600`, `bg-indigo-600`              |
+| Success (green)  | Complete, positive state            | `text-green-500`, `bg-green-50`, `bg-green-600` |
+| Warning (amber)  | Alerts, warnings, medium confidence | `text-amber-700`, `bg-amber-50`, `bg-amber-500` |
+| Error (red)      | Errors, destructive actions         | `text-red-500`, `bg-red-50`, `bg-red-600`       |
+| Neutral (gray)   | Low confidence, secondary actions   | `text-gray-400`, `bg-gray-50`                   |
 
 ## Typography
 
@@ -47,13 +47,13 @@ Font family is inherited from the host environment (no local override).
 
 All interactive elements follow these conventions:
 
-| Element           | Focus Style                                      |
-|-------------------|--------------------------------------------------|
-| Toolbar buttons   | `focus:outline-none focus:ring-2 focus:ring-{color}-500 focus:ring-offset-2` |
-| Card actions      | Same as above, with `focus:ring-offset-1`        |
-| Card container    | `focus-within:ring-2 focus-within:ring-indigo-500` |
-| Date input        | `focus:outline-none focus:ring-2 focus:ring-indigo-500` |
-| Tab order         | Native DOM order (left-to-right, top-to-bottom) |
+| Element         | Focus Style                                                                  |
+| --------------- | ---------------------------------------------------------------------------- |
+| Toolbar buttons | `focus:outline-none focus:ring-2 focus:ring-{color}-500 focus:ring-offset-2` |
+| Card actions    | Same as above, with `focus:ring-offset-1`                                    |
+| Card container  | `focus-within:ring-2 focus-within:ring-indigo-500`                           |
+| Date input      | `focus:outline-none focus:ring-2 focus:ring-indigo-500`                      |
+| Tab order       | Native DOM order (left-to-right, top-to-bottom)                              |
 
 ### Keyboard interactions
 
@@ -63,20 +63,20 @@ All interactive elements follow these conventions:
 
 ## Accessibility Patterns
 
-| Pattern               | Implementation                                              |
-|-----------------------|-------------------------------------------------------------|
-| Landmark region       | `role="region"` + `aria-labelledby` on root container       |
-| Live region           | `aria-live="polite"` + `aria-atomic="true"` on content area |
-| Loading indicator     | `role="status"` + `aria-busy="true"` + `aria-label`        |
-| Error announcement    | `role="alert"` on error container                           |
-| Empty state           | `role="status"` with `aria-live="polite"`                  |
-| Button groups         | `role="group"` + `aria-label` for action clusters           |
-| Toggle buttons        | `aria-pressed` for state control buttons                    |
-| Icon decoration       | `aria-hidden="true"` on all decorative SVGs                 |
-| List semantics        | `<ul>` + `aria-label` + `<li>` for reminder list            |
-| Signal list           | `role="list"` + `aria-label` + `role="listitem"`            |
-| Inline editing        | `autoFocus` on input, Escape to cancel, Enter to save       |
-| Screen-reader labels  | `aria-label` on all icon-only or ambiguous controls         |
+| Pattern              | Implementation                                              |
+| -------------------- | ----------------------------------------------------------- |
+| Landmark region      | `role="region"` + `aria-labelledby` on root container       |
+| Live region          | `aria-live="polite"` + `aria-atomic="true"` on content area |
+| Loading indicator    | `role="status"` + `aria-busy="true"` + `aria-label`         |
+| Error announcement   | `role="alert"` on error container                           |
+| Empty state          | `role="status"` with `aria-live="polite"`                   |
+| Button groups        | `role="group"` + `aria-label` for action clusters           |
+| Toggle buttons       | `aria-pressed` for state control buttons                    |
+| Icon decoration      | `aria-hidden="true"` on all decorative SVGs                 |
+| List semantics       | `<ul>` + `aria-label` + `<li>` for reminder list            |
+| Signal list          | `role="list"` + `aria-label` + `role="listitem"`            |
+| Inline editing       | `autoFocus` on input, Escape to cancel, Enter to save       |
+| Screen-reader labels | `aria-label` on all icon-only or ambiguous controls         |
 
 ## Animation & Transition
 

--- a/tools/v1/individual/follow-up-reminder/index.ts
+++ b/tools/v1/individual/follow-up-reminder/index.ts
@@ -19,3 +19,10 @@ export type {
   SignalType,
 } from "./services/followUpReminder";
 export { sampleEmails, sampleEmailList } from "./services/fixtures";
+export {
+  FollowUpReminder,
+  FollowUpReminderCard,
+  FollowUpReminderEmptyState,
+  FollowUpReminderErrorState,
+  FollowUpReminderLoadingState,
+} from "./components";


### PR DESCRIPTION
closes #361 

Here's a summary of what was created:

**8 new files + 1 modified — all under `tools/v1/individual/follow-up-reminder/`**

### Created files

| File | Purpose |
|---|---|
| `components/FollowUpReminder.tsx` | Main state-machine shell (`idle \| loading \| success \| error \| empty`) with live region and demo controls |
| `components/FollowUpReminderCard.tsx` | Reminder card with confidence badge, signals tags, warnings, and action controls (Confirm/Snooze/Edit/Complete/Dismiss) — includes inline date editing with Escape-to-cancel |
| `components/FollowUpReminderLoadingState.tsx` | Accessible spinner with `role="status" aria-busy="true"` |
| `components/FollowUpReminderEmptyState.tsx` | Empty state with `role="status" aria-live="polite"` |
| `components/FollowUpReminderErrorState.tsx` | Error state with `role="alert"` and retry action |
| `components/index.ts` | Barrel export for all components |
| `docs/style-guide.md` | Documents colour palette, typography, spacing, focus styles, keyboard interactions, and ARIA patterns |

### Modified files

- `index.ts` — added re-exports for all component types

### Accessibility features

- `role="region"` + `aria-labelledby` on root container
- `aria-live="polite"` + `aria-atomic="true"` on content area
- `role="alert"` on errors, `role="status"` on loading/empty
- `aria-busy="true"` on loading indicator
- `aria-pressed` on state toggle buttons
- `aria-label` on all interactive controls
- `aria-hidden="true"` on decorative SVGs
- `focus-within:ring-2` on cards, `focus:ring-2` on all buttons/inputs
- Escape key cancels inline date editing
- Semantic `<ul>`/`<li>` for reminder list, `role="list"` for signals