### PR TITLE
docs: add suspicious sender watchlist test plan by huazhuang80-star

### DIFF
--- a/tools/v2/team/suspicious-sender-watchlist/README.md
+++ b/tools/v2/team/suspicious-sender-watchlist/README.md
@@ -10,3 +10,9 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See `specs.md` for the architecture contract, issue categories, and contributor expectations.
+
+## Review and test documentation
+
+- [Setup guide](./docs/SETUP.md)
+- [OSS review notes](./docs/REVIEW_NOTES.md)
+- [Folder-local test plan](./tests/TEST_PLAN.md)

--- a/tools/v2/team/suspicious-sender-watchlist/docs/REVIEW_NOTES.md
+++ b/tools/v2/team/suspicious-sender-watchlist/docs/REVIEW_NOTES.md
@@ -1,0 +1,39 @@
+# Suspicious Sender Watchlist OSS Review Notes
+
+This document gives maintainers a short review path for the folder-local
+testing and documentation pass.
+
+## What this PR adds
+
+| Deliverable | Location |
+| --- | --- |
+| Setup guide | `docs/SETUP.md` |
+| Test plan | `tests/TEST_PLAN.md` |
+| Review notes | `docs/REVIEW_NOTES.md` |
+| README links | `README.md` |
+
+No file outside `tools/v2/team/suspicious-sender-watchlist/` is part of this
+change.
+
+## Review checklist
+
+```bash
+git diff --name-only | grep -v "tools/v2/team/suspicious-sender-watchlist/"
+```
+
+- [ ] Documentation explains independent review without app integration.
+- [ ] Test plan covers exact sender, domain, expired, suppressed, and false-positive cases.
+- [ ] No live threat feed, production mailbox data, wallet, or database config is introduced.
+- [ ] No app-wide shell, routing, inbox, authentication, or design-system code is touched.
+
+## Future behavior to validate
+
+The watchlist should classify incoming senders from local inputs:
+
+- sender address and normalized domain
+- watchlist entries with severity, reason, and review status
+- suppression or expiry metadata
+- audit events for teammate edits
+
+The first implementation should prefer pure service functions so every rule can
+be tested without a browser, wallet, API, or live mailbox.

--- a/tools/v2/team/suspicious-sender-watchlist/docs/SETUP.md
+++ b/tools/v2/team/suspicious-sender-watchlist/docs/SETUP.md
@@ -1,0 +1,72 @@
+# Suspicious Sender Watchlist Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Matches the main Stealth frontend baseline |
+| npm | 10+ | Used from the repository root |
+
+No live mailbox, wallet, Stellar account, database, or threat-intelligence API is
+required for this isolated testing and documentation pass.
+
+## Folder boundary
+
+All work for this tool stays inside:
+
+```text
+tools/v2/team/suspicious-sender-watchlist/
+```
+
+Do not modify the main application shell, dashboard layout, routing, inbox
+architecture, wallet core, Stellar integration, database schema, authentication,
+or shared design system for this issue.
+
+## Recommended local layout
+
+```text
+tools/v2/team/suspicious-sender-watchlist/
+  docs/
+    SETUP.md
+    REVIEW_NOTES.md
+  tests/
+    TEST_PLAN.md
+  README.md
+  specs.md
+```
+
+Future implementation work can add folder-local `fixtures/`, `services/`,
+`hooks/`, `components/`, and `.test.ts` files.
+
+## Validation commands
+
+From the repository root:
+
+```bash
+# Confirm this contribution stays folder-local
+git diff --name-only | grep -v "tools/v2/team/suspicious-sender-watchlist/"
+
+# Once executable tests are added
+npx vitest run tools/v2/team/suspicious-sender-watchlist/tests
+
+# Optional project-level checks
+npx tsc --noEmit
+npm run lint
+```
+
+The folder-local scope command should return no output for this issue.
+
+## Fixture guidance
+
+Use synthetic, deterministic fixtures only:
+
+| Fixture | Purpose |
+| --- | --- |
+| `known-bad-sender` | Sender that should always match the watchlist |
+| `domain-level-hit` | Domain match that should warn on any mailbox from that domain |
+| `false-positive-sender` | Similar address that must not match |
+| `expired-entry` | Watchlist entry past its review window |
+| `suppressed-entry` | Entry paused by a teammate with audit reason |
+
+Do not include production sender addresses, private mailbox identifiers, wallet
+secrets, API tokens, or real threat-intelligence exports.

--- a/tools/v2/team/suspicious-sender-watchlist/tests/TEST_PLAN.md
+++ b/tools/v2/team/suspicious-sender-watchlist/tests/TEST_PLAN.md
@@ -1,0 +1,80 @@
+# Suspicious Sender Watchlist Test Plan
+
+## Summary
+
+This plan defines folder-local coverage for a shared suspicious sender
+watchlist. It is intentionally scoped to
+`tools/v2/team/suspicious-sender-watchlist/` and does not require app wiring.
+
+## Goals
+
+- Detect exact sender and domain-level watchlist hits.
+- Avoid false positives for similar but distinct addresses.
+- Preserve audit history for teammate changes.
+- Respect expiry and suppression states.
+- Keep all fixtures synthetic and safe to commit.
+
+## Proposed test topology
+
+```text
+tools/v2/team/suspicious-sender-watchlist/
+  fixtures/
+    senders.fixture.ts
+  services/
+    watchlist.service.ts
+  tests/
+    watchlist.service.test.ts
+    TEST_PLAN.md
+```
+
+## Unit scenarios
+
+| Area | Scenario | Expected result |
+| --- | --- | --- |
+| Exact match | `fraud@example.test` exists in watchlist | High-confidence hit |
+| Domain match | `any@bad-domain.test` matches domain rule | Domain hit with rule reason |
+| False positive | `fraudulent@example.test` vs `fraud@example.test` | No hit |
+| Case handling | `Fraud@Example.Test` | Normalized exact match |
+| Expired entry | Entry review window has passed | Warning is inactive or stale |
+| Suppressed entry | Teammate suppresses sender with reason | No active warning, audit preserved |
+| Severity sorting | Multiple rules match | Highest severity appears first |
+| Empty input | Blank sender address | Validation error |
+| Audit export | Watchlist history serialized | No private mailbox content included |
+
+## Integration scenarios
+
+### New suspicious sender
+
+1. Alice adds `fraud@example.test` with a high severity reason.
+2. Bob opens a message from that address.
+3. Verify the sender is flagged and the reason is visible.
+4. Verify the warning remains inside the team tool boundary.
+
+### Domain-level warning
+
+1. Alice adds `bad-domain.test` as a domain watchlist entry.
+2. Bob opens mail from `alerts@bad-domain.test`.
+3. Verify a domain-level warning appears.
+4. Verify `alerts@good-domain.test` does not match.
+
+### Suppression workflow
+
+1. A sender is flagged.
+2. A teammate suppresses the entry with a review reason.
+3. The same sender is checked again.
+4. Verify the active warning is suppressed and the audit trail records who did it.
+
+## Manual review checklist
+
+- [ ] Warning text identifies whether the match is sender-level or domain-level.
+- [ ] Severity and reason are visible to team users.
+- [ ] Suppression requires a reason.
+- [ ] Expired entries are clearly stale.
+- [ ] Keyboard users can inspect warning details.
+- [ ] No fixture contains real sender addresses or production mailbox data.
+
+## Known limitations
+
+- Realtime team synchronization should be added only in a future integration issue.
+- External threat-intelligence ingestion is out of scope for the isolated V2 tool.
+- UI and accessibility tests should be added when components are implemented.


### PR DESCRIPTION
Closes #

## Summary
- adds folder-local setup and OSS review notes for Suspicious Sender Watchlist
- documents test coverage for sender/domain hits, false positives, expiry, suppression, and audit export
- links the new review/test docs from the tool README

## Validation
- `git diff --check` passed
- staged only files under `tools/v2/team/suspicious-sender-watchlist/`

## Local limitation
- Fresh checkout does not have `node_modules`, and this environment does not expose `npm` or `npx`, so I could not run Vitest locally.