### PR TITLE
[codex] Add customer support macro safety guards

### DIFF
--- a/tools/v1/team/customer-support-macro-tool/docs/SECURITY_PERFORMANCE.md
+++ b/tools/v1/team/customer-support-macro-tool/docs/SECURITY_PERFORMANCE.md
@@ -1,0 +1,56 @@
+# Customer Support Macro Tool Security and Performance
+
+This document records folder-local safety constraints for the isolated Customer
+Support Macro Tool. It does not change the main app shell, routing, wallet,
+Stellar integration, database schema, mail renderer, or shared design system.
+
+## Threat Assumptions
+
+- Macro titles, bodies, and tags may be typed or pasted from untrusted sources.
+- Macro bodies may contain HTML-looking text, script snippets, invisible control
+  characters, or misleading bidirectional formatting marks.
+- Future UI surfaces may render macro previews, search results, or copied macro
+  output near live customer mail.
+- Large team libraries can make search and rendering expensive if every macro is
+  processed on every keystroke.
+
+## Guard Helpers
+
+`services/security.service.ts` provides pure helpers for future UI and service
+work:
+
+- `sanitizeMacroText(value)` removes invisible control characters and escapes
+  HTML-sensitive characters.
+- `validateMacroSafety(input)` rejects unsafe tag counts and oversized tags
+  before they reach rendering or search.
+- `limitMacrosForSearch(macros, limit)` caps large macro lists before expensive
+  search or preview work.
+
+These helpers are intentionally dependency-free and folder-local.
+
+## Input Constraints
+
+- Tags should be limited to 12 per macro.
+- Individual tags should be 40 characters or fewer.
+- Macro text displayed in preview contexts should pass through
+  `sanitizeMacroText`.
+- Existing length validation in `macro.service.ts` remains responsible for title
+  and body size limits.
+
+## Performance Constraints
+
+- Search and preview flows should process a bounded macro slice by default.
+- The current default search cap is 250 macros.
+- Future integration work can add pagination, virtualization, or server-backed
+  search without changing the folder-local guard contract.
+
+## Review Notes
+
+Run the focused guard tests from the repository root:
+
+```bash
+npx vitest run tools/v1/team/customer-support-macro-tool/tests/security.service.test.ts
+```
+
+The tests cover hostile text sanitization, malformed tag input, and large-list
+search capping.

--- a/tools/v1/team/customer-support-macro-tool/services/security.service.ts
+++ b/tools/v1/team/customer-support-macro-tool/services/security.service.ts
@@ -1,0 +1,63 @@
+export const MACRO_SECURITY_LIMITS = {
+  maxTags: 12,
+  maxTagLength: 40,
+  maxSearchableMacros: 250,
+};
+
+export type MacroSafetyField = "title" | "body" | "tags";
+
+export type MacroSafetyError = {
+  field: MacroSafetyField;
+  message: string;
+};
+
+export type MacroSafetyInput = {
+  title?: string;
+  body?: string;
+  tags?: string[];
+};
+
+export type LimitedMacroList<T> = {
+  items: T[];
+  truncated: boolean;
+};
+
+const INVISIBLE_CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u202A-\u202E\u2066-\u2069]/g;
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function sanitizeMacroText(value: string): string {
+  return value
+    .replace(INVISIBLE_CONTROL_CHARS, "")
+    .replace(/[&<>"']/g, (char) => HTML_ESCAPE_MAP[char]);
+}
+
+export function validateMacroSafety(input: MacroSafetyInput): MacroSafetyError[] {
+  const errors: MacroSafetyError[] = [];
+
+  if (input.tags && input.tags.length > MACRO_SECURITY_LIMITS.maxTags) {
+    errors.push({ field: "tags", message: "Use 12 tags or fewer." });
+  }
+
+  if (input.tags?.some((tag) => tag.trim().length > MACRO_SECURITY_LIMITS.maxTagLength)) {
+    errors.push({ field: "tags", message: "Tags must be 40 characters or fewer." });
+  }
+
+  return errors;
+}
+
+export function limitMacrosForSearch<T>(
+  macros: readonly T[],
+  limit = MACRO_SECURITY_LIMITS.maxSearchableMacros,
+): LimitedMacroList<T> {
+  return {
+    items: macros.slice(0, limit),
+    truncated: macros.length > limit,
+  };
+}

--- a/tools/v1/team/customer-support-macro-tool/tests/security.service.test.ts
+++ b/tools/v1/team/customer-support-macro-tool/tests/security.service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  limitMacrosForSearch,
+  sanitizeMacroText,
+  validateMacroSafety,
+} from "../services/security.service";
+
+describe("customer support macro safety guards", () => {
+  it("escapes html-sensitive characters and strips invisible control characters", () => {
+    const hostile = '<img src=x onerror="alert(1)"> Refund approved\u202E';
+
+    const safe = sanitizeMacroText(hostile);
+
+    expect(safe).toBe("&lt;img src=x onerror=&quot;alert(1)&quot;&gt; Refund approved");
+    expect(safe).not.toContain("<");
+    expect(safe).not.toContain("\u202E");
+  });
+
+  it("reports unsafe macro tag input before it reaches rendering or search", () => {
+    const errors = validateMacroSafety({
+      title: " Refund follow-up ",
+      body: "Thanks for your patience.",
+      tags: Array.from({ length: 13 }, (_, index) =>
+        index === 12 ? "x".repeat(41) : `tag-${index}`,
+      ),
+    });
+
+    expect(errors).toEqual([
+      { field: "tags", message: "Use 12 tags or fewer." },
+      { field: "tags", message: "Tags must be 40 characters or fewer." },
+    ]);
+  });
+
+  it("caps large macro lists before expensive search or rendering work", () => {
+    const macros = Array.from({ length: 305 }, (_, index) => ({ id: `macro-${index}` }));
+
+    const result = limitMacrosForSearch(macros, 250);
+
+    expect(result.truncated).toBe(true);
+    expect(result.items).toHaveLength(250);
+    expect(result.items[0]).toEqual({ id: "macro-0" });
+    expect(macros).toHaveLength(305);
+  });
+});


### PR DESCRIPTION
## Summary

- Add folder-local security/performance guard helpers for macro text, tags, and large search collections.
- Add focused Vitest coverage for hostile text sanitization, unsafe tag input, and large-list capping.
- Document threat assumptions, input constraints, and performance boundaries for future UI/integration work.

## Scope

- All changes stay inside `tools/v1/team/customer-support-macro-tool/`.
- No main app shell, routing, inbox architecture, wallet, Stellar, database, mail renderer, or shared design-system files are touched.
- No network calls, secrets, or production customer mail are introduced.

## Validation

- Verified TDD red state first: the new guard test failed because `../services/security.service` did not exist.
- `pnpm dlx vitest run tools/v1/team/customer-support-macro-tool/tests/security.service.test.ts` -> 3 tests passed.
- Confirmed the GitHub compare contains only files inside `tools/v1/team/customer-support-macro-tool/`.

Closes #
