### PR TITLE
Add confidential mode suggestion UI surface

### DIFF
--- a/tools/v2/individual/confidential-mode-suggestion/README.md
+++ b/tools/v2/individual/confidential-mode-suggestion/README.md
@@ -1,15 +1,53 @@
 # Confidential Mode Suggestion
 
-This folder is the isolated workspace for the Confidential Mode Suggestion tool.
+Confidential Mode Suggestion is an isolated V2 individual tool workspace for
+reviewing draft privacy risks and suggesting safer sending protections before a
+future mail-app integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\confidential-mode-suggestion\
-`
+```text
+tools/v2/individual/confidential-mode-suggestion/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds a folder-local UI surface, synthetic fixtures, and standalone
+contract tests. No app mount or live mailbox data is required to review the
+contribution.
+
+Run from the repository root:
+
+```bash
+node tools/v2/individual/confidential-mode-suggestion/tests/ui-contract.test.mjs
+```
+
+## UI Workflow
+
+1. Show empty, loading, error, and ready states.
+2. Summarize confidential-mode suggestions by state.
+3. Let users filter suggestions by `all`, `suggested`, `blocked`, or `safe`.
+4. Render accessible action buttons for applying or dismissing each suggestion.
+5. Keep the UI folder-local until a future integration issue connects it to the
+   mail app.
+
+## Documentation Map
+
+- `components/` contains the isolated React UI surface.
+- `fixtures/sample-suggestions.json` contains deterministic synthetic examples.
+- `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
+- `docs/VISUAL_STYLE.md` documents the local visual treatment.
+- `tests/ui-contract.test.mjs` validates the fixture and accessibility contract.
+
+## Known Limitations
+
+- This contribution does not add app routing or production mail access.
+- Suggestions are supplied as local props instead of being detected live.
+- Applying or dismissing a suggestion is exposed as a callback for future UI
+  wiring; no mailbox mutation happens here.

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeEmptyState.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeEmptyState.tsx
@@ -1,0 +1,41 @@
+import { MailPlus, ShieldCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface ConfidentialModeEmptyStateProps {
+  action?: ReactNode;
+  description?: string;
+  title?: string;
+}
+
+export function ConfidentialModeEmptyState({
+  action,
+  description = "Add a draft sample to preview confidential-mode recommendations.",
+  title = "No privacy suggestions yet",
+}: ConfidentialModeEmptyStateProps) {
+  return (
+    <section
+      aria-label="No confidential-mode suggestions"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="status"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-800"
+      >
+        <ShieldCheck className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      {action ? (
+        <div className="mt-6">{action}</div>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-slate-500">
+          <MailPlus aria-hidden="true" className="size-4" />
+          Awaiting draft input
+        </div>
+      )}
+    </section>
+  );
+}
+
+export type { ConfidentialModeEmptyStateProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeErrorState.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeErrorState.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface ConfidentialModeErrorStateProps {
+  details?: string;
+  onRetry?: () => void;
+  title?: string;
+}
+
+export function ConfidentialModeErrorState({
+  details = "Confidential-mode suggestions could not be prepared. Retry with the same local draft or review manually.",
+  onRetry,
+  title = "Privacy review failed",
+}: ConfidentialModeErrorStateProps) {
+  return (
+    <section
+      aria-label="Confidential-mode suggestion error"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="alert"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-red-700"
+      >
+        <AlertTriangle className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-red-900">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{details}</p>
+      {onRetry ? (
+        <button
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          onClick={onRetry}
+          type="button"
+        >
+          <RotateCcw aria-hidden="true" className="size-4" />
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+export type { ConfidentialModeErrorStateProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeLoadingState.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeLoadingState.tsx
@@ -1,0 +1,34 @@
+interface ConfidentialModeLoadingStateProps {
+  message?: string;
+  rowCount?: number;
+}
+
+export function ConfidentialModeLoadingState({
+  message = "Reviewing draft privacy signals...",
+  rowCount = 3,
+}: ConfidentialModeLoadingStateProps) {
+  return (
+    <section aria-busy="true" aria-live="polite" className="space-y-4" role="status">
+      <span className="sr-only">{message}</span>
+      {Array.from({ length: rowCount }).map((_, index) => (
+        <div
+          aria-hidden="true"
+          className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          key={index}
+        >
+          <div className="flex items-start gap-4">
+            <div className="size-10 animate-pulse rounded-md bg-slate-200" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-full animate-pulse rounded bg-slate-100" />
+            </div>
+            <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export type { ConfidentialModeLoadingStateProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeSuggestionTool.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeSuggestionTool.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from "react";
+import { Filter, MailPlus } from "lucide-react";
+import type {
+  ConfidentialModeSummary as Summary,
+  ConfidentialSuggestion,
+  ConfidentialSuggestionStatus,
+} from "../types";
+import { ConfidentialModeEmptyState } from "./ConfidentialModeEmptyState";
+import { ConfidentialModeErrorState } from "./ConfidentialModeErrorState";
+import { ConfidentialModeLoadingState } from "./ConfidentialModeLoadingState";
+import { ConfidentialModeSummary } from "./ConfidentialModeSummary";
+import { ConfidentialSuggestionCard } from "./ConfidentialSuggestionCard";
+
+type ToolViewState = "loading" | "error" | "ready";
+type FilterValue = "all" | ConfidentialSuggestionStatus;
+
+interface ConfidentialModeSuggestionToolProps {
+  errorMessage?: string;
+  initialState?: ToolViewState;
+  onApplySuggestion?: (suggestion: ConfidentialSuggestion) => void;
+  onDismissSuggestion?: (suggestion: ConfidentialSuggestion) => void;
+  onRequestDraft?: () => void;
+  suggestions?: ConfidentialSuggestion[];
+}
+
+const filterOptions: Array<{ label: string; value: FilterValue }> = [
+  { label: "All", value: "all" },
+  { label: "Suggested", value: "suggested" },
+  { label: "Blocked", value: "blocked" },
+  { label: "Safe", value: "safe" },
+];
+
+function summarizeSuggestions(suggestions: ConfidentialSuggestion[]): Summary {
+  return suggestions.reduce(
+    (summary, suggestion) => {
+      summary.totalSuggestions += 1;
+      summary[suggestion.status] += 1;
+      return summary;
+    },
+    {
+      totalSuggestions: 0,
+      suggested: 0,
+      blocked: 0,
+      safe: 0,
+    },
+  );
+}
+
+export function ConfidentialModeSuggestionTool({
+  errorMessage,
+  initialState = "ready",
+  onApplySuggestion,
+  onDismissSuggestion,
+  onRequestDraft,
+  suggestions = [],
+}: ConfidentialModeSuggestionToolProps) {
+  const [viewState, setViewState] = useState<ToolViewState>(initialState);
+  const [filter, setFilter] = useState<FilterValue>("all");
+
+  const summary = useMemo(() => summarizeSuggestions(suggestions), [suggestions]);
+  const filteredSuggestions = useMemo(
+    () =>
+      filter === "all"
+        ? suggestions
+        : suggestions.filter((suggestion) => suggestion.status === filter),
+    [filter, suggestions],
+  );
+
+  if (viewState === "loading") {
+    return <ConfidentialModeLoadingState />;
+  }
+
+  if (viewState === "error") {
+    return (
+      <ConfidentialModeErrorState details={errorMessage} onRetry={() => setViewState("ready")} />
+    );
+  }
+
+  if (suggestions.length === 0) {
+    return (
+      <ConfidentialModeEmptyState
+        action={
+          onRequestDraft ? (
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={onRequestDraft}
+              type="button"
+            >
+              <MailPlus aria-hidden="true" className="size-4" />
+              Add draft sample
+            </button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="confidential-mode-title"
+      className="mx-auto w-full max-w-5xl space-y-6 rounded-lg border border-slate-200 bg-slate-50 p-4 md:p-6"
+    >
+      <header>
+        <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          Individual V2 tool
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-slate-950" id="confidential-mode-title">
+          Confidential Mode Suggestion
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          Review draft privacy signals and decide whether confidential mode, manual review, or a
+          standard send is appropriate.
+        </p>
+      </header>
+
+      <ConfidentialModeSummary summary={summary} />
+
+      <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <Filter aria-hidden="true" className="size-4" />
+          Filter suggestions
+        </div>
+        <fieldset className="flex flex-wrap gap-2">
+          <legend className="sr-only">Confidential-mode suggestion filter</legend>
+          {filterOptions.map((option) => (
+            <label
+              className={`cursor-pointer rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                filter === option.value
+                  ? "border-slate-950 bg-slate-950 text-white"
+                  : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+              }`}
+              key={option.value}
+            >
+              <input
+                checked={filter === option.value}
+                className="sr-only"
+                name="confidential-mode-filter"
+                onChange={() => setFilter(option.value)}
+                type="radio"
+                value={option.value}
+              />
+              {option.label}
+            </label>
+          ))}
+        </fieldset>
+      </div>
+
+      {filteredSuggestions.length > 0 ? (
+        <div aria-label="Confidential-mode suggestion results" className="space-y-3" role="list">
+          {filteredSuggestions.map((suggestion) => (
+            <div key={suggestion.id} role="listitem">
+              <ConfidentialSuggestionCard
+                onApplySuggestion={onApplySuggestion}
+                onDismissSuggestion={onDismissSuggestion}
+                suggestion={suggestion}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <ConfidentialModeEmptyState
+          description="No suggestions match the current filter. Choose another status to continue reviewing."
+          title="No matching suggestions"
+        />
+      )}
+    </section>
+  );
+}
+
+export { summarizeSuggestions };
+export type { ConfidentialModeSuggestionToolProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeSummary.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialModeSummary.tsx
@@ -1,0 +1,30 @@
+import type { ConfidentialModeSummary as Summary } from "../types";
+
+interface ConfidentialModeSummaryProps {
+  summary: Summary;
+}
+
+const summaryItems = [
+  ["suggested", "Suggested"],
+  ["blocked", "Blocked"],
+  ["safe", "Safe"],
+  ["totalSuggestions", "Total"],
+] as const;
+
+export function ConfidentialModeSummary({ summary }: ConfidentialModeSummaryProps) {
+  return (
+    <dl
+      aria-label="Confidential-mode suggestion summary"
+      className="grid grid-cols-2 gap-3 md:grid-cols-4"
+    >
+      {summaryItems.map(([key, label]) => (
+        <div className="rounded-lg border border-slate-200 bg-white p-4" key={key}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-1 text-2xl font-semibold text-slate-950">{summary[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export type { ConfidentialModeSummaryProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialSuggestionCard.tsx
+++ b/tools/v2/individual/confidential-mode-suggestion/components/ConfidentialSuggestionCard.tsx
@@ -1,0 +1,118 @@
+import { CheckCircle2, EyeOff, LockKeyhole, ShieldAlert } from "lucide-react";
+import type { ConfidentialSuggestion } from "../types";
+
+interface ConfidentialSuggestionCardProps {
+  onApplySuggestion?: (suggestion: ConfidentialSuggestion) => void;
+  onDismissSuggestion?: (suggestion: ConfidentialSuggestion) => void;
+  suggestion: ConfidentialSuggestion;
+}
+
+const statusStyles: Record<ConfidentialSuggestion["status"], string> = {
+  suggested: "border-blue-200 bg-blue-50 text-blue-800",
+  blocked: "border-red-200 bg-red-50 text-red-800",
+  safe: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+const statusIcons = {
+  suggested: LockKeyhole,
+  blocked: ShieldAlert,
+  safe: CheckCircle2,
+};
+
+function formatMode(suggestion: ConfidentialSuggestion): string {
+  if (suggestion.recommendedMode === "confidential-mode") {
+    return "Confidential mode";
+  }
+  if (suggestion.recommendedMode === "manual-review") {
+    return "Manual review";
+  }
+  return "Standard send";
+}
+
+export function ConfidentialSuggestionCard({
+  onApplySuggestion,
+  onDismissSuggestion,
+  suggestion,
+}: ConfidentialSuggestionCardProps) {
+  const StatusIcon = statusIcons[suggestion.status];
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        <div
+          aria-hidden="true"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-md border ${statusStyles[suggestion.status]}`}
+        >
+          <StatusIcon className="size-5" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-slate-950">
+              {suggestion.draftTitle}
+            </h3>
+            <span
+              className={`rounded-md border px-2 py-1 text-xs font-medium ${statusStyles[suggestion.status]}`}
+            >
+              {suggestion.status}
+            </span>
+          </div>
+
+          <p className="mt-2 text-sm text-slate-700">
+            {formatMode(suggestion)} for {suggestion.recipientLabel}
+          </p>
+
+          <p className="mt-3 text-sm leading-6 text-slate-600">{suggestion.reason}</p>
+
+          <ul aria-label={`Privacy signals for ${suggestion.draftTitle}`} className="mt-4 space-y-2">
+            {suggestion.signals.map((signal) => (
+              <li
+                className="rounded-md bg-slate-50 px-3 py-2 text-sm text-slate-700"
+                key={signal.id}
+              >
+                <span className="font-medium text-slate-950">{signal.label}</span>
+                <span className="ml-2 rounded-md bg-white px-2 py-1 text-xs text-slate-600">
+                  {signal.severity}
+                </span>
+                <span className="mt-1 block text-xs leading-5 text-slate-500">
+                  {signal.evidence}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap gap-2 md:flex-col">
+          {onApplySuggestion && suggestion.status === "suggested" ? (
+            <button
+              aria-label={`Apply confidential mode to ${suggestion.draftTitle}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onApplySuggestion(suggestion)}
+              type="button"
+            >
+              <LockKeyhole aria-hidden="true" className="size-4" />
+              Apply
+            </button>
+          ) : null}
+          {onDismissSuggestion ? (
+            <button
+              aria-label={`Dismiss privacy suggestion for ${suggestion.draftTitle}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onDismissSuggestion(suggestion)}
+              type="button"
+            >
+              <EyeOff aria-hidden="true" className="size-4" />
+              Dismiss
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <p className="mt-4 border-t border-slate-100 pt-3 text-sm text-slate-600">
+        {suggestion.suggestedAction}
+      </p>
+    </article>
+  );
+}
+
+export type { ConfidentialSuggestionCardProps };

--- a/tools/v2/individual/confidential-mode-suggestion/components/index.ts
+++ b/tools/v2/individual/confidential-mode-suggestion/components/index.ts
@@ -1,0 +1,15 @@
+export { ConfidentialModeEmptyState } from "./ConfidentialModeEmptyState";
+export { ConfidentialModeErrorState } from "./ConfidentialModeErrorState";
+export { ConfidentialModeLoadingState } from "./ConfidentialModeLoadingState";
+export {
+  ConfidentialModeSuggestionTool,
+  summarizeSuggestions,
+} from "./ConfidentialModeSuggestionTool";
+export { ConfidentialModeSummary } from "./ConfidentialModeSummary";
+export { ConfidentialSuggestionCard } from "./ConfidentialSuggestionCard";
+export type { ConfidentialModeEmptyStateProps } from "./ConfidentialModeEmptyState";
+export type { ConfidentialModeErrorStateProps } from "./ConfidentialModeErrorState";
+export type { ConfidentialModeLoadingStateProps } from "./ConfidentialModeLoadingState";
+export type { ConfidentialModeSuggestionToolProps } from "./ConfidentialModeSuggestionTool";
+export type { ConfidentialModeSummaryProps } from "./ConfidentialModeSummary";
+export type { ConfidentialSuggestionCardProps } from "./ConfidentialSuggestionCard";

--- a/tools/v2/individual/confidential-mode-suggestion/docs/ACCESSIBILITY.md
+++ b/tools/v2/individual/confidential-mode-suggestion/docs/ACCESSIBILITY.md
@@ -1,0 +1,35 @@
+# Accessibility Notes
+
+## State Announcements
+
+- `ConfidentialModeLoadingState` uses `role="status"`, `aria-live="polite"`,
+  and `aria-busy="true"` so assistive technology can announce review progress.
+- `ConfidentialModeErrorState` uses `role="alert"` for immediate failure
+  announcement.
+- `ConfidentialModeEmptyState` uses `role="status"` with a scoped
+  `aria-label`.
+- The ready view is labelled by `confidential-mode-title`.
+
+## Keyboard Behavior
+
+- Status filters are native radio inputs wrapped by labels, so tab and arrow-key
+  behavior follows browser defaults.
+- Apply, dismiss, retry, and add-draft actions are native buttons.
+- Focus indicators use `focus-visible` outlines with sufficient offset.
+- The UI does not trap focus or create hidden modal states.
+
+## Screen Reader Names
+
+- Decorative icons use `aria-hidden="true"`.
+- Apply buttons include the draft title in `aria-label`.
+- Dismiss buttons include the draft title in `aria-label`.
+- The result list uses `role="list"` and `role="listitem"` wrappers.
+- Each suggestion card labels its privacy-signal list with the draft title.
+
+## Manual Checklist
+
+- Tab through add-draft, filter, apply, dismiss, and retry controls.
+- Confirm focus outlines remain visible at each stop.
+- Confirm loading and error states announce with screen-reader tooling.
+- Confirm icon-backed buttons have readable accessible names.
+- Confirm filtered empty results announce as a status region.

--- a/tools/v2/individual/confidential-mode-suggestion/docs/VISUAL_STYLE.md
+++ b/tools/v2/individual/confidential-mode-suggestion/docs/VISUAL_STYLE.md
@@ -1,0 +1,30 @@
+# Visual Style Notes
+
+## Layout
+
+- The ready state uses a constrained `max-w-5xl` tool surface matching other V2
+  individual tool workspaces.
+- Summary metrics use a compact responsive definition list.
+- Suggestion cards use a single-level card structure with actions aligned beside
+  the reviewed draft content on wider screens.
+
+## Color System
+
+- `suggested` uses blue for recommended confidential-mode action.
+- `blocked` uses red for high-risk drafts requiring manual review.
+- `safe` uses emerald for drafts that do not need extra protection.
+- Status chips always include text labels; color is never the only signal.
+
+## Typography
+
+- Tool title uses a compact `text-2xl` heading.
+- Card titles use `text-base` so long draft names wrap without dominating the
+  workflow.
+- Supporting copy uses `text-sm` and `leading-6` for scan-friendly review.
+
+## Interaction Treatment
+
+- Primary apply action uses a dark filled button.
+- Secondary dismiss and add-draft actions use bordered buttons.
+- All controls keep the same focus-visible outline treatment as adjacent V2 tool
+  components.

--- a/tools/v2/individual/confidential-mode-suggestion/fixtures/sample-suggestions.json
+++ b/tools/v2/individual/confidential-mode-suggestion/fixtures/sample-suggestions.json
@@ -1,0 +1,70 @@
+{
+  "tool": "confidential-mode-suggestion",
+  "suggestions": [
+    {
+      "id": "suggestion-contract-attachment",
+      "draftTitle": "Vendor contract renewal",
+      "recipientLabel": "external vendor",
+      "status": "suggested",
+      "recommendedMode": "confidential-mode",
+      "expiresIn": "7 days",
+      "preventForwarding": true,
+      "requirePasscode": true,
+      "signals": [
+        {
+          "id": "attachment-contract",
+          "label": "Sensitive attachment",
+          "severity": "high",
+          "evidence": "Draft references an unsigned renewal agreement."
+        },
+        {
+          "id": "external-domain",
+          "label": "External recipient",
+          "severity": "medium",
+          "evidence": "Recipient is outside the organization."
+        }
+      ],
+      "reason": "The draft includes a sensitive contract and an external recipient.",
+      "suggestedAction": "Apply confidential mode with forwarding disabled and passcode required."
+    },
+    {
+      "id": "suggestion-credential-block",
+      "draftTitle": "Temporary account access",
+      "recipientLabel": "customer contact",
+      "status": "blocked",
+      "recommendedMode": "manual-review",
+      "expiresIn": "1 day",
+      "preventForwarding": true,
+      "requirePasscode": true,
+      "signals": [
+        {
+          "id": "secret-text",
+          "label": "Credential-like text",
+          "severity": "high",
+          "evidence": "Draft mentions a temporary password."
+        }
+      ],
+      "reason": "Credentials should not be sent until the user removes secret values.",
+      "suggestedAction": "Block send and ask the user to remove credentials before continuing."
+    },
+    {
+      "id": "suggestion-standard-safe",
+      "draftTitle": "Team lunch poll",
+      "recipientLabel": "internal team",
+      "status": "safe",
+      "recommendedMode": "standard-send",
+      "preventForwarding": false,
+      "requirePasscode": false,
+      "signals": [
+        {
+          "id": "low-risk-content",
+          "label": "Low-risk content",
+          "severity": "low",
+          "evidence": "Draft contains scheduling text and no personal or financial data."
+        }
+      ],
+      "reason": "The draft does not contain sensitive indicators.",
+      "suggestedAction": "No confidential-mode action is required."
+    }
+  ]
+}

--- a/tools/v2/individual/confidential-mode-suggestion/specs.md
+++ b/tools/v2/individual/confidential-mode-suggestion/specs.md
@@ -1,41 +1,33 @@
-# Confidential Mode Suggestion
-
-Suggest privacy protections.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/confidential-mode-suggestion/README.md"
-  @"
-
 # Confidential Mode Suggestion Specs
 
 ## Purpose
 
-Suggest privacy protections.
+Suggest privacy protections before a user sends a sensitive message.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/individual/confidential-mode-suggestion/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Provide empty, loading, error, and ready UI states.
+- Expose folder-local components for the primary review workflow.
+- Include native keyboard support for filters and actions.
+- Provide accessible labels for icon-backed controls.
+- Document focus, screen-reader, and visual treatment.
+- Use synthetic fixtures only.
+
+## Recommended Internal Structure
+
+- `components/` for folder-local UI components.
+- `fixtures/` for deterministic suggestion examples.
+- `tests/` for standalone contract checks.
+- `docs/` for accessibility and local visual style notes.

--- a/tools/v2/individual/confidential-mode-suggestion/tests/ui-contract.test.mjs
+++ b/tools/v2/individual/confidential-mode-suggestion/tests/ui-contract.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+async function loadFixture() {
+  const raw = await readLocal("fixtures/sample-suggestions.json");
+  return JSON.parse(raw);
+}
+
+test("sample suggestions fixture follows the local UI contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "confidential-mode-suggestion");
+  assert.ok(Array.isArray(fixture.suggestions));
+  assert.equal(fixture.suggestions.length, 3);
+
+  const statuses = new Set();
+
+  for (const suggestion of fixture.suggestions) {
+    assert.ok(suggestion.id, "suggestion needs a stable id");
+    assert.ok(suggestion.draftTitle, `${suggestion.id} needs a draft title`);
+    assert.ok(suggestion.recipientLabel, `${suggestion.id} needs a recipient label`);
+    assert.ok(["suggested", "blocked", "safe"].includes(suggestion.status));
+    assert.ok(
+      ["confidential-mode", "manual-review", "standard-send"].includes(
+        suggestion.recommendedMode,
+      ),
+    );
+    assert.equal(typeof suggestion.preventForwarding, "boolean");
+    assert.equal(typeof suggestion.requirePasscode, "boolean");
+    assert.ok(Array.isArray(suggestion.signals));
+    assert.ok(suggestion.signals.length >= 1, `${suggestion.id} needs at least one signal`);
+    assert.ok(suggestion.reason, `${suggestion.id} needs a reason`);
+    assert.ok(suggestion.suggestedAction, `${suggestion.id} needs a suggested action`);
+
+    for (const signal of suggestion.signals) {
+      assert.ok(signal.id, `${suggestion.id} signal needs an id`);
+      assert.ok(signal.label, `${suggestion.id} signal needs a label`);
+      assert.ok(["high", "medium", "low"].includes(signal.severity));
+      assert.ok(signal.evidence, `${suggestion.id} signal needs evidence`);
+    }
+
+    statuses.add(suggestion.status);
+  }
+
+  for (const status of ["suggested", "blocked", "safe"]) {
+    assert.ok(statuses.has(status), `fixture must include ${status}`);
+  }
+});
+
+test("loading, error, and empty states expose screen-reader roles", async () => {
+  const loadingState = await readLocal("components/ConfidentialModeLoadingState.tsx");
+  const errorState = await readLocal("components/ConfidentialModeErrorState.tsx");
+  const emptyState = await readLocal("components/ConfidentialModeEmptyState.tsx");
+
+  assert.match(loadingState, /role="status"/);
+  assert.match(loadingState, /aria-live="polite"/);
+  assert.match(loadingState, /aria-busy="true"/);
+  assert.match(errorState, /role="alert"/);
+  assert.match(errorState, /type="button"/);
+  assert.match(emptyState, /role="status"/);
+  assert.match(emptyState, /aria-label="No confidential-mode suggestions"/);
+});
+
+test("ready tool uses native filters and labelled result list", async () => {
+  const tool = await readLocal("components/ConfidentialModeSuggestionTool.tsx");
+
+  assert.match(tool, /aria-labelledby="confidential-mode-title"/);
+  assert.match(tool, /<fieldset/);
+  assert.match(tool, /<legend className="sr-only">Confidential-mode suggestion filter<\/legend>/);
+  assert.match(tool, /type="radio"/);
+  assert.match(tool, /name="confidential-mode-filter"/);
+  assert.match(tool, /role="list"/);
+  assert.match(tool, /role="listitem"/);
+});
+
+test("suggestion card labels icon-backed controls", async () => {
+  const card = await readLocal("components/ConfidentialSuggestionCard.tsx");
+
+  assert.match(card, /aria-label=\{`Apply confidential mode to \$\{suggestion\.draftTitle\}`\}/);
+  assert.match(
+    card,
+    /aria-label=\{`Dismiss privacy suggestion for \$\{suggestion\.draftTitle\}`\}/,
+  );
+  assert.match(card, /aria-hidden="true"/);
+  assert.match(card, /type="button"/);
+  assert.match(card, /aria-label=\{`Privacy signals for \$\{suggestion\.draftTitle\}`\}/);
+});
+
+test("component barrel exports the local UI surface", async () => {
+  const index = await readLocal("components/index.ts");
+
+  for (const exportName of [
+    "ConfidentialModeEmptyState",
+    "ConfidentialModeErrorState",
+    "ConfidentialModeLoadingState",
+    "ConfidentialModeSuggestionTool",
+    "ConfidentialModeSummary",
+    "ConfidentialSuggestionCard",
+  ]) {
+    assert.match(index, new RegExp(`\\b${exportName}\\b`));
+  }
+});
+
+test("documentation covers focus, keyboard, screen-reader, and color states", async () => {
+  const accessibility = await readLocal("docs/ACCESSIBILITY.md");
+  const visualStyle = await readLocal("docs/VISUAL_STYLE.md");
+
+  assert.match(accessibility, /Keyboard Behavior/);
+  assert.match(accessibility, /Screen Reader Names/);
+  assert.match(accessibility, /focus/i);
+  assert.match(visualStyle, /suggested/);
+  assert.match(visualStyle, /blocked/);
+  assert.match(visualStyle, /safe/);
+});

--- a/tools/v2/individual/confidential-mode-suggestion/types.ts
+++ b/tools/v2/individual/confidential-mode-suggestion/types.ts
@@ -1,0 +1,30 @@
+export type ConfidentialSuggestionStatus = "suggested" | "blocked" | "safe";
+export type ConfidentialSignalSeverity = "high" | "medium" | "low";
+
+export interface ConfidentialSignal {
+  id: string;
+  label: string;
+  severity: ConfidentialSignalSeverity;
+  evidence: string;
+}
+
+export interface ConfidentialSuggestion {
+  id: string;
+  draftTitle: string;
+  recipientLabel: string;
+  status: ConfidentialSuggestionStatus;
+  recommendedMode: "confidential-mode" | "manual-review" | "standard-send";
+  expiresIn?: string;
+  preventForwarding: boolean;
+  requirePasscode: boolean;
+  signals: ConfidentialSignal[];
+  reason: string;
+  suggestedAction: string;
+}
+
+export interface ConfidentialModeSummary {
+  totalSuggestions: number;
+  suggested: number;
+  blocked: number;
+  safe: number;
+}


### PR DESCRIPTION
## Summary
- add a folder-local React UI surface for confidential-mode suggestions
- cover empty, loading, error, ready, filtered, and result-card states
- document keyboard, focus, screen-reader, and local visual treatment
- add synthetic fixtures and standalone contract tests

## Validation
- node tools\v2\individual\confidential-mode-suggestion\tests\ui-contract.test.mjs
- git diff --check

Closes 