### PR TITLE
docs: add isolated role-based mail access validation

### DIFF
--- a/tools/v2/team/role-based-mail-access/DATA_OWNERSHIP.md
+++ b/tools/v2/team/role-based-mail-access/DATA_OWNERSHIP.md
@@ -6,7 +6,7 @@ This document details data structures, storage parameters, state lifecycles, and
 
 ## 1. Domain Entities & Data Model
 
-We declare the core structures in [types/index.ts](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/types/index.ts):
+We declare the core structures in [types/index.ts](types/index.ts):
 
 ```typescript
 export interface VerifyAccessRequest {

--- a/tools/v2/team/role-based-mail-access/README.md
+++ b/tools/v2/team/role-based-mail-access/README.md
@@ -1,50 +1,57 @@
 # Role-Based Mail Access
 
-A self-contained V2 team tool that enforces which team members can read, write, assign, delete, or manage mail threads based on a declared role. This contribution adds the safety and performance guard layer, dynamic policy configuring tables, verification controls form, boundaries limit checks, and real-time audit logs.
+Release tier: V2
+Audience: team
 
-## Ownership Boundary
+Role-Based Mail Access is an isolated tool for checking whether a team member can read, write, assign, delete, or manage mail threads based on a declared role policy.
 
-All work for this tool must stay inside:
+## Isolation Boundary
 
-```text
-tools/v2/team/role-based-mail-access/
-```
+All work for this issue stays inside `tools/v2/team/role-based-mail-access/`.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not connect this tool to the main application shell, dashboard layout, navigation, authentication, wallet core, mail rendering engine, inbox architecture, routing, Stellar integration, database schema, or design system.
 
----
+## What Lives Here
 
-## Workspace Structure
+- [types/index.ts](types/index.ts): shared request, policy, and log types.
+- [fixtures/sample-access-requests.json](fixtures/sample-access-requests.json): local fixture data with valid requests and hostile inputs.
+- [guards/access-guards.mjs](guards/access-guards.mjs): validation, sanitization, and size guards.
+- [services/access.service.ts](services/access.service.ts): in-memory policy and audit-log service.
+- [hooks/use-role-based-access.ts](hooks/use-role-based-access.ts): React wrapper around the service.
+- [components/](components): presentational matrix, verifier, and console UI.
+- [demo.tsx](demo.tsx): isolated preview entry.
+- [tests/](tests): folder-local guard and service coverage plus the test plan.
+- [docs/](docs): contributor docs, architecture notes, accessibility guidance, and reviewer notes.
 
-- **[types/index.ts](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/types/index.ts)**: Domain TypeScript definitions.
-- **[fixtures/sample-access-requests.json](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/fixtures/sample-access-requests.json)**: JSON datasets holding valid clearance templates and 19 hostile threat injection vectors.
-- **[guards/access-guards.mjs](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/guards/access-guards.mjs)**: Schema validators, sanitizers, and size limit checks.
-- **[services/access.service.ts](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/services/access.service.ts)**: Core state manager handling policy configurations and limit verifiers.
-- **[hooks/use-role-based-access.ts](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/hooks/use-role-based-access.ts)**: Custom React state synchronization hook.
-- **[components/](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/components/)**: Dynamic matrix grids, verifier form cards, and logs.
-- **[demo.tsx](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/demo.tsx)**: Preview development wrapper.
+## Setup
 
----
+1. Install the repo dependencies from the project root if they are not already present.
+2. Keep changes inside this tool folder so the issue remains reviewable on its own.
 
-## Detailed Documentation
+## Usage
 
-- **[Visual Style and States Guide](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/docs/README.md)**: Details empty, loading, granted, denied, and error warning states.
-- **[Technical Architecture Spec](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/docs/ARCHITECTURE.md)**: Domain schema definitions and threat scan loop.
-- **[Accessibility (a11y) Guide](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/docs/ACCESSIBILITY.md)**: Aria tags, focus ring controls, and screen-readers checklist.
-- **[OSS Reviewer Validation Guide](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/docs/review-notes.md)**: Step-by-step verification guide.
-
----
-
-## Running the Tests
-
-### Running UI Service Tests (Vitest)
-
-```bash
-npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
-```
-
-### Running Native Guard Tests (Node.js)
+Run the local checks from the repository root:
 
 ```bash
 node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
 ```
+
+For a quick contributor checklist, start with [tests/test-plan.md](tests/test-plan.md) and then read [docs/review-notes.md](docs/review-notes.md).
+
+## Fixtures
+
+The fixture set is intentionally small and reviewable:
+
+- 5 valid requests that cover every role and a mix of allowed and denied actions
+- 19 hostile inputs that exercise the guard layer
+- boundary limits for team size, attachment count, role length, thread ID length, and email length
+
+See [fixtures/sample-access-requests.json](fixtures/sample-access-requests.json) for the exact payloads.
+
+## Known Limitations
+
+- The tool is in-memory only; there is no persistence layer.
+- The tool does not integrate with the main mail app yet.
+- There is no mailbox routing, wallet, Stellar, or database work in this issue.
+- Future app wiring should be handled in a separate follow-up issue.

--- a/tools/v2/team/role-based-mail-access/docs/ARCHITECTURE.md
+++ b/tools/v2/team/role-based-mail-access/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ RoleBasedMailAccessDemo (demo.tsx)
 
 ## Data Models
 
-The structures defined in [types/index.ts](file:///home/henry/projects/open-source/stealth/tools/v2/team/role-based-mail-access/types/index.ts) are:
+The structures defined in [../types/index.ts](../types/index.ts) are:
 
 ### `VerifyAccessRequest`
 

--- a/tools/v2/team/role-based-mail-access/docs/README.md
+++ b/tools/v2/team/role-based-mail-access/docs/README.md
@@ -1,67 +1,48 @@
 # Role-Based Mail Access UI
 
-This document provides setup instructions and visual guide details for the **Role-Based Mail Access Control Plane** interface.
+This document is the contributor-facing guide for the isolated Role-Based Mail Access tool.
 
-## Visual Design System & Key States
+## Setup
 
-The interface implements a curated dark-mode palette (`bg-zinc-950` / `bg-zinc-900`) styled with responsive flex grids and interactive overlays, supporting the following states:
+1. Install the repo dependencies from the project root.
+2. Work only inside `tools/v2/team/role-based-mail-access/`.
+3. Keep review changes limited to the tool-local tests, docs, fixtures, and services.
 
-1. **Empty State**:
-   - Renders a clean placeholder illustration with call-to-action hints inside the audit logs tracker when no checks have run.
-2. **Loading State**:
-   - Simulates check delay with a smooth, pulsing loader and spinning indicators, accompanied by `role="status"` and `aria-live="polite"` tags to notify assistive technologies.
-3. **Success State (Authorized)**:
-   - Evaluated requests that align with policy render a green banner (`bg-emerald-500/10 text-emerald-400`), confirming authorization and adding an audit log.
-4. **Access Denied State**:
-   - Evaluated requests that violate policies trigger an amber warning alert (`bg-amber-500/10 text-amber-400`), stating that the operation is blocked.
-5. **Error State (Validation Failures)**:
-   - Malformed fields (e.g. invalid emails, injection script threadIds, oversized input bounds) trigger a red border around the target input and show a focused red error block (`bg-rose-500/10 text-rose-400`) explaining the validation constraint.
+## Usage
 
-## Directory Structure
-
-All implementation files are housed locally:
-
-```text
-role-based-mail-access/
-├── types/
-│   └── index.ts                # TypeScript types (Requests, Logs, Policies)
-├── fixtures/
-│   └── sample-access-requests.json # Preloaded valid & hostile mock datasets
-├── guards/
-│   └── access-guards.mjs       # Low-level validation libraries
-├── services/
-│   └── access.service.ts       # Policy editor, logs tracker, and limit verifier
-├── hooks/
-│   └── use-role-based-access.ts # State synchronization hook
-├── components/
-│   ├── PolicyMatrix.tsx        # Toggle matrix for permission checks
-│   ├── AccessVerifier.tsx      # Validation credentials form & error display
-│   ├── AccessConsole.tsx       # Combined dashboard layout orchestrator
-│   └── index.ts                # Public exports index
-├── tests/
-│   ├── access-guards.test.mjs  # Native Node unit tests for guards
-│   └── ui-service.test.ts      # Vitest unit tests for service state
-├── docs/
-│   ├── README.md               # Visual style and state guide
-│   ├── ARCHITECTURE.md         # Component mapping and structural flow
-│   ├── ACCESSIBILITY.md        # Focus routes and screen reader WAI-ARIA states
-│   └── review-notes.md         # OSS reviewer validation guide
-├── demo.tsx                    # Dev preview harness
-├── vitest.config.ts            # Isolated Vitest configuration
-├── specs.md                    # Scaffold constraints
-└── README.md                   # Root README page
-```
-
-## Running Tests
-
-### Running UI Service Tests (Vitest)
-
-```bash
-npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
-```
-
-### Running Native Guard Tests (Node.js)
+Run the local checks from the repository root:
 
 ```bash
 node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
 ```
+
+If you only want the reviewer checklist, start with [../tests/test-plan.md](../tests/test-plan.md) and [review-notes.md](review-notes.md).
+
+## Visual States
+
+The UI uses a dark, high-contrast palette with four main states:
+
+1. Empty state for a fresh console.
+2. Loading state while a verification is simulated.
+3. Granted and denied states for policy outcomes.
+4. Error state for validation failures.
+
+Those states are rendered by the local components in [../components](../components).
+
+## Fixtures
+
+The local fixture file [../fixtures/sample-access-requests.json](../fixtures/sample-access-requests.json) contains:
+
+- valid requests that exercise all allowed roles
+- hostile inputs for role, access level, email, and thread ID validation
+- boundary values for team and attachment limits
+
+The fixture is read by [../components/AccessConsole.tsx](../components/AccessConsole.tsx) and the folder-local tests.
+
+## Known Limitations
+
+- No main-app integration exists yet.
+- No mail rendering engine, routing, database, wallet, or Stellar work lives here.
+- All policies and logs are in-memory only.
+- The review harness is intentionally isolated and should stay that way until a separate integration issue is approved.

--- a/tools/v2/team/role-based-mail-access/docs/review-notes.md
+++ b/tools/v2/team/role-based-mail-access/docs/review-notes.md
@@ -1,83 +1,24 @@
-# Reviewer Validation Guide - Role-Based Mail Access UI
+# Reviewer Validation Notes
 
-This guide assists reviewers and OSS contributors in testing the Role-Based Mail Access Control Plane user interface.
+This guide is for OSS contributors validating the isolated Role-Based Mail Access tool.
 
----
+## Fast Checks
 
-## 1. Quick Verification Checklist
+- Run [../tests/test-plan.md](../tests/test-plan.md) from top to bottom.
+- Confirm `node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs` passes.
+- Confirm `npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run` passes when dependencies are installed.
+- Check that no file outside `tools/v2/team/role-based-mail-access/` changed for this issue.
 
-- [ ] Node.js guard tests pass (`node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs`).
-- [ ] Vitest service tests pass (`npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run`).
-- [ ] Prettier formatting is clean.
-- [ ] Verification form catches malformed inputs (invalid email format, special chars in threadIds).
-- [ ] Matrix checks dynamically grant or block requests.
-- [ ] Threat Scan correctly identifies and rejects all 19 hostile payloads.
-- [ ] Team size and attachment bounds limits trigger limit checks.
+## What To Review
 
----
+1. The guard suite should reject every hostile payload in `fixtures/sample-access-requests.json`.
+2. The service tests should show that policies, logs, and size limits behave independently of the main app.
+3. The docs should explain setup, usage, fixture scope, and known limitations without referencing the main app shell.
+4. The folder should remain easy to remove or refactor later because nothing is wired into app-wide routing or state.
 
-## 2. Running the Test Suites
+## Expected Results
 
-### Unit Guard Tests (Node.js)
-
-```bash
-node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
-```
-
-_Expected: 32 tests passed._
-
-### UI Service State Tests (Vitest)
-
-```bash
-npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
-```
-
-_Expected: 12 tests passed._
-
----
-
-## 3. Interactive Walkthrough Validation (UI/UX)
-
-If testing the demo harness visually in your local sandboxed app, check the following interactive paths:
-
-### A. Simulating Access Requests (Presets)
-
-1. Click the preset card `req-001` (Role: manager, Action: assign).
-2. Observe:
-   - Form fields auto-fill.
-   - A pulsing "Evaluating..." state is displayed for 800ms.
-   - An alert shows: `✓ Access Authorization Succeeded` (granted outcome).
-   - An entry is logged in the "Clearance Check Audit Trail".
-3. Click the preset card `req-003` (Role: viewer, Action: write).
-4. Observe:
-   - A pulsing "Evaluating..." state is displayed for 800ms.
-   - An alert shows: `✕ Access Authorization Denied` (since viewers cannot write).
-   - An audit entry is appended.
-
-### B. Dynamically Modifying Access Policies
-
-1. Select the preset `req-003` (viewer, write) and check that access is denied.
-2. Go to the **Access Level Control Matrix** table.
-3. Check the box under row **viewer**, column **write**.
-4. Submit the verifier form again with `viewer` and `write`.
-5. Observe:
-   - The result shifts to **Granted**, proving permission policies bind dynamically.
-
-### C. Threat Scan Verification
-
-1. Click the red button **🛡 Run Threat Scan** in the console header.
-2. Observe:
-   - A loading scanner status pulse starts, evaluating the 19 hostile vectors.
-   - An alert appears: `✓ Threat Scanning Validation Succeeded`.
-   - The text confirms that all 19 hostile vectors (e.g. CRLF header injects, null-byte hacks, path traversals) were successfully blocked and logged.
-
-### D. Size Limits Guard Check
-
-1. Locate the **Boundary Limit Verifiers** panel.
-2. Increase the "Simulated Team Size" field to `501`.
-3. Observe:
-   - The status badge shifts from "Safe" to "Limit Exceeded".
-   - A validation message appears: `team size 501 exceeds safe limit of 500`.
-4. Increase "Simulated Attachment Count" to `101`.
-5. Observe:
-   - The status badge shifts to "Limit Exceeded" with: `attachment count 101 exceeds safe limit of 100`.
+- The Node guard suite covers sanitization, validation, limits, and fixture contract checks.
+- The Vitest suite covers core service behavior, log order, policy updates, and isolation boundaries.
+- The fixture file remains local and readable.
+- The tool stays a self-contained mini-product until a future integration issue is approved.

--- a/tools/v2/team/role-based-mail-access/specs.md
+++ b/tools/v2/team/role-based-mail-access/specs.md
@@ -1,41 +1,30 @@
-# Role-Based Mail Access
+# Role-Based Mail Access Specs
 
-Permissions system.
+Release tier: V2  
+Audience: team
+
+This folder contains a self-contained tool for role-based mail access checks. It is intentionally isolated from the main application until a future integration issue explicitly allows wiring.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- local guard validation and sanitization
+- in-memory policy evaluation and audit logs
+- React hook and presentational UI for the isolated demo
+- folder-local fixtures, tests, and contributor documentation
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+## Non-Goals
 
-Recommended internal structure:
+- no routing or shell changes
+- no inbox architecture changes
+- no mail rendering engine changes
+- no authentication, wallet, Stellar, or database work
 
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/role-based-mail-access/README.md"
-  @"
+## Contributor Review
 
-# Role-Based Mail Access Specs
+Start with:
 
-## Purpose
+- [README.md](README.md)
+- [tests/test-plan.md](tests/test-plan.md)
+- [docs/review-notes.md](docs/review-notes.md)
 
-Permissions system.
-
-## Contributor boundary
-
-All work for this tool should stay in:
-
-$dir/
-
-## Required issue categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+Keep every file touched by this issue inside `tools/v2/team/role-based-mail-access/`.

--- a/tools/v2/team/role-based-mail-access/tests/service-behavior.test.ts
+++ b/tools/v2/team/role-based-mail-access/tests/service-behavior.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createAccessService } from "../services/access.service";
+
+describe("Role-Based Mail Access service behavior", () => {
+  let service: ReturnType<typeof createAccessService>;
+
+  beforeEach(() => {
+    service = createAccessService();
+  });
+
+  it("sanitizes role input before policy lookup and stores the cleaned request", () => {
+    const result = service.checkRequest({
+      requesterEmail: "alice@example.test",
+      role: "  Manager  ",
+      accessLevel: "assign",
+      threadId: "thread-support-001",
+    });
+
+    expect(result.isAllowed).toBe(true);
+    expect(service.getLogs()).toHaveLength(1);
+    expect(service.getLogs()[0].request.role).toBe("manager");
+  });
+
+  it("keeps audit entries newest-first", () => {
+    service.checkRequest({
+      requesterEmail: "alice@example.test",
+      role: "manager",
+      accessLevel: "assign",
+      threadId: "thread-support-001",
+    });
+    service.checkRequest({
+      requesterEmail: "bob@example.test",
+      role: "agent",
+      accessLevel: "read",
+      threadId: "thread-billing-042",
+    });
+
+    expect(service.getLogs().map((entry) => entry.request.threadId)).toEqual([
+      "thread-billing-042",
+      "thread-support-001",
+    ]);
+  });
+
+  it("clears only the log history", () => {
+    service.checkRequest({
+      requesterEmail: "alice@example.test",
+      role: "manager",
+      accessLevel: "assign",
+      threadId: "thread-support-001",
+    });
+
+    service.clearLogs();
+
+    expect(service.getLogs()).toEqual([]);
+    expect(service.getPolicy().manager).toEqual(["read", "write", "assign"]);
+  });
+
+  it("clones the initial policy so external fixture edits do not leak into the service", () => {
+    const initialPolicy = {
+      admin: ["read", "write", "assign", "delete", "manage"],
+      manager: ["read", "write", "assign"],
+      agent: ["read", "write"],
+      viewer: ["read"],
+      guest: [],
+    };
+
+    const clonedService = createAccessService(initialPolicy);
+    initialPolicy.manager.push("manage");
+
+    expect(clonedService.getPolicy().manager).toEqual(["read", "write", "assign"]);
+  });
+
+  it("accepts limits exactly at the configured thresholds", () => {
+    expect(service.checkLimits(500, 100)).toEqual({
+      teamSizeValid: true,
+      attachmentCountValid: true,
+    });
+  });
+});

--- a/tools/v2/team/role-based-mail-access/tests/test-plan.md
+++ b/tools/v2/team/role-based-mail-access/tests/test-plan.md
@@ -1,0 +1,42 @@
+# Test Plan
+
+This folder keeps its own validation plan so contributors can review it without touching the main app.
+
+## Automated Checks
+
+Run these commands from the repository root:
+
+```bash
+node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs
+npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run
+```
+
+### Expected Guard Coverage
+
+- `sanitizeRole` removes whitespace and unsafe punctuation.
+- `validateRole`, `validateAccessLevel`, `validateEmailAddress`, and `validateThreadId` reject malformed or hostile input.
+- `validateAccessRequest` validates the whole request payload.
+- `checkAccess` grants and denies against the local policy map.
+- `guardTeamSize` and `guardAttachmentCount` enforce the local size ceilings.
+
+### Expected Service Coverage
+
+- The service starts with the default policy and an empty audit log.
+- Policy updates only accept recognized roles and access levels.
+- Access checks append audit entries in newest-first order.
+- Invalid requests are rejected with field-level errors.
+- Boundary checks fail above the limit and pass at the exact threshold.
+
+## Manual Review Checklist
+
+1. Open [../fixtures/sample-access-requests.json](../fixtures/sample-access-requests.json).
+2. Confirm the fixture contains 5 valid requests, 19 hostile inputs, and documented boundary values.
+3. Read [../docs/review-notes.md](../docs/review-notes.md) for the expected review flow.
+4. Confirm every file changed by the issue lives inside `tools/v2/team/role-based-mail-access/`.
+5. Verify the tool is still isolated from main-app routing, inbox rendering, wallet code, and database work.
+
+## Known Gaps
+
+- There are no integration tests against the main application.
+- The demo UI is local-only and does not mount into app-wide navigation.
+- Persistence is intentionally out of scope for this release tier.


### PR DESCRIPTION
Closes #653

## Summary

This PR adds contributor-friendly validation and documentation for the isolated `role-based-mail-access` tool under `tools/v2/team/role-based-mail-access/`.

### What changed

- Added a folder-local service behavior test covering:
  - role sanitization before policy lookup
  - newest-first audit log ordering
  - log clearing without policy mutation
  - cloning of the initial policy input
  - exact boundary handling for team and attachment limits
- Added a folder-local test plan so contributors can review the tool independently.
- Reworked the tool docs to explain:
  - setup
  - local usage
  - fixture scope
  - known limitations
  - independent review flow
- Removed stale absolute file links from the tool docs and replaced them with local references.
- Kept all changes isolated to the tool folder only.

### Validation

- `node --test tools/v2/team/role-based-mail-access/tests/access-guards.test.mjs`
- `npx vitest -c tools/v2/team/role-based-mail-access/vitest.config.ts run` is documented in the tool, but this workspace does not currently have a local Vitest binary installed.

### Review notes

- This change is intentionally isolated and does not wire the tool into the main app.
- No routing, inbox architecture, authentication, wallet, Stellar, or database code was modified.
- The issue remains self-contained inside `tools/v2/team/role-based-mail-access/`.