### PR TITLE
Add email translator UI surface

### DIFF
--- a/tools/v2/individual/email-translator/README.md
+++ b/tools/v2/individual/email-translator/README.md
@@ -1,41 +1,56 @@
 # Email Translator
 
-The Email Translator helps **Individual** users translate email body content between languages. A caller supplies the source text (for example, a draft or pasted message); the tool detects or accepts a source language, lets the user choose a target language, and produces translated output with copy-to-clipboard support. It is designed as an isolated V2 later-release mini-product and does not read from or write to the main mail inbox.
+Email Translator is an isolated V2 individual tool workspace for translating
+email body content between languages before a future mail-app integration.
+
+## Ownership Boundary
+
+All work for this tool must stay inside:
+
+```text
+tools/v2/individual/email-translator/
+```
+
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
 ## Current Status
 
-**Architecture only — implementation deferred.** This folder contains the architectural contract, module placeholders, and contributor rules. No TypeScript components, services, or hooks are implemented yet. Future issues should implement against `ARCHITECTURE.md` without modifying core application files.
+This folder now contains an isolated UI surface for the translator workflow. It
+does not call live translation providers, read inbox data, send email, or persist
+translated output. Future core-service issues can connect the UI to a local
+translation provider contract.
 
-## Folder Structure
+## Reviewer Setup
 
-```
-email-translator/
-├── ARCHITECTURE.md    # Module boundaries, data ownership, integration rules
-├── README.md          # This file
-├── components/        # EmailTranslatorShell, LanguageSelector, etc. (planned)
-├── services/          # translationProvider, translationService, languageDetector (planned)
-├── hooks/             # useTranslation, useLanguageDetect (planned)
-├── tests/             # Local unit and integration tests (planned)
-└── docs/              # Extended local documentation (planned)
+Run the local contract test from the repository root:
+
+```bash
+node tools/v2/individual/email-translator/tests/ui-contract.test.mjs
 ```
 
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for component, service, and hook responsibilities.
+## UI Workflow
 
-## Contributor Rules
+1. Show empty, loading, error, and translated states.
+2. Let users choose source and target languages with labelled native selects.
+3. Render translated examples with confidence, warnings, preserved elements, and
+   copy actions.
+4. Keep translation actions callback-based until a future service issue wires the
+   provider layer.
 
-1. **Stay inside this folder.** All code, tests, fixtures, and docs must live under `tools/v2/individual/email-translator/`.
-2. **Do not wire into the main app.** No changes to shell, routing, inbox, wallet, Stellar core, database schema, or design system.
-3. **Use local fixtures only.** Sample email bodies and mock translation responses belong in this tree — not in main app test helpers.
-4. **Follow module boundaries.** UI in `components/`, logic in `services/`, state in `hooks/`, coverage in `tests/`, prose in `docs/`.
-5. **Document integration separately.** If the tool needs inbox or compose integration, open a follow-up issue — do not implement it here.
+## Documentation Map
 
-Keep changes small and reviewable. Prefer mock translation providers until a security-reviewed external provider is approved.
+- `ARCHITECTURE.md` documents the folder-local module boundary.
+- `components/` contains the isolated React UI surface.
+- `fixtures/sample-translations.json` contains deterministic synthetic examples.
+- `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
+- `docs/VISUAL_STYLE.md` documents the local visual treatment.
+- `tests/ui-contract.test.mjs` validates the fixture and accessibility contract.
 
-## Labels
+## Known Limitations
 
-- GrantFox OSS
-- Maybe Rewarded
-- Official Campaign
-- Tooling Ecosystem
-- V2 Later Tool
-- Individual Tool
+- This contribution does not add live translation.
+- Copy behavior is exposed as local UI logic and callbacks only.
+- Inbox, compose, provider configuration, secrets, and persistence remain out of
+  scope for this isolated V2 folder.

--- a/tools/v2/individual/email-translator/components/CopyTranslationButton.tsx
+++ b/tools/v2/individual/email-translator/components/CopyTranslationButton.tsx
@@ -1,0 +1,43 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+interface CopyTranslationButtonProps {
+  label?: string;
+  onCopy?: (text: string) => void;
+  text: string;
+}
+
+export function CopyTranslationButton({
+  label = "Copy translation",
+  onCopy,
+  text,
+}: CopyTranslationButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    onCopy?.(text);
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(text);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }
+
+  return (
+    <button
+      aria-live="polite"
+      className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+      onClick={handleCopy}
+      type="button"
+    >
+      {copied ? (
+        <Check aria-hidden="true" className="size-4 text-emerald-700" />
+      ) : (
+        <Copy aria-hidden="true" className="size-4" />
+      )}
+      {copied ? "Copied" : label}
+    </button>
+  );
+}
+
+export type { CopyTranslationButtonProps };

--- a/tools/v2/individual/email-translator/components/EmailTranslatorEmptyState.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorEmptyState.tsx
@@ -1,0 +1,41 @@
+import { Languages, MailPlus } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface EmailTranslatorEmptyStateProps {
+  action?: ReactNode;
+  description?: string;
+  title?: string;
+}
+
+export function EmailTranslatorEmptyState({
+  action,
+  description = "Add an email draft or message sample to preview translation output.",
+  title = "No email text to translate",
+}: EmailTranslatorEmptyStateProps) {
+  return (
+    <section
+      aria-label="No translation results"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="status"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-blue-200 bg-blue-50 text-blue-800"
+      >
+        <Languages className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      {action ? (
+        <div className="mt-6">{action}</div>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-slate-500">
+          <MailPlus aria-hidden="true" className="size-4" />
+          Awaiting email text
+        </div>
+      )}
+    </section>
+  );
+}
+
+export type { EmailTranslatorEmptyStateProps };

--- a/tools/v2/individual/email-translator/components/EmailTranslatorErrorState.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorErrorState.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface EmailTranslatorErrorStateProps {
+  details?: string;
+  onRetry?: () => void;
+  title?: string;
+}
+
+export function EmailTranslatorErrorState({
+  details = "The translation preview could not be prepared. Retry with the same local input or review the draft manually.",
+  onRetry,
+  title = "Translation preview failed",
+}: EmailTranslatorErrorStateProps) {
+  return (
+    <section
+      aria-label="Email translator error"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="alert"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-red-700"
+      >
+        <AlertTriangle className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-red-900">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{details}</p>
+      {onRetry ? (
+        <button
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          onClick={onRetry}
+          type="button"
+        >
+          <RotateCcw aria-hidden="true" className="size-4" />
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+export type { EmailTranslatorErrorStateProps };

--- a/tools/v2/individual/email-translator/components/EmailTranslatorLoadingState.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorLoadingState.tsx
@@ -1,0 +1,34 @@
+interface EmailTranslatorLoadingStateProps {
+  message?: string;
+  rowCount?: number;
+}
+
+export function EmailTranslatorLoadingState({
+  message = "Preparing translation preview...",
+  rowCount = 2,
+}: EmailTranslatorLoadingStateProps) {
+  return (
+    <section aria-busy="true" aria-live="polite" className="space-y-4" role="status">
+      <span className="sr-only">{message}</span>
+      {Array.from({ length: rowCount }).map((_, index) => (
+        <div
+          aria-hidden="true"
+          className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          key={index}
+        >
+          <div className="flex items-start gap-4">
+            <div className="size-10 animate-pulse rounded-md bg-slate-200" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+              <div className="h-20 w-full animate-pulse rounded bg-slate-100" />
+            </div>
+            <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export type { EmailTranslatorLoadingStateProps };

--- a/tools/v2/individual/email-translator/components/EmailTranslatorShell.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorShell.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState } from "react";
+import { ArrowRightLeft, MailPlus } from "lucide-react";
+import type {
+  EmailTranslationResult,
+  EmailTranslationStatus,
+  EmailTranslatorSummary as Summary,
+  TranslatorLanguage,
+} from "../types";
+import { EmailTranslatorEmptyState } from "./EmailTranslatorEmptyState";
+import { EmailTranslatorErrorState } from "./EmailTranslatorErrorState";
+import { EmailTranslatorLoadingState } from "./EmailTranslatorLoadingState";
+import { EmailTranslatorSummary } from "./EmailTranslatorSummary";
+import { LanguageSelector } from "./LanguageSelector";
+import { TranslationResultCard } from "./TranslationResultCard";
+
+type TranslatorViewState = "loading" | "error" | "ready";
+type FilterValue = "all" | EmailTranslationStatus;
+
+interface EmailTranslatorShellProps {
+  errorMessage?: string;
+  initialState?: TranslatorViewState;
+  languages?: TranslatorLanguage[];
+  onCopyTranslation?: (text: string) => void;
+  onRequestEmailText?: () => void;
+  onRequestTranslation?: (sourceLanguage: string, targetLanguage: string) => void;
+  onReviewTranslation?: (result: EmailTranslationResult) => void;
+  results?: EmailTranslationResult[];
+}
+
+const defaultLanguages: TranslatorLanguage[] = [
+  { code: "auto", label: "Auto-detect" },
+  { code: "en", label: "English" },
+  { code: "es", label: "Spanish", nativeLabel: "Español" },
+  { code: "fr", label: "French", nativeLabel: "Français" },
+  { code: "de", label: "German", nativeLabel: "Deutsch" },
+  { code: "ja", label: "Japanese", nativeLabel: "日本語" },
+];
+
+const filterOptions: Array<{ label: string; value: FilterValue }> = [
+  { label: "All", value: "all" },
+  { label: "Translated", value: "translated" },
+  { label: "Review", value: "needs-review" },
+  { label: "Blocked", value: "blocked" },
+];
+
+function summarizeTranslations(results: EmailTranslationResult[]): Summary {
+  return results.reduce(
+    (summary, result) => {
+      summary.totalTranslations += 1;
+      if (result.status === "needs-review") {
+        summary.needsReview += 1;
+      } else {
+        summary[result.status] += 1;
+      }
+      return summary;
+    },
+    {
+      totalTranslations: 0,
+      translated: 0,
+      needsReview: 0,
+      blocked: 0,
+    },
+  );
+}
+
+export function EmailTranslatorShell({
+  errorMessage,
+  initialState = "ready",
+  languages = defaultLanguages,
+  onCopyTranslation,
+  onRequestEmailText,
+  onRequestTranslation,
+  onReviewTranslation,
+  results = [],
+}: EmailTranslatorShellProps) {
+  const [viewState, setViewState] = useState<TranslatorViewState>(initialState);
+  const [sourceLanguage, setSourceLanguage] = useState("auto");
+  const [targetLanguage, setTargetLanguage] = useState("es");
+  const [filter, setFilter] = useState<FilterValue>("all");
+
+  const summary = useMemo(() => summarizeTranslations(results), [results]);
+  const filteredResults = useMemo(
+    () => (filter === "all" ? results : results.filter((result) => result.status === filter)),
+    [filter, results],
+  );
+
+  if (viewState === "loading") {
+    return <EmailTranslatorLoadingState />;
+  }
+
+  if (viewState === "error") {
+    return (
+      <EmailTranslatorErrorState details={errorMessage} onRetry={() => setViewState("ready")} />
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <EmailTranslatorEmptyState
+        action={
+          onRequestEmailText ? (
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={onRequestEmailText}
+              type="button"
+            >
+              <MailPlus aria-hidden="true" className="size-4" />
+              Add email text
+            </button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="email-translator-title"
+      className="mx-auto w-full max-w-5xl space-y-6 rounded-lg border border-slate-200 bg-slate-50 p-4 md:p-6"
+    >
+      <header>
+        <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          Individual V2 tool
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-slate-950" id="email-translator-title">
+          Email Translator
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          Preview translated email text, review confidence and warnings, and copy safe results for
+          a future compose integration.
+        </p>
+      </header>
+
+      <EmailTranslatorSummary summary={summary} />
+
+      <div className="rounded-lg border border-slate-200 bg-white p-4">
+        <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
+          <LanguageSelector
+            description="Use auto-detect when the source language is unknown."
+            id="email-translator-source-language"
+            label="Source language"
+            languages={languages}
+            onChange={setSourceLanguage}
+            value={sourceLanguage}
+          />
+          <div
+            aria-hidden="true"
+            className="hidden size-10 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-500 md:flex"
+          >
+            <ArrowRightLeft className="size-4" />
+          </div>
+          <LanguageSelector
+            description="Choose the language for the translated email body."
+            id="email-translator-target-language"
+            label="Target language"
+            languages={languages.filter((language) => language.code !== "auto")}
+            onChange={setTargetLanguage}
+            value={targetLanguage}
+          />
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3 border-t border-slate-100 pt-4 md:flex-row md:items-center md:justify-between">
+          <fieldset className="flex flex-wrap gap-2">
+            <legend className="sr-only">Translation result filter</legend>
+            {filterOptions.map((option) => (
+              <label
+                className={`cursor-pointer rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                  filter === option.value
+                    ? "border-slate-950 bg-slate-950 text-white"
+                    : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+                }`}
+                key={option.value}
+              >
+                <input
+                  checked={filter === option.value}
+                  className="sr-only"
+                  name="email-translator-filter"
+                  onChange={() => setFilter(option.value)}
+                  type="radio"
+                  value={option.value}
+                />
+                {option.label}
+              </label>
+            ))}
+          </fieldset>
+
+          {onRequestTranslation ? (
+            <button
+              aria-label={`Translate email from ${sourceLanguage} to ${targetLanguage}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onRequestTranslation(sourceLanguage, targetLanguage)}
+              type="button"
+            >
+              <ArrowRightLeft aria-hidden="true" className="size-4" />
+              Translate
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {filteredResults.length > 0 ? (
+        <div aria-label="Email translation results" className="space-y-3" role="list">
+          {filteredResults.map((result) => (
+            <div key={result.id} role="listitem">
+              <TranslationResultCard
+                onCopy={onCopyTranslation}
+                onReviewTranslation={onReviewTranslation}
+                result={result}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmailTranslatorEmptyState
+          description="No translations match the current filter. Choose another status to continue reviewing."
+          title="No matching translations"
+        />
+      )}
+    </section>
+  );
+}
+
+export { defaultLanguages, summarizeTranslations };
+export type { EmailTranslatorShellProps };

--- a/tools/v2/individual/email-translator/components/EmailTranslatorSummary.tsx
+++ b/tools/v2/individual/email-translator/components/EmailTranslatorSummary.tsx
@@ -1,0 +1,27 @@
+import type { EmailTranslatorSummary as Summary } from "../types";
+
+interface EmailTranslatorSummaryProps {
+  summary: Summary;
+}
+
+const summaryItems = [
+  ["translated", "Translated"],
+  ["needsReview", "Review"],
+  ["blocked", "Blocked"],
+  ["totalTranslations", "Total"],
+] as const;
+
+export function EmailTranslatorSummary({ summary }: EmailTranslatorSummaryProps) {
+  return (
+    <dl aria-label="Email translation summary" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {summaryItems.map(([key, label]) => (
+        <div className="rounded-lg border border-slate-200 bg-white p-4" key={key}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-1 text-2xl font-semibold text-slate-950">{summary[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export type { EmailTranslatorSummaryProps };

--- a/tools/v2/individual/email-translator/components/LanguageSelector.tsx
+++ b/tools/v2/individual/email-translator/components/LanguageSelector.tsx
@@ -1,0 +1,50 @@
+import type { TranslatorLanguage } from "../types";
+
+interface LanguageSelectorProps {
+  description?: string;
+  id: string;
+  label: string;
+  languages: TranslatorLanguage[];
+  onChange?: (languageCode: string) => void;
+  value: string;
+}
+
+export function LanguageSelector({
+  description,
+  id,
+  label,
+  languages,
+  onChange,
+  value,
+}: LanguageSelectorProps) {
+  const descriptionId = description ? `${id}-description` : undefined;
+
+  return (
+    <div className="min-w-0 flex-1">
+      <label className="text-sm font-medium text-slate-800" htmlFor={id}>
+        {label}
+      </label>
+      {description ? (
+        <p className="mt-1 text-xs leading-5 text-slate-500" id={descriptionId}>
+          {description}
+        </p>
+      ) : null}
+      <select
+        aria-describedby={descriptionId}
+        className="mt-2 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+        id={id}
+        onChange={(event) => onChange?.(event.target.value)}
+        value={value}
+      >
+        {languages.map((language) => (
+          <option key={language.code} value={language.code}>
+            {language.label}
+            {language.nativeLabel ? ` (${language.nativeLabel})` : ""}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export type { LanguageSelectorProps };

--- a/tools/v2/individual/email-translator/components/TranslationResultCard.tsx
+++ b/tools/v2/individual/email-translator/components/TranslationResultCard.tsx
@@ -1,0 +1,119 @@
+import { CheckCircle2, FileQuestion, ShieldAlert } from "lucide-react";
+import type { EmailTranslationResult } from "../types";
+import { CopyTranslationButton } from "./CopyTranslationButton";
+
+interface TranslationResultCardProps {
+  onCopy?: (text: string) => void;
+  onReviewTranslation?: (result: EmailTranslationResult) => void;
+  result: EmailTranslationResult;
+}
+
+const statusStyles: Record<EmailTranslationResult["status"], string> = {
+  translated: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  "needs-review": "border-amber-200 bg-amber-50 text-amber-800",
+  blocked: "border-red-200 bg-red-50 text-red-800",
+};
+
+const statusIcons = {
+  translated: CheckCircle2,
+  "needs-review": FileQuestion,
+  blocked: ShieldAlert,
+};
+
+function formatConfidence(confidence: number): string {
+  return `${Math.round(confidence * 100)}% confidence`;
+}
+
+export function TranslationResultCard({
+  onCopy,
+  onReviewTranslation,
+  result,
+}: TranslationResultCardProps) {
+  const StatusIcon = statusIcons[result.status];
+  const shouldReview = result.status !== "translated";
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        <div
+          aria-hidden="true"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-md border ${statusStyles[result.status]}`}
+        >
+          <StatusIcon className="size-5" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-slate-950">
+              {result.subject}
+            </h3>
+            <span
+              className={`rounded-md border px-2 py-1 text-xs font-medium ${statusStyles[result.status]}`}
+            >
+              {result.status}
+            </span>
+          </div>
+
+          <p className="mt-2 text-sm text-slate-700">
+            {result.sourceLanguage.toUpperCase()} to {result.targetLanguage.toUpperCase()} ·{" "}
+            {formatConfidence(result.confidence)}
+          </p>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Source
+              </h4>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                {result.sourceText}
+              </p>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-white p-3">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Translation
+              </h4>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-800">
+                {result.translatedText}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
+            {result.preservedElements.map((item) => (
+              <span className="rounded-md bg-slate-100 px-2 py-1" key={item}>
+                Preserved {item}
+              </span>
+            ))}
+            {result.warnings.map((warning) => (
+              <span className="rounded-md bg-amber-100 px-2 py-1 text-amber-800" key={warning}>
+                {warning}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap gap-2 md:flex-col">
+          {result.status !== "blocked" ? (
+            <CopyTranslationButton
+              label={`Copy ${result.subject} translation`}
+              onCopy={onCopy}
+              text={result.translatedText}
+            />
+          ) : null}
+          {onReviewTranslation && shouldReview ? (
+            <button
+              aria-label={`Review translation for ${result.subject}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onReviewTranslation(result)}
+              type="button"
+            >
+              Review
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export type { TranslationResultCardProps };

--- a/tools/v2/individual/email-translator/components/index.ts
+++ b/tools/v2/individual/email-translator/components/index.ts
@@ -1,0 +1,20 @@
+export { CopyTranslationButton } from "./CopyTranslationButton";
+export { EmailTranslatorEmptyState } from "./EmailTranslatorEmptyState";
+export { EmailTranslatorErrorState } from "./EmailTranslatorErrorState";
+export { EmailTranslatorLoadingState } from "./EmailTranslatorLoadingState";
+export {
+  EmailTranslatorShell,
+  defaultLanguages,
+  summarizeTranslations,
+} from "./EmailTranslatorShell";
+export { EmailTranslatorSummary } from "./EmailTranslatorSummary";
+export { LanguageSelector } from "./LanguageSelector";
+export { TranslationResultCard } from "./TranslationResultCard";
+export type { CopyTranslationButtonProps } from "./CopyTranslationButton";
+export type { EmailTranslatorEmptyStateProps } from "./EmailTranslatorEmptyState";
+export type { EmailTranslatorErrorStateProps } from "./EmailTranslatorErrorState";
+export type { EmailTranslatorLoadingStateProps } from "./EmailTranslatorLoadingState";
+export type { EmailTranslatorShellProps } from "./EmailTranslatorShell";
+export type { EmailTranslatorSummaryProps } from "./EmailTranslatorSummary";
+export type { LanguageSelectorProps } from "./LanguageSelector";
+export type { TranslationResultCardProps } from "./TranslationResultCard";

--- a/tools/v2/individual/email-translator/docs/ACCESSIBILITY.md
+++ b/tools/v2/individual/email-translator/docs/ACCESSIBILITY.md
@@ -1,0 +1,38 @@
+# Accessibility Notes
+
+## State Announcements
+
+- `EmailTranslatorLoadingState` uses `role="status"`, `aria-live="polite"`,
+  and `aria-busy="true"` so assistive technology can announce translation
+  progress.
+- `EmailTranslatorErrorState` uses `role="alert"` for immediate failure
+  announcement.
+- `EmailTranslatorEmptyState` uses `role="status"` with a scoped
+  `aria-label`.
+- The ready view is labelled by `email-translator-title`.
+
+## Keyboard Behavior
+
+- Source and target languages are native `select` elements with visible labels.
+- Result filters are native radio inputs wrapped by labels.
+- Translate, review, retry, add-text, and copy actions are native buttons.
+- Focus indicators use `focus-visible` outlines with sufficient offset.
+- The UI does not trap focus or create hidden modal states.
+
+## Screen Reader Names
+
+- Decorative icons use `aria-hidden="true"`.
+- The translate button includes source and target language codes in its
+  `aria-label`.
+- Review buttons include the email subject in `aria-label`.
+- Copy status updates use `aria-live="polite"`.
+- The result list uses `role="list"` and `role="listitem"` wrappers.
+
+## Manual Checklist
+
+- Tab through language selects, filters, translate, copy, review, retry, and
+  add-text controls.
+- Confirm focus outlines remain visible at each stop.
+- Confirm loading and error states announce with screen-reader tooling.
+- Confirm each icon-backed control has a text label or accessible name.
+- Confirm filtered empty results announce as a status region.

--- a/tools/v2/individual/email-translator/docs/VISUAL_STYLE.md
+++ b/tools/v2/individual/email-translator/docs/VISUAL_STYLE.md
@@ -1,0 +1,31 @@
+# Visual Style Notes
+
+## Layout
+
+- The ready state uses a constrained `max-w-5xl` tool surface matching adjacent
+  V2 individual tool workspaces.
+- Source and target language controls sit in one responsive row on desktop and
+  stack on narrow screens.
+- Translation result cards use a two-column source/translation comparison when
+  space allows.
+
+## Color System
+
+- `translated` uses emerald for successful output.
+- `needs-review` uses amber for translations requiring human review.
+- `blocked` uses red for unsafe translation attempts.
+- Status chips always include text labels; color is never the only signal.
+
+## Typography
+
+- Tool title uses a compact `text-2xl` heading.
+- Card titles use `text-base` so long subjects wrap cleanly.
+- Email body previews use `whitespace-pre-wrap`, `text-sm`, and `leading-6` to
+  preserve readable message structure.
+
+## Interaction Treatment
+
+- The translate and review actions use dark filled buttons.
+- Copy and add-text actions use bordered buttons.
+- All controls keep the same focus-visible outline treatment as adjacent V2 tool
+  components.

--- a/tools/v2/individual/email-translator/fixtures/sample-translations.json
+++ b/tools/v2/individual/email-translator/fixtures/sample-translations.json
@@ -1,0 +1,48 @@
+{
+  "tool": "email-translator",
+  "languages": [
+    { "code": "auto", "label": "Auto-detect" },
+    { "code": "en", "label": "English" },
+    { "code": "es", "label": "Spanish", "nativeLabel": "Español" },
+    { "code": "fr", "label": "French", "nativeLabel": "Français" },
+    { "code": "de", "label": "German", "nativeLabel": "Deutsch" }
+  ],
+  "results": [
+    {
+      "id": "translation-ready",
+      "subject": "Project update",
+      "sourceLanguage": "en",
+      "targetLanguage": "es",
+      "sourceText": "Hi Marta,\n\nCould you review the attached timeline before Friday?\n\nThanks,\nAlex",
+      "translatedText": "Hola Marta,\n\n¿Podrías revisar el cronograma adjunto antes del viernes?\n\nGracias,\nAlex",
+      "status": "translated",
+      "confidence": 0.96,
+      "preservedElements": ["greeting", "deadline", "signoff"],
+      "warnings": []
+    },
+    {
+      "id": "translation-review",
+      "subject": "Legal clause question",
+      "sourceLanguage": "en",
+      "targetLanguage": "fr",
+      "sourceText": "Please review clause 4.2 before we send this to the customer.",
+      "translatedText": "Veuillez examiner la clause 4.2 avant que nous l'envoyions au client.",
+      "status": "needs-review",
+      "confidence": 0.74,
+      "preservedElements": ["clause number"],
+      "warnings": ["Legal wording needs review"]
+    },
+    {
+      "id": "translation-blocked",
+      "subject": "Account credentials",
+      "sourceLanguage": "en",
+      "targetLanguage": "de",
+      "sourceText": "The temporary password is included below.",
+      "translatedText": "",
+      "status": "blocked",
+      "confidence": 0,
+      "preservedElements": [],
+      "warnings": ["Remove secrets before translation"]
+    }
+  ]
+}

--- a/tools/v2/individual/email-translator/specs.md
+++ b/tools/v2/individual/email-translator/specs.md
@@ -1,41 +1,34 @@
-# Email Translator
-
-Translate emails between languages.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/email-translator/README.md"
-  @"
-
 # Email Translator Specs
 
 ## Purpose
 
-Translate emails between languages.
+Translate email body content between languages while preserving enough context
+for a user to review the result before sending.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/individual/email-translator/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Provide empty, loading, error, and success UI states.
+- Expose folder-local components for the primary translation workflow.
+- Include labelled source and target language controls.
+- Include keyboard-accessible actions for translate, review, and copy.
+- Document focus, screen-reader, and visual treatment.
+- Use synthetic fixtures only.
+
+## Recommended Internal Structure
+
+- `components/` for folder-local UI components.
+- `fixtures/` for deterministic translation examples.
+- `tests/` for standalone contract checks.
+- `docs/` for accessibility and local visual style notes.

--- a/tools/v2/individual/email-translator/tests/ui-contract.test.mjs
+++ b/tools/v2/individual/email-translator/tests/ui-contract.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+async function loadFixture() {
+  const raw = await readLocal("fixtures/sample-translations.json");
+  return JSON.parse(raw);
+}
+
+test("sample translations fixture follows the local UI contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "email-translator");
+  assert.ok(Array.isArray(fixture.languages));
+  assert.ok(Array.isArray(fixture.results));
+  assert.ok(fixture.languages.some((language) => language.code === "auto"));
+
+  const statuses = new Set();
+
+  for (const result of fixture.results) {
+    assert.ok(result.id, "translation result needs a stable id");
+    assert.ok(result.subject, `${result.id} needs a subject`);
+    assert.ok(result.sourceLanguage, `${result.id} needs a source language`);
+    assert.ok(result.targetLanguage, `${result.id} needs a target language`);
+    assert.ok(result.sourceText, `${result.id} needs source text`);
+    assert.ok(["translated", "needs-review", "blocked"].includes(result.status));
+    assert.equal(typeof result.confidence, "number");
+    assert.ok(result.confidence >= 0 && result.confidence <= 1);
+    assert.ok(Array.isArray(result.preservedElements));
+    assert.ok(Array.isArray(result.warnings));
+
+    if (result.status === "translated") {
+      assert.ok(result.translatedText, `${result.id} translated output is missing`);
+      assert.ok(result.confidence >= 0.9, `${result.id} confidence should be high`);
+    }
+
+    if (result.status === "needs-review") {
+      assert.ok(result.warnings.length > 0, `${result.id} should explain review need`);
+    }
+
+    if (result.status === "blocked") {
+      assert.equal(result.translatedText, "", `${result.id} blocked output should be empty`);
+      assert.ok(result.warnings.length > 0, `${result.id} should explain block reason`);
+    }
+
+    statuses.add(result.status);
+  }
+
+  for (const status of ["translated", "needs-review", "blocked"]) {
+    assert.ok(statuses.has(status), `fixture must include ${status}`);
+  }
+});
+
+test("loading, error, and empty states expose screen-reader roles", async () => {
+  const loadingState = await readLocal("components/EmailTranslatorLoadingState.tsx");
+  const errorState = await readLocal("components/EmailTranslatorErrorState.tsx");
+  const emptyState = await readLocal("components/EmailTranslatorEmptyState.tsx");
+
+  assert.match(loadingState, /role="status"/);
+  assert.match(loadingState, /aria-live="polite"/);
+  assert.match(loadingState, /aria-busy="true"/);
+  assert.match(errorState, /role="alert"/);
+  assert.match(errorState, /type="button"/);
+  assert.match(emptyState, /role="status"/);
+  assert.match(emptyState, /aria-label="No translation results"/);
+});
+
+test("shell uses labelled language controls and native filters", async () => {
+  const shell = await readLocal("components/EmailTranslatorShell.tsx");
+  const selector = await readLocal("components/LanguageSelector.tsx");
+
+  assert.match(shell, /aria-labelledby="email-translator-title"/);
+  assert.match(shell, /id="email-translator-source-language"/);
+  assert.match(shell, /id="email-translator-target-language"/);
+  assert.match(shell, /<fieldset/);
+  assert.match(shell, /<legend className="sr-only">Translation result filter<\/legend>/);
+  assert.match(shell, /type="radio"/);
+  assert.match(shell, /name="email-translator-filter"/);
+  assert.match(shell, /role="list"/);
+  assert.match(shell, /role="listitem"/);
+  assert.match(selector, /<label/);
+  assert.match(selector, /htmlFor=\{id\}/);
+  assert.match(selector, /<select/);
+});
+
+test("result cards and copy controls are keyboard and screen-reader friendly", async () => {
+  const card = await readLocal("components/TranslationResultCard.tsx");
+  const copyButton = await readLocal("components/CopyTranslationButton.tsx");
+
+  assert.match(card, /aria-label=\{`Review translation for \$\{result\.subject\}`\}/);
+  assert.match(card, /type="button"/);
+  assert.match(card, /aria-hidden="true"/);
+  assert.match(copyButton, /aria-live="polite"/);
+  assert.match(copyButton, /type="button"/);
+  assert.match(copyButton, /navigator\.clipboard\.writeText/);
+});
+
+test("component barrel exports the local UI surface", async () => {
+  const index = await readLocal("components/index.ts");
+
+  for (const exportName of [
+    "CopyTranslationButton",
+    "EmailTranslatorEmptyState",
+    "EmailTranslatorErrorState",
+    "EmailTranslatorLoadingState",
+    "EmailTranslatorShell",
+    "EmailTranslatorSummary",
+    "LanguageSelector",
+    "TranslationResultCard",
+  ]) {
+    assert.match(index, new RegExp(`\\b${exportName}\\b`));
+  }
+});
+
+test("documentation covers focus, keyboard, screen-reader, and status colors", async () => {
+  const accessibility = await readLocal("docs/ACCESSIBILITY.md");
+  const visualStyle = await readLocal("docs/VISUAL_STYLE.md");
+
+  assert.match(accessibility, /Keyboard Behavior/);
+  assert.match(accessibility, /Screen Reader Names/);
+  assert.match(accessibility, /focus/i);
+  assert.match(visualStyle, /translated/);
+  assert.match(visualStyle, /needs-review/);
+  assert.match(visualStyle, /blocked/);
+});

--- a/tools/v2/individual/email-translator/types.ts
+++ b/tools/v2/individual/email-translator/types.ts
@@ -1,0 +1,27 @@
+export type EmailTranslationStatus = "translated" | "needs-review" | "blocked";
+
+export interface TranslatorLanguage {
+  code: string;
+  label: string;
+  nativeLabel?: string;
+}
+
+export interface EmailTranslationResult {
+  id: string;
+  subject: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  sourceText: string;
+  translatedText: string;
+  status: EmailTranslationStatus;
+  confidence: number;
+  preservedElements: string[];
+  warnings: string[];
+}
+
+export interface EmailTranslatorSummary {
+  totalTranslations: number;
+  translated: number;
+  needsReview: number;
+  blocked: number;
+}


### PR DESCRIPTION
## Summary
- add a folder-local React UI surface for email translation review
- cover empty, loading, error, translated, needs-review, and blocked states
- add labelled language selectors, result filters, review/copy actions, and synthetic fixtures
- document keyboard, focus, screen-reader, and local visual treatment

## Validation
- node tools\v2\individual\email-translator\tests\ui-contract.test.mjs
- git diff --check

Closes 