### PR TITLE
docs: add email translator test plan

### DIFF
--- a/tools/v2/individual/email-translator/README.md
+++ b/tools/v2/individual/email-translator/README.md
@@ -4,7 +4,7 @@ The Email Translator helps **Individual** users translate email body content bet
 
 ## Current Status
 
-**Architecture only — implementation deferred.** This folder contains the architectural contract, module placeholders, and contributor rules. No TypeScript components, services, or hooks are implemented yet. Future issues should implement against `ARCHITECTURE.md` without modifying core application files.
+**Architecture and local review assets only — implementation deferred.** This folder contains the architectural contract, module placeholders, contributor rules, and a folder-local test plan. No TypeScript components, services, or hooks are implemented yet. Future issues should implement against `ARCHITECTURE.md` without modifying core application files.
 
 ## Folder Structure
 
@@ -15,11 +15,24 @@ email-translator/
 ├── components/        # EmailTranslatorShell, LanguageSelector, etc. (planned)
 ├── services/          # translationProvider, translationService, languageDetector (planned)
 ├── hooks/             # useTranslation, useLanguageDetect (planned)
-├── tests/             # Local unit and integration tests (planned)
-└── docs/              # Extended local documentation (planned)
+├── fixtures/          # Synthetic review scenarios for future implementation
+├── tests/             # Folder-local fixture contract tests and future coverage
+└── docs/              # Test plan and review notes
 ```
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for component, service, and hook responsibilities.
+See [docs/TEST_PLAN.md](./docs/TEST_PLAN.md) for setup, usage, fixtures, and known limitations.
+See [docs/REVIEW_NOTES.md](./docs/REVIEW_NOTES.md) for independent review guidance.
+
+## Local Validation
+
+Run the folder-local fixture contract test from the repository root:
+
+```bash
+node --test tools/v2/individual/email-translator/tests/fixture-contract.test.mjs
+```
+
+This test validates the synthetic review fixtures that future service, hook, and UI tests should reuse. It does not call a live translation provider or the main app.
 
 ## Contributor Rules
 

--- a/tools/v2/individual/email-translator/docs/REVIEW_NOTES.md
+++ b/tools/v2/individual/email-translator/docs/REVIEW_NOTES.md
@@ -1,0 +1,47 @@
+# Email Translator Review Notes
+
+## What Changed
+
+- Added deterministic synthetic review scenarios for the isolated Email Translator tool.
+- Added a Node built-in fixture contract test that runs without app-wide setup.
+- Added this review guide and a folder-local test plan.
+- Replaced stale generated text in `specs.md` with a clean contributor-facing specification.
+- Updated the README with validation commands and local documentation links.
+
+## Boundary Check
+
+All changed files should stay inside:
+
+```text
+tools/v2/individual/email-translator/
+```
+
+This change does not mount the tool in the main app, add routes, change inbox behavior, touch wallet or Stellar code, or introduce a live translation provider.
+
+## Suggested Review Flow
+
+1. Inspect the file list and confirm the boundary above.
+2. Run:
+
+   ```bash
+   node --test tools/v2/individual/email-translator/tests/fixture-contract.test.mjs
+   ```
+
+3. Check that `fixtures/review-scenarios.json` uses synthetic email content only.
+4. Read `docs/TEST_PLAN.md` and confirm it explains setup, fixture usage, future coverage, and limitations.
+5. Confirm `specs.md` no longer contains generated shell/script fragments.
+
+## Acceptance Criteria Mapping
+
+- Tests or test plans live inside the tool folder: `tests/fixture-contract.test.mjs` and `docs/TEST_PLAN.md`.
+- Documentation explains independent review: this file and `docs/TEST_PLAN.md`.
+- Issue remains isolated from app-wide tests: the test uses Node built-ins and local JSON fixtures.
+- Files changed are limited to the tool folder.
+- The contribution is self-contained and reviewable without a full app run.
+
+## Follow-Up Work
+
+- Add service tests when `translationService` exists.
+- Add hook tests when `useTranslation` and `useLanguageDetect` exist.
+- Add component accessibility tests when the UI surface exists.
+- Add provider-specific accuracy and safety tests only after a provider has been approved.

--- a/tools/v2/individual/email-translator/docs/TEST_PLAN.md
+++ b/tools/v2/individual/email-translator/docs/TEST_PLAN.md
@@ -1,0 +1,86 @@
+# Email Translator Test Plan
+
+## Scope
+
+This plan covers only the isolated Email Translator workspace:
+
+```text
+tools/v2/individual/email-translator/
+```
+
+The tool is not wired into the main app yet. Current validation focuses on contributor-ready fixtures, documented review paths, and future test expectations for the planned service, hook, and UI modules.
+
+## Setup
+
+From the repository root, run the folder-local fixture contract test:
+
+```bash
+node --test tools/v2/individual/email-translator/tests/fixture-contract.test.mjs
+```
+
+No app server, live translation provider, API key, wallet, inbox fixture, or database is required.
+
+## Fixture Inventory
+
+The local scenarios live in:
+
+```text
+tools/v2/individual/email-translator/fixtures/review-scenarios.json
+```
+
+They cover:
+
+- successful Latin-language translation review
+- successful non-Latin source text review
+- empty source validation
+- unsupported target language validation
+- copy-ready output state expectations
+
+The fixture contract test verifies stable ids, distinct source and target languages, review focus notes, and success/error/empty/copy-ready state coverage.
+
+## Future Service Tests
+
+When `services/translationService` and provider modules are implemented, add tests under `tests/` that reuse the local fixtures and verify:
+
+- empty source text is rejected before provider calls
+- unsupported language codes are rejected before provider calls
+- successful provider responses preserve sender names, dates, amounts, and action requests
+- provider failures become normalized recoverable errors
+- no fixture requires live network access or production secrets
+
+## Future Hook Tests
+
+When `hooks/useTranslation` and `hooks/useLanguageDetect` are implemented, add hook tests that verify:
+
+- initial idle state
+- loading state during translation
+- success state with translated text
+- recoverable error state
+- source and target language changes
+- no persistence to main app stores
+
+## Future Component Tests
+
+When component modules are implemented, add component tests that verify:
+
+- source text is visible or intentionally read-only
+- language selectors have accessible labels
+- translate controls are keyboard operable
+- errors are announced in a reviewable way
+- copy feedback is exposed without requiring integration with the main mail UI
+
+## Known Limitations
+
+- The tool is architecture-only today, so this plan does not validate real translation accuracy.
+- No live provider is approved or configured in this folder.
+- Clipboard behavior should be mocked in future component tests.
+- Main inbox, compose, routing, wallet, Stellar, and database integration are intentionally out of scope.
+
+## Independent Review
+
+Reviewers can validate this issue without running the full app:
+
+1. Confirm all changed files stay under `tools/v2/individual/email-translator/`.
+2. Run the fixture contract test command above.
+3. Read `fixtures/review-scenarios.json` and confirm all examples are synthetic.
+4. Confirm the plan documents setup, usage, fixtures, and limitations.

--- a/tools/v2/individual/email-translator/fixtures/review-scenarios.json
+++ b/tools/v2/individual/email-translator/fixtures/review-scenarios.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "en-to-es-support-reply",
+    "title": "English support reply translated to Spanish",
+    "sourceLanguage": "en",
+    "targetLanguage": "es",
+    "sourceText": "Hello Mina, your invoice has been received and our billing team will follow up before Friday.",
+    "expectedReviewFocus": [
+      "keeps named recipients unchanged",
+      "keeps billing timing intact",
+      "does not invent payment confirmation"
+    ],
+    "uiStates": [
+      "success",
+      "copy-ready"
+    ]
+  },
+  {
+    "id": "fr-to-en-calendar-note",
+    "title": "French calendar note translated to English",
+    "sourceLanguage": "fr",
+    "targetLanguage": "en",
+    "sourceText": "Bonjour, la reunion produit est deplacee a 14h30 demain. Merci de confirmer votre presence.",
+    "expectedReviewFocus": [
+      "preserves tomorrow timing",
+      "preserves meeting intent",
+      "keeps confirmation request visible"
+    ],
+    "uiStates": [
+      "success",
+      "copy-ready"
+    ]
+  },
+  {
+    "id": "ja-to-en-short-message",
+    "title": "Japanese short email translated to English",
+    "sourceLanguage": "ja",
+    "targetLanguage": "en",
+    "sourceText": "ご連絡ありがとうございます。資料を確認して、本日中に返信します。",
+    "expectedReviewFocus": [
+      "handles non-Latin input",
+      "keeps same-day response promise",
+      "does not add unsupported details"
+    ],
+    "uiStates": [
+      "success",
+      "copy-ready"
+    ]
+  },
+  {
+    "id": "empty-source-error",
+    "title": "Empty source text validation",
+    "sourceLanguage": "en",
+    "targetLanguage": "de",
+    "sourceText": "",
+    "expectedReviewFocus": [
+      "blocks translation until source text exists",
+      "returns a user-readable validation error",
+      "does not call provider"
+    ],
+    "uiStates": [
+      "error",
+      "empty"
+    ]
+  },
+  {
+    "id": "unsupported-language-error",
+    "title": "Unsupported target language validation",
+    "sourceLanguage": "en",
+    "targetLanguage": "tlh",
+    "sourceText": "Please translate this product update for the regional team.",
+    "expectedReviewFocus": [
+      "rejects unsupported target language",
+      "keeps source text local",
+      "surfaces a recoverable error state"
+    ],
+    "uiStates": [
+      "error"
+    ]
+  }
+]

--- a/tools/v2/individual/email-translator/specs.md
+++ b/tools/v2/individual/email-translator/specs.md
@@ -1,41 +1,42 @@
-# Email Translator
-
-Translate emails between languages.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/email-translator/README.md"
-  @"
-
 # Email Translator Specs
 
 ## Purpose
 
-Translate emails between languages.
+Translate email body content between supported languages for individual users without reading from or writing to the main mail application.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay in:
 
-$dir/
+```text
+tools/v2/individual/email-translator/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or shared design system unless a future integration issue explicitly allows it.
+
+## Release Context
+
+- Release tier: V2 Later
+- Audience: Individual
+- Current status: Architecture and local review assets only
+
+## Expected Local Modules
+
+- `components/`: planned UI shell, language selectors, source input, translated output, and copy feedback.
+- `services/`: planned provider abstraction, translation orchestration, language detection, validation, and normalized error handling.
+- `hooks/`: planned React state bridge between components and services.
+- `fixtures/`: synthetic email bodies and expected review metadata.
+- `tests/`: folder-local unit, integration, and fixture contract tests.
+- `docs/`: setup, test plan, review notes, limitations, and future integration notes.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Review Contract
+
+The tool should remain self-contained until a later integration issue mounts it in the mail experience. Tests and documentation should be reviewable without app-wide fixtures, live providers, real email content, or production secrets.

--- a/tools/v2/individual/email-translator/tests/fixture-contract.test.mjs
+++ b/tools/v2/individual/email-translator/tests/fixture-contract.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(testDir, "..", "fixtures", "review-scenarios.json");
+
+async function loadScenarios() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+describe("Email Translator review fixtures", () => {
+  it("provide deterministic coverage for future service, hook, and UI tests", async () => {
+    const scenarios = await loadScenarios();
+
+    assert.equal(Array.isArray(scenarios), true);
+    assert.ok(scenarios.length >= 5, "expected success and error review scenarios");
+
+    const ids = new Set();
+    const uiStates = new Set();
+    const languagePairs = new Set();
+
+    for (const scenario of scenarios) {
+      assert.match(scenario.id, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      assert.equal(ids.has(scenario.id), false, `duplicate id: ${scenario.id}`);
+      ids.add(scenario.id);
+
+      assert.equal(typeof scenario.title, "string");
+      assert.ok(scenario.title.length > 10);
+
+      assert.match(scenario.sourceLanguage, /^[a-z]{2,3}$/);
+      assert.match(scenario.targetLanguage, /^[a-z]{2,3}$/);
+      assert.notEqual(
+        scenario.sourceLanguage,
+        scenario.targetLanguage,
+        `${scenario.id} should translate between different languages`
+      );
+      languagePairs.add(`${scenario.sourceLanguage}:${scenario.targetLanguage}`);
+
+      assert.equal(typeof scenario.sourceText, "string");
+      assert.equal(Array.isArray(scenario.expectedReviewFocus), true);
+      assert.ok(
+        scenario.expectedReviewFocus.length >= 3,
+        `${scenario.id} should name at least three review expectations`
+      );
+      assert.equal(Array.isArray(scenario.uiStates), true);
+      assert.ok(scenario.uiStates.length > 0, `${scenario.id} should name UI states`);
+
+      for (const state of scenario.uiStates) {
+        uiStates.add(state);
+      }
+    }
+
+    assert.ok(languagePairs.size >= 4, "expected multiple language pairs");
+    assert.ok(uiStates.has("success"), "expected success state coverage");
+    assert.ok(uiStates.has("error"), "expected error state coverage");
+    assert.ok(uiStates.has("copy-ready"), "expected copy-ready state coverage");
+    assert.ok(uiStates.has("empty"), "expected empty state coverage");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #498.

Adds folder-local testing and documentation assets for the isolated Email Translator tool under `tools/v2/individual/email-translator/`.

## Changes

- Added deterministic synthetic review scenarios for future service, hook, and UI coverage.
- Added a Node built-in fixture contract test that validates fixture shape and required success/error/empty/copy-ready state coverage.
- Added a folder-local test plan covering setup, usage, fixtures, future service/hook/component tests, and known limitations.
- Added review notes that map the change to the issue acceptance criteria.
- Cleaned up stale generated fragments in `specs.md` and linked local validation from the README.

## Validation

- `node --test tools/v2/individual/email-translator/tests/fixture-contract.test.mjs`
- `git diff --check`

## Boundary check

- All changed files stay inside `tools/v2/individual/email-translator/`.
- No main app shell, routing, inbox, wallet, Stellar, database, or shared design system files were modified.
- No live translation provider, production data, secrets, or network calls were added.