### PR TITLE
Add manager review queue test documentation

### DIFF
--- a/tools/v2/team/manager-review-queue/README.md
+++ b/tools/v2/team/manager-review-queue/README.md
@@ -1,15 +1,53 @@
 # Manager Review Queue
 
-This folder is the isolated workspace for the Manager Review Queue tool.
+Manager Review Queue is an isolated V2 team tool workspace for validating and
+reviewing manager approval requests before any future mail-app integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\manager-review-queue\
-`
+```text
+tools/v2/team/manager-review-queue/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+Run the folder-local tests from the repository root:
+
+```bash
+node tools/v2/team/manager-review-queue/tests/review-guards.test.mjs
+node tools/v2/team/manager-review-queue/tests/documentation-contract.test.mjs
+```
+
+The first command validates security and performance guards against deterministic
+fixtures. The second command checks that contributor-facing documentation and
+fixture contracts stay reviewable.
+
+## Documentation Map
+
+- `docs/api.md` documents the local core-feature API contract.
+- `docs/security-and-performance.md` documents guard behavior and limits.
+- `docs/ACCESSIBILITY.md` documents keyboard and screen-reader expectations.
+- `docs/VISUAL_STYLE.md` documents the local UI treatment.
+- `docs/test-plan.md` lists automated and manual validation steps.
+- `docs/review-notes.md` summarizes review scope and known limitations.
+
+## Fixture Map
+
+- `fixtures/sample-review-requests.json` contains valid requests, hostile input
+  samples, and sanitizer edge cases.
+- `tests/review-guards.test.mjs` consumes that fixture and validates guard
+  behavior without network calls or production data.
+
+## Known Limitations
+
+- The tool is not mounted in the main app.
+- Tests run against local fixtures and pure guards only.
+- No network calls or production data are required.
+- Main app routing, inbox data, persistence, authentication, wallet, and Stellar
+  integration remain out of scope.

--- a/tools/v2/team/manager-review-queue/docs/review-notes.md
+++ b/tools/v2/team/manager-review-queue/docs/review-notes.md
@@ -1,0 +1,40 @@
+# Manager Review Queue Review Notes
+
+## Scope
+
+This folder is a self-contained mini-product workspace for manager approval
+review. The current review target is the folder-local guard, fixture, and
+documentation contract. No production integration is required.
+
+## How To Review
+
+1. Run the two Node test commands listed in `docs/test-plan.md`.
+2. Confirm fixture data is synthetic and uses `.test` domains.
+3. Confirm guard limits are documented before future contributors connect UI or
+   service code to real data.
+4. Confirm README and specs describe the local ownership boundary.
+
+## Evidence Provided
+
+- `tests/review-guards.test.mjs` exercises validation, sanitization, and
+  performance guard behavior.
+- `tests/documentation-contract.test.mjs` protects the contributor-facing review
+  contract from drifting back to placeholder text.
+- `fixtures/sample-review-requests.json` provides valid, hostile, and edge-case
+  examples.
+- `docs/test-plan.md` gives maintainers a short repeatable review checklist.
+
+## Known Limitations
+
+- The tests do not mount React components.
+- The queue does not read from the main inbox or a database.
+- The service layer uses local mock behavior only.
+- Future integration must add adapter tests outside this issue.
+
+## Safety Notes
+
+- No secrets, payment data, production messages, or real manager approvals are
+  included.
+- No live network calls are required.
+- Any future renderer must HTML-escape sanitized note and subject text before
+  display.

--- a/tools/v2/team/manager-review-queue/docs/test-plan.md
+++ b/tools/v2/team/manager-review-queue/docs/test-plan.md
@@ -1,0 +1,46 @@
+# Manager Review Queue Test Plan
+
+## Automated Checks
+
+Run from the repository root:
+
+```bash
+node tools/v2/team/manager-review-queue/tests/review-guards.test.mjs
+node tools/v2/team/manager-review-queue/tests/documentation-contract.test.mjs
+```
+
+`review-guards.test.mjs` verifies:
+
+- valid request ids, statuses, priorities, and submitter emails
+- rejection of path traversal, XSS-like ids, SQL-like ids, CRLF injection, null
+  bytes, unknown statuses, and unknown priorities
+- note and subject sanitization
+- queue, history, attachment, and tag guard limits
+- deterministic fixture coverage for valid requests, hostile inputs, and edge
+  cases
+
+`documentation-contract.test.mjs` verifies:
+
+- README setup commands remain present
+- specs do not regress to generated template placeholders
+- fixtures include required review scenarios
+- review docs cover independent setup, limitations, and safety boundaries
+
+## Manual Review Checklist
+
+- Confirm all changed files are under `tools/v2/team/manager-review-queue/`.
+- Confirm no main app route, inbox, wallet, Stellar, auth, or database file is
+  modified.
+- Read `docs/security-and-performance.md` and confirm limits match the exported
+  `LIMITS` object in `guards/review-guards.mjs`.
+- Inspect `fixtures/sample-review-requests.json` and confirm every email address
+  uses `.test` domains.
+- Confirm docs describe empty, loading, error, and success review states without
+  requiring app integration.
+
+## Out Of Scope
+
+- Main app integration.
+- Live network calls.
+- Production data, real customer emails, or real manager approvals.
+- Persistent storage and database schema changes.

--- a/tools/v2/team/manager-review-queue/specs.md
+++ b/tools/v2/team/manager-review-queue/specs.md
@@ -1,41 +1,33 @@
-# Manager Review Queue
-
-Manager approvals.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/manager-review-queue/README.md"
-  @"
-
 # Manager Review Queue Specs
 
 ## Purpose
 
-Manager approvals.
+Provide a folder-local manager approval queue workspace with reviewable tests,
+fixtures, and documentation for team approval workflows.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/team/manager-review-queue/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Keep guard tests, fixtures, and documentation inside the tool folder.
+- Validate review id, status, priority, submitter email, notes, subjects, queue
+  size, history size, attachment count, and tags.
+- Document automated setup, manual review steps, fixtures, and known limits.
+- Avoid live network calls, production data, or app-wide test dependencies.
+
+## Recommended Internal Structure
+
+- `guards/` for pure validation and performance guards.
+- `fixtures/` for deterministic review request examples.
+- `tests/` for standalone Node tests.
+- `docs/` for API, accessibility, test plan, review notes, and security notes.

--- a/tools/v2/team/manager-review-queue/tests/documentation-contract.test.mjs
+++ b/tools/v2/team/manager-review-queue/tests/documentation-contract.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+async function loadFixture() {
+  const raw = await readLocal("fixtures/sample-review-requests.json");
+  return JSON.parse(raw);
+}
+
+test("README documents isolated reviewer setup", async () => {
+  const readme = await readLocal("README.md");
+
+  assert.match(readme, /tools\/v2\/team\/manager-review-queue\//);
+  assert.match(readme, /review-guards\.test\.mjs/);
+  assert.match(readme, /documentation-contract\.test\.mjs/);
+  assert.match(readme, /Known Limitations/);
+  assert.match(readme, /no network calls/i);
+});
+
+test("specs do not contain generated placeholder fragments", async () => {
+  const specs = await readLocal("specs.md");
+
+  for (const placeholder of ["Hashtable", "$dir", "Set-Content", "    ests/"]) {
+    assert.doesNotMatch(specs, new RegExp(placeholder.replace("$", "\\$")));
+  }
+
+  assert.match(specs, /Contributor Boundary/);
+  assert.match(specs, /Required Local Behavior/);
+  assert.match(specs, /tests\/` for standalone Node tests/);
+});
+
+test("fixture contains valid, hostile, and edge-case coverage", async () => {
+  const fixture = await loadFixture();
+
+  assert.ok(Array.isArray(fixture.validRequests));
+  assert.ok(Array.isArray(fixture.hostileInputs));
+  assert.ok(Array.isArray(fixture.edgeCases));
+  assert.ok(fixture.validRequests.length >= 3);
+  assert.ok(fixture.hostileInputs.length >= 8);
+  assert.ok(fixture.edgeCases.length >= 4);
+
+  for (const request of fixture.validRequests) {
+    assert.match(request.submitterEmail, /\.test$/);
+    assert.ok(request.reviewId);
+    assert.ok(request.status);
+    assert.ok(request.priority);
+  }
+});
+
+test("test plan documents automated and manual validation", async () => {
+  const testPlan = await readLocal("docs/test-plan.md");
+
+  assert.match(testPlan, /Automated Checks/);
+  assert.match(testPlan, /Manual Review Checklist/);
+  assert.match(testPlan, /review-guards\.test\.mjs/);
+  assert.match(testPlan, /documentation-contract\.test\.mjs/);
+  assert.match(testPlan, /Out Of Scope/);
+});
+
+test("review notes cover safety boundaries and limitations", async () => {
+  const reviewNotes = await readLocal("docs/review-notes.md");
+
+  assert.match(reviewNotes, /How To Review/);
+  assert.match(reviewNotes, /Known Limitations/);
+  assert.match(reviewNotes, /Safety Notes/);
+  assert.match(reviewNotes, /No secrets/);
+  assert.match(reviewNotes, /No live network calls/);
+});


### PR DESCRIPTION
## Summary
- replace placeholder README/spec text with isolated reviewer setup and tool boundaries
- add a folder-local test plan and review notes for the manager review queue
- add documentation contract tests for fixture shape, setup commands, and safety boundaries

## Validation
- node tools\v2\team\manager-review-queue\tests\review-guards.test.mjs
- node tools\v2\team\manager-review-queue\tests\documentation-contract.test.mjs
- git diff --check

Closes #628