### PR TITLE
perf(calendar): cut per-render derivation in the workspace

### DIFF
--- a/src/features/calendar/components/CalendarWorkspace.tsx
+++ b/src/features/calendar/components/CalendarWorkspace.tsx
@@ -123,7 +123,19 @@ export function CalendarWorkspace({
       return date.getMonth() === month.getMonth() && date.getFullYear() === month.getFullYear();
     });
   }, [month, selectedDate, view, visibleEvents]);
-  const eventDates = visibleEvents.map((event) => parseISO(event.date));
+  const eventDates = useMemo(
+    () => visibleEvents.map((event) => parseISO(event.date)),
+    [visibleEvents],
+  );
+  // Precompute per-calendar event counts once (O(events)) instead of filtering
+  // the full event list for every calendar row each render (O(calendars × events)).
+  const eventCountByCalendar = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const event of events) {
+      counts.set(event.calendarId, (counts.get(event.calendarId) ?? 0) + 1);
+    }
+    return counts;
+  }, [events]);
   const visibleCalendarCount = visibleIds.size;
   const emptyState =
     visibleCalendarCount === 0
@@ -288,7 +300,7 @@ export function CalendarWorkspace({
                         </span>
                         <span className="flex-1">{calendar.name}</span>
                         <span className="text-[10px] text-muted-foreground">
-                          {events.filter((event) => event.calendarId === calendar.id).length}
+                          {eventCountByCalendar.get(calendar.id) ?? 0}
                         </span>
                       </button>
                     ))}


### PR DESCRIPTION
## Summary
Scoped render-work reduction for the Calendar Workspace (issue #923). Removes two derivations that recomputed on every render. No behavior or visual change.

Closes #923

## Hotspots (identified before changing code)
On every `CalendarWorkspace` render:
1. **`eventDates`** mapped `parseISO` over every visible event and allocated a fresh array (un-memoized) — handed down to the month grid each render.
2. **Per-calendar event count** ran `events.filter(e => e.calendarId === calendar.id).length` *inside* the `calendars.map`, i.e. **O(calendars × events)** every render.

## Changes (`src/features/calendar/components/CalendarWorkspace.tsx`)
- Memoize `eventDates` on `visibleEvents`.
- Precompute an `eventCountByCalendar` Map once (**O(events)**, memoized on `events`) and look it up per calendar row, replacing the per-row full-list filter.

Counts are identical (all events per calendar, regardless of visibility), so output is byte-for-byte the same. The hook's existing `visibleEvents` / `visibleIds` / `displayedEvents` memos are untouched.

## Performance note (reasoned)
- Calendar-list rendering drops from O(calendars × events) to O(events) (memoized).
- The date array is no longer re-`parseISO`'d and re-allocated each render.
Reasoned, not profiled; no behavior change.
