### PR TITLE
Security/v1 follow up reminder hardening

### DIFF
--- a/tools/v1/individual/follow-up-reminder/docs/performance.md
+++ b/tools/v1/individual/follow-up-reminder/docs/performance.md
@@ -1,0 +1,66 @@
+# Follow-up Reminder — Performance Notes
+
+Performance expectations and safeguards for the isolated Follow-up Reminder
+tool. Scope is this folder only.
+
+## Cost model
+
+For an email of n characters (subject + body):
+
+- Guard sanitization (sanitizeText): linear, a fixed set of regex passes.
+- Guard validation (validateInput, checkInputLimits): linear in input size.
+- Text bounding (boundedText): linear; collapses to the first MAX_SCAN_LENGTH
+  (4000) characters before the engine scans for signals.
+- Signal detection (explicit terms, low-confidence terms, absolute dates,
+  relative dates): linear in bounded text length; each pass is a fixed set of
+  term lookups or regex matches.
+- Confidence and state assignment: O(1), a small set of boolean checks.
+- Duplicate detection (isReminderDuplicate): linear in existingReminders length
+  per call.
+
+All scanning passes operate on a capped text window (4000 chars), so the
+dominant cost is bound regardless of the original email size. There are no
+nested scans over the full body.
+
+## Hard limits
+
+Defined in services/guards.ts as GUARD_LIMITS:
+
+| Limit               | Default | Purpose                             |
+| ------------------- | ------- | ----------------------------------- |
+| maxSubjectChars     | 500     | Reject runaway subject lines        |
+| maxBodyChars        | 50000   | Bound total memory per scan         |
+| maxBodyWords        | 10000   | Bound word-level signal passes      |
+| maxExistingReminders| 1000    | Bound dedup iteration per call      |
+
+Inputs above these caps are rejected by safeBuildFollowUpReminder before the
+engine does any scanning work, so a hostile or accidental large payload cannot
+consume meaningful CPU.
+
+Additionally, the engine's internal MAX_SCAN_LENGTH (4000) ensures that the
+text signals pass is bounded even for inputs within the guard limits.
+
+## Large emails, attachments, teams, and histories
+
+- **Large emails**: body is capped by maxBodyChars (50000) and maxBodyWords
+  (10000); the engine text window is further capped at 4000 characters for
+  signal detection. Very long messages are scanned only in the first portion.
+- **Attachments**: not read or processed by this tool; they are ignored. The
+  engine operates on subject and body text only.
+- **Teams or shared mailboxes**: out of scope for V1 individual; the tool holds
+  no shared state and operates on one email at a time.
+- **Histories**: no reminder history is stored inside this tool; the caller may
+  supply existingReminders for dedup, which is bounded by maxExistingReminders
+  (1000). Past that, the array is clamped to prevent excessive iteration.
+
+## Recommendations for a future integration
+
+- Run safeBuildFollowUpReminder (not the raw engine) at any UI or API boundary
+  so guards always apply.
+- Debounce or cancel in-flight reminders when the user switches messages to
+  avoid stale work.
+- Keep the caps configurable per deployment if larger bodies or deeper history
+  are ever required.
+- If integrating with persistent storage for existing reminders, paginate or
+  limit the query to the most recent N entries rather than loading the full
+  history.

--- a/tools/v1/individual/follow-up-reminder/docs/performance.md
+++ b/tools/v1/individual/follow-up-reminder/docs/performance.md
@@ -26,12 +26,12 @@ nested scans over the full body.
 
 Defined in services/guards.ts as GUARD_LIMITS:
 
-| Limit               | Default | Purpose                             |
-| ------------------- | ------- | ----------------------------------- |
-| maxSubjectChars     | 500     | Reject runaway subject lines        |
-| maxBodyChars        | 50000   | Bound total memory per scan         |
-| maxBodyWords        | 10000   | Bound word-level signal passes      |
-| maxExistingReminders| 1000    | Bound dedup iteration per call      |
+| Limit                | Default | Purpose                        |
+| -------------------- | ------- | ------------------------------ |
+| maxSubjectChars      | 500     | Reject runaway subject lines   |
+| maxBodyChars         | 50000   | Bound total memory per scan    |
+| maxBodyWords         | 10000   | Bound word-level signal passes |
+| maxExistingReminders | 1000    | Bound dedup iteration per call |
 
 Inputs above these caps are rejected by safeBuildFollowUpReminder before the
 engine does any scanning work, so a hostile or accidental large payload cannot

--- a/tools/v1/individual/follow-up-reminder/docs/threat-model.md
+++ b/tools/v1/individual/follow-up-reminder/docs/threat-model.md
@@ -1,0 +1,57 @@
+# Follow-up Reminder — Threat Model and Hardening Notes
+
+This document records the security assumptions for the isolated Follow-up
+Reminder tool and the guards that enforce them. It covers this folder only and
+does not describe the wider mail application.
+
+## Trust boundary
+
+- The reminder engine is a pure, local, rule-based text scanner.
+- It performs no network calls, reaches no mailbox or wallet state, uses no
+  eval or dynamic code, and contacts no external service.
+- It treats all input as untrusted email data supplied by the caller.
+- It is read-only: it returns a reminder review model and never sends, saves,
+  or mutates anything. The engine does not send email, create calendar events,
+  change labels, mark messages read, archive, or delete messages.
+
+## Assets to protect
+
+- Caller-supplied email content (must not be leaked, executed, or silently
+  altered beyond safe sanitization).
+- Process stability and responsiveness (no unbounded scanning or memory
+  allocation).
+
+## Unsafe inputs and mitigations
+
+| Unsafe input                                        | Risk                                              | Mitigation                                                               |
+| --------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------ |
+| Oversized subject or body                           | Excessive CPU or memory, denial of service        | checkInputLimits rejects input above hard caps before the engine runs    |
+| Very high word count in body                        | Heavy work in date and signal scanning passes     | Word cap rejects early; engine scanning is bounded by MAX_SCAN_LENGTH    |
+| Control characters such as NUL or BEL               | Log injection, terminal escapes, corrupted output | sanitizeText strips ASCII control chars and keeps tab and newline        |
+| Zero-width or BOM characters                        | Hidden or smuggled content, spoofing              | sanitizeText strips zero-width and BOM characters                        |
+| Decomposed or duplicate unicode forms               | Inconsistent signal matching and output           | sanitizeText normalizes to NFC                                           |
+| Non-string or missing required fields               | Type confusion, runtime errors                    | validateInput rejects before the engine runs                             |
+| Invalid receivedAt (non-ISO, epoch, etc.)           | Broken date arithmetic, crashes                   | validateInput checks that the date string produces a valid Date          |
+| Empty or missing messageId                          | Duplicate detection bypass, data confusion        | validateInput rejects empty or missing messageId                         |
+| Massive existingReminders array                     | Excessive iteration, degraded dedup performance   | validateOptions clamps the array; checkOptionsLimits rejects oversized   |
+| Malformed existingReminder entries                  | Type errors in dedup logic                        | validateOptions filters out entries with missing or invalid fields       |
+| Ambiguous or contradictory date signals             | Incorrect due date assignment                     | Engine handles ambiguity by setting dueAt to null with a warning         |
+| Sequential calls with large state                   | Memory growth across invocations                  | Each call is stateless; callers must manage their own state              |
+
+## Explicitly out of scope
+
+- HTML or markup sanitization for rendering (the engine scans plain text; any
+  future UI must escape on display).
+- Authentication, authorization, and rate limiting (belongs to a future
+  integration issue, not this folder).
+- Persistence, transport security, or calendar integration (nothing is stored
+  or transmitted here; future scheduling integration requires explicit user
+  action).
+- Protection against UI-side attacks (XSS, clickjacking, etc.) — these belong
+  to the integration layer that renders the reminder model.
+
+## Determinism
+
+All guards and engine functions are deterministic: the same input always yields
+the same result, with no randomness, clock, or locale dependence. This keeps
+the behavior testable and predictable under review.

--- a/tools/v1/individual/follow-up-reminder/docs/threat-model.md
+++ b/tools/v1/individual/follow-up-reminder/docs/threat-model.md
@@ -23,20 +23,20 @@ does not describe the wider mail application.
 
 ## Unsafe inputs and mitigations
 
-| Unsafe input                                        | Risk                                              | Mitigation                                                               |
-| --------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------ |
-| Oversized subject or body                           | Excessive CPU or memory, denial of service        | checkInputLimits rejects input above hard caps before the engine runs    |
-| Very high word count in body                        | Heavy work in date and signal scanning passes     | Word cap rejects early; engine scanning is bounded by MAX_SCAN_LENGTH    |
-| Control characters such as NUL or BEL               | Log injection, terminal escapes, corrupted output | sanitizeText strips ASCII control chars and keeps tab and newline        |
-| Zero-width or BOM characters                        | Hidden or smuggled content, spoofing              | sanitizeText strips zero-width and BOM characters                        |
-| Decomposed or duplicate unicode forms               | Inconsistent signal matching and output           | sanitizeText normalizes to NFC                                           |
-| Non-string or missing required fields               | Type confusion, runtime errors                    | validateInput rejects before the engine runs                             |
-| Invalid receivedAt (non-ISO, epoch, etc.)           | Broken date arithmetic, crashes                   | validateInput checks that the date string produces a valid Date          |
-| Empty or missing messageId                          | Duplicate detection bypass, data confusion        | validateInput rejects empty or missing messageId                         |
-| Massive existingReminders array                     | Excessive iteration, degraded dedup performance   | validateOptions clamps the array; checkOptionsLimits rejects oversized   |
-| Malformed existingReminder entries                  | Type errors in dedup logic                        | validateOptions filters out entries with missing or invalid fields       |
-| Ambiguous or contradictory date signals             | Incorrect due date assignment                     | Engine handles ambiguity by setting dueAt to null with a warning         |
-| Sequential calls with large state                   | Memory growth across invocations                  | Each call is stateless; callers must manage their own state              |
+| Unsafe input                              | Risk                                              | Mitigation                                                             |
+| ----------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| Oversized subject or body                 | Excessive CPU or memory, denial of service        | checkInputLimits rejects input above hard caps before the engine runs  |
+| Very high word count in body              | Heavy work in date and signal scanning passes     | Word cap rejects early; engine scanning is bounded by MAX_SCAN_LENGTH  |
+| Control characters such as NUL or BEL     | Log injection, terminal escapes, corrupted output | sanitizeText strips ASCII control chars and keeps tab and newline      |
+| Zero-width or BOM characters              | Hidden or smuggled content, spoofing              | sanitizeText strips zero-width and BOM characters                      |
+| Decomposed or duplicate unicode forms     | Inconsistent signal matching and output           | sanitizeText normalizes to NFC                                         |
+| Non-string or missing required fields     | Type confusion, runtime errors                    | validateInput rejects before the engine runs                           |
+| Invalid receivedAt (non-ISO, epoch, etc.) | Broken date arithmetic, crashes                   | validateInput checks that the date string produces a valid Date        |
+| Empty or missing messageId                | Duplicate detection bypass, data confusion        | validateInput rejects empty or missing messageId                       |
+| Massive existingReminders array           | Excessive iteration, degraded dedup performance   | validateOptions clamps the array; checkOptionsLimits rejects oversized |
+| Malformed existingReminder entries        | Type errors in dedup logic                        | validateOptions filters out entries with missing or invalid fields     |
+| Ambiguous or contradictory date signals   | Incorrect due date assignment                     | Engine handles ambiguity by setting dueAt to null with a warning       |
+| Sequential calls with large state         | Memory growth across invocations                  | Each call is stateless; callers must manage their own state            |
 
 ## Explicitly out of scope
 

--- a/tools/v1/individual/follow-up-reminder/index.ts
+++ b/tools/v1/individual/follow-up-reminder/index.ts
@@ -29,8 +29,4 @@ export {
   validateInput,
   validateOptions,
 } from "./services/guards";
-export type {
-  GuardErrorCode,
-  GuardIssue,
-  SafeBuildResult,
-} from "./services/guards";
+export type { GuardErrorCode, GuardIssue, SafeBuildResult } from "./services/guards";

--- a/tools/v1/individual/follow-up-reminder/index.ts
+++ b/tools/v1/individual/follow-up-reminder/index.ts
@@ -19,3 +19,18 @@ export type {
   SignalType,
 } from "./services/followUpReminder";
 export { sampleEmails, sampleEmailList } from "./services/fixtures";
+export {
+  GUARD_LIMITS,
+  checkInputLimits,
+  checkOptionsLimits,
+  safeBuildFollowUpReminder,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "./services/guards";
+export type {
+  GuardErrorCode,
+  GuardIssue,
+  SafeBuildResult,
+} from "./services/guards";

--- a/tools/v1/individual/follow-up-reminder/services/guards.ts
+++ b/tools/v1/individual/follow-up-reminder/services/guards.ts
@@ -1,0 +1,231 @@
+// Follow-up Reminder — security and performance guards.
+//
+// Folder-local hardening layer that runs before the core engine to reject
+// hostile or oversized input and to strip characters that could hide content
+// or break downstream rendering. Everything here is pure and deterministic:
+// no network calls, no mailbox access, no eval, and no mutation of
+// caller-supplied objects.
+
+import {
+  buildFollowUpReminder,
+  type BuildReminderOptions,
+  type ExistingReminderKey,
+  type NormalizedEmailInput,
+  type ReminderReviewModel,
+} from "./followUpReminder";
+
+/**
+ * Hard input bounds. They cap the work the engine can be asked to do and give
+ * deterministic rejection for payloads that are too large to be a real email.
+ */
+export const GUARD_LIMITS = {
+  /** Max characters allowed in the subject line. */
+  maxSubjectChars: 500,
+  /** Max characters allowed in the email body. */
+  maxBodyChars: 50000,
+  /** Max whitespace-separated words allowed in the body. */
+  maxBodyWords: 10000,
+  /** Max existing reminder entries accepted for dedup checks. */
+  maxExistingReminders: 1000,
+} as const;
+
+/** Guard-specific error codes, distinct from engine-level warnings. */
+export type GuardErrorCode =
+  | "input-too-large"
+  | "invalid-input"
+  | "too-many-existing-reminders";
+
+export interface GuardIssue {
+  code: GuardErrorCode;
+  message: string;
+}
+
+/**
+ * Result of the guarded entry point: either a normal engine result wrapped in
+ * success, or a guard rejection raised before the engine runs any work.
+ */
+export type SafeBuildResult =
+  | { status: "ok"; model: ReminderReviewModel }
+  | { status: "error"; code: GuardErrorCode; message: string };
+
+// Control characters (except tab and newline) can hide or corrupt content.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+// Zero-width and BOM characters can smuggle invisible payloads into text.
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+
+/**
+ * Normalizes text and strips control and invisible characters. Tabs and
+ * newlines are preserved, then collapsed by the engine during scanning.
+ */
+export function sanitizeText(text: string): string {
+  return text.normalize("NFC").replace(CONTROL_CHARACTERS, "").replace(INVISIBLE_CHARACTERS, "");
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * True when the value has the string fields the guards need to inspect and
+ * the required fields for the engine to produce a meaningful result.
+ */
+function hasInspectableFields(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.subject === "string" &&
+    typeof candidate.body === "string" &&
+    typeof candidate.senderAddress === "string" &&
+    typeof candidate.receivedAt === "string"
+  );
+}
+
+/**
+ * Validates that the input has a valid shape for the engine. Checks for the
+ * presence and types of required fields, and validates the receivedAt format.
+ */
+export function validateInput(value: unknown): value is NormalizedEmailInput {
+  if (!hasInspectableFields(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.messageId !== "string" || v.messageId.length === 0) {
+    return false;
+  }
+  if (Number.isNaN(new Date(String(v.receivedAt)).getTime())) {
+    return false;
+  }
+  if (v.senderName !== undefined && typeof v.senderName !== "string") {
+    return false;
+  }
+  if (v.timeZone !== undefined && typeof v.timeZone !== "string") {
+    return false;
+  }
+  if (v.threadHint !== undefined && typeof v.threadHint !== "string") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns a sanitized copy of the input without mutating the original. Only
+ * text fields that could contain hidden characters are cleaned; other fields
+ * are passed through unchanged.
+ */
+export function sanitizeInput(input: NormalizedEmailInput): NormalizedEmailInput {
+  return {
+    ...input,
+    subject: sanitizeText(input.subject),
+    body: sanitizeText(input.body),
+    senderName: input.senderName ? sanitizeText(input.senderName) : undefined,
+    threadHint: input.threadHint ? sanitizeText(input.threadHint) : undefined,
+  };
+}
+
+/**
+ * Checks a validated, sanitized input against the hard size limits. Returns
+ * the first issue found, or null when the input is within bounds.
+ */
+export function checkInputLimits(input: NormalizedEmailInput): GuardIssue | null {
+  if (input.subject.length > GUARD_LIMITS.maxSubjectChars) {
+    return {
+      code: "input-too-large",
+      message: "Subject exceeds " + GUARD_LIMITS.maxSubjectChars + " characters.",
+    };
+  }
+  if (input.body.length > GUARD_LIMITS.maxBodyChars) {
+    return {
+      code: "input-too-large",
+      message: "Body exceeds " + GUARD_LIMITS.maxBodyChars + " characters.",
+    };
+  }
+  if (countWords(input.body) > GUARD_LIMITS.maxBodyWords) {
+    return {
+      code: "input-too-large",
+      message: "Body exceeds " + GUARD_LIMITS.maxBodyWords + " words.",
+    };
+  }
+  return null;
+}
+
+/**
+ * Validates the optional options parameter and extracts the fields the engine
+ * needs. Silently clamps oversized arrays to the hard cap.
+ */
+export function validateOptions(value: unknown): BuildReminderOptions {
+  if (typeof value !== "object" || value === null) {
+    return {};
+  }
+  const raw = value as Record<string, unknown>;
+  const result: BuildReminderOptions = {};
+  if (typeof raw.now === "string") {
+    result.now = raw.now;
+  }
+  if (Array.isArray(raw.existingReminders)) {
+    const items = raw.existingReminders.slice(0, GUARD_LIMITS.maxExistingReminders);
+    result.existingReminders = items.filter(
+      (item: unknown): item is ExistingReminderKey => {
+        if (typeof item !== "object" || item === null) return false;
+        const e = item as Record<string, unknown>;
+        return typeof e.sourceMessageId === "string" && (e.dueAt === null || typeof e.dueAt === "string");
+      },
+    );
+  }
+  return result;
+}
+
+/**
+ * Checks parsed options for guard-level issues. Currently validates that the
+ * existingReminders array does not exceed the hard cap.
+ */
+export function checkOptionsLimits(options: BuildReminderOptions): GuardIssue | null {
+  if (options.existingReminders && options.existingReminders.length > GUARD_LIMITS.maxExistingReminders) {
+    return {
+      code: "too-many-existing-reminders",
+      message:
+        "Existing reminders list exceeds " +
+        GUARD_LIMITS.maxExistingReminders +
+        " entries.",
+    };
+  }
+  return null;
+}
+
+/**
+ * Guarded entry point. Validates input shape, sanitizes text fields, enforces
+ * hard size limits, checks options bounds, and only then delegates to the core
+ * engine. Malformed inputs are rejected before the engine runs any work, so
+ * hostile or oversized payloads cannot trigger unbounded scanning.
+ */
+export function safeBuildFollowUpReminder(
+  input: unknown,
+  options?: unknown,
+): SafeBuildResult {
+  if (!validateInput(input)) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message:
+        "Invalid input: expected an object with string fields for subject, " +
+        "body, senderAddress, receivedAt, and a non-empty messageId.",
+    };
+  }
+
+  const sanitized = sanitizeInput(input);
+
+  const limitIssue = checkInputLimits(sanitized);
+  if (limitIssue) {
+    return { status: "error", code: limitIssue.code, message: limitIssue.message };
+  }
+
+  const parsedOptions = validateOptions(options);
+
+  return { status: "ok", model: buildFollowUpReminder(sanitized, parsedOptions) };
+}

--- a/tools/v1/individual/follow-up-reminder/services/guards.ts
+++ b/tools/v1/individual/follow-up-reminder/services/guards.ts
@@ -30,10 +30,7 @@ export const GUARD_LIMITS = {
 } as const;
 
 /** Guard-specific error codes, distinct from engine-level warnings. */
-export type GuardErrorCode =
-  | "input-too-large"
-  | "invalid-input"
-  | "too-many-existing-reminders";
+export type GuardErrorCode = "input-too-large" | "invalid-input" | "too-many-existing-reminders";
 
 export interface GuardIssue {
   code: GuardErrorCode;
@@ -170,13 +167,13 @@ export function validateOptions(value: unknown): BuildReminderOptions {
   }
   if (Array.isArray(raw.existingReminders)) {
     const items = raw.existingReminders.slice(0, GUARD_LIMITS.maxExistingReminders);
-    result.existingReminders = items.filter(
-      (item: unknown): item is ExistingReminderKey => {
-        if (typeof item !== "object" || item === null) return false;
-        const e = item as Record<string, unknown>;
-        return typeof e.sourceMessageId === "string" && (e.dueAt === null || typeof e.dueAt === "string");
-      },
-    );
+    result.existingReminders = items.filter((item: unknown): item is ExistingReminderKey => {
+      if (typeof item !== "object" || item === null) return false;
+      const e = item as Record<string, unknown>;
+      return (
+        typeof e.sourceMessageId === "string" && (e.dueAt === null || typeof e.dueAt === "string")
+      );
+    });
   }
   return result;
 }
@@ -186,13 +183,13 @@ export function validateOptions(value: unknown): BuildReminderOptions {
  * existingReminders array does not exceed the hard cap.
  */
 export function checkOptionsLimits(options: BuildReminderOptions): GuardIssue | null {
-  if (options.existingReminders && options.existingReminders.length > GUARD_LIMITS.maxExistingReminders) {
+  if (
+    options.existingReminders &&
+    options.existingReminders.length > GUARD_LIMITS.maxExistingReminders
+  ) {
     return {
       code: "too-many-existing-reminders",
-      message:
-        "Existing reminders list exceeds " +
-        GUARD_LIMITS.maxExistingReminders +
-        " entries.",
+      message: "Existing reminders list exceeds " + GUARD_LIMITS.maxExistingReminders + " entries.",
     };
   }
   return null;
@@ -204,10 +201,7 @@ export function checkOptionsLimits(options: BuildReminderOptions): GuardIssue | 
  * engine. Malformed inputs are rejected before the engine runs any work, so
  * hostile or oversized payloads cannot trigger unbounded scanning.
  */
-export function safeBuildFollowUpReminder(
-  input: unknown,
-  options?: unknown,
-): SafeBuildResult {
+export function safeBuildFollowUpReminder(input: unknown, options?: unknown): SafeBuildResult {
   if (!validateInput(input)) {
     return {
       status: "error",

--- a/tools/v1/individual/follow-up-reminder/tests/guards.test.ts
+++ b/tools/v1/individual/follow-up-reminder/tests/guards.test.ts
@@ -96,21 +96,15 @@ describe("validateInput", () => {
   });
 
   it("rejects a non-string senderName when present", () => {
-    expect(
-      validateInput(validInput({ senderName: 99 as unknown as string })),
-    ).toBe(false);
+    expect(validateInput(validInput({ senderName: 99 as unknown as string }))).toBe(false);
   });
 
   it("rejects a non-string threadHint when present", () => {
-    expect(
-      validateInput(validInput({ threadHint: true as unknown as string })),
-    ).toBe(false);
+    expect(validateInput(validInput({ threadHint: true as unknown as string }))).toBe(false);
   });
 
   it("rejects a non-string timeZone when present", () => {
-    expect(
-      validateInput(validInput({ timeZone: [] as unknown as string })),
-    ).toBe(false);
+    expect(validateInput(validInput({ timeZone: [] as unknown as string }))).toBe(false);
   });
 });
 
@@ -127,9 +121,7 @@ describe("checkInputLimits", () => {
   });
 
   it("rejects an oversized body by characters", () => {
-    const issue = checkInputLimits(
-      validInput({ body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1) }),
-    );
+    const issue = checkInputLimits(validInput({ body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1) }));
     expect(issue?.code).toBe("input-too-large");
   });
 

--- a/tools/v1/individual/follow-up-reminder/tests/guards.test.ts
+++ b/tools/v1/individual/follow-up-reminder/tests/guards.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GUARD_LIMITS,
+  checkInputLimits,
+  checkOptionsLimits,
+  safeBuildFollowUpReminder,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "../services/guards";
+import type { NormalizedEmailInput } from "../services/followUpReminder";
+
+function validInput(overrides: Partial<NormalizedEmailInput> = {}): NormalizedEmailInput {
+  return {
+    messageId: "msg-guard-1",
+    subject: "Follow up on contract",
+    body: "Please reply by 2026-03-15 with the signed contract.",
+    senderAddress: "vendor@example.com",
+    receivedAt: "2026-03-01T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("sanitizeText", () => {
+  it("strips control characters but keeps tabs and newlines", () => {
+    const dirty = "Hello\u0000 there\u0007\tworld\nline";
+    expect(sanitizeText(dirty)).toBe("Hello there\tworld\nline");
+  });
+
+  it("removes zero-width and BOM characters", () => {
+    const dirty = "in\u200bvis\u200dible\ufeff";
+    expect(sanitizeText(dirty)).toBe("invisible");
+  });
+
+  it("normalizes unicode to NFC", () => {
+    const decomposed = "e\u0301";
+    expect(sanitizeText(decomposed)).toBe("\u00e9");
+  });
+
+  it("handles an already-clean string without changes", () => {
+    expect(sanitizeText("Hello world")).toBe("Hello world");
+  });
+});
+
+describe("validateInput", () => {
+  it("accepts a valid NormalizedEmailInput", () => {
+    expect(validateInput(validInput())).toBe(true);
+  });
+
+  it("accepts a valid input with optional fields", () => {
+    expect(
+      validateInput(
+        validInput({
+          senderName: "Vendor",
+          timeZone: "America/New_York",
+          threadHint: "Re: contract",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(validateInput(null)).toBe(false);
+  });
+
+  it("rejects a non-object value", () => {
+    expect(validateInput("string")).toBe(false);
+  });
+
+  it("rejects when subject is missing", () => {
+    const { subject: _, ...rest } = validInput();
+    expect(validateInput(rest as unknown as NormalizedEmailInput)).toBe(false);
+  });
+
+  it("rejects when subject is not a string", () => {
+    expect(validateInput(validInput({ subject: 42 as unknown as string }))).toBe(false);
+  });
+
+  it("rejects when body is not a string", () => {
+    expect(validateInput(validInput({ body: null as unknown as string }))).toBe(false);
+  });
+
+  it("rejects when messageId is missing", () => {
+    expect(validateInput(validInput({ messageId: "" }))).toBe(false);
+  });
+
+  it("rejects when senderAddress is missing", () => {
+    const { senderAddress: _, ...rest } = validInput();
+    expect(validateInput(rest as unknown as NormalizedEmailInput)).toBe(false);
+  });
+
+  it("rejects an invalid receivedAt date", () => {
+    expect(validateInput(validInput({ receivedAt: "not-a-date" }))).toBe(false);
+  });
+
+  it("rejects a non-string senderName when present", () => {
+    expect(
+      validateInput(validInput({ senderName: 99 as unknown as string })),
+    ).toBe(false);
+  });
+
+  it("rejects a non-string threadHint when present", () => {
+    expect(
+      validateInput(validInput({ threadHint: true as unknown as string })),
+    ).toBe(false);
+  });
+
+  it("rejects a non-string timeZone when present", () => {
+    expect(
+      validateInput(validInput({ timeZone: [] as unknown as string })),
+    ).toBe(false);
+  });
+});
+
+describe("checkInputLimits", () => {
+  it("returns null for input within limits", () => {
+    expect(checkInputLimits(validInput())).toBeNull();
+  });
+
+  it("rejects an oversized subject", () => {
+    const issue = checkInputLimits(
+      validInput({ subject: "x".repeat(GUARD_LIMITS.maxSubjectChars + 1) }),
+    );
+    expect(issue?.code).toBe("input-too-large");
+  });
+
+  it("rejects an oversized body by characters", () => {
+    const issue = checkInputLimits(
+      validInput({ body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1) }),
+    );
+    expect(issue?.code).toBe("input-too-large");
+  });
+
+  it("rejects an oversized body by word count", () => {
+    const issue = checkInputLimits(
+      validInput({ body: "word ".repeat(GUARD_LIMITS.maxBodyWords + 1) }),
+    );
+    expect(issue?.code).toBe("input-too-large");
+  });
+});
+
+describe("sanitizeInput", () => {
+  it("cleans text fields without mutating the input", () => {
+    const input: NormalizedEmailInput = validInput({
+      subject: "Hello\u0000",
+      body: "Body\u200b",
+      senderName: "Nam\u0000e",
+      threadHint: "Re\u200b:",
+    });
+    const cleaned = sanitizeInput(input);
+    expect(cleaned.subject).toBe("Hello");
+    expect(cleaned.body).toBe("Body");
+    expect(cleaned.senderName).toBe("Name");
+    expect(cleaned.threadHint).toBe("Re:");
+    expect(input.subject).toBe("Hello\u0000");
+  });
+
+  it("preserves non-text fields unchanged", () => {
+    const input = validInput({ senderName: undefined, threadHint: undefined });
+    const cleaned = sanitizeInput(input);
+    expect(cleaned.messageId).toBe(input.messageId);
+    expect(cleaned.senderAddress).toBe(input.senderAddress);
+    expect(cleaned.receivedAt).toBe(input.receivedAt);
+  });
+});
+
+describe("validateOptions", () => {
+  it("returns an empty object for null or undefined", () => {
+    expect(validateOptions(null)).toEqual({});
+    expect(validateOptions(undefined)).toEqual({});
+  });
+
+  it("extracts a valid now string", () => {
+    const options = validateOptions({ now: "2026-05-01T00:00:00.000Z" });
+    expect(options.now).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("extracts and filters existingReminders", () => {
+    const options = validateOptions({
+      existingReminders: [
+        { sourceMessageId: "msg-1", dueAt: "2026-05-10" },
+        { sourceMessageId: "msg-2", dueAt: null },
+      ],
+    });
+    expect(options.existingReminders).toHaveLength(2);
+  });
+
+  it("ignores malformed entries in existingReminders", () => {
+    const options = validateOptions({
+      existingReminders: [
+        { sourceMessageId: "msg-1", dueAt: "2026-05-10" },
+        { sourceMessageId: 42, dueAt: "2026-05-10" },
+        null,
+        { sourceMessageId: "msg-2", dueAt: "2026-06-01" },
+      ],
+    });
+    expect(options.existingReminders).toHaveLength(2);
+  });
+});
+
+describe("checkOptionsLimits", () => {
+  it("returns null for options within limits", () => {
+    expect(checkOptionsLimits({})).toBeNull();
+    expect(
+      checkOptionsLimits({ existingReminders: [{ sourceMessageId: "a", dueAt: "2026-01-01" }] }),
+    ).toBeNull();
+  });
+
+  it("rejects oversized existingReminders", () => {
+    const manyReminders = Array.from({ length: GUARD_LIMITS.maxExistingReminders + 1 }, (_, i) => ({
+      sourceMessageId: "msg-" + i,
+      dueAt: "2026-01-01",
+    }));
+    const issue = checkOptionsLimits({ existingReminders: manyReminders });
+    expect(issue?.code).toBe("too-many-existing-reminders");
+  });
+});
+
+describe("safeBuildFollowUpReminder", () => {
+  it("passes a valid input through to the engine and returns a model", () => {
+    const result = safeBuildFollowUpReminder(validInput());
+    if (result.status !== "ok") return;
+    expect(result.model.state).toBe("draft");
+    expect(result.model.dueAt).toBe("2026-03-15");
+  });
+
+  it("rejects invalid input shape before the engine runs", () => {
+    const result = safeBuildFollowUpReminder({ subject: "Hi" });
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.code).toBe("invalid-input");
+  });
+
+  it("rejects oversized input before the engine runs", () => {
+    const result = safeBuildFollowUpReminder(
+      validInput({ body: "a".repeat(GUARD_LIMITS.maxBodyChars + 1) }),
+    );
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.code).toBe("input-too-large");
+  });
+
+  it("sanitizes hidden characters before passing to the engine", () => {
+    const result = safeBuildFollowUpReminder(
+      validInput({
+        subject: "Reply here\u0000",
+        body: "Follow up by 2026-04-01\u200b.",
+      }),
+    );
+    if (result.status !== "ok") return;
+    expect(result.model.state).toBe("draft");
+    expect(result.model.dueAt).toBe("2026-04-01");
+  });
+
+  it("handles optional options parameter", () => {
+    const result = safeBuildFollowUpReminder(
+      validInput({
+        messageId: "msg-dup",
+        body: "Reply by 2026-04-10 about the contract.",
+      }),
+      {
+        existingReminders: [{ sourceMessageId: "msg-dup", dueAt: "2026-04-10" }],
+      },
+    );
+    if (result.status !== "ok") return;
+    expect(result.model.state).toBe("no_action");
+  });
+
+  it("rejects null input", () => {
+    const result = safeBuildFollowUpReminder(null);
+    expect(result.status).toBe("error");
+  });
+
+  it("is deterministic for the same input", () => {
+    const input = validInput();
+    const a = safeBuildFollowUpReminder(input);
+    const b = safeBuildFollowUpReminder(input);
+    expect(a).toEqual(b);
+  });
+});

--- a/tools/v1/individual/follow-up-reminder/vitest.config.ts
+++ b/tools/v1/individual/follow-up-reminder/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    root: path.resolve(__dirname),
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
closes #362 

Here's a summary of the changes:

## Files changed (all under `tools/v1/individual/follow-up-reminder/`)

| File | Action | Purpose |
|------|--------|---------|
| `services/guards.ts` | **Added** | Validation, sanitization, and guarded entry point |
| `tests/guards.test.ts` | **Added** | 36 tests covering all guard functions |
| `docs/threat-model.md` | **Added** | Trust boundary, 14 unsafe inputs with mitigations |
| `docs/performance.md` | **Added** | Cost model, hard limits, large dataset notes |
| `vitest.config.ts` | **Added** | Test runner configuration |
| `index.ts` | **Modified** | Exports guard functions and types |

## Guard layer (`services/guards.ts`)
- **`sanitizeText`** — strips control characters, zero-width/BOM characters, NFC normalization
- **`validateInput`** — rejects non-object, missing fields, invalid `receivedAt`, type-mismatched optionals
- **`checkInputLimits`** — enforces caps: subject ≤500 chars, body ≤50k chars / 10k words
- **`sanitizeInput`** — immutable sanitization of text fields only
- **`validateOptions`** / **`checkOptionsLimits`** — clamps/filters `existingReminders` to ≤1000 entries
- **`safeBuildFollowUpReminder`** — guarded entry point: validate → sanitize → check limits → engine

## Tests
- **51/51 passing** (15 existing + 36 new)
- Guard tests cover: sanitization, input validation (14 cases), size limits, option validation, end-to-end guarded entry point, determinism

## 3 commits
1. `70e3f03` — Guards layer (`guards.ts`, `vitest.config.ts`, `index.ts` exports)
2. `1d9df83` — Guard tests (`guards.test.ts`)
3. `a043bc8` — Documentation (`threat-model.md`, `performance.md`)