### PR TITLE
Add email template library core service

### DIFF
--- a/tools/v2/individual/email-template-library/README.md
+++ b/tools/v2/individual/email-template-library/README.md
@@ -1,15 +1,34 @@
 # Email Template Library
 
-This folder is the isolated workspace for the Email Template Library tool.
+This folder is the isolated workspace for the Email Template Library tool. The
+current implementation provides the core template service only; it is not
+mounted in the main app.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\email-template-library\
-`
+```text
+tools/v2/individual/email-template-library/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Review Map
+
+- `services/template-service.mjs` contains the folder-local pure template engine.
+- `index.mjs` exposes the future UI-facing API surface.
+- `fixtures/templates.json` provides deterministic demo templates and categories.
+- `tests/template-service.test.mjs` covers validation, CRUD, search, and rendering.
+- `docs/contract.md` documents inputs, outputs, loading states, and error states.
+- `DATA_OWNERSHIP.md`, `MODULE_BOUNDARIES.md`, and `INTEGRATION_CONSTRAINTS.md` define the isolation model.
+
+## Current Behavior
+
+The service stores templates in memory, validates template payloads, searches by
+name/category/content, extracts `{{variable}}` placeholders, and renders declared
+variables with caller-provided values. Missing values are reported instead of
+being guessed.
+
+The engine is pure and local. It does not call live services, read production
+mail, require credentials, persist data, or change any main app behavior.

--- a/tools/v2/individual/email-template-library/docs/contract.md
+++ b/tools/v2/individual/email-template-library/docs/contract.md
@@ -1,0 +1,45 @@
+# Email Template Library Contract
+
+## Purpose
+
+The core service stores and renders individual email templates in memory. It is
+designed as an isolated V2 tool engine that future UI work can wrap without
+connecting to the main app.
+
+## Inputs
+
+`createTemplateService({ initialTemplates, categories })` accepts deterministic
+local fixtures:
+
+- template `id`, `name`, `categoryId`, `subject`, `body`, and `variables`,
+- category `id` and `name`,
+- render values as a plain object keyed by declared variable names.
+
+Template placeholders use `{{variableName}}` syntax. Variable keys must start
+with a letter and contain only letters, numbers, or underscores.
+
+## Outputs
+
+The service exposes:
+
+- `listTemplates()` and `listCategories()` for cloned read models,
+- `getTemplate(id)` for a single cloned template or `null`,
+- `saveTemplate(template)` for create/update results,
+- `deleteTemplate(id)` for deterministic delete results,
+- `searchTemplates(query, options)` for text/category search,
+- `renderTemplate(id, values)` for rendered subject/body and missing variables.
+
+## Loading, Empty, Success, And Error States
+
+The service is synchronous and pure. A future hook can wrap it in UI state:
+
+- `loading`: caller is loading local fixture data or storage adapters,
+- `empty`: `listTemplates()` or `searchTemplates()` returns an empty array,
+- `success`: service methods return `ok: true` or non-empty read models,
+- `error`: validation or unknown-template results return `ok: false`.
+
+## Isolation
+
+This implementation does not persist data, read production mail, call network
+services, query databases, use authentication context, or modify main app routes.
+Durable storage and compose integration should be handled by future issues.

--- a/tools/v2/individual/email-template-library/fixtures/templates.json
+++ b/tools/v2/individual/email-template-library/fixtures/templates.json
@@ -1,0 +1,77 @@
+{
+  "categories": [
+    {
+      "id": "support",
+      "name": "Support"
+    },
+    {
+      "id": "sales",
+      "name": "Sales"
+    },
+    {
+      "id": "follow-up",
+      "name": "Follow Up"
+    }
+  ],
+  "templates": [
+    {
+      "id": "tpl-support-password-reset",
+      "name": "Password reset follow-up",
+      "categoryId": "support",
+      "subject": "Password reset steps for {{firstName}}",
+      "body": "Hi {{firstName}}, here are the password reset steps for your account: {{resetSteps}}. Reply if you still cannot sign in.",
+      "variables": [
+        {
+          "key": "firstName",
+          "label": "First name"
+        },
+        {
+          "key": "resetSteps",
+          "label": "Reset steps"
+        }
+      ]
+    },
+    {
+      "id": "tpl-sales-demo",
+      "name": "Demo scheduling reply",
+      "categoryId": "sales",
+      "subject": "Demo times for {{companyName}}",
+      "body": "Hi {{firstName}}, I can offer {{timeOptionOne}} or {{timeOptionTwo}} for a product demo with {{companyName}}.",
+      "variables": [
+        {
+          "key": "firstName",
+          "label": "First name"
+        },
+        {
+          "key": "companyName",
+          "label": "Company name"
+        },
+        {
+          "key": "timeOptionOne",
+          "label": "First time option"
+        },
+        {
+          "key": "timeOptionTwo",
+          "label": "Second time option"
+        }
+      ]
+    },
+    {
+      "id": "tpl-follow-up",
+      "name": "Gentle follow-up",
+      "categoryId": "follow-up",
+      "subject": "Following up on {{topic}}",
+      "body": "Hi {{firstName}}, I wanted to follow up on {{topic}}. Let me know if this is still useful.",
+      "variables": [
+        {
+          "key": "firstName",
+          "label": "First name"
+        },
+        {
+          "key": "topic",
+          "label": "Topic"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/v2/individual/email-template-library/index.mjs
+++ b/tools/v2/individual/email-template-library/index.mjs
@@ -1,0 +1,6 @@
+export {
+  createTemplateService,
+  extractTemplateVariables,
+  normalizeTemplate,
+  validateTemplate,
+} from "./services/template-service.mjs";

--- a/tools/v2/individual/email-template-library/services/template-service.mjs
+++ b/tools/v2/individual/email-template-library/services/template-service.mjs
@@ -1,0 +1,199 @@
+const VARIABLE_PATTERN = /{{\s*([A-Za-z][A-Za-z0-9_]*)\s*}}/g;
+const WHITESPACE = /\s+/g;
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cleanString(value, maxChars = 5000) {
+  const raw = typeof value === "string" ? value : "";
+  const cleaned = raw.replace(WHITESPACE, " ").trim();
+  return cleaned.length <= maxChars ? cleaned : cleaned.slice(0, maxChars).trimEnd();
+}
+
+function cloneTemplate(template) {
+  return {
+    id: template.id,
+    name: template.name,
+    categoryId: template.categoryId ?? null,
+    subject: template.subject,
+    body: template.body,
+    variables: template.variables.map((variable) => ({ ...variable })),
+  };
+}
+
+function normalizeVariable(variable) {
+  if (!isPlainObject(variable)) return null;
+  const key = cleanString(variable.key, 80);
+  const label = cleanString(variable.label ?? variable.key, 120);
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(key)) return null;
+  return { key, label: label || key };
+}
+
+export function extractTemplateVariables(...parts) {
+  const found = [];
+  for (const part of parts) {
+    const text = typeof part === "string" ? part : "";
+    for (const match of text.matchAll(VARIABLE_PATTERN)) {
+      found.push(match[1]);
+    }
+  }
+  return [...new Set(found)];
+}
+
+export function validateTemplate(template) {
+  if (!isPlainObject(template)) return ["template must be an object"];
+
+  const errors = [];
+  if (!cleanString(template.id, 120)) errors.push("id is required");
+  if (!cleanString(template.name, 160)) errors.push("name is required");
+  if (template.categoryId !== null && template.categoryId !== undefined && typeof template.categoryId !== "string") {
+    errors.push("categoryId must be a string or null");
+  }
+  if (typeof template.subject !== "string") errors.push("subject must be a string");
+  if (typeof template.body !== "string") errors.push("body must be a string");
+  if (!Array.isArray(template.variables)) errors.push("variables must be an array");
+
+  if (Array.isArray(template.variables)) {
+    const keys = template.variables.map((variable) => normalizeVariable(variable)?.key).filter(Boolean);
+    if (keys.length !== template.variables.length) errors.push("variables must have valid keys");
+    if (new Set(keys).size !== keys.length) errors.push("variable keys must be unique");
+  }
+
+  return errors;
+}
+
+export function normalizeTemplate(template) {
+  const errors = validateTemplate(template);
+  if (errors.length > 0) {
+    return { ok: false, errors, value: null };
+  }
+
+  const subject = cleanString(template.subject, 500);
+  const body = cleanString(template.body, 8000);
+  const declaredVariables = template.variables.map((variable) => normalizeVariable(variable));
+  const placeholderKeys = extractTemplateVariables(subject, body);
+  const declaredKeys = new Set(declaredVariables.map((variable) => variable.key));
+  const missingDeclarations = placeholderKeys.filter((key) => !declaredKeys.has(key));
+  const variables = [
+    ...declaredVariables,
+    ...missingDeclarations.map((key) => ({ key, label: key })),
+  ];
+
+  return {
+    ok: true,
+    errors: [],
+    value: {
+      id: cleanString(template.id, 120),
+      name: cleanString(template.name, 160),
+      categoryId: template.categoryId ? cleanString(template.categoryId, 120) : null,
+      subject,
+      body,
+      variables,
+    },
+  };
+}
+
+function renderText(text, values, missing) {
+  return text.replace(VARIABLE_PATTERN, (_match, key) => {
+    const value = values?.[key];
+    if (value === undefined || value === null || value === "") {
+      missing.add(key);
+      return `{{${key}}}`;
+    }
+    return cleanString(String(value), 1000);
+  });
+}
+
+export function createTemplateService(config = {}) {
+  const initialTemplates = Array.isArray(config.initialTemplates) ? config.initialTemplates : [];
+  const categories = Array.isArray(config.categories) ? config.categories.map((category) => ({ ...category })) : [];
+  let templates = initialTemplates.map((template) => normalizeTemplate(template)).filter((result) => result.ok).map((result) => result.value);
+
+  function listTemplates() {
+    return templates.map(cloneTemplate);
+  }
+
+  function listCategories() {
+    return categories.map((category) => ({ ...category }));
+  }
+
+  function getTemplate(id) {
+    const template = templates.find((item) => item.id === id);
+    return template ? cloneTemplate(template) : null;
+  }
+
+  function saveTemplate(template) {
+    const normalized = normalizeTemplate(template);
+    if (!normalized.ok) {
+      return { ok: false, errors: normalized.errors, template: null };
+    }
+
+    const next = normalized.value;
+    const index = templates.findIndex((item) => item.id === next.id);
+    templates = index === -1
+      ? [...templates, next]
+      : templates.map((item, itemIndex) => (itemIndex === index ? next : item));
+
+    return { ok: true, errors: [], template: cloneTemplate(next) };
+  }
+
+  function deleteTemplate(id) {
+    const exists = templates.some((item) => item.id === id);
+    templates = templates.filter((item) => item.id !== id);
+    return { ok: exists, deleted: exists };
+  }
+
+  function searchTemplates(query, options = {}) {
+    const normalizedQuery = cleanString(query, 200).toLowerCase();
+    const categoryId = options.categoryId ?? null;
+    let result = templates;
+
+    if (categoryId) result = result.filter((template) => template.categoryId === categoryId);
+    if (normalizedQuery) {
+      result = result.filter((template) => {
+        return [template.name, template.subject, template.body, template.categoryId ?? ""]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedQuery);
+      });
+    }
+
+    return result.map(cloneTemplate);
+  }
+
+  function renderTemplate(id, values = {}) {
+    const template = templates.find((item) => item.id === id);
+    if (!template) {
+      return {
+        ok: false,
+        errors: [`template ${id} not found`],
+        subject: "",
+        body: "",
+        missingVariables: [],
+      };
+    }
+
+    const missing = new Set();
+    const subject = renderText(template.subject, values, missing);
+    const body = renderText(template.body, values, missing);
+
+    return {
+      ok: true,
+      errors: [],
+      subject,
+      body,
+      missingVariables: [...missing],
+    };
+  }
+
+  return {
+    listTemplates,
+    listCategories,
+    getTemplate,
+    saveTemplate,
+    deleteTemplate,
+    searchTemplates,
+    renderTemplate,
+  };
+}

--- a/tools/v2/individual/email-template-library/specs.md
+++ b/tools/v2/individual/email-template-library/specs.md
@@ -4,9 +4,9 @@ Personal template system.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: individual
+- Folder ownership: `tools/v2/individual/email-template-library/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
@@ -15,22 +15,22 @@ Recommended internal structure:
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/individual/email-template-library/README.md"
-  @"
 
-# Email Template Library Specs
+## Core Feature Contract
 
-## Purpose
+The core feature owns a deterministic personal template engine. It should remain
+framework-free and folder-local until a future integration issue connects it to
+UI, storage, mail compose, or app settings.
 
-Personal template system.
+The core feature work should:
 
-## Contributor boundary
-
-All work for this tool should stay in:
-
-$dir/
+- validate malformed or missing template input,
+- support in-memory create, update, delete, search, and render flows,
+- document loading, empty, success, and error states for future UI work,
+- avoid live network calls, production data, secrets, persistence, or global app wiring,
+- expose only a folder-local API from `index.mjs`.
 
 ## Required issue categories
 

--- a/tools/v2/individual/email-template-library/tests/template-service.test.mjs
+++ b/tools/v2/individual/email-template-library/tests/template-service.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  createTemplateService,
+  extractTemplateVariables,
+  normalizeTemplate,
+  validateTemplate,
+} from "../index.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "templates.json");
+
+async function loadFixtures() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("extractTemplateVariables returns unique declared placeholders", () => {
+  const variables = extractTemplateVariables("Hi {{firstName}}", "{{ firstName }} from {{companyName}}");
+  assert.deepEqual(variables, ["firstName", "companyName"]);
+});
+
+test("validateTemplate reports malformed template payloads", () => {
+  const errors = validateTemplate({
+    id: "",
+    name: "",
+    categoryId: 123,
+    subject: 1,
+    body: null,
+    variables: [{ key: "bad key", label: "Bad" }],
+  });
+
+  assert.deepEqual(errors, [
+    "id is required",
+    "name is required",
+    "categoryId must be a string or null",
+    "subject must be a string",
+    "body must be a string",
+    "variables must have valid keys",
+  ]);
+});
+
+test("normalizeTemplate adds missing placeholder declarations", () => {
+  const result = normalizeTemplate({
+    id: "tpl-auto",
+    name: "Auto declarations",
+    categoryId: null,
+    subject: "Hello {{firstName}}",
+    body: "Ticket {{ticketId}} is ready.",
+    variables: [{ key: "firstName", label: "First name" }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value.variables.map((variable) => variable.key), ["firstName", "ticketId"]);
+});
+
+test("createTemplateService lists cloned templates and categories", async () => {
+  const { templates, categories } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates, categories });
+
+  const listed = service.listTemplates();
+  listed[0].name = "mutated outside";
+
+  assert.equal(service.listTemplates().length, 3);
+  assert.equal(service.listTemplates()[0].name, "Password reset follow-up");
+  assert.equal(service.listCategories().length, 3);
+});
+
+test("getTemplate returns null for unknown ids", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+
+  assert.equal(service.getTemplate("missing"), null);
+});
+
+test("saveTemplate creates and updates templates immutably", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+
+  const createResult = service.saveTemplate({
+    id: "tpl-new",
+    name: "New template",
+    categoryId: "support",
+    subject: "Hello {{firstName}}",
+    body: "Thanks, {{firstName}}.",
+    variables: [{ key: "firstName", label: "First name" }],
+  });
+
+  assert.equal(createResult.ok, true);
+  assert.equal(service.listTemplates().length, 4);
+
+  const updateResult = service.saveTemplate({
+    ...createResult.template,
+    name: "Updated template",
+  });
+
+  assert.equal(updateResult.ok, true);
+  assert.equal(service.getTemplate("tpl-new").name, "Updated template");
+  assert.equal(service.listTemplates().length, 4);
+});
+
+test("saveTemplate rejects invalid templates without mutating the store", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+  const result = service.saveTemplate({ id: "", name: "", subject: "", body: "", variables: [] });
+
+  assert.equal(result.ok, false);
+  assert.equal(service.listTemplates().length, 3);
+});
+
+test("deleteTemplate removes existing templates and reports missing ids", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+
+  assert.deepEqual(service.deleteTemplate("tpl-follow-up"), { ok: true, deleted: true });
+  assert.equal(service.getTemplate("tpl-follow-up"), null);
+  assert.deepEqual(service.deleteTemplate("tpl-follow-up"), { ok: false, deleted: false });
+});
+
+test("searchTemplates filters by text and category", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+
+  assert.equal(service.searchTemplates("demo").length, 1);
+  assert.equal(service.searchTemplates("", { categoryId: "support" }).length, 1);
+  assert.equal(service.searchTemplates("follow", { categoryId: "sales" }).length, 0);
+});
+
+test("renderTemplate substitutes provided values and reports missing variables", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+  const result = service.renderTemplate("tpl-sales-demo", {
+    firstName: "Ari",
+    companyName: "Example Co",
+    timeOptionOne: "Tuesday 10:00",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.subject, "Demo times for Example Co");
+  assert.match(result.body, /Tuesday 10:00/);
+  assert.deepEqual(result.missingVariables, ["timeOptionTwo"]);
+});
+
+test("renderTemplate returns an error result for unknown ids", async () => {
+  const { templates } = await loadFixtures();
+  const service = createTemplateService({ initialTemplates: templates });
+  const result = service.renderTemplate("missing", {});
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.errors, ["template missing not found"]);
+});


### PR DESCRIPTION
## Summary
- add a folder-local email template library service for V2 individual contexts
- add deterministic local templates/categories and render/search fixtures
- document input/output, loading, empty, success, and error states for future UI work

## Validation
- `node tools\v2\individual\email-template-library\tests\template-service.test.mjs`
- `node -e "import('./tools/v2/individual/email-template-library/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`

## Notes
- Scope is limited to `tools/v2/individual/email-template-library/`
- No main app integration, live network calls, secrets, production data, persistence, or public payout details are included

Closes 