### PR TITLE
[codex] Define follow-up reminder architecture contract

### DIFF
--- a/tools/v1/individual/follow-up-reminder/README.md
+++ b/tools/v1/individual/follow-up-reminder/README.md
@@ -11,23 +11,45 @@ All work for this tool must stay inside:
 tools/v1/individual/follow-up-reminder/
 ```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, calendar providers, notification systems,
+or existing design system unless a future integration issue explicitly allows
+it.
+
+## Contributor Setup
+
+This folder ships local services, components, fixtures, tests, and architecture
+notes. Contributors should use these files as the launch contract:
+
+- `index.ts` exposes the folder-local public API.
+- `services/followUpReminder.ts` implements the pure reminder suggestion engine.
+- `services/fixtures.ts` provides synthetic email fixtures.
+- `components/` contains isolated review UI components.
+- `docs/architecture.md` defines module boundaries, data ownership, dependency
+  rules, and future integration constraints.
+- `docs/engine.md` documents inputs, outputs, states, signals, and duplicate
+  avoidance.
+- `docs/style-guide.md` documents local UI and accessibility conventions.
+- `docs/test-plan.md` and `docs/fixtures.md` describe expected test coverage and
+  deterministic fixtures.
+- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
 
 ## Intended Use
 
 - Inspect normalized email subject, body, sender, and received time.
 - Suggest follow-up reminder drafts from explicit requests and dates.
-- Let a user confirm, edit, snooze, complete, or dismiss a reminder.
+- Let a user confirm, edit, snooze, complete, or dismiss a reminder in a future
+  integration.
 - Keep the tool advisory; it must not send email, create external calendar
   events, change labels, or mark messages read automatically.
 
 ## Reminder States
 
 - `draft`: suggested but not confirmed by the user.
-- `scheduled`: confirmed reminder with a due time.
-- `snoozed`: temporarily delayed by explicit user action.
-- `completed`: user marked the follow-up done.
-- `dismissed`: user rejected the reminder.
+- `no_action`: no reminder should be suggested by the engine.
+
+Future UI workflows may display scheduled, snoozed, completed, or dismissed
+states after a separate integration issue defines persistence and user actions.
 
 ## Testing Focus
 

--- a/tools/v1/individual/follow-up-reminder/docs/architecture.md
+++ b/tools/v1/individual/follow-up-reminder/docs/architecture.md
@@ -1,0 +1,90 @@
+# Follow-up Reminder Architecture Contract
+
+This document defines the folder-local architecture for the Follow-up Reminder
+tool. It is scoped only to `tools/v1/individual/follow-up-reminder/` and does
+not wire the tool into the main mail application.
+
+## Module map
+
+| Module | Owns | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| `index.ts` | Public folder-local exports | `services/*`, `components/*` | Main app shell, routes, inbox, wallet, Stellar, database, design system |
+| `services/followUpReminder.ts` | Pure deterministic reminder suggestion engine | Local constants and helpers | Network calls, calendar APIs, mailbox mutation |
+| `services/fixtures.ts` | Synthetic email samples and expected scenarios | Local service types | Production email data |
+| `components/` | Isolated review UI pieces | Local props and local exports | Shared design-system internals, router, app stores |
+| `hooks/` | Reserved future local UI state adapters | `index.ts`, local fixtures | Main app stores, router hooks, persistence APIs |
+| `tests/` | Unit and component coverage for this folder | Local modules and synthetic fixtures | Live services or production data |
+| `docs/` | Architecture, engine behavior, fixtures, style, test plan | Local file references | App-level integration promises |
+
+## Data ownership
+
+This folder owns only the data needed to propose a reviewable reminder:
+
+- normalized email subject and body
+- sender address and optional sender name
+- source message id
+- received timestamp and optional timezone
+- thread hints supplied by the caller
+- reminder signals, warnings, confidence, and draft/no-action state
+- synthetic fixtures and expected local test data
+
+The following data remains outside this folder:
+
+- inbox message records and read/archive/delete state
+- authenticated user/session state
+- calendar provider connections and scheduled event ids
+- notification scheduler state
+- wallet or Stellar account state
+- database persistence
+- analytics and telemetry
+- production email content
+
+## Dependency rules
+
+- Future feature work should import from `index.ts` rather than deep-linking to
+  service or component internals.
+- Services must stay pure and deterministic. Expected validation, ambiguous
+  dates, low-confidence signals, and duplicate checks should be returned as
+  review model fields or warnings rather than thrown exceptions.
+- Components must receive data through props and local callbacks. They must not
+  reach into app stores, routes, mailbox state, or persistence APIs.
+- Future hooks may coordinate local idle, loading, draft, warning, and error
+  state, but may not connect to main app stores without a separate integration
+  issue.
+- Tests must use synthetic fixtures. They must not call live calendar,
+  notification, inbox, wallet, Stellar, or analytics services.
+
+## Allowed future changes
+
+Future contributors may add:
+
+- deterministic reminder signal detectors;
+- local hooks for review workflow state;
+- isolated components for editing due time, snoozing, completing, or dismissing
+  a reminder draft;
+- synthetic fixtures and tests for ambiguous dates, duplicates, and
+  low-confidence contexts;
+- docs that clarify review flows, engine behavior, accessibility, or handoff.
+
+## Forbidden future changes without a separate integration issue
+
+Future contributors must not:
+
+- mount this tool in a route, dashboard, navigation item, or inbox panel;
+- send email, create calendar events, schedule notifications, archive, delete,
+  label, or mark messages read;
+- import from the main app shell, routing, inbox, wallet, Stellar, database,
+  authentication, analytics, or shared design-system internals;
+- add live network calls, provider keys, secrets, production data, or external
+  calendar-provider mutations;
+- persist reminder state outside this folder.
+
+## Review checklist
+
+- All modified files are under `tools/v1/individual/follow-up-reminder/`.
+- Public exports remain intentional and folder-local.
+- New behavior is covered by local tests, or the change is documentation-only.
+- No live network calls, secrets, provider keys, production data, or calendar
+  mutations were added.
+- User review remains required before any future schedule, notification, or
+  mailbox action.

--- a/tools/v1/individual/follow-up-reminder/specs.md
+++ b/tools/v1/individual/follow-up-reminder/specs.md
@@ -8,7 +8,21 @@ Create reviewable reminder drafts from emails in a V1 individual workspace.
 - Audience: individual
 - Folder ownership: `tools/v1/individual/follow-up-reminder/`
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database,
+calendar providers, notification systems, or design system unless a future
+integration issue explicitly allows it.
+
+## Internal Structure
+
+- `index.ts` is the only folder-local public API future work should import from.
+- `services/` owns pure reminder suggestion logic and synthetic fixtures.
+- `components/` owns isolated review UI components.
+- `hooks/` is reserved for future local state adapters and must stay free of
+  main app stores or router hooks.
+- `tests/` owns local unit and component coverage.
+- `docs/` owns architecture, engine, style, fixtures, test plan, and handoff
+  notes.
 
 ## Purpose
 
@@ -46,6 +60,17 @@ creation explicit, editable, and reversible.
 - Low-confidence contexts such as newsletters, receipts, FYI-only messages, or
   no-action updates.
 
+## Data Ownership And Dependencies
+
+- This folder owns normalized reminder input, synthetic fixtures, suggestion
+  signals, review models, warnings, local UI props, and local tests.
+- The main inbox, mail renderer, authenticated user/session state, calendar
+  provider, notification scheduler, wallet/Stellar state, database, analytics,
+  and design-system internals remain outside this folder.
+- Future contributors should import through `index.ts` instead of reaching into
+  service or component internals.
+- Tests must use synthetic senders, message ids, and dates only.
+
 ## Required Issue Categories
 
 - Architecture
@@ -69,6 +94,24 @@ creation explicit, editable, and reversible.
 - Do not create external calendar events or send replies automatically.
 - Date parsing must be bounded for long messages.
 - Fixtures must use synthetic senders, message ids, and dates only.
+
+## Future Contributor Rules
+
+Future contributors may:
+
+- add local services, hooks, components, fixtures, docs, and tests;
+- extend reminder signals when deterministic tests and docs cover them;
+- add local UI state adapters for idle, loading, draft, warning, and error
+  states.
+
+Future contributors may not:
+
+- mount this tool into app routes, dashboard navigation, or inbox panels;
+- send, save, schedule, notify, archive, delete, or mark messages read;
+- import from inbox, wallet, Stellar, database, authentication, routing, or
+  shared design-system internals;
+- introduce live network calls, secrets, provider keys, production data, or
+  calendar-provider mutations.
 
 ## Testing Expectations
 


### PR DESCRIPTION
## Summary
- Add a folder-local architecture contract for the Follow-up Reminder tool.
- Update README and specs with module boundaries, data ownership, dependency rules, and future contributor constraints.
- Clarify that reminder suggestions remain advisory and cannot schedule, notify, send, or mutate mailbox state from this isolated folder.

## Scope
- All changes stay inside `tools/v1/individual/follow-up-reminder/`.
- No main app routing, inbox, wallet, Stellar, database, calendar, notification, or design-system integration is introduced.
- No live network calls, secrets, provider keys, production data, or calendar mutations are introduced.

## Validation
- Compared PR branch against `main`; only 3 files under the issue folder changed.
- Checked changed files for network calls, local machine paths, environment access, and credential-like strings; matches are documentation-only forbidden-action notes.
- Documentation-only change; no executable behavior changed.

Refs #359