### PR TITLE
docs: add email ownership test plan by huazhuang80-star

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -13,3 +13,12 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Review and test documentation
+
+- [Setup guide](./docs/SETUP.md)
+- [OSS review notes](./docs/REVIEW_NOTES.md)
+- [Folder-local test plan](./tests/TEST_PLAN.md)
+
+This contribution documents the review path for ownership history behavior
+without wiring the tool into the main application.

--- a/tools/v1/team/email-ownership-tracker/docs/REVIEW_NOTES.md
+++ b/tools/v1/team/email-ownership-tracker/docs/REVIEW_NOTES.md
@@ -1,0 +1,62 @@
+# Email Ownership Tracker OSS Review Notes
+
+This document helps maintainers review the folder-local testing and
+documentation pass for the Email Ownership Tracker tool.
+
+## What this PR adds
+
+| Deliverable | Location |
+| --- | --- |
+| Setup guide | `docs/SETUP.md` |
+| Test plan | `tests/TEST_PLAN.md` |
+| Review notes | `docs/REVIEW_NOTES.md` |
+| README links | `README.md` |
+
+No files outside `tools/v1/team/email-ownership-tracker/` are part of this
+change.
+
+## Review checklist
+
+```bash
+# Should return no files outside the ownership tracker folder
+git diff --name-only | grep -v "tools/v1/team/email-ownership-tracker/"
+```
+
+- [ ] Documentation explains how to review the tool independently.
+- [ ] Test plan covers assignment, release, handoff, stale owner, and audit history.
+- [ ] No production mailbox, wallet, Stellar, or database configuration is introduced.
+- [ ] No app-wide shell, routing, authentication, or inbox code is touched.
+
+## Core behavior to validate later
+
+Email Ownership Tracker should answer:
+
+- Who currently owns this message or thread?
+- When was ownership assigned?
+- Was the item released, reassigned, or timed out?
+- What safe audit trail can be shown to teammates?
+
+The future service layer should use local inputs and return deterministic
+ownership state without network calls.
+
+## Out of scope for this PR
+
+- UI components
+- app route integration
+- persistence adapters
+- external notification delivery
+- wallet or Stellar signing
+- root-level test changes
+
+## Follow-up implementation notes
+
+Prefer a pure, testable API first:
+
+```ts
+assignOwner(ownershipState, messageRef, teammate)
+releaseOwner(ownershipState, messageRef, teammate)
+transferOwner(ownershipState, messageRef, fromTeammate, toTeammate)
+```
+
+That shape keeps ownership rules reviewable before the tool is connected to the
+shared inbox UI.

--- a/tools/v1/team/email-ownership-tracker/docs/SETUP.md
+++ b/tools/v1/team/email-ownership-tracker/docs/SETUP.md
@@ -1,0 +1,80 @@
+# Email Ownership Tracker Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Matches the main Stealth frontend baseline |
+| npm | 10+ | Used from the repository root |
+
+No live mailbox, wallet, Stellar account, database, or relay server is required
+for this isolated documentation and test-plan pass.
+
+## Folder boundary
+
+All work for this tool must stay inside:
+
+```text
+tools/v1/team/email-ownership-tracker/
+```
+
+Do not modify app routing, dashboard layout, authentication, wallet core,
+Stellar integration, database schema, shared inbox architecture, or the design
+system for this issue.
+
+## Recommended local layout
+
+```text
+tools/v1/team/email-ownership-tracker/
+  docs/
+    SETUP.md
+    REVIEW_NOTES.md
+  tests/
+    TEST_PLAN.md
+  README.md
+  specs.md
+```
+
+Future implementation work can add folder-local `fixtures/`, `services/`,
+`hooks/`, and `.test.ts` files.
+
+## Validation commands
+
+From the repository root:
+
+```bash
+# Confirm the contribution stays folder-local
+git diff --name-only | grep -v "tools/v1/team/email-ownership-tracker/"
+
+# Once service tests exist
+npx vitest run tools/v1/team/email-ownership-tracker/tests
+
+# Optional project-level checks
+npx tsc --noEmit
+npm run lint
+```
+
+The folder-local check should return no output for this issue.
+
+## Fixture guidance
+
+Fixtures should be deterministic and safe to commit:
+
+| Fixture | Purpose |
+| --- | --- |
+| `unassigned-thread` | Message or thread with no current owner |
+| `assigned-thread` | Active owner with assigned timestamp |
+| `handoff-history` | Ownership transferred between teammates |
+| `released-thread` | Owner explicitly releases the item |
+| `stale-owner` | Owner has not acted before a configured timeout |
+| `audit-export-safe` | History view with redacted external payloads |
+
+Use fake Stealth addresses and synthetic message ids only. Do not include
+production sender data, wallet secrets, private keys, or mailbox identifiers.
+
+## Known limitations
+
+- This issue documents setup, review notes, and a test plan; it does not add the
+  ownership service implementation.
+- Persistence adapter choice is deferred until the core feature issue lands.
+- App shell and shared inbox integration remain out of scope.

--- a/tools/v1/team/email-ownership-tracker/tests/TEST_PLAN.md
+++ b/tools/v1/team/email-ownership-tracker/tests/TEST_PLAN.md
@@ -1,0 +1,82 @@
+# Email Ownership Tracker Test Plan
+
+## Summary
+
+This folder-local test plan defines the expected coverage for ownership history
+behavior. It is intentionally scoped to
+`tools/v1/team/email-ownership-tracker/` so contributors can validate the tool
+without touching the main app.
+
+## Goals
+
+- Track the current owner for a message or thread.
+- Preserve an audit trail for assignment, release, transfer, and timeout events.
+- Prevent unauthorized teammates from mutating ownership.
+- Keep fixtures fake, deterministic, and safe to commit.
+
+## Proposed test topology
+
+```text
+tools/v1/team/email-ownership-tracker/
+  fixtures/
+    ownership.fixture.ts
+  services/
+    ownership.service.ts
+  tests/
+    ownership.service.test.ts
+    TEST_PLAN.md
+```
+
+## Unit scenarios
+
+| Area | Scenario | Expected result |
+| --- | --- | --- |
+| Assignment | Alice claims unassigned message M1 | Alice becomes owner |
+| Duplicate assignment | Bob claims M1 while Alice owns it | Operation is rejected |
+| Release | Alice releases M1 | M1 becomes unassigned with release event |
+| Transfer | Alice transfers M1 to Bob | Bob becomes owner, audit records both users |
+| Unauthorized release | Bob releases Alice-owned M1 | Operation is rejected |
+| Stale owner | Alice exceeds stale threshold | State marks ownership stale but keeps audit history |
+| Thread scope | Alice owns thread T1 | All T1 messages inherit owner unless overridden |
+| Message override | Bob owns message M2 in T1 | M2 owner is Bob, thread owner remains Alice |
+| Audit export | Ownership history is serialized | External payload fields are excluded |
+
+## Integration scenarios
+
+### Claim and handoff
+
+1. Alice claims message M1.
+2. Bob attempts to claim M1 and is rejected.
+3. Alice transfers ownership to Bob.
+4. Bob claims responsibility successfully.
+5. Verify audit history contains claim, rejected claim, and transfer events.
+
+### Release and reclaim
+
+1. Alice claims thread T1.
+2. Alice releases T1.
+3. Bob claims T1.
+4. Verify current owner is Bob and the release event is preserved.
+
+### Stale owner warning
+
+1. Alice claims M1.
+2. The fixture clock advances beyond the stale threshold.
+3. Bob opens M1.
+4. Verify Bob sees a stale-owner warning and can request handoff.
+
+## Manual review checklist
+
+- [ ] Current owner is visible in the message/thread context.
+- [ ] Handoff and release states are clear to keyboard users.
+- [ ] Stale ownership is warning-level unless the future policy says otherwise.
+- [ ] Audit history does not expose private sender content to external payloads.
+- [ ] All fixture users and message ids are synthetic.
+- [ ] No root-level tests or app integration files are modified.
+
+## Known limitations
+
+- Durable storage is not selected yet.
+- Thread-level vs message-level precedence should be confirmed by maintainers
+  before implementation.
+- UI accessibility tests should be added only after UI components exist.


### PR DESCRIPTION
Closes 

## Summary
- adds folder-local setup and OSS review notes for Email Ownership Tracker
- documents test coverage for assignment, release, handoff, stale ownership, and audit export behavior
- links the new docs/test plan from the tool README

## Validation
- `git diff --check` passed
- staged only files under `tools/v1/team/email-ownership-tracker/`

## Note
This is a documented test plan because the folder currently has README/spec files but no service implementation yet.