### PR TITLE
Add publish checklist for demo data changes

### DIFF
--- a/src/features/demo-admin-dashboard/PublishChecklist.md
+++ b/src/features/demo-admin-dashboard/PublishChecklist.md
@@ -1,0 +1,54 @@
+# PublishChecklist
+
+Pre-publish readiness panel for the demo admin dashboard. Tells maintainers
+whether a draft dataset is safe and complete enough to populate the demo UI.
+All data is fake and deterministic; nothing here touches production mail flows.
+
+## Pieces
+
+- `publishChecklist-types.ts` — `PublishChecklistItem`, `PublishChecklistStatus`,
+  `PublishChecklistResult`, and summary types.
+- `publishChecklist.ts` — `buildPublishChecklist`, `summarizePublishChecklist`,
+  `sortPublishChecklistItems`, `isReadyToPublish`.
+- `publishChecklistFixtures.ts` — ready, blocked, and validation-error scenarios.
+- `components/PublishChecklist.tsx` — the checklist panel UI.
+
+## Checks
+
+`buildPublishChecklist(drafts, validationIssues?)` runs these gates:
+
+1. Draft dataset is not empty (blocked when empty).
+2. Each draft has `id`, `subject`, `body`, and `recipients` (blocked).
+3. Each draft has at least one recipient (blocked).
+4. Recipients use `example.com`, `example.org`, or `*.stealth.demo` only (blocked).
+5. No blocking validation errors from field-level validators (blocked).
+6. Validation warnings reviewed (warning — does not block publish).
+
+## Behavior
+
+- Items are grouped by status (blocked, warning, pass).
+- A summary row shows counts per status.
+- `readyToPublish` is true when no item is blocked.
+- When `onPublish` is provided, the publish button is disabled until all blockers
+  are resolved.
+- With all checks passing, a friendly ready state is shown.
+
+## Usage
+
+```tsx
+import {
+  PublishChecklist,
+  buildPublishChecklist,
+  demoPublishChecklistReady,
+} from "@/features/demo-admin-dashboard";
+
+const result = buildPublishChecklist(drafts, validationIssues);
+
+<PublishChecklist result={result} onPublish={() => adapter.publishDataset(dataset)} />;
+```
+
+## Follow-up integration (out of scope here)
+
+Wiring `PublishChecklist` into the tabbed `DemoAdminDashboard` shell is a
+deliberate follow-up so that no files outside `src/features/demo-admin-dashboard/`
+change in this issue.

--- a/src/features/demo-admin-dashboard/components/PublishChecklist.tsx
+++ b/src/features/demo-admin-dashboard/components/PublishChecklist.tsx
@@ -1,0 +1,155 @@
+import { AlertCircle, AlertTriangle, CheckCircle2, CircleDashed } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { summarizePublishChecklist } from "../publishChecklist";
+import type {
+  PublishChecklistItem,
+  PublishChecklistResult,
+  PublishChecklistStatus,
+} from "../publishChecklist-types";
+
+const STATUS_ICON: Record<PublishChecklistStatus, LucideIcon> = {
+  pass: CheckCircle2,
+  warning: AlertTriangle,
+  blocked: AlertCircle,
+};
+
+const STATUS_LABEL: Record<PublishChecklistStatus, string> = {
+  pass: "Passed",
+  warning: "Warning",
+  blocked: "Blocked",
+};
+
+const STATUS_STYLES: Record<PublishChecklistStatus, string> = {
+  pass: "border-emerald-500/30 bg-emerald-500/10 text-emerald-300",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-300",
+  blocked: "border-red-500/30 bg-red-500/10 text-red-300",
+};
+
+const STATUS_ORDER: PublishChecklistStatus[] = ["blocked", "warning", "pass"];
+
+export type PublishChecklistProps = {
+  result: PublishChecklistResult;
+  onPublish?: () => void;
+  title?: string;
+  className?: string;
+};
+
+function groupByStatus(items: PublishChecklistItem[]) {
+  return STATUS_ORDER.map((status) => ({
+    status,
+    items: items.filter((entry) => entry.status === status),
+  })).filter((group) => group.items.length > 0);
+}
+
+export function PublishChecklist({
+  result,
+  onPublish,
+  title = "Publish checklist",
+  className,
+}: PublishChecklistProps) {
+  const summary = summarizePublishChecklist(result.items);
+  const groups = groupByStatus(result.items);
+  const publishDisabled = !result.readyToPublish || !onPublish;
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-3 rounded-lg border border-white/10 bg-white/[0.02] p-4",
+        className,
+      )}
+      aria-label={title}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+          <p className="text-xs text-muted-foreground">
+            {result.readyToPublish
+              ? "This draft dataset is ready to populate the demo UI."
+              : "Resolve blocked items before publishing."}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 text-[11px] font-medium">
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-emerald-300">
+            {summary.pass} passed
+          </span>
+          <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-amber-300">
+            {summary.warning} warnings
+          </span>
+          <span className="rounded-full border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-red-300">
+            {summary.blocked} blocked
+          </span>
+        </div>
+      </header>
+
+      {result.readyToPublish && summary.blocked === 0 && summary.warning === 0 ? (
+        <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-4 text-sm text-emerald-300">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span>All checks passed. You can publish this dataset to the demo UI.</span>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map((group) => {
+            const Icon = STATUS_ICON[group.status];
+            return (
+              <div key={group.status} className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <Icon className="h-3.5 w-3.5" />
+                  <span>
+                    {STATUS_LABEL[group.status]} ({group.items.length})
+                  </span>
+                </div>
+                <ul className="flex flex-col gap-1.5">
+                  {group.items.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className={cn(
+                        "rounded-md border px-3 py-2 text-left",
+                        STATUS_STYLES[entry.status],
+                      )}
+                    >
+                      <span className="block text-[13px] font-medium text-foreground">
+                        {entry.label}
+                      </span>
+                      {entry.detail ? (
+                        <p className="mt-0.5 text-[11px] text-muted-foreground">{entry.detail}</p>
+                      ) : null}
+                      {entry.hint ? (
+                        <p className="mt-1 text-[11px] text-muted-foreground/80">{entry.hint}</p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {onPublish ? (
+        <footer className="flex items-center justify-end border-t border-white/10 pt-3">
+          <button
+            type="button"
+            disabled={publishDisabled}
+            onClick={onPublish}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+              publishDisabled
+                ? "cursor-not-allowed bg-muted text-muted-foreground"
+                : "bg-primary text-primary-foreground hover:bg-primary/90",
+            )}
+            aria-disabled={publishDisabled}
+          >
+            {result.readyToPublish ? (
+              <CheckCircle2 className="h-4 w-4" />
+            ) : (
+              <CircleDashed className="h-4 w-4" />
+            )}
+            Publish to demo UI
+          </button>
+        </footer>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -187,6 +187,11 @@ export * from "./validation";
 export * from "./validationFixtures";
 export { ValidationResultsPanel } from "./ValidationResultsPanel";
 export type { ValidationResultsPanelProps } from "./ValidationResultsPanel";
+export * from "./publishChecklist-types";
+export * from "./publishChecklist";
+export * from "./publishChecklistFixtures";
+export { PublishChecklist } from "./components/PublishChecklist";
+export type { PublishChecklistProps } from "./components/PublishChecklist";
 
 // Proof record editor, helpers, and formatting
 export { ProofRecordEditor } from "./ProofRecordEditor";

--- a/src/features/demo-admin-dashboard/publishChecklist-types.ts
+++ b/src/features/demo-admin-dashboard/publishChecklist-types.ts
@@ -1,0 +1,27 @@
+/** Outcome of a single pre-publish readiness check. */
+export type PublishChecklistStatus = "pass" | "warning" | "blocked";
+
+/** One row in the publish checklist shown to maintainers. */
+export type PublishChecklistItem = {
+  id: string;
+  label: string;
+  status: PublishChecklistStatus;
+  /** Human-readable detail when the check did not pass. */
+  detail?: string;
+  /** Optional short hint on how to resolve a failure. */
+  hint?: string;
+};
+
+/** Aggregate result returned by `buildPublishChecklist`. */
+export type PublishChecklistResult = {
+  items: PublishChecklistItem[];
+  /** True when no item is blocked — the dataset may be published. */
+  readyToPublish: boolean;
+};
+
+export type PublishChecklistSummary = {
+  pass: number;
+  warning: number;
+  blocked: number;
+  total: number;
+};

--- a/src/features/demo-admin-dashboard/publishChecklist.test.ts
+++ b/src/features/demo-admin-dashboard/publishChecklist.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPublishChecklist,
+  isReadyToPublish,
+  SAFE_RECIPIENT_DOMAIN_PATTERN,
+  sortPublishChecklistItems,
+  summarizePublishChecklist,
+} from "./publishChecklist";
+import {
+  demoPublishChecklistBlocked,
+  demoPublishChecklistReady,
+  demoPublishChecklistWithValidationErrors,
+  publishBlockedDraftsNoRecipients,
+  publishBlockedDraftsUnsafeDomain,
+  publishReadyDrafts,
+} from "./publishChecklistFixtures";
+import { draftSample } from "./fixtures/draftFixtures";
+import { demoValidationIssues, demoValidationIssuesEmpty } from "./validationFixtures";
+
+describe("SAFE_RECIPIENT_DOMAIN_PATTERN", () => {
+  it("accepts example.com and example.org addresses", () => {
+    expect("alice@example.com").toMatch(SAFE_RECIPIENT_DOMAIN_PATTERN);
+    expect("bob@example.org").toMatch(SAFE_RECIPIENT_DOMAIN_PATTERN);
+  });
+
+  it("accepts stealth.demo handles", () => {
+    expect("demo@team.stealth.demo").toMatch(SAFE_RECIPIENT_DOMAIN_PATTERN);
+  });
+
+  it("rejects real-looking domains", () => {
+    expect("user@gmail.com").not.toMatch(SAFE_RECIPIENT_DOMAIN_PATTERN);
+  });
+});
+
+describe("publishChecklist module", () => {
+  describe("buildPublishChecklist", () => {
+    it("returns all passes for a valid draft dataset", () => {
+      const result = buildPublishChecklist(publishReadyDrafts, demoValidationIssuesEmpty);
+      expect(result.readyToPublish).toBe(true);
+      expect(result.items.every((item) => item.status !== "blocked")).toBe(true);
+    });
+
+    it("blocks when the draft dataset is empty", () => {
+      const result = buildPublishChecklist([], demoValidationIssuesEmpty);
+      expect(result.readyToPublish).toBe(false);
+      expect(result.items.find((item) => item.id === "drafts-present")?.status).toBe("blocked");
+    });
+
+    it("blocks when drafts have no recipients", () => {
+      const result = buildPublishChecklist(
+        publishBlockedDraftsNoRecipients,
+        demoValidationIssuesEmpty,
+      );
+      expect(result.readyToPublish).toBe(false);
+      expect(result.items.find((item) => item.id === "recipients-present")?.status).toBe("blocked");
+    });
+
+    it("blocks when recipients use unsafe domains", () => {
+      const result = buildPublishChecklist(
+        publishBlockedDraftsUnsafeDomain,
+        demoValidationIssuesEmpty,
+      );
+      expect(result.readyToPublish).toBe(false);
+      expect(result.items.find((item) => item.id === "safe-domains")?.status).toBe("blocked");
+    });
+
+    it("blocks when validation errors exist", () => {
+      const result = buildPublishChecklist(publishReadyDrafts, demoValidationIssues);
+      expect(result.readyToPublish).toBe(false);
+      expect(result.items.find((item) => item.id === "validation-errors")?.status).toBe("blocked");
+    });
+
+    it("warns but does not block on validation warnings only", () => {
+      const warningsOnly = demoValidationIssues.filter((issue) => issue.severity !== "error");
+      const result = buildPublishChecklist(publishReadyDrafts, warningsOnly);
+      expect(result.readyToPublish).toBe(true);
+      expect(result.items.find((item) => item.id === "validation-warnings")?.status).toBe(
+        "warning",
+      );
+    });
+
+    it("blocks incomplete drafts missing required fields", () => {
+      const incomplete = [{ ...draftSample, subject: "" }];
+      const result = buildPublishChecklist(incomplete, demoValidationIssuesEmpty);
+      expect(result.items.find((item) => item.id === "draft-fields")?.status).toBe("blocked");
+    });
+  });
+
+  describe("summarizePublishChecklist", () => {
+    it("counts items by status for validation-error fixture", () => {
+      const summary = summarizePublishChecklist(demoPublishChecklistWithValidationErrors.items);
+      expect(summary.blocked).toBeGreaterThan(0);
+      expect(summary.total).toBe(demoPublishChecklistWithValidationErrors.items.length);
+    });
+
+    it("reports no blockers for ready fixture", () => {
+      expect(summarizePublishChecklist(demoPublishChecklistReady.items).blocked).toBe(0);
+    });
+
+    it("reports blockers for blocked fixture", () => {
+      expect(summarizePublishChecklist(demoPublishChecklistBlocked.items).blocked).toBeGreaterThan(
+        0,
+      );
+    });
+  });
+
+  describe("sortPublishChecklistItems", () => {
+    it("orders blocked before warnings before passes", () => {
+      const sorted = sortPublishChecklistItems(demoPublishChecklistWithValidationErrors.items);
+      const statuses = sorted.map((item) => item.status);
+      expect(statuses.indexOf("blocked")).toBeLessThan(statuses.indexOf("warning"));
+      expect(statuses.indexOf("warning")).toBeLessThan(statuses.indexOf("pass"));
+    });
+  });
+
+  describe("isReadyToPublish", () => {
+    it("is false when any item is blocked", () => {
+      expect(isReadyToPublish(demoPublishChecklistBlocked.items)).toBe(false);
+    });
+
+    it("is true for the ready fixture", () => {
+      expect(isReadyToPublish(demoPublishChecklistReady.items)).toBe(true);
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/publishChecklist.ts
+++ b/src/features/demo-admin-dashboard/publishChecklist.ts
@@ -1,0 +1,182 @@
+import type { Draft } from "./types/draft";
+import type {
+  PublishChecklistItem,
+  PublishChecklistResult,
+  PublishChecklistStatus,
+  PublishChecklistSummary,
+} from "./publishChecklist-types";
+import { isDatasetValid } from "./validation";
+import type { ValidationIssue } from "./validation-types";
+
+/** Allowed recipient domains for demo data (matches QA checklist). */
+export const SAFE_RECIPIENT_DOMAIN_PATTERN = /(@example\.(com|org)|@[\w.-]+\.stealth\.demo)$/i;
+
+const STATUS_RANK: Record<PublishChecklistStatus, number> = {
+  blocked: 0,
+  warning: 1,
+  pass: 2,
+};
+
+function item(
+  id: string,
+  label: string,
+  status: PublishChecklistStatus,
+  detail?: string,
+  hint?: string,
+): PublishChecklistItem {
+  return { id, label, status, detail, hint };
+}
+
+function isSafeRecipient(address: string): boolean {
+  return SAFE_RECIPIENT_DOMAIN_PATTERN.test(address.trim());
+}
+
+function hasRequiredDraftFields(draft: Draft): boolean {
+  return Boolean(
+    draft.id?.trim() &&
+    draft.subject?.trim() &&
+    draft.body?.trim() &&
+    Array.isArray(draft.recipients),
+  );
+}
+
+/** Count checklist items by status. */
+export function summarizePublishChecklist(items: PublishChecklistItem[]): PublishChecklistSummary {
+  const summary: PublishChecklistSummary = {
+    pass: 0,
+    warning: 0,
+    blocked: 0,
+    total: items.length,
+  };
+  for (const entry of items) {
+    summary[entry.status] += 1;
+  }
+  return summary;
+}
+
+/** Sort blocked first, then warnings, then passes (stable by label). */
+export function sortPublishChecklistItems(items: PublishChecklistItem[]): PublishChecklistItem[] {
+  return [...items].sort((a, b) => {
+    const byStatus = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+    if (byStatus !== 0) return byStatus;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/** True when every item is pass or warning (no blockers). */
+export function isReadyToPublish(items: PublishChecklistItem[]): boolean {
+  return items.every((entry) => entry.status !== "blocked");
+}
+
+/**
+ * Build the pre-publish checklist for a draft dataset.
+ * Optional validation issues from field-level validators are folded in.
+ */
+export function buildPublishChecklist(
+  drafts: Draft[],
+  validationIssues: ValidationIssue[] = [],
+): PublishChecklistResult {
+  const items: PublishChecklistItem[] = [];
+
+  if (drafts.length === 0) {
+    items.push(
+      item(
+        "drafts-present",
+        "Draft dataset is not empty",
+        "blocked",
+        "Add at least one draft before publishing.",
+        "Insert a template or create a draft in the Templates tab.",
+      ),
+    );
+  } else {
+    items.push(item("drafts-present", "Draft dataset is not empty", "pass"));
+  }
+
+  const incompleteDrafts = drafts.filter((draft) => !hasRequiredDraftFields(draft));
+  if (incompleteDrafts.length > 0) {
+    items.push(
+      item(
+        "draft-fields",
+        "Each draft has required fields",
+        "blocked",
+        `${incompleteDrafts.length} draft(s) are missing id, subject, body, or recipients.`,
+        "Fill in every required field on each draft row.",
+      ),
+    );
+  } else if (drafts.length > 0) {
+    items.push(item("draft-fields", "Each draft has required fields", "pass"));
+  }
+
+  const draftsWithoutRecipients = drafts.filter((draft) => draft.recipients.length === 0);
+  if (draftsWithoutRecipients.length > 0) {
+    items.push(
+      item(
+        "recipients-present",
+        "Each draft has at least one recipient",
+        "blocked",
+        `${draftsWithoutRecipients.length} draft(s) have no recipients.`,
+        "Add one or more demo addresses per draft.",
+      ),
+    );
+  } else if (drafts.length > 0) {
+    items.push(item("recipients-present", "Each draft has at least one recipient", "pass"));
+  }
+
+  const unsafeRecipients: string[] = [];
+  for (const draft of drafts) {
+    for (const recipient of draft.recipients) {
+      if (!isSafeRecipient(recipient)) {
+        unsafeRecipients.push(recipient);
+      }
+    }
+  }
+  if (unsafeRecipients.length > 0) {
+    items.push(
+      item(
+        "safe-domains",
+        "Recipients use safe demo domains only",
+        "blocked",
+        `Unsafe addresses: ${unsafeRecipients.slice(0, 3).join(", ")}${unsafeRecipients.length > 3 ? "…" : ""}`,
+        "Use example.com, example.org, or a *.stealth.demo handle.",
+      ),
+    );
+  } else if (drafts.length > 0) {
+    items.push(item("safe-domains", "Recipients use safe demo domains only", "pass"));
+  }
+
+  const errorCount = validationIssues.filter((issue) => issue.severity === "error").length;
+  if (!isDatasetValid(validationIssues)) {
+    items.push(
+      item(
+        "validation-errors",
+        "No blocking validation errors",
+        "blocked",
+        `${errorCount} validation error(s) must be resolved.`,
+        "Open the validation panel and fix each error before publishing.",
+      ),
+    );
+  } else {
+    items.push(item("validation-errors", "No blocking validation errors", "pass"));
+  }
+
+  const warningCount = validationIssues.filter((issue) => issue.severity === "warning").length;
+  if (warningCount > 0) {
+    items.push(
+      item(
+        "validation-warnings",
+        "Validation warnings reviewed",
+        "warning",
+        `${warningCount} warning(s) remain — review before publishing.`,
+        "Warnings do not block publish but may affect the demo preview.",
+      ),
+    );
+  } else {
+    items.push(item("validation-warnings", "Validation warnings reviewed", "pass"));
+  }
+
+  const sorted = sortPublishChecklistItems(items);
+  return {
+    items: sorted,
+    readyToPublish: isReadyToPublish(sorted),
+  };
+}

--- a/src/features/demo-admin-dashboard/publishChecklistFixtures.ts
+++ b/src/features/demo-admin-dashboard/publishChecklistFixtures.ts
@@ -1,0 +1,44 @@
+import { draftSample } from "./fixtures/draftFixtures";
+import type { Draft } from "./types/draft";
+import { buildPublishChecklist } from "./publishChecklist";
+import type { PublishChecklistResult } from "./publishChecklist-types";
+import { demoValidationIssues, demoValidationIssuesEmpty } from "./validationFixtures";
+
+/** A single valid draft for checklist demos. */
+export const publishReadyDrafts: Draft[] = [draftSample];
+
+/** Drafts missing recipients — triggers a blocked checklist item. */
+export const publishBlockedDraftsNoRecipients: Draft[] = [
+  {
+    id: "draft-empty-recipients",
+    subject: "No recipients",
+    body: "This draft cannot be published yet.",
+    recipients: [],
+  },
+];
+
+/** Draft with a non-demo recipient domain — triggers safe-domain blocker. */
+export const publishBlockedDraftsUnsafeDomain: Draft[] = [
+  {
+    id: "draft-unsafe",
+    subject: "Unsafe recipient",
+    body: "Uses a real-looking domain.",
+    recipients: ["user@gmail.com"],
+  },
+];
+
+/** Checklist result when the dataset is ready to publish. */
+export const demoPublishChecklistReady: PublishChecklistResult = buildPublishChecklist(
+  publishReadyDrafts,
+  demoValidationIssuesEmpty,
+);
+
+/** Checklist result with blockers from empty recipients. */
+export const demoPublishChecklistBlocked: PublishChecklistResult = buildPublishChecklist(
+  publishBlockedDraftsNoRecipients,
+  demoValidationIssuesEmpty,
+);
+
+/** Checklist result combining draft issues and validation errors. */
+export const demoPublishChecklistWithValidationErrors: PublishChecklistResult =
+  buildPublishChecklist(publishReadyDrafts, demoValidationIssues);


### PR DESCRIPTION
## Summary
- Add PublishChecklist panel component that shows admins whether a draft dataset is ready to populate the demo UI
- Implement buildPublishChecklist with validation checks for empty datasets, required fields, safe recipient domains, and validation error/warning states
- Include deterministic fixtures, 16 unit tests, and documentation; all changes scoped to src/features/demo-admin-dashboard/

Closes #194

## Test plan
- [x] npx vitest run src/features/demo-admin-dashboard/publishChecklist.test.ts (16 tests pass)
- [x] bun run test (CI unit tests pass)
- [x] bun x tsc --noEmit
- [ ] CI pipeline green on PR

Made with [Cursor](https://cursor.com)