### PR TITLE
Add legal compliance review flag core engine

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/README.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/README.md
@@ -1,15 +1,33 @@
 # Legal and Compliance Review Flag
 
-This folder is the isolated workspace for the Legal and Compliance Review Flag tool.
+This folder is the isolated workspace for the Legal and Compliance Review Flag
+tool. The current implementation provides the core review-flag engine only; it
+is not mounted in the main app.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\legal-and-compliance-review-flag\
-`
+```text
+tools/v2/team/legal-and-compliance-review-flag/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `review-engine.mjs` contains the folder-local pure review flag engine.
+- `index.mjs` exposes the future UI-facing API surface.
+- `fixtures/review-cases.json` provides deterministic local cases.
+- `tests/review-engine.test.mjs` covers validation, classification, and empty states.
+- `docs/contract.md` documents inputs, outputs, loading states, and error states.
+- `specs.md` records the tool scope and issue categories.
+
+## Current Behavior
+
+The engine evaluates local mail or document-review context against a deterministic
+rule set. It flags legal/compliance-sensitive messages, assigns severity, returns
+matched terms, and suggests next actions for reviewers.
+
+The engine is pure and local. It does not call live services, read production
+mail, require credentials, persist data, or change any main app behavior.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/contract.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/contract.md
@@ -1,0 +1,66 @@
+# Legal And Compliance Review Flag Contract
+
+## Purpose
+
+The core engine classifies local mail or document-review context to decide
+whether a legal or compliance reviewer should inspect it before a team responds.
+It is deterministic and folder-local so reviewers can audit behavior without
+external services.
+
+## Inputs
+
+`classifyReviewContext(input, rules, options)` accepts:
+
+- `input.id`: stable local context identifier,
+- `input.subject`: message or review subject,
+- `input.body`: message body or document summary,
+- `input.source`: optional source such as `team-mail` or `support-mail`,
+- `input.labels`: optional local labels,
+- `rules`: local rule objects with `id`, `label`, `severity`, `keywords`, `nextAction`, and `score`.
+
+The engine validates malformed input and does not read production mail, secrets,
+network resources, database rows, wallet state, or global app state.
+
+## Outputs
+
+The result shape is:
+
+```js
+{
+  state: "success" | "empty" | "error",
+  ok: boolean,
+  errors: string[],
+  warnings: string[],
+  reviewRequired: boolean,
+  severity: "low" | "medium" | "high" | "critical",
+  score: number,
+  matches: [
+    {
+      ruleId: string,
+      label: string,
+      severity: string,
+      score: number,
+      matchedTerms: string[],
+      nextAction: string
+    }
+  ],
+  nextActions: string[]
+}
+```
+
+## Loading, Empty, Success, And Error States
+
+The engine is synchronous and pure. A future UI hook can wrap local fixture or
+cache retrieval in a loading state:
+
+- `loading`: caller is retrieving local rules or cached review context,
+- `success`: one or more rules matched the context,
+- `empty`: the context is valid but no rules matched or no rules were provided,
+- `error`: validation failed and user-facing errors are available.
+
+## Rule Model
+
+Default rules cover contract language, privacy/personal data, regulatory
+requests, billing disputes, and security disclosures. A future integration can
+replace these rules with a local policy bundle, but should not call external
+policy engines from this isolated tool without a separate integration issue.

--- a/tools/v2/team/legal-and-compliance-review-flag/fixtures/review-cases.json
+++ b/tools/v2/team/legal-and-compliance-review-flag/fixtures/review-cases.json
@@ -1,0 +1,25 @@
+{
+  "cases": {
+    "contractReview": {
+      "id": "review-001",
+      "source": "team-mail",
+      "subject": "New enterprise MSA terms need approval",
+      "body": "The customer sent a master services agreement and DPA for signature before launch.",
+      "labels": ["contract", "enterprise"]
+    },
+    "regulatoryRequest": {
+      "id": "review-002",
+      "source": "team-mail",
+      "subject": "Court order received for account records",
+      "body": "A regulator sent a subpoena and requested account data by Friday.",
+      "labels": ["urgent", "legal"]
+    },
+    "routineSupport": {
+      "id": "review-003",
+      "source": "support-mail",
+      "subject": "How do I reset notification preferences?",
+      "body": "A customer needs help changing weekly digest settings.",
+      "labels": ["support"]
+    }
+  }
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/index.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/index.mjs
@@ -1,0 +1,9 @@
+export {
+  DEFAULT_REVIEW_OPTIONS,
+  DEFAULT_RULES,
+  classifyReviewContext,
+  matchReviewRule,
+  normalizeReviewContext,
+  validateReviewContext,
+  validateReviewRule,
+} from "./review-engine.mjs";

--- a/tools/v2/team/legal-and-compliance-review-flag/review-engine.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/review-engine.mjs
@@ -1,0 +1,234 @@
+const HTML_TAG = /<[^>]+>/g;
+const NON_WORD = /[^a-z0-9]+/gi;
+const WHITESPACE = /\s+/g;
+
+export const DEFAULT_REVIEW_OPTIONS = Object.freeze({
+  maxBodyChars: 10000,
+  maxRules: 50,
+  reviewThreshold: 4,
+});
+
+export const DEFAULT_RULES = Object.freeze([
+  {
+    id: "legal-contract",
+    label: "Contract language",
+    severity: "high",
+    keywords: ["contract", "agreement", "terms", "msa", "dpa", "nda"],
+    nextAction: "Route to legal owner before responding.",
+    score: 5,
+  },
+  {
+    id: "privacy-data",
+    label: "Privacy or personal data",
+    severity: "high",
+    keywords: ["personal data", "pii", "gdpr", "ccpa", "privacy", "data subject"],
+    nextAction: "Request privacy review and avoid sharing raw personal data.",
+    score: 5,
+  },
+  {
+    id: "regulatory-request",
+    label: "Regulatory request",
+    severity: "critical",
+    keywords: ["subpoena", "regulator", "law enforcement", "court order", "audit notice"],
+    nextAction: "Escalate immediately to legal and compliance leads.",
+    score: 8,
+  },
+  {
+    id: "payment-dispute",
+    label: "Payment or billing dispute",
+    severity: "medium",
+    keywords: ["chargeback", "refund dispute", "billing dispute", "invoice dispute"],
+    nextAction: "Attach account context and route to finance compliance.",
+    score: 3,
+  },
+  {
+    id: "security-disclosure",
+    label: "Security disclosure",
+    severity: "high",
+    keywords: ["vulnerability", "breach", "incident", "security disclosure", "exploit"],
+    nextAction: "Open a coordinated security review before external replies.",
+    score: 5,
+  },
+]);
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanText(value, maxChars = DEFAULT_REVIEW_OPTIONS.maxBodyChars) {
+  const raw = typeof value === "string" ? value : "";
+  const cleaned = raw.replace(HTML_TAG, " ").replace(WHITESPACE, " ").trim();
+
+  if (cleaned.length <= maxChars) {
+    return { text: cleaned, truncated: false };
+  }
+
+  return {
+    text: cleaned.slice(0, Math.max(0, maxChars - 3)).trimEnd() + "...",
+    truncated: true,
+  };
+}
+
+function normalizePhrase(value) {
+  return String(value).toLowerCase().replace(NON_WORD, " ").replace(WHITESPACE, " ").trim();
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+export function validateReviewContext(input) {
+  if (!isPlainObject(input)) {
+    return ["input must be an object"];
+  }
+
+  const errors = [];
+  if (!String(input.id ?? "").trim()) errors.push("id is required");
+  if (!String(input.subject ?? "").trim()) errors.push("subject is required");
+  if (!String(input.body ?? "").trim()) errors.push("body is required");
+  if (input.source !== undefined && typeof input.source !== "string") {
+    errors.push("source must be a string when provided");
+  }
+  if (input.labels !== undefined && !Array.isArray(input.labels)) {
+    errors.push("labels must be an array when provided");
+  }
+
+  return errors;
+}
+
+export function normalizeReviewContext(input, options = DEFAULT_REVIEW_OPTIONS) {
+  const config = { ...DEFAULT_REVIEW_OPTIONS, ...options };
+  const errors = validateReviewContext(input);
+  if (errors.length > 0) {
+    return { ok: false, errors, warnings: [], value: null };
+  }
+
+  const subject = cleanText(input.subject, 240);
+  const body = cleanText(input.body, config.maxBodyChars);
+  const labels = Array.isArray(input.labels)
+    ? input.labels.map((label) => normalizePhrase(label)).filter(Boolean)
+    : [];
+  const combinedText = normalizePhrase(`${subject.text} ${body.text} ${labels.join(" ")}`);
+  const warnings = [];
+
+  if (subject.truncated) warnings.push("subject-truncated");
+  if (body.truncated) warnings.push("body-truncated");
+
+  return {
+    ok: true,
+    errors: [],
+    warnings,
+    value: {
+      id: cleanText(input.id, 120).text,
+      subject: subject.text,
+      body: body.text,
+      source: typeof input.source === "string" ? input.source : "unknown",
+      labels: unique(labels),
+      combinedText,
+    },
+  };
+}
+
+export function validateReviewRule(rule) {
+  if (!isPlainObject(rule)) return ["rule must be an object"];
+
+  const errors = [];
+  if (!String(rule.id ?? "").trim()) errors.push("rule id is required");
+  if (!String(rule.label ?? "").trim()) errors.push("rule label is required");
+  if (!["low", "medium", "high", "critical"].includes(rule.severity)) {
+    errors.push("rule severity is invalid");
+  }
+  if (!Array.isArray(rule.keywords) || rule.keywords.length === 0) {
+    errors.push("rule keywords must be a non-empty array");
+  }
+  if (!Number.isFinite(Number(rule.score)) || Number(rule.score) <= 0) {
+    errors.push("rule score must be positive");
+  }
+
+  return errors;
+}
+
+export function matchReviewRule(rule, normalizedContext) {
+  const errors = validateReviewRule(rule);
+  if (errors.length > 0) {
+    return { rule, matched: false, matchedTerms: [], score: 0, errors };
+  }
+
+  const matchedTerms = rule.keywords
+    .map((keyword) => normalizePhrase(keyword))
+    .filter((keyword) => keyword && normalizedContext.combinedText.includes(keyword));
+
+  return {
+    rule,
+    matched: matchedTerms.length > 0,
+    matchedTerms,
+    score: matchedTerms.length > 0 ? Number(rule.score) + matchedTerms.length - 1 : 0,
+    errors: [],
+  };
+}
+
+function highestSeverity(matches) {
+  const rank = { low: 1, medium: 2, high: 3, critical: 4 };
+  return matches.reduce((current, match) => {
+    return rank[match.severity] > rank[current] ? match.severity : current;
+  }, "low");
+}
+
+export function classifyReviewContext(input, rules = DEFAULT_RULES, options = DEFAULT_REVIEW_OPTIONS) {
+  const config = { ...DEFAULT_REVIEW_OPTIONS, ...options };
+  const normalized = normalizeReviewContext(input, config);
+  if (!normalized.ok) {
+    return {
+      state: "error",
+      ok: false,
+      errors: normalized.errors,
+      warnings: [],
+      reviewRequired: false,
+      severity: "low",
+      score: 0,
+      matches: [],
+      nextActions: [],
+    };
+  }
+
+  if (!Array.isArray(rules) || rules.length === 0) {
+    return {
+      state: "empty",
+      ok: true,
+      errors: [],
+      warnings: normalized.warnings,
+      reviewRequired: false,
+      severity: "low",
+      score: 0,
+      matches: [],
+      nextActions: [],
+    };
+  }
+
+  const ruleSet = rules.slice(0, config.maxRules);
+  const matches = ruleSet
+    .map((rule) => matchReviewRule(rule, normalized.value))
+    .filter((match) => match.matched)
+    .map((match) => ({
+      ruleId: match.rule.id,
+      label: match.rule.label,
+      severity: match.rule.severity,
+      score: match.score,
+      matchedTerms: match.matchedTerms,
+      nextAction: match.rule.nextAction,
+    }));
+  const score = matches.reduce((sum, match) => sum + match.score, 0);
+  const reviewRequired = score >= config.reviewThreshold || matches.some((match) => match.severity === "critical");
+
+  return {
+    state: matches.length > 0 ? "success" : "empty",
+    ok: true,
+    errors: [],
+    warnings: [...normalized.warnings, ...(rules.length > config.maxRules ? ["rules-capped"] : [])],
+    reviewRequired,
+    severity: matches.length > 0 ? highestSeverity(matches) : "low",
+    score,
+    matches,
+    nextActions: unique(matches.map((match) => match.nextAction).filter(Boolean)),
+  };
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/specs.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/specs.md
@@ -4,9 +4,9 @@ Compliance workflow.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/legal-and-compliance-review-flag/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,21 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/legal-and-compliance-review-flag/README.md"
-  @"
 
-# Legal and Compliance Review Flag Specs
+## Core Feature Contract
 
-## Purpose
+The core engine classifies local review contexts for legal/compliance sensitivity.
+It must stay deterministic and folder-local until a future integration issue
+connects it to real mail, policy, or ticket systems.
 
-Compliance workflow.
+The core feature work should:
 
-## Contributor boundary
-
-All work for this tool should stay in:
-
-$dir/
+- validate malformed or missing input,
+- document loading, empty, success, and error states for future UI work,
+- avoid live network calls, production data, secrets, or global app wiring,
+- expose only a folder-local API from `index.mjs`.
 
 ## Required issue categories
 

--- a/tools/v2/team/legal-and-compliance-review-flag/tests/review-engine.test.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/tests/review-engine.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  DEFAULT_REVIEW_OPTIONS,
+  DEFAULT_RULES,
+  classifyReviewContext,
+  matchReviewRule,
+  normalizeReviewContext,
+  validateReviewContext,
+  validateReviewRule,
+} from "../review-engine.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "review-cases.json");
+
+async function loadFixtures() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("validateReviewContext reports malformed inputs", () => {
+  const errors = validateReviewContext({
+    id: "",
+    subject: "",
+    body: "",
+    source: 123,
+    labels: "legal",
+  });
+
+  assert.deepEqual(errors, [
+    "id is required",
+    "subject is required",
+    "body is required",
+    "source must be a string when provided",
+    "labels must be an array when provided",
+  ]);
+});
+
+test("normalizeReviewContext strips HTML and reports body truncation", () => {
+  const result = normalizeReviewContext({
+    id: "review-html",
+    subject: "<b>Contract</b> review",
+    body: "<script>bad()</script>" + "privacy ".repeat(DEFAULT_REVIEW_OPTIONS.maxBodyChars),
+    labels: ["Legal"],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.subject, "Contract review");
+  assert.ok(result.warnings.includes("body-truncated"));
+  assert.ok(result.value.combinedText.includes("privacy"));
+  assert.ok(result.value.labels.includes("legal"));
+});
+
+test("validateReviewRule reports invalid rules", () => {
+  assert.deepEqual(validateReviewRule({ id: "", label: "", severity: "urgent", keywords: [], score: 0 }), [
+    "rule id is required",
+    "rule label is required",
+    "rule severity is invalid",
+    "rule keywords must be a non-empty array",
+    "rule score must be positive",
+  ]);
+});
+
+test("matchReviewRule identifies matched terms and score", async () => {
+  const { cases } = await loadFixtures();
+  const normalized = normalizeReviewContext(cases.contractReview).value;
+  const match = matchReviewRule(DEFAULT_RULES[0], normalized);
+
+  assert.equal(match.matched, true);
+  assert.ok(match.matchedTerms.includes("msa"));
+  assert.ok(match.matchedTerms.includes("dpa"));
+  assert.ok(match.score >= DEFAULT_RULES[0].score);
+});
+
+test("classifyReviewContext flags contract review as high severity", async () => {
+  const { cases } = await loadFixtures();
+  const result = classifyReviewContext(cases.contractReview);
+
+  assert.equal(result.state, "success");
+  assert.equal(result.ok, true);
+  assert.equal(result.reviewRequired, true);
+  assert.equal(result.severity, "high");
+  assert.ok(result.matches.some((match) => match.ruleId === "legal-contract"));
+  assert.ok(result.nextActions.includes("Route to legal owner before responding."));
+});
+
+test("classifyReviewContext treats regulatory requests as critical", async () => {
+  const { cases } = await loadFixtures();
+  const result = classifyReviewContext(cases.regulatoryRequest);
+
+  assert.equal(result.reviewRequired, true);
+  assert.equal(result.severity, "critical");
+  assert.ok(result.matches.some((match) => match.ruleId === "regulatory-request"));
+});
+
+test("classifyReviewContext returns empty state for routine support", async () => {
+  const { cases } = await loadFixtures();
+  const result = classifyReviewContext(cases.routineSupport);
+
+  assert.equal(result.state, "empty");
+  assert.equal(result.reviewRequired, false);
+  assert.equal(result.score, 0);
+  assert.deepEqual(result.matches, []);
+});
+
+test("classifyReviewContext returns error state for invalid context", () => {
+  const result = classifyReviewContext({ id: "", subject: "", body: "" });
+
+  assert.equal(result.state, "error");
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes("id is required"));
+});
+
+test("classifyReviewContext handles no local rules as an empty state", async () => {
+  const { cases } = await loadFixtures();
+  const result = classifyReviewContext(cases.contractReview, []);
+
+  assert.equal(result.state, "empty");
+  assert.equal(result.reviewRequired, false);
+  assert.deepEqual(result.nextActions, []);
+});
+
+test("classifyReviewContext caps rules and reports a warning", async () => {
+  const { cases } = await loadFixtures();
+  const manyRules = Array.from({ length: DEFAULT_REVIEW_OPTIONS.maxRules + 2 }, (_, index) => ({
+    ...DEFAULT_RULES[0],
+    id: `contract-${index}`,
+  }));
+  const result = classifyReviewContext(cases.contractReview, manyRules);
+
+  assert.ok(result.warnings.includes("rules-capped"));
+  assert.equal(result.matches.length, DEFAULT_REVIEW_OPTIONS.maxRules);
+});


### PR DESCRIPTION
## Summary
- add a folder-local legal/compliance review flag engine for V2 team contexts
- add deterministic local review cases and rule matching fixtures
- document input/output, loading, empty, success, and error states for future UI work

## Validation
- `node tools\v2\team\legal-and-compliance-review-flag\tests\review-engine.test.mjs`
- `node -e "import('./tools/v2/team/legal-and-compliance-review-flag/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`

## Notes
- Scope is limited to `tools/v2/team/legal-and-compliance-review-flag/`
- No main app integration, live network calls, secrets, production data, or public payout details are included

Closes 