### PR TITLE
Add shared team inbox core service

### DIFF
--- a/tools/v1/team/shared-team-inbox/README.md
+++ b/tools/v1/team/shared-team-inbox/README.md
@@ -18,6 +18,12 @@ Support teams that share an address (support@, ops@, team@) need ownership track
 
 See [docs/setup.md](./docs/setup.md) for full instructions.
 
+For the folder-local core engine added here, no package install is required:
+
+```bash
+node tools/v1/team/shared-team-inbox/tests/shared-inbox-service.test.mjs
+```
+
 Quick start:
 
 ```bash
@@ -59,6 +65,18 @@ When testing, fixtures should cover:
 - **Internal comments** — Author, body, timestamp, visibility flag (team-only).
 - **Status transitions** — Valid status values and allowed transitions.
 - **Team rosters** — List of authorized Stealth addresses.
+
+## Core Engine Surface
+
+This folder exposes a local core API from `index.mjs`:
+
+- `createSharedInboxService`
+- `normalizeMessage`
+- `SharedInboxError`
+- status and transition constants for future UI work
+
+The reference implementation is synchronous and in-memory. It does not send
+mail, call a relay, read production inbox data, or modify the main app.
 
 ## Known Limitations
 

--- a/tools/v1/team/shared-team-inbox/docs/contract.md
+++ b/tools/v1/team/shared-team-inbox/docs/contract.md
@@ -1,0 +1,61 @@
+# Shared Team Inbox Core Contract
+
+## Inputs
+
+`createSharedInboxService({ teamMembers })` accepts a synthetic team roster of
+email-like addresses. The service exposes folder-local methods only:
+
+- `ingestMessage(message)`
+- `listMessages(filters)`
+- `claimMessage(messageId, actor, note)`
+- `releaseMessage(messageId, actor)`
+- `updateStatus(messageId, actor, nextStatus)`
+- `addInternalComment(messageId, actor, body)`
+- `sendReply(messageId, actor, body)`
+
+Messages require:
+
+- `id`
+- `deliveryProofHash`
+- `sharedInboxAddress`
+- `senderAddress`
+- `subject`
+- `body`
+- optional `receivedAt`, `status`, and `assignee`
+
+## Outputs
+
+Read methods return cloned data so callers cannot mutate service state directly.
+`ingestMessage` returns:
+
+- `status`: `stored` or `duplicate`
+- `loading`: always `false` for this synchronous local service
+- `error`: `null` unless future async adapters are introduced
+- `message`: normalized stored message
+
+Mutation methods return the updated message, comment, or reply object.
+
+## Loading States
+
+This reference implementation is synchronous and in-memory, so every public
+method returns with `loading: false`. A future durable adapter should expose
+loading state at the hook/UI layer without changing this folder-local core
+contract.
+
+## Error States
+
+The service throws `SharedInboxError` for:
+
+- malformed messages
+- unknown message ids
+- actors outside the team roster
+- invalid status transitions
+- empty comments or replies
+- replies attempted before a message is claimed
+
+## Privacy And Network Rules
+
+- No live network calls are made.
+- No secrets, production messages, or user credentials are required.
+- Fixtures use `.test` domains and synthetic delivery proof hashes.
+- Replies are stored as local records only; no email is sent.

--- a/tools/v1/team/shared-team-inbox/fixtures/sample-shared-inbox.json
+++ b/tools/v1/team/shared-team-inbox/fixtures/sample-shared-inbox.json
@@ -1,0 +1,54 @@
+{
+  "tool": "shared-team-inbox",
+  "teamMembers": [
+    "alice@example.test",
+    "bob@example.test",
+    "carol@example.test"
+  ],
+  "messages": [
+    {
+      "id": "msg-001",
+      "deliveryProofHash": "proof-msg-001",
+      "sharedInboxAddress": "support@example.test",
+      "senderAddress": "customer.one@example.test",
+      "subject": "Login help",
+      "body": "I need help signing in to my account.",
+      "receivedAt": "2026-06-20T09:00:00.000Z"
+    },
+    {
+      "id": "msg-002",
+      "deliveryProofHash": "proof-msg-002",
+      "sharedInboxAddress": "support@example.test",
+      "senderAddress": "customer.two@example.test",
+      "subject": "Billing question",
+      "body": "Can you confirm whether the latest invoice was received?",
+      "receivedAt": "2026-06-20T10:00:00.000Z"
+    }
+  ],
+  "duplicateMessage": {
+    "id": "msg-duplicate",
+    "deliveryProofHash": "proof-msg-001",
+    "sharedInboxAddress": "support@example.test",
+    "senderAddress": "customer.one@example.test",
+    "subject": "Duplicate login help",
+    "body": "This has the same delivery proof hash.",
+    "receivedAt": "2026-06-20T11:00:00.000Z"
+  },
+  "invalidMessages": [
+    {
+      "id": "missing-proof",
+      "sharedInboxAddress": "support@example.test",
+      "senderAddress": "customer@example.test",
+      "subject": "Missing proof",
+      "body": "This message is missing a proof hash."
+    },
+    {
+      "id": "bad-sender",
+      "deliveryProofHash": "proof-bad-sender",
+      "sharedInboxAddress": "support@example.test",
+      "senderAddress": "customer@example.test\r\nBcc: attacker@example.test",
+      "subject": "Injected sender",
+      "body": "This sender contains CRLF injection."
+    }
+  ]
+}

--- a/tools/v1/team/shared-team-inbox/index.mjs
+++ b/tools/v1/team/shared-team-inbox/index.mjs
@@ -1,0 +1,8 @@
+export {
+  LIMITS,
+  MESSAGE_STATUSES,
+  SharedInboxError,
+  VALID_TRANSITIONS,
+  createSharedInboxService,
+  normalizeMessage,
+} from "./services/shared-inbox-service.mjs";

--- a/tools/v1/team/shared-team-inbox/services/shared-inbox-service.mjs
+++ b/tools/v1/team/shared-team-inbox/services/shared-inbox-service.mjs
@@ -1,0 +1,311 @@
+const MESSAGE_STATUSES = ["unassigned", "claimed", "in-progress", "awaiting-reply", "resolved"];
+const VALID_TRANSITIONS = {
+  unassigned: new Set(["claimed", "in-progress"]),
+  claimed: new Set(["unassigned", "in-progress", "awaiting-reply", "resolved"]),
+  "in-progress": new Set(["awaiting-reply", "resolved", "claimed"]),
+  "awaiting-reply": new Set(["in-progress", "resolved"]),
+  resolved: new Set(["in-progress"]),
+};
+
+const LIMITS = {
+  MAX_MESSAGE_BODY_LENGTH: 20_000,
+  MAX_COMMENT_LENGTH: 4_000,
+  MAX_REPLY_LENGTH: 20_000,
+  MAX_TEAM_SIZE: 100,
+};
+
+export class SharedInboxError extends Error {
+  constructor(message, code, field) {
+    super(message);
+    this.name = "SharedInboxError";
+    this.code = code;
+    this.field = field;
+  }
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function cleanText(value, maxLength = Number.POSITIVE_INFINITY) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function assertPlainObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new SharedInboxError(`${field} must be a plain object`, "invalid-input", field);
+  }
+}
+
+function validateEmailAddress(value, field) {
+  const email = cleanText(value);
+  if (!email) {
+    throw new SharedInboxError(`${field} is required`, "missing-field", field);
+  }
+  if (/[\r\n\0]/.test(email)) {
+    throw new SharedInboxError(`${field} contains unsafe control characters`, "unsafe-input", field);
+  }
+  const at = email.lastIndexOf("@");
+  if (at < 1 || at === email.length - 1) {
+    throw new SharedInboxError(`${field} must be an email-like address`, "invalid-input", field);
+  }
+  return email;
+}
+
+function validateTeamRoster(teamMembers = []) {
+  if (!Array.isArray(teamMembers)) {
+    throw new SharedInboxError("teamMembers must be an array", "invalid-input", "teamMembers");
+  }
+  if (teamMembers.length > LIMITS.MAX_TEAM_SIZE) {
+    throw new SharedInboxError("teamMembers exceeds safe team size", "too-large", "teamMembers");
+  }
+  return teamMembers.map((member) => validateEmailAddress(member, "teamMembers"));
+}
+
+function validateStatus(status) {
+  if (!MESSAGE_STATUSES.includes(status)) {
+    throw new SharedInboxError(`unsupported status: ${status}`, "invalid-status", "status");
+  }
+  return status;
+}
+
+function normalizeMessage(input) {
+  assertPlainObject(input, "message");
+  const id = cleanText(input.id);
+  const deliveryProofHash = cleanText(input.deliveryProofHash);
+  const subject = cleanText(input.subject, 998);
+  const body = cleanText(input.body, LIMITS.MAX_MESSAGE_BODY_LENGTH);
+
+  if (!id) {
+    throw new SharedInboxError("message id is required", "missing-field", "id");
+  }
+  if (!deliveryProofHash) {
+    throw new SharedInboxError(
+      "deliveryProofHash is required",
+      "missing-field",
+      "deliveryProofHash",
+    );
+  }
+  if (!subject) {
+    throw new SharedInboxError("subject is required", "missing-field", "subject");
+  }
+  if (!body) {
+    throw new SharedInboxError("body is required", "missing-field", "body");
+  }
+
+  return {
+    id,
+    deliveryProofHash,
+    sharedInboxAddress: validateEmailAddress(input.sharedInboxAddress, "sharedInboxAddress"),
+    senderAddress: validateEmailAddress(input.senderAddress, "senderAddress"),
+    subject,
+    body,
+    receivedAt: cleanText(input.receivedAt) || new Date(0).toISOString(),
+    status: validateStatus(input.status ?? "unassigned"),
+    assignee: input.assignee ? validateEmailAddress(input.assignee, "assignee") : null,
+    comments: [],
+    replies: [],
+  };
+}
+
+function recordActivity(state, type, messageId, actor, details = {}) {
+  state.activityCount += 1;
+  const activity = {
+    id: `activity-${String(state.activityCount).padStart(3, "0")}`,
+    type,
+    messageId,
+    actor,
+    at: new Date().toISOString(),
+    details,
+  };
+  state.activities.push(activity);
+  return activity;
+}
+
+function createState(teamMembers = []) {
+  return {
+    teamMembers: validateTeamRoster(teamMembers),
+    messages: new Map(),
+    proofHashes: new Map(),
+    activities: [],
+    activityCount: 0,
+  };
+}
+
+function getMessageOrThrow(state, messageId) {
+  const message = state.messages.get(messageId);
+  if (!message) {
+    throw new SharedInboxError(`message not found: ${messageId}`, "not-found", "messageId");
+  }
+  return message;
+}
+
+function assertTeamMember(state, actor) {
+  const normalized = validateEmailAddress(actor, "actor");
+  if (!state.teamMembers.includes(normalized)) {
+    throw new SharedInboxError("actor is not in the team roster", "unauthorized", "actor");
+  }
+  return normalized;
+}
+
+function assertTransition(from, to) {
+  validateStatus(from);
+  validateStatus(to);
+  if (from === to) {
+    return true;
+  }
+  if (!VALID_TRANSITIONS[from].has(to)) {
+    throw new SharedInboxError(
+      `invalid status transition: ${from} -> ${to}`,
+      "invalid-transition",
+      "status",
+    );
+  }
+  return true;
+}
+
+function listMessages(state, filters = {}) {
+  let messages = [...state.messages.values()];
+  if (filters.status) {
+    validateStatus(filters.status);
+    messages = messages.filter((message) => message.status === filters.status);
+  }
+  if (filters.assignee) {
+    const assignee = validateEmailAddress(filters.assignee, "assignee");
+    messages = messages.filter((message) => message.assignee === assignee);
+  }
+  return messages
+    .sort((a, b) => b.receivedAt.localeCompare(a.receivedAt))
+    .map((message) => clone(message));
+}
+
+export function createSharedInboxService(options = {}) {
+  const state = createState(options.teamMembers ?? []);
+
+  return {
+    getState() {
+      return {
+        teamMembers: clone(state.teamMembers),
+        messages: listMessages(state),
+        activities: clone(state.activities),
+      };
+    },
+
+    ingestMessage(input) {
+      const message = normalizeMessage(input);
+      const existingId = state.proofHashes.get(message.deliveryProofHash);
+
+      if (existingId) {
+        return {
+          status: "duplicate",
+          loading: false,
+          error: null,
+          message: clone(state.messages.get(existingId)),
+        };
+      }
+
+      state.messages.set(message.id, message);
+      state.proofHashes.set(message.deliveryProofHash, message.id);
+      recordActivity(state, "message-ingested", message.id, "system");
+
+      return {
+        status: "stored",
+        loading: false,
+        error: null,
+        message: clone(message),
+      };
+    },
+
+    listMessages(filters = {}) {
+      return {
+        loading: false,
+        error: null,
+        messages: listMessages(state, filters),
+      };
+    },
+
+    claimMessage(messageId, actor, note = "") {
+      const member = assertTeamMember(state, actor);
+      const message = getMessageOrThrow(state, messageId);
+      if (message.status === "resolved") {
+        throw new SharedInboxError("resolved messages must be reopened before claiming", "invalid-transition", "status");
+      }
+      message.assignee = member;
+      message.status = "claimed";
+      recordActivity(state, "message-claimed", message.id, member, { note: cleanText(note) });
+      return clone(message);
+    },
+
+    releaseMessage(messageId, actor) {
+      const member = assertTeamMember(state, actor);
+      const message = getMessageOrThrow(state, messageId);
+      assertTransition(message.status, "unassigned");
+      message.assignee = null;
+      message.status = "unassigned";
+      recordActivity(state, "message-released", message.id, member);
+      return clone(message);
+    },
+
+    updateStatus(messageId, actor, nextStatus) {
+      const member = assertTeamMember(state, actor);
+      const message = getMessageOrThrow(state, messageId);
+      const status = validateStatus(nextStatus);
+      assertTransition(message.status, status);
+      message.status = status;
+      recordActivity(state, "status-updated", message.id, member, { status });
+      return clone(message);
+    },
+
+    addInternalComment(messageId, actor, body) {
+      const member = assertTeamMember(state, actor);
+      const message = getMessageOrThrow(state, messageId);
+      const text = cleanText(body, LIMITS.MAX_COMMENT_LENGTH);
+      if (!text) {
+        throw new SharedInboxError("comment body is required", "missing-field", "body");
+      }
+      const comment = {
+        id: `comment-${message.id}-${message.comments.length + 1}`,
+        author: member,
+        body: text,
+        visibility: "team-only",
+        createdAt: new Date().toISOString(),
+        deleted: false,
+      };
+      message.comments.push(comment);
+      recordActivity(state, "comment-added", message.id, member, { commentId: comment.id });
+      return clone(comment);
+    },
+
+    sendReply(messageId, actor, body) {
+      const member = assertTeamMember(state, actor);
+      const message = getMessageOrThrow(state, messageId);
+      const text = cleanText(body, LIMITS.MAX_REPLY_LENGTH);
+      if (!text) {
+        throw new SharedInboxError("reply body is required", "missing-field", "body");
+      }
+      if (!message.assignee) {
+        throw new SharedInboxError("message must be claimed before replying", "invalid-state", "assignee");
+      }
+      const reply = {
+        id: `reply-${message.id}-${message.replies.length + 1}`,
+        from: message.sharedInboxAddress,
+        to: message.senderAddress,
+        body: text,
+        sentBy: member,
+        sentAt: new Date().toISOString(),
+      };
+      message.replies.push(reply);
+      message.status = "resolved";
+      recordActivity(state, "reply-sent", message.id, member, { replyId: reply.id });
+      return clone(reply);
+    },
+  };
+}
+
+export { LIMITS, MESSAGE_STATUSES, VALID_TRANSITIONS, normalizeMessage };

--- a/tools/v1/team/shared-team-inbox/tests/README.md
+++ b/tools/v1/team/shared-team-inbox/tests/README.md
@@ -18,6 +18,16 @@ Folder-local test strategy for the Shared Team Inbox tool.
 
 ## Unit Test Scenarios
 
+Current standalone coverage:
+
+```bash
+node tools/v1/team/shared-team-inbox/tests/shared-inbox-service.test.mjs
+```
+
+This validates the folder-local reference service for ingestion, duplicate
+delivery proof handling, assignment, release, status transitions, internal
+comments, local reply records, and cloned state snapshots.
+
 ### Message ingestion
 
 - New message from relay is stored with normalized fields.

--- a/tools/v1/team/shared-team-inbox/tests/shared-inbox-service.test.mjs
+++ b/tools/v1/team/shared-team-inbox/tests/shared-inbox-service.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  MESSAGE_STATUSES,
+  SharedInboxError,
+  createSharedInboxService,
+  normalizeMessage,
+} from "../index.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-shared-inbox.json");
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("normalizes valid shared inbox messages", async () => {
+  const fixture = await loadFixture();
+  const message = normalizeMessage(fixture.messages[0]);
+
+  assert.equal(message.id, "msg-001");
+  assert.equal(message.status, "unassigned");
+  assert.equal(message.assignee, null);
+  assert.deepEqual(message.comments, []);
+  assert.deepEqual(message.replies, []);
+});
+
+test("rejects malformed message fixtures", async () => {
+  const fixture = await loadFixture();
+
+  for (const invalidMessage of fixture.invalidMessages) {
+    assert.throws(() => normalizeMessage(invalidMessage), SharedInboxError);
+  }
+});
+
+test("ingests messages and skips duplicate delivery proofs", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+
+  const first = service.ingestMessage(fixture.messages[0]);
+  const duplicate = service.ingestMessage(fixture.duplicateMessage);
+
+  assert.equal(first.status, "stored");
+  assert.equal(duplicate.status, "duplicate");
+  assert.equal(duplicate.message.id, "msg-001");
+  assert.equal(service.listMessages().messages.length, 1);
+});
+
+test("lists messages newest first and filters by status", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+
+  for (const message of fixture.messages) {
+    service.ingestMessage(message);
+  }
+
+  const all = service.listMessages().messages;
+  assert.deepEqual(
+    all.map((message) => message.id),
+    ["msg-002", "msg-001"],
+  );
+
+  service.claimMessage("msg-001", "alice@example.test");
+  assert.deepEqual(
+    service.listMessages({ status: "claimed" }).messages.map((message) => message.id),
+    ["msg-001"],
+  );
+});
+
+test("claims and releases messages for team members", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  const claimed = service.claimMessage("msg-001", "alice@example.test", "Taking this one");
+  assert.equal(claimed.status, "claimed");
+  assert.equal(claimed.assignee, "alice@example.test");
+
+  const released = service.releaseMessage("msg-001", "alice@example.test");
+  assert.equal(released.status, "unassigned");
+  assert.equal(released.assignee, null);
+});
+
+test("rejects actors outside the team roster", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  assert.throws(
+    () => service.claimMessage("msg-001", "outsider@example.test"),
+    SharedInboxError,
+  );
+});
+
+test("enforces documented status transitions", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  assert.throws(
+    () => service.updateStatus("msg-001", "alice@example.test", "resolved"),
+    SharedInboxError,
+  );
+
+  service.claimMessage("msg-001", "alice@example.test");
+  const inProgress = service.updateStatus("msg-001", "alice@example.test", "in-progress");
+  assert.equal(inProgress.status, "in-progress");
+});
+
+test("adds internal comments as team-only records", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  const comment = service.addInternalComment("msg-001", "bob@example.test", "Known issue.");
+  assert.equal(comment.author, "bob@example.test");
+  assert.equal(comment.visibility, "team-only");
+  assert.equal(comment.deleted, false);
+
+  assert.throws(() => service.addInternalComment("msg-001", "bob@example.test", ""), SharedInboxError);
+});
+
+test("sends local reply records only after claim", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  assert.throws(
+    () => service.sendReply("msg-001", "alice@example.test", "Thanks for writing in."),
+    SharedInboxError,
+  );
+
+  service.claimMessage("msg-001", "alice@example.test");
+  const reply = service.sendReply("msg-001", "alice@example.test", "Thanks for writing in.");
+  assert.equal(reply.from, "support@example.test");
+  assert.equal(reply.to, "customer.one@example.test");
+  assert.equal(service.listMessages({ status: "resolved" }).messages.length, 1);
+});
+
+test("state snapshots are cloned", async () => {
+  const fixture = await loadFixture();
+  const service = createSharedInboxService({ teamMembers: fixture.teamMembers });
+  service.ingestMessage(fixture.messages[0]);
+
+  const snapshot = service.getState();
+  snapshot.messages[0].subject = "mutated";
+
+  assert.equal(service.getState().messages[0].subject, "Login help");
+});
+
+test("exports expected status values", () => {
+  assert.deepEqual(MESSAGE_STATUSES, [
+    "unassigned",
+    "claimed",
+    "in-progress",
+    "awaiting-reply",
+    "resolved",
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a folder-local shared team inbox core service with ingestion, duplicate detection, assignment, status transitions, comments, replies, and activity snapshots
- add synthetic fixtures and a local contract document for inputs, outputs, loading, and error states
- add standalone Node coverage for the core workflow without linking into the main app

## Validation
- node tools\v1\team\shared-team-inbox\tests\shared-inbox-service.test.mjs
- node -e "import('./tools/v1/team/shared-team-inbox/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --check

Closes 