### PR TITLE
[codex] Add demo message template scenario registry

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/templateRegistry.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/templateRegistry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { messageTemplates } from "../templates/messageTemplates";
+import {
+  buildTemplateRegistry,
+  getTemplatesForScenario,
+  messageTemplateScenarios,
+  validateTemplateRegistry,
+} from "../templates/templateRegistry";
+
+describe("message template scenario registry", () => {
+  it("builds deterministic scenario entries from the template catalog", () => {
+    const registry = buildTemplateRegistry(messageTemplates, messageTemplateScenarios);
+    const second = buildTemplateRegistry(messageTemplates, messageTemplateScenarios);
+
+    expect(registry).toEqual(second);
+    expect(registry.map((entry) => entry.scenario.id)).toEqual([
+      "first-run-onboarding",
+      "paid-message-proof",
+      "account-security",
+      "event-follow-up",
+      "product-update",
+      "internal-review",
+    ]);
+    expect(registry[0].templates.map((template) => template.id)).toEqual(["welcome-intro"]);
+  });
+
+  it("returns templates for a known scenario id", () => {
+    const templates = getTemplatesForScenario(
+      "paid-message-proof",
+      messageTemplates,
+      messageTemplateScenarios,
+    );
+
+    expect(templates.map((template) => template.id)).toEqual([
+      "postage-receipt",
+      "delivery-proof",
+    ]);
+  });
+
+  it("validates duplicate scenario ids and missing template references", () => {
+    const [firstScenario] = messageTemplateScenarios;
+    const issues = validateTemplateRegistry(messageTemplates, [
+      firstScenario,
+      firstScenario,
+      {
+        id: "broken-scenario",
+        label: "Broken scenario",
+        description: "References a missing template.",
+        templateIds: ["not-a-template"],
+        metadata: {
+          demoGoal: "invalid fixture",
+          safeDataNotes: ["synthetic only"],
+          previewSurface: "templates",
+        },
+      },
+    ]);
+
+    expect(issues).toEqual([
+      'Duplicate scenario id "first-run-onboarding".',
+      'Scenario "broken-scenario" references missing template "not-a-template".',
+    ]);
+  });
+
+  it("keeps every catalog template covered by at least one scenario", () => {
+    const covered = new Set(messageTemplateScenarios.flatMap((scenario) => scenario.templateIds));
+    expect(messageTemplates.every((template) => covered.has(template.id))).toBe(true);
+    expect(validateTemplateRegistry(messageTemplates, messageTemplateScenarios)).toEqual([]);
+  });
+});

--- a/src/features/demo-admin-dashboard/docs/message-template-registry.md
+++ b/src/features/demo-admin-dashboard/docs/message-template-registry.md
@@ -1,0 +1,38 @@
+# Message Template Registry
+
+The message template registry groups deterministic demo templates into review
+scenarios that maintainers can use when populating demo inbox data.
+
+## Files
+
+- `templates/messageTemplates.ts` owns the template catalog.
+- `templates/templateRegistry.ts` owns scenario metadata and registry helpers.
+- `templates/templateToDraft.ts` converts a selected template into a local
+  `Draft` without mutating production mail state.
+
+## Scenario metadata
+
+Each `MessageTemplateScenario` includes:
+
+- `id`: stable scenario identifier.
+- `label`: short maintainer-facing label.
+- `description`: what the scenario demonstrates.
+- `templateIds`: ordered template ids from the catalog.
+- `metadata.demoGoal`: why maintainers would load this scenario.
+- `metadata.safeDataNotes`: review notes proving the data is fake and safe.
+- `metadata.previewSurface`: the dashboard area expected to preview it.
+
+## Registry helpers
+
+- `buildTemplateRegistry(templates, scenarios)` returns deterministic scenario
+  entries with resolved template objects.
+- `getTemplatesForScenario(id, templates, scenarios)` returns the templates for
+  one known scenario, or an empty list for an unknown id.
+- `validateTemplateRegistry(templates, scenarios)` reports duplicate scenario
+  ids and missing template references.
+
+## Safety
+
+The registry adds metadata only. It does not import production mail data, call
+network services, send email, persist drafts, or touch files outside
+`src/features/demo-admin-dashboard/`.

--- a/src/features/demo-admin-dashboard/templates/index.ts
+++ b/src/features/demo-admin-dashboard/templates/index.ts
@@ -9,4 +9,13 @@ export {
   removeDraft,
   type InsertResult,
 } from "./templateToDraft";
+export {
+  buildTemplateRegistry,
+  getTemplatesForScenario,
+  messageTemplateScenarios,
+  validateTemplateRegistry,
+  type MessageTemplateScenario,
+  type TemplateRegistryEntry,
+  type TemplateScenarioMetadata,
+} from "./templateRegistry";
 export { TEMPLATE_CATEGORY_LABEL, type MessageTemplate, type TemplateCategory } from "./types";

--- a/src/features/demo-admin-dashboard/templates/templateRegistry.ts
+++ b/src/features/demo-admin-dashboard/templates/templateRegistry.ts
@@ -1,0 +1,149 @@
+import type { MessageTemplate } from "./types";
+
+export interface TemplateScenarioMetadata {
+  /** Why this group is useful for maintainers populating demo data. */
+  demoGoal: string;
+  /** Safety notes reviewers can use to confirm the data stays fake. */
+  safeDataNotes: string[];
+  /** Where the scenario is expected to be previewed inside the demo admin dashboard. */
+  previewSurface: "templates" | "mail" | "campaigns" | "audit";
+}
+
+export interface MessageTemplateScenario {
+  id: string;
+  label: string;
+  description: string;
+  templateIds: string[];
+  metadata: TemplateScenarioMetadata;
+}
+
+export interface TemplateRegistryEntry {
+  scenario: MessageTemplateScenario;
+  templates: MessageTemplate[];
+}
+
+export const messageTemplateScenarios: MessageTemplateScenario[] = [
+  {
+    id: "first-run-onboarding",
+    label: "First-run onboarding",
+    description: "Welcome copy for a brand-new Stealth demo mailbox.",
+    templateIds: ["welcome-intro"],
+    metadata: {
+      demoGoal: "Populate a new-account inbox with a friendly first message.",
+      safeDataNotes: ["Uses only the reserved new.user*stealth.demo recipient."],
+      previewSurface: "templates",
+    },
+  },
+  {
+    id: "paid-message-proof",
+    label: "Paid message proof",
+    description: "Receipt-style messages that show fake postage and proof metadata.",
+    templateIds: ["postage-receipt", "delivery-proof"],
+    metadata: {
+      demoGoal: "Exercise proof, receipt, and postage-like preview states without live value.",
+      safeDataNotes: [
+        "Amounts are tiny synthetic XLM examples.",
+        "Proof references are demo strings and not live settlement data.",
+      ],
+      previewSurface: "mail",
+    },
+  },
+  {
+    id: "account-security",
+    label: "Account security",
+    description: "One-time code copy for security and OTP demo surfaces.",
+    templateIds: ["verify-code"],
+    metadata: {
+      demoGoal: "Show a security-sensitive message shape using a fixed fake code.",
+      safeDataNotes: ["The passkey is deterministic demo text and is not an auth secret."],
+      previewSurface: "mail",
+    },
+  },
+  {
+    id: "event-follow-up",
+    label: "Event follow-up",
+    description: "Calendar-style invitation copy for event preview cards.",
+    templateIds: ["event-invite"],
+    metadata: {
+      demoGoal: "Populate calendar and RSVP preview states with a fake event invitation.",
+      safeDataNotes: ["Date, location, and organizer details are synthetic."],
+      previewSurface: "mail",
+    },
+  },
+  {
+    id: "product-update",
+    label: "Product update",
+    description: "Digest-style product copy for long-form message rendering.",
+    templateIds: ["product-newsletter"],
+    metadata: {
+      demoGoal: "Exercise newsletter and list rendering in the demo inbox.",
+      safeDataNotes: ["No external links or real subscriber data are included."],
+      previewSurface: "templates",
+    },
+  },
+  {
+    id: "internal-review",
+    label: "Internal review",
+    description: "Maintainer-facing status note for campaign and copy review flows.",
+    templateIds: ["campaign-review-note"],
+    metadata: {
+      demoGoal: "Support admin review scenarios before template copy is inserted.",
+      safeDataNotes: ["Recipients use only the campaign-team*stealth.demo handle."],
+      previewSurface: "campaigns",
+    },
+  },
+];
+
+function templateMap(templates: readonly MessageTemplate[]): Map<string, MessageTemplate> {
+  return new Map(templates.map((template) => [template.id, template]));
+}
+
+export function validateTemplateRegistry(
+  templates: readonly MessageTemplate[],
+  scenarios: readonly MessageTemplateScenario[],
+): string[] {
+  const templatesById = templateMap(templates);
+  const seenScenarioIds = new Set<string>();
+  const issues: string[] = [];
+
+  for (const scenario of scenarios) {
+    if (seenScenarioIds.has(scenario.id)) {
+      issues.push('Duplicate scenario id "' + scenario.id + '".');
+    }
+    seenScenarioIds.add(scenario.id);
+
+    for (const templateId of scenario.templateIds) {
+      if (!templatesById.has(templateId)) {
+        issues.push(
+          'Scenario "' + scenario.id + '" references missing template "' + templateId + '".',
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function buildTemplateRegistry(
+  templates: readonly MessageTemplate[],
+  scenarios: readonly MessageTemplateScenario[] = messageTemplateScenarios,
+): TemplateRegistryEntry[] {
+  const templatesById = templateMap(templates);
+
+  return scenarios.map((scenario) => ({
+    scenario,
+    templates: scenario.templateIds
+      .map((templateId) => templatesById.get(templateId))
+      .filter((template): template is MessageTemplate => Boolean(template)),
+  }));
+}
+
+export function getTemplatesForScenario(
+  scenarioId: string,
+  templates: readonly MessageTemplate[],
+  scenarios: readonly MessageTemplateScenario[] = messageTemplateScenarios,
+): MessageTemplate[] {
+  return buildTemplateRegistry(templates, scenarios).find(
+    (entry) => entry.scenario.id === scenarioId,
+  )?.templates ?? [];
+}


### PR DESCRIPTION
## Summary
- Add a scenario metadata registry for the demo admin message template catalog.
- Expose deterministic helpers to build scenario entries, look up templates by scenario, and validate duplicate/missing references.
- Add registry documentation and focused unit coverage for scenario order, lookup, validation, and catalog coverage.

## Scope
- All changes stay inside `src/features/demo-admin-dashboard/`.
- No production inbox, mail reader, calendar, sender-conversion, protocol, routing, or app-shell files are touched.
- No live network calls, secrets, private keys, or real user data are introduced.

## Validation
- `pnpm dlx vitest run src/features/demo-admin-dashboard/__tests__/templateRegistry.test.ts` -> 4 tests passed.
- `pnpm dlx --package typescript tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --strict src/features/demo-admin-dashboard/templates/templateRegistry.ts` -> exit 0.
- Compared PR branch against `main`; only 4 files under `src/features/demo-admin-dashboard/` changed.

Refs #207