### PR TITLE
docs: add invoice approval test plan

### DIFF
--- a/tools/v2/team/invoice-approval-workflow/README.md
+++ b/tools/v2/team/invoice-approval-workflow/README.md
@@ -1,15 +1,42 @@
 # Invoice Approval Workflow
 
-This folder is the isolated workspace for the Invoice Approval Workflow tool.
+The Invoice Approval Workflow is an isolated V2 team tool for reviewing invoice requests before payment approval. It is intended to model team-local review states, approval rules, audit notes, and rejection reasons without reading from or writing to the main mail app.
+
+## Current Status
+
+**Local review assets only - implementation deferred.** This folder contains contributor documentation, synthetic invoice review fixtures, and a fixture contract test. No app integration, live payment flow, wallet interaction, or external invoice provider is implemented here.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\invoice-approval-workflow\
-`
+```text
+tools/v2/team/invoice-approval-workflow/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```text
+- README.md
+- specs.md
+- fixtures/approval-scenarios.json
+- tests/fixture-contract.test.mjs
+- docs/TEST_PLAN.md
+- docs/REVIEW_NOTES.md
+```
+
+See [specs.md](./specs.md) for contributor boundaries and expected modules.
+See [docs/TEST_PLAN.md](./docs/TEST_PLAN.md) for setup, fixtures, future coverage, and known limitations.
+See [docs/REVIEW_NOTES.md](./docs/REVIEW_NOTES.md) for independent validation notes.
+
+## Local Validation
+
+Run the folder-local fixture contract test from the repository root:
+
+```bash
+node --test tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs
+```
+
+This validates synthetic approval scenarios only. It does not run app-wide tests, process real invoices, trigger payments, or require secrets.

--- a/tools/v2/team/invoice-approval-workflow/docs/REVIEW_NOTES.md
+++ b/tools/v2/team/invoice-approval-workflow/docs/REVIEW_NOTES.md
@@ -1,0 +1,48 @@
+# Invoice Approval Workflow Review Notes
+
+## What Changed
+
+- Added deterministic synthetic invoice approval scenarios.
+- Added a Node built-in fixture contract test for local validation.
+- Added a folder-local test plan with setup, fixture inventory, future coverage, and known limitations.
+- Added this independent review guide.
+- Replaced stale generated text in `specs.md` with a clean contributor-facing specification.
+- Expanded the README with local validation instructions and documentation links.
+
+## Boundary Check
+
+All changed files should stay inside:
+
+```text
+tools/v2/team/invoice-approval-workflow/
+```
+
+This change does not mount the tool in the main app, add routes, touch inbox behavior, change wallet or Stellar code, change database schema, or add any live payment provider.
+
+## Suggested Review Flow
+
+1. Inspect the file list and confirm the boundary above.
+2. Run:
+
+   ```bash
+   node --test tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs
+   ```
+
+3. Confirm `fixtures/approval-scenarios.json` uses synthetic vendors and invoices.
+4. Confirm `docs/TEST_PLAN.md` explains setup, fixtures, future tests, and limitations.
+5. Confirm `specs.md` no longer contains generated shell/script fragments.
+
+## Acceptance Criteria Mapping
+
+- Tests or test plans live inside the tool folder: `tests/fixture-contract.test.mjs` and `docs/TEST_PLAN.md`.
+- Documentation explains independent review: this file and `docs/TEST_PLAN.md`.
+- Issue remains isolated from app-wide tests: the test uses Node built-ins and local JSON fixtures.
+- Files changed are limited to the tool folder.
+- The contribution is self-contained and reviewable without a full app run.
+
+## Follow-Up Work
+
+- Add service tests when invoice validation and state transition helpers exist.
+- Add hook tests when the review state hook exists.
+- Add component accessibility tests when the UI surface exists.
+- Add integration tests only after a future issue explicitly connects this tool to app data or payment rails.

--- a/tools/v2/team/invoice-approval-workflow/docs/TEST_PLAN.md
+++ b/tools/v2/team/invoice-approval-workflow/docs/TEST_PLAN.md
@@ -1,0 +1,85 @@
+# Invoice Approval Workflow Test Plan
+
+## Scope
+
+This plan covers only the isolated team tool workspace:
+
+```text
+tools/v2/team/invoice-approval-workflow/
+```
+
+The tool is not connected to the main app, inbox, wallet, Stellar code, database, or any live payment rail. Current validation focuses on local fixtures, documented review paths, and future test expectations.
+
+## Setup
+
+From the repository root, run:
+
+```bash
+node --test tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs
+```
+
+No app server, payment account, vendor account, API key, mailbox fixture, or database is required.
+
+## Fixture Inventory
+
+The synthetic review scenarios live in:
+
+```text
+tools/v2/team/invoice-approval-workflow/fixtures/approval-scenarios.json
+```
+
+They cover:
+
+- a standard approval
+- a missing purchase order request for more information
+- a large contract blocked for policy review
+- a duplicate invoice rejection
+- a near-due foreign currency invoice that stays pending
+
+The fixture contract test verifies stable ids, positive amounts, ISO-style due dates, three-letter currencies, review signals, all planned workflow states, and multi-currency coverage.
+
+## Future Service Tests
+
+When local service modules are implemented, add tests under `tests/` that reuse the fixtures and verify:
+
+- duplicate invoices are rejected before payment approval
+- missing purchase orders move to `needs_information`
+- high-value invoices move to `blocked`
+- approved invoices still produce review audit notes
+- no scenario triggers live payment execution
+
+## Future Hook Tests
+
+When hooks are implemented, add hook tests that verify:
+
+- initial queue state
+- selected invoice state
+- state transitions across review actions
+- recoverable validation errors
+- no persistence to main app stores
+
+## Future Component Tests
+
+When UI components are implemented, add component tests that verify:
+
+- invoice amount, vendor, due date, and purchase order are visible
+- approval/rejection controls are keyboard operable
+- rejection and blocked states require a visible reason
+- pending and needs-information states are announced clearly
+- audit notes remain visible without mounting the main app
+
+## Known Limitations
+
+- This plan does not validate a real payment or payment provider.
+- The current fixture contract test validates review scenario structure, not production workflow logic.
+- The tool has no approved integration with mailbox, finance, wallet, Stellar, or database modules.
+- All invoice content is synthetic and should stay synthetic until a future integration issue defines data handling rules.
+
+## Independent Review
+
+Reviewers can validate this issue without running the full app:
+
+1. Confirm all changed files stay under `tools/v2/team/invoice-approval-workflow/`.
+2. Run the fixture contract test command above.
+3. Confirm the fixtures are synthetic and cover all planned workflow states.
+4. Confirm this plan documents setup, usage, fixtures, future coverage, and limitations.

--- a/tools/v2/team/invoice-approval-workflow/fixtures/approval-scenarios.json
+++ b/tools/v2/team/invoice-approval-workflow/fixtures/approval-scenarios.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "standard-software-renewal-approved",
+    "title": "Standard software renewal can be approved",
+    "invoice": {
+      "vendor": "Northstar Analytics",
+      "amount": 1240.5,
+      "currency": "USD",
+      "dueDate": "2026-07-15",
+      "purchaseOrder": "PO-2026-1042"
+    },
+    "reviewSignals": [
+      "purchase order matches vendor",
+      "amount is below team approval threshold",
+      "due date leaves more than five business days"
+    ],
+    "expectedState": "approved"
+  },
+  {
+    "id": "missing-po-needs-information",
+    "title": "Missing purchase order requires more information",
+    "invoice": {
+      "vendor": "Harbor Design Studio",
+      "amount": 875,
+      "currency": "USD",
+      "dueDate": "2026-07-03",
+      "purchaseOrder": ""
+    },
+    "reviewSignals": [
+      "purchase order is missing",
+      "vendor is otherwise known",
+      "reviewer should request procurement context"
+    ],
+    "expectedState": "needs_information"
+  },
+  {
+    "id": "large-contract-blocked",
+    "title": "Large contract invoice is blocked for policy review",
+    "invoice": {
+      "vendor": "Atlas Infrastructure",
+      "amount": 18500,
+      "currency": "USD",
+      "dueDate": "2026-07-21",
+      "purchaseOrder": "PO-2026-1188"
+    },
+    "reviewSignals": [
+      "amount exceeds team approval threshold",
+      "legal review is required before approval",
+      "finance lead must be included"
+    ],
+    "expectedState": "blocked"
+  },
+  {
+    "id": "duplicate-invoice-rejected",
+    "title": "Duplicate invoice is rejected",
+    "invoice": {
+      "vendor": "Northstar Analytics",
+      "amount": 1240.5,
+      "currency": "USD",
+      "dueDate": "2026-07-15",
+      "purchaseOrder": "PO-2026-1042"
+    },
+    "reviewSignals": [
+      "same vendor, amount, due date, and purchase order already exist",
+      "duplicate payment risk should be prevented",
+      "reviewer should keep an audit note"
+    ],
+    "expectedState": "rejected"
+  },
+  {
+    "id": "urgent-foreign-currency-pending-review",
+    "title": "Foreign currency invoice remains pending review",
+    "invoice": {
+      "vendor": "Kite Localization",
+      "amount": 2100,
+      "currency": "EUR",
+      "dueDate": "2026-07-01",
+      "purchaseOrder": "PO-2026-1202"
+    },
+    "reviewSignals": [
+      "currency conversion needs confirmation",
+      "due date is near",
+      "reviewer should confirm budget owner"
+    ],
+    "expectedState": "pending_review"
+  }
+]

--- a/tools/v2/team/invoice-approval-workflow/specs.md
+++ b/tools/v2/team/invoice-approval-workflow/specs.md
@@ -1,41 +1,54 @@
-# Invoice Approval Workflow
-
-Invoice review process.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/invoice-approval-workflow/README.md"
-  @"
-
 # Invoice Approval Workflow Specs
 
 ## Purpose
 
-Invoice review process.
+Help a team review invoice approval requests before any payment action happens. The isolated tool should model approval states, review evidence, validation outcomes, and audit notes without connecting to a live payment rail.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay in:
 
-$dir/
+```text
+tools/v2/team/invoice-approval-workflow/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, shared design system, or any live payment flow unless a future integration issue explicitly allows it.
+
+## Release Context
+
+- Release tier: V2 Later
+- Audience: Team
+- Current status: Local fixtures, tests, and documentation only
+
+## Expected Local Modules
+
+- `components/`: planned review queue UI, invoice detail panel, approval controls, rejection reason form, and audit note display.
+- `services/`: planned invoice validation helpers, state transition rules, approver policy checks, and audit event builders.
+- `hooks/`: planned React state bridge between components and local services.
+- `fixtures/`: synthetic invoice requests and expected review outcomes.
+- `tests/`: folder-local fixture, service, hook, and component tests.
+- `docs/`: setup, test plan, review notes, limitations, and future integration notes.
+
+## Workflow States
+
+Future implementation should distinguish at least:
+
+- `pending_review`
+- `needs_information`
+- `approved`
+- `rejected`
+- `blocked`
+
+Payment execution remains out of scope. An approval state means the local review workflow is satisfied, not that money has moved.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Review Contract
+
+Tests and documentation should be reviewable without app-wide fixtures, real invoices, live vendors, payment credentials, production secrets, or external network calls.

--- a/tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs
+++ b/tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(testDir, "..", "fixtures", "approval-scenarios.json");
+const allowedStates = new Set([
+  "pending_review",
+  "needs_information",
+  "approved",
+  "rejected",
+  "blocked"
+]);
+
+async function loadScenarios() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+describe("Invoice Approval Workflow fixtures", () => {
+  it("define deterministic review scenarios for future local tests", async () => {
+    const scenarios = await loadScenarios();
+
+    assert.equal(Array.isArray(scenarios), true);
+    assert.ok(scenarios.length >= 5, "expected broad review-state coverage");
+
+    const ids = new Set();
+    const states = new Set();
+    const currencies = new Set();
+
+    for (const scenario of scenarios) {
+      assert.match(scenario.id, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      assert.equal(ids.has(scenario.id), false, `duplicate id: ${scenario.id}`);
+      ids.add(scenario.id);
+
+      assert.equal(typeof scenario.title, "string");
+      assert.ok(scenario.title.length > 12);
+
+      assert.equal(typeof scenario.invoice.vendor, "string");
+      assert.ok(scenario.invoice.vendor.length > 2);
+      assert.equal(typeof scenario.invoice.amount, "number");
+      assert.ok(scenario.invoice.amount > 0, `${scenario.id} amount must be positive`);
+      assert.match(scenario.invoice.currency, /^[A-Z]{3}$/);
+      assert.match(scenario.invoice.dueDate, /^\d{4}-\d{2}-\d{2}$/);
+      assert.equal(typeof scenario.invoice.purchaseOrder, "string");
+      currencies.add(scenario.invoice.currency);
+
+      assert.equal(Array.isArray(scenario.reviewSignals), true);
+      assert.ok(
+        scenario.reviewSignals.length >= 3,
+        `${scenario.id} should name at least three review signals`
+      );
+
+      assert.ok(
+        allowedStates.has(scenario.expectedState),
+        `${scenario.id} has unsupported state ${scenario.expectedState}`
+      );
+      states.add(scenario.expectedState);
+    }
+
+    for (const state of allowedStates) {
+      assert.ok(states.has(state), `missing ${state} scenario`);
+    }
+
+    assert.ok(currencies.has("USD"), "expected USD invoice coverage");
+    assert.ok(currencies.size >= 2, "expected at least one non-USD invoice");
+  });
+});


### PR DESCRIPTION
## Summary

Closes 

Adds folder-local testing and documentation assets for the isolated Invoice Approval Workflow tool under `tools/v2/team/invoice-approval-workflow/`.

## Changes

- Added deterministic synthetic invoice review scenarios covering approved, needs-information, blocked, rejected, and pending-review states.
- Added a Node built-in fixture contract test that validates fixture shape, review signals, workflow states, positive amounts, due dates, and multi-currency coverage.
- Added a folder-local test plan covering setup, fixture usage, future service/hook/component tests, and known limitations.
- Added review notes that map the change to the issue acceptance criteria.
- Cleaned stale generated fragments in `specs.md` and expanded the README with local validation instructions.

## Validation

- `node --test tools/v2/team/invoice-approval-workflow/tests/fixture-contract.test.mjs`
- `git diff --check`

## Boundary check

- All changed files stay inside `tools/v2/team/invoice-approval-workflow/`.
- No main app shell, routing, inbox, wallet, Stellar, database, shared design system, live payment provider, production data, secrets, or network calls were added.