### PR TITLE
docs: add collision detection test plan by huazhuang80-star

### DIFF
--- a/tools/v1/team/collision-detection/README.md
+++ b/tools/v1/team/collision-detection/README.md
@@ -13,3 +13,12 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Review and test documentation
+
+- [Setup guide](./docs/SETUP.md)
+- [OSS review notes](./docs/REVIEW_NOTES.md)
+- [Folder-local test plan](./tests/TEST_PLAN.md)
+
+This contribution keeps the tool isolated and documents the expected review path
+until implementation code is added in a later folder-local feature issue.

--- a/tools/v1/team/collision-detection/docs/REVIEW_NOTES.md
+++ b/tools/v1/team/collision-detection/docs/REVIEW_NOTES.md
@@ -1,0 +1,61 @@
+# Collision Detection OSS Review Notes
+
+This document gives maintainers and OSS contributors a fast way to review the
+testing and documentation pass for the Collision Detection tool.
+
+## What this PR adds
+
+| Deliverable | Location |
+| --- | --- |
+| Setup guide | `docs/SETUP.md` |
+| Test plan | `tests/TEST_PLAN.md` |
+| Review notes | `docs/REVIEW_NOTES.md` |
+| README links | `README.md` |
+
+No file outside `tools/v1/team/collision-detection/` is part of this change.
+
+## Review checklist
+
+```bash
+# Should return no files outside the collision-detection folder
+git diff --name-only | grep -v "tools/v1/team/collision-detection/"
+```
+
+- [ ] Documentation explains how to review the tool independently.
+- [ ] Test plan covers duplicate response prevention and ownership handoff.
+- [ ] No production mailbox, wallet, Stellar, or database configuration is introduced.
+- [ ] No main app routing, shell, authentication, or inbox code is touched.
+
+## Core behavior to validate later
+
+Collision Detection should prevent two teammates from responding to the same
+external message at the same time without blocking legitimate handoffs or
+unrelated new messages from the same sender.
+
+The future service layer should make these decisions from local inputs:
+
+- source message id or thread id
+- current responder identity
+- draft state and timestamp
+- ownership or handoff record
+- resolution status
+
+## Out of scope for this PR
+
+- UI components
+- realtime transport
+- app-wide route registration
+- persistence adapters
+- Stellar or wallet integration
+- root-level tests
+
+## Follow-up implementation notes
+
+When code is added, prefer pure functions first:
+
+```ts
+detectCollision(threadState, proposedResponder)
+```
+
+That API shape makes the safety logic easy to test without a browser, server,
+wallet, or live inbox connection.

--- a/tools/v1/team/collision-detection/docs/SETUP.md
+++ b/tools/v1/team/collision-detection/docs/SETUP.md
@@ -1,0 +1,80 @@
+# Collision Detection Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Matches the main Stealth frontend baseline |
+| npm | 10+ | Used from the repository root |
+
+No wallet, Stellar account, relay server, or production inbox data is required
+for this isolated testing and documentation pass.
+
+## Folder boundary
+
+All review work for this issue stays inside:
+
+```text
+tools/v1/team/collision-detection/
+```
+
+Do not wire this tool into the app shell, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system while reviewing
+this issue.
+
+## Recommended local layout
+
+```text
+tools/v1/team/collision-detection/
+  docs/
+    SETUP.md
+    REVIEW_NOTES.md
+  tests/
+    TEST_PLAN.md
+  README.md
+  specs.md
+```
+
+Future implementation PRs can add `fixtures/`, `services/`, `hooks/`, and
+`.test.ts` files inside this folder without changing the folder boundary.
+
+## Validation commands
+
+From the repository root:
+
+```bash
+# Confirm this contribution is folder-local
+git diff --name-only | grep -v "tools/v1/team/collision-detection/"
+
+# When implementation tests are added later
+npx vitest run tools/v1/team/collision-detection/tests
+
+# Optional full project checks
+npx tsc --noEmit
+npm run lint
+```
+
+The first command should produce no output for this issue.
+
+## Fixture guidance
+
+Use deterministic, local-only fixtures. A useful minimal fixture set is:
+
+| Fixture | Purpose |
+| --- | --- |
+| `single-owner-thread` | Baseline thread with one active responder |
+| `parallel-draft-thread` | Two teammates drafting against the same sender message |
+| `resolved-thread` | Previously handled message that should not trigger a new collision |
+| `same-sender-new-topic` | Same sender but unrelated subject/body |
+| `handoff-thread` | Explicit ownership transfer between teammates |
+
+Fixtures must not include live customer messages, private keys, wallet secrets,
+production mailbox identifiers, or real sender data.
+
+## Known limitations
+
+- This issue documents the expected test plan; it does not implement collision
+  detection services.
+- App integration and UI behavior are intentionally out of scope.
+- Realtime multi-tab conflict resolution should be tested in a future
+  implementation issue once the data model is available.

--- a/tools/v1/team/collision-detection/tests/TEST_PLAN.md
+++ b/tools/v1/team/collision-detection/tests/TEST_PLAN.md
@@ -1,0 +1,81 @@
+# Collision Detection Test Plan
+
+## Summary
+
+This folder-local plan defines how contributors should test the Collision
+Detection tool once service code is added. The first reviewable milestone is a
+documented plan because the folder currently contains only README/spec files.
+
+## Goals
+
+- Prevent duplicate teammate responses to the same external message.
+- Allow explicit ownership handoff without false positive collisions.
+- Keep all tests local to `tools/v1/team/collision-detection/`.
+- Avoid live inbox data, secrets, wallet state, network calls, and app-wide tests.
+
+## Proposed test topology
+
+```text
+tools/v1/team/collision-detection/
+  fixtures/
+    collision.fixture.ts
+  services/
+    collision.service.ts
+  tests/
+    collision.service.test.ts
+    TEST_PLAN.md
+```
+
+## Unit scenarios
+
+| Area | Scenario | Expected result |
+| --- | --- | --- |
+| Active responder | Alice starts a draft on message M1 | No collision for Alice |
+| Duplicate responder | Bob starts a draft on M1 while Alice owns it | Collision returned |
+| Same thread | Bob starts a draft on another message in thread T1 | Collision depends on thread policy |
+| Handoff | Alice transfers ownership of M1 to Bob | Bob allowed, Alice warned |
+| Resolved message | Bob opens a message marked resolved | No active collision |
+| New topic | Same sender sends unrelated message M2 | No collision with M1 |
+| Stale draft | Alice draft exceeds stale threshold | Bob receives warning, not hard block |
+| Missing metadata | Thread id is absent | Service falls back to message id |
+
+## Integration scenarios
+
+### Parallel draft protection
+
+1. Alice opens message M1 and starts a reply.
+2. Bob opens the same message.
+3. Bob attempts to start a reply.
+4. Verify Bob receives a collision state with Alice as the active responder.
+5. Verify no external reply payload is created for Bob.
+
+### Handoff workflow
+
+1. Alice owns message M1.
+2. Alice creates an explicit handoff to Bob.
+3. Bob starts a draft for M1.
+4. Verify Bob is allowed.
+5. Verify Alice is shown a passive warning if she tries to continue editing.
+
+### False positive guard
+
+1. Alice owns message M1 from sender S1.
+2. Sender S1 sends a new unrelated message M2.
+3. Bob opens M2.
+4. Verify M2 is not blocked by M1 ownership.
+
+## Manual review checklist
+
+- [ ] Collision warning names the active teammate.
+- [ ] Warning explains whether the response is blocked or only stale.
+- [ ] Handoff state is visible and reversible before sending.
+- [ ] Keyboard users can reach the warning and handoff controls.
+- [ ] No collision state leaks to the external sender.
+- [ ] No test fixture includes production sender data.
+
+## Known limitations
+
+- The policy for message-level vs thread-level locking is still open; tests
+  should name which policy they assert.
+- Realtime behavior needs an implementation issue with a chosen transport.
+- UI and accessibility tests should be added only after components exist.


### PR DESCRIPTION
Closes #

## Summary
- adds folder-local setup and OSS review notes for Collision Detection
- documents the test plan for duplicate-response prevention, handoff, stale drafts, and false-positive guards
- links the new review/test documents from the tool README

## Validation
- `git diff --check` passed
- reviewed `git diff --name-only` and staged only files under `tools/v1/team/collision-detection/`

## Note
This is a documented test plan because the tool folder currently has README/spec files but no service implementation yet.