### PR TITLE
perf: optimize command palette rendering, search performance, and shortcut routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -743,6 +742,27 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
       "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -4882,7 +4902,6 @@
       "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4893,7 +4912,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4904,7 +4922,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4954,7 +4971,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -5345,7 +5361,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5596,7 +5611,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6145,8 +6159,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6326,7 +6339,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6387,7 +6399,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8007,7 +8018,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8110,7 +8120,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8142,7 +8151,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8155,7 +8163,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
       "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8459,7 +8466,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8882,7 +8888,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8954,7 +8959,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -9105,7 +9109,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9415,7 +9418,6 @@
       "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/features/command-palette/CommandPalette.tsx
+++ b/src/features/command-palette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   AlertTriangle,
@@ -61,36 +61,43 @@ export function CommandPalette({
     setActiveIndex((index) => Math.min(index, Math.max(0, selectable.length - 1)));
   }, [selectable.length]);
 
-  const activate = (row: PaletteRow) => {
-    switch (row.type) {
-      case "command": {
-        if (!row.command.availability.enabled) return;
-        if (row.command.dangerous && row.command.confirm) {
-          setConfirming(row.command);
+  const handleActivate = useCallback(
+    (row: PaletteRow) => {
+      switch (row.type) {
+        case "command": {
+          if (!row.command.availability.enabled) return;
+          if (row.command.dangerous && row.command.confirm) {
+            setConfirming(row.command);
+            return;
+          }
+          onRunCommand(row.command.id);
+          onClose();
           return;
         }
-        onRunCommand(row.command.id);
-        onClose();
-        return;
+        case "folder":
+          onNavigate(row.folder);
+          onClose();
+          return;
+        case "sender":
+          onSelectEmail(row.email);
+          onClose();
+          return;
+        case "proof":
+          onRunCommand("inspect-proof", row.email);
+          onClose();
+          return;
+        case "setting":
+          onOpenSettings(row.setting.id);
+          onClose();
+          return;
       }
-      case "folder":
-        onNavigate(row.folder);
-        onClose();
-        return;
-      case "sender":
-        onSelectEmail(row.email);
-        onClose();
-        return;
-      case "proof":
-        onRunCommand("inspect-proof", row.email);
-        onClose();
-        return;
-      case "setting":
-        onOpenSettings(row.setting.id);
-        onClose();
-        return;
-    }
-  };
+    },
+    [onRunCommand, onClose, onNavigate, onSelectEmail, onOpenSettings],
+  );
+
+  const handleHover = useCallback((index: number) => {
+    setActiveIndex(index);
+  }, []);
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (confirming) {
@@ -123,7 +130,7 @@ export function CommandPalette({
     if (event.key === "Enter") {
       event.preventDefault();
       const row = selectable[activeIndex];
-      if (row) activate(row);
+      if (row) handleActivate(row);
     }
   };
 
@@ -187,8 +194,8 @@ export function CommandPalette({
                       section={section}
                       activeIndex={activeIndex}
                       selectableIndexByKey={selectableIndexByKey}
-                      onHover={setActiveIndex}
-                      onActivate={activate}
+                      onHover={handleHover}
+                      onActivate={handleActivate}
                     />
                   ))}
                 </ul>
@@ -206,7 +213,7 @@ export function CommandPalette({
   );
 }
 
-function PaletteSectionView({
+const PaletteSectionView = memo(function PaletteSectionView({
   section,
   activeIndex,
   selectableIndexByKey,
@@ -232,25 +239,28 @@ function PaletteSectionView({
             key={row.key}
             row={row}
             active={active}
-            onHover={() => selectableIndex !== undefined && onHover(selectableIndex)}
-            onActivate={() => onActivate(row)}
+            selectableIndex={selectableIndex}
+            onHover={onHover}
+            onActivate={onActivate}
           />
         );
       })}
     </>
   );
-}
+});
 
-function RowView({
+const RowView = memo(function RowView({
   row,
   active,
+  selectableIndex,
   onHover,
   onActivate,
 }: {
   row: PaletteRow;
   active: boolean;
-  onHover: () => void;
-  onActivate: () => void;
+  selectableIndex: number | undefined;
+  onHover: (index: number) => void;
+  onActivate: (row: PaletteRow) => void;
 }) {
   const ref = useRef<HTMLButtonElement>(null);
   useEffect(() => {
@@ -264,14 +274,24 @@ function RowView({
       ? row.command.availability.help
       : undefined;
 
+  const handleMouseEnter = () => {
+    if (selectableIndex !== undefined && !active) {
+      onHover(selectableIndex);
+    }
+  };
+
+  const handleActivate = () => {
+    onActivate(row);
+  };
+
   return (
     <li>
       <button
         ref={ref}
         type="button"
         disabled={disabled}
-        onMouseMove={onHover}
-        onClick={onActivate}
+        onMouseEnter={handleMouseEnter}
+        onClick={handleActivate}
         aria-disabled={disabled}
         className={cn(
           "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition",
@@ -309,7 +329,7 @@ function RowView({
       </button>
     </li>
   );
-}
+});
 
 type RowMeta = { Icon: LucideIcon; label: string; sub?: string; hint?: string; danger?: boolean };
 

--- a/src/features/command-palette/ShortcutOverlay.tsx
+++ b/src/features/command-palette/ShortcutOverlay.tsx
@@ -28,18 +28,14 @@ export function ShortcutOverlay({ open, onClose }: Props) {
   const shortcuts = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return SHORTCUT_DEFINITIONS;
-    return SHORTCUT_DEFINITIONS.filter((shortcut) =>
-      [
-        shortcut.label,
-        shortcut.description,
-        shortcut.keys.join(" "),
-        shortcut.keywords.join(" "),
-        shortcut.conflict ?? "",
-      ]
-        .join(" ")
-        .toLowerCase()
-        .includes(q),
-    );
+    return SHORTCUT_DEFINITIONS.filter((shortcut) => {
+      if (shortcut.label.toLowerCase().includes(q)) return true;
+      if (shortcut.description.toLowerCase().includes(q)) return true;
+      if (shortcut.keywords.some((k) => k.toLowerCase().includes(q))) return true;
+      if (shortcut.keys.some((k) => k.toLowerCase().includes(q))) return true;
+      if (shortcut.conflict?.toLowerCase().includes(q)) return true;
+      return false;
+    });
   }, [query]);
 
   return (

--- a/src/features/command-palette/search.ts
+++ b/src/features/command-palette/search.ts
@@ -30,13 +30,9 @@ export const SETTINGS_SHORTCUTS: SettingShortcut[] = [
 ];
 
 /**
- * Subsequence fuzzy score. Returns -1 when the query isn't a subsequence of the
- * text; otherwise higher is better. Rewards consecutive runs and word-boundary
- * hits, and lightly prefers shorter targets. O(text length) — cheap enough to
- * run across the whole dataset on every keystroke.
+ * Internal helper for subsequencing a query that has already been trimmed and lowercased.
  */
-export function fuzzyScore(query: string, text: string): number {
-  const q = query.trim().toLowerCase();
+function fuzzyScorePrepared(q: string, text: string): number {
   if (!q) return 0;
   const t = text.toLowerCase();
 
@@ -64,6 +60,16 @@ export function fuzzyScore(query: string, text: string): number {
   return score - t.length * 0.01;
 }
 
+/**
+ * Subsequence fuzzy score. Returns -1 when the query isn't a subsequence of the
+ * text; otherwise higher is better. Rewards consecutive runs and word-boundary
+ * hits, and lightly prefers shorter targets. O(text length) — cheap enough to
+ * run across the whole dataset on every keystroke.
+ */
+export function fuzzyScore(query: string, text: string): number {
+  return fuzzyScorePrepared(query.trim().toLowerCase(), text);
+}
+
 export type PaletteRow =
   | { type: "command"; key: string; command: ResolvedCommand }
   | { type: "folder"; key: string; folder: MailFolder; label: string }
@@ -78,13 +84,41 @@ const GROUP_ORDER: CommandGroupId[] = ["protocol", "delivery", "message", "navig
 
 const PER_GROUP_CAP = 5;
 
+let lastEmails: Email[] | null = null;
+let cachedUniqueSenders: Email[] = [];
+
+function getUniqueSenders(emails: Email[]): Email[] {
+  if (emails === lastEmails) return cachedUniqueSenders;
+  const seen = new Set<string>();
+  const unique = emails.filter((email) => {
+    if (seen.has(email.email)) return false;
+    seen.add(email.email);
+    return true;
+  });
+  lastEmails = emails;
+  cachedUniqueSenders = unique;
+  return unique;
+}
+
 function rank<T>(items: T[], query: string, toText: (item: T) => string, cap: number): T[] {
-  return items
-    .map((item) => ({ item, score: fuzzyScore(query, toText(item)) }))
-    .filter((entry) => entry.score >= 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, cap)
-    .map((entry) => entry.item);
+  const q = query.trim().toLowerCase();
+  const scored: { item: T; score: number }[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const score = fuzzyScorePrepared(q, toText(item));
+    if (score >= 0) {
+      scored.push({ item, score });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const result: T[] = [];
+  const limit = Math.min(scored.length, cap);
+  for (let i = 0; i < limit; i++) {
+    result.push(scored[i].item);
+  }
+  return result;
 }
 
 /**
@@ -152,12 +186,7 @@ export function buildPaletteModel(
   }
 
   // Unique senders, keyed by address.
-  const seen = new Set<string>();
-  const uniqueSenders = emails.filter((email) => {
-    if (seen.has(email.email)) return false;
-    seen.add(email.email);
-    return true;
-  });
+  const uniqueSenders = getUniqueSenders(emails);
   const senders = rank(uniqueSenders, q, (email) => `${email.from} ${email.email}`, PER_GROUP_CAP);
   if (senders.length) {
     sections.push({

--- a/src/features/command-palette/shortcuts.ts
+++ b/src/features/command-palette/shortcuts.ts
@@ -147,6 +147,17 @@ export function getShortcutAction(event: ShortcutEventLike): ShortcutActionId | 
   const key = event.key.toLowerCase();
   const hasCommandModifier = !!event.metaKey || !!event.ctrlKey;
 
+  // Suppress all global shortcuts if any dialog or modal is open, except Ctrl/Cmd+K.
+  if (typeof document !== "undefined") {
+    const activeDialog = document.querySelector(
+      '[role="dialog"], [aria-modal="true"], [data-state="open"]',
+    );
+    if (activeDialog) {
+      if (hasCommandModifier && key === "k") return "open-palette";
+      return null;
+    }
+  }
+
   if (hasCommandModifier && key === "k") return "open-palette";
   if (hasCommandModifier && key === "n") return "compose";
   if (!hasCommandModifier && key === "e") return "archive-thread";

--- a/tests/unit/command-palette/shortcuts.test.ts
+++ b/tests/unit/command-palette/shortcuts.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { getShortcutAction, isEditableTarget } from "../../../src/features/command-palette";
 
@@ -53,5 +54,20 @@ describe("shortcut guards", () => {
     expect(getShortcutAction({ key: "n", metaKey: true, target: null })).toBe("compose");
     expect(getShortcutAction({ key: "?", shiftKey: true, target: null })).toBe("open-shortcuts");
     expect(getShortcutAction({ key: ",", target: null })).toBe("open-settings");
+  });
+
+  it("suppresses global shortcuts when a dialog is open in the DOM, except for open-palette", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+
+    try {
+      expect(getShortcutAction({ key: "k", ctrlKey: true, target: null })).toBe("open-palette");
+      expect(getShortcutAction({ key: "n", metaKey: true, target: null })).toBeNull();
+      expect(getShortcutAction({ key: "?", shiftKey: true, target: null })).toBeNull();
+      expect(getShortcutAction({ key: ",", target: null })).toBeNull();
+    } finally {
+      document.body.removeChild(dialog);
+    }
   });
 });


### PR DESCRIPTION
Closes #928

## Summary

Optimizes the Command Palette surface's rendering and search performance, and adds safety guards to the global keyboard shortcut routing.

## Details

### 1. Command Palette Render Optimizations
- **Memoized Views**: Wrapped `<RowView>` and `<PaletteSectionView>` in `React.memo` to skip re-rendering rows whose active selection state or description hasn't changed.
- **Reference-Stable Handlers**: Converted `onHover` and `onActivate` inside `CommandPalette` to stable `useCallback` hook references, preventing parent re-renders from invalidating child component memoization.
- **Micro-Interaction Latency**: Replaced `onMouseMove` with `onMouseEnter` in `RowView` and added a safeguard to only trigger state updates if the hovered index is not already active, preventing state changes on minor mouse jitters.

### 2. Search & Fuzzy Filtering Performance
- **Cached Unique Senders**: Added a referential cache for unique senders filtering, running the `O(emails)` filter operation only when the `emails` array reference changes, rather than on every typed character.
- **Single-Loop Rank**: Refactored the `rank` function to use a single loop, avoiding multiple arrays mapping/filtering/slicing/mapping steps.
- **Pre-Processed Fuzzy Match**: Trimmed and lowercased the search query once per search call, using a pre-processed helper `fuzzyScorePrepared` to avoid repeating string preprocessing for every item comparison.

### 3. Keyboard Shortcut Routing Safety
- **Active Dialog Guard**: Updated `getShortcutAction` to inspect the DOM and suppress global shortcuts (e.g., archiving `E`, blocking `B`, settings `,`) if a modal/dialog element (`[role="dialog"]`) is open.
- **Added Unit Test**: Wrote a new test case in `shortcuts.test.ts` under JSDOM environment to ensure global shortcut suppression behaves correctly.

## Verification

- Wrote and verified JSDOM test suite.
- Ran all unit tests successfully (593 tests passed):
  ```bash
  npm run test
  ```
- Checked code formatting and styling (0 errors):
  ```bash
  npm run lint
  ```
- Ran production build successfully:
  ```bash
  npm run build
  ```
