### PR TITLE
docs: add team calendar extraction test plan by huazhuang80-star

### DIFF
--- a/tools/v2/team/team-calendar-extraction/README.md
+++ b/tools/v2/team/team-calendar-extraction/README.md
@@ -13,3 +13,9 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Review and test documentation
+
+- [Setup guide](./docs/SETUP.md)
+- [OSS review notes](./docs/REVIEW_NOTES.md)
+- [Folder-local test plan](./tests/TEST_PLAN.md)

--- a/tools/v2/team/team-calendar-extraction/docs/REVIEW_NOTES.md
+++ b/tools/v2/team/team-calendar-extraction/docs/REVIEW_NOTES.md
@@ -1,0 +1,40 @@
+# Team Calendar Extraction OSS Review Notes
+
+This document gives maintainers and contributors a fast review path for the
+folder-local testing and documentation pass.
+
+## What this PR adds
+
+| Deliverable | Location |
+| --- | --- |
+| Setup guide | `docs/SETUP.md` |
+| Test plan | `tests/TEST_PLAN.md` |
+| Review notes | `docs/REVIEW_NOTES.md` |
+| README links | `README.md` |
+
+No file outside `tools/v2/team/team-calendar-extraction/` is part of this
+change.
+
+## Review checklist
+
+```bash
+git diff --name-only | grep -v "tools/v2/team/team-calendar-extraction/"
+```
+
+- [ ] Documentation explains independent review without calendar or app integration.
+- [ ] Test plan covers date parsing, time zones, recurrence, duplicates, and confidence thresholds.
+- [ ] No live mailbox, calendar API, wallet, or database configuration is introduced.
+- [ ] No app shell, routing, inbox, authentication, or design-system code is touched.
+
+## Future behavior to validate
+
+The extractor should return structured candidate events from local email input:
+
+- title or inferred subject
+- start/end datetime with source timezone
+- attendees and organizer candidates
+- confidence score and evidence snippets
+- duplicate or merge hints
+
+Low-confidence extraction should never silently create a calendar event; it
+should be marked for teammate review.

--- a/tools/v2/team/team-calendar-extraction/docs/SETUP.md
+++ b/tools/v2/team/team-calendar-extraction/docs/SETUP.md
@@ -1,0 +1,73 @@
+# Team Calendar Extraction Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Matches the main Stealth frontend baseline |
+| npm | 10+ | Used from the repository root |
+
+No live mailbox, calendar account, wallet, Stellar account, database, or third
+party calendar API is required for this isolated testing and documentation pass.
+
+## Folder boundary
+
+All work for this tool stays inside:
+
+```text
+tools/v2/team/team-calendar-extraction/
+```
+
+Do not modify the main app shell, routing, inbox architecture, wallet core,
+Stellar integration, database schema, authentication, or shared design system.
+
+## Recommended local layout
+
+```text
+tools/v2/team/team-calendar-extraction/
+  docs/
+    SETUP.md
+    REVIEW_NOTES.md
+  tests/
+    TEST_PLAN.md
+  README.md
+  specs.md
+  vitest.config.ts
+```
+
+Future implementation work can add folder-local fixtures, services, hooks,
+components, and `.test.ts` files.
+
+## Validation commands
+
+From the repository root:
+
+```bash
+# Confirm this contribution stays folder-local
+git diff --name-only | grep -v "tools/v2/team/team-calendar-extraction/"
+
+# Once executable tests are added
+npx vitest run --config tools/v2/team/team-calendar-extraction/vitest.config.ts
+
+# Optional project-level checks
+npx tsc --noEmit
+npm run lint
+```
+
+The folder-local scope command should return no output for this issue.
+
+## Fixture guidance
+
+Use synthetic messages and calendar event payloads only:
+
+| Fixture | Purpose |
+| --- | --- |
+| `explicit-date-email` | Direct date/time extraction |
+| `relative-date-email` | Phrases like tomorrow, next Friday, EOD |
+| `timezone-email` | Sender and recipient in different zones |
+| `multi-event-email` | Multiple events in one message |
+| `low-confidence-email` | Ambiguous text requiring manual review |
+| `duplicate-event-email` | Same event mentioned twice |
+
+Fixtures must not include real customer messages, production calendar ids,
+private mailbox identifiers, wallet secrets, or live meeting links.

--- a/tools/v2/team/team-calendar-extraction/tests/TEST_PLAN.md
+++ b/tools/v2/team/team-calendar-extraction/tests/TEST_PLAN.md
@@ -1,0 +1,80 @@
+# Team Calendar Extraction Test Plan
+
+## Summary
+
+This plan defines folder-local coverage for extracting shared calendar event
+candidates from team email content.
+
+## Goals
+
+- Extract explicit dates, relative dates, times, attendees, and event titles.
+- Preserve evidence snippets so teammates can review each candidate.
+- Avoid duplicate event creation from repeated mentions.
+- Flag ambiguous extraction for manual review.
+- Keep all fixtures local and synthetic.
+
+## Proposed test topology
+
+```text
+tools/v2/team/team-calendar-extraction/
+  fixtures/
+    calendar-emails.fixture.ts
+  services/
+    calendarExtraction.service.ts
+  tests/
+    calendarExtraction.service.test.ts
+    TEST_PLAN.md
+```
+
+## Unit scenarios
+
+| Area | Scenario | Expected result |
+| --- | --- | --- |
+| Explicit date | "June 24 at 10:00" | One event candidate with exact start |
+| Relative date | "next Friday morning" | Candidate resolved from fixture clock |
+| Time zone | "3pm London time" | Candidate stores timezone evidence |
+| Duration | "30 min sync" | End time inferred from duration |
+| Attendees | Named teammates in message | Attendees extracted as candidates |
+| Multiple events | Two separate dates in one email | Two candidates returned |
+| Duplicate mention | Same event repeated in thread | One candidate with duplicate evidence |
+| Low confidence | "sometime next week" | Manual-review candidate, no auto-create |
+| No event | Status email with no schedule language | Empty result |
+| Invalid input | Empty body | Validation error |
+
+## Integration scenarios
+
+### Explicit meeting email
+
+1. Fixture email contains title, date, time, and attendees.
+2. Extraction service runs against the body.
+3. Verify one event candidate is returned.
+4. Verify evidence points to the source phrase.
+
+### Ambiguous scheduling thread
+
+1. Fixture thread contains "maybe next week".
+2. Service attempts extraction.
+3. Verify candidate is marked low confidence.
+4. Verify no auto-create flag is set.
+
+### Duplicate event guard
+
+1. Fixture thread mentions the same customer kickoff twice.
+2. Service extracts candidates.
+3. Verify only one normalized candidate remains.
+4. Verify duplicate evidence is preserved for review.
+
+## Manual review checklist
+
+- [ ] Candidate event title is understandable without opening the whole email.
+- [ ] Time zone evidence is visible.
+- [ ] Low-confidence candidates require teammate confirmation.
+- [ ] Duplicate candidates can be reviewed before acceptance.
+- [ ] Keyboard users can inspect extraction evidence.
+- [ ] Fixtures use synthetic senders, attendees, and meeting links only.
+
+## Known limitations
+
+- Natural language parsing policy is not implemented in this documentation pass.
+- Real calendar provider writes are out of scope for the isolated V2 tool.
+- App integration should be handled by a future explicit integration issue.


### PR DESCRIPTION
Closes #683hhgt

## Summary
- adds folder-local setup and OSS review notes for Team Calendar Extraction
- documents test coverage for explicit/relative dates, time zones, duplicate events, low-confidence extraction, and evidence snippets
- links the new review/test docs from the tool README

## Validation
- `git diff --check` passed
- staged only files under `tools/v2/team/team-calendar-extraction/`

## Local limitation
- Fresh checkout does not have `node_modules`, and this environment does not expose `npm` or `npx`, so I could not run Vitest locally.