### PR TITLE
[codex] Add shared contact notes usage review guide

### DIFF
--- a/tools/v2/team/shared-contact-notes/README.md
+++ b/tools/v2/team/shared-contact-notes/README.md
@@ -17,6 +17,19 @@ Do not modify the main application shell, dashboard layout, routing, inbox
 architecture, wallet core, Stellar integration, database schema, or shared
 design system from this issue.
 
+## Independent Review Quick Start
+
+Reviewers can validate this tool without booting the full mail application:
+
+```bash
+npm ci
+npx vitest run tools/v2/team/shared-contact-notes/tests/service.test.ts
+npx vitest run tools/v2/team/shared-contact-notes/tests/components.test.tsx
+```
+
+Use `docs/USAGE.md` for the setup flow, local usage example, fixture notes,
+and known limitations that should be considered during review.
+
 ## Review Map
 
 - `types.ts` defines all data types and input contracts.
@@ -30,6 +43,7 @@ design system from this issue.
 - `tests/test-plan.md` documents all test scenarios.
 - `hooks/useContactNotes.ts` provides React hook wrapping NoteService with `useReducer`.
 - `components/` contains all React UI components with empty, loading, error, and success states.
+- `docs/USAGE.md` documents local setup, usage, fixtures, review checks, and limitations.
 - `docs/ACCESSIBILITY.md` documents WCAG 2.1 AA compliance measures.
 - `docs/review-notes.md` gives maintainers a review checklist.
 
@@ -41,7 +55,7 @@ The engine provides note management for shared contacts:
 - **Read** all notes for a specific contact, or a single note by id.
 - **Update** note content (partial updates supported).
 - **Delete** a note permanently.
-- **Archive** a note (idempotent — archiving an archived note is a no-op).
+- **Archive** a note (idempotent - archiving an archived note is a no-op).
 
 All operations are async with a configurable delay for deterministic loading
 state simulation. With `delayMs: 0` (the default), operations resolve
@@ -49,8 +63,8 @@ immediately but still return Promises, allowing UI layers to always await.
 
 ## Known Limitations
 
-- No persistence — the store is an in-memory `Map`.
-- No authentication or authorization — any caller can perform any operation.
+- No persistence - the store is an in-memory `Map`.
+- No authentication or authorization - any caller can perform any operation.
 - No integration with the main application's contact models.
 - The UI layer is self-contained and not wired into the main app shell or routing.
 - No real-time or multi-user collaboration support.

--- a/tools/v2/team/shared-contact-notes/docs/USAGE.md
+++ b/tools/v2/team/shared-contact-notes/docs/USAGE.md
@@ -1,0 +1,83 @@
+# Shared Contact Notes Usage
+
+This document gives maintainers and OSS contributors a folder-local way to
+review Shared Contact Notes without connecting it to the main mail app.
+
+## Setup
+
+Run commands from the repository root so Vitest can resolve the shared TypeScript
+and Vite configuration:
+
+```bash
+npm ci
+npx vitest run tools/v2/team/shared-contact-notes/tests/service.test.ts
+npx vitest run tools/v2/team/shared-contact-notes/tests/components.test.tsx
+```
+
+The tool is intentionally isolated. A review should not require changes to app
+routing, dashboard navigation, auth, wallet logic, Stellar integration, database
+schema, or the shared design system.
+
+## Service Usage
+
+Use `NoteService` when testing the core note workflow in isolation:
+
+```ts
+import { seedNotes } from "../fixtures/notes";
+import { NoteService } from "../service";
+
+const service = new NoteService(seedNotes);
+
+const created = await service.create({
+  contactId: "contact-alice",
+  content: "Follow up after renewal review.",
+  authorId: "user-manager",
+});
+
+const notesForAlice = await service.getByContact(created.contactId);
+```
+
+The service returns defensive copies so callers cannot mutate the internal
+in-memory store by editing returned objects.
+
+## Fixture Notes
+
+`fixtures/notes.ts` provides deterministic review data:
+
+| Fixture | Contact | Purpose |
+| --- | --- | --- |
+| `note-alice-1` | `contact-alice` | Active note for multi-note contact coverage |
+| `note-alice-2` | `contact-alice` | Second active note for ordering and count checks |
+| `note-bob-1` | `contact-bob` | Archived note coverage |
+| `note-carol-1` | `contact-carol` | Single-note contact coverage |
+| `note-dave-1` | `contact-dave` | Additional independent contact coverage |
+
+Use these fixtures for local tests and manual review notes instead of connecting
+to production contacts or main app state.
+
+## Review Checklist
+
+- Confirm all changed files stay under `tools/v2/team/shared-contact-notes/`.
+- Run the folder-local service and component tests listed above.
+- Read `tests/test-plan.md` to compare executable coverage with the intended
+  scenarios.
+- Confirm the tool remains disconnected from main app navigation and routing.
+- Confirm future app integration needs are recorded as follow-up work, not added
+  to this isolated review.
+
+## Known Limitations
+
+- Notes are stored in memory only; there is no persistence layer.
+- There is no authentication, authorization, or role-based permission model.
+- The tool does not consume the main app's contact, mailbox, or organization
+  models yet.
+- There is no real-time collaboration or multi-user conflict handling.
+- The component layer is reviewed as an isolated surface and is not mounted in
+  the production app shell.
+
+## Follow-Up Boundaries
+
+Future integration work can decide how notes map to real contacts, which roles
+can create or archive notes, and where the UI appears in the mail workflow. Those
+decisions should remain outside this issue so the current contribution stays
+self-contained and reviewable.


### PR DESCRIPTION
## Summary

- Add `docs/USAGE.md` for folder-local setup, usage, fixtures, review checks, and known limitations.
- Link the new review guide from the Shared Contact Notes README.
- Keep all changes inside `tools/v2/team/shared-contact-notes/` for #658.

## Validation

- Confirmed changed files are limited to the Shared Contact Notes tool folder.
- Checked the docs include setup, usage, fixture notes, review checklist, and known limitations.
- Did not run Vitest locally because the repository clone failed in this environment; this PR changes documentation only.

Closes #658
