### PR TITLE
[codex] Define email tone rewriter architecture contract

### DIFF
--- a/tools/v1/individual/email-tone-rewriter/README.md
+++ b/tools/v1/individual/email-tone-rewriter/README.md
@@ -6,34 +6,45 @@ This folder is the isolated workspace for the Email Tone Rewriter tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\email-tone-rewriter\
-`
+```text
+tools/v1/individual/email-tone-rewriter/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, mail send actions, or existing design
+system unless a future integration issue explicitly allows it.
 
 ## Contributor Setup
 
-This folder does not contain executable tool code yet. Until a feature issue
-adds the implementation, contributors should use these local documents as the
-launch contract:
+This folder ships a local architecture contract, deterministic services,
+fixtures, tests, and hardening notes. Contributors should use these files as
+the launch contract:
 
 - `specs.md` defines the behavior and ownership boundary.
-- `docs/test-plan.md` lists the acceptance scenarios future unit and component
-  tests should cover.
+- `docs/architecture.md` defines internal module boundaries, data ownership,
+  dependency rules, and future integration constraints.
+- `services/emailToneRewriter.ts` implements the pure core rewrite engine.
+- `services/guards.ts` implements the folder-local safety and performance
+  guard layer.
+- `services/fixtures.ts` provides deterministic synthetic requests.
+- `tests/` contains executable unit coverage for the service and guards.
+- `docs/test-plan.md` lists the acceptance scenarios future tests should cover.
 - `docs/fixtures.md` describes synthetic rewrite requests and expected outputs.
+- `docs/threat-model.md` documents security assumptions and unsafe inputs.
+- `docs/performance.md` documents cost model and hard limits.
 - `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
 
 ## Intended Usage
 
 The tool helps an individual user rewrite a draft email into a selected tone,
-such as concise, friendly, formal, or apologetic. A future implementation should
-accept a draft, requested tone, and optional constraints, then return a
-reviewable rewrite without sending or saving anything automatically.
+such as concise, friendly, formal, or apologetic. It accepts a draft, requested
+tone, and optional constraints, then returns a reviewable rewrite without
+sending, saving, or mutating mailbox state.
 
 ## Known Limitations
 
-- No production code is present in this folder yet.
-- The documented tests are a plan, not an executable suite.
+- Rewriting is deterministic and rule based; no external AI provider is called.
+- The tool has no UI integration, route, persistence, mailbox connection, or
+  send action.
 - Main app routing, inbox integration, send actions, and persistence are
   intentionally out of scope until a future integration issue allows them.

--- a/tools/v1/individual/email-tone-rewriter/docs/architecture.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/architecture.md
@@ -1,0 +1,84 @@
+# Email Tone Rewriter Architecture Contract
+
+This document defines the folder-local architecture for the Email Tone
+Rewriter. It is scoped only to
+`tools/v1/individual/email-tone-rewriter/` and does not grant permission to
+wire the tool into the main app.
+
+## Module map
+
+| Module | Owns | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| `index.ts` | Public folder-local exports | `services/*` | Main app routes, inbox, wallet, Stellar, database, design system |
+| `services/emailToneRewriter.ts` | Pure deterministic rewrite engine and typed results | Local constants and helpers | Network calls, mailbox APIs, external AI providers |
+| `services/guards.ts` | Sanitization, hard limits, guarded entry point | Local service types and engine | Runtime secrets, storage, user/session state |
+| `services/fixtures.ts` | Synthetic rewrite samples | Local types | Production email data |
+| `hooks/` | Future UI state adapters | `index.ts`, local fixtures | Main app stores or router hooks |
+| `components/` | Future isolated review UI | Local hooks, local props, local class names | Shared design-system internals or global app shell |
+| `tests/` | Unit and future component coverage | Local modules and synthetic fixtures | Live services or production data |
+| `docs/` | Architecture, test plans, fixtures, security, performance | Local file references | App-level integration promises |
+
+## Data ownership
+
+This folder owns only normalized draft data used for tone rewriting:
+
+- `subject`
+- `bodyText`
+- target `tone`
+- optional `maxWords`
+- deterministic fixture ids and examples
+- derived rewrite output, preserved key points, word count, and guard errors
+
+The following data remains outside this folder and must not be read, written,
+or mutated here:
+
+- inbox message records
+- send queues and SMTP/provider state
+- authenticated user/session state
+- wallet or Stellar account state
+- database records
+- analytics and telemetry
+- production email content
+
+## Dependency rules
+
+- Future UI work should import from `index.ts` rather than reaching into
+  service internals.
+- Services must stay pure and deterministic. They should accept plain objects
+  and return typed results instead of throwing for expected validation errors.
+- The guarded entry point, `safeRewriteEmailTone`, is the boundary future UI or
+  API adapters should call before rendering a rewrite.
+- Tests must use local fixtures or synthetic inline inputs. They must not call
+  live providers, read mailbox state, or require secrets.
+- Documentation should describe integration constraints as follow-up work, not
+  implement those integrations in this folder.
+
+## Allowed future changes
+
+Future contributors may add:
+
+- new local tones with deterministic fixtures and tests;
+- local hooks that model idle, loading, ready, and error states;
+- isolated components that display a reviewable rewrite before save/send;
+- additional guard limits or sanitizers with unit coverage;
+- docs that clarify fixtures, threat model, performance, or handoff flows.
+
+## Forbidden future changes without a separate integration issue
+
+Future contributors must not:
+
+- mount the rewriter in a route, dashboard, navigation item, or inbox panel;
+- send, save, archive, delete, or persist email content;
+- import from the main app shell, routing, inbox, wallet, Stellar, database,
+  authentication, or shared design-system layers;
+- add external AI provider calls, API keys, secrets, or production data;
+- write telemetry or analytics events from this isolated folder.
+
+## Review checklist
+
+- All modified files are under `tools/v1/individual/email-tone-rewriter/`.
+- New behavior has local tests or explicit documentation explaining why it is
+  documentation-only.
+- The public surface remains folder-local.
+- No live network calls, secrets, provider keys, or production data were added.
+- User review is preserved before any future save or send action.

--- a/tools/v1/individual/email-tone-rewriter/specs.md
+++ b/tools/v1/individual/email-tone-rewriter/specs.md
@@ -8,15 +8,23 @@ Rewrite email tone for different contexts.
 - Audience: individual
 - Folder ownership: `tools/v1/individual/email-tone-rewriter/`
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database, mail
+send actions, or design system unless a future integration issue explicitly
+allows it.
 
-Recommended internal structure:
+## Internal structure
 
-- components/
-- services/
-- hooks/
-- tests/
-- docs/
+- `index.ts` is the only folder-local public API surface future tool work
+  should import from.
+- `services/` owns pure rewrite, fixture, and guard logic.
+- `hooks/` is reserved for future UI state adapters and must stay free of main
+  app imports until an integration issue exists.
+- `components/` is reserved for future isolated UI and must use local props and
+  local class names only.
+- `tests/` owns unit and future component coverage for this folder.
+- `docs/` owns fixtures, test plans, architecture, threat model, performance,
+  and contributor handoff notes.
 
 # Email Tone Rewriter Specs
 
@@ -29,10 +37,13 @@ and keeping the result reviewable before any send action.
 
 All work for this tool should stay in:
 
-`tools/v1/individual/email-tone-rewriter/`
+```text
+tools/v1/individual/email-tone-rewriter/
+```
 
-Do not add imports from the main inbox, routing, wallet, Stellar, database, or
-design-system layers until a later integration issue explicitly allows it.
+Do not add imports from the main inbox, routing, wallet, Stellar, database,
+mail rendering, authentication, or design-system layers until a later
+integration issue explicitly allows it.
 
 ## Required issue categories
 
@@ -44,7 +55,7 @@ design-system layers until a later integration issue explicitly allows it.
 
 ## Core Behavior Contract
 
-The future implementation should:
+The implementation should:
 
 - accept a normalized draft input with `subject`, `bodyText`, target `tone`, and
   optional length constraints;
@@ -56,6 +67,34 @@ The future implementation should:
 - reject empty drafts or unsupported tone values with deterministic validation
   errors;
 - never send, save, or mutate the mailbox before explicit user confirmation.
+
+## Ownership and dependencies
+
+- Draft text, selected tone, length constraints, synthetic fixtures, and guard
+  limits are owned by this folder.
+- Mailbox records, authenticated users, routing, persistence, wallet/Stellar
+  state, analytics, and design-system state are owned outside this folder and
+  must not be imported or mutated here.
+- External AI providers are out of scope for this isolated V1 contract. Any
+  future provider adapter must be introduced by a separate integration issue
+  and keep a deterministic local fallback for tests.
+
+## Future contributor rules
+
+Future contributors may:
+
+- add folder-local services, hooks, components, fixtures, tests, and docs;
+- expand supported tones when tests and docs define deterministic behavior;
+- add UI review states that operate on local props and local service results.
+
+Future contributors may not:
+
+- mount the tool in app routes or navigation;
+- send, save, archive, delete, or persist emails;
+- import from inbox, wallet, Stellar, database, authentication, or shared
+  design-system internals;
+- introduce live network calls, secrets, production data, or provider keys in
+  this folder.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- Add a folder-local architecture contract for Email Tone Rewriter.
- Update README and specs so they reflect the current services, guards, fixtures, tests, and docs that now exist on main.
- Document data ownership, dependency boundaries, allowed future changes, and integration constraints for future contributors.

## Scope
- All changes stay inside `tools/v1/individual/email-tone-rewriter/`.
- No main app routing, inbox, wallet, Stellar, database, mail send, or design-system integration is introduced.
- No live network calls, secrets, provider keys, or production data are introduced.

## Validation
- Compared PR branch against `main`; only 3 files under the issue folder changed.
- Checked changed files for network calls, local machine paths, environment access, and credential-like strings; matches are documentation-only forbidden-action notes.
- Documentation-only change; no executable behavior changed.

Refs #349