### PR TITLE
docs: add shared contact notes setup guide by huazhuang80-star

### DIFF
--- a/tools/v2/team/shared-contact-notes/README.md
+++ b/tools/v2/team/shared-contact-notes/README.md
@@ -31,6 +31,7 @@ design system from this issue.
 - `hooks/useContactNotes.ts` provides React hook wrapping NoteService with `useReducer`.
 - `components/` contains all React UI components with empty, loading, error, and success states.
 - `docs/ACCESSIBILITY.md` documents WCAG 2.1 AA compliance measures.
+- `docs/SETUP.md` explains how to review and run this tool independently.
 - `docs/review-notes.md` gives maintainers a review checklist.
 
 ## Intended Behavior

--- a/tools/v2/team/shared-contact-notes/docs/SETUP.md
+++ b/tools/v2/team/shared-contact-notes/docs/SETUP.md
@@ -1,0 +1,86 @@
+# Shared Contact Notes Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Matches the main Stealth frontend baseline |
+| npm | 10+ | Used from the repository root |
+
+No wallet, Stellar account, database, relay server, or production contact data
+is required to review this isolated tool.
+
+## Folder boundary
+
+All work for this tool stays inside:
+
+```text
+tools/v2/team/shared-contact-notes/
+```
+
+Do not wire this tool into the app shell, routing, dashboard layout, inbox
+architecture, wallet core, Stellar integration, database schema, or shared
+design system from this issue.
+
+## Install dependencies
+
+From the repository root:
+
+```bash
+npm install
+```
+
+This tool uses the project-level Vitest, TypeScript, React, and testing-library
+dependencies already declared in `package.json`.
+
+## Run the folder-local tests
+
+```bash
+npx vitest run tools/v2/team/shared-contact-notes/tests
+```
+
+To focus on one layer:
+
+```bash
+npx vitest run tools/v2/team/shared-contact-notes/tests/service.test.ts
+npx vitest run tools/v2/team/shared-contact-notes/tests/components.test.tsx
+```
+
+## Review the fixtures
+
+The deterministic seed data lives in:
+
+```text
+tools/v2/team/shared-contact-notes/fixtures/notes.ts
+```
+
+Fixtures use synthetic contact ids, user ids, content, and timestamps. Do not
+replace them with production contact records or real customer data.
+
+## Validate isolation
+
+Before opening or merging a PR:
+
+```bash
+git diff --name-only | grep -v "tools/v2/team/shared-contact-notes/"
+```
+
+The command should return no output for this issue.
+
+## Optional project checks
+
+```bash
+npx tsc --noEmit
+npm run lint
+```
+
+These commands are helpful for maintainers, but this V2 tool is intentionally
+not wired into the main app yet.
+
+## Known limitations
+
+- Notes are stored in memory only.
+- There is no authentication or authorization layer yet.
+- The UI is self-contained and not connected to the main contact model.
+- Realtime collaboration and persistence should be handled by future
+  integration issues.

--- a/tools/v2/team/shared-contact-notes/docs/review-notes.md
+++ b/tools/v2/team/shared-contact-notes/docs/review-notes.md
@@ -19,6 +19,22 @@ self-contained mini-product under `tools/v2/team/shared-contact-notes/`.
   not-found errors, determinism guarantees, and loading state behavior.
 - The public API is exported through `index.ts` (barrel).
 
+## Quick Validation
+
+```bash
+# Run only this tool's service and component tests
+npx vitest run tools/v2/team/shared-contact-notes/tests
+
+# Confirm review scope stays folder-local
+git diff --name-only | grep -v "tools/v2/team/shared-contact-notes/"
+
+# Optional project-wide checks from the repo root
+npx tsc --noEmit
+npm run lint
+```
+
+The folder-local scope command should return no files for this issue.
+
 ## What Is Intentionally Not Included
 
 - No application shell, routing, navigation, or dashboard integration.


### PR DESCRIPTION
Closes #658.

## Summary
- adds a folder-local setup guide for Shared Contact Notes
- links the setup guide from the README review map
- adds quick validation commands to the existing review notes

## Validation
- `git diff --check` passed
- staged only files under `tools/v2/team/shared-contact-notes/`

## Local limitation
- Fresh checkout does not have `node_modules`, and this environment does not expose `npm` or `npx`, so I could not run the Vitest suite locally.