### PR TITLE
Add mail-to-ticket safety and performance guards

### DIFF
--- a/tools/v2/team/mail-to-ticket-converter/README.md
+++ b/tools/v2/team/mail-to-ticket-converter/README.md
@@ -1,15 +1,37 @@
 # Mail-to-Ticket Converter
 
 This folder is the isolated workspace for the Mail-to-Ticket Converter tool.
+The current contribution adds safety and performance guardrails only; the tool
+is not mounted in the main app.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\mail-to-ticket-converter\
-`
+```text
+tools/v2/team/mail-to-ticket-converter/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `guards.mjs` normalizes untrusted email input into a safe ticket candidate.
+- `index.mjs` exposes the folder-local public API.
+- `fixtures/sample-mails.json` contains deterministic safe, hostile, and large-mail examples.
+- `tests/guards.test.mjs` validates malformed input handling and processing-budget behavior.
+- `docs/security-performance.md` documents threat assumptions, unsafe inputs, and scaling notes.
+- `specs.md` records the local contributor boundary and future issue categories.
+
+## Current Behavior
+
+The guard helpers:
+
+- reject malformed mail-like objects with structured errors,
+- strip HTML/script content and control characters from ticket text,
+- redact common secret-like values before ticket generation,
+- cap subject, body, attachment, and thread work to avoid large input spikes,
+- return reviewable warnings instead of calling external services.
+
+All helpers are pure and local. They do not perform network calls, read
+production data, require credentials, or persist anything.

--- a/tools/v2/team/mail-to-ticket-converter/docs/security-performance.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/security-performance.md
@@ -1,0 +1,55 @@
+# Security and Performance Notes
+
+## Threat Assumptions
+
+Every email field is untrusted. The converter must assume hostile senders can
+control subject lines, body text, attachment names, MIME types, thread content,
+and timestamps. Future integrations should keep raw mail out of logs and avoid
+feeding unsanitized content into HTML, markdown, shell commands, or remote APIs.
+
+Unsafe inputs include:
+
+- HTML and script-like content in subject or body fields,
+- control characters and path traversal strings in attachment names,
+- pasted passwords, API keys, bearer tokens, or reset links,
+- oversized bodies, attachment lists, or thread histories,
+- malformed envelope data such as missing IDs or invalid sender addresses.
+
+## Current Guardrails
+
+`guards.mjs` adds a folder-local normalization layer:
+
+- `validateMailEnvelope()` returns reviewable errors for malformed objects.
+- `sanitizeText()` strips script/style blocks, HTML tags, and control characters.
+- Secret-like assignments and bearer tokens are redacted before ticket text is generated.
+- `evaluateProcessingBudget()` computes size pressure before expensive processing.
+- `normalizeTicketCandidate()` caps body, attachment, and thread previews.
+
+The helpers do not fetch attachments, call external services, read production
+mailboxes, or persist ticket data. They only normalize objects passed by future
+callers.
+
+## Performance Constraints
+
+The default processing limits are intentionally conservative:
+
+- subject: 160 characters,
+- body preview: 12,000 characters,
+- attachments: 8 entries,
+- single attachment size: 10 MiB,
+- total attachment size: 25 MiB,
+- thread preview: 50 items.
+
+Large attachments are marked `skipped`; callers should process them through a
+separate, explicit attachment pipeline instead of inline conversion. Long
+threads are summarized by preview only so future UI work can remain responsive.
+
+## Follow-Up Integration Guidance
+
+Before this tool is connected to the mail app, add an integration issue for:
+
+- permission checks on who can convert team mail into tickets,
+- audit logging with redacted ticket payloads,
+- attachment malware scanning or explicit attachment exclusion,
+- backpressure when multiple team members convert the same mailbox,
+- UI review states for warnings such as `large-attachment-skipped`.

--- a/tools/v2/team/mail-to-ticket-converter/fixtures/sample-mails.json
+++ b/tools/v2/team/mail-to-ticket-converter/fixtures/sample-mails.json
@@ -1,0 +1,105 @@
+{
+  "safeEmail": {
+    "id": "mail-001",
+    "from": "ops@example.com",
+    "subject": "Cannot access team mailbox",
+    "body": "The support team cannot access the shared mailbox after the latest role update.",
+    "receivedAt": "2026-06-22T09:30:00Z",
+    "attachments": [
+      {
+        "filename": "screenshot.png",
+        "contentType": "image/png",
+        "sizeBytes": 240000
+      }
+    ],
+    "thread": [
+      {
+        "from": "ops@example.com",
+        "body": "This started after the admin role update."
+      }
+    ]
+  },
+  "hostileEmail": {
+    "id": "mail-evil",
+    "from": "attacker@example.com",
+    "subject": "<script>alert('x')</script>Urgent password reset",
+    "body": "password=super-secret \u0000 <script>steal()</script> Please create a ticket. Authorization: Bearer abc.def.ghi",
+    "receivedAt": "2026-06-22T10:00:00Z",
+    "attachments": [
+      {
+        "filename": "../../payload.html",
+        "contentType": "text/html",
+        "sizeBytes": 15000000
+      }
+    ],
+    "thread": []
+  },
+  "largeEmail": {
+    "id": "mail-large",
+    "from": "archive@example.com",
+    "subject": "Import large archive as support ticket",
+    "body": "A very large support archive is available in an external system. Do not fetch it automatically.",
+    "receivedAt": "2026-06-22T11:00:00Z",
+    "attachments": [
+      {
+        "filename": "archive-01.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-02.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-03.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-04.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-05.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-06.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-07.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-08.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      },
+      {
+        "filename": "archive-09.zip",
+        "contentType": "application/zip",
+        "sizeBytes": 12000000
+      }
+    ],
+    "thread": [
+      {
+        "from": "archive@example.com",
+        "body": "Thread item 1"
+      },
+      {
+        "from": "archive@example.com",
+        "body": "Thread item 2"
+      },
+      {
+        "from": "archive@example.com",
+        "body": "Thread item 3"
+      }
+    ]
+  }
+}

--- a/tools/v2/team/mail-to-ticket-converter/guards.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/guards.mjs
@@ -1,0 +1,161 @@
+const CONTROL_CHARS_EXCEPT_WHITESPACE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const SCRIPT_OR_STYLE_BLOCK = /<(script|style)\b[\s\S]*?<\/\1>/gi;
+const HTML_TAG = /<[^>]+>/g;
+const WHITESPACE = /\s+/g;
+const SECRET_ASSIGNMENT =
+  /\b(password|passcode|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|secret)\s*[:=]\s*([^\s,;]+)/gi;
+const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/g;
+const EMAIL_ADDRESS = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+
+export const DEFAULT_LIMITS = Object.freeze({
+  maxSubjectChars: 160,
+  maxBodyChars: 12000,
+  maxAttachmentCount: 8,
+  maxAttachmentBytes: 10 * 1024 * 1024,
+  maxTotalAttachmentBytes: 25 * 1024 * 1024,
+  maxThreadItems: 50,
+});
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asString(value) {
+  return typeof value === "string" ? value : "";
+}
+
+export function sanitizeText(value, maxChars = DEFAULT_LIMITS.maxBodyChars) {
+  const raw = asString(value);
+  const redacted = raw
+    .replace(SCRIPT_OR_STYLE_BLOCK, " ")
+    .replace(HTML_TAG, " ")
+    .replace(CONTROL_CHARS_EXCEPT_WHITESPACE, " ")
+    .replace(SECRET_ASSIGNMENT, "$1=[REDACTED]")
+    .replace(BEARER_TOKEN, "Bearer [REDACTED]")
+    .replace(WHITESPACE, " ")
+    .trim();
+
+  if (redacted.length <= maxChars) {
+    return { value: redacted, truncated: false, rawLength: raw.length };
+  }
+
+  return {
+    value: redacted.slice(0, Math.max(0, maxChars - 3)).trimEnd() + "...",
+    truncated: true,
+    rawLength: raw.length,
+  };
+}
+
+export function validateMailEnvelope(raw) {
+  const errors = [];
+
+  if (!isPlainObject(raw)) {
+    return ["mail must be an object"];
+  }
+
+  if (!asString(raw.id).trim()) errors.push("id is required");
+  if (!EMAIL_ADDRESS.test(asString(raw.from).trim())) errors.push("from must be an email address");
+  if (!asString(raw.subject).trim()) errors.push("subject is required");
+  if (!asString(raw.body).trim()) errors.push("body is required");
+  if (raw.attachments !== undefined && !Array.isArray(raw.attachments)) {
+    errors.push("attachments must be an array when provided");
+  }
+  if (raw.thread !== undefined && !Array.isArray(raw.thread)) {
+    errors.push("thread must be an array when provided");
+  }
+
+  return errors;
+}
+
+export function evaluateProcessingBudget(raw, limits = DEFAULT_LIMITS) {
+  const attachments = Array.isArray(raw?.attachments) ? raw.attachments : [];
+  const thread = Array.isArray(raw?.thread) ? raw.thread : [];
+  const bodyChars = asString(raw?.body).length;
+  const totalAttachmentBytes = attachments.reduce((sum, attachment) => {
+    const size = Number(attachment?.sizeBytes);
+    return Number.isFinite(size) && size > 0 ? sum + size : sum;
+  }, 0);
+  const warnings = [];
+
+  if (bodyChars > limits.maxBodyChars) warnings.push("body-truncated");
+  if (attachments.length > limits.maxAttachmentCount) warnings.push("attachment-count-capped");
+  if (totalAttachmentBytes > limits.maxTotalAttachmentBytes) {
+    warnings.push("attachment-total-size-exceeded");
+  }
+  if (
+    attachments.some((attachment) => {
+      const size = Number(attachment?.sizeBytes);
+      return Number.isFinite(size) && size > limits.maxAttachmentBytes;
+    })
+  ) {
+    warnings.push("large-attachment-skipped");
+  }
+  if (thread.length > limits.maxThreadItems) warnings.push("thread-capped");
+
+  return {
+    bodyChars,
+    attachmentCount: attachments.length,
+    totalAttachmentBytes,
+    threadItems: thread.length,
+    safeAttachmentLimit: Math.min(attachments.length, limits.maxAttachmentCount),
+    safeThreadLimit: Math.min(thread.length, limits.maxThreadItems),
+    warnings,
+  };
+}
+
+export function normalizeAttachment(attachment, limits = DEFAULT_LIMITS) {
+  const filename = sanitizeText(attachment?.filename ?? "unnamed", 120).value || "unnamed";
+  const contentType = sanitizeText(attachment?.contentType ?? "application/octet-stream", 120).value;
+  const sizeBytes = Number(attachment?.sizeBytes);
+  const safeSizeBytes = Number.isFinite(sizeBytes) && sizeBytes > 0 ? sizeBytes : 0;
+
+  return {
+    filename,
+    contentType,
+    sizeBytes: safeSizeBytes,
+    skipped: safeSizeBytes > limits.maxAttachmentBytes,
+  };
+}
+
+export function normalizeTicketCandidate(raw, limits = DEFAULT_LIMITS) {
+  const errors = validateMailEnvelope(raw);
+  if (errors.length > 0) {
+    return { ok: false, errors, warnings: [], ticket: null };
+  }
+
+  const budget = evaluateProcessingBudget(raw, limits);
+  const subject = sanitizeText(raw.subject, limits.maxSubjectChars);
+  const body = sanitizeText(raw.body, limits.maxBodyChars);
+  const rawAttachments = Array.isArray(raw.attachments) ? raw.attachments : [];
+  const rawThread = Array.isArray(raw.thread) ? raw.thread : [];
+  const attachments = rawAttachments
+    .slice(0, limits.maxAttachmentCount)
+    .map((attachment) => normalizeAttachment(attachment, limits));
+  const threadPreview = rawThread.slice(0, limits.maxThreadItems).map((item) => ({
+    from: sanitizeText(item?.from ?? "unknown", 120).value,
+    body: sanitizeText(item?.body ?? "", 500).value,
+  }));
+  const warnings = [...budget.warnings];
+
+  if (subject.truncated) warnings.push("subject-truncated");
+  if (body.truncated && !warnings.includes("body-truncated")) warnings.push("body-truncated");
+  if (attachments.some((attachment) => attachment.skipped) && !warnings.includes("large-attachment-skipped")) {
+    warnings.push("large-attachment-skipped");
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    warnings: [...new Set(warnings)],
+    budget,
+    ticket: {
+      sourceMailId: sanitizeText(raw.id, 120).value,
+      requester: sanitizeText(raw.from, 254).value.toLowerCase(),
+      title: subject.value,
+      description: body.value,
+      receivedAt: asString(raw.receivedAt).trim() || null,
+      attachments,
+      threadPreview,
+    },
+  };
+}

--- a/tools/v2/team/mail-to-ticket-converter/index.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/index.mjs
@@ -1,0 +1,8 @@
+export {
+  DEFAULT_LIMITS,
+  evaluateProcessingBudget,
+  normalizeAttachment,
+  normalizeTicketCandidate,
+  sanitizeText,
+  validateMailEnvelope,
+} from "./guards.mjs";

--- a/tools/v2/team/mail-to-ticket-converter/specs.md
+++ b/tools/v2/team/mail-to-ticket-converter/specs.md
@@ -4,9 +4,9 @@ Convert mail into tickets.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/mail-to-ticket-converter/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,22 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/mail-to-ticket-converter/README.md"
-  @"
 
-# Mail-to-Ticket Converter Specs
+## Security and Performance Guardrails
 
-## Purpose
+This tool accepts untrusted email content, so local helpers must treat every
+sender, subject, body, attachment name, and thread item as hostile until it is
+validated and normalized.
 
-Convert mail into tickets.
+Guardrail work should:
 
-## Contributor boundary
-
-All work for this tool should stay in:
-
-$dir/
+- avoid live network calls and production mail data,
+- keep all fixtures deterministic and local,
+- cap expensive work before parsing attachments or long histories,
+- redact likely secrets from generated ticket fields,
+- return structured errors and warnings instead of throwing raw parser failures.
 
 ## Required issue categories
 

--- a/tools/v2/team/mail-to-ticket-converter/tests/guards.test.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/tests/guards.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  DEFAULT_LIMITS,
+  evaluateProcessingBudget,
+  normalizeTicketCandidate,
+  sanitizeText,
+  validateMailEnvelope,
+} from "../guards.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-mails.json");
+
+async function loadFixtures() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("validateMailEnvelope returns structured errors for malformed input", () => {
+  const errors = validateMailEnvelope({
+    id: "",
+    from: "not-an-email",
+    subject: "",
+    body: "",
+    attachments: "bad",
+    thread: "bad"
+  });
+
+  assert.deepEqual(errors, [
+    "id is required",
+    "from must be an email address",
+    "subject is required",
+    "body is required",
+    "attachments must be an array when provided",
+    "thread must be an array when provided"
+  ]);
+});
+
+test("sanitizeText removes HTML, script blocks, control characters, and secret values", () => {
+  const result = sanitizeText(
+    "password=super-secret \u0000 <script>steal()</script><b>Hello</b> Bearer abc.def.ghi",
+    200
+  );
+
+  assert.equal(result.value, "password=[REDACTED] Hello Bearer [REDACTED]");
+  assert.equal(result.truncated, false);
+});
+
+test("normalizeTicketCandidate creates a safe ticket candidate for normal mail", async () => {
+  const { safeEmail } = await loadFixtures();
+  const result = normalizeTicketCandidate(safeEmail);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ticket.sourceMailId, "mail-001");
+  assert.equal(result.ticket.requester, "ops@example.com");
+  assert.equal(result.ticket.title, "Cannot access team mailbox");
+  assert.equal(result.ticket.attachments.length, 1);
+  assert.equal(result.ticket.attachments[0].skipped, false);
+});
+
+test("normalizeTicketCandidate accepts mail without optional attachments or thread", () => {
+  const result = normalizeTicketCandidate({
+    id: "mail-minimal",
+    from: "team@example.com",
+    subject: "Minimal message",
+    body: "Please create a ticket."
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ticket.attachments.length, 0);
+  assert.equal(result.ticket.threadPreview.length, 0);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("normalizeTicketCandidate sanitizes hostile mail before ticket generation", async () => {
+  const { hostileEmail } = await loadFixtures();
+  const result = normalizeTicketCandidate(hostileEmail);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ticket.title, "Urgent password reset");
+  assert.match(result.ticket.description, /password=\[REDACTED\]/);
+  assert.match(result.ticket.description, /Bearer \[REDACTED\]/);
+  assert.doesNotMatch(result.ticket.description, /<script>/);
+  assert.doesNotMatch(result.ticket.description, /super-secret/);
+  assert.equal(result.ticket.attachments[0].skipped, true);
+  assert.ok(result.warnings.includes("large-attachment-skipped"));
+});
+
+test("evaluateProcessingBudget flags attachment and thread work before expensive processing", () => {
+  const thread = Array.from({ length: DEFAULT_LIMITS.maxThreadItems + 3 }, (_, index) => ({
+    from: "archive@example.com",
+    body: `Thread item ${index}`
+  }));
+  const raw = {
+    body: "x".repeat(DEFAULT_LIMITS.maxBodyChars + 1),
+    attachments: Array.from({ length: DEFAULT_LIMITS.maxAttachmentCount + 1 }, (_, index) => ({
+      filename: `archive-${index}.zip`,
+      sizeBytes: DEFAULT_LIMITS.maxAttachmentBytes + 1
+    })),
+    thread
+  };
+
+  const budget = evaluateProcessingBudget(raw);
+
+  assert.ok(budget.warnings.includes("body-truncated"));
+  assert.ok(budget.warnings.includes("attachment-count-capped"));
+  assert.ok(budget.warnings.includes("attachment-total-size-exceeded"));
+  assert.ok(budget.warnings.includes("large-attachment-skipped"));
+  assert.ok(budget.warnings.includes("thread-capped"));
+  assert.equal(budget.safeAttachmentLimit, DEFAULT_LIMITS.maxAttachmentCount);
+  assert.equal(budget.safeThreadLimit, DEFAULT_LIMITS.maxThreadItems);
+});
+
+test("normalizeTicketCandidate caps attachment and thread output", async () => {
+  const { largeEmail } = await loadFixtures();
+  const result = normalizeTicketCandidate({
+    ...largeEmail,
+    thread: Array.from({ length: DEFAULT_LIMITS.maxThreadItems + 10 }, (_, index) => ({
+      from: "archive@example.com",
+      body: `Thread item ${index}`
+    }))
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ticket.attachments.length, DEFAULT_LIMITS.maxAttachmentCount);
+  assert.equal(result.ticket.threadPreview.length, DEFAULT_LIMITS.maxThreadItems);
+  assert.ok(result.warnings.includes("attachment-count-capped"));
+  assert.ok(result.warnings.includes("thread-capped"));
+});


### PR DESCRIPTION
## Summary
- add folder-local mail-to-ticket guard helpers for untrusted email normalization
- document threat assumptions, unsafe inputs, and performance limits
- add deterministic fixtures and Node tests for malformed, hostile, and large mail inputs

## Validation
- `node tools\v2\team\mail-to-ticket-converter\tests\guards.test.mjs`
- `git diff --check`

## Notes
- Scope is limited to `tools/v2/team/mail-to-ticket-converter/`
- No main app integration, network calls, secrets, production data, or public payout details are included

Closes #622