### PR TITLE
[codex] Add collision detection review fixtures and test plan

### DIFF
--- a/tools/v1/team/collision-detection/README.md
+++ b/tools/v1/team/collision-detection/README.md
@@ -1,15 +1,74 @@
 # Collision Detection
 
-This folder is the isolated workspace for the Collision Detection tool.
+Collision Detection is an isolated V1 team tool workspace for reviewing whether
+a proposed outbound response duplicates work already present in a shared mailbox
+thread. It is not wired into the main mail app yet.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\team\collision-detection\
-`
+```text
+tools/v1/team/collision-detection/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not connect this tool to the app shell, dashboard navigation, inbox routing,
+authentication, wallet code, Stellar integration, database schema, mail renderer,
+or the shared design system unless a future integration issue explicitly allows
+that work.
 
-See specs.md for the issue categories and contributor expectations.
+## Setup and Independent Review
+
+This issue is documentation and test-planning focused. Reviewers can validate the
+folder locally without booting the full mail app:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('tools/v1/team/collision-detection/fixtures/collision-cases.json', 'utf8'))"
+```
+
+When executable tests are added in a later implementation issue, keep them under
+this folder and run them with a folder-scoped command such as:
+
+```bash
+npx vitest run tools/v1/team/collision-detection/tests
+```
+
+## Usage Model
+
+The future detector should accept one draft reply plus prior team responses for
+the same thread, then return one of the outcomes documented in `specs.md`.
+Reviewers can use `fixtures/collision-cases.json` as the first usage contract:
+
+- load a fixture case,
+- compare `draftReply.body` with `priorResponses[].body`,
+- classify the case as `duplicate`, `possible_duplicate`, `distinct`, or
+  `invalid_input`,
+- keep any UI or mailbox integration as follow-up work.
+
+## Review Map
+
+- `specs.md` defines the expected input model, outcomes, and boundaries.
+- `fixtures/collision-cases.json` provides synthetic duplicate, possible
+  duplicate, distinct, and invalid-input cases.
+- `tests/test-plan.md` documents review scenarios until executable tests exist.
+- `docs/review-notes.md` gives maintainers a folder-local review checklist.
+- `docs/validation-notes.md` records what can be validated before integration.
+
+## Intended Behavior
+
+The tool should help reviewers classify a draft reply against prior team
+responses in the same conversation:
+
+- `duplicate` when the draft materially repeats an existing response.
+- `possible_duplicate` when the draft overlaps enough to require human review.
+- `distinct` when the draft covers a separate request or materially different
+  answer.
+- `invalid_input` when required draft or thread context is missing.
+
+## Known Limitations
+
+- This folder does not contain a production detector service yet.
+- The fixtures are synthetic and do not represent live mailbox data.
+- There is no persistence, authorization model, or app integration in this
+  issue.
+- Human review is still required for borderline semantic matches.

--- a/tools/v1/team/collision-detection/docs/review-notes.md
+++ b/tools/v1/team/collision-detection/docs/review-notes.md
@@ -1,0 +1,30 @@
+# Collision Detection Review Notes
+
+Use these notes to review the isolated Collision Detection folder for #428.
+
+## Scope Checklist
+
+- All changed files stay under `tools/v1/team/collision-detection/`.
+- The contribution does not modify app shell, routing, auth, wallet, Stellar,
+  database, mail renderer, or shared design-system files.
+- Fixtures use synthetic `.test`-style thread data and do not include live
+  mailbox content.
+- Follow-up integration questions stay documented instead of being implemented
+  in this issue.
+
+## Documentation Checklist
+
+- `README.md` explains the ownership boundary and independent review flow.
+- `specs.md` defines inputs, outcomes, and out-of-scope work.
+- `tests/test-plan.md` maps fixtures to expected outcomes.
+- `docs/validation-notes.md` records what can be validated before production
+  integration.
+
+## Reviewer Questions
+
+- Are the four initial outcomes enough for launch review?
+- Should future semantic matching use deterministic heuristics, a model-assisted
+  scorer, or both?
+- What team role should be allowed to override a `duplicate` or
+  `possible_duplicate` warning?
+- Which future integration issue will provide live thread context?

--- a/tools/v1/team/collision-detection/docs/validation-notes.md
+++ b/tools/v1/team/collision-detection/docs/validation-notes.md
@@ -1,0 +1,31 @@
+# Collision Detection Validation Notes
+
+## What This Issue Can Validate
+
+- Folder ownership and review boundaries are clear.
+- Fixture data is parseable JSON.
+- The expected outcomes cover duplicate, possible duplicate, distinct, and
+  invalid-input cases.
+- The test plan is folder-local and does not depend on app-wide test wiring.
+
+## What This Issue Cannot Validate Yet
+
+- Production mailbox retrieval.
+- Real semantic scoring accuracy.
+- UI warnings or override flows.
+- Authorization for team-level duplicate checks.
+- Database persistence or audit logging.
+
+## Manual Validation Steps
+
+1. Confirm the changed files are limited to `tools/v1/team/collision-detection/`.
+2. Parse `fixtures/collision-cases.json`.
+3. Review `tests/test-plan.md` against the expected outcomes in `specs.md`.
+4. Confirm no instructions require live mailbox data or external service calls.
+
+## Follow-Up Recommendations
+
+- Add a pure detector service that consumes the input shape from `specs.md`.
+- Add Vitest coverage for all fixture outcomes.
+- Add UI copy only after a future integration issue defines where the warning
+  should appear.

--- a/tools/v1/team/collision-detection/fixtures/collision-cases.json
+++ b/tools/v1/team/collision-detection/fixtures/collision-cases.json
@@ -1,0 +1,69 @@
+{
+  "description": "Synthetic collision detection review cases for the isolated V1 team tool.",
+  "cases": [
+    {
+      "id": "exact-duplicate-renewal",
+      "expectedOutcome": "duplicate",
+      "threadId": "thread-renewal-001",
+      "draftReply": {
+        "authorId": "agent-lina",
+        "body": "Your renewal was approved and the updated terms are attached."
+      },
+      "priorResponses": [
+        {
+          "authorId": "agent-mika",
+          "body": "Your renewal was approved and the updated terms are attached.",
+          "sentAt": "2026-06-17T09:00:00Z"
+        }
+      ]
+    },
+    {
+      "id": "possible-duplicate-shipping",
+      "expectedOutcome": "possible_duplicate",
+      "threadId": "thread-shipping-014",
+      "draftReply": {
+        "authorId": "agent-rao",
+        "body": "We found the delayed package and expect delivery by Friday."
+      },
+      "priorResponses": [
+        {
+          "authorId": "agent-eli",
+          "body": "The delayed package has been located. Current estimate is Friday delivery.",
+          "sentAt": "2026-06-17T10:30:00Z"
+        }
+      ]
+    },
+    {
+      "id": "distinct-billing-followup",
+      "expectedOutcome": "distinct",
+      "threadId": "thread-billing-022",
+      "draftReply": {
+        "authorId": "agent-nora",
+        "body": "The duplicate invoice was voided and the corrected receipt is ready."
+      },
+      "priorResponses": [
+        {
+          "authorId": "agent-omar",
+          "body": "We reset access for the billing portal and sent a temporary sign-in link.",
+          "sentAt": "2026-06-17T11:45:00Z"
+        }
+      ]
+    },
+    {
+      "id": "invalid-empty-draft",
+      "expectedOutcome": "invalid_input",
+      "threadId": "thread-empty-003",
+      "draftReply": {
+        "authorId": "agent-lina",
+        "body": ""
+      },
+      "priorResponses": [
+        {
+          "authorId": "agent-mika",
+          "body": "We need a complete draft before checking for collision risk.",
+          "sentAt": "2026-06-17T12:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/v1/team/collision-detection/specs.md
+++ b/tools/v1/team/collision-detection/specs.md
@@ -1,41 +1,56 @@
-# Collision Detection
-
-Prevent duplicate responses.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/collision-detection/README.md"
-  @"
-
 # Collision Detection Specs
 
 ## Purpose
 
-Prevent duplicate responses.
+Prevent duplicate team responses by comparing a draft reply with previous
+messages in the same shared mailbox thread.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V1
+- Audience: team
+- Folder ownership: `tools/v1/team/collision-detection/`
 
-$dir/
+The tool must remain self-contained until a future integration issue connects it
+to live mail data or the main inbox workflow.
 
-## Required issue categories
+## Candidate Input Shape
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+The future detector can be reviewed against this minimal input contract:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `threadId` | string | Yes | Stable thread identifier from the caller |
+| `draftReply` | object | Yes | Proposed outbound reply |
+| `draftReply.authorId` | string | Yes | Team member preparing the response |
+| `draftReply.body` | string | Yes | Plain-text body used for comparison |
+| `priorResponses` | array | Yes | Earlier team responses in the same thread |
+| `priorResponses[].authorId` | string | Yes | Sender of the prior response |
+| `priorResponses[].body` | string | Yes | Plain-text body of the prior response |
+| `priorResponses[].sentAt` | string | No | ISO timestamp when available |
+
+## Expected Outcomes
+
+| Outcome | Meaning |
+| --- | --- |
+| `duplicate` | The draft repeats an existing answer closely enough to block by default. |
+| `possible_duplicate` | The draft overlaps with a prior answer and needs human review. |
+| `distinct` | The draft appears to answer a different request or add new information. |
+| `invalid_input` | Required draft or thread data is missing or empty. |
+
+## Review Heuristics
+
+- Exact or near-exact normalized body matches should be `duplicate`.
+- Same recipient and same resolution intent with small wording changes should be
+  `possible_duplicate`.
+- Different task, recipient, or resolution should be `distinct`.
+- Empty draft body, missing thread id, or missing response context should be
+  `invalid_input`.
+
+## Out of Scope
+
+- No production mailbox reads.
+- No automatic sending or blocking behavior.
+- No database schema changes.
+- No app navigation, dashboard, or routing changes.
+- No shared design-system changes.

--- a/tools/v1/team/collision-detection/tests/test-plan.md
+++ b/tools/v1/team/collision-detection/tests/test-plan.md
@@ -1,0 +1,42 @@
+# Collision Detection Test Plan
+
+This folder does not include an executable detector yet. Until the service is
+implemented, use this plan and `fixtures/collision-cases.json` to review the
+expected behavior independently.
+
+## Fixture Validation
+
+Run from the repository root:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('tools/v1/team/collision-detection/fixtures/collision-cases.json', 'utf8'))"
+```
+
+## Scenario Matrix
+
+| Case | Fixture | Expected Result | Review Focus |
+| --- | --- | --- | --- |
+| Exact duplicate | `exact-duplicate-renewal` | `duplicate` | Same thread, same body, prior response exists |
+| Semantic overlap | `possible-duplicate-shipping` | `possible_duplicate` | Similar resolution with different wording |
+| Different response | `distinct-billing-followup` | `distinct` | Same team workflow but different customer problem |
+| Empty draft | `invalid-empty-draft` | `invalid_input` | Required draft body is missing |
+
+## Future Executable Tests
+
+When the detector service is added, keep tests in this folder and cover:
+
+- Normalized exact body matches.
+- Case and whitespace-insensitive comparisons.
+- Semantic overlap cases that should not auto-block.
+- Distinct replies in the same thread.
+- Empty draft bodies.
+- Missing `threadId`.
+- Missing `priorResponses`.
+- Defensive behavior when optional timestamps are absent.
+
+## Review Boundaries
+
+- Do not import production mailbox data.
+- Do not call external services.
+- Do not wire the tool into inbox routing or navigation.
+- Do not add app-wide tests for this issue.


### PR DESCRIPTION
## Summary

- Replace broken placeholder README/spec text with clear Collision Detection review docs.
- Add synthetic collision fixtures covering duplicate, possible duplicate, distinct, and invalid input outcomes.
- Add a folder-local test plan plus review and validation notes for maintainers.

## Scope

- All changes stay inside `tools/v1/team/collision-detection/`.
- No app shell, dashboard, routing, auth, wallet, Stellar, database, mail renderer, or shared design-system files are touched.
- Fixture data is synthetic and does not use live mailbox content.

## Validation

- Parsed `fixtures/collision-cases.json` with Node successfully.
- Checked the new docs for setup, usage model, fixtures, review notes, and known limitations.
- Confirmed the GitHub compare contains only files inside `tools/v1/team/collision-detection/`.

Closes 
