### PR TITLE
perf(onboarding): stabilize the submit callback

### DIFF
--- a/src/features/onboarding/useOnboarding.ts
+++ b/src/features/onboarding/useOnboarding.ts
@@ -124,7 +124,11 @@ export function useOnboarding(options: {
     } finally {
       setIsSubmitting(false);
     }
-  }, [options, progress.draft]);
+    // Depend on options.onComplete (not the whole options object): callers pass
+    // useOnboarding({ onComplete }) with a fresh object literal every render, so
+    // depending on `options` rebuilt this callback on every render. Narrowing to
+    // the function keeps `submit` stable while onComplete is stable.
+  }, [options.onComplete, progress.draft]);
 
   return {
     step: progress.step,


### PR DESCRIPTION
## Summary
Scoped performance fix for the Onboarding surface (issue #933): stabilize the `submit` callback so it stops being rebuilt on every render. No behavior change.

Closes #933

## Hotspot (identified before changing code)
`OnboardingModal` calls `useOnboarding({ onComplete })` with a **fresh object literal on every render**. Inside the hook, the memoized `submit` callback depended on the whole `options` object — which therefore changed identity every render — so `submit` was recreated on every render. That churned the `onSubmit` prop handed down through `stepProps` to the steps (notably `PolicyReviewStep`).

## Change (`src/features/onboarding/useOnboarding.ts`)
- Narrow the `submit` dependency from `[options, progress.draft]` to `[options.onComplete, progress.draft]` — the only fields it actually reads. `submit` now stays referentially stable while `onComplete` is stable, instead of changing every render. Also satisfies `react-hooks/exhaustive-deps`.


