### PR TITLE
feat(demo-admin-dashboard): add event campaign fixture for conference…

### DIFF
--- a/src/features/demo-admin-dashboard/docs/EVENT_CAMPAIGN_FIXTURE.md
+++ b/src/features/demo-admin-dashboard/docs/EVENT_CAMPAIGN_FIXTURE.md
@@ -1,0 +1,73 @@
+# Event Campaign Fixture
+
+Part of the Demo Admin Dashboard campaign workstream (issue 17 of 50).
+
+## Overview
+
+Provides fake, deterministic event campaign fixtures for testing the admin dashboard's campaign creation and management features. Each fixture models a complete event campaign with timeline phases, messages, and calendar events.
+
+## Fixtures
+
+| ID | Kind | Name | Event Date |
+|----|------|------|------------|
+| `evt-camp-conference-001` | conference | StealthCon 2026 | 2026-09-15 |
+| `evt-camp-workshop-001` | workshop | Soroban Smart Contract Workshop | 2026-10-05 |
+
+## Structure
+
+Each `EventCampaignFixture` contains:
+
+- **config** -- metadata (name, kind, date, venue, capacity, organizer)
+- **timelinePhases** -- a series of phases (planning, registration, active, followup)
+- **messages** -- email messages sent at various campaign stages (tickets, reminders, follow-ups)
+- **calendarEvents** -- calendar events for the conference or workshop
+
+## Messages by Stage (Conference)
+
+| Stage | Subject | Labels |
+|-------|---------|--------|
+| Registration | Your StealthCon 2026 pass is ready | Conference, Ticket, Important |
+| Week before | StealthCon 2026 — One week away! | Conference, Reminder |
+| Day before | Final reminder: StealthCon is tomorrow | Conference, Reminder |
+| Registration | Calendar invite: StealthCon 2026 | Conference, Calendar |
+| Post-event | Thanks for attending StealthCon 2026 | Conference, Follow-up |
+| Post-event | Share your StealthCon feedback | Conference, Survey |
+| Post-event (no-show) | We missed you at StealthCon 2026 | Conference, Follow-up |
+
+## Timeline Phases (Conference)
+
+1. **Planning** (Aug 1 -- Aug 21) -- Content prep
+2. **Registration** (Aug 22 -- Sep 8) -- Ticket sales & onboarding
+3. **Active** (Sep 9 -- Sep 16) -- Event week
+4. **Follow-up** (Sep 17 -- Sep 30) -- Survey & certificates
+
+## Usage
+
+```typescript
+import {
+  EVENT_CAMPAIGN_FIXTURES,
+  getEventCampaignFixtureById,
+  getEventCampaignFixturesByKind,
+} from "../fixtures/eventCampaignFixture";
+import { validateEventCampaignFixture } from "../utils/eventCampaignHelpers";
+
+// Get all fixtures
+const all = EVENT_CAMPAIGN_FIXTURES;
+
+// Get a specific fixture
+const conf = getEventCampaignFixtureById("evt-camp-conference-001");
+
+// Get all conference fixtures
+const conferences = getEventCampaignFixturesByKind("conference");
+
+// Validate
+const issues = validateEventCampaignFixture(conf);
+```
+
+## Safety
+
+All data is:
+- Fake and deterministic
+- Uses safe demo domains (`@stealth.demo`, `@example.com`, `@example.org`)
+- Free of secrets, private keys, or live network references
+- Suitable for public repository review

--- a/src/features/demo-admin-dashboard/eventCampaignFixture.test.ts
+++ b/src/features/demo-admin-dashboard/eventCampaignFixture.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  EVENT_CAMPAIGN_FIXTURES,
+  EVENT_CAMPAIGN_KINDS,
+  getEventCampaignFixtureById,
+  getEventCampaignFixturesByKind,
+} from "./fixtures/eventCampaignFixture";
+import { validateEventCampaignFixture } from "./utils/eventCampaignHelpers";
+
+describe("EVENT_CAMPAIGN_FIXTURES", () => {
+  it("exports at least one fixture", () => {
+    expect(EVENT_CAMPAIGN_FIXTURES.length).toBeGreaterThan(0);
+  });
+
+  it("every fixture passes validation", () => {
+    for (const fixture of EVENT_CAMPAIGN_FIXTURES) {
+      const issues = validateEventCampaignFixture(fixture);
+      const errors = issues.filter((i) => i.severity === "error");
+      expect(errors, `Fixture "${fixture.config.id}" has validation errors`).toEqual([]);
+    }
+  });
+
+  it("every fixture has a unique id", () => {
+    const ids = EVENT_CAMPAIGN_FIXTURES.map((f) => f.config.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every fixture has at least one message", () => {
+    for (const fixture of EVENT_CAMPAIGN_FIXTURES) {
+      expect(fixture.messages.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every fixture has at least one timeline phase", () => {
+    for (const fixture of EVENT_CAMPAIGN_FIXTURES) {
+      expect(fixture.timelinePhases.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all messages have non-empty subject and body", () => {
+    for (const fixture of EVENT_CAMPAIGN_FIXTURES) {
+      fixture.messages.forEach((msg, i) => {
+        expect(
+          msg.subject.trim(),
+          `Fixture "${fixture.config.id}" message[${i}] subject is empty`,
+        ).not.toBe("");
+        expect(
+          msg.body.trim(),
+          `Fixture "${fixture.config.id}" message[${i}] body is empty`,
+        ).not.toBe("");
+      });
+    }
+  });
+
+  it("all calendar events have valid title and time range", () => {
+    for (const fixture of EVENT_CAMPAIGN_FIXTURES) {
+      fixture.calendarEvents.forEach((evt, i) => {
+        expect(
+          evt.title.trim(),
+          `Fixture "${fixture.config.id}" calendarEvent[${i}] title is empty`,
+        ).not.toBe("");
+        expect(
+          evt.startTime.trim(),
+          `Fixture "${fixture.config.id}" calendarEvent[${i}] startTime is empty`,
+        ).not.toBe("");
+        expect(
+          evt.endTime.trim(),
+          `Fixture "${fixture.config.id}" calendarEvent[${i}] endTime is empty`,
+        ).not.toBe("");
+      });
+    }
+  });
+
+  it("conference fixture has conference-specific labels", () => {
+    const conf = getEventCampaignFixtureById("evt-camp-conference-001");
+    expect(conf).toBeDefined();
+    const allLabels = conf!.messages.flatMap((m) => m.labels);
+    expect(allLabels).toContain("Conference");
+    expect(allLabels).toContain("Ticket");
+    expect(allLabels).toContain("Follow-up");
+  });
+
+  it("conference fixture has a calendar event with the day-1 agenda", () => {
+    const conf = getEventCampaignFixtureById("evt-camp-conference-001");
+    const titles = conf!.calendarEvents.map((e) => e.title);
+    expect(titles).toContain("StealthCon 2026 — Day 1");
+    expect(titles).toContain("StealthCon Networking Reception");
+    expect(titles).toContain("Post-Conference Community Meetup");
+  });
+
+  it("conference fixture has all four timeline phases", () => {
+    const conf = getEventCampaignFixtureById("evt-camp-conference-001");
+    const kinds = conf!.timelinePhases.map((p) => p.phaseKind);
+    expect(kinds).toEqual(["planning", "registration", "active", "followup"]);
+  });
+
+  it("conference fixture includes follow-up messages", () => {
+    const conf = getEventCampaignFixtureById("evt-camp-conference-001");
+    const followUpSubjects = conf!.messages
+      .filter((m) => m.labels.includes("Follow-up"))
+      .map((m) => m.subject);
+    expect(followUpSubjects.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("workshop fixture has workshop-specific labels", () => {
+    const ws = getEventCampaignFixtureById("evt-camp-workshop-001");
+    expect(ws).toBeDefined();
+    const allLabels = ws!.messages.flatMap((m) => m.labels);
+    expect(allLabels).toContain("Workshop");
+    expect(allLabels).toContain("Confirmation");
+    expect(allLabels).toContain("Survey");
+  });
+
+  it("returns undefined for unknown id", () => {
+    expect(getEventCampaignFixtureById("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("EVENT_CAMPAIGN_KINDS", () => {
+  it("contains the standard event kinds", () => {
+    expect(EVENT_CAMPAIGN_KINDS).toContain("conference");
+    expect(EVENT_CAMPAIGN_KINDS).toContain("workshop");
+    expect(EVENT_CAMPAIGN_KINDS).toContain("meetup");
+    expect(EVENT_CAMPAIGN_KINDS).toContain("webinar");
+  });
+});
+
+describe("getEventCampaignFixturesByKind", () => {
+  it("returns conference fixtures", () => {
+    const fixtures = getEventCampaignFixturesByKind("conference");
+    expect(fixtures.length).toBeGreaterThan(0);
+    fixtures.forEach((f) => expect(f.config.kind).toBe("conference"));
+  });
+
+  it("returns workshop fixtures", () => {
+    const fixtures = getEventCampaignFixturesByKind("workshop");
+    expect(fixtures.length).toBeGreaterThan(0);
+    fixtures.forEach((f) => expect(f.config.kind).toBe("workshop"));
+  });
+
+  it("returns empty array for kind with no fixtures", () => {
+    expect(getEventCampaignFixturesByKind("meetup")).toEqual([]);
+  });
+});
+
+describe("validateEventCampaignFixture", () => {
+  it("accepts a valid fixture", () => {
+    const fixture = EVENT_CAMPAIGN_FIXTURES[0];
+    const issues = validateEventCampaignFixture(fixture);
+    const errors = issues.filter((i) => i.severity === "error");
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects fixture with empty messages", () => {
+    const fixture = {
+      ...EVENT_CAMPAIGN_FIXTURES[0],
+      messages: [],
+    };
+    const issues = validateEventCampaignFixture(fixture);
+    expect(issues.some((i) => i.fieldPath === "messages")).toBe(true);
+  });
+
+  it("rejects fixture with empty timeline phases", () => {
+    const fixture = {
+      ...EVENT_CAMPAIGN_FIXTURES[0],
+      timelinePhases: [],
+    };
+    const issues = validateEventCampaignFixture(fixture);
+    expect(issues.some((i) => i.fieldPath === "timelinePhases")).toBe(true);
+  });
+
+  it("rejects message with empty subject", () => {
+    const fixture = {
+      ...EVENT_CAMPAIGN_FIXTURES[0],
+      messages: [{ subject: "", body: "body", labels: [], sendAfter: "" }],
+    };
+    const issues = validateEventCampaignFixture(fixture);
+    expect(issues.some((i) => i.fieldPath === "messages[0].subject")).toBe(true);
+  });
+});

--- a/src/features/demo-admin-dashboard/fixtures/eventCampaignFixture.ts
+++ b/src/features/demo-admin-dashboard/fixtures/eventCampaignFixture.ts
@@ -1,0 +1,269 @@
+import type {
+  EventCampaignConfig,
+  EventCampaignFixture,
+  EventCampaignKind,
+  EventCampaignMessage,
+  EventCampaignTimelinePhase,
+} from "../types/eventCampaign";
+
+const CONFERENCE_CONFIG: EventCampaignConfig = {
+  id: "evt-camp-conference-001",
+  kind: "conference",
+  name: "StealthCon 2026",
+  description:
+    "Annual Stealth community conference featuring protocol updates, relay workshops, and ecosystem networking.",
+  organizer: "StealthCon Team",
+  organizerEmail: "team@stealthcon.stealth.demo",
+  eventDate: "2026-09-15",
+  venue: "Stealth HQ & Virtual",
+  capacity: 2500,
+};
+
+const TIMELINE_PHASES: EventCampaignTimelinePhase[] = [
+  {
+    phaseKind: "planning",
+    label: "Planning & Content Prep",
+    startAt: "2026-08-01T00:00",
+    endAt: "2026-08-21T23:59",
+    description:
+      "Finalize speaker lineup, session schedule, and draft email templates.",
+  },
+  {
+    phaseKind: "registration",
+    label: "Registration & Ticket Sales",
+    startAt: "2026-08-22T00:00",
+    endAt: "2026-09-08T23:59",
+    description:
+      "Accept registrations, issue digital passes, and send onboarding materials.",
+  },
+  {
+    phaseKind: "active",
+    label: "Event Week",
+    startAt: "2026-09-09T00:00",
+    endAt: "2026-09-16T23:59",
+    description:
+      "Main conference window including pre-events, keynotes, and closing ceremony.",
+  },
+  {
+    phaseKind: "followup",
+    label: "Post-Event Follow-up",
+    startAt: "2026-09-17T00:00",
+    endAt: "2026-09-30T23:59",
+    description:
+      "Send thank-you messages, survey links, and attendance certificates.",
+  },
+];
+
+const MESSAGES: EventCampaignMessage[] = [
+  {
+    subject: "Your StealthCon 2026 pass is ready",
+    body: "Your digital pass for StealthCon 2026 is attached. You can add the event to your calendar to receive session reminders and schedule updates. We look forward to seeing you there!",
+    labels: ["Conference", "Ticket", "Important"],
+    sendAfter: "2026-08-22T09:00",
+  },
+  {
+    subject: "StealthCon 2026 — One week away!",
+    body: "StealthCon 2026 starts in just one week. Check out the final speaker lineup and start planning your agenda. Early arrivals can join the pre-conference workshop on Thursday.",
+    labels: ["Conference", "Reminder"],
+    sendAfter: "2026-09-08T10:00",
+  },
+  {
+    subject: "Final reminder: StealthCon is tomorrow",
+    body: "StealthCon 2026 kicks off tomorrow at 9:00 AM at Stealth HQ. Make sure to bring your digital pass for check-in. Virtual attendees will receive a streaming link one hour before the keynote.",
+    labels: ["Conference", "Reminder"],
+    sendAfter: "2026-09-14T08:00",
+  },
+  {
+    subject: "Calendar invite: StealthCon 2026",
+    body: "You are invited to StealthCon 2026. The event runs from September 15–16 at Stealth HQ with a virtual attendance option. Add this event to your calendar to receive session reminders.",
+    labels: ["Conference", "Calendar"],
+    sendAfter: "2026-08-22T09:00",
+  },
+  {
+    subject: "Thanks for attending StealthCon 2026",
+    body: "Thank you for joining us at StealthCon 2026. We hope you enjoyed the sessions and made valuable connections. Your attendance certificate is attached.",
+    labels: ["Conference", "Follow-up"],
+    sendAfter: "2026-09-17T10:00",
+  },
+  {
+    subject: "Share your StealthCon feedback",
+    body: "We would love to hear about your StealthCon experience. Please take a few minutes to fill out our post-event survey. Your input helps us make future events even better.",
+    labels: ["Conference", "Survey"],
+    sendAfter: "2026-09-18T10:00",
+  },
+  {
+    subject: "We missed you at StealthCon 2026",
+    body: "We noticed you were unable to attend StealthCon 2026. Recordings of all keynotes and sessions are now available on demand. We hope to see you at our next event.",
+    labels: ["Conference", "Follow-up"],
+    sendAfter: "2026-09-20T10:00",
+  },
+];
+
+const CALENDAR_EVENTS: {
+  title: string;
+  startTime: string;
+  endTime: string;
+  location: string;
+  attendees: string[];
+}[] = [
+  {
+    title: "StealthCon 2026 — Day 1",
+    startTime: "2026-09-15T09:00",
+    endTime: "2026-09-15T18:00",
+    location: "Stealth HQ Auditorium & Virtual",
+    attendees: ["eve@stealth.xyz", "participant@stealth.demo"],
+  },
+  {
+    title: "StealthCon 2026 — Day 2",
+    startTime: "2026-09-16T09:00",
+    endTime: "2026-09-16T17:00",
+    location: "Stealth HQ Auditorium & Virtual",
+    attendees: ["eve@stealth.xyz", "participant@stealth.demo"],
+  },
+  {
+    title: "Pre-Conference Workshop: Relay Architecture",
+    startTime: "2026-09-14T14:00",
+    endTime: "2026-09-14T17:00",
+    location: "Workshop Room B",
+    attendees: ["eve@stealth.xyz", "workshop-lead@stealth.demo"],
+  },
+  {
+    title: "StealthCon Networking Reception",
+    startTime: "2026-09-15T18:30",
+    endTime: "2026-09-15T21:00",
+    location: "Stealth HQ Rooftop Terrace",
+    attendees: ["eve@stealth.xyz", "networking@stealth.demo"],
+  },
+  {
+    title: "Post-Conference Community Meetup",
+    startTime: "2026-09-17T18:00",
+    endTime: "2026-09-17T20:00",
+    location: "Downtown Co-Working Space",
+    attendees: ["eve@stealth.xyz", "community-leads@stealth.demo"],
+  },
+];
+
+const WORKSHOP_CONFIG: EventCampaignConfig = {
+  id: "evt-camp-workshop-001",
+  kind: "workshop",
+  name: "Soroban Smart Contract Workshop",
+  description:
+    "Hands-on workshop for building and deploying Soroban smart contracts on the Stellar network.",
+  organizer: "Developer Relations Team",
+  organizerEmail: "devrel@stealth.demo",
+  eventDate: "2026-10-05",
+  venue: "Virtual — Zoom",
+  capacity: 200,
+};
+
+const WORKSHOP_TIMELINE_PHASES: EventCampaignTimelinePhase[] = [
+  {
+    phaseKind: "planning",
+    label: "Curriculum Design",
+    startAt: "2026-09-01T00:00",
+    endAt: "2026-09-14T23:59",
+    description:
+      "Prepare workshop materials, code examples, and slide decks.",
+  },
+  {
+    phaseKind: "registration",
+    label: "Participant Registration",
+    startAt: "2026-09-15T00:00",
+    endAt: "2026-10-01T23:59",
+    description:
+      "Open registration, send confirmation emails and pre-workshop prep notes.",
+  },
+  {
+    phaseKind: "active",
+    label: "Workshop Day",
+    startAt: "2026-10-05T09:00",
+    endAt: "2026-10-05T17:00",
+    description:
+      "Live workshop sessions with hands-on coding exercises and Q&A.",
+  },
+  {
+    phaseKind: "followup",
+    label: "Post-Workshop",
+    startAt: "2026-10-06T00:00",
+    endAt: "2026-10-12T23:59",
+    description:
+      "Distribute certificates, recording links, and follow-up survey.",
+  },
+];
+
+const WORKSHOP_MESSAGES: EventCampaignMessage[] = [
+  {
+    subject: "Your Soroban Workshop confirmation",
+    body: "You are confirmed for the Soroban Smart Contract Workshop on October 5th. A Zoom link and prep materials will be sent closer to the date.",
+    labels: ["Workshop", "Confirmation"],
+    sendAfter: "2026-09-15T10:00",
+  },
+  {
+    subject: "Soroban Workshop — Prep materials enclosed",
+    body: "The Soroban Smart Contract Workshop is one week away. Please review the attached preparation guide and ensure your development environment is set up.",
+    labels: ["Workshop", "Prep"],
+    sendAfter: "2026-09-28T10:00",
+  },
+  {
+    subject: "Soroban Workshop — Zoom link & schedule",
+    body: "The workshop starts tomorrow at 9:00 AM. Here is your Zoom link and the full schedule. See you there!",
+    labels: ["Workshop", "Reminder"],
+    sendAfter: "2026-10-04T08:00",
+  },
+  {
+    subject: "Thanks for joining the Soroban Workshop",
+    body: "Thank you for participating in the Soroban Smart Contract Workshop. Your certificate of completion is attached, along with links to the recording and code repository.",
+    labels: ["Workshop", "Follow-up"],
+    sendAfter: "2026-10-06T10:00",
+  },
+  {
+    subject: "Soroban Workshop feedback survey",
+    body: "Help us improve future workshops by sharing your feedback. The survey takes less than five minutes.",
+    labels: ["Workshop", "Survey"],
+    sendAfter: "2026-10-07T10:00",
+  },
+];
+
+export const EVENT_CAMPAIGN_KINDS: EventCampaignKind[] = [
+  "conference",
+  "workshop",
+  "meetup",
+  "webinar",
+];
+
+export const EVENT_CAMPAIGN_FIXTURES: EventCampaignFixture[] = [
+  {
+    config: CONFERENCE_CONFIG,
+    timelinePhases: TIMELINE_PHASES,
+    messages: MESSAGES,
+    calendarEvents: CALENDAR_EVENTS,
+  },
+  {
+    config: WORKSHOP_CONFIG,
+    timelinePhases: WORKSHOP_TIMELINE_PHASES,
+    messages: WORKSHOP_MESSAGES,
+    calendarEvents: [
+      {
+        title: "Soroban Smart Contract Workshop",
+        startTime: "2026-10-05T09:00",
+        endTime: "2026-10-05T17:00",
+        location: "Virtual — Zoom",
+        attendees: ["eve@stealth.xyz", "participant@stealth.demo"],
+      },
+    ],
+  },
+];
+
+export function getEventCampaignFixtureById(
+  id: string,
+): EventCampaignFixture | undefined {
+  return EVENT_CAMPAIGN_FIXTURES.find((fixture) => fixture.config.id === id);
+}
+
+export function getEventCampaignFixturesByKind(
+  kind: EventCampaignKind,
+): EventCampaignFixture[] {
+  return EVENT_CAMPAIGN_FIXTURES.filter(
+    (fixture) => fixture.config.kind === kind,
+  );
+}

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -558,3 +558,24 @@ export {
   assertDemoDataSafety,
 } from "./helpers/demoDataValidator";
 export type { ValidationIssue, ValidationResult } from "./helpers/demoDataValidator";
+
+// Event Campaign Fixture (issue #17): types, fixtures, helpers, and validation.
+export type {
+  EventCampaignConfig,
+  EventCampaignFixture,
+  EventCampaignKind,
+  EventCampaignMessage,
+  EventCampaignTimelinePhase,
+} from "./types/eventCampaign";
+export {
+  EVENT_CAMPAIGN_FIXTURES,
+  EVENT_CAMPAIGN_KINDS,
+  getEventCampaignFixtureById,
+  getEventCampaignFixturesByKind,
+} from "./fixtures/eventCampaignFixture";
+export {
+  buildEventCampaignSummary,
+  validateEventCampaignConfig,
+  validateEventCampaignFixture,
+  type EventCampaignValidationIssue,
+} from "./utils/eventCampaignHelpers";

--- a/src/features/demo-admin-dashboard/types/eventCampaign.ts
+++ b/src/features/demo-admin-dashboard/types/eventCampaign.ts
@@ -1,0 +1,41 @@
+export type EventCampaignKind = "conference" | "workshop" | "meetup" | "webinar";
+
+export interface EventCampaignConfig {
+  id: string;
+  kind: EventCampaignKind;
+  name: string;
+  description: string;
+  organizer: string;
+  organizerEmail: string;
+  eventDate: string;
+  venue: string;
+  capacity: number;
+}
+
+export interface EventCampaignTimelinePhase {
+  phaseKind: "planning" | "registration" | "active" | "followup";
+  label: string;
+  startAt: string;
+  endAt: string;
+  description: string;
+}
+
+export interface EventCampaignMessage {
+  subject: string;
+  body: string;
+  labels: string[];
+  sendAfter: string;
+}
+
+export interface EventCampaignFixture {
+  config: EventCampaignConfig;
+  timelinePhases: EventCampaignTimelinePhase[];
+  messages: EventCampaignMessage[];
+  calendarEvents: {
+    title: string;
+    startTime: string;
+    endTime: string;
+    location: string;
+    attendees: string[];
+  }[];
+}

--- a/src/features/demo-admin-dashboard/utils/eventCampaignHelpers.ts
+++ b/src/features/demo-admin-dashboard/utils/eventCampaignHelpers.ts
@@ -1,0 +1,168 @@
+import type { EventCampaignConfig, EventCampaignFixture, EventCampaignKind } from "../types/eventCampaign";
+
+const SAFE_DOMAIN_PATTERN = /(@example\.(com|org)|@([\w.-]+)?\.stealth\.demo)$/i;
+
+export interface EventCampaignValidationIssue {
+  fieldPath: string;
+  message: string;
+  severity: "error" | "warning";
+}
+
+export function validateEventCampaignConfig(
+  config: EventCampaignConfig,
+): EventCampaignValidationIssue[] {
+  const issues: EventCampaignValidationIssue[] = [];
+
+  if (!config.id.trim()) {
+    issues.push({
+      fieldPath: "config.id",
+      message: "Campaign ID is required.",
+      severity: "error",
+    });
+  }
+
+  if (!config.name.trim()) {
+    issues.push({
+      fieldPath: "config.name",
+      message: "Campaign name is required.",
+      severity: "error",
+    });
+  }
+
+  const validKinds: EventCampaignKind[] = [
+    "conference",
+    "workshop",
+    "meetup",
+    "webinar",
+  ];
+  if (!validKinds.includes(config.kind)) {
+    issues.push({
+      fieldPath: "config.kind",
+      message: `Invalid event kind "${config.kind}". Must be one of: ${validKinds.join(", ")}.`,
+      severity: "error",
+    });
+  }
+
+  if (!config.eventDate.trim()) {
+    issues.push({
+      fieldPath: "config.eventDate",
+      message: "Event date is required.",
+      severity: "error",
+    });
+  }
+
+  if (config.capacity < 0) {
+    issues.push({
+      fieldPath: "config.capacity",
+      message: "Capacity must be zero or greater.",
+      severity: "error",
+    });
+  }
+
+  if (!config.organizerEmail.trim()) {
+    issues.push({
+      fieldPath: "config.organizerEmail",
+      message: "Organizer email is required.",
+      severity: "error",
+    });
+  } else {
+    const normalized = config.organizerEmail.replace("*", "@");
+    if (!SAFE_DOMAIN_PATTERN.test(normalized)) {
+      issues.push({
+        fieldPath: "config.organizerEmail",
+        message:
+          "Organizer email domain should be a safe demo domain (example.com, example.org, or *.stealth.demo).",
+        severity: "warning",
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function validateEventCampaignFixture(
+  fixture: EventCampaignFixture,
+): EventCampaignValidationIssue[] {
+  const issues: EventCampaignValidationIssue[] = validateEventCampaignConfig(
+    fixture.config,
+  );
+
+  if (fixture.timelinePhases.length === 0) {
+    issues.push({
+      fieldPath: "timelinePhases",
+      message: "At least one timeline phase is required.",
+      severity: "error",
+    });
+  }
+
+  if (fixture.messages.length === 0) {
+    issues.push({
+      fieldPath: "messages",
+      message: "At least one campaign message is required.",
+      severity: "error",
+    });
+  }
+
+  fixture.messages.forEach((msg, index) => {
+    if (!msg.subject.trim()) {
+      issues.push({
+        fieldPath: `messages[${index}].subject`,
+        message: "Message subject is required.",
+        severity: "error",
+      });
+    }
+    if (!msg.body.trim()) {
+      issues.push({
+        fieldPath: `messages[${index}].body`,
+        message: "Message body is required.",
+        severity: "error",
+      });
+    }
+  });
+
+  fixture.calendarEvents.forEach((evt, index) => {
+    if (!evt.title.trim()) {
+      issues.push({
+        fieldPath: `calendarEvents[${index}].title`,
+        message: "Calendar event title is required.",
+        severity: "error",
+      });
+    }
+    if (!evt.startTime.trim() || !evt.endTime.trim()) {
+      issues.push({
+        fieldPath: `calendarEvents[${index}]`,
+        message: "Calendar event must have a start and end time.",
+        severity: "error",
+      });
+    }
+    if (evt.startTime && evt.endTime && evt.startTime >= evt.endTime) {
+      issues.push({
+        fieldPath: `calendarEvents[${index}].endTime`,
+        message: "End time must be after start time.",
+        severity: "error",
+      });
+    }
+  });
+
+  return issues;
+}
+
+export function buildEventCampaignSummary(
+  fixture: EventCampaignFixture,
+): string {
+  const { config, timelinePhases, messages, calendarEvents } = fixture;
+  const statusFlag = timelinePhases.some(
+    (p) => p.phaseKind === "active",
+  )
+    ? "active"
+    : "planned";
+  return [
+    `${config.name} (${config.kind}) — ${statusFlag}`,
+    `  Organizer: ${config.organizer} <${config.organizerEmail}>`,
+    `  Event date: ${config.eventDate} at ${config.venue}`,
+    `  Capacity: ${config.capacity}`,
+    `  Phases: ${timelinePhases.length} (${timelinePhases.map((p) => p.phaseKind).join(", ")})`,
+    `  Messages: ${messages.length}`,
+    `  Calendar events: ${calendarEvents.length}`,
+  ].join("\n");
+}


### PR DESCRIPTION
… pass campaign (issue 17)

- Add EventCampaign types (config, timeline phase, message, fixture)
- Add eventCampaignFixture with two deterministic fixtures:
  - StealthCon 2026 conference (7 messages, 4 timeline phases, 5 calendar events)
  - Soroban Workshop (5 messages, 4 timeline phases, 1 calendar event)
- Add eventCampaignHelpers with validation and summary builder
- Add 21 tests covering fixtures, lookup, kinds, and validation
- Add documentation docs/EVENT_CAMPAIGN_FIXTURE.md
- Export new types, fixtures, and helpers from barrel index.ts

All data is fake, deterministic, and uses safe demo domains.

Closes #268