### PR TITLE
[codex] Add email-to-todo core converter service

### DIFF
--- a/tools/v1/individual/email-to-todo-converter/README.md
+++ b/tools/v1/individual/email-to-todo-converter/README.md
@@ -10,15 +10,22 @@ All work for this tool must stay inside:
 tools/v1/individual/email-to-todo-converter/
 ```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
 ## Contributor Setup
 
-This tool does not ship executable code yet. Until a feature issue adds the
-implementation, contributors should use the local documentation in this folder
-as the launch contract:
+This tool ships folder-local code and documentation only. Contributors should
+use the local files in this folder as the launch contract:
 
 - `specs.md` defines the behavior and folder ownership boundary.
+- `services/emailToTodoCore.ts` implements the deterministic core extraction
+  service.
+- `fixtures/emailToTodoFixtures.ts` provides local sample emails for tests and
+  future UI work.
+- `docs/core-engine.md` documents the service inputs, outputs, loading state,
+  and error state.
 - `docs/test-plan.md` lists the acceptance scenarios that future tests should
   cover.
 - `docs/fixtures.md` describes the fixture emails and expected task outputs.
@@ -26,14 +33,15 @@ as the launch contract:
 
 ## Intended Usage
 
-The tool converts an email into one or more actionable tasks. A future feature
-implementation should accept a normalized email object, extract the task title,
-due date, priority, source metadata, and completion state, then return a
-reviewable task draft without mutating the mailbox or main application state.
+The tool converts an email into one or more actionable tasks. The core service
+accepts a normalized email object, extracts the task title, due date, priority,
+source metadata, and completion state, then returns a reviewable task draft
+without mutating the mailbox or main application state.
 
 ## Known Limitations
 
-- No production code is present in this folder yet.
-- The documented tests are a plan, not an executable suite.
+- Extraction is deterministic and pattern based; no LLM or external task
+  provider is called.
+- Persistence and saving remain out of scope.
 - Main app routing, inbox integration, and persistence are intentionally out of
   scope until a future integration issue allows them.

--- a/tools/v1/individual/email-to-todo-converter/docs/core-engine.md
+++ b/tools/v1/individual/email-to-todo-converter/docs/core-engine.md
@@ -1,0 +1,58 @@
+# Email-to-Todo Converter Core Engine
+
+The core engine is a folder-local, deterministic service for turning one
+normalized email into a reviewable task draft. It does not import from the main
+application and does not make network calls.
+
+## API surface
+
+- `services/emailToTodoCore.ts` exports `convertEmailToTodos(email)`.
+- `services/index.ts` re-exports the service and types.
+- `index.ts` is the folder-local public entry point for future tool work.
+- `fixtures/emailToTodoFixtures.ts` exports deterministic sample emails.
+
+## Input
+
+`EmailToTodoInput` requires:
+
+- `id`: stable email identifier used to derive deterministic task ids.
+- `subject`: normalized subject text.
+- `sender`: source sender.
+- `receivedAt`: ISO-8601 timestamp.
+- `bodyText`: plain text body.
+- `labels`: optional local labels.
+
+Blank subject and body are rejected together so the service does not create an
+empty task draft.
+
+## Output
+
+`convertEmailToTodos` returns an `EmailToTodoResult`:
+
+- `success`: one task draft was created and is ready for user review.
+- `empty`: the email was valid, but no clear action item was detected.
+- `error`: required input was missing or invalid.
+
+Task drafts include deterministic `id`, `title`, `notes`, `dueDate`,
+`priority`, `completed`, and `source` fields. The `completed` field is always
+`false` because this service only prepares drafts.
+
+## Loading state
+
+The service itself is synchronous and deterministic, so it does not expose a
+runtime loading flag. A future UI can enter a loading state before invoking the
+service and leave that state when a `success`, `empty`, or `error` result is
+returned. No background sync or mailbox mutation happens here.
+
+## Error state
+
+Validation errors are returned as readable strings in `errors`. The current
+checks cover missing email id, missing sender, invalid `receivedAt`, and blank
+subject/body content.
+
+## Deterministic extraction
+
+The extractor scores subject and body sentences for direct request language and
+known action verbs. It recognizes simple due date phrases such as `today`,
+`tomorrow`, `by Friday`, and `due 2026-07-01`. High priority is assigned when
+urgent language such as `urgent`, `asap`, `critical`, or `blocking` appears.

--- a/tools/v1/individual/email-to-todo-converter/fixtures/emailToTodoFixtures.ts
+++ b/tools/v1/individual/email-to-todo-converter/fixtures/emailToTodoFixtures.ts
@@ -1,0 +1,34 @@
+import type { EmailToTodoInput } from "../services/emailToTodoCore";
+
+export const directRequestEmail: EmailToTodoInput = {
+  id: "email-direct-request",
+  subject: "Please review the invoice by Friday",
+  sender: "billing@example.com",
+  receivedAt: "2026-06-19T09:00:00Z",
+  bodyText: "Please review the attached invoice by Friday and let me know if anything is missing.",
+  labels: ["inbox"],
+};
+
+export const urgentFollowUpEmail: EmailToTodoInput = {
+  id: "email-urgent-follow-up",
+  subject: "Urgent: follow up with partner",
+  sender: "ops@example.com",
+  receivedAt: "2026-06-19T10:30:00Z",
+  bodyText: "Can you follow up with the partner today? This is blocking the launch checklist.",
+  labels: ["important"],
+};
+
+export const newsletterEmail: EmailToTodoInput = {
+  id: "email-newsletter",
+  subject: "Weekly product updates",
+  sender: "newsletter@example.com",
+  receivedAt: "2026-06-19T11:00:00Z",
+  bodyText: "Here are this week's product updates and release notes.",
+  labels: ["newsletter"],
+};
+
+export const emailToTodoFixtures = {
+  directRequestEmail,
+  urgentFollowUpEmail,
+  newsletterEmail,
+};

--- a/tools/v1/individual/email-to-todo-converter/index.ts
+++ b/tools/v1/individual/email-to-todo-converter/index.ts
@@ -1,0 +1,16 @@
+export {
+  convertEmailToTodos,
+  type EmailTodoDraft,
+  type EmailTodoSource,
+  type EmailToTodoInput,
+  type EmailToTodoPriority,
+  type EmailToTodoResult,
+  type EmailToTodoStatus,
+} from "./services";
+
+export {
+  directRequestEmail,
+  emailToTodoFixtures,
+  newsletterEmail,
+  urgentFollowUpEmail,
+} from "./fixtures/emailToTodoFixtures";

--- a/tools/v1/individual/email-to-todo-converter/services/emailToTodoCore.ts
+++ b/tools/v1/individual/email-to-todo-converter/services/emailToTodoCore.ts
@@ -1,0 +1,322 @@
+export type EmailToTodoPriority = "normal" | "high";
+export type EmailToTodoStatus = "success" | "empty" | "error";
+
+export interface EmailToTodoInput {
+  id: string;
+  subject: string;
+  sender: string;
+  receivedAt: string;
+  bodyText: string;
+  labels?: string[];
+}
+
+export interface EmailTodoSource {
+  emailId: string;
+  subject: string;
+  sender: string;
+  receivedAt: string;
+  labels: string[];
+}
+
+export interface EmailTodoDraft {
+  id: string;
+  title: string;
+  notes: string;
+  dueDate: string | null;
+  priority: EmailToTodoPriority;
+  completed: false;
+  source: EmailTodoSource;
+}
+
+export interface EmailToTodoResult {
+  status: EmailToTodoStatus;
+  message: string;
+  tasks: EmailTodoDraft[];
+  errors?: string[];
+}
+
+interface ActionCandidate {
+  text: string;
+  source: "subject" | "body";
+  score: number;
+}
+
+const ACTION_VERBS = [
+  "approve",
+  "book",
+  "call",
+  "check",
+  "confirm",
+  "draft",
+  "follow up",
+  "prepare",
+  "reply",
+  "review",
+  "schedule",
+  "send",
+  "share",
+  "sign",
+  "submit",
+  "update",
+];
+
+const DIRECT_REQUEST_PATTERNS = [
+  /\bplease\b/i,
+  /\bcan you\b/i,
+  /\bcould you\b/i,
+  /\bwould you\b/i,
+  /\bneed you to\b/i,
+  /\bplease\s+help\b/i,
+];
+
+const HIGH_PRIORITY_PATTERNS = [
+  /\burgent\b/i,
+  /\basap\b/i,
+  /\bimmediately\b/i,
+  /\bcritical\b/i,
+  /\bblocking\b/i,
+];
+
+const WEEKDAY_TO_UTC_DAY: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function sentenceCase(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function isValidTimestamp(value: string): boolean {
+  return normalizeWhitespace(value).length > 0 && !Number.isNaN(new Date(value).getTime());
+}
+
+function validateEmail(email: EmailToTodoInput): string[] {
+  const errors: string[] = [];
+
+  if (normalizeWhitespace(email.id).length === 0) {
+    errors.push("Email id is required.");
+  }
+  if (normalizeWhitespace(email.sender).length === 0) {
+    errors.push("Sender is required.");
+  }
+  if (!isValidTimestamp(email.receivedAt)) {
+    errors.push("receivedAt must be a valid ISO-8601 timestamp.");
+  }
+  if (
+    normalizeWhitespace(email.subject).length === 0 &&
+    normalizeWhitespace(email.bodyText).length === 0
+  ) {
+    errors.push("Subject or bodyText is required.");
+  }
+
+  return errors;
+}
+
+function containsActionVerb(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return ACTION_VERBS.some((verb) => {
+    const escaped = verb.replace(/\s+/g, "\\s+");
+    return new RegExp("\\b" + escaped + "\\b", "i").test(normalized);
+  });
+}
+
+function requestScore(text: string): number {
+  let score = 0;
+
+  if (DIRECT_REQUEST_PATTERNS.some((pattern) => pattern.test(text))) {
+    score += 3;
+  }
+  if (containsActionVerb(text)) {
+    score += 2;
+  }
+  if (HIGH_PRIORITY_PATTERNS.some((pattern) => pattern.test(text))) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function splitBodySentences(bodyText: string): string[] {
+  return normalizeWhitespace(bodyText)
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+}
+
+function actionCandidates(email: EmailToTodoInput): ActionCandidate[] {
+  const candidates: ActionCandidate[] = [];
+  const subject = normalizeWhitespace(email.subject);
+
+  if (subject.length > 0) {
+    const score = requestScore(subject);
+    if (score > 0) {
+      candidates.push({ text: subject, source: "subject", score });
+    }
+  }
+
+  for (const sentence of splitBodySentences(email.bodyText)) {
+    const score = requestScore(sentence);
+    if (score > 0) {
+      candidates.push({ text: sentence, source: "body", score });
+    }
+  }
+
+  return candidates.sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    if (left.source !== right.source) {
+      return left.source === "subject" ? -1 : 1;
+    }
+    return left.text.length - right.text.length;
+  });
+}
+
+function stripRequestPrefix(text: string): string {
+  return text
+    .replace(/^\s*urgent:\s*/i, "")
+    .replace(/^\s*please\s+help\s+(?:me\s+)?(?:to\s+)?/i, "")
+    .replace(/^\s*please\s+/i, "")
+    .replace(/^\s*(?:can|could|would)\s+you\s+/i, "")
+    .replace(/^\s*i\s+need\s+you\s+to\s+/i, "")
+    .replace(/^\s*need\s+you\s+to\s+/i, "");
+}
+
+function stripDueDateLanguage(text: string): string {
+  return text
+    .replace(/\s+(?:by|before|due(?:\s+on)?|on)\s+\d{4}-\d{2}-\d{2}\b.*$/i, "")
+    .replace(
+      /\s+(?:by|before|due(?:\s+on)?|on)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b.*$/i,
+      "",
+    )
+    .replace(/\s+(?:today|tomorrow)\b.*$/i, "")
+    .replace(/\s+and\s+(?:let me know|reply|send|share|confirm)\b.*$/i, "");
+}
+
+function buildTitle(candidate: ActionCandidate): string {
+  const withoutPrefix = stripRequestPrefix(candidate.text);
+  const withoutDueDate = stripDueDateLanguage(withoutPrefix);
+  const cleaned = normalizeWhitespace(withoutDueDate).replace(/[.!?]+$/g, "");
+  return sentenceCase(cleaned);
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const copy = new Date(date.getTime());
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function nextWeekdayDate(receivedAt: Date, weekdayName: string): string {
+  const targetDay = WEEKDAY_TO_UTC_DAY[weekdayName.toLowerCase()];
+  const receivedDay = receivedAt.getUTCDay();
+  let delta = targetDay - receivedDay;
+  if (delta <= 0) {
+    delta += 7;
+  }
+  return toIsoDate(addUtcDays(receivedAt, delta));
+}
+
+function extractDueDate(email: EmailToTodoInput, candidate: ActionCandidate): string | null {
+  const haystack = normalizeWhitespace(candidate.text + " " + email.subject + " " + email.bodyText);
+  const receivedAt = new Date(email.receivedAt);
+
+  const explicitIso = haystack.match(/\b(?:by|before|due(?:\s+on)?|on)\s+(\d{4}-\d{2}-\d{2})\b/i);
+  if (explicitIso) {
+    return explicitIso[1];
+  }
+
+  if (/\btoday\b/i.test(haystack)) {
+    return toIsoDate(receivedAt);
+  }
+  if (/\btomorrow\b/i.test(haystack)) {
+    return toIsoDate(addUtcDays(receivedAt, 1));
+  }
+
+  const weekday = haystack.match(
+    /\b(?:by|before|due(?:\s+on)?|on)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
+  );
+  if (weekday) {
+    return nextWeekdayDate(receivedAt, weekday[1]);
+  }
+
+  return null;
+}
+
+function detectPriority(email: EmailToTodoInput): EmailToTodoPriority {
+  const haystack = email.subject + " " + email.bodyText + " " + (email.labels ?? []).join(" ");
+  return HIGH_PRIORITY_PATTERNS.some((pattern) => pattern.test(haystack)) ? "high" : "normal";
+}
+
+function slugify(value: string): string {
+  const slug = normalizeWhitespace(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "email";
+}
+
+function buildNotes(email: EmailToTodoInput, candidate: ActionCandidate): string {
+  const source = candidate.source === "subject" ? "subject" : "body";
+  return "Detected from email " + source + ': "' + normalizeWhitespace(candidate.text) + '"';
+}
+
+function buildTask(email: EmailToTodoInput, candidate: ActionCandidate): EmailTodoDraft {
+  return {
+    id: "todo-" + slugify(email.id) + "-1",
+    title: buildTitle(candidate),
+    notes: buildNotes(email, candidate),
+    dueDate: extractDueDate(email, candidate),
+    priority: detectPriority(email),
+    completed: false,
+    source: {
+      emailId: normalizeWhitespace(email.id),
+      subject: normalizeWhitespace(email.subject),
+      sender: normalizeWhitespace(email.sender),
+      receivedAt: email.receivedAt,
+      labels: email.labels ?? [],
+    },
+  };
+}
+
+export function convertEmailToTodos(email: EmailToTodoInput): EmailToTodoResult {
+  const errors = validateEmail(email);
+  if (errors.length > 0) {
+    return {
+      status: "error",
+      message: "Email could not be converted because required fields are missing or invalid.",
+      tasks: [],
+      errors,
+    };
+  }
+
+  const [candidate] = actionCandidates(email);
+  if (!candidate) {
+    return {
+      status: "empty",
+      message: "No clear action item was detected in this email.",
+      tasks: [],
+    };
+  }
+
+  return {
+    status: "success",
+    message: "Task draft ready for user review. No mailbox or task data was mutated.",
+    tasks: [buildTask(email, candidate)],
+  };
+}

--- a/tools/v1/individual/email-to-todo-converter/services/index.ts
+++ b/tools/v1/individual/email-to-todo-converter/services/index.ts
@@ -1,0 +1,9 @@
+export {
+  convertEmailToTodos,
+  type EmailTodoDraft,
+  type EmailTodoSource,
+  type EmailToTodoInput,
+  type EmailToTodoPriority,
+  type EmailToTodoResult,
+  type EmailToTodoStatus,
+} from "./emailToTodoCore";

--- a/tools/v1/individual/email-to-todo-converter/tests/emailToTodoCore.test.ts
+++ b/tools/v1/individual/email-to-todo-converter/tests/emailToTodoCore.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { convertEmailToTodos, type EmailToTodoInput } from "../services/emailToTodoCore";
+
+function email(overrides: Partial<EmailToTodoInput> = {}): EmailToTodoInput {
+  return {
+    id: "email-direct-request",
+    subject: "Please review the invoice by Friday",
+    sender: "billing@example.com",
+    receivedAt: "2026-06-19T09:00:00Z",
+    bodyText: "Please review the attached invoice by Friday and let me know if anything is missing.",
+    labels: ["inbox"],
+    ...overrides,
+  };
+}
+
+describe("convertEmailToTodos", () => {
+  it("extracts a deterministic task from a direct request subject", () => {
+    const first = convertEmailToTodos(email());
+    const second = convertEmailToTodos(email());
+
+    expect(first).toEqual(second);
+    expect(first.status).toBe("success");
+    expect(first.tasks).toHaveLength(1);
+    expect(first.tasks[0]).toMatchObject({
+      id: "todo-email-direct-request-1",
+      title: "Review the invoice",
+      dueDate: "2026-06-26",
+      priority: "normal",
+      completed: false,
+      source: {
+        emailId: "email-direct-request",
+        subject: "Please review the invoice by Friday",
+        sender: "billing@example.com",
+        receivedAt: "2026-06-19T09:00:00Z",
+      },
+    });
+  });
+
+  it("prefers a direct action sentence from the body when it carries more detail", () => {
+    const result = convertEmailToTodos(
+      email({
+        id: "email-urgent-follow-up",
+        subject: "Urgent: follow up with partner",
+        sender: "ops@example.com",
+        receivedAt: "2026-06-19T10:30:00Z",
+        bodyText: "Can you follow up with the partner today? This is blocking the launch checklist.",
+        labels: ["important"],
+      }),
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.tasks[0]).toMatchObject({
+      id: "todo-email-urgent-follow-up-1",
+      title: "Follow up with the partner",
+      dueDate: "2026-06-19",
+      priority: "high",
+    });
+  });
+
+  it("returns an empty state when no clear action is detected", () => {
+    const result = convertEmailToTodos(
+      email({
+        id: "email-newsletter",
+        subject: "Weekly product updates",
+        sender: "newsletter@example.com",
+        receivedAt: "2026-06-19T11:00:00Z",
+        bodyText: "Here are this week's product updates and release notes.",
+        labels: ["newsletter"],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: "empty",
+      tasks: [],
+      message: "No clear action item was detected in this email.",
+    });
+  });
+
+  it("returns validation errors instead of creating a blank task", () => {
+    const result = convertEmailToTodos(
+      email({
+        id: " ",
+        subject: " ",
+        sender: " ",
+        receivedAt: "not-a-date",
+        bodyText: " ",
+      }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.tasks).toEqual([]);
+    expect(result.errors).toEqual([
+      "Email id is required.",
+      "Sender is required.",
+      "receivedAt must be a valid ISO-8601 timestamp.",
+      "Subject or bodyText is required.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a folder-local deterministic core service for converting normalized emails into reviewable todo drafts.
- Add local fixtures and unit coverage for direct request, urgent follow-up, no-action, and validation-error cases.
- Document the core API surface, inputs, outputs, loading expectations, and error states.

## Scope
- All changes stay inside `tools/v1/individual/email-to-todo-converter/`.
- No main app routing, inbox, wallet, Stellar, database, or design-system integration is introduced.
- No live network calls, secrets, or production data are introduced.

## Validation
- `pnpm dlx vitest run tools/v1/individual/email-to-todo-converter/tests/emailToTodoCore.test.ts` -> 4 tests passed.
- `pnpm dlx --package typescript tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --strict tools/v1/individual/email-to-todo-converter/services/emailToTodoCore.ts tools/v1/individual/email-to-todo-converter/services/index.ts tools/v1/individual/email-to-todo-converter/fixtures/emailToTodoFixtures.ts tools/v1/individual/email-to-todo-converter/index.ts` -> exit 0.

Refs #355