### PR TITLE
feat(demo-admin): build bulk folder move tool for draft messages

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/bulkMovePanel.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/bulkMovePanel.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBulkFolderMove,
+  getMessageFolderLabel,
+  isValidMessageFolder,
+  previewBulkFolderMove,
+  summarizeBulkFolderMove,
+  validateBulkFolderMove,
+} from "../bulkMovePanel";
+import type { EditableMessage } from "../constants/messageListEditorModel";
+
+function makeMessage(id: string, folder: EditableMessage["folder"]): EditableMessage {
+  return {
+    id,
+    subject: `Subject ${id}`,
+    sender: `sender-${id}@example.com`,
+    preview: `Preview ${id}`,
+    folder,
+    unread: false,
+    starred: false,
+  };
+}
+
+function sampleMessages(): EditableMessage[] {
+  return [makeMessage("m1", "inbox"), makeMessage("m2", "drafts"), makeMessage("m3", "archive")];
+}
+
+describe("isValidMessageFolder", () => {
+  it("accepts known folders and rejects unknown values", () => {
+    expect(isValidMessageFolder("inbox")).toBe(true);
+    expect(isValidMessageFolder("drafts")).toBe(true);
+    expect(isValidMessageFolder("snoozed")).toBe(false);
+    expect(isValidMessageFolder("pending")).toBe(false);
+  });
+});
+
+describe("validateBulkFolderMove", () => {
+  it("rejects empty selection", () => {
+    const result = validateBulkFolderMove(sampleMessages(), [], "drafts");
+    expect(result).toEqual({ ok: false, error: "Select at least one message to move." });
+  });
+
+  it("rejects invalid target folders", () => {
+    const result = validateBulkFolderMove(sampleMessages(), ["m1"], "snoozed");
+    expect(result).toEqual({ ok: false, error: "Choose a valid destination folder." });
+  });
+
+  it("rejects unknown message ids", () => {
+    const result = validateBulkFolderMove(sampleMessages(), ["m1", "missing"], "drafts");
+    expect(result).toEqual({ ok: false, error: "Unknown message id(s): missing" });
+  });
+
+  it("accepts valid input", () => {
+    expect(validateBulkFolderMove(sampleMessages(), ["m1", "m2"], "drafts")).toEqual({ ok: true });
+  });
+});
+
+describe("previewBulkFolderMove", () => {
+  it("counts moves and skips for already-matched folders", () => {
+    const preview = previewBulkFolderMove(sampleMessages(), ["m1", "m2", "m3"], "drafts");
+    expect(preview).toEqual({
+      targetFolder: "drafts",
+      selectedCount: 3,
+      movedCount: 2,
+      skippedCount: 1,
+    });
+  });
+});
+
+describe("applyBulkFolderMove", () => {
+  it("moves selected messages without mutating input", () => {
+    const messages = sampleMessages();
+    const result = applyBulkFolderMove(messages, ["m1", "m3"], "drafts");
+
+    expect(messages[0].folder).toBe("inbox");
+    expect(messages[2].folder).toBe("archive");
+    expect(result.messages[0].folder).toBe("drafts");
+    expect(result.messages[1].folder).toBe("drafts");
+    expect(result.messages[2].folder).toBe("drafts");
+  });
+
+  it("skips messages already in the target folder", () => {
+    const result = applyBulkFolderMove(sampleMessages(), ["m2"], "drafts");
+
+    expect(result.changes[0]).toMatchObject({
+      id: "m2",
+      applied: false,
+      skippedReason: "already in target folder",
+    });
+    expect(result.summary.movedCount).toBe(0);
+    expect(result.summary.skippedCount).toBe(1);
+  });
+});
+
+describe("summarizeBulkFolderMove", () => {
+  it("summarizes successful moves", () => {
+    const result = applyBulkFolderMove(sampleMessages(), ["m1", "m3"], "drafts");
+    expect(summarizeBulkFolderMove(result)).toBe(
+      `Moved 2 messages to ${getMessageFolderLabel("drafts")}.`,
+    );
+  });
+
+  it("reports when nothing changed", () => {
+    const result = applyBulkFolderMove(sampleMessages(), ["m2"], "drafts");
+    expect(summarizeBulkFolderMove(result)).toBe(
+      `No changes — all already in the target folder (1 skipped).`,
+    );
+  });
+
+  it("reports partial skips", () => {
+    const result = applyBulkFolderMove(sampleMessages(), ["m1", "m2"], "drafts");
+    expect(summarizeBulkFolderMove(result)).toBe(
+      `Moved 1 message to ${getMessageFolderLabel("drafts")} (1 skipped — already in ${getMessageFolderLabel("drafts")}).`,
+    );
+  });
+});

--- a/src/features/demo-admin-dashboard/bulkMovePanel.ts
+++ b/src/features/demo-admin-dashboard/bulkMovePanel.ts
@@ -1,0 +1,161 @@
+import {
+  MESSAGE_FOLDERS,
+  type EditableMessage,
+  type MessageFolder,
+} from "./constants/messageListEditorModel";
+import { FOLDER_DEFINITIONS } from "./constants/folderTaxonomy";
+
+export interface BulkMoveMessageChange {
+  id: string;
+  subject: string;
+  fromFolder: MessageFolder;
+  toFolder: MessageFolder;
+  applied: boolean;
+  skippedReason?: string;
+}
+
+export interface BulkMoveAuditSummary {
+  targetFolder: MessageFolder;
+  selectedCount: number;
+  movedCount: number;
+  skippedCount: number;
+}
+
+export interface BulkMoveEditResult {
+  messages: EditableMessage[];
+  targetFolder: MessageFolder;
+  changes: BulkMoveMessageChange[];
+  summary: BulkMoveAuditSummary;
+}
+
+export type BulkMoveValidation = { ok: true } | { ok: false; error: string };
+
+export function isValidMessageFolder(folder: string): folder is MessageFolder {
+  return (MESSAGE_FOLDERS as readonly string[]).includes(folder);
+}
+
+export function getMessageFolderLabel(folder: MessageFolder): string {
+  return FOLDER_DEFINITIONS[folder].label;
+}
+
+export function validateBulkFolderMove(
+  messages: EditableMessage[],
+  selectedIds: string[],
+  targetFolder: string,
+): BulkMoveValidation {
+  if (selectedIds.length === 0) {
+    return { ok: false, error: "Select at least one message to move." };
+  }
+
+  if (!isValidMessageFolder(targetFolder)) {
+    return { ok: false, error: "Choose a valid destination folder." };
+  }
+
+  const knownIds = new Set(messages.map((message) => message.id));
+  const missingIds = selectedIds.filter((id) => !knownIds.has(id));
+  if (missingIds.length > 0) {
+    return { ok: false, error: `Unknown message id(s): ${missingIds.join(", ")}` };
+  }
+
+  return { ok: true };
+}
+
+export function previewBulkFolderMove(
+  messages: EditableMessage[],
+  selectedIds: string[],
+  targetFolder: MessageFolder,
+): BulkMoveAuditSummary {
+  const selected = new Set(selectedIds);
+  let movedCount = 0;
+  let skippedCount = 0;
+
+  for (const message of messages) {
+    if (!selected.has(message.id)) {
+      continue;
+    }
+    if (message.folder === targetFolder) {
+      skippedCount++;
+    } else {
+      movedCount++;
+    }
+  }
+
+  return {
+    targetFolder,
+    selectedCount: selectedIds.length,
+    movedCount,
+    skippedCount,
+  };
+}
+
+export function applyBulkFolderMove(
+  messages: EditableMessage[],
+  selectedIds: string[],
+  targetFolder: MessageFolder,
+): BulkMoveEditResult {
+  const selected = new Set(selectedIds);
+  const changes: BulkMoveMessageChange[] = [];
+
+  const nextMessages = messages.map((message) => {
+    if (!selected.has(message.id)) {
+      return message;
+    }
+
+    const fromFolder = message.folder;
+    if (fromFolder === targetFolder) {
+      changes.push({
+        id: message.id,
+        subject: message.subject,
+        fromFolder,
+        toFolder: targetFolder,
+        applied: false,
+        skippedReason: "already in target folder",
+      });
+      return message;
+    }
+
+    changes.push({
+      id: message.id,
+      subject: message.subject,
+      fromFolder,
+      toFolder: targetFolder,
+      applied: true,
+    });
+    return { ...message, folder: targetFolder };
+  });
+
+  const movedCount = changes.filter((change) => change.applied).length;
+  const skippedCount = changes.filter((change) => !change.applied).length;
+
+  return {
+    messages: nextMessages,
+    targetFolder,
+    changes,
+    summary: {
+      targetFolder,
+      selectedCount: changes.length,
+      movedCount,
+      skippedCount,
+    },
+  };
+}
+
+export function summarizeBulkFolderMove(result: BulkMoveEditResult): string {
+  const { summary } = result;
+  const targetLabel = getMessageFolderLabel(summary.targetFolder);
+
+  if (summary.movedCount === 0) {
+    const reason =
+      summary.skippedCount > 0 ? "all already in the target folder" : "no messages selected";
+    return `No changes — ${reason} (${summary.skippedCount} skipped).`;
+  }
+
+  const messageWord = summary.movedCount === 1 ? "message" : "messages";
+  const base = `Moved ${summary.movedCount} ${messageWord} to ${targetLabel}`;
+
+  if (summary.skippedCount === 0) {
+    return `${base}.`;
+  }
+
+  return `${base} (${summary.skippedCount} skipped — already in ${targetLabel}).`;
+}

--- a/src/features/demo-admin-dashboard/components/BulkMovePanel.tsx
+++ b/src/features/demo-admin-dashboard/components/BulkMovePanel.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from "react";
+import { ArrowRight, FolderInput, MoveRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  MESSAGE_FOLDERS,
+  type EditableMessage,
+  type MessageFolder,
+} from "../constants/messageListEditorModel";
+import {
+  applyBulkFolderMove,
+  getMessageFolderLabel,
+  previewBulkFolderMove,
+  summarizeBulkFolderMove,
+  validateBulkFolderMove,
+  type BulkMoveEditResult,
+} from "../bulkMovePanel";
+
+export interface BulkMovePanelProps {
+  /** Full demo message list used to resolve moves. */
+  messages: EditableMessage[];
+  /** IDs of the messages selected for a bulk move. */
+  selectedIds: string[];
+  /** Called with the updated list and audit result after a successful move. */
+  onApply?: (result: BulkMoveEditResult) => void;
+  className?: string;
+}
+
+export function BulkMovePanel({ messages, selectedIds, onApply, className }: BulkMovePanelProps) {
+  const [targetFolder, setTargetFolder] = useState<MessageFolder>("drafts");
+  const [lastResult, setLastResult] = useState<BulkMoveEditResult | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const selectedMessages = useMemo(
+    () => messages.filter((message) => selectedIds.includes(message.id)),
+    [messages, selectedIds],
+  );
+
+  const preview = useMemo(
+    () => previewBulkFolderMove(messages, selectedIds, targetFolder),
+    [messages, selectedIds, targetFolder],
+  );
+
+  const handleMove = () => {
+    const validation = validateBulkFolderMove(messages, selectedIds, targetFolder);
+    if (!validation.ok) {
+      setValidationError(validation.error);
+      setLastResult(null);
+      return;
+    }
+
+    setValidationError(null);
+    const result = applyBulkFolderMove(messages, selectedIds, targetFolder);
+    setLastResult(result);
+    onApply?.(result);
+  };
+
+  if (selectedMessages.length === 0) {
+    return (
+      <section
+        className={cn(
+          "flex flex-col items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] p-6 text-center",
+          className,
+        )}
+      >
+        <FolderInput className="h-8 w-8 text-muted-foreground opacity-50" />
+        <p className="text-sm text-muted-foreground">
+          No messages selected. Select one or more demo messages to move between folders.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4",
+        className,
+      )}
+    >
+      <header className="flex items-center gap-2">
+        <MoveRight className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Bulk folder move</h3>
+      </header>
+
+      <p className="text-sm text-muted-foreground">
+        Move {selectedMessages.length} selected message
+        {selectedMessages.length === 1 ? "" : "s"} to another demo folder.
+      </p>
+
+      <ul className="flex flex-col gap-1">
+        {selectedMessages.map((message) => (
+          <li
+            key={message.id}
+            className="flex items-center justify-between rounded-lg border border-white/[0.06] px-3 py-2 text-sm"
+          >
+            <span className="truncate pr-3">{message.subject || "(no subject)"}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {getMessageFolderLabel(message.folder)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="bulk-move-target-folder" className="text-sm font-medium">
+          Destination folder
+        </label>
+        <select
+          id="bulk-move-target-folder"
+          value={targetFolder}
+          onChange={(event) => setTargetFolder(event.target.value as MessageFolder)}
+          className="rounded-lg border border-white/[0.08] bg-transparent px-3 py-2 text-sm outline-none focus:border-sky-500/40"
+        >
+          {MESSAGE_FOLDERS.map((folder) => (
+            <option key={folder} value={folder}>
+              {getMessageFolderLabel(folder)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-sm">
+        <p className="font-medium">Move preview</p>
+        <p className="mt-1 text-muted-foreground">
+          {preview.movedCount} will move to {getMessageFolderLabel(preview.targetFolder)}
+          {preview.skippedCount > 0
+            ? `; ${preview.skippedCount} already in ${getMessageFolderLabel(preview.targetFolder)}`
+            : ""}
+          .
+        </p>
+        {preview.movedCount > 0 ? (
+          <ul className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
+            {selectedMessages
+              .filter((message) => message.folder !== targetFolder)
+              .map((message) => (
+                <li key={message.id} className="flex items-center gap-1">
+                  <span className="truncate">{message.subject || message.id}</span>
+                  <ArrowRight className="h-3 w-3 shrink-0" />
+                  <span>{getMessageFolderLabel(targetFolder)}</span>
+                </li>
+              ))}
+          </ul>
+        ) : null}
+      </div>
+
+      {validationError ? (
+        <p className="text-sm text-rose-300" role="alert">
+          {validationError}
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={handleMove}
+        disabled={preview.movedCount === 0}
+        className={cn(
+          "flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors",
+          preview.movedCount > 0
+            ? "border-sky-500/30 bg-sky-500/10 text-sky-200 hover:bg-sky-500/20"
+            : "cursor-not-allowed border-white/[0.06] text-muted-foreground opacity-60",
+        )}
+      >
+        <MoveRight className="h-4 w-4" />
+        Move to {getMessageFolderLabel(targetFolder)}
+      </button>
+
+      {lastResult ? (
+        <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 text-sm">
+          <p className="font-medium">{summarizeBulkFolderMove(lastResult)}</p>
+          <ul className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
+            {lastResult.changes
+              .filter((change) => change.applied)
+              .map((change) => (
+                <li key={change.id}>
+                  {change.subject}: {getMessageFolderLabel(change.fromFolder)} →{" "}
+                  {getMessageFolderLabel(change.toFolder)}
+                </li>
+              ))}
+            {lastResult.changes
+              .filter((change) => !change.applied)
+              .map((change) => (
+                <li key={change.id}>
+                  {change.subject}: skipped ({change.skippedReason})
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/demo-admin-dashboard/docs/BULK_MOVE_PANEL.md
+++ b/src/features/demo-admin-dashboard/docs/BULK_MOVE_PANEL.md
@@ -1,0 +1,56 @@
+# Bulk Move Panel
+
+Lets an admin move multiple selected demo messages between mailbox folders at
+once, with validation, a move preview, and an audit summary of what changed.
+
+All logic and UI live inside `src/features/demo-admin-dashboard/` and operate on
+fake, deterministic demo data (`EditableMessage[]`). Nothing here touches real
+mail flows, network calls, or data outside this folder.
+
+## Pieces
+
+- `bulkMovePanel.ts` — pure, immutable helpers:
+  - `isValidMessageFolder` — checks a folder id against the message-list
+    taxonomy (`MessageFolder`).
+  - `validateBulkFolderMove` — rejects empty selections, unknown message ids, and
+    invalid destination folders before a move runs.
+  - `previewBulkFolderMove` — counts how many selected messages would move vs
+    skip without mutating input.
+  - `applyBulkFolderMove(messages, selectedIds, targetFolder)` — returns a new
+    message list plus a per-message change log and an audit summary. Inputs are
+    never mutated.
+  - `summarizeBulkFolderMove(result)` — a one-line human summary.
+- `components/BulkMovePanel.tsx` — selected-message list, destination folder
+  picker, move preview, and audit output.
+
+## Folder taxonomy
+
+Bulk moves use `MessageFolder` from the message-list editor model (`inbox`,
+`sent`, `drafts`, `archive`, `spam`, `trash`). Display labels come from the
+shared `FOLDER_DEFINITIONS` map. The `snoozed` folder is intentionally excluded
+here because it is not part of the editable message-list model.
+
+## Validation
+
+- **Selection:** at least one message id must be selected.
+- **Target folder:** must be a known `MessageFolder`.
+- **Message ids:** every selected id must exist in the provided message list.
+
+Validation errors are surfaced in the panel before any move is applied.
+
+## Skip rules
+
+A selected message already filed under the destination folder is skipped (never
+duplicated or re-written). Skipped messages are reported per item and counted in
+the audit summary.
+
+## Audit summary
+
+`applyBulkFolderMove` returns a `summary` with the target folder, number of
+selected messages, and counts for moved vs skipped items. Example line:
+`Moved 2 messages to Drafts (1 skipped — already in Drafts).`
+
+## Follow-up
+
+Wiring this component into the main dashboard view is intentionally left as a
+follow-up so this change stays scoped and independently reviewable.

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -503,6 +503,24 @@ export type {
   BulkLabelOperation,
 } from "./bulkLabelPanel";
 
+// Bulk move panel (issue #204): move selected demo messages between mailbox folders.
+export { BulkMovePanel } from "./components/BulkMovePanel";
+export type { BulkMovePanelProps } from "./components/BulkMovePanel";
+export {
+  applyBulkFolderMove,
+  getMessageFolderLabel,
+  isValidMessageFolder,
+  previewBulkFolderMove,
+  summarizeBulkFolderMove,
+  validateBulkFolderMove,
+} from "./bulkMovePanel";
+export type {
+  BulkMoveAuditSummary,
+  BulkMoveEditResult,
+  BulkMoveMessageChange,
+  BulkMoveValidation,
+} from "./bulkMovePanel";
+
 // Draft dataset JSON import (issue #272): JSON -> safe drafts mapper with error output.
 export { mapImportedDataset, parseDatasetImport } from "./helpers/datasetImport";
 export type { DatasetImportIssue, DatasetImportResult } from "./types/datasetImport";


### PR DESCRIPTION
## Summary

- Adds \BulkMovePanel\ so admins can move selected demo messages between mailbox folders in the demo admin dashboard.
- Introduces pure helpers in \ulkMovePanel.ts\: move validation, move preview, immutable apply logic, and audit summary strings.
- Includes unit tests and \docs/BULK_MOVE_PANEL.md\. All changes are scoped to \src/features/demo-admin-dashboard/\.

Closes #204

## Test plan

- [x] \un x vitest run src/features/demo-admin-dashboard/__tests__/bulkMovePanel.test.ts\ (11 tests)
- [x] \un run test\ (592 unit tests)
- [x] \un x tsc --noEmit\
- [x] \un run build\
- [x] ESLint on changed files

Made with [Cursor](https://cursor.com)