### PR TITLE
Add invoice approval safety guards

### DIFF
--- a/tools/v2/team/invoice-approval-workflow/README.md
+++ b/tools/v2/team/invoice-approval-workflow/README.md
@@ -1,15 +1,44 @@
 # Invoice Approval Workflow
 
-This folder is the isolated workspace for the Invoice Approval Workflow tool.
+Invoice Approval Workflow is an isolated V2 team tool workspace for reviewing
+invoice submissions before any future mail-app or accounting integration.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\invoice-approval-workflow\
-`
+```text
+tools/v2/team/invoice-approval-workflow/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+Run the folder-local tests from the repository root:
+
+```bash
+node tools/v2/team/invoice-approval-workflow/tests/invoice-guards.test.mjs
+```
+
+The tests validate security and performance guards against deterministic local
+fixtures. No app install, live network call, production invoice, or payment data
+is required.
+
+## Documentation Map
+
+- `guards/invoice-guards.mjs` exposes pure validation and performance guards.
+- `fixtures/sample-invoices.json` contains synthetic valid, hostile, and edge
+  case examples.
+- `docs/security-and-performance.md` documents threat assumptions, limits, and
+  review guidance.
+- `tests/invoice-guards.test.mjs` validates the folder-local guard contract.
+
+## Known Limitations
+
+- This contribution does not add app UI or accounting-system integration.
+- Invoice approval state is represented through local validation only.
+- Payment rails, bank details, persistence, authentication, and mail rendering
+  remain out of scope.

--- a/tools/v2/team/invoice-approval-workflow/docs/security-and-performance.md
+++ b/tools/v2/team/invoice-approval-workflow/docs/security-and-performance.md
@@ -1,0 +1,48 @@
+# Security and Performance - Invoice Approval Workflow
+
+## Threat Assumptions
+
+- Invoice submissions may come from a future UI, webhook, or imported email
+  attachment and must be treated as untrusted until validated.
+- Vendor names, invoice numbers, memos, filenames, and approver emails can carry
+  hostile input.
+- This tool is isolated and does not yet connect to the main app, payment rails,
+  persistence, authentication, or mail rendering.
+
+## Unsafe Input Handling
+
+| Input | Risk | Guard |
+| --- | --- | --- |
+| `invoiceId` | path traversal or lookup abuse | allow only letters, numbers, `_`, and `-` |
+| `invoiceNumber` | control characters or markup-like values | strip controls, enforce safe characters |
+| `vendorName` | markup injection | strip controls and reject `<` or `>` |
+| `approverEmail` | CRLF header injection | reject `\r`, `\n`, and null bytes |
+| `amount` | negative, infinite, or huge values | require finite positive values under approval cap |
+| attachments | path traversal, unsafe MIME, large files | safe filename, allowlist MIME, max size |
+| free-text memo | control characters and render cost | strip controls and cap length |
+
+Renderers must still HTML-escape sanitized text before display.
+
+## Performance Limits
+
+| Data set | Limit | Rationale |
+| --- | ---: | --- |
+| line items | 200 | prevents large synchronous validation loops |
+| attachments | 25 | prevents eager preview or scan overload |
+| attachment size | 25 MB | keeps local review bounded |
+| approval history | 500 | requires pagination for long audit trails |
+| team members | 100 | avoids unbounded reviewer search |
+| memo length | 2,000 chars | keeps render and review cost small |
+
+Future integrations should paginate server-side and call these guards per page.
+
+## Review Commands
+
+Run from the repository root:
+
+```bash
+node tools/v2/team/invoice-approval-workflow/tests/invoice-guards.test.mjs
+```
+
+The test suite uses only local fixtures and synthetic `.test` emails. It does not
+load real invoice PDFs, bank details, customer data, or live network resources.

--- a/tools/v2/team/invoice-approval-workflow/fixtures/sample-invoices.json
+++ b/tools/v2/team/invoice-approval-workflow/fixtures/sample-invoices.json
@@ -1,0 +1,134 @@
+{
+  "validInvoices": [
+    {
+      "id": "valid-001",
+      "invoiceId": "invoice-2026-001",
+      "invoiceNumber": "INV-2026-001",
+      "vendorName": "Northwind Supplies",
+      "currency": "USD",
+      "amount": 1250.5,
+      "status": "pending",
+      "approverEmail": "manager@example.test",
+      "memo": "Office equipment invoice for review.",
+      "lineItems": [
+        { "description": "Standing desks", "amount": 900.0 },
+        { "description": "Monitor arms", "amount": 350.5 }
+      ],
+      "attachments": [
+        {
+          "filename": "invoice-2026-001.pdf",
+          "mimeType": "application/pdf",
+          "sizeBytes": 450000
+        }
+      ]
+    },
+    {
+      "id": "valid-002",
+      "invoiceId": "invoice_urgent_42",
+      "invoiceNumber": "ACME.42",
+      "vendorName": "Acme Consulting",
+      "currency": "eur",
+      "amount": 4999.99,
+      "status": "escalated",
+      "approverEmail": "finance.lead@example.test",
+      "memo": "Requires approval before quarter close.",
+      "lineItems": [
+        { "description": "Implementation review", "amount": 4999.99 }
+      ],
+      "attachments": []
+    }
+  ],
+  "hostileInputs": [
+    {
+      "id": "hostile-001",
+      "field": "invoiceId",
+      "value": "../../etc/passwd",
+      "reason": "path traversal attempt"
+    },
+    {
+      "id": "hostile-002",
+      "field": "invoiceNumber",
+      "value": "INV<script>",
+      "reason": "markup in invoice number"
+    },
+    {
+      "id": "hostile-003",
+      "field": "vendorName",
+      "value": "<script>alert(1)</script>",
+      "reason": "markup in vendor name"
+    },
+    {
+      "id": "hostile-004",
+      "field": "status",
+      "value": "paid",
+      "reason": "status not in allowlist"
+    },
+    {
+      "id": "hostile-005",
+      "field": "currency",
+      "value": "BTC",
+      "reason": "unsupported currency"
+    },
+    {
+      "id": "hostile-006",
+      "field": "approverEmail",
+      "value": "manager@example.test\r\nBcc: attacker@example.test",
+      "reason": "CRLF header injection"
+    },
+    {
+      "id": "hostile-007",
+      "field": "amount",
+      "value": -50,
+      "reason": "negative amount"
+    },
+    {
+      "id": "hostile-008",
+      "field": "amount",
+      "value": 1000000.01,
+      "reason": "amount exceeds approval cap"
+    }
+  ],
+  "sanitizerCases": [
+    {
+      "id": "sanitize-001",
+      "field": "memo",
+      "value": "Review\u0000notes\u001Fwith controls",
+      "expected": "Reviewnoteswith controls"
+    },
+    {
+      "id": "sanitize-002",
+      "field": "invoiceNumber",
+      "value": " INV-2026-002\r\nX-Injected: yes ",
+      "expected": "INV-2026-002X-Injected: yes"
+    },
+    {
+      "id": "sanitize-003",
+      "field": "vendorName",
+      "value": "  Example Vendor\u0000  ",
+      "expected": "Example Vendor"
+    }
+  ],
+  "unsafeAttachments": [
+    {
+      "id": "attachment-001",
+      "filename": "../invoice.pdf",
+      "mimeType": "application/pdf",
+      "sizeBytes": 10,
+      "reason": "path separator in filename"
+    },
+    {
+      "id": "attachment-002",
+      "filename": "invoice.exe",
+      "mimeType": "application/x-msdownload",
+      "sizeBytes": 10,
+      "reason": "unsupported MIME type"
+    },
+    {
+      "id": "attachment-003",
+      "filename": "invoice.pdf",
+      "mimeType": "application/pdf",
+      "sizeBytes": 999999999,
+      "reason": "oversized attachment"
+    }
+  ]
+}

--- a/tools/v2/team/invoice-approval-workflow/guards/invoice-guards.mjs
+++ b/tools/v2/team/invoice-approval-workflow/guards/invoice-guards.mjs
@@ -1,0 +1,334 @@
+const ALLOWED_STATUSES = new Set(["pending", "approved", "rejected", "escalated"]);
+const ALLOWED_CURRENCIES = new Set(["USD", "EUR", "GBP", "AUD", "CAD", "JPY"]);
+const ALLOWED_ATTACHMENT_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "text/csv",
+]);
+
+const LIMITS = {
+  MAX_INVOICE_ID_LENGTH: 128,
+  MAX_INVOICE_NUMBER_LENGTH: 64,
+  MAX_VENDOR_NAME_LENGTH: 160,
+  MAX_APPROVER_EMAIL_LENGTH: 254,
+  MAX_MEMO_LENGTH: 2_000,
+  MAX_AMOUNT: 1_000_000,
+  MAX_LINE_ITEMS: 200,
+  MAX_ATTACHMENTS: 25,
+  MAX_ATTACHMENT_BYTES: 25 * 1024 * 1024,
+  MAX_HISTORY_EVENTS: 500,
+  MAX_TEAM_MEMBERS: 100,
+};
+
+const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const SAFE_INVOICE_NUMBER_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+export class InvoiceValidationError extends Error {
+  constructor(message, field) {
+    super(message);
+    this.name = "InvoiceValidationError";
+    this.field = field;
+  }
+}
+
+function stripControlCharacters(value, preserveNewlines = false) {
+  const pattern = preserveNewlines
+    ? /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g
+    : /[\x00-\x1F\x7F-\x9F]/g;
+  return value.replace(pattern, "");
+}
+
+function truncate(value, maxLength) {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+export function validateInvoiceId(id) {
+  if (typeof id !== "string" || id.length === 0) {
+    throw new InvoiceValidationError("invoiceId must be a non-empty string", "invoiceId");
+  }
+  if (id.length > LIMITS.MAX_INVOICE_ID_LENGTH) {
+    throw new InvoiceValidationError(
+      `invoiceId exceeds max length of ${LIMITS.MAX_INVOICE_ID_LENGTH}`,
+      "invoiceId",
+    );
+  }
+  if (!SAFE_ID_PATTERN.test(id)) {
+    throw new InvoiceValidationError(
+      "invoiceId may only contain letters, numbers, underscores, and dashes",
+      "invoiceId",
+    );
+  }
+  return id;
+}
+
+export function sanitizeInvoiceNumber(invoiceNumber) {
+  if (typeof invoiceNumber !== "string") {
+    return "";
+  }
+  const sanitized = truncate(
+    stripControlCharacters(invoiceNumber).trim(),
+    LIMITS.MAX_INVOICE_NUMBER_LENGTH,
+  );
+  return sanitized;
+}
+
+export function validateInvoiceNumber(invoiceNumber) {
+  const sanitized = sanitizeInvoiceNumber(invoiceNumber);
+  if (!sanitized) {
+    throw new InvoiceValidationError(
+      "invoiceNumber must be a non-empty string",
+      "invoiceNumber",
+    );
+  }
+  if (!SAFE_INVOICE_NUMBER_PATTERN.test(sanitized)) {
+    throw new InvoiceValidationError(
+      "invoiceNumber may only contain letters, numbers, dots, underscores, and dashes",
+      "invoiceNumber",
+    );
+  }
+  return sanitized;
+}
+
+export function sanitizeVendorName(vendorName) {
+  if (typeof vendorName !== "string") {
+    return "";
+  }
+  return truncate(stripControlCharacters(vendorName).trim(), LIMITS.MAX_VENDOR_NAME_LENGTH);
+}
+
+export function validateVendorName(vendorName) {
+  const sanitized = sanitizeVendorName(vendorName);
+  if (!sanitized) {
+    throw new InvoiceValidationError("vendorName must be a non-empty string", "vendorName");
+  }
+  if (/[<>]/.test(sanitized)) {
+    throw new InvoiceValidationError("vendorName must not contain markup characters", "vendorName");
+  }
+  return sanitized;
+}
+
+export function sanitizeMemo(memo) {
+  if (typeof memo !== "string") {
+    return "";
+  }
+  return truncate(stripControlCharacters(memo, true).trim(), LIMITS.MAX_MEMO_LENGTH);
+}
+
+export function validateStatus(status) {
+  if (typeof status !== "string" || status.length === 0) {
+    throw new InvoiceValidationError("status must be a non-empty string", "status");
+  }
+  if (!ALLOWED_STATUSES.has(status)) {
+    throw new InvoiceValidationError(
+      `"${status}" is not a recognized status`,
+      "status",
+    );
+  }
+  return status;
+}
+
+export function validateCurrency(currency) {
+  if (typeof currency !== "string" || currency.length === 0) {
+    throw new InvoiceValidationError("currency must be a non-empty string", "currency");
+  }
+  const normalized = currency.toUpperCase();
+  if (!ALLOWED_CURRENCIES.has(normalized)) {
+    throw new InvoiceValidationError(
+      `"${currency}" is not an allowed currency`,
+      "currency",
+    );
+  }
+  return normalized;
+}
+
+export function validateAmount(amount) {
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    throw new InvoiceValidationError("amount must be a finite number", "amount");
+  }
+  if (amount <= 0) {
+    throw new InvoiceValidationError("amount must be greater than zero", "amount");
+  }
+  if (amount > LIMITS.MAX_AMOUNT) {
+    throw new InvoiceValidationError(
+      `amount exceeds max of ${LIMITS.MAX_AMOUNT}`,
+      "amount",
+    );
+  }
+  if (Math.round(amount * 100) !== amount * 100) {
+    throw new InvoiceValidationError("amount must not exceed two decimal places", "amount");
+  }
+  return amount;
+}
+
+export function validateApproverEmail(email) {
+  if (typeof email !== "string" || email.length === 0) {
+    throw new InvoiceValidationError("approverEmail must be a non-empty string", "approverEmail");
+  }
+  if (email.length > LIMITS.MAX_APPROVER_EMAIL_LENGTH) {
+    throw new InvoiceValidationError(
+      `approverEmail exceeds max length of ${LIMITS.MAX_APPROVER_EMAIL_LENGTH}`,
+      "approverEmail",
+    );
+  }
+  if (/[\r\n\0]/.test(email)) {
+    throw new InvoiceValidationError(
+      "approverEmail contains illegal control characters",
+      "approverEmail",
+    );
+  }
+  const at = email.lastIndexOf("@");
+  if (at < 1 || at === email.length - 1) {
+    throw new InvoiceValidationError("approverEmail is malformed", "approverEmail");
+  }
+  return email;
+}
+
+export function guardLineItems(lineItems) {
+  if (!Array.isArray(lineItems)) {
+    throw new InvoiceValidationError("lineItems must be an array", "lineItems");
+  }
+  if (lineItems.length > LIMITS.MAX_LINE_ITEMS) {
+    throw new InvoiceValidationError(
+      `line item count ${lineItems.length} exceeds safe limit of ${LIMITS.MAX_LINE_ITEMS}`,
+      "lineItems",
+    );
+  }
+  return true;
+}
+
+export function validateLineItems(lineItems) {
+  guardLineItems(lineItems);
+  let total = 0;
+
+  for (let index = 0; index < lineItems.length; index += 1) {
+    const item = lineItems[index];
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new InvoiceValidationError(`line item ${index} must be an object`, "lineItems");
+    }
+    if (typeof item.description !== "string" || item.description.trim().length === 0) {
+      throw new InvoiceValidationError(
+        `line item ${index} needs a description`,
+        "lineItems",
+      );
+    }
+    total += validateAmount(item.amount);
+  }
+
+  return Number(total.toFixed(2));
+}
+
+export function guardAttachments(attachments) {
+  if (!Array.isArray(attachments)) {
+    throw new InvoiceValidationError("attachments must be an array", "attachments");
+  }
+  if (attachments.length > LIMITS.MAX_ATTACHMENTS) {
+    throw new InvoiceValidationError(
+      `attachment count ${attachments.length} exceeds safe limit of ${LIMITS.MAX_ATTACHMENTS}`,
+      "attachments",
+    );
+  }
+  return true;
+}
+
+export function validateAttachment(attachment) {
+  if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+    throw new InvoiceValidationError("attachment must be an object", "attachments");
+  }
+  if (typeof attachment.filename !== "string" || attachment.filename.trim().length === 0) {
+    throw new InvoiceValidationError("attachment filename is required", "attachments");
+  }
+  if (/[\\/\0\r\n]/.test(attachment.filename)) {
+    throw new InvoiceValidationError("attachment filename contains unsafe characters", "attachments");
+  }
+  if (!ALLOWED_ATTACHMENT_TYPES.has(attachment.mimeType)) {
+    throw new InvoiceValidationError("attachment MIME type is not allowed", "attachments");
+  }
+  if (
+    typeof attachment.sizeBytes !== "number" ||
+    !Number.isFinite(attachment.sizeBytes) ||
+    attachment.sizeBytes < 0
+  ) {
+    throw new InvoiceValidationError("attachment size must be a non-negative number", "attachments");
+  }
+  if (attachment.sizeBytes > LIMITS.MAX_ATTACHMENT_BYTES) {
+    throw new InvoiceValidationError(
+      `attachment exceeds max size of ${LIMITS.MAX_ATTACHMENT_BYTES} bytes`,
+      "attachments",
+    );
+  }
+  return true;
+}
+
+export function validateAttachments(attachments) {
+  guardAttachments(attachments);
+  for (const attachment of attachments) {
+    validateAttachment(attachment);
+  }
+  return true;
+}
+
+export function guardApprovalHistory(history) {
+  if (!Array.isArray(history)) {
+    throw new InvoiceValidationError("approval history must be an array", "history");
+  }
+  if (history.length > LIMITS.MAX_HISTORY_EVENTS) {
+    throw new InvoiceValidationError(
+      `history count ${history.length} exceeds safe limit of ${LIMITS.MAX_HISTORY_EVENTS}`,
+      "history",
+    );
+  }
+  return true;
+}
+
+export function guardTeamMembers(teamMembers) {
+  if (!Array.isArray(teamMembers)) {
+    throw new InvoiceValidationError("teamMembers must be an array", "teamMembers");
+  }
+  if (teamMembers.length > LIMITS.MAX_TEAM_MEMBERS) {
+    throw new InvoiceValidationError(
+      `team member count ${teamMembers.length} exceeds safe limit of ${LIMITS.MAX_TEAM_MEMBERS}`,
+      "teamMembers",
+    );
+  }
+  return true;
+}
+
+export function validateInvoiceSubmission(invoice) {
+  if (!invoice || typeof invoice !== "object" || Array.isArray(invoice)) {
+    throw new InvoiceValidationError("invoice must be a plain object", "invoice");
+  }
+
+  const invoiceId = validateInvoiceId(invoice.invoiceId);
+  const invoiceNumber = validateInvoiceNumber(invoice.invoiceNumber);
+  const vendorName = validateVendorName(invoice.vendorName);
+  const currency = validateCurrency(invoice.currency);
+  const amount = validateAmount(invoice.amount);
+  const status = validateStatus(invoice.status);
+  const approverEmail = validateApproverEmail(invoice.approverEmail);
+  const lineItemTotal = validateLineItems(invoice.lineItems ?? []);
+  validateAttachments(invoice.attachments ?? []);
+
+  if (lineItemTotal > 0 && Number(lineItemTotal.toFixed(2)) !== amount) {
+    throw new InvoiceValidationError("line item total must match invoice amount", "lineItems");
+  }
+
+  return {
+    invoiceId,
+    invoiceNumber,
+    vendorName,
+    currency,
+    amount,
+    status,
+    approverEmail,
+    memo: sanitizeMemo(invoice.memo),
+    lineItemTotal,
+  };
+}
+
+export {
+  ALLOWED_ATTACHMENT_TYPES,
+  ALLOWED_CURRENCIES,
+  ALLOWED_STATUSES,
+  LIMITS,
+};

--- a/tools/v2/team/invoice-approval-workflow/specs.md
+++ b/tools/v2/team/invoice-approval-workflow/specs.md
@@ -1,41 +1,35 @@
-# Invoice Approval Workflow
-
-Invoice review process.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/invoice-approval-workflow/README.md"
-  @"
-
 # Invoice Approval Workflow Specs
 
 ## Purpose
 
-Invoice review process.
+Provide safety and performance constraints for invoice review requests before any
+future integration with team workflows, mail data, or accounting systems.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/team/invoice-approval-workflow/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Validate invoice ids, invoice numbers, statuses, currencies, amounts, vendor
+  names, approver emails, and full invoice submissions.
+- Sanitize free-text memo, vendor, and invoice-number fields.
+- Guard against oversized line item lists, attachments, approval history, and
+  team member lists before iteration.
+- Document threat assumptions, unsafe input examples, and performance limits.
+- Use synthetic fixtures only.
+
+## Recommended Internal Structure
+
+- `guards/` for pure validation, sanitization, and size guards.
+- `fixtures/` for deterministic invoice examples.
+- `tests/` for standalone Node tests.
+- `docs/` for security and performance review notes.

--- a/tools/v2/team/invoice-approval-workflow/tests/invoice-guards.test.mjs
+++ b/tools/v2/team/invoice-approval-workflow/tests/invoice-guards.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  InvoiceValidationError,
+  LIMITS,
+  guardApprovalHistory,
+  guardAttachments,
+  guardLineItems,
+  guardTeamMembers,
+  sanitizeInvoiceNumber,
+  sanitizeMemo,
+  sanitizeVendorName,
+  validateAmount,
+  validateApproverEmail,
+  validateAttachment,
+  validateAttachments,
+  validateCurrency,
+  validateInvoiceId,
+  validateInvoiceNumber,
+  validateInvoiceSubmission,
+  validateLineItems,
+  validateStatus,
+  validateVendorName,
+} from "../guards/invoice-guards.mjs";
+
+const currentDir = join(fileURLToPath(import.meta.url), "..");
+const fixture = JSON.parse(
+  readFileSync(join(currentDir, "..", "fixtures", "sample-invoices.json"), "utf8"),
+);
+
+describe("validateInvoiceId", () => {
+  it("accepts safe invoice ids", () => {
+    assert.equal(validateInvoiceId("invoice-2026-001"), "invoice-2026-001");
+    assert.equal(validateInvoiceId("INVOICE_42"), "INVOICE_42");
+  });
+
+  it("rejects empty, non-string, path, and oversized ids", () => {
+    assert.throws(() => validateInvoiceId(""), InvoiceValidationError);
+    assert.throws(() => validateInvoiceId(null), InvoiceValidationError);
+    assert.throws(() => validateInvoiceId("../bad"), InvoiceValidationError);
+    assert.throws(
+      () => validateInvoiceId("x".repeat(LIMITS.MAX_INVOICE_ID_LENGTH + 1)),
+      InvoiceValidationError,
+    );
+  });
+});
+
+describe("invoice number guards", () => {
+  it("sanitizes control characters", () => {
+    assert.equal(sanitizeInvoiceNumber(" INV-1\r\nX-Test "), "INV-1X-Test");
+  });
+
+  it("validates safe invoice numbers", () => {
+    assert.equal(validateInvoiceNumber("INV-2026.001"), "INV-2026.001");
+  });
+
+  it("rejects empty and unsafe invoice numbers", () => {
+    assert.throws(() => validateInvoiceNumber(""), InvoiceValidationError);
+    assert.throws(() => validateInvoiceNumber("INV<script>"), InvoiceValidationError);
+  });
+});
+
+describe("vendor and memo sanitizers", () => {
+  it("sanitizes vendor names and memos", () => {
+    assert.equal(sanitizeVendorName("  Vendor\0Name  "), "VendorName");
+    assert.equal(sanitizeMemo("line1\nline2\0"), "line1\nline2");
+  });
+
+  it("caps long memo text", () => {
+    assert.equal(sanitizeMemo("x".repeat(LIMITS.MAX_MEMO_LENGTH + 1)).length, LIMITS.MAX_MEMO_LENGTH);
+  });
+
+  it("rejects empty or markup-like vendor names", () => {
+    assert.throws(() => validateVendorName(""), InvoiceValidationError);
+    assert.throws(() => validateVendorName("<script>Vendor</script>"), InvoiceValidationError);
+  });
+});
+
+describe("status, currency, amount, and approver email", () => {
+  it("accepts allowed statuses and currencies", () => {
+    assert.equal(validateStatus("pending"), "pending");
+    assert.equal(validateCurrency("usd"), "USD");
+  });
+
+  it("rejects unknown statuses and currencies", () => {
+    assert.throws(() => validateStatus("paid"), InvoiceValidationError);
+    assert.throws(() => validateCurrency("BTC"), InvoiceValidationError);
+  });
+
+  it("validates finite positive amounts with two decimals", () => {
+    assert.equal(validateAmount(1250.5), 1250.5);
+    assert.throws(() => validateAmount(-1), InvoiceValidationError);
+    assert.throws(() => validateAmount(Number.POSITIVE_INFINITY), InvoiceValidationError);
+    assert.throws(() => validateAmount(10.001), InvoiceValidationError);
+    assert.throws(() => validateAmount(LIMITS.MAX_AMOUNT + 0.01), InvoiceValidationError);
+  });
+
+  it("rejects malformed or injected approver emails", () => {
+    assert.equal(validateApproverEmail("manager@example.test"), "manager@example.test");
+    assert.throws(() => validateApproverEmail("@example.test"), InvoiceValidationError);
+    assert.throws(
+      () => validateApproverEmail("manager@example.test\r\nBcc: bad@example.test"),
+      InvoiceValidationError,
+    );
+  });
+});
+
+describe("line item guards", () => {
+  it("guards line item collection size", () => {
+    assert.equal(guardLineItems(new Array(LIMITS.MAX_LINE_ITEMS).fill({})), true);
+    assert.throws(
+      () => guardLineItems(new Array(LIMITS.MAX_LINE_ITEMS + 1).fill({})),
+      InvoiceValidationError,
+    );
+    assert.throws(() => guardLineItems(null), InvoiceValidationError);
+  });
+
+  it("validates line item totals", () => {
+    assert.equal(
+      validateLineItems([
+        { description: "Service", amount: 10 },
+        { description: "Tax", amount: 1.25 },
+      ]),
+      11.25,
+    );
+    assert.throws(() => validateLineItems([{ description: "", amount: 10 }]), InvoiceValidationError);
+    assert.throws(() => validateLineItems([{ description: "Bad", amount: -1 }]), InvoiceValidationError);
+  });
+});
+
+describe("attachment guards", () => {
+  it("guards attachment collection size", () => {
+    assert.equal(guardAttachments(new Array(LIMITS.MAX_ATTACHMENTS).fill({})), true);
+    assert.throws(
+      () => guardAttachments(new Array(LIMITS.MAX_ATTACHMENTS + 1).fill({})),
+      InvoiceValidationError,
+    );
+  });
+
+  it("validates safe attachments", () => {
+    assert.equal(
+      validateAttachment({
+        filename: "invoice.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 10,
+      }),
+      true,
+    );
+  });
+
+  it("rejects unsafe attachments from fixtures", () => {
+    for (const attachment of fixture.unsafeAttachments) {
+      assert.throws(() => validateAttachment(attachment), InvoiceValidationError);
+    }
+  });
+
+  it("validates attachment arrays", () => {
+    assert.equal(
+      validateAttachments([
+        {
+          filename: "invoice.csv",
+          mimeType: "text/csv",
+          sizeBytes: 500,
+        },
+      ]),
+      true,
+    );
+  });
+});
+
+describe("large collection guards", () => {
+  it("guards approval history", () => {
+    assert.equal(guardApprovalHistory(new Array(LIMITS.MAX_HISTORY_EVENTS).fill({})), true);
+    assert.throws(
+      () => guardApprovalHistory(new Array(LIMITS.MAX_HISTORY_EVENTS + 1).fill({})),
+      InvoiceValidationError,
+    );
+  });
+
+  it("guards team member lists", () => {
+    assert.equal(guardTeamMembers(new Array(LIMITS.MAX_TEAM_MEMBERS).fill({})), true);
+    assert.throws(
+      () => guardTeamMembers(new Array(LIMITS.MAX_TEAM_MEMBERS + 1).fill({})),
+      InvoiceValidationError,
+    );
+  });
+});
+
+describe("fixture-driven invoice submission validation", () => {
+  for (const invoice of fixture.validInvoices) {
+    it(`${invoice.id} validates and normalizes`, () => {
+      const result = validateInvoiceSubmission(invoice);
+
+      assert.equal(result.invoiceId, invoice.invoiceId);
+      assert.equal(result.invoiceNumber, invoice.invoiceNumber);
+      assert.equal(result.vendorName, invoice.vendorName);
+      assert.equal(result.currency, invoice.currency.toUpperCase());
+      assert.equal(result.lineItemTotal, invoice.amount);
+    });
+  }
+
+  it("rejects mismatched line item totals", () => {
+    assert.throws(
+      () =>
+        validateInvoiceSubmission({
+          ...fixture.validInvoices[0],
+          amount: 999.99,
+        }),
+      InvoiceValidationError,
+    );
+  });
+});
+
+describe("fixture-driven hostile inputs", () => {
+  const validators = {
+    invoiceId: validateInvoiceId,
+    invoiceNumber: validateInvoiceNumber,
+    vendorName: validateVendorName,
+    status: validateStatus,
+    currency: validateCurrency,
+    approverEmail: validateApproverEmail,
+    amount: validateAmount,
+  };
+
+  for (const entry of fixture.hostileInputs) {
+    it(`${entry.id}: ${entry.reason} is rejected`, () => {
+      const validator = validators[entry.field];
+      assert.ok(validator, `missing validator for ${entry.field}`);
+      assert.throws(() => validator(entry.value), InvoiceValidationError);
+    });
+  }
+});
+
+describe("fixture-driven sanitizer cases", () => {
+  const sanitizers = {
+    memo: sanitizeMemo,
+    invoiceNumber: sanitizeInvoiceNumber,
+    vendorName: sanitizeVendorName,
+  };
+
+  for (const entry of fixture.sanitizerCases) {
+    it(`${entry.id}: ${entry.field} sanitizes as expected`, () => {
+      assert.equal(sanitizers[entry.field](entry.value), entry.expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add folder-local invoice approval validation, sanitization, and performance guards
- add synthetic invoice, hostile input, sanitizer, and attachment fixtures
- document threat assumptions, unsafe inputs, and bounded collection limits
- add standalone Node coverage for the guard contract

## Validation
- node tools\v2\team\invoice-approval-workflow\tests\invoice-guards.test.mjs
- git diff --check

Closes 