### PR TITLE
[codex] Add email ownership tracker core service

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -1,15 +1,50 @@
 # Email Ownership Tracker
 
-This folder is the isolated workspace for the Email Ownership Tracker tool.
+Email Ownership Tracker is an isolated V1 team tool engine for coordinating
+which teammate owns a shared mailbox thread. It is not wired into the main mail
+app yet.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\team\email-ownership-tracker\
-`
+```text
+tools/v1/team/email-ownership-tracker/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not connect this tool to the app shell, dashboard navigation, inbox routing,
+authentication, wallet code, Stellar integration, database schema, mail renderer,
+or the shared design system unless a future integration issue explicitly allows
+that work.
 
-See specs.md for the issue categories and contributor expectations.
+## Core API
+
+- `OwnershipTrackerService` manages deterministic in-memory thread ownership.
+- `claimThread(threadId, input)` assigns an unowned or released thread to a
+  teammate.
+- `releaseThread(threadId, input)` releases a thread only when requested by the
+  current owner.
+- `listThreads()` and `getThread(threadId)` return defensive copies.
+- `getHistory(threadId?)` exposes folder-local ownership events for review.
+
+## State Model
+
+Thread ownership can be:
+
+- `unassigned` before anyone claims the thread.
+- `assigned` while a teammate owns the thread.
+- `released` after the current owner gives it back to the team queue.
+
+Loading state is expected to be handled by a future UI or integration layer. The
+current engine is synchronous and deterministic so it can be tested without live
+mailbox data, network calls, or production secrets.
+
+## Review
+
+Run the folder-local service test when project dependencies are available:
+
+```bash
+npx vitest run tools/v1/team/email-ownership-tracker/tests/service.test.ts
+```
+
+The fixtures in `fixtures/ownership-cases.ts` use public-safe `.test` senders.

--- a/tools/v1/team/email-ownership-tracker/docs/review-notes.md
+++ b/tools/v1/team/email-ownership-tracker/docs/review-notes.md
@@ -1,0 +1,21 @@
+# Email Ownership Tracker Review Notes
+
+## Scope Checklist
+
+- All changed files stay under `tools/v1/team/email-ownership-tracker/`.
+- The engine is not imported by the main app.
+- Fixtures use synthetic `.test` senders.
+- There are no network calls, secrets, or production mailbox records.
+
+## Behavior Checklist
+
+- Unassigned and released threads can be claimed.
+- A thread owned by another teammate cannot be claimed.
+- Only the current owner can release an assigned thread.
+- Returned thread and event objects are defensive copies.
+
+## Follow-Up Boundaries
+
+- UI states belong in the separate UI and accessibility issue.
+- Persistence belongs in a future integration issue.
+- Role-based override policy should be decided before mounting in the live inbox.

--- a/tools/v1/team/email-ownership-tracker/fixtures/ownership-cases.ts
+++ b/tools/v1/team/email-ownership-tracker/fixtures/ownership-cases.ts
@@ -1,0 +1,31 @@
+import type { OwnershipThread } from "../types";
+
+export const ownershipThreads: OwnershipThread[] = [
+  {
+    id: "thread-enterprise-renewal",
+    subject: "Enterprise renewal timing",
+    sender: "renewals@example.test",
+    status: "unassigned",
+    ownerId: null,
+    ownerName: null,
+    updatedAt: "2026-06-17T09:00:00Z",
+  },
+  {
+    id: "thread-delivery-proof",
+    subject: "Delivery proof mismatch",
+    sender: "ops@example.test",
+    status: "assigned",
+    ownerId: "agent-mika",
+    ownerName: "Mika",
+    updatedAt: "2026-06-17T09:10:00Z",
+  },
+  {
+    id: "thread-refund-policy",
+    subject: "Refund policy clarification",
+    sender: "billing@example.test",
+    status: "released",
+    ownerId: null,
+    ownerName: null,
+    updatedAt: "2026-06-17T09:20:00Z",
+  },
+];

--- a/tools/v1/team/email-ownership-tracker/index.ts
+++ b/tools/v1/team/email-ownership-tracker/index.ts
@@ -1,0 +1,9 @@
+export { OwnershipTrackerService } from "./service";
+export type {
+  ClaimThreadInput,
+  OwnershipEvent,
+  OwnershipEventType,
+  OwnershipStatus,
+  OwnershipThread,
+  ReleaseThreadInput,
+} from "./types";

--- a/tools/v1/team/email-ownership-tracker/service.ts
+++ b/tools/v1/team/email-ownership-tracker/service.ts
@@ -1,0 +1,120 @@
+import type {
+  ClaimThreadInput,
+  OwnershipEvent,
+  OwnershipThread,
+  ReleaseThreadInput,
+} from "./types";
+
+function cloneThread(thread: OwnershipThread): OwnershipThread {
+  return { ...thread };
+}
+
+function requireText(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${field} is required.`);
+  }
+  return normalized;
+}
+
+export class OwnershipTrackerService {
+  private readonly threads = new Map<string, OwnershipThread>();
+  private readonly events: OwnershipEvent[] = [];
+
+  constructor(seedThreads: OwnershipThread[] = []) {
+    for (const thread of seedThreads) {
+      this.threads.set(thread.id, cloneThread(thread));
+    }
+  }
+
+  listThreads(): OwnershipThread[] {
+    return Array.from(this.threads.values()).map(cloneThread);
+  }
+
+  getThread(threadId: string): OwnershipThread {
+    const id = requireText(threadId, "threadId");
+    const thread = this.threads.get(id);
+    if (!thread) {
+      throw new Error(`Thread ${id} was not found.`);
+    }
+    return cloneThread(thread);
+  }
+
+  claimThread(threadId: string, input: ClaimThreadInput): OwnershipThread {
+    const id = requireText(threadId, "threadId");
+    const teammateId = requireText(input.teammateId, "teammateId");
+    const teammateName = requireText(input.teammateName, "teammateName");
+    const now = requireText(input.now, "now");
+    const thread = this.threads.get(id);
+
+    if (!thread) {
+      throw new Error(`Thread ${id} was not found.`);
+    }
+
+    if (thread.ownerId && thread.ownerId !== teammateId) {
+      throw new Error(`Thread is already owned by ${thread.ownerName ?? thread.ownerId}.`);
+    }
+
+    const assigned: OwnershipThread = {
+      ...thread,
+      status: "assigned",
+      ownerId: teammateId,
+      ownerName: teammateName,
+      updatedAt: now,
+    };
+
+    this.threads.set(id, assigned);
+    this.events.push({
+      threadId: id,
+      type: "claimed",
+      teammateId,
+      teammateName,
+      occurredAt: now,
+    });
+    return cloneThread(assigned);
+  }
+
+  releaseThread(threadId: string, input: ReleaseThreadInput): OwnershipThread {
+    const id = requireText(threadId, "threadId");
+    const teammateId = requireText(input.teammateId, "teammateId");
+    const now = requireText(input.now, "now");
+    const thread = this.threads.get(id);
+
+    if (!thread) {
+      throw new Error(`Thread ${id} was not found.`);
+    }
+
+    if (!thread.ownerId) {
+      throw new Error("Thread is not currently owned.");
+    }
+
+    if (thread.ownerId !== teammateId) {
+      throw new Error("Only the current owner can release this thread.");
+    }
+
+    const released: OwnershipThread = {
+      ...thread,
+      status: "released",
+      ownerId: null,
+      ownerName: null,
+      updatedAt: now,
+    };
+
+    this.threads.set(id, released);
+    this.events.push({
+      threadId: id,
+      type: "released",
+      teammateId,
+      teammateName: null,
+      occurredAt: now,
+    });
+    return cloneThread(released);
+  }
+
+  getHistory(threadId?: string): OwnershipEvent[] {
+    const events = threadId
+      ? this.events.filter((event) => event.threadId === requireText(threadId, "threadId"))
+      : this.events;
+    return events.map((event) => ({ ...event }));
+  }
+}

--- a/tools/v1/team/email-ownership-tracker/specs.md
+++ b/tools/v1/team/email-ownership-tracker/specs.md
@@ -1,41 +1,57 @@
-# Email Ownership Tracker
-
-Track ownership history.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/email-ownership-tracker/README.md"
-  @"
-
 # Email Ownership Tracker Specs
 
 ## Purpose
 
-Track ownership history.
+Track ownership for shared mailbox threads so teammates can avoid duplicate
+responses and see who is responsible for the next action.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V1
+- Audience: team
+- Folder ownership: `tools/v1/team/email-ownership-tracker/`
 
-$dir/
+This issue implements only the isolated core engine. Main app integration,
+database persistence, routing, and UI mounting are out of scope.
 
-## Required issue categories
+## Inputs
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+`OwnershipTrackerService` accepts deterministic seed threads:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `id` | string | Yes | Stable thread identifier |
+| `subject` | string | Yes | Public-safe thread title for review |
+| `sender` | string | Yes | Synthetic sender address in fixtures |
+| `status` | `unassigned`, `assigned`, `released` | Yes | Current ownership state |
+| `ownerId` | string or null | Yes | Current teammate id when assigned |
+| `ownerName` | string or null | Yes | Current teammate display name |
+| `updatedAt` | string | Yes | ISO timestamp supplied by the caller |
+
+## Outputs
+
+- Claiming returns the updated `OwnershipThread`.
+- Releasing returns the updated `OwnershipThread`.
+- Listing and lookup methods return defensive copies.
+- Ownership events are kept in memory for folder-local review.
+
+## Error States
+
+- Missing `threadId`, teammate id, teammate name, or timestamp throws an error.
+- Unknown thread id throws an error.
+- Claiming a thread owned by another teammate throws an error.
+- Releasing a thread without ownership throws an error.
+- Releasing a thread owned by another teammate throws an error.
+
+## Loading States
+
+The core service is synchronous by design. Future hooks or UI components can add
+loading and retry states when this engine is connected to persistence or live
+mailbox data.
+
+## Safety Notes
+
+- No network calls.
+- No secrets or production data.
+- No app-wide imports.
+- No main application wiring.

--- a/tools/v1/team/email-ownership-tracker/tests/service.test.ts
+++ b/tools/v1/team/email-ownership-tracker/tests/service.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { ownershipThreads } from "../fixtures/ownership-cases";
+import { OwnershipTrackerService } from "../service";
+
+describe("OwnershipTrackerService", () => {
+  it("assigns an unowned thread to the requesting teammate", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+
+    const assigned = service.claimThread("thread-enterprise-renewal", {
+      teammateId: "agent-lina",
+      teammateName: "Lina",
+      now: "2026-06-17T10:00:00Z",
+    });
+
+    expect(assigned).toMatchObject({
+      id: "thread-enterprise-renewal",
+      status: "assigned",
+      ownerId: "agent-lina",
+      ownerName: "Lina",
+      updatedAt: "2026-06-17T10:00:00Z",
+    });
+  });
+
+  it("rejects a claim when another teammate already owns the thread", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+
+    expect(() =>
+      service.claimThread("thread-delivery-proof", {
+        teammateId: "agent-lina",
+        teammateName: "Lina",
+        now: "2026-06-17T10:00:00Z",
+      }),
+    ).toThrow("Thread is already owned by Mika.");
+  });
+
+  it("allows a released thread to be claimed again", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+
+    const assigned = service.claimThread("thread-refund-policy", {
+      teammateId: "agent-omar",
+      teammateName: "Omar",
+      now: "2026-06-17T10:05:00Z",
+    });
+
+    expect(assigned.status).toBe("assigned");
+    expect(assigned.ownerId).toBe("agent-omar");
+  });
+
+  it("releases only the current owner of a thread", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+
+    expect(() =>
+      service.releaseThread("thread-delivery-proof", {
+        teammateId: "agent-lina",
+        now: "2026-06-17T10:08:00Z",
+      }),
+    ).toThrow("Only the current owner can release this thread.");
+
+    const released = service.releaseThread("thread-delivery-proof", {
+      teammateId: "agent-mika",
+      now: "2026-06-17T10:10:00Z",
+    });
+
+    expect(released).toMatchObject({
+      status: "released",
+      ownerId: null,
+      ownerName: null,
+      updatedAt: "2026-06-17T10:10:00Z",
+    });
+  });
+
+  it("returns defensive copies of stored threads", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+    const [first] = service.listThreads();
+    first.subject = "mutated outside the service";
+
+    expect(service.getThread(first.id).subject).toBe("Enterprise renewal timing");
+  });
+
+  it("records claim and release history for review", () => {
+    const service = new OwnershipTrackerService(ownershipThreads);
+
+    service.claimThread("thread-enterprise-renewal", {
+      teammateId: "agent-lina",
+      teammateName: "Lina",
+      now: "2026-06-17T10:00:00Z",
+    });
+    service.releaseThread("thread-enterprise-renewal", {
+      teammateId: "agent-lina",
+      now: "2026-06-17T10:30:00Z",
+    });
+
+    expect(service.getHistory("thread-enterprise-renewal")).toEqual([
+      {
+        threadId: "thread-enterprise-renewal",
+        type: "claimed",
+        teammateId: "agent-lina",
+        teammateName: "Lina",
+        occurredAt: "2026-06-17T10:00:00Z",
+      },
+      {
+        threadId: "thread-enterprise-renewal",
+        type: "released",
+        teammateId: "agent-lina",
+        teammateName: null,
+        occurredAt: "2026-06-17T10:30:00Z",
+      },
+    ]);
+  });
+});

--- a/tools/v1/team/email-ownership-tracker/types.ts
+++ b/tools/v1/team/email-ownership-tracker/types.ts
@@ -1,0 +1,32 @@
+export type OwnershipStatus = "unassigned" | "assigned" | "released";
+
+export type OwnershipThread = {
+  id: string;
+  subject: string;
+  sender: string;
+  status: OwnershipStatus;
+  ownerId: string | null;
+  ownerName: string | null;
+  updatedAt: string;
+};
+
+export type ClaimThreadInput = {
+  teammateId: string;
+  teammateName: string;
+  now: string;
+};
+
+export type ReleaseThreadInput = {
+  teammateId: string;
+  now: string;
+};
+
+export type OwnershipEventType = "claimed" | "released";
+
+export type OwnershipEvent = {
+  threadId: string;
+  type: OwnershipEventType;
+  teammateId: string;
+  teammateName: string | null;
+  occurredAt: string;
+};


### PR DESCRIPTION
## Summary

- Add an isolated `OwnershipTrackerService` for claiming, releasing, listing, and reviewing shared-thread ownership.
- Add deterministic `.test` fixtures and folder-local Vitest coverage for successful claims, ownership conflicts, releases, defensive copies, and ownership history.
- Replace generated placeholder README/spec content with documented inputs, outputs, loading expectations, and error states.

## Scope

- All changes stay inside `tools/v1/team/email-ownership-tracker/`.
- No main app wiring, routing, auth, wallet, Stellar, database, mail renderer, or shared design-system files are touched.
- No live network calls, secrets, or production mailbox data are introduced.

## Validation

- Verified TDD red state first: the new service test failed because `../service` did not exist.
- `pnpm dlx vitest run tools/v1/team/email-ownership-tracker/tests/service.test.ts` -> 6 tests passed.
- Confirmed the GitHub compare contains only files inside `tools/v1/team/email-ownership-tracker/`.

Closes #435
