### PR TITLE
feat(demo-admin): implement visual dataset diffing

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/diffHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/diffHelpers.test.ts
@@ -16,7 +16,9 @@ describe("diffHelpers", () => {
       const msg001 = diff.messages.find((m) => m.id === "msg-001");
       expect(msg001?.type).toBe("changed");
       expect(msg001?.fields.some((f) => f.fieldName === "subject")).toBe(true);
-      expect(msg001?.fields.find((f) => f.fieldName === "subject")?.newValue).toBe("Welcome (Updated)");
+      expect(msg001?.fields.find((f) => f.fieldName === "subject")?.newValue).toBe(
+        "Welcome (Updated)",
+      );
 
       const msg002 = diff.messages.find((m) => m.id === "msg-002");
       expect(msg002?.type).toBe("removed");

--- a/src/features/demo-admin-dashboard/__tests__/diffHelpers.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/diffHelpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { calculateDatasetDiff } from "../utils/diffHelpers";
+import { originalDatasetFixture, currentDatasetDraftFixture } from "../fixtures/diffFixtures";
+
+describe("diffHelpers", () => {
+  describe("calculateDatasetDiff", () => {
+    it("should correctly identify added, removed, and changed items", () => {
+      const diff = calculateDatasetDiff(originalDatasetFixture, currentDatasetDraftFixture);
+
+      // Summary checks
+      expect(diff.summary.added).toBe(2); // 1 message (msg-003) + 1 sender (newbie)
+      expect(diff.summary.removed).toBe(2); // 1 message (msg-002) + 1 sender (colleague)
+      expect(diff.summary.changed).toBe(1); // 1 message (msg-001)
+
+      // Message checks
+      const msg001 = diff.messages.find((m) => m.id === "msg-001");
+      expect(msg001?.type).toBe("changed");
+      expect(msg001?.fields.some((f) => f.fieldName === "subject")).toBe(true);
+      expect(msg001?.fields.find((f) => f.fieldName === "subject")?.newValue).toBe("Welcome (Updated)");
+
+      const msg002 = diff.messages.find((m) => m.id === "msg-002");
+      expect(msg002?.type).toBe("removed");
+
+      const msg003 = diff.messages.find((m) => m.id === "msg-003");
+      expect(msg003?.type).toBe("added");
+
+      // Sender checks
+      const colleague = diff.senders.find((s) => s.id === "colleague@example.org");
+      expect(colleague?.type).toBe("removed");
+
+      const newbie = diff.senders.find((s) => s.id === "newbie@example.com");
+      expect(newbie?.type).toBe("added");
+    });
+
+    it("should return empty diff for identical datasets", () => {
+      const diff = calculateDatasetDiff(originalDatasetFixture, originalDatasetFixture);
+      expect(diff.summary.added).toBe(0);
+      expect(diff.summary.removed).toBe(0);
+      expect(diff.summary.changed).toBe(0);
+      expect(diff.messages).toHaveLength(0);
+      expect(diff.senders).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/components/DatasetDiffPanel.css
+++ b/src/features/demo-admin-dashboard/components/DatasetDiffPanel.css
@@ -28,9 +28,15 @@
   font-weight: 600;
 }
 
-.dataset-diff-panel__summary-item--added { color: #4ade80; }
-.dataset-diff-panel__summary-item--removed { color: #f87171; }
-.dataset-diff-panel__summary-item--changed { color: #60a5fa; }
+.dataset-diff-panel__summary-item--added {
+  color: #4ade80;
+}
+.dataset-diff-panel__summary-item--removed {
+  color: #f87171;
+}
+.dataset-diff-panel__summary-item--changed {
+  color: #60a5fa;
+}
 
 .dataset-diff-panel__section {
   display: flex;
@@ -66,9 +72,18 @@
   text-transform: uppercase;
 }
 
-.dataset-diff-panel__badge--added { background: rgba(74, 222, 128, 0.2); color: #4ade80; }
-.dataset-diff-panel__badge--removed { background: rgba(248, 113, 113, 0.2); color: #f87171; }
-.dataset-diff-panel__badge--changed { background: rgba(96, 165, 250, 0.2); color: #60a5fa; }
+.dataset-diff-panel__badge--added {
+  background: rgba(74, 222, 128, 0.2);
+  color: #4ade80;
+}
+.dataset-diff-panel__badge--removed {
+  background: rgba(248, 113, 113, 0.2);
+  color: #f87171;
+}
+.dataset-diff-panel__badge--changed {
+  background: rgba(96, 165, 250, 0.2);
+  color: #60a5fa;
+}
 
 .dataset-diff-panel__fields {
   display: flex;

--- a/src/features/demo-admin-dashboard/components/DatasetDiffPanel.css
+++ b/src/features/demo-admin-dashboard/components/DatasetDiffPanel.css
@@ -1,0 +1,117 @@
+.dataset-diff-panel {
+  background: var(--dashboard-panel, rgba(15, 23, 42, 0.72));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 1.25rem;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.dataset-diff-panel__header {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  padding-bottom: 1rem;
+}
+
+.dataset-diff-panel__summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.dataset-diff-panel__summary-item {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.dataset-diff-panel__summary-item--added { color: #4ade80; }
+.dataset-diff-panel__summary-item--removed { color: #f87171; }
+.dataset-diff-panel__summary-item--changed { color: #60a5fa; }
+
+.dataset-diff-panel__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dataset-diff-panel__item {
+  background: rgba(30, 41, 59, 0.4);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.dataset-diff-panel__item-header {
+  align-items: center;
+  background: rgba(51, 65, 85, 0.3);
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.dataset-diff-panel__item-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.dataset-diff-panel__badge {
+  border-radius: 999px;
+  font-size: 0.625rem;
+  font-weight: 800;
+  padding: 0.125rem 0.5rem;
+  text-transform: uppercase;
+}
+
+.dataset-diff-panel__badge--added { background: rgba(74, 222, 128, 0.2); color: #4ade80; }
+.dataset-diff-panel__badge--removed { background: rgba(248, 113, 113, 0.2); color: #f87171; }
+.dataset-diff-panel__badge--changed { background: rgba(96, 165, 250, 0.2); color: #60a5fa; }
+
+.dataset-diff-panel__fields {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0;
+}
+
+.dataset-diff-panel__field {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 120px 1fr 1fr;
+  padding: 0.5rem 1rem;
+}
+
+.dataset-diff-panel__field:not(:last-child) {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.dataset-diff-panel__field-name {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.dataset-diff-panel__field-old,
+.dataset-diff-panel__field-new {
+  font-size: 0.875rem;
+  word-break: break-all;
+}
+
+.dataset-diff-panel__field-old {
+  color: #f87171;
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+
+.dataset-diff-panel__field-new {
+  color: #4ade80;
+}
+
+.dataset-diff-panel__empty {
+  color: #94a3b8;
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+}

--- a/src/features/demo-admin-dashboard/components/DatasetDiffPanel.tsx
+++ b/src/features/demo-admin-dashboard/components/DatasetDiffPanel.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import type { DatasetDiff, ItemDiff, FieldDiff } from "../types/diff";
+import "./DatasetDiffPanel.css";
+
+interface DatasetDiffPanelProps {
+  diff: DatasetDiff;
+  title?: string;
+}
+
+/**
+ * DatasetDiffPanel provides a visual comparison between an original fixture
+ * and the current draft dataset. It highlights added, removed, and changed
+ * items and fields in a safe, deterministic way for demo-admin review.
+ */
+export const DatasetDiffPanel: React.FC<DatasetDiffPanelProps> = ({
+  diff,
+  title = "Dataset Changes",
+}) => {
+  const { messages, senders, summary } = diff;
+
+  const hasChanges = messages.length > 0 || senders.length > 0;
+
+  return (
+    <div className="dataset-diff-panel">
+      <header className="dataset-diff-panel__header">
+        <h3>{title}</h3>
+        <div className="dataset-diff-panel__summary">
+          <span className="dataset-diff-panel__summary-item dataset-diff-panel__summary-item--added">
+            +{summary.added} added
+          </span>
+          <span className="dataset-diff-panel__summary-item dataset-diff-panel__summary-item--removed">
+            -{summary.removed} removed
+          </span>
+          <span className="dataset-diff-panel__summary-item dataset-diff-panel__summary-item--changed">
+            {summary.changed} changed
+          </span>
+        </div>
+      </header>
+
+      {!hasChanges ? (
+        <div className="dataset-diff-panel__empty">No changes detected.</div>
+      ) : (
+        <>
+          {messages.length > 0 && (
+            <div className="dataset-diff-panel__section">
+              <h4>Messages</h4>
+              {messages.map((m) => (
+                <DiffItem key={m.id} item={m} />
+              ))}
+            </div>
+          )}
+
+          {senders.length > 0 && (
+            <div className="dataset-diff-panel__section">
+              <h4>Senders</h4>
+              {senders.map((s) => (
+                <DiffItem key={s.id} item={s} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+const DiffItem: React.FC<{ item: ItemDiff }> = ({ item }) => {
+  return (
+    <div className="dataset-diff-panel__item">
+      <div className="dataset-diff-panel__item-header">
+        <span className={`dataset-diff-panel__badge dataset-diff-panel__badge--${item.type}`}>
+          {item.type}
+        </span>
+        <span className="dataset-diff-panel__item-id">{item.id}</span>
+      </div>
+      <div className="dataset-diff-panel__fields">
+        {item.fields.map((f, i) => (
+          <DiffField key={`${item.id}-${f.fieldName}-${i}`} field={f} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DiffField: React.FC<{ field: FieldDiff }> = ({ field }) => {
+  const formatValue = (val: any) => {
+    if (val === undefined || val === null) return "-";
+    if (typeof val === "object") return JSON.stringify(val);
+    return String(val);
+  };
+
+  return (
+    <div className="dataset-diff-panel__field">
+      <span className="dataset-diff-panel__field-name">{field.fieldName}</span>
+      <span className="dataset-diff-panel__field-old">
+        {field.type !== "added" ? formatValue(field.oldValue) : ""}
+      </span>
+      <span className="dataset-diff-panel__field-new">
+        {field.type !== "removed" ? formatValue(field.newValue) : ""}
+      </span>
+    </div>
+  );
+};

--- a/src/features/demo-admin-dashboard/fixtures/diffFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/diffFixtures.ts
@@ -1,0 +1,115 @@
+import type { DemoDataset } from "../types/dataset";
+
+export const originalDatasetFixture: DemoDataset = {
+  id: "original-v1",
+  name: "Baseline Demo",
+  description: "Initial seed data for demo environment.",
+  messages: [
+    {
+      id: "msg-001",
+      threadId: "t-001",
+      subject: "Welcome",
+      snippet: "Welcome to stealth demo.",
+      body: "This is a baseline welcome message.",
+      sender: {
+        address: "admin@stealth.demo",
+        name: "Stealth Admin",
+        isTrusted: true,
+      },
+      recipients: ["user@example.com"],
+      date: "2024-01-01T10:00:00Z",
+      isRead: true,
+      isStarred: false,
+      labels: ["inbox"],
+      attachments: [],
+    },
+    {
+      id: "msg-002",
+      threadId: "t-002",
+      subject: "Meeting Request",
+      snippet: "Can we meet tomorrow?",
+      body: "Let's discuss the project.",
+      sender: {
+        address: "colleague@example.org",
+        name: "Colleague",
+        isTrusted: false,
+      },
+      recipients: ["user@example.com"],
+      date: "2024-01-01T11:00:00Z",
+      isRead: false,
+      isStarred: true,
+      labels: ["work"],
+      attachments: [],
+    },
+  ],
+  senders: [
+    {
+      address: "admin@stealth.demo",
+      name: "Stealth Admin",
+      isTrusted: true,
+    },
+    {
+      address: "colleague@example.org",
+      name: "Colleague",
+      isTrusted: false,
+    },
+  ],
+};
+
+export const currentDatasetDraftFixture: DemoDataset = {
+  id: "draft-v1",
+  name: "Modified Demo",
+  description: "Initial seed data with some edits.",
+  messages: [
+    {
+      id: "msg-001",
+      threadId: "t-001",
+      subject: "Welcome (Updated)", // Changed
+      snippet: "Welcome to stealth demo.",
+      body: "This is a baseline welcome message. Now with more info!", // Changed
+      sender: {
+        address: "admin@stealth.demo",
+        name: "Stealth Admin",
+        isTrusted: true,
+      },
+      recipients: ["user@example.com"],
+      date: "2024-01-01T10:00:00Z",
+      isRead: true,
+      isStarred: true, // Changed
+      labels: ["inbox", "updated"], // Changed
+      attachments: [],
+    },
+    // msg-002 removed
+    {
+      id: "msg-003", // Added
+      threadId: "t-003",
+      subject: "New Message",
+      snippet: "A new message in the draft.",
+      body: "This message was added in the draft.",
+      sender: {
+        address: "newbie@example.com",
+        name: "Newbie",
+        isTrusted: false,
+      },
+      recipients: ["user@example.com"],
+      date: "2024-01-02T09:00:00Z",
+      isRead: false,
+      isStarred: false,
+      labels: ["new"],
+      attachments: [],
+    },
+  ],
+  senders: [
+    {
+      address: "admin@stealth.demo",
+      name: "Stealth Admin",
+      isTrusted: true,
+    },
+    // colleague removed
+    {
+      address: "newbie@example.com", // Added
+      name: "Newbie",
+      isTrusted: false,
+    },
+  ],
+};

--- a/src/features/demo-admin-dashboard/types/diff.ts
+++ b/src/features/demo-admin-dashboard/types/diff.ts
@@ -1,0 +1,29 @@
+/**
+ * Types for visual diffing of demo datasets.
+ * All implementations must remain safe, fake, and deterministic.
+ */
+
+export type DiffType = "added" | "removed" | "changed" | "unchanged";
+
+export interface FieldDiff {
+  fieldName: string;
+  oldValue: any;
+  newValue: any;
+  type: DiffType;
+}
+
+export interface ItemDiff {
+  id: string;
+  type: DiffType;
+  fields: FieldDiff[];
+}
+
+export interface DatasetDiff {
+  messages: ItemDiff[];
+  senders: ItemDiff[];
+  summary: {
+    added: number;
+    removed: number;
+    changed: number;
+  };
+}

--- a/src/features/demo-admin-dashboard/utils/diffHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/diffHelpers.ts
@@ -6,10 +6,7 @@ import type { DatasetDiff, FieldDiff, ItemDiff, DiffType } from "../types/diff";
  * Only compares top-level fields. For nested objects, it does a shallow comparison
  * or string representation check to keep the visual diff simple.
  */
-export function getFieldDiffs<T extends Record<string, any>>(
-  oldItem: T,
-  newItem: T
-): FieldDiff[] {
+export function getFieldDiffs<T extends Record<string, any>>(oldItem: T, newItem: T): FieldDiff[] {
   const diffs: FieldDiff[] = [];
   const allKeys = Array.from(new Set([...Object.keys(oldItem), ...Object.keys(newItem)]));
 
@@ -40,7 +37,7 @@ export function getFieldDiffs<T extends Record<string, any>>(
 export function compareItemList<T extends { id?: string; address?: string }>(
   oldList: T[] = [],
   newList: T[] = [],
-  idField: keyof T = "id" as keyof T
+  idField: keyof T = "id" as keyof T,
 ): ItemDiff[] {
   const diffs: ItemDiff[] = [];
   const oldMap = new Map(oldList.map((item) => [item[idField] as string, item]));
@@ -82,15 +79,12 @@ export function compareItemList<T extends { id?: string; address?: string }>(
 /**
  * Generates a full dataset diff between the original fixture and current draft.
  */
-export function calculateDatasetDiff(
-  original: DemoDataset,
-  current: DemoDataset
-): DatasetDiff {
+export function calculateDatasetDiff(original: DemoDataset, current: DemoDataset): DatasetDiff {
   const messageDiffs = compareItemList(original.messages, current.messages);
   const senderDiffs = compareItemList(
     original.senders || [],
     current.senders || [],
-    "address" as any
+    "address" as any,
   );
 
   const summary = {

--- a/src/features/demo-admin-dashboard/utils/diffHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/diffHelpers.ts
@@ -1,0 +1,113 @@
+import type { DemoDataset, DemoMessage, DemoSender } from "../types/dataset";
+import type { DatasetDiff, FieldDiff, ItemDiff, DiffType } from "../types/diff";
+
+/**
+ * Compares two objects and returns a list of field differences.
+ * Only compares top-level fields. For nested objects, it does a shallow comparison
+ * or string representation check to keep the visual diff simple.
+ */
+export function getFieldDiffs<T extends Record<string, any>>(
+  oldItem: T,
+  newItem: T
+): FieldDiff[] {
+  const diffs: FieldDiff[] = [];
+  const allKeys = Array.from(new Set([...Object.keys(oldItem), ...Object.keys(newItem)]));
+
+  for (const key of allKeys) {
+    const oldValue = oldItem[key];
+    const newValue = newItem[key];
+
+    if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+      let type: DiffType = "changed";
+      if (oldValue === undefined) type = "added";
+      else if (newValue === undefined) type = "removed";
+
+      diffs.push({
+        fieldName: key,
+        oldValue,
+        newValue,
+        type,
+      });
+    }
+  }
+
+  return diffs;
+}
+
+/**
+ * Compares two lists of items (messages or senders) by their unique ID.
+ */
+export function compareItemList<T extends { id?: string; address?: string }>(
+  oldList: T[] = [],
+  newList: T[] = [],
+  idField: keyof T = "id" as keyof T
+): ItemDiff[] {
+  const diffs: ItemDiff[] = [];
+  const oldMap = new Map(oldList.map((item) => [item[idField] as string, item]));
+  const newMap = new Map(newList.map((item) => [item[idField] as string, item]));
+
+  const allIds = Array.from(new Set([...oldMap.keys(), ...newMap.keys()]));
+
+  for (const id of allIds) {
+    const oldItem = oldMap.get(id);
+    const newItem = newMap.get(id);
+
+    if (!oldItem && newItem) {
+      diffs.push({
+        id,
+        type: "added",
+        fields: getFieldDiffs({} as T, newItem),
+      });
+    } else if (oldItem && !newItem) {
+      diffs.push({
+        id,
+        type: "removed",
+        fields: getFieldDiffs(oldItem, {} as T),
+      });
+    } else if (oldItem && newItem) {
+      const fieldDiffs = getFieldDiffs(oldItem, newItem);
+      if (fieldDiffs.length > 0) {
+        diffs.push({
+          id,
+          type: "changed",
+          fields: fieldDiffs,
+        });
+      }
+    }
+  }
+
+  return diffs;
+}
+
+/**
+ * Generates a full dataset diff between the original fixture and current draft.
+ */
+export function calculateDatasetDiff(
+  original: DemoDataset,
+  current: DemoDataset
+): DatasetDiff {
+  const messageDiffs = compareItemList(original.messages, current.messages);
+  const senderDiffs = compareItemList(
+    original.senders || [],
+    current.senders || [],
+    "address" as any
+  );
+
+  const summary = {
+    added:
+      messageDiffs.filter((d) => d.type === "added").length +
+      senderDiffs.filter((d) => d.type === "added").length,
+    removed:
+      messageDiffs.filter((d) => d.type === "removed").length +
+      senderDiffs.filter((d) => d.type === "removed").length,
+    changed:
+      messageDiffs.filter((d) => d.type === "changed").length +
+      senderDiffs.filter((d) => d.type === "changed").length,
+  };
+
+  return {
+    messages: messageDiffs,
+    senders: senderDiffs,
+    summary,
+  };
+}


### PR DESCRIPTION
- closes #191 

Summary
This PR introduces a visual diffing system to compare original data fixtures with current draft datasets within the Demo Admin Dashboard. This enables maintainers to review changes to messages and senders before applying them to the demo environment.
 Key Changes
- Core Types : Added diff.ts defining the structured diff format ( DatasetDiff , ItemDiff , FieldDiff ).
- Diff Logic : Implemented diffHelpers.ts to perform deterministic comparisons of datasets, identifying added, removed, or modified fields.
- Visual Component : Created DatasetDiffPanel.tsx and DatasetDiffPanel.css to provide a clear, color-coded UI for reviewing changes.
- Testing : Added comprehensive unit tests in diffHelpers.test.ts along with safe, fake fixtures in diffFixtures.ts . Verification
- Unit Tests : Executed npx vitest on the new helper functions, confirming 100% coverage of addition, removal, and modification scenarios.
- Scope Check : Verified that no files outside the demo-admin-dashboard feature folder were modified.
- Data Safety : Confirmed all test data uses safe domains ( @example.com , *.stealth.demo ) and contains no PII or secrets.