### PR TITLE
docs: add knowledge base suggestion test plan

### DIFF
--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,15 +1,42 @@
 # Knowledge Base Suggestion
 
-This folder is the isolated workspace for the Knowledge Base Suggestion tool.
+The Knowledge Base Suggestion tool is an isolated V2 team workspace for proposing internal documentation updates from team context. It should help reviewers reason about suggested articles, stale docs, duplicates, missing runbooks, and blocked sensitive content without reading from or writing to the main mail app.
+
+## Current Status
+
+**Local review assets only - implementation deferred.** This folder contains contributor documentation, synthetic suggestion fixtures, and a fixture contract test. No app integration, mailbox ingestion, live knowledge base provider, or external index is implemented here.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\knowledge-base-suggestion\
-`
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```text
+- README.md
+- specs.md
+- fixtures/suggestion-scenarios.json
+- tests/fixture-contract.test.mjs
+- docs/TEST_PLAN.md
+- docs/REVIEW_NOTES.md
+```
+
+See [specs.md](./specs.md) for contributor boundaries and expected modules.
+See [docs/TEST_PLAN.md](./docs/TEST_PLAN.md) for setup, fixture usage, future coverage, and known limitations.
+See [docs/REVIEW_NOTES.md](./docs/REVIEW_NOTES.md) for independent validation notes.
+
+## Local Validation
+
+Run the folder-local fixture contract test from the repository root:
+
+```bash
+node --test tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs
+```
+
+This validates synthetic suggestion scenarios only. It does not run app-wide tests, read real messages, publish docs, call a search index, or require secrets.

--- a/tools/v2/team/knowledge-base-suggestion/docs/REVIEW_NOTES.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/REVIEW_NOTES.md
@@ -1,0 +1,48 @@
+# Knowledge Base Suggestion Review Notes
+
+## What Changed
+
+- Added deterministic synthetic knowledge base suggestion scenarios.
+- Added a Node built-in fixture contract test for local validation.
+- Added a folder-local test plan with setup, fixture inventory, future coverage, and known limitations.
+- Added this independent review guide.
+- Replaced stale generated text in `specs.md` with a clean contributor-facing specification.
+- Expanded the README with local validation instructions and documentation links.
+
+## Boundary Check
+
+All changed files should stay inside:
+
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
+
+This change does not mount the tool in the main app, add routes, touch inbox behavior, change wallet or Stellar code, change database schema, or add any live knowledge base provider.
+
+## Suggested Review Flow
+
+1. Inspect the file list and confirm the boundary above.
+2. Run:
+
+   ```bash
+   node --test tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs
+   ```
+
+3. Confirm `fixtures/suggestion-scenarios.json` uses synthetic source context only.
+4. Confirm `docs/TEST_PLAN.md` explains setup, fixtures, future tests, and limitations.
+5. Confirm `specs.md` no longer contains generated shell/script fragments.
+
+## Acceptance Criteria Mapping
+
+- Tests or test plans live inside the tool folder: `tests/fixture-contract.test.mjs` and `docs/TEST_PLAN.md`.
+- Documentation explains independent review: this file and `docs/TEST_PLAN.md`.
+- Issue remains isolated from app-wide tests: the test uses Node built-ins and local JSON fixtures.
+- Files changed are limited to the tool folder.
+- The contribution is self-contained and reviewable without a full app run.
+
+## Follow-Up Work
+
+- Add service tests when suggestion scoring, duplicate detection, and sensitivity guards exist.
+- Add hook tests when the review state hook exists.
+- Add component accessibility tests when the UI surface exists.
+- Add integration tests only after a future issue explicitly connects this tool to app data or document providers.

--- a/tools/v2/team/knowledge-base-suggestion/docs/TEST_PLAN.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/TEST_PLAN.md
@@ -1,0 +1,86 @@
+# Knowledge Base Suggestion Test Plan
+
+## Scope
+
+This plan covers only the isolated team tool workspace:
+
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
+
+The tool is not connected to the main app, inbox, wallet, Stellar code, database, live knowledge base, or external search index. Current validation focuses on local fixtures, documented review paths, and future test expectations.
+
+## Setup
+
+From the repository root, run:
+
+```bash
+node --test tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs
+```
+
+No app server, mailbox fixture, document provider, search index, API key, or database is required.
+
+## Fixture Inventory
+
+The synthetic review scenarios live in:
+
+```text
+tools/v2/team/knowledge-base-suggestion/fixtures/suggestion-scenarios.json
+```
+
+They cover:
+
+- a missing incident runbook that can become a suggestion
+- a stale onboarding article that needs reviewer confirmation
+- a duplicate VPN setup suggestion
+- secret-looking context that should be blocked
+- a low-evidence feature request that should be rejected
+
+The fixture contract test verifies stable ids, target article slugs, article sections, review signals, all planned outcomes, and broad section coverage.
+
+## Future Service Tests
+
+When local service modules are implemented, add tests under `tests/` that reuse the fixtures and verify:
+
+- duplicate suggestions return `duplicate`
+- secret-looking context returns `blocked`
+- stale articles return `needs_review`
+- low-evidence proposals return `rejected`
+- high-quality missing-doc proposals return `suggested`
+- no service publishes content or calls a live provider
+
+## Future Hook Tests
+
+When hooks are implemented, add hook tests that verify:
+
+- initial suggestion queue state
+- selected suggestion state
+- outcome transitions across reviewer actions
+- recoverable validation errors
+- no persistence to main app stores
+
+## Future Component Tests
+
+When UI components are implemented, add component tests that verify:
+
+- source context, target slug, section, and review signals are visible
+- reviewer actions are keyboard operable
+- blocked and rejected states require clear reasons
+- duplicate suggestions show the existing article slug
+- sensitive context warnings are announced without mounting the main app
+
+## Known Limitations
+
+- This plan does not validate a real knowledge base provider or search index.
+- The current fixture contract test validates scenario structure, not production suggestion scoring.
+- The tool has no approved integration with mailbox, docs, wallet, Stellar, or database modules.
+- All source context is synthetic and should stay synthetic until a future integration issue defines data handling rules.
+
+## Independent Review
+
+Reviewers can validate this issue without running the full app:
+
+1. Confirm all changed files stay under `tools/v2/team/knowledge-base-suggestion/`.
+2. Run the fixture contract test command above.
+3. Confirm the fixtures are synthetic and cover all planned outcomes.
+4. Confirm this plan documents setup, usage, fixtures, future coverage, and limitations.

--- a/tools/v2/team/knowledge-base-suggestion/fixtures/suggestion-scenarios.json
+++ b/tools/v2/team/knowledge-base-suggestion/fixtures/suggestion-scenarios.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "missing-runbook-suggested",
+    "title": "Missing incident runbook becomes a new article suggestion",
+    "sourceContext": "Several support handoffs mention manual steps for rotating webhook credentials after an integration outage.",
+    "targetArticle": {
+      "slug": "incident-response/webhook-credential-rotation",
+      "section": "Incident Response",
+      "exists": false
+    },
+    "reviewSignals": [
+      "repeated team context names the same operational gap",
+      "suggestion has a clear article section",
+      "no existing article slug matches the proposed runbook"
+    ],
+    "expectedOutcome": "suggested"
+  },
+  {
+    "id": "stale-onboarding-needs-review",
+    "title": "Stale onboarding article needs reviewer confirmation",
+    "sourceContext": "New team members keep asking whether the sandbox API token is still provisioned by the old onboarding script.",
+    "targetArticle": {
+      "slug": "onboarding/sandbox-api-token",
+      "section": "Onboarding",
+      "exists": true
+    },
+    "reviewSignals": [
+      "existing article may be stale",
+      "source context does not include the replacement command",
+      "owner confirmation is needed before editing"
+    ],
+    "expectedOutcome": "needs_review"
+  },
+  {
+    "id": "duplicate-vpn-guide-duplicate",
+    "title": "Duplicate VPN setup suggestion is detected",
+    "sourceContext": "A user asks for a VPN setup guide, but the knowledge base already has the current team VPN article.",
+    "targetArticle": {
+      "slug": "it/vpn-setup",
+      "section": "Information Technology",
+      "exists": true
+    },
+    "reviewSignals": [
+      "existing article already covers the request",
+      "suggestion should link to current documentation",
+      "no new article is needed"
+    ],
+    "expectedOutcome": "duplicate"
+  },
+  {
+    "id": "secret-containing-context-blocked",
+    "title": "Context with secret-looking content is blocked",
+    "sourceContext": "The draft includes an API key shaped token and asks to document it for the team.",
+    "targetArticle": {
+      "slug": "security/shared-api-key",
+      "section": "Security",
+      "exists": false
+    },
+    "reviewSignals": [
+      "source context may contain sensitive credentials",
+      "suggestion should not publish secret material",
+      "security review is required before any article is drafted"
+    ],
+    "expectedOutcome": "blocked"
+  },
+  {
+    "id": "low-evidence-feature-request-rejected",
+    "title": "Low-evidence feature request is rejected",
+    "sourceContext": "One message says a future dashboard might need a new knowledge base page, but no workflow details are available.",
+    "targetArticle": {
+      "slug": "product/future-dashboard",
+      "section": "Product",
+      "exists": false
+    },
+    "reviewSignals": [
+      "single low-detail source",
+      "no actionable article outline",
+      "proposal should wait for stronger evidence"
+    ],
+    "expectedOutcome": "rejected"
+  }
+]

--- a/tools/v2/team/knowledge-base-suggestion/specs.md
+++ b/tools/v2/team/knowledge-base-suggestion/specs.md
@@ -1,41 +1,54 @@
-# Knowledge Base Suggestion
-
-Suggest internal documentation.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/knowledge-base-suggestion/README.md"
-  @"
-
 # Knowledge Base Suggestion Specs
 
 ## Purpose
 
-Suggest internal documentation.
+Help a team propose internal knowledge base updates from reviewable local context. The isolated tool should model suggestion quality, target article metadata, duplicate handling, sensitivity checks, and reviewer outcomes without publishing content or connecting to a live knowledge base.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay in:
 
-$dir/
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, shared design system, mail rendering engine, or external document index unless a future integration issue explicitly allows it.
+
+## Release Context
+
+- Release tier: V2 Later
+- Audience: Team
+- Current status: Local fixtures, tests, and documentation only
+
+## Expected Local Modules
+
+- `components/`: planned suggestion list, article preview, evidence panel, reviewer actions, and sensitivity warnings.
+- `services/`: planned suggestion scoring, duplicate detection, stale article checks, sensitivity guards, and audit note builders.
+- `hooks/`: planned React state bridge between components and local services.
+- `fixtures/`: synthetic suggestion requests and expected review outcomes.
+- `tests/`: folder-local fixture, service, hook, and component tests.
+- `docs/`: setup, test plan, review notes, limitations, and future integration notes.
+
+## Review Outcomes
+
+Future implementation should distinguish at least:
+
+- `suggested`
+- `needs_review`
+- `duplicate`
+- `rejected`
+- `blocked`
+
+Publishing remains out of scope. A suggestion outcome means the local review workflow classified the proposal, not that a production article changed.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Review Contract
+
+Tests and documentation should be reviewable without app-wide fixtures, real messages, production docs, external search indexes, live providers, secrets, or network calls.

--- a/tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs
+++ b/tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(testDir, "..", "fixtures", "suggestion-scenarios.json");
+const allowedOutcomes = new Set([
+  "suggested",
+  "needs_review",
+  "duplicate",
+  "rejected",
+  "blocked"
+]);
+
+async function loadScenarios() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+describe("Knowledge Base Suggestion fixtures", () => {
+  it("define deterministic suggestion scenarios for future local tests", async () => {
+    const scenarios = await loadScenarios();
+
+    assert.equal(Array.isArray(scenarios), true);
+    assert.ok(scenarios.length >= 5, "expected broad suggestion outcome coverage");
+
+    const ids = new Set();
+    const outcomes = new Set();
+    const sections = new Set();
+
+    for (const scenario of scenarios) {
+      assert.match(scenario.id, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      assert.equal(ids.has(scenario.id), false, `duplicate id: ${scenario.id}`);
+      ids.add(scenario.id);
+
+      assert.equal(typeof scenario.title, "string");
+      assert.ok(scenario.title.length > 12);
+      assert.equal(typeof scenario.sourceContext, "string");
+      assert.ok(scenario.sourceContext.length > 30);
+
+      assert.match(scenario.targetArticle.slug, /^[a-z0-9]+(?:[/-][a-z0-9]+)*$/);
+      assert.equal(typeof scenario.targetArticle.section, "string");
+      assert.ok(scenario.targetArticle.section.length > 2);
+      assert.equal(typeof scenario.targetArticle.exists, "boolean");
+      sections.add(scenario.targetArticle.section);
+
+      assert.equal(Array.isArray(scenario.reviewSignals), true);
+      assert.ok(
+        scenario.reviewSignals.length >= 3,
+        `${scenario.id} should name at least three review signals`
+      );
+
+      assert.ok(
+        allowedOutcomes.has(scenario.expectedOutcome),
+        `${scenario.id} has unsupported outcome ${scenario.expectedOutcome}`
+      );
+      outcomes.add(scenario.expectedOutcome);
+    }
+
+    for (const outcome of allowedOutcomes) {
+      assert.ok(outcomes.has(outcome), `missing ${outcome} scenario`);
+    }
+
+    assert.ok(sections.size >= 4, "expected several target article sections");
+  });
+});


### PR DESCRIPTION
## Summary

Closes 

Adds folder-local testing and documentation assets for the isolated Knowledge Base Suggestion tool under `tools/v2/team/knowledge-base-suggestion/`.

## Changes

- Added deterministic synthetic knowledge base suggestion scenarios covering suggested, needs-review, duplicate, rejected, and blocked outcomes.
- Added a Node built-in fixture contract test that validates fixture shape, target article slugs, sections, review signals, planned outcomes, and section coverage.
- Added a folder-local test plan covering setup, fixture usage, future service/hook/component tests, and known limitations.
- Added review notes that map the change to the issue acceptance criteria.
- Cleaned stale generated fragments in `specs.md` and expanded the README with local validation instructions.

## Validation

- `node --test tools/v2/team/knowledge-base-suggestion/tests/fixture-contract.test.mjs`
- `git diff --check`

## Boundary check

- All changed files stay inside `tools/v2/team/knowledge-base-suggestion/`.
- No main app shell, routing, inbox, wallet, Stellar, database, shared design system, live knowledge base provider, production data, secrets, or network calls were added.