### PR TITLE
Add draft improver core engine

### DIFF
--- a/tools/v2/individual/draft-improver/README.md
+++ b/tools/v2/individual/draft-improver/README.md
@@ -1,15 +1,50 @@
 # Draft Improver
 
-This folder is the isolated workspace for the Draft Improver tool.
+Draft Improver is an isolated V2 individual tool workspace for reviewing and
+improving email drafts before sending.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\draft-improver\
-`
+```text
+tools/v2/individual/draft-improver/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, fixtures, and a standalone Node
+test. No app install or live service is required to review the contribution.
+
+Run from the repository root:
+
+```bash
+node tools/v2/individual/draft-improver/tests/draft-improver-service.test.mjs
+```
+
+## Core Workflow
+
+1. Normalize a draft into subject, body, tone, audience, and channel fields.
+2. Evaluate clarity, tone, actionability, formatting, and privacy risk.
+3. Return review status, score, detected issues, suggestions, and a deterministic
+   improved draft.
+4. Keep all state folder-local so a future UI can consume the API without
+   touching the main app.
+
+## Documentation Map
+
+- `services/draft-improver-service.mjs` exposes the pure core engine.
+- `fixtures/sample-drafts.json` contains deterministic review examples.
+- `docs/contract.md` documents inputs, outputs, loading states, and error states.
+- `tests/draft-improver-service.test.mjs` validates the local contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or live email sending.
+- Suggestions are deterministic heuristics, not AI-generated rewrites.
+- Mailbox access, contact lookup, attachment handling, and delivery remain out
+  of scope for this isolated V2 folder.

--- a/tools/v2/individual/draft-improver/docs/contract.md
+++ b/tools/v2/individual/draft-improver/docs/contract.md
@@ -1,0 +1,68 @@
+# Draft Improver Contract
+
+## Inputs
+
+`improveDraft(input)` accepts a plain object:
+
+- `id`: optional stable draft id. Defaults to `draft-local`.
+- `subject`: optional draft subject.
+- `body`: draft body text. Empty bodies are blocked.
+- `recipientName`: optional name used for a missing greeting.
+- `senderName`: optional name used for a missing signoff.
+- `tone`: `neutral`, `warm`, `formal`, or `concise`.
+- `channel`: `email`, `reply`, or `follow-up`.
+- `audience`: `general`, `customer`, `manager`, `peer`, or `recruiter`.
+
+## Outputs
+
+Each review returns:
+
+- `status`: `ready`, `needs-review`, `blocked`, or `error`.
+- `loading`: always `false` for the pure helper result.
+- `error`: `null` or an error object with `code` and `message`.
+- `reviewRequired`: true when the user should review before sending.
+- `score`: deterministic quality score from 0 to 100.
+- `input`: normalized draft fields.
+- `output`: improved subject, body, tone, channel, and audience.
+- `issues`: detected quality or privacy issues.
+- `suggestions`: user-facing suggestions mapped from issues.
+- `appliedChanges`: deterministic rewrite operations.
+- `metrics`: word count, sentence count, greeting, signoff, and call-to-action
+  indicators.
+
+## Loading States
+
+`createDraftImproverService()` exposes a folder-local service state for future UI
+work:
+
+- `idle`: no review has started.
+- `loading`: a review is in progress.
+- `ready`: the latest review completed.
+- `error`: invalid input prevented review.
+
+The current implementation is synchronous and deterministic, so result objects
+return with `loading: false`.
+
+## Error States
+
+Invalid inputs return:
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "invalid-input",
+    "message": "Draft input must be an object."
+  }
+}
+```
+
+Drafts that contain sensitive data are not treated as runtime errors. They return
+`blocked` with a `sensitive-data` issue so future UI can explain the safety
+problem without losing the draft context.
+
+## Privacy and Network Rules
+
+- No live network calls are made.
+- No secrets, production mail, personal contacts, or payment data are required.
+- Fixtures use synthetic names and local examples only.

--- a/tools/v2/individual/draft-improver/fixtures/sample-drafts.json
+++ b/tools/v2/individual/draft-improver/fixtures/sample-drafts.json
@@ -1,0 +1,72 @@
+{
+  "tool": "draft-improver",
+  "sourceDrafts": [
+    {
+      "id": "draft-ready",
+      "subject": "Project timeline review",
+      "body": "Hi Maya,\n\nCould you review the updated project timeline and confirm whether Friday still works for the handoff?\n\nThanks,\nAlex",
+      "recipientName": "Maya",
+      "senderName": "Alex",
+      "tone": "neutral",
+      "channel": "email",
+      "audience": "peer"
+    },
+    {
+      "id": "draft-needs-review",
+      "subject": "",
+      "body": "Per my last email, I need the launch notes ASAP!!",
+      "recipientName": "Jordan",
+      "senderName": "Alex",
+      "tone": "warm",
+      "channel": "email",
+      "audience": "manager"
+    },
+    {
+      "id": "draft-blocked-sensitive",
+      "subject": "Account access",
+      "body": "Hi Sam,\n\nThe password is temporary-pass-123. Please use it today.\n\nThanks,\nAlex",
+      "recipientName": "Sam",
+      "senderName": "Alex",
+      "tone": "neutral",
+      "channel": "email",
+      "audience": "customer"
+    },
+    {
+      "id": "draft-short",
+      "subject": "",
+      "body": "Need this fixed.",
+      "recipientName": "Riley",
+      "senderName": "Alex",
+      "tone": "formal",
+      "channel": "email",
+      "audience": "general"
+    }
+  ],
+  "expected": [
+    {
+      "id": "draft-ready",
+      "status": "ready",
+      "reviewRequired": false,
+      "minimumScore": 90
+    },
+    {
+      "id": "draft-needs-review",
+      "status": "needs-review",
+      "reviewRequired": true,
+      "requiredIssues": ["tone-risk", "too-short", "missing-greeting", "missing-signoff"],
+      "requiredChanges": ["Replace confrontational follow-up phrasing.", "Collapse repeated punctuation."]
+    },
+    {
+      "id": "draft-blocked-sensitive",
+      "status": "blocked",
+      "reviewRequired": true,
+      "requiredIssues": ["sensitive-data"]
+    },
+    {
+      "id": "draft-short",
+      "status": "needs-review",
+      "reviewRequired": true,
+      "requiredIssues": ["too-short", "missing-action"]
+    }
+  ]
+}

--- a/tools/v2/individual/draft-improver/index.mjs
+++ b/tools/v2/individual/draft-improver/index.mjs
@@ -1,0 +1,8 @@
+export {
+  analyzeDraft,
+  createDraftImproverService,
+  improveDraft,
+  normalizeDraftInput,
+  suggestSubjectLine,
+  summarizeResults,
+} from "./services/draft-improver-service.mjs";

--- a/tools/v2/individual/draft-improver/services/draft-improver-service.mjs
+++ b/tools/v2/individual/draft-improver/services/draft-improver-service.mjs
@@ -1,0 +1,494 @@
+const VALID_TONES = new Set(["neutral", "warm", "formal", "concise"]);
+const VALID_CHANNELS = new Set(["email", "reply", "follow-up"]);
+const VALID_AUDIENCES = new Set(["general", "customer", "manager", "peer", "recruiter"]);
+
+const HARSH_PHRASES = [
+  {
+    pattern: /\bASAP\b/gi,
+    replacement: "when you have a chance",
+    label: "Replace ASAP with a calmer timeline.",
+  },
+  {
+    pattern: /\bper my last email\b/gi,
+    replacement: "following up on my earlier note",
+    label: "Replace confrontational follow-up phrasing.",
+  },
+  {
+    pattern: /\bobviously\b/gi,
+    replacement: "it looks like",
+    label: "Soften language that can read as dismissive.",
+  },
+  {
+    pattern: /\bjust checking in\b/gi,
+    replacement: "following up",
+    label: "Use a more direct follow-up phrase.",
+  },
+];
+
+const CTA_PATTERNS = [
+  /\bplease\b/i,
+  /\bcould you\b/i,
+  /\bcan you\b/i,
+  /\blet me know\b/i,
+  /\bconfirm\b/i,
+  /\breview\b/i,
+  /\bapprove\b/i,
+  /\bsend\b/i,
+  /\bshare\b/i,
+];
+
+const SENSITIVE_PATTERNS = [
+  /\bpassword\b/i,
+  /\bapi[_ -]?key\b/i,
+  /\bsecret\b/i,
+  /\bssn\b/i,
+  /\bsocial security\b/i,
+  /\bcredit card\b/i,
+  /\bbank account\b/i,
+  /\brouting number\b/i,
+];
+
+function cleanText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeWhitespace(value) {
+  return cleanText(value)
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trim().replace(/[ \t]+/g, " "))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function countWords(value) {
+  const words = normalizeWhitespace(value).match(/[A-Za-z0-9']+/g);
+  return words ? words.length : 0;
+}
+
+function splitSentences(value) {
+  return normalizeWhitespace(value)
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+}
+
+function hasGreeting(value) {
+  return /^(hi|hello|dear|good morning|good afternoon|hey)\b/i.test(normalizeWhitespace(value));
+}
+
+function hasSignoff(value) {
+  const lines = normalizeWhitespace(value)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const lastTwoLines = lines.slice(-2).join(" ");
+  return /\b(thanks|thank you|best|regards|sincerely)\b/i.test(lastTwoLines);
+}
+
+function hasCallToAction(value) {
+  return CTA_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function containsSensitiveText(value) {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function containsHarshPhrase(value) {
+  return HARSH_PHRASES.some(({ pattern }) => {
+    pattern.lastIndex = 0;
+    const matched = pattern.test(value);
+    pattern.lastIndex = 0;
+    return matched;
+  });
+}
+
+function countShoutingWords(value) {
+  const matches = value.match(/\b[A-Z]{4,}\b/g);
+  return matches ? matches.length : 0;
+}
+
+function normalizeEnum(value, allowed, fallback) {
+  const normalized = cleanText(value).toLowerCase();
+  return allowed.has(normalized) ? normalized : fallback;
+}
+
+function titleCase(value) {
+  const cleaned = value.toLowerCase();
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+function trimSentence(value, maxLength = 72) {
+  const cleaned = normalizeWhitespace(value)
+    .replace(/^(hi|hello|dear|hey)\s+[^,\n]+,?\s*/i, "")
+    .replace(/[.!?]+$/g, "")
+    .trim();
+
+  if (cleaned.length <= maxLength) {
+    return titleCase(cleaned);
+  }
+
+  const shortened = cleaned.slice(0, maxLength - 1).replace(/\s+\S*$/, "");
+  return `${titleCase(shortened)}...`;
+}
+
+function makeIssue(id, severity, message, suggestion) {
+  return { id, severity, message, suggestion };
+}
+
+export function normalizeDraftInput(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("Draft input must be an object.");
+  }
+
+  return {
+    id: cleanText(input.id) || "draft-local",
+    subject: cleanText(input.subject),
+    body: normalizeWhitespace(input.body),
+    recipientName: cleanText(input.recipientName),
+    senderName: cleanText(input.senderName),
+    tone: normalizeEnum(input.tone, VALID_TONES, "neutral"),
+    channel: normalizeEnum(input.channel, VALID_CHANNELS, "email"),
+    audience: normalizeEnum(input.audience, VALID_AUDIENCES, "general"),
+  };
+}
+
+export function suggestSubjectLine(body, fallback = "Draft follow-up") {
+  const firstSentence = splitSentences(body)[0];
+  if (!firstSentence) {
+    return fallback;
+  }
+  return trimSentence(firstSentence);
+}
+
+export function analyzeDraft(input) {
+  const draft = normalizeDraftInput(input);
+  const body = draft.body;
+  const wordCount = countWords(body);
+  const sentenceCount = splitSentences(body).length;
+  const issues = [];
+
+  if (!body) {
+    issues.push(
+      makeIssue(
+        "missing-body",
+        "blocking",
+        "Draft body is empty.",
+        "Add the message body before reviewing the draft.",
+      ),
+    );
+  }
+
+  if (containsSensitiveText(body)) {
+    issues.push(
+      makeIssue(
+        "sensitive-data",
+        "blocking",
+        "Draft may contain sensitive credentials or payment data.",
+        "Remove secrets, card data, bank details, or government identifiers before sending.",
+      ),
+    );
+  }
+
+  if (body && wordCount < 12) {
+    issues.push(
+      makeIssue(
+        "too-short",
+        "warning",
+        "Draft may be too short to give enough context.",
+        "Add the reason for the message and the action you need.",
+      ),
+    );
+  }
+
+  if (wordCount > 180) {
+    issues.push(
+      makeIssue(
+        "too-long",
+        "warning",
+        "Draft may be too long for a quick email.",
+        "Shorten background details and move extra context below the request.",
+      ),
+    );
+  }
+
+  if (body && !hasCallToAction(body)) {
+    issues.push(
+      makeIssue(
+        "missing-action",
+        "warning",
+        "Draft does not include a clear next action.",
+        "Ask for a specific reply, review, approval, or confirmation.",
+      ),
+    );
+  }
+
+  if (containsHarshPhrase(body) || /!!|\?\?/.test(body) || countShoutingWords(body) > 1) {
+    issues.push(
+      makeIssue(
+        "tone-risk",
+        "warning",
+        "Draft contains wording or punctuation that can read as harsh.",
+        "Use calmer phrasing and remove repeated punctuation.",
+      ),
+    );
+  }
+
+  if (body && draft.channel === "email" && !hasGreeting(body)) {
+    issues.push(
+      makeIssue(
+        "missing-greeting",
+        "info",
+        "Draft does not start with a greeting.",
+        "Add a short greeting when the recipient is known.",
+      ),
+    );
+  }
+
+  if (body && !hasSignoff(body)) {
+    issues.push(
+      makeIssue(
+        "missing-signoff",
+        "info",
+        "Draft does not include a signoff.",
+        "Close with a simple signoff so the message feels complete.",
+      ),
+    );
+  }
+
+  const blocking = issues.filter((issue) => issue.severity === "blocking").length;
+  const warnings = issues.filter((issue) => issue.severity === "warning").length;
+  const info = issues.filter((issue) => issue.severity === "info").length;
+  const score = Math.max(0, Math.min(100, 100 - blocking * 40 - warnings * 12 - info * 5));
+  const status = blocking > 0 ? "blocked" : warnings > 0 ? "needs-review" : "ready";
+
+  return {
+    id: draft.id,
+    status,
+    reviewRequired: status !== "ready",
+    score,
+    issues,
+    metrics: {
+      wordCount,
+      sentenceCount,
+      hasGreeting: hasGreeting(body),
+      hasSignoff: hasSignoff(body),
+      hasCallToAction: hasCallToAction(body),
+    },
+    normalizedDraft: clone(draft),
+  };
+}
+
+function applyTone(body, tone) {
+  if (!body) {
+    return body;
+  }
+
+  if (tone === "formal") {
+    return body.replace(/^Hi\b/i, "Hello").replace(/^Hey\b/i, "Hello");
+  }
+
+  if (tone === "warm") {
+    return body.replace(/\bThanks,\s*$/i, "Thank you,");
+  }
+
+  if (tone === "concise") {
+    return body
+      .replace(/\bI just wanted to\b/gi, "I want to")
+      .replace(/\bI am writing to\b/gi, "I");
+  }
+
+  return body;
+}
+
+function rewriteBody(draft, analysis) {
+  if (!draft.body) {
+    return {
+      body: "",
+      appliedChanges: [],
+    };
+  }
+
+  let nextBody = draft.body;
+  const appliedChanges = [];
+
+  for (const phrase of HARSH_PHRASES) {
+    if (phrase.pattern.test(nextBody)) {
+      nextBody = nextBody.replace(phrase.pattern, phrase.replacement);
+      appliedChanges.push(phrase.label);
+    }
+    phrase.pattern.lastIndex = 0;
+  }
+
+  if (/!!+/.test(nextBody) || /\?\?+/.test(nextBody)) {
+    nextBody = nextBody.replace(/!{2,}/g, "!").replace(/\?{2,}/g, "?");
+    appliedChanges.push("Collapse repeated punctuation.");
+  }
+
+  if (!analysis.metrics.hasGreeting && draft.recipientName) {
+    nextBody = `Hi ${draft.recipientName},\n\n${nextBody}`;
+    appliedChanges.push("Add recipient greeting.");
+  }
+
+  if (!analysis.metrics.hasCallToAction) {
+    nextBody = `${nextBody}\n\nPlease let me know what next step you recommend.`;
+    appliedChanges.push("Add a clear next-action request.");
+  }
+
+  if (!analysis.metrics.hasSignoff) {
+    const signoffName = draft.senderName ? `\n${draft.senderName}` : "";
+    nextBody = `${nextBody}\n\nThanks,${signoffName}`;
+    appliedChanges.push("Add a simple signoff.");
+  }
+
+  nextBody = applyTone(normalizeWhitespace(nextBody), draft.tone);
+
+  return {
+    body: nextBody,
+    appliedChanges,
+  };
+}
+
+export function improveDraft(input) {
+  try {
+    const draft = normalizeDraftInput(input);
+    const analysis = analyzeDraft(draft);
+    const rewrite = rewriteBody(draft, analysis);
+    const subject = draft.subject || suggestSubjectLine(rewrite.body || draft.body);
+
+    return {
+      id: draft.id,
+      status: analysis.status,
+      loading: false,
+      error: null,
+      reviewRequired: analysis.reviewRequired,
+      score: analysis.score,
+      input: clone(draft),
+      output: {
+        subject,
+        body: rewrite.body,
+        tone: draft.tone,
+        channel: draft.channel,
+        audience: draft.audience,
+      },
+      issues: analysis.issues,
+      suggestions: analysis.issues.map((issue) => ({
+        issueId: issue.id,
+        severity: issue.severity,
+        suggestion: issue.suggestion,
+      })),
+      appliedChanges: rewrite.appliedChanges,
+      metrics: analysis.metrics,
+    };
+  } catch (error) {
+    return {
+      id: "draft-error",
+      status: "error",
+      loading: false,
+      error: {
+        code: "invalid-input",
+        message: error instanceof Error ? error.message : "Unable to review draft.",
+      },
+      reviewRequired: true,
+      score: 0,
+      input: null,
+      output: null,
+      issues: [],
+      suggestions: [],
+      appliedChanges: [],
+      metrics: null,
+    };
+  }
+}
+
+export function summarizeResults(results) {
+  const summary = {
+    totalDrafts: results.length,
+    ready: 0,
+    needsReview: 0,
+    blocked: 0,
+    errors: 0,
+  };
+
+  for (const result of results) {
+    if (result.status === "ready") {
+      summary.ready += 1;
+    } else if (result.status === "needs-review") {
+      summary.needsReview += 1;
+    } else if (result.status === "blocked") {
+      summary.blocked += 1;
+    } else if (result.status === "error") {
+      summary.errors += 1;
+    }
+  }
+
+  return summary;
+}
+
+export function createDraftImproverService(options = {}) {
+  const defaults = options.defaults ?? {};
+  let state = {
+    status: "idle",
+    loading: false,
+    error: null,
+  };
+
+  function setState(nextState) {
+    state = { ...state, ...nextState };
+  }
+
+  return {
+    getState() {
+      return clone(state);
+    },
+
+    improveDraft(draft) {
+      setState({ status: "loading", loading: true, error: null });
+      const nextDraft =
+        draft && typeof draft === "object" && !Array.isArray(draft)
+          ? { ...defaults, ...draft }
+          : draft;
+      const result = improveDraft(nextDraft);
+      setState({
+        status: result.status === "error" ? "error" : "ready",
+        loading: false,
+        error: result.error,
+      });
+      return result;
+    },
+
+    improveMany(drafts) {
+      if (!Array.isArray(drafts)) {
+        const errorResult = improveDraft(null);
+        setState({ status: "error", loading: false, error: errorResult.error });
+        return {
+          loading: false,
+          error: errorResult.error,
+          results: [],
+          summary: summarizeResults([]),
+        };
+      }
+
+      setState({ status: "loading", loading: true, error: null });
+      const results = drafts.map((draft) => {
+        if (!draft || typeof draft !== "object" || Array.isArray(draft)) {
+          return improveDraft(draft);
+        }
+        return improveDraft({ ...defaults, ...draft });
+      });
+      setState({ status: "ready", loading: false, error: null });
+
+      return {
+        loading: false,
+        error: null,
+        results,
+        summary: summarizeResults(results),
+      };
+    },
+  };
+}

--- a/tools/v2/individual/draft-improver/specs.md
+++ b/tools/v2/individual/draft-improver/specs.md
@@ -1,41 +1,36 @@
-# Draft Improver
-
-Improve draft quality before sending.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/draft-improver/README.md"
-  @"
-
 # Draft Improver Specs
 
 ## Purpose
 
-Improve draft quality before sending.
+Improve draft quality before sending by producing a self-contained review result
+with deterministic rewrite suggestions.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/individual/draft-improver/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Normalize draft inputs without requiring external services.
+- Detect missing body content, missing call to action, overly terse drafts,
+  overly long drafts, harsh phrasing, excessive punctuation, missing greeting,
+  missing signoff, and sensitive-data risk.
+- Return a deterministic improved draft body and suggested subject line.
+- Mark drafts as `ready`, `needs-review`, `blocked`, or `error`.
+- Preserve the original draft id for traceability.
+- Keep review fixtures synthetic and free of personal data.
+
+## Recommended Internal Structure
+
+- `services/` for pure core behavior.
+- `fixtures/` for deterministic local examples.
+- `tests/` for standalone Node tests.
+- `docs/` for input, output, loading, and error-state contracts.

--- a/tools/v2/individual/draft-improver/tests/draft-improver-service.test.mjs
+++ b/tools/v2/individual/draft-improver/tests/draft-improver-service.test.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  analyzeDraft,
+  createDraftImproverService,
+  improveDraft,
+  normalizeDraftInput,
+  suggestSubjectLine,
+  summarizeResults,
+} from "../index.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-drafts.json");
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("normalizes draft input with safe defaults", () => {
+  const draft = normalizeDraftInput({
+    id: "  demo  ",
+    body: "  Hello Pat, \n\n Please review this. \n\n Thanks, Alex  ",
+    tone: "LOUD",
+    channel: "unknown",
+    audience: "peer",
+  });
+
+  assert.equal(draft.id, "demo");
+  assert.equal(draft.tone, "neutral");
+  assert.equal(draft.channel, "email");
+  assert.equal(draft.audience, "peer");
+  assert.equal(draft.body, "Hello Pat,\n\nPlease review this.\n\nThanks, Alex");
+});
+
+test("detects ready drafts without forcing review", () => {
+  const result = improveDraft({
+    id: "ready",
+    subject: "Timeline",
+    body: "Hi Maya,\n\nCould you review the updated project timeline and confirm Friday works?\n\nThanks,\nAlex",
+  });
+
+  assert.equal(result.status, "ready");
+  assert.equal(result.reviewRequired, false);
+  assert.equal(result.error, null);
+  assert.ok(result.score >= 90);
+});
+
+test("returns blocked status for empty bodies", () => {
+  const result = improveDraft({ id: "empty", body: "" });
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.reviewRequired, true);
+  assert.ok(result.issues.some((issue) => issue.id === "missing-body"));
+  assert.equal(result.output.body, "");
+});
+
+test("blocks likely sensitive data without dropping context", () => {
+  const result = improveDraft({
+    id: "sensitive",
+    body: "Hi Sam,\n\nThe password is temporary-pass-123. Please use it today.\n\nThanks,\nAlex",
+  });
+
+  assert.equal(result.status, "blocked");
+  assert.ok(result.issues.some((issue) => issue.id === "sensitive-data"));
+  assert.equal(result.input.id, "sensitive");
+});
+
+test("softens harsh phrasing and repeated punctuation", () => {
+  const result = improveDraft({
+    id: "tone",
+    body: "Per my last email, I need the launch notes ASAP!!",
+    recipientName: "Jordan",
+    senderName: "Alex",
+    tone: "warm",
+  });
+
+  assert.equal(result.status, "needs-review");
+  assert.match(result.output.body, /Hi Jordan,/);
+  assert.match(result.output.body, /following up on my earlier note/);
+  assert.match(result.output.body, /when you have a chance!/);
+  assert.doesNotMatch(result.output.body, /ASAP|!!/);
+  assert.ok(result.appliedChanges.includes("Add recipient greeting."));
+});
+
+test("adds a call-to-action suggestion when missing", () => {
+  const result = improveDraft({
+    id: "missing-action",
+    body: "Hi Riley,\n\nThe report is attached.\n\nThanks,\nAlex",
+  });
+
+  assert.equal(result.status, "needs-review");
+  assert.ok(result.issues.some((issue) => issue.id === "missing-action"));
+  assert.match(result.output.body, /Please let me know what next step you recommend\./);
+});
+
+test("suggests a subject from the improved body", () => {
+  const result = improveDraft({
+    id: "subject",
+    body: "Hi Priya,\n\nCould you review the launch checklist before Thursday?\n\nThanks,\nAlex",
+  });
+
+  assert.equal(result.output.subject, "Could you review the launch checklist before thursday");
+  assert.equal(suggestSubjectLine(""), "Draft follow-up");
+});
+
+test("analyzes drafts without mutating the input object", () => {
+  const input = {
+    id: "immutable",
+    body: "Need this fixed.",
+    recipientName: "Riley",
+  };
+  const snapshot = JSON.stringify(input);
+  const analysis = analyzeDraft(input);
+
+  assert.equal(JSON.stringify(input), snapshot);
+  assert.equal(analysis.id, "immutable");
+  assert.equal(analysis.status, "needs-review");
+});
+
+test("service exposes loading and error state contract", () => {
+  const service = createDraftImproverService();
+
+  assert.deepEqual(service.getState(), {
+    status: "idle",
+    loading: false,
+    error: null,
+  });
+
+  const invalid = service.improveDraft(null);
+
+  assert.equal(invalid.status, "error");
+  assert.equal(service.getState().status, "error");
+  assert.equal(service.getState().loading, false);
+  assert.equal(service.getState().error.code, "invalid-input");
+});
+
+test("batch review summarizes result statuses", async () => {
+  const fixture = await loadFixture();
+  const service = createDraftImproverService();
+  const batch = service.improveMany(fixture.sourceDrafts);
+
+  assert.equal(batch.loading, false);
+  assert.equal(batch.error, null);
+  assert.equal(batch.results.length, fixture.sourceDrafts.length);
+  assert.deepEqual(batch.summary, summarizeResults(batch.results));
+  assert.equal(batch.summary.totalDrafts, 4);
+  assert.equal(batch.summary.ready, 1);
+  assert.equal(batch.summary.needsReview, 2);
+  assert.equal(batch.summary.blocked, 1);
+});
+
+test("batch review preserves invalid draft errors", () => {
+  const service = createDraftImproverService();
+  const batch = service.improveMany([null]);
+
+  assert.equal(batch.results.length, 1);
+  assert.equal(batch.results[0].status, "error");
+  assert.equal(batch.summary.errors, 1);
+});
+
+test("sample fixture follows the local draft-improver contract", async () => {
+  const fixture = await loadFixture();
+  assert.equal(fixture.tool, "draft-improver");
+  assert.ok(Array.isArray(fixture.sourceDrafts));
+  assert.ok(Array.isArray(fixture.expected));
+  assert.equal(fixture.sourceDrafts.length, fixture.expected.length);
+
+  const results = fixture.sourceDrafts.map((draft) => improveDraft(draft));
+
+  for (const expected of fixture.expected) {
+    const result = results.find((item) => item.id === expected.id);
+    assert.ok(result, `${expected.id} result is missing`);
+    assert.equal(result.status, expected.status, `${expected.id} status mismatch`);
+    assert.equal(
+      result.reviewRequired,
+      expected.reviewRequired,
+      `${expected.id} reviewRequired mismatch`,
+    );
+
+    if (expected.minimumScore) {
+      assert.ok(result.score >= expected.minimumScore, `${expected.id} score is too low`);
+    }
+
+    for (const issueId of expected.requiredIssues ?? []) {
+      assert.ok(
+        result.issues.some((issue) => issue.id === issueId),
+        `${expected.id} missing issue ${issueId}`,
+      );
+    }
+
+    for (const change of expected.requiredChanges ?? []) {
+      assert.ok(
+        result.appliedChanges.includes(change),
+        `${expected.id} missing change ${change}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a folder-local draft improver service for deterministic draft review and rewrites
- document the input/output, loading, error, and privacy contracts
- add synthetic fixtures and standalone Node tests for ready, needs-review, blocked, and error states

## Validation
- node tools\v2\individual\draft-improver\tests\draft-improver-service.test.mjs
- node -e "import('./tools/v2/individual/draft-improver/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --check

Closes #485