### PR TITLE
Add escalation tool test documentation

### DIFF
--- a/tools/v2/team/escalation-tool/README.md
+++ b/tools/v2/team/escalation-tool/README.md
@@ -1,15 +1,49 @@
 # Escalation Tool
 
-This folder is the isolated workspace for the Escalation Tool tool.
+Escalation Tool is an isolated V2 team workspace for defining how mail or
+workflow conversations should be escalated to the right reviewer, team, or
+severity queue.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\escalation-tool\
-`
+```text
+tools/v2/team/escalation-tool/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Current Status
+
+This contribution adds testing and documentation scaffolding for future
+implementation. It does not add live routing, mailbox access, notification
+delivery, or persistence.
+
+## Reviewer Setup
+
+Run the folder-local contract test from the repository root:
+
+```bash
+node tools/v2/team/escalation-tool/tests/documentation-contract.test.mjs
+```
+
+The test validates fixture shape, documentation coverage, and isolation
+boundaries for this tool.
+
+## Documentation Map
+
+- `fixtures/sample-escalations.json` contains deterministic escalation examples.
+- `docs/test-plan.md` lists automated and manual review steps.
+- `docs/review-notes.md` documents current scope and known limitations.
+- `tests/documentation-contract.test.mjs` protects the contributor-facing
+  documentation contract.
+
+## Known Limitations
+
+- No escalation engine is implemented yet.
+- No live notifications, mail data, team directory, or SLA service is connected.
+- Future implementation should add pure services and tests in this folder before
+  any main app integration.

--- a/tools/v2/team/escalation-tool/docs/review-notes.md
+++ b/tools/v2/team/escalation-tool/docs/review-notes.md
@@ -1,0 +1,38 @@
+# Escalation Tool Review Notes
+
+## Scope
+
+This issue adds test and documentation scaffolding for the isolated Escalation
+Tool workspace. The folder does not yet include a routing engine, hooks, or UI
+components.
+
+## How To Review
+
+1. Run `node tools/v2/team/escalation-tool/tests/documentation-contract.test.mjs`.
+2. Inspect `fixtures/sample-escalations.json` for state coverage and synthetic
+   data.
+3. Confirm README and specs describe the local boundary.
+4. Confirm future implementation notes do not require main app changes.
+
+## Fixture Intent
+
+The sample fixture includes:
+
+- `queued`: conversation waiting for assignment
+- `assigned`: conversation already routed to a team member
+- `escalated`: critical SLA-risk conversation
+- `resolved`: completed conversation that should remain closed
+- `blocked`: missing routing owner that needs human review
+
+## Known Limitations
+
+- No routing logic is implemented in this issue.
+- No UI surface is mounted.
+- No real mail, customer, or team directory data is included.
+- Future work should add a pure service layer before any app integration.
+
+## Safety Notes
+
+- No secrets, payment data, or production content is included.
+- No live network calls are required.
+- Fixture email addresses use `.test` domains.

--- a/tools/v2/team/escalation-tool/docs/test-plan.md
+++ b/tools/v2/team/escalation-tool/docs/test-plan.md
@@ -1,0 +1,44 @@
+# Escalation Tool Test Plan
+
+## Automated Check
+
+Run from the repository root:
+
+```bash
+node tools/v2/team/escalation-tool/tests/documentation-contract.test.mjs
+```
+
+The contract test validates:
+
+- README setup commands and local ownership boundary
+- specs do not contain generated placeholder fragments
+- fixtures include all expected escalation states
+- fixture emails use `.test` domains
+- review notes describe scope, safety, and known limitations
+
+## Manual Review Checklist
+
+- Confirm every changed file is under `tools/v2/team/escalation-tool/`.
+- Confirm no route, inbox, wallet, Stellar, auth, database, or shared design
+  system file is modified.
+- Confirm fixtures are synthetic and do not contain real customer data.
+- Confirm `blocked` examples explain why a conversation cannot be routed.
+- Confirm future implementation guidance keeps services local to this folder.
+
+## Future Automated Coverage
+
+When routing logic is added, tests should cover:
+
+- owner-team matching
+- severity promotion
+- SLA countdown thresholds
+- blocked states for missing owner or malformed input
+- resolved conversations staying closed unless reopened
+
+## Out Of Scope
+
+- Main app integration.
+- Live notifications.
+- Production inbox data.
+- Team directory lookups.
+- SLA service calls.

--- a/tools/v2/team/escalation-tool/fixtures/sample-escalations.json
+++ b/tools/v2/team/escalation-tool/fixtures/sample-escalations.json
@@ -1,0 +1,63 @@
+{
+  "tool": "escalation-tool",
+  "states": ["queued", "assigned", "escalated", "resolved", "blocked"],
+  "requests": [
+    {
+      "id": "esc-queued-001",
+      "conversationId": "conv-2026-001",
+      "subject": "Billing question needs triage",
+      "state": "queued",
+      "severity": "medium",
+      "ownerTeam": "support-ops",
+      "slaMinutesRemaining": 240,
+      "signals": ["billing", "customer-reply"],
+      "expectedAction": "Assign to the support operations queue."
+    },
+    {
+      "id": "esc-assigned-001",
+      "conversationId": "conv-2026-002",
+      "subject": "Enterprise legal review",
+      "state": "assigned",
+      "severity": "high",
+      "ownerTeam": "legal",
+      "assignee": "legal-reviewer@example.test",
+      "slaMinutesRemaining": 90,
+      "signals": ["contract", "enterprise"],
+      "expectedAction": "Keep assigned and request legal review notes."
+    },
+    {
+      "id": "esc-escalated-001",
+      "conversationId": "conv-2026-003",
+      "subject": "Security incident follow-up",
+      "state": "escalated",
+      "severity": "critical",
+      "ownerTeam": "security",
+      "assignee": "security-lead@example.test",
+      "slaMinutesRemaining": 15,
+      "signals": ["security", "incident", "sla-risk"],
+      "expectedAction": "Escalate to security lead and flag SLA risk."
+    },
+    {
+      "id": "esc-resolved-001",
+      "conversationId": "conv-2026-004",
+      "subject": "Resolved onboarding question",
+      "state": "resolved",
+      "severity": "low",
+      "ownerTeam": "customer-success",
+      "slaMinutesRemaining": 0,
+      "signals": ["onboarding", "resolved"],
+      "expectedAction": "Keep closed unless the customer replies again."
+    },
+    {
+      "id": "esc-blocked-001",
+      "conversationId": "conv-2026-005",
+      "subject": "Missing owner for refund review",
+      "state": "blocked",
+      "severity": "high",
+      "ownerTeam": "",
+      "slaMinutesRemaining": 60,
+      "signals": ["refund", "missing-owner"],
+      "expectedAction": "Request owner team before routing."
+    }
+  ]
+}

--- a/tools/v2/team/escalation-tool/specs.md
+++ b/tools/v2/team/escalation-tool/specs.md
@@ -1,41 +1,35 @@
-# Escalation Tool
-
-Escalate conversations.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/escalation-tool/README.md"
-  @"
-
 # Escalation Tool Specs
 
 ## Purpose
 
-Escalate conversations.
+Define a folder-local testing and documentation foundation for escalating team
+conversations based on severity, owner, SLA risk, and review status.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v2/team/escalation-tool/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Keep test plans, review notes, and fixtures inside the tool folder.
+- Describe expected escalation states: `queued`, `assigned`, `escalated`,
+  `resolved`, and `blocked`.
+- Document setup, usage, fixtures, and known limitations.
+- Provide fixture examples for normal, high-priority, blocked, and resolved
+  escalation scenarios.
+- Avoid live network calls, production data, and app-wide test dependencies.
+
+## Recommended Future Structure
+
+- `services/` for pure escalation routing rules.
+- `fixtures/` for deterministic conversation examples.
+- `tests/` for standalone Node tests.
+- `docs/` for setup, test plan, review notes, and future integration guidance.

--- a/tools/v2/team/escalation-tool/tests/documentation-contract.test.mjs
+++ b/tools/v2/team/escalation-tool/tests/documentation-contract.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+async function loadFixture() {
+  const raw = await readLocal("fixtures/sample-escalations.json");
+  return JSON.parse(raw);
+}
+
+test("README documents local reviewer setup", async () => {
+  const readme = await readLocal("README.md");
+
+  assert.match(readme, /tools\/v2\/team\/escalation-tool\//);
+  assert.match(readme, /documentation-contract\.test\.mjs/);
+  assert.match(readme, /Known Limitations/);
+  assert.match(readme, /No live notifications/);
+});
+
+test("specs do not contain generated placeholder fragments", async () => {
+  const specs = await readLocal("specs.md");
+
+  for (const placeholder of ["Hashtable", "$dir", "Set-Content", "    ests/"]) {
+    assert.doesNotMatch(specs, new RegExp(placeholder.replace("$", "\\$")));
+  }
+
+  assert.match(specs, /Contributor Boundary/);
+  assert.match(specs, /Required Local Behavior/);
+  assert.match(specs, /Recommended Future Structure/);
+});
+
+test("sample escalation fixture covers required states", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "escalation-tool");
+  assert.ok(Array.isArray(fixture.states));
+  assert.ok(Array.isArray(fixture.requests));
+
+  const expectedStates = ["queued", "assigned", "escalated", "resolved", "blocked"];
+  const seenStates = new Set(fixture.requests.map((request) => request.state));
+
+  for (const state of expectedStates) {
+    assert.ok(fixture.states.includes(state), `states must list ${state}`);
+    assert.ok(seenStates.has(state), `requests must include ${state}`);
+  }
+});
+
+test("sample escalation requests are reviewable and synthetic", async () => {
+  const fixture = await loadFixture();
+
+  for (const request of fixture.requests) {
+    assert.ok(request.id, "request needs stable id");
+    assert.ok(request.conversationId, `${request.id} needs conversation id`);
+    assert.ok(request.subject, `${request.id} needs subject`);
+    assert.ok(["low", "medium", "high", "critical"].includes(request.severity));
+    assert.ok(Array.isArray(request.signals), `${request.id} needs signals`);
+    assert.ok(request.expectedAction, `${request.id} needs expected action`);
+
+    if (request.assignee) {
+      assert.match(request.assignee, /\.test$/);
+    }
+
+    if (request.state === "blocked") {
+      assert.equal(request.ownerTeam, "");
+      assert.match(request.expectedAction, /owner/i);
+    }
+  }
+});
+
+test("test plan and review notes explain independent validation", async () => {
+  const testPlan = await readLocal("docs/test-plan.md");
+  const reviewNotes = await readLocal("docs/review-notes.md");
+
+  assert.match(testPlan, /Automated Check/);
+  assert.match(testPlan, /Manual Review Checklist/);
+  assert.match(testPlan, /Out Of Scope/);
+  assert.match(reviewNotes, /How To Review/);
+  assert.match(reviewNotes, /Known Limitations/);
+  assert.match(reviewNotes, /Safety Notes/);
+  assert.match(reviewNotes, /No live network calls/);
+});


### PR DESCRIPTION
## Summary
- replace placeholder README/spec text with isolated reviewer setup and boundaries
- add synthetic escalation fixtures covering queued, assigned, escalated, resolved, and blocked states
- add a folder-local test plan, review notes, and documentation contract tests

## Validation
- node tools\v2\team\escalation-tool\tests\documentation-contract.test.mjs
- git diff --check

Closes