### PR TITLE
fix(receipts): close keyboard and screen-reader gaps in provenance UI

### DIFF
--- a/src/components/mail/PostageDisputePanel.tsx
+++ b/src/components/mail/PostageDisputePanel.tsx
@@ -8,8 +8,8 @@ import {
   History,
   Info,
 } from "lucide-react";
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useId, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 /**
@@ -77,6 +77,12 @@ function DisabledAction({
 
 export function PostageDisputePanel({ postageStatus, amountXlm }: PostageDisputePanelProps) {
   const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const prefersReducedMotion = useReducedMotion();
+  const accordionTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { duration: 0.22, ease: "easeInOut" as const };
+  const chevronTransition = prefersReducedMotion ? { duration: 0 } : { duration: 0.2 };
 
   const isDisputable = postageStatus === "expired" || postageStatus === "pending";
 
@@ -84,12 +90,15 @@ export function PostageDisputePanel({ postageStatus, amountXlm }: PostageDispute
     <div className="mt-2 rounded-xl border border-amber-500/20 bg-amber-500/[0.03]">
       {/* Header toggle */}
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left"
+        className="flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left focus:outline-none focus:ring-2 focus:ring-amber-400/30"
         aria-expanded={open}
+        aria-controls={panelId}
+        aria-label={open ? "Hide dispute and appeal details" : "Show dispute and appeal details"}
       >
         <div className="flex items-center gap-2">
-          <Flag className="h-3.5 w-3.5 text-amber-400/80 shrink-0" />
+          <Flag className="h-3.5 w-3.5 text-amber-400/80 shrink-0" aria-hidden="true" />
           <span className="text-[10.5px] font-semibold uppercase tracking-[0.14em] text-amber-400/80">
             Dispute &amp; Appeal
           </span>
@@ -97,19 +106,22 @@ export function PostageDisputePanel({ postageStatus, amountXlm }: PostageDispute
             Roadmap
           </span>
         </div>
-        <motion.div animate={{ rotate: open ? 180 : 0 }} transition={{ duration: 0.2 }}>
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        <motion.div animate={{ rotate: open ? 180 : 0 }} transition={chevronTransition}>
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
         </motion.div>
       </button>
 
       <AnimatePresence initial={false}>
         {open && (
           <motion.div
-            initial={{ height: 0, opacity: 0 }}
+            id={panelId}
+            initial={prefersReducedMotion ? false : { height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.22, ease: "easeInOut" }}
+            exit={prefersReducedMotion ? undefined : { height: 0, opacity: 0 }}
+            transition={accordionTransition}
             className="overflow-hidden"
+            role="region"
+            aria-label="Postage dispute and appeal placeholder"
           >
             <div className="space-y-3 border-t border-amber-500/[0.12] px-3 pb-3 pt-2.5">
               {/* Roadmap notice */}

--- a/src/components/mail/ProvenanceInspector.tsx
+++ b/src/components/mail/ProvenanceInspector.tsx
@@ -2,6 +2,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import { X, Copy, Check, FileJson, Cpu } from "lucide-react";
 import { useState } from "react";
 import type { ProvenanceItemDetails } from "./provenance";
+import { motionPresets } from "@/lib/motion-presets";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import { copyFieldAriaLabel } from "./provenance-a11y";
 
 export function ProvenanceInspector({
   open,
@@ -15,6 +18,8 @@ export function ProvenanceInspector({
   onShowToast?: (message: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
+  const dialogRef = useFocusTrap(open && details !== null, onClose);
+  const headingId = "provenance-inspector-title";
 
   const handleCopyJson = async () => {
     if (!details) return;
@@ -34,33 +39,36 @@ export function ProvenanceInspector({
         <>
           {/* Overlay */}
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
+            {...motionPresets.patterns.modal.backdrop}
             onClick={onClose}
             className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
           />
 
           {/* Modal Container */}
           <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 16 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 16 }}
-            transition={{ type: "spring", stiffness: 350, damping: 28 }}
-            className="glass-modal fixed left-1/2 top-1/2 z-[60] w-[min(540px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl shadow-2xl"
+            {...motionPresets.patterns.modal.content}
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={headingId}
+            tabIndex={-1}
+            className="glass-modal fixed left-1/2 top-1/2 z-[60] w-[min(540px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl shadow-2xl focus:outline-none"
           >
             {/* Header */}
             <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
               <div className="flex items-center gap-2">
-                <Cpu className="h-4 w-4 text-emerald-300" />
-                <h3 className="text-sm font-semibold text-foreground">{details.title}</h3>
+                <Cpu className="h-4 w-4 text-emerald-300" aria-hidden="true" />
+                <h3 id={headingId} className="text-sm font-semibold text-foreground">
+                  {details.title}
+                </h3>
               </div>
               <button
+                type="button"
                 onClick={onClose}
-                className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
+                className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground focus:outline-none focus:ring-2 focus:ring-white/10"
                 aria-label="Close dialog"
               >
-                <X className="h-4 w-4" />
+                <X className="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
 
@@ -71,7 +79,11 @@ export function ProvenanceInspector({
               </p>
 
               {/* Technical key-value list */}
-              <div className="rounded-xl border border-white/[0.06] bg-black/15 overflow-hidden">
+              <div
+                className="rounded-xl border border-white/[0.06] bg-black/15 overflow-hidden"
+                role="region"
+                aria-label="Verification fields"
+              >
                 <div className="divide-y divide-white/[0.05]">
                   {details.keyValuePairs.map((pair, idx) => (
                     <div key={idx} className="grid grid-cols-[140px_1fr] p-3 gap-2">
@@ -96,27 +108,33 @@ export function ProvenanceInspector({
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                    <FileJson className="h-3 w-3" />
+                    <FileJson className="h-3 w-3" aria-hidden="true" />
                     <span>Raw Verification Record (JSON)</span>
                   </div>
                   <button
+                    type="button"
                     onClick={handleCopyJson}
-                    className="flex items-center gap-1 rounded border border-white/10 bg-white/[0.04] px-2 py-1 text-[10px] text-muted-foreground transition hover:border-white/20 hover:text-foreground hover:bg-white/[0.08]"
+                    aria-label={copyFieldAriaLabel("raw JSON record", copied)}
+                    aria-pressed={copied}
+                    className="flex items-center gap-1 rounded border border-white/10 bg-white/[0.04] px-2 py-1 text-[10px] text-muted-foreground transition hover:border-white/20 hover:text-foreground hover:bg-white/[0.08] focus:outline-none focus:ring-2 focus:ring-white/10"
                   >
                     {copied ? (
                       <>
-                        <Check className="h-3 w-3 text-emerald-400" />
+                        <Check className="h-3 w-3 text-emerald-400" aria-hidden="true" />
                         <span className="text-emerald-400">Copied</span>
                       </>
                     ) : (
                       <>
-                        <Copy className="h-3 w-3" />
+                        <Copy className="h-3 w-3" aria-hidden="true" />
                         <span>Copy JSON</span>
                       </>
                     )}
                   </button>
                 </div>
-                <pre className="scrollbar-thin overflow-auto rounded-xl border border-white/[0.06] bg-black/25 p-3.5 font-mono text-[11px] leading-relaxed text-foreground/80 max-h-56">
+                <pre
+                  className="scrollbar-thin overflow-auto rounded-xl border border-white/[0.06] bg-black/25 p-3.5 font-mono text-[11px] leading-relaxed text-foreground/80 max-h-56"
+                  aria-label="Raw verification JSON"
+                >
                   {details.rawJson}
                 </pre>
               </div>
@@ -125,8 +143,9 @@ export function ProvenanceInspector({
             {/* Footer */}
             <div className="flex justify-end border-t border-white/5 px-5 py-3.5 bg-black/10">
               <button
+                type="button"
                 onClick={onClose}
-                className="rounded-lg border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-semibold text-foreground transition hover:bg-white/[0.08] hover:border-white/20"
+                className="rounded-lg border border-white/10 bg-white/[0.03] px-4 py-2 text-xs font-semibold text-foreground transition hover:bg-white/[0.08] hover:border-white/20 focus:outline-none focus:ring-2 focus:ring-white/10"
               >
                 Done
               </button>

--- a/src/components/mail/ProvenancePanel.tsx
+++ b/src/components/mail/ProvenancePanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useId, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import {
   Shield,
   ShieldCheck,
@@ -18,13 +18,19 @@ import {
 } from "lucide-react";
 import {
   getEmailProvenance,
-  type ProvenanceDetails,
   type ProvenanceItemDetails,
   type ProvenanceTimelineItem,
 } from "./provenance";
 import { ProvenanceInspector } from "./ProvenanceInspector";
 import { PostageDisputePanel, type PostageDisputeStatus } from "./PostageDisputePanel";
 import type { Email } from "./data";
+import {
+  copyFieldAriaLabel,
+  inspectFieldAriaLabel,
+  provenanceStatusHeading,
+  technicalProvenanceToggleLabel,
+  timelineStepAriaLabel,
+} from "./provenance-a11y";
 
 /** Map provenance status strings to the contract PostageStatus enum values. */
 function deriveDisputeStatus(status: string): PostageDisputeStatus {
@@ -38,6 +44,8 @@ function deriveDisputeStatus(status: string): PostageDisputeStatus {
   return "pending";
 }
 
+const focusRingClass = "focus:outline-none focus:ring-2 focus:ring-white/10";
+
 export function ProvenancePanel({
   email,
   onShowToast,
@@ -50,12 +58,20 @@ export function ProvenancePanel({
   const [expanded, setExpanded] = useState(false);
   const [inspectItem, setInspectItem] = useState<ProvenanceItemDetails | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const technicalDetailsId = useId();
+  const statusHeadingId = useId();
+  const timelineHeadingId = useId();
+  const accordionTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { duration: 0.25, ease: "easeInOut" as const };
+  const chevronTransition = prefersReducedMotion ? { duration: 0 } : { duration: 0.2 };
 
   if (!email) {
     return (
-      <div className="text-center py-6 text-xs text-muted-foreground">
+      <p className="text-center py-6 text-xs text-muted-foreground" role="status">
         Select a message to view cryptographic provenance.
-      </div>
+      </p>
     );
   }
 
@@ -92,6 +108,8 @@ export function ProvenancePanel({
   };
 
   const isVerified = provenance.senderIdentity.isVerified;
+  const isSpam = email.folder === "spam";
+  const completedSteps = provenance.timeline.filter((item) => item.status === "complete").length;
 
   // Render a single field row inside the detailed panel
   const FieldRow = ({
@@ -116,28 +134,31 @@ export function ProvenancePanel({
     return (
       <div className="flex flex-col gap-1 rounded-lg border border-white/[0.04] bg-white/[0.02] p-2.5 transition hover:bg-white/[0.04]">
         <div className="flex items-center gap-2">
-          <Icon className="h-3.5 w-3.5 text-muted-foreground/80 shrink-0" />
+          <Icon className="h-3.5 w-3.5 text-muted-foreground/80 shrink-0" aria-hidden="true" />
           <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {label}
           </span>
           <div className="ml-auto flex items-center gap-1.5">
             <button
+              type="button"
               onClick={() => handleCopy(fieldKey, rawValue, label)}
-              className="rounded p-1 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
-              title={`Copy ${label}`}
+              className={`rounded p-1 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground ${focusRingClass}`}
+              aria-label={copyFieldAriaLabel(label, isCopied)}
+              aria-pressed={isCopied}
             >
               {isCopied ? (
-                <Check className="h-3 w-3 text-emerald-400" />
+                <Check className="h-3 w-3 text-emerald-400" aria-hidden="true" />
               ) : (
-                <Copy className="h-3 w-3" />
+                <Copy className="h-3 w-3" aria-hidden="true" />
               )}
             </button>
             <button
+              type="button"
               onClick={() => setInspectItem(inspectorData)}
-              className="rounded p-1 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
-              title={`Inspect ${label}`}
+              className={`rounded p-1 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground ${focusRingClass}`}
+              aria-label={inspectFieldAriaLabel(label)}
             >
-              <Search className="h-3 w-3" />
+              <Search className="h-3 w-3" aria-hidden="true" />
             </button>
           </div>
         </div>
@@ -158,13 +179,16 @@ export function ProvenancePanel({
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" role="region" aria-label="Message provenance and receipt details">
       {/* High-level status header */}
-      <div className="flex items-start gap-3 rounded-xl border border-white/[0.06] bg-black/15 p-3">
-        <div className="mt-0.5 shrink-0">
+      <section
+        className="flex items-start gap-3 rounded-xl border border-white/[0.06] bg-black/15 p-3"
+        aria-labelledby={statusHeadingId}
+      >
+        <div className="mt-0.5 shrink-0" aria-hidden="true">
           {isVerified ? (
             <ShieldCheck className="h-5 w-5 text-emerald-300" />
-          ) : email.folder === "spam" ? (
+          ) : isSpam ? (
             <ShieldAlert className="h-5 w-5 text-red-300" />
           ) : (
             <Shield className="h-5 w-5 text-amber-200" />
@@ -172,33 +196,34 @@ export function ProvenancePanel({
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
-            <span className="text-xs font-semibold text-foreground">
-              {isVerified
-                ? "Secure On-Chain Route"
-                : email.folder === "spam"
-                  ? "SMTP Bridged (Unverified)"
-                  : "Awaiting Envelope Proof"}
-            </span>
+            <h4 id={statusHeadingId} className="text-xs font-semibold text-foreground">
+              {provenanceStatusHeading(isVerified, isSpam)}
+            </h4>
           </div>
           <p className="mt-1 text-[10.5px] leading-relaxed text-muted-foreground/90">
             {isVerified
               ? `Delivered via ${provenance.relaySource.nodeId} with a verified postage record.`
-              : email.folder === "spam"
+              : isSpam
                 ? "Bridged message without Stellar cryptographic signatures."
                 : "Message processed but security verification is currently in progress."}
           </p>
         </div>
-      </div>
+      </section>
 
-      <div className="mt-4 rounded-2xl border border-white/[0.06] bg-black/10 p-3">
-        <div className="flex items-center justify-between gap-3 text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+      <section
+        className="mt-4 rounded-2xl border border-white/[0.06] bg-black/10 p-3"
+        aria-labelledby={timelineHeadingId}
+      >
+        <div
+          id={timelineHeadingId}
+          className="flex items-center justify-between gap-3 text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
+        >
           <span>Proof Timeline</span>
-          <span>
-            {provenance.timeline.filter((item) => item.status === "complete").length}/
-            {provenance.timeline.length} complete
+          <span aria-live="polite">
+            {completedSteps}/{provenance.timeline.length} complete
           </span>
         </div>
-        <div className="mt-3 space-y-3">
+        <ol className="mt-3 space-y-3" aria-label="Proof timeline steps">
           {provenance.timeline.map((item, index) => {
             const Icon = getTimelineIcon(item.key);
             const statusStyles =
@@ -209,8 +234,12 @@ export function ProvenancePanel({
                   : "border-white/10 bg-white/10 text-muted-foreground";
 
             return (
-              <div key={item.key} className="grid grid-cols-[auto_1fr] gap-3">
-                <div className="relative flex flex-col items-center">
+              <li
+                key={item.key}
+                className="grid grid-cols-[auto_1fr] gap-3"
+                aria-label={timelineStepAriaLabel(item)}
+              >
+                <div className="relative flex flex-col items-center" aria-hidden="true">
                   <span
                     className={`grid h-9 w-9 place-items-center rounded-full border ${statusStyles}`}
                   >
@@ -228,37 +257,47 @@ export function ProvenancePanel({
                         {item.description}
                       </p>
                     </div>
-                    <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                    <time
+                      className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
+                      dateTime={item.timestamp}
+                    >
                       {item.timestamp}
-                    </span>
+                    </time>
                   </div>
                 </div>
-              </div>
+              </li>
             );
           })}
-        </div>
-      </div>
+        </ol>
+      </section>
 
       {/* Accordion Toggle for Progressive Disclosure */}
       <div className="border-t border-white/[0.06] pt-1">
         <button
+          type="button"
           onClick={() => setExpanded(!expanded)}
-          className="flex w-full items-center justify-between py-2 text-[10.5px] font-semibold uppercase tracking-[0.14em] text-muted-foreground transition hover:text-foreground"
+          className={`flex w-full items-center justify-between py-2 text-[10.5px] font-semibold uppercase tracking-[0.14em] text-muted-foreground transition hover:text-foreground ${focusRingClass}`}
+          aria-expanded={expanded}
+          aria-controls={technicalDetailsId}
+          aria-label={technicalProvenanceToggleLabel(expanded)}
         >
           <span>Technical Provenance</span>
-          <motion.div animate={{ rotate: expanded ? 180 : 0 }} transition={{ duration: 0.2 }}>
-            <ChevronDown className="h-3.5 w-3.5" />
+          <motion.div animate={{ rotate: expanded ? 180 : 0 }} transition={chevronTransition}>
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
           </motion.div>
         </button>
 
         <AnimatePresence initial={false}>
           {expanded && (
             <motion.div
-              initial={{ height: 0, opacity: 0 }}
+              id={technicalDetailsId}
+              initial={prefersReducedMotion ? false : { height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.25, ease: "easeInOut" }}
+              exit={prefersReducedMotion ? undefined : { height: 0, opacity: 0 }}
+              transition={accordionTransition}
               className="overflow-hidden"
+              role="region"
+              aria-label="Technical provenance fields"
             >
               <div className="space-y-2 pb-2 pt-1.5">
                 <FieldRow

--- a/src/components/mail/provenance-a11y.ts
+++ b/src/components/mail/provenance-a11y.ts
@@ -1,0 +1,42 @@
+import type { ProvenanceTimelineItem } from "./provenance";
+
+/** Screen-reader label for a proof timeline step status. */
+export function timelineStepStatusLabel(status: ProvenanceTimelineItem["status"]): string {
+  switch (status) {
+    case "complete":
+      return "Complete";
+    case "pending":
+      return "Pending";
+    case "skipped":
+      return "Skipped";
+    default:
+      return "Unknown";
+  }
+}
+
+/** Accessible name for the provenance security summary heading. */
+export function provenanceStatusHeading(isVerified: boolean, isSpam: boolean): string {
+  if (isVerified) return "Secure on-chain route";
+  if (isSpam) return "SMTP bridged, unverified";
+  return "Awaiting envelope proof";
+}
+
+/** Accessible name for copy-to-clipboard controls on provenance fields. */
+export function copyFieldAriaLabel(label: string, copied: boolean): string {
+  return copied ? `${label} copied to clipboard` : `Copy ${label}`;
+}
+
+/** Accessible name for inspect controls on provenance fields. */
+export function inspectFieldAriaLabel(label: string): string {
+  return `Inspect ${label}`;
+}
+
+/** Accessible name for the technical provenance disclosure toggle. */
+export function technicalProvenanceToggleLabel(expanded: boolean): string {
+  return expanded ? "Hide technical provenance details" : "Show technical provenance details";
+}
+
+/** Full step announcement for timeline list items. */
+export function timelineStepAriaLabel(item: ProvenanceTimelineItem): string {
+  return `${item.title}, ${timelineStepStatusLabel(item.status)}${item.timestamp ? `, ${item.timestamp}` : ""}`;
+}

--- a/tests/unit/mail/provenance-a11y.test.ts
+++ b/tests/unit/mail/provenance-a11y.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  copyFieldAriaLabel,
+  inspectFieldAriaLabel,
+  provenanceStatusHeading,
+  technicalProvenanceToggleLabel,
+  timelineStepAriaLabel,
+  timelineStepStatusLabel,
+} from "../../../src/components/mail/provenance-a11y";
+import type { ProvenanceTimelineItem } from "../../../src/components/mail/provenance";
+
+describe("provenance accessibility labels", () => {
+  it("maps timeline statuses to screen-reader text", () => {
+    expect(timelineStepStatusLabel("complete")).toBe("Complete");
+    expect(timelineStepStatusLabel("pending")).toBe("Pending");
+    expect(timelineStepStatusLabel("skipped")).toBe("Skipped");
+  });
+
+  it("describes the provenance security summary heading", () => {
+    expect(provenanceStatusHeading(true, false)).toBe("Secure on-chain route");
+    expect(provenanceStatusHeading(false, true)).toBe("SMTP bridged, unverified");
+    expect(provenanceStatusHeading(false, false)).toBe("Awaiting envelope proof");
+  });
+
+  it("announces copy control state", () => {
+    expect(copyFieldAriaLabel("Receipt Record", false)).toBe("Copy Receipt Record");
+    expect(copyFieldAriaLabel("Receipt Record", true)).toBe("Receipt Record copied to clipboard");
+  });
+
+  it("names inspect controls", () => {
+    expect(inspectFieldAriaLabel("Message Hash")).toBe("Inspect Message Hash");
+  });
+
+  it("labels the technical provenance disclosure toggle", () => {
+    expect(technicalProvenanceToggleLabel(false)).toBe("Show technical provenance details");
+    expect(technicalProvenanceToggleLabel(true)).toBe("Hide technical provenance details");
+  });
+
+  it("builds a full timeline step announcement", () => {
+    const item: ProvenanceTimelineItem = {
+      key: "receiptRecord",
+      title: "Read receipt",
+      description: "Recipient opened the message.",
+      status: "complete",
+      timestamp: "10:42 AM",
+    };
+
+    expect(timelineStepAriaLabel(item)).toBe("Read receipt, Complete, 10:42 AM");
+  });
+});


### PR DESCRIPTION
## Summary
- Add accessible labels and semantic structure to `ProvenancePanel` (timeline list, disclosure toggle, copy/inspect controls, status regions).
- Wire `ProvenanceInspector` with `useFocusTrap`, dialog ARIA, motion presets, and visible focus rings.
- Honor `prefers-reduced-motion` for provenance and postage dispute accordions.
- Add unit tests for provenance accessibility label helpers.

Closes #952

## Test plan
- [x] `bun run test` (598 unit tests passing)
- [x] `bun x tsc --noEmit`
- [x] `bun x eslint` on touched files
- [ ] Manual keyboard walkthrough: tab through provenance panel controls, expand technical provenance, open inspector modal, verify Escape closes and focus restores
- [ ] Screen reader spot-check: timeline steps announce status, copy buttons expose pressed state

Made with [Cursor](https://cursor.com)