### PR TITLE
Add knowledge base suggestion core engine

### DIFF
--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,15 +1,34 @@
 # Knowledge Base Suggestion
 
 This folder is the isolated workspace for the Knowledge Base Suggestion tool.
+The current implementation provides the core suggestion engine only; it is not
+mounted in the main app.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\knowledge-base-suggestion\
-`
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `engine.mjs` contains the folder-local pure suggestion engine.
+- `index.mjs` exposes the future UI-facing API surface.
+- `fixtures/kb-suggestions.json` provides deterministic local article fixtures.
+- `tests/engine.test.mjs` covers validation, ranking, empty states, and large input warnings.
+- `docs/contract.md` documents inputs, outputs, loading states, and error states.
+- `specs.md` records the tool scope and issue categories.
+
+## Current Behavior
+
+The engine scores local knowledge base articles against an inbound mail or
+support context. It uses deterministic token overlap, tag matching, optional
+team matching, and article priority. It returns reviewable suggestions with
+matched terms and reasons.
+
+The engine is pure and local. It does not call live services, read production
+mail, require credentials, or persist data.

--- a/tools/v2/team/knowledge-base-suggestion/docs/contract.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/contract.md
@@ -1,0 +1,67 @@
+# Knowledge Base Suggestion Contract
+
+## Purpose
+
+The core engine suggests local knowledge base articles for an inbound team mail
+or support context. It is intentionally deterministic so reviewers can inspect
+the matching behavior without external services.
+
+## Inputs
+
+`suggestKnowledgeBaseArticles(input, articles, options)` accepts:
+
+- `input.id`: stable mail or support context identifier,
+- `input.subject`: short user-visible subject,
+- `input.body`: message body or issue description,
+- `input.teamId`: optional team scope such as `support` or `security`,
+- `input.labels`: optional local labels already assigned by a caller,
+- `articles`: local article fixtures with `id`, `title`, `summary`, `keywords`, optional `tags`, optional `teamIds`, `priority`, and `href`.
+
+The engine validates malformed input and does not read production mail, secrets,
+network resources, or global app state.
+
+## Outputs
+
+The result shape is:
+
+```js
+{
+  state: "success" | "empty" | "error",
+  ok: boolean,
+  errors: string[],
+  warnings: string[],
+  suggestions: [
+    {
+      articleId: string,
+      title: string,
+      summary: string,
+      href: string | null,
+      score: number,
+      matchedTerms: string[],
+      reasons: string[]
+    }
+  ]
+}
+```
+
+## Loading, Empty, Success, And Error States
+
+The engine is synchronous and pure; a future UI hook can wrap it in async loading
+state if it later reads from a local cache. Suggested UI state mapping:
+
+- `loading`: caller is retrieving local article fixtures or cache data,
+- `success`: `state === "success"` and at least one suggestion exists,
+- `empty`: `state === "empty"` with no article passing `minScore`,
+- `error`: `state === "error"` with validation messages in `errors`.
+
+## Matching Rules
+
+The scoring model is intentionally simple:
+
+- shared tokens between the mail context and article title/summary/keywords,
+- optional `teamId` match,
+- optional label/tag match,
+- small boost for high-priority articles.
+
+This is enough for a reviewable core feature without embedding machine learning,
+live search, secrets, or production data.

--- a/tools/v2/team/knowledge-base-suggestion/engine.mjs
+++ b/tools/v2/team/knowledge-base-suggestion/engine.mjs
@@ -1,0 +1,219 @@
+const HTML_TAG = /<[^>]+>/g;
+const NON_WORD = /[^a-z0-9]+/gi;
+const WHITESPACE = /\s+/g;
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "has",
+  "have",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "our",
+  "please",
+  "the",
+  "this",
+  "to",
+  "with",
+]);
+
+export const DEFAULT_OPTIONS = Object.freeze({
+  maxInputChars: 8000,
+  maxSuggestions: 3,
+  minScore: 2,
+});
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanText(value, maxChars = DEFAULT_OPTIONS.maxInputChars) {
+  const raw = typeof value === "string" ? value : "";
+  const cleaned = raw.replace(HTML_TAG, " ").replace(WHITESPACE, " ").trim();
+
+  if (cleaned.length <= maxChars) {
+    return { text: cleaned, truncated: false };
+  }
+
+  return {
+    text: cleaned.slice(0, Math.max(0, maxChars - 3)).trimEnd() + "...",
+    truncated: true,
+  };
+}
+
+export function tokenize(value) {
+  return cleanText(value, Number.MAX_SAFE_INTEGER)
+    .text.toLowerCase()
+    .replace(NON_WORD, " ")
+    .split(WHITESPACE)
+    .filter((token) => token.length >= 3 && !STOP_WORDS.has(token));
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+export function validateSuggestionInput(input) {
+  if (!isPlainObject(input)) {
+    return ["input must be an object"];
+  }
+
+  const errors = [];
+  if (!String(input.id ?? "").trim()) errors.push("id is required");
+  if (!String(input.subject ?? "").trim()) errors.push("subject is required");
+  if (!String(input.body ?? "").trim()) errors.push("body is required");
+  if (input.teamId !== undefined && typeof input.teamId !== "string") {
+    errors.push("teamId must be a string when provided");
+  }
+  if (input.labels !== undefined && !Array.isArray(input.labels)) {
+    errors.push("labels must be an array when provided");
+  }
+
+  return errors;
+}
+
+export function normalizeSuggestionInput(input, options = DEFAULT_OPTIONS) {
+  const config = { ...DEFAULT_OPTIONS, ...options };
+  const errors = validateSuggestionInput(input);
+  if (errors.length > 0) {
+    return { ok: false, errors, value: null, warnings: [] };
+  }
+
+  const subject = cleanText(input.subject, 240);
+  const body = cleanText(input.body, config.maxInputChars);
+  const labels = Array.isArray(input.labels)
+    ? input.labels.map((label) => cleanText(label, 60).text.toLowerCase()).filter(Boolean)
+    : [];
+  const warnings = [];
+
+  if (body.truncated) warnings.push("body-truncated");
+  if (subject.truncated) warnings.push("subject-truncated");
+
+  return {
+    ok: true,
+    errors: [],
+    warnings,
+    value: {
+      id: cleanText(input.id, 120).text,
+      subject: subject.text,
+      body: body.text,
+      teamId: typeof input.teamId === "string" ? input.teamId : null,
+      labels: unique(labels),
+      tokens: unique([...tokenize(subject.text), ...tokenize(body.text), ...labels]),
+    },
+  };
+}
+
+export function validateArticle(article) {
+  const errors = [];
+  if (!isPlainObject(article)) return ["article must be an object"];
+  if (!String(article.id ?? "").trim()) errors.push("article id is required");
+  if (!String(article.title ?? "").trim()) errors.push("article title is required");
+  if (!Array.isArray(article.keywords)) errors.push("article keywords must be an array");
+  if (article.teamIds !== undefined && !Array.isArray(article.teamIds)) {
+    errors.push("article teamIds must be an array when provided");
+  }
+  return errors;
+}
+
+export function scoreArticle(article, normalizedInput) {
+  const articleErrors = validateArticle(article);
+  if (articleErrors.length > 0) {
+    return { article, score: 0, matchedTerms: [], reasons: ["invalid-article"] };
+  }
+
+  const inputTokens = new Set(normalizedInput.tokens);
+  const articleTerms = unique([
+    ...tokenize(article.title),
+    ...tokenize(article.summary ?? ""),
+    ...article.keywords.map((keyword) => String(keyword).toLowerCase()),
+  ]);
+  const matchedTerms = articleTerms.filter((term) => inputTokens.has(term));
+  const reasons = [];
+  let score = matchedTerms.length;
+
+  if (normalizedInput.teamId && Array.isArray(article.teamIds) && article.teamIds.includes(normalizedInput.teamId)) {
+    score += 2;
+    reasons.push("team-match");
+  }
+
+  const inputLabels = new Set(normalizedInput.labels);
+  const articleTags = Array.isArray(article.tags) ? article.tags.map((tag) => String(tag).toLowerCase()) : [];
+  const tagMatches = articleTags.filter((tag) => inputLabels.has(tag));
+  if (tagMatches.length > 0) {
+    score += tagMatches.length;
+    reasons.push("label-match");
+  }
+
+  if (article.priority === "high") {
+    score += 1;
+    reasons.push("high-priority");
+  }
+
+  if (matchedTerms.length > 0) reasons.push("keyword-match");
+
+  return {
+    article,
+    score,
+    matchedTerms,
+    reasons: unique(reasons),
+  };
+}
+
+export function suggestKnowledgeBaseArticles(input, articles, options = DEFAULT_OPTIONS) {
+  const config = { ...DEFAULT_OPTIONS, ...options };
+  const normalized = normalizeSuggestionInput(input, config);
+  if (!normalized.ok) {
+    return {
+      state: "error",
+      ok: false,
+      errors: normalized.errors,
+      warnings: [],
+      suggestions: [],
+    };
+  }
+
+  if (!Array.isArray(articles) || articles.length === 0) {
+    return {
+      state: "empty",
+      ok: true,
+      errors: [],
+      warnings: normalized.warnings,
+      suggestions: [],
+    };
+  }
+
+  const suggestions = articles
+    .map((article) => scoreArticle(article, normalized.value))
+    .filter((result) => result.score >= config.minScore)
+    .sort((a, b) => b.score - a.score || a.article.title.localeCompare(b.article.title))
+    .slice(0, config.maxSuggestions)
+    .map((result) => ({
+      articleId: result.article.id,
+      title: result.article.title,
+      summary: result.article.summary ?? "",
+      href: result.article.href ?? null,
+      score: result.score,
+      matchedTerms: result.matchedTerms,
+      reasons: result.reasons,
+    }));
+
+  return {
+    state: suggestions.length > 0 ? "success" : "empty",
+    ok: true,
+    errors: [],
+    warnings: normalized.warnings,
+    suggestions,
+  };
+}

--- a/tools/v2/team/knowledge-base-suggestion/fixtures/kb-suggestions.json
+++ b/tools/v2/team/knowledge-base-suggestion/fixtures/kb-suggestions.json
@@ -1,0 +1,67 @@
+{
+  "articles": [
+    {
+      "id": "kb-001",
+      "title": "Reset shared mailbox access",
+      "summary": "Steps for restoring team mailbox access after role or group changes.",
+      "keywords": ["mailbox", "access", "role", "group", "permission", "reset"],
+      "tags": ["access", "mailbox"],
+      "teamIds": ["support", "operations"],
+      "priority": "high",
+      "href": "/kb/shared-mailbox-access"
+    },
+    {
+      "id": "kb-002",
+      "title": "Triage suspicious sender reports",
+      "summary": "How to classify sender spoofing, phishing, and suspicious domain reports.",
+      "keywords": ["sender", "spoofing", "phishing", "domain", "suspicious", "report"],
+      "tags": ["security"],
+      "teamIds": ["security", "support"],
+      "priority": "high",
+      "href": "/kb/suspicious-sender-triage"
+    },
+    {
+      "id": "kb-003",
+      "title": "Create a knowledge base article from support mail",
+      "summary": "Template for turning repeated support questions into reusable documentation.",
+      "keywords": ["knowledge", "article", "support", "documentation", "template", "question"],
+      "tags": ["documentation"],
+      "teamIds": ["support"],
+      "priority": "normal",
+      "href": "/kb/article-template"
+    },
+    {
+      "id": "kb-004",
+      "title": "Escalate legal review requests",
+      "summary": "When and how team members should route compliance-sensitive messages.",
+      "keywords": ["legal", "compliance", "review", "contract", "risk", "escalate"],
+      "tags": ["legal", "compliance"],
+      "teamIds": ["legal", "operations"],
+      "priority": "normal",
+      "href": "/kb/legal-review-routing"
+    }
+  ],
+  "requests": {
+    "mailboxAccess": {
+      "id": "msg-001",
+      "subject": "Team cannot access shared mailbox",
+      "body": "Support agents lost mailbox permissions after a role group update.",
+      "teamId": "support",
+      "labels": ["access", "mailbox"]
+    },
+    "securityReport": {
+      "id": "msg-002",
+      "subject": "Suspicious sender domain report",
+      "body": "A customer reported phishing from a spoofing domain that looks like our support address.",
+      "teamId": "security",
+      "labels": ["security"]
+    },
+    "unknown": {
+      "id": "msg-003",
+      "subject": "Office snack preferences",
+      "body": "The team is voting on snacks for the next planning session.",
+      "teamId": "operations",
+      "labels": []
+    }
+  }
+}

--- a/tools/v2/team/knowledge-base-suggestion/index.mjs
+++ b/tools/v2/team/knowledge-base-suggestion/index.mjs
@@ -1,0 +1,9 @@
+export {
+  DEFAULT_OPTIONS,
+  normalizeSuggestionInput,
+  scoreArticle,
+  suggestKnowledgeBaseArticles,
+  tokenize,
+  validateArticle,
+  validateSuggestionInput,
+} from "./engine.mjs";

--- a/tools/v2/team/knowledge-base-suggestion/specs.md
+++ b/tools/v2/team/knowledge-base-suggestion/specs.md
@@ -4,9 +4,9 @@ Suggest internal documentation.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/knowledge-base-suggestion/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,21 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/knowledge-base-suggestion/README.md"
-  @"
 
-# Knowledge Base Suggestion Specs
+## Core Feature Contract
 
-## Purpose
+The core engine accepts a local mail/support context and a local article list,
+then returns ranked knowledge base suggestions. It must remain deterministic
+until a future integration issue connects it to a real knowledge base.
 
-Suggest internal documentation.
+The core feature work should:
 
-## Contributor boundary
-
-All work for this tool should stay in:
-
-$dir/
+- validate malformed or missing input,
+- document loading, empty, success, and error states for future UI work,
+- avoid live network calls, production data, secrets, or global app wiring,
+- expose only a folder-local API from `index.mjs`.
 
 ## Required issue categories
 

--- a/tools/v2/team/knowledge-base-suggestion/tests/engine.test.mjs
+++ b/tools/v2/team/knowledge-base-suggestion/tests/engine.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  DEFAULT_OPTIONS,
+  normalizeSuggestionInput,
+  scoreArticle,
+  suggestKnowledgeBaseArticles,
+  tokenize,
+  validateArticle,
+  validateSuggestionInput,
+} from "../engine.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "kb-suggestions.json");
+
+async function loadFixtures() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("validateSuggestionInput reports malformed request fields", () => {
+  const errors = validateSuggestionInput({
+    id: "",
+    subject: "",
+    body: "",
+    teamId: 123,
+    labels: "security",
+  });
+
+  assert.deepEqual(errors, [
+    "id is required",
+    "subject is required",
+    "body is required",
+    "teamId must be a string when provided",
+    "labels must be an array when provided",
+  ]);
+});
+
+test("tokenize normalizes HTML and ignores short/common words", () => {
+  assert.deepEqual(tokenize("<b>Please</b> reset the shared mailbox access"), [
+    "reset",
+    "shared",
+    "mailbox",
+    "access",
+  ]);
+});
+
+test("normalizeSuggestionInput documents a large-input warning", () => {
+  const result = normalizeSuggestionInput({
+    id: "msg-large",
+    subject: "Long support request",
+    body: "mailbox ".repeat(DEFAULT_OPTIONS.maxInputChars),
+    teamId: "support",
+    labels: ["Access", "Mailbox"],
+  });
+
+  assert.equal(result.ok, true);
+  assert.ok(result.warnings.includes("body-truncated"));
+  assert.deepEqual(result.value.labels, ["access", "mailbox"]);
+  assert.ok(result.value.tokens.includes("mailbox"));
+});
+
+test("validateArticle reports invalid local article fixtures", () => {
+  assert.deepEqual(validateArticle({ id: "", title: "", keywords: "mail" }), [
+    "article id is required",
+    "article title is required",
+    "article keywords must be an array",
+  ]);
+});
+
+test("scoreArticle rewards keyword, label, team, and high-priority matches", async () => {
+  const { articles, requests } = await loadFixtures();
+  const normalized = normalizeSuggestionInput(requests.mailboxAccess).value;
+  const score = scoreArticle(articles[0], normalized);
+
+  assert.equal(score.article.id, "kb-001");
+  assert.ok(score.score >= 6);
+  assert.ok(score.matchedTerms.includes("mailbox"));
+  assert.ok(score.reasons.includes("keyword-match"));
+  assert.ok(score.reasons.includes("label-match"));
+  assert.ok(score.reasons.includes("team-match"));
+  assert.ok(score.reasons.includes("high-priority"));
+});
+
+test("suggestKnowledgeBaseArticles ranks the most relevant mailbox article first", async () => {
+  const { articles, requests } = await loadFixtures();
+  const result = suggestKnowledgeBaseArticles(requests.mailboxAccess, articles);
+
+  assert.equal(result.state, "success");
+  assert.equal(result.ok, true);
+  assert.equal(result.suggestions[0].articleId, "kb-001");
+  assert.ok(result.suggestions[0].score >= result.suggestions.at(-1).score);
+});
+
+test("suggestKnowledgeBaseArticles supports security report context", async () => {
+  const { articles, requests } = await loadFixtures();
+  const result = suggestKnowledgeBaseArticles(requests.securityReport, articles);
+
+  assert.equal(result.state, "success");
+  assert.equal(result.suggestions[0].articleId, "kb-002");
+  assert.ok(result.suggestions[0].matchedTerms.includes("phishing"));
+});
+
+test("suggestKnowledgeBaseArticles returns empty state when no article passes the threshold", async () => {
+  const { articles, requests } = await loadFixtures();
+  const result = suggestKnowledgeBaseArticles(requests.unknown, articles, {
+    ...DEFAULT_OPTIONS,
+    minScore: 10,
+  });
+
+  assert.equal(result.state, "empty");
+  assert.deepEqual(result.suggestions, []);
+});
+
+test("suggestKnowledgeBaseArticles returns error state for invalid input", async () => {
+  const { articles } = await loadFixtures();
+  const result = suggestKnowledgeBaseArticles({ id: "", subject: "", body: "" }, articles);
+
+  assert.equal(result.state, "error");
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("id is required"));
+});
+
+test("suggestKnowledgeBaseArticles caps suggestion count", async () => {
+  const { articles, requests } = await loadFixtures();
+  const result = suggestKnowledgeBaseArticles(requests.mailboxAccess, articles, {
+    maxSuggestions: 1,
+  });
+
+  assert.equal(result.suggestions.length, 1);
+  assert.equal(result.suggestions[0].articleId, "kb-001");
+});


### PR DESCRIPTION
## Summary
- add a folder-local knowledge base suggestion engine for V2 team support contexts
- add deterministic local article/request fixtures with no network or production data dependency
- document input/output, loading, empty, success, and error states for future UI work

## Validation
- `node tools\v2\team\knowledge-base-suggestion\tests\engine.test.mjs`
- `git diff --check`

## Notes
- Scope is limited to `tools/v2/team/knowledge-base-suggestion/`
- No main app integration, live network calls, secrets, production data, or public payout details are included

Closes #