### PR TITLE
[codex] Define customer support macro architecture contract

### DIFF
--- a/tools/v1/team/customer-support-macro-tool/README.md
+++ b/tools/v1/team/customer-support-macro-tool/README.md
@@ -17,9 +17,10 @@ apply reusable response templates ("macros") with variable interpolation.
 4. [Usage](#4-usage)
 5. [Fixtures](#5-fixtures)
 6. [Running tests](#6-running-tests)
-7. [Known limitations](#7-known-limitations)
-8. [OSS reviewer notes](#8-oss-reviewer-notes)
-9. [Integration roadmap](#9-integration-roadmap)
+7. [Architecture contract](#7-architecture-contract)
+8. [Known limitations](#8-known-limitations)
+9. [OSS reviewer notes](#9-oss-reviewer-notes)
+10. [Integration roadmap](#10-integration-roadmap)
 
 ---
 
@@ -53,6 +54,8 @@ customer-support-macro-tool/
 │   ├── storage.service.test.ts # Unit tests — persistence layer
 │   └── TEST_PLAN.md            # Full test strategy document
 ├── docs/
+│   ├── ARCHITECTURE.md         # Folder-local architecture contract
+│   ├── REVIEW_NOTES.md         # OSS review guide
 │   └── SETUP.md                # Dev setup guide
 ├── README.md                   ← you are here
 └── specs.md                    # Issue categories and contributor expectations
@@ -95,7 +98,7 @@ const body = interpolateMacro(macro.body, {
   customer_name: "Alice",
   company_name: "Acme Corp",
 });
-// → "Hi Alice, welcome to Acme Corp support!"
+// -> "Hi Alice, welcome to Acme Corp support!"
 ```
 
 ### Using the React hook
@@ -171,7 +174,20 @@ coverage targets, and a description of every test case.
 
 ---
 
-## 7. Known limitations
+## 7. Architecture contract
+
+See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for the folder-local
+architecture contract. It defines:
+
+- service, storage, hook, fixture, test, docs, and future component boundaries;
+- data owned by this tool versus data owned by the main app;
+- dependency rules that keep this folder isolated from app shell, inbox,
+  wallet, Stellar, database, routing, and design-system internals;
+- allowed future changes and changes that require a separate integration issue.
+
+---
+
+## 8. Known limitations
 
 | Limitation                  | Detail                                                                                                                              |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
@@ -184,15 +200,16 @@ coverage targets, and a description of every test case.
 
 ---
 
-## 8. OSS reviewer notes
+## 9. OSS reviewer notes
 
 ### How to review this contribution independently
 
-1. **Read `tests/TEST_PLAN.md`** — it maps every test file to the feature it exercises.
-2. **Run the tests** (`npx vitest run tools/v1/team/customer-support-macro-tool/tests`) — all should pass.
-3. **Inspect the services** — `macro.service.ts` contains only pure functions. No side effects, no React, no imports from `src/`.
-4. **Check isolation** — `grep -r "from.*src/" tools/v1/team/customer-support-macro-tool/` should return **zero** results.
-5. **Verify boundary** — no file outside `tools/v1/team/customer-support-macro-tool/` is modified by this PR.
+1. **Read `docs/ARCHITECTURE.md`** — it defines module boundaries and integration guardrails.
+2. **Read `tests/TEST_PLAN.md`** — it maps every test file to the feature it exercises.
+3. **Run the tests** (`npx vitest run tools/v1/team/customer-support-macro-tool/tests`) — all should pass.
+4. **Inspect the services** — `macro.service.ts` contains only pure functions. No side effects, no React, no imports from `src/`.
+5. **Check isolation** — `grep -r "from.*src/" tools/v1/team/customer-support-macro-tool/` should return **zero** results.
+6. **Verify boundary** — no file outside `tools/v1/team/customer-support-macro-tool/` is modified by this PR.
 
 ### What reviewers should NOT worry about
 
@@ -202,7 +219,7 @@ coverage targets, and a description of every test case.
 
 ---
 
-## 9. Integration roadmap
+## 10. Integration roadmap
 
 When a future integration issue is opened, the following adapter points are ready:
 

--- a/tools/v1/team/customer-support-macro-tool/docs/ARCHITECTURE.md
+++ b/tools/v1/team/customer-support-macro-tool/docs/ARCHITECTURE.md
@@ -1,0 +1,105 @@
+# Customer Support Macro Tool — Architecture Contract
+
+This document defines the folder-local architecture for the Customer Support
+Macro Tool. It is scoped only to
+`tools/v1/team/customer-support-macro-tool/` and does not wire the tool into the
+main app.
+
+## Module map
+
+| Module | Owns | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| `services/macro.service.ts` | Macro data model, validation, CRUD, search, sorting, usage tracking, interpolation | Local types and pure helpers | React, storage, network calls, main app imports |
+| `services/storage.service.ts` | Storage adapter interface, localStorage adapter, in-memory adapter, load/save/clear helpers | `Macro` type from the macro service | Main app persistence, database, auth/session state |
+| `hooks/useMacros.ts` | React state wrapper over services and storage adapters | Local services, local fixtures via caller options | App shell, routing, inbox, wallet, Stellar, design system |
+| `fixtures/macros.fixture.ts` | Synthetic macro examples for tests and local development | Local macro types | Production ticket data, customer data, live mail |
+| `tests/` | Service, storage, and future hook/component coverage | Local modules and fixtures | Live storage services, production data, app-level mocks |
+| `docs/` | Setup, review notes, architecture, future handoff | Local file references | Integration promises outside the issue scope |
+| `components/` | Reserved for the UI/accessibility issue | Local hooks, local props, local fixtures | Main app shell, shared design-system internals |
+
+## Data ownership
+
+This folder owns only the data needed to create and apply reusable support
+macros:
+
+- macro id, title, body, category, tags, timestamps, usage count, favorite flag;
+- macro create/update/search/sort inputs;
+- variable interpolation maps for `{{snake_case}}` placeholders;
+- local storage adapter payloads;
+- synthetic fixtures and test-only data.
+
+The following data remains outside this folder and must not be read or mutated
+here:
+
+- live inbox messages and threads;
+- production customer tickets;
+- authenticated user/session state;
+- wallet or Stellar account state;
+- database records;
+- analytics and telemetry;
+- app routes, navigation, and shell layout;
+- shared design-system state.
+
+## Dependency rules
+
+- Services must remain pure unless the file is explicitly a storage adapter.
+- `macro.service.ts` must not import React, storage adapters, `src/`, or browser
+  globals.
+- `storage.service.ts` owns persistence boundaries and must expose adapter-based
+  helpers so tests can use `createInMemoryAdapter`.
+- `useMacros.ts` may compose local services and a provided `StorageAdapter`, but
+  must not import from the app shell, inbox, routing, wallet, Stellar, database,
+  or design system.
+- Future components should receive data and callbacks through local props and
+  hooks. They should not mutate mail, send replies, or mount themselves into
+  app navigation.
+- Tests must use local fixtures and adapters. They must not require live
+  browser storage, network access, production tickets, or real customer data.
+
+## Public API shape
+
+Future consumers should treat these as the stable folder-local surfaces:
+
+- Pure service functions: `createMacro`, `updateMacro`, `deleteMacro`,
+  `recordMacroUsage`, `searchMacros`, `sortMacros`, `extractVariables`,
+  `interpolateMacro`, and `validateMacroInput`.
+- Storage helpers: `loadMacros`, `saveMacros`, `clearMacros`,
+  `createInMemoryAdapter`, and `StorageAdapter`.
+- React hook: `useMacros({ storageAdapter, seedMacros })`.
+- Fixture entry points: `FIXTURE_MACROS`, `FIXTURE_MACRO_NO_VARS`, and
+  `FIXTURE_MACRO_WITH_VARS`.
+
+## Allowed future changes
+
+Future contributors may add:
+
+- local UI components for macro listing, editing, variable prompts, and apply
+  flows;
+- local hook tests once the repository adds the required testing utilities;
+- additional categories or validation rules when tests and docs cover them;
+- folder-local docs for UI states, accessibility, and review flows.
+
+## Forbidden future changes without a separate integration issue
+
+Future contributors must not:
+
+- mount this tool into app routes, dashboard navigation, compose surfaces, or
+  inbox panels;
+- send email, write to production tickets, mutate mailbox state, or call live
+  support APIs;
+- import from the main app shell, routing, inbox, wallet, Stellar, database,
+  authentication, analytics, or shared design-system internals;
+- add live network calls, secrets, provider keys, production customer data, or
+  private ticket content;
+- replace the storage adapter boundary with direct app persistence.
+
+## Review checklist
+
+- All modified files are under `tools/v1/team/customer-support-macro-tool/`.
+- Service changes have local unit tests.
+- Storage changes can run with `createInMemoryAdapter`.
+- UI changes, if any, remain unmounted and folder-local.
+- No live network calls, secrets, provider keys, production data, or app-level
+  mutations were added.
+- Any future integration need is documented as follow-up work instead of being
+  implemented here.

--- a/tools/v1/team/customer-support-macro-tool/specs.md
+++ b/tools/v1/team/customer-support-macro-tool/specs.md
@@ -13,8 +13,9 @@ with variable interpolation (`{{customer_name}}`, etc.) for personalisation.
 - **Folder ownership:** `tools/v1/team/customer-support-macro-tool/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main
-app, routing, inbox architecture, wallet core, Stellar core, or design system
-unless a future integration issue explicitly allows it.
+app, routing, inbox architecture, wallet core, Stellar core, database,
+authentication, analytics, or design system unless a future integration issue
+explicitly allows it.
 
 ## Recommended internal structure
 
@@ -25,18 +26,29 @@ customer-support-macro-tool/
 ├── hooks/        # React hooks (implemented)
 ├── tests/        # Unit tests + test plan (implemented)
 ├── fixtures/     # Local test data (implemented)
-└── docs/         # Setup and review guides (implemented)
+└── docs/         # Setup, review, and architecture guides (implemented)
 ```
+
+## Architecture contract
+
+See `docs/ARCHITECTURE.md` for the authoritative folder-local architecture
+contract. Future contributors should treat that file as the boundary document
+for:
+
+- service, storage, hook, fixture, test, docs, and future component modules;
+- data owned by the tool versus data owned by the main app;
+- dependency rules and forbidden imports;
+- allowed future changes and integration-only changes.
 
 ## Required issue categories
 
-| Category                  | Status                                                                    |
-| ------------------------- | ------------------------------------------------------------------------- |
-| Architecture              | Addressed — service layer, storage adapter pattern, hook interface        |
-| Feature                   | Addressed — CRUD, search, sort, interpolation, validation, usage tracking |
-| UI and accessibility      | Deferred — separate UI issue                                              |
-| Security and performance  | Addressed — input validation, no external deps, immutable patterns        |
-| Testing and documentation | ✅ Completed — this issue                                                 |
+| Category                  | Status                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| Architecture              | Addressed — service/storage/hook boundaries and `docs/ARCHITECTURE.md`        |
+| Feature                   | Addressed — CRUD, search, sort, interpolation, validation, usage tracking     |
+| UI and accessibility      | Deferred — separate UI issue                                                  |
+| Security and performance  | Addressed — input validation, no external deps, adapter isolation             |
+| Testing and documentation | Addressed — tests, setup, review notes, test plan, and architecture contract  |
 
 ## Macro categories
 
@@ -68,5 +80,22 @@ All work for this tool stays in:
 tools/v1/team/customer-support-macro-tool/
 ```
 
-Pull requests that modify files outside this folder will be rejected unless
-a future integration issue explicitly grants expanded scope.
+Pull requests that modify files outside this folder will be rejected unless a
+future integration issue explicitly grants expanded scope.
+
+Future contributors may:
+
+- add local services, storage adapters, hooks, components, fixtures, tests, and
+  docs;
+- extend categories, validation, and search behavior with local tests;
+- build UI surfaces that remain unmounted and folder-local.
+
+Future contributors may not:
+
+- mount the tool into app routes, dashboards, inbox panels, or compose surfaces;
+- send email, mutate mailbox state, write to production tickets, or call live
+  support APIs;
+- import from main app shell, routing, inbox, wallet, Stellar, database,
+  authentication, analytics, or shared design-system internals;
+- add live network calls, secrets, provider keys, production customer data, or
+  private ticket content.


### PR DESCRIPTION
Summary:
- Adds a folder-local architecture contract for the V1 Customer Support Macro Tool.
- Documents module boundaries across services, hooks, fixtures, tests, docs, and future components.
- Clarifies data ownership, dependency limits, integration constraints, and future contributor rules.

Scope:
- Documentation-only change under tools/v1/team/customer-support-macro-tool.
- No runtime logic, package, dependency, network, or app-shell changes.

Validation:
- Compared branch against main: one commit, three documentation files changed.
- Local sensitive-pattern scan found only documentation guidance and variable-token examples; no credentials or external endpoints were added.

Refs #429