### PR TITLE
docs: add team digest setup guide by huazhuang80-star

### DIFF
--- a/tools/v2/team/team-digest-generator/README.md
+++ b/tools/v2/team/team-digest-generator/README.md
@@ -18,6 +18,7 @@ integration issue explicitly allows it.
 
 - **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Module boundaries, data ownership, integration constraints, and contributor guidelines
 - **[specs.md](./specs.md)** - Issue categories and scope
+- **[docs/SETUP.md](./docs/SETUP.md)** - Local setup and validation commands
 - **[docs/](./docs/)** - API reference, threat model, performance notes
 
 ## Recommended Internal Structure

--- a/tools/v2/team/team-digest-generator/docs/SETUP.md
+++ b/tools/v2/team/team-digest-generator/docs/SETUP.md
@@ -1,0 +1,74 @@
+# Team Digest Generator Setup Guide
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20+ | Required for the folder-local Node test |
+| npm | 10+ | Optional for project-level checks |
+
+No live mailbox, wallet, Stellar account, database, or mail relay is required to
+review this isolated V2 tool.
+
+## Folder boundary
+
+All work for this tool stays inside:
+
+```text
+tools/v2/team/team-digest-generator/
+```
+
+Do not modify the main application shell, dashboard layout, routing, inbox
+architecture, wallet core, Stellar integration, database schema, authentication,
+or shared design system for this issue.
+
+## Run the executable fixture test
+
+From the repository root:
+
+```bash
+node --test tools/v2/team/team-digest-generator/tests/digest-fixtures.test.mjs
+```
+
+The test validates that the sample team activity fixture maps to the expected
+digest contract and that the local service output stays deterministic.
+
+## Review the fixtures
+
+Start with:
+
+```text
+tools/v2/team/team-digest-generator/tests/fixtures.ts
+```
+
+Fixtures should remain synthetic and safe to commit. Do not add production
+mailbox exports, real customer messages, private meeting links, wallet secrets,
+or live team identifiers.
+
+## Validate isolation
+
+Before opening or merging a PR:
+
+```bash
+git diff --name-only | grep -v "tools/v2/team/team-digest-generator/"
+```
+
+The command should return no output for this issue.
+
+## Optional project checks
+
+```bash
+npx tsc --noEmit
+npm run lint
+```
+
+These checks are useful for maintainers, but this V2 tool remains isolated and
+is not wired into the main app.
+
+## Known limitations
+
+- The digest tool uses local fixtures and deterministic service logic only.
+- Main app integration, routing, shared mailbox permissions, and persistence are
+  out of scope.
+- UI-level accessibility tests should be expanded when a future issue adds the
+  rendered digest surface.

--- a/tools/v2/team/team-digest-generator/docs/review-notes.md
+++ b/tools/v2/team/team-digest-generator/docs/review-notes.md
@@ -34,6 +34,22 @@ implements the following deterministic rules:
 - Manual review of fixture signals against expected digest item properties.
 - Confirmed the service output matches fixture expectations for all six items.
 
+## Quick Validation
+
+```bash
+# Run this tool's executable Node test
+node --test tools/v2/team/team-digest-generator/tests/digest-fixtures.test.mjs
+
+# Confirm review scope stays folder-local
+git diff --name-only | grep -v "tools/v2/team/team-digest-generator/"
+
+# Optional project-wide checks from the repo root
+npx tsc --noEmit
+npm run lint
+```
+
+The folder-local scope command should return no files for this issue.
+
 ## Reviewer Focus
 
 - The issue is intentionally limited to testing, documentation, and core logic.


### PR DESCRIPTION
Closes #688.

## Summary
- adds a folder-local setup guide for Team Digest Generator
- links the setup guide from the README documentation list
- adds quick validation commands to the existing review notes

## Validation
- `node --test tools/v2/team/team-digest-generator/tests/digest-fixtures.test.mjs` passed (2 tests)
- `git diff --check` passed
- staged only files under `tools/v2/team/team-digest-generator/`