### PR TITLE
[codex] Add command palette shortcut regression coverage

### DIFF
--- a/tests/unit/command-palette/shortcuts.test.ts
+++ b/tests/unit/command-palette/shortcuts.test.ts
@@ -12,9 +12,9 @@ function editableTarget(tagName: string, parentElement: any = null) {
 
 describe("shortcut guards", () => {
   it("treats inputs, textareas, selects, and textboxes as editable", () => {
-    expect(isEditableTarget(editableTarget("INPUT"))).toBe(true);
-    expect(isEditableTarget(editableTarget("TEXTAREA"))).toBe(true);
-    expect(isEditableTarget(editableTarget("SELECT"))).toBe(true);
+    expect(isEditableTarget(editableTarget("INPUT") as EventTarget)).toBe(true);
+    expect(isEditableTarget(editableTarget("TEXTAREA") as EventTarget)).toBe(true);
+    expect(isEditableTarget(editableTarget("SELECT") as EventTarget)).toBe(true);
     expect(
       isEditableTarget({
         tagName: "DIV",
@@ -53,5 +53,20 @@ describe("shortcut guards", () => {
     expect(getShortcutAction({ key: "n", metaKey: true, target: null })).toBe("compose");
     expect(getShortcutAction({ key: "?", shiftKey: true, target: null })).toBe("open-shortcuts");
     expect(getShortcutAction({ key: ",", target: null })).toBe("open-settings");
+  });
+
+  it("maps bare-letter mailbox shortcuts outside editable fields", () => {
+    expect(getShortcutAction({ key: "E", target: null })).toBe("archive-thread");
+    expect(getShortcutAction({ key: "z", target: null })).toBe("snooze-thread");
+    expect(getShortcutAction({ key: "a", target: null })).toBe("approve-sender");
+    expect(getShortcutAction({ key: "B", target: null })).toBe("block-sender");
+    expect(getShortcutAction({ key: "c", target: null })).toBe("open-calendar");
+    expect(getShortcutAction({ key: "I", target: null })).toBe("open-proof-inspector");
+  });
+
+  it("ignores alt-modified and unsupported shortcut keys", () => {
+    expect(getShortcutAction({ key: "k", ctrlKey: true, altKey: true, target: null })).toBeNull();
+    expect(getShortcutAction({ key: "e", altKey: true, target: null })).toBeNull();
+    expect(getShortcutAction({ key: "x", target: null })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Extend command palette shortcut regression coverage for bare-letter mailbox shortcuts.
- Add edge coverage confirming Alt-modified and unsupported keys do not route to actions.
- Keep coverage focused on existing user-visible keyboard routing behavior.

## Scope
- Only `tests/unit/command-palette/shortcuts.test.ts` changed.
- No app behavior, UI, inbox, routing, or command execution code changed.
- No real user data, secrets, private keys, or live customer mail introduced.

## Validation
- `pnpm dlx vitest run tests/unit/command-palette/shortcuts.test.ts` -> 6 tests passed.
- Compared PR branch against `main`; only the command palette shortcut test file changed.

Refs #929