### PR TITLE
polish: tighten focus and pressed states

### DIFF
--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -167,7 +167,7 @@ export function CommandPalette({
                     value={q}
                     onChange={(event) => setQ(event.target.value)}
                     placeholder="Run a command or search folders, senders, proofs…"
-                    className="w-full bg-transparent text-sm placeholder:text-muted-foreground/70 focus:outline-none"
+                    className="glow-ring w-full rounded-md bg-transparent text-sm placeholder:text-muted-foreground/70 focus:outline-none"
                   />
                   {context.email && (
                     <span className="hidden max-w-[140px] truncate rounded-md border border-white/10 bg-black/30 px-1.5 py-0.5 text-[10px] text-muted-foreground sm:inline">
@@ -357,14 +357,14 @@ function ConfirmPanel({
       <div className="mt-5 flex gap-3">
         <button
           onClick={onCancel}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="glow-ring flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground active:scale-[0.98]"
         >
           Cancel
         </button>
         <button
           autoFocus
           onClick={onConfirm}
-          className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-red-500/90 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-red-500"
+          className="glow-ring flex flex-1 items-center justify-center gap-2 rounded-xl bg-red-500/90 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-red-500 active:scale-[0.98]"
         >
           {command.confirm?.confirmLabel}
           <CornerDownLeft className="h-3.5 w-3.5" />

--- a/src/features/command-palette/ShortcutOverlay.tsx
+++ b/src/features/command-palette/ShortcutOverlay.tsx
@@ -76,7 +76,7 @@ export function ShortcutOverlay({ open, onClose }: Props) {
                   </p>
                 </div>
               </div>
-              <div className="mt-4 flex items-center gap-3 rounded-2xl border border-white/8 bg-black/20 px-4 py-3">
+              <div className="mt-4 flex items-center gap-3 rounded-2xl border border-white/8 bg-black/20 px-4 py-3 transition focus-within:border-white/20 focus-within:bg-black/30">
                 <Search className="h-4 w-4 text-muted-foreground" />
                 <input
                   autoFocus


### PR DESCRIPTION
## Summary
Interaction-state polish for the Command Palette surface (issue #926). Tightens visible focus and pressed feedback using existing tokens — no behavior, copy, or layout change.

Closes #926

## Context
The palette and shortcut overlay already have empty states ("No matches…" / "No shortcuts match…"), disabled rows, hover, keyboard navigation, and proper dialog roles. The one consistent gap was **visible focus / pressed feedback**, which this fills.

## Changes
- **ConfirmPanel (dangerous-command confirm dialog)** — added the existing `glow-ring` focus token and `active:scale` pressed feedback to the Cancel and Confirm buttons. Confirm is autofocused today but showed no focus ring.
- **Command palette search input** — added `glow-ring` so keyboard focus is visible (matches the topbar search treatment).
- **Shortcut overlay search box** — added a `focus-within` border/background lift so the whole search pill reads as focused.

No new styling tokens; reuses `glow-ring`, the `focus-within` pattern, and the `active:` variant.

