### PR TITLE
Add internal comment thread guards

### DIFF
--- a/tools/v1/team/internal-comment-thread/README.md
+++ b/tools/v1/team/internal-comment-thread/README.md
@@ -18,6 +18,12 @@ Support and operations teams need a private channel to discuss context, next ste
 
 See [docs/setup.md](./docs/setup.md) for full instructions.
 
+Security and performance guard tests can run without installing packages:
+
+```bash
+node tools/v1/team/internal-comment-thread/tests/comment-guards.test.mjs
+```
+
 Quick start:
 
 ```bash
@@ -66,6 +72,12 @@ When testing, fixtures should cover:
 - No attachment of files or images to comments.
 - No search or filtering over comment history.
 - Ephemeral state by default (in-memory storage; restart loses data unless a durable adapter is connected).
+
+## Security Guard Surface
+
+This folder includes `guards/comment-guards.mjs` for target validation, author
+validation, comment body sanitization, collection size guards, and explicit
+checks that external payloads do not contain internal comment text.
 
 ## OSS Review Notes
 

--- a/tools/v1/team/internal-comment-thread/docs/security-and-performance.md
+++ b/tools/v1/team/internal-comment-thread/docs/security-and-performance.md
@@ -1,0 +1,54 @@
+# Security and Performance - Internal Comment Thread
+
+## Firm Privacy Boundary
+
+Internal comments are team-only. Comment body text must never appear in any
+reply, forward, external notification, log payload, or delivery path that could
+reach an external sender.
+
+## Guard Coverage
+
+`guards/comment-guards.mjs` provides:
+
+- target validation for message/thread references
+- author validation against a team roster
+- comment body sanitization and length limits
+- comment history and team roster size guards
+- external payload leakage checks for comment body text
+- a local external reply payload builder that includes only reply content
+
+## Unsafe Inputs
+
+| Input | Risk | Guard |
+| --- | --- | --- |
+| target id | path traversal or lookup abuse | safe id allowlist |
+| target kind | attaching comments outside shared inbox scope | `message` or `thread` only |
+| author | CRLF injection or outsider access | email-like check and roster membership |
+| comment body | control chars, empty body, render cost | sanitization and max length |
+| comment history | expensive scans | max history size |
+| team roster | expensive authorization checks | max team size |
+| external payload | accidental comment leakage | explicit serialized payload inspection |
+
+## Performance Limits
+
+| Data set | Limit |
+| --- | ---: |
+| target id | 128 chars |
+| author | 254 chars |
+| comment body | 4,000 chars |
+| comment history | 500 comments |
+| team roster | 100 members |
+| external payload inspection | 50,000 bytes |
+
+Future integrations should page long histories and run leakage checks only on
+bounded reply/notification payloads.
+
+## Review Command
+
+Run from the repository root:
+
+```bash
+node tools/v1/team/internal-comment-thread/tests/comment-guards.test.mjs
+```
+
+The tests use synthetic `.test` addresses only and make no live network calls.

--- a/tools/v1/team/internal-comment-thread/fixtures/comment-guard-fixtures.json
+++ b/tools/v1/team/internal-comment-thread/fixtures/comment-guard-fixtures.json
@@ -1,0 +1,71 @@
+{
+  "teamMembers": [
+    "alice@example.test",
+    "bob@example.test",
+    "carol@example.test"
+  ],
+  "validComments": [
+    {
+      "id": "valid-001",
+      "target": { "kind": "message", "id": "msg-001" },
+      "author": "alice@example.test",
+      "body": "Customer is on the legacy plan. Check the migration note before replying."
+    },
+    {
+      "id": "valid-002",
+      "target": { "kind": "thread", "id": "thread-002" },
+      "author": "bob@example.test",
+      "body": "Legal already approved the wording for this thread."
+    }
+  ],
+  "hostileInputs": [
+    {
+      "id": "hostile-001",
+      "field": "target",
+      "value": { "kind": "message", "id": "../msg-001" },
+      "reason": "path traversal target id"
+    },
+    {
+      "id": "hostile-002",
+      "field": "target",
+      "value": { "kind": "external", "id": "msg-001" },
+      "reason": "unsupported target kind"
+    },
+    {
+      "id": "hostile-003",
+      "field": "author",
+      "value": "alice@example.test\r\nBcc: customer@example.test",
+      "reason": "header injection in author"
+    },
+    {
+      "id": "hostile-004",
+      "field": "author",
+      "value": "outsider@example.test",
+      "reason": "author outside team roster"
+    },
+    {
+      "id": "hostile-005",
+      "field": "body",
+      "value": "",
+      "reason": "empty comment"
+    }
+  ],
+  "leakScenario": {
+    "message": {
+      "senderAddress": "customer@example.test",
+      "subject": "Account migration question"
+    },
+    "replyBody": "Thanks for reaching out. We will follow up with migration options.",
+    "comments": [
+      {
+        "id": "comment-001",
+        "body": "Do not mention the internal discount exception.",
+        "author": "alice@example.test"
+      }
+    ],
+    "unsafePayload": {
+      "to": "customer@example.test",
+      "body": "Do not mention the internal discount exception."
+    }
+  }
+}

--- a/tools/v1/team/internal-comment-thread/guards/comment-guards.mjs
+++ b/tools/v1/team/internal-comment-thread/guards/comment-guards.mjs
@@ -1,0 +1,161 @@
+const TARGET_KINDS = new Set(["message", "thread"]);
+
+const LIMITS = {
+  MAX_TARGET_ID_LENGTH: 128,
+  MAX_AUTHOR_LENGTH: 254,
+  MAX_COMMENT_LENGTH: 4_000,
+  MAX_COMMENT_HISTORY: 500,
+  MAX_TEAM_MEMBERS: 100,
+  MAX_EXPORT_PAYLOAD_BYTES: 50_000,
+};
+
+const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export class InternalCommentGuardError extends Error {
+  constructor(message, field) {
+    super(message);
+    this.name = "InternalCommentGuardError";
+    this.field = field;
+  }
+}
+
+function stripControlCharacters(value, preserveNewlines = true) {
+  const pattern = preserveNewlines
+    ? /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g
+    : /[\x00-\x1F\x7F-\x9F]/g;
+  return value.replace(pattern, "");
+}
+
+function cleanText(value, maxLength, preserveNewlines = true) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return stripControlCharacters(value, preserveNewlines).trim().slice(0, maxLength);
+}
+
+export function validateTarget(target) {
+  if (!target || typeof target !== "object" || Array.isArray(target)) {
+    throw new InternalCommentGuardError("target must be a plain object", "target");
+  }
+  if (!TARGET_KINDS.has(target.kind)) {
+    throw new InternalCommentGuardError("target kind must be message or thread", "target.kind");
+  }
+  if (typeof target.id !== "string" || target.id.length === 0) {
+    throw new InternalCommentGuardError("target id is required", "target.id");
+  }
+  if (target.id.length > LIMITS.MAX_TARGET_ID_LENGTH) {
+    throw new InternalCommentGuardError("target id exceeds max length", "target.id");
+  }
+  if (!SAFE_ID_PATTERN.test(target.id)) {
+    throw new InternalCommentGuardError("target id contains unsafe characters", "target.id");
+  }
+  return { kind: target.kind, id: target.id };
+}
+
+export function validateAuthor(author, teamMembers = []) {
+  if (typeof author !== "string" || author.length === 0) {
+    throw new InternalCommentGuardError("author is required", "author");
+  }
+  if (author.length > LIMITS.MAX_AUTHOR_LENGTH) {
+    throw new InternalCommentGuardError("author exceeds max length", "author");
+  }
+  if (/[\r\n\0]/.test(author)) {
+    throw new InternalCommentGuardError("author contains unsafe control characters", "author");
+  }
+  const at = author.lastIndexOf("@");
+  if (at < 1 || at === author.length - 1) {
+    throw new InternalCommentGuardError("author must be an email-like address", "author");
+  }
+  if (teamMembers.length > 0 && !teamMembers.includes(author)) {
+    throw new InternalCommentGuardError("author is not in the team roster", "author");
+  }
+  return author;
+}
+
+export function sanitizeCommentBody(body) {
+  return cleanText(body, LIMITS.MAX_COMMENT_LENGTH, true);
+}
+
+export function validateCommentBody(body) {
+  const sanitized = sanitizeCommentBody(body);
+  if (!sanitized) {
+    throw new InternalCommentGuardError("comment body is required", "body");
+  }
+  return sanitized;
+}
+
+export function guardCommentHistory(comments) {
+  if (!Array.isArray(comments)) {
+    throw new InternalCommentGuardError("comments must be an array", "comments");
+  }
+  if (comments.length > LIMITS.MAX_COMMENT_HISTORY) {
+    throw new InternalCommentGuardError("comment history exceeds safe limit", "comments");
+  }
+  return true;
+}
+
+export function guardTeamRoster(teamMembers) {
+  if (!Array.isArray(teamMembers)) {
+    throw new InternalCommentGuardError("teamMembers must be an array", "teamMembers");
+  }
+  if (teamMembers.length > LIMITS.MAX_TEAM_MEMBERS) {
+    throw new InternalCommentGuardError("team roster exceeds safe limit", "teamMembers");
+  }
+  for (const member of teamMembers) {
+    validateAuthor(member);
+  }
+  return true;
+}
+
+export function validateCommentInput(input, teamMembers = []) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new InternalCommentGuardError("comment input must be a plain object", "comment");
+  }
+  guardTeamRoster(teamMembers);
+  return {
+    target: validateTarget(input.target),
+    author: validateAuthor(input.author, teamMembers),
+    body: validateCommentBody(input.body),
+    visibility: "team-only",
+  };
+}
+
+export function assertExternalPayloadDoesNotLeakComment(payload, comments) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new InternalCommentGuardError("payload must be a plain object", "payload");
+  }
+  if (!Array.isArray(comments)) {
+    throw new InternalCommentGuardError("comments must be an array", "comments");
+  }
+  const serialized = JSON.stringify(payload);
+  if (serialized.length > LIMITS.MAX_EXPORT_PAYLOAD_BYTES) {
+    throw new InternalCommentGuardError("payload exceeds safe inspection size", "payload");
+  }
+  for (const comment of comments) {
+    const body = typeof comment?.body === "string" ? comment.body : "";
+    if (body && serialized.includes(body)) {
+      throw new InternalCommentGuardError(
+        "external payload contains internal comment body",
+        "payload",
+      );
+    }
+  }
+  return true;
+}
+
+export function buildExternalReplyPayload(message, replyBody) {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    throw new InternalCommentGuardError("message must be a plain object", "message");
+  }
+  const body = cleanText(replyBody, LIMITS.MAX_COMMENT_LENGTH, true);
+  if (!body) {
+    throw new InternalCommentGuardError("reply body is required", "replyBody");
+  }
+  return {
+    to: cleanText(message.senderAddress, LIMITS.MAX_AUTHOR_LENGTH, false),
+    subject: cleanText(message.subject, 998, false),
+    body,
+  };
+}
+
+export { LIMITS, TARGET_KINDS };

--- a/tools/v1/team/internal-comment-thread/tests/README.md
+++ b/tools/v1/team/internal-comment-thread/tests/README.md
@@ -1,5 +1,16 @@
 # Test Plan
 
+Current standalone guard coverage:
+
+```bash
+node tools/v1/team/internal-comment-thread/tests/comment-guards.test.mjs
+```
+
+The guard suite validates target references, team-member authors, comment body
+sanitization, bounded comment histories, bounded team rosters, and the
+non-negotiable rule that internal comment body text cannot leak into external
+reply payloads.
+
 Folder-local test strategy for the Internal Comment Thread tool.
 
 > Tests will be written as `.test.ts` files alongside the source implementation. This document defines the plan and coverage expectations.

--- a/tools/v1/team/internal-comment-thread/tests/comment-guards.test.mjs
+++ b/tools/v1/team/internal-comment-thread/tests/comment-guards.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  InternalCommentGuardError,
+  LIMITS,
+  assertExternalPayloadDoesNotLeakComment,
+  buildExternalReplyPayload,
+  guardCommentHistory,
+  guardTeamRoster,
+  sanitizeCommentBody,
+  validateAuthor,
+  validateCommentBody,
+  validateCommentInput,
+  validateTarget,
+} from "../guards/comment-guards.mjs";
+
+const currentDir = join(fileURLToPath(import.meta.url), "..");
+const fixture = JSON.parse(
+  readFileSync(join(currentDir, "..", "fixtures", "comment-guard-fixtures.json"), "utf8"),
+);
+
+describe("validateTarget", () => {
+  it("accepts message and thread targets", () => {
+    assert.deepEqual(validateTarget({ kind: "message", id: "msg-001" }), {
+      kind: "message",
+      id: "msg-001",
+    });
+    assert.deepEqual(validateTarget({ kind: "thread", id: "thread_002" }), {
+      kind: "thread",
+      id: "thread_002",
+    });
+  });
+
+  it("rejects unsafe target values", () => {
+    assert.throws(() => validateTarget(null), InternalCommentGuardError);
+    assert.throws(() => validateTarget({ kind: "external", id: "msg-001" }), InternalCommentGuardError);
+    assert.throws(() => validateTarget({ kind: "message", id: "../bad" }), InternalCommentGuardError);
+    assert.throws(
+      () => validateTarget({ kind: "message", id: "x".repeat(LIMITS.MAX_TARGET_ID_LENGTH + 1) }),
+      InternalCommentGuardError,
+    );
+  });
+});
+
+describe("validateAuthor", () => {
+  it("accepts team members", () => {
+    assert.equal(
+      validateAuthor("alice@example.test", fixture.teamMembers),
+      "alice@example.test",
+    );
+  });
+
+  it("rejects malformed or unauthorized authors", () => {
+    assert.throws(() => validateAuthor("alice@example.test\r\nBcc: bad@example.test"), InternalCommentGuardError);
+    assert.throws(() => validateAuthor("@example.test"), InternalCommentGuardError);
+    assert.throws(() => validateAuthor("outsider@example.test", fixture.teamMembers), InternalCommentGuardError);
+  });
+});
+
+describe("comment body guards", () => {
+  it("strips control characters while preserving newlines", () => {
+    assert.equal(sanitizeCommentBody("line1\nline2\0"), "line1\nline2");
+  });
+
+  it("rejects empty comments and caps long comments", () => {
+    assert.throws(() => validateCommentBody(""), InternalCommentGuardError);
+    assert.equal(
+      sanitizeCommentBody("x".repeat(LIMITS.MAX_COMMENT_LENGTH + 1)).length,
+      LIMITS.MAX_COMMENT_LENGTH,
+    );
+  });
+});
+
+describe("collection guards", () => {
+  it("guards team roster size and shape", () => {
+    assert.equal(guardTeamRoster(fixture.teamMembers), true);
+    assert.throws(() => guardTeamRoster(null), InternalCommentGuardError);
+    assert.throws(
+      () => guardTeamRoster(new Array(LIMITS.MAX_TEAM_MEMBERS + 1).fill("a@example.test")),
+      InternalCommentGuardError,
+    );
+  });
+
+  it("guards comment history size", () => {
+    assert.equal(guardCommentHistory(new Array(LIMITS.MAX_COMMENT_HISTORY).fill({})), true);
+    assert.throws(
+      () => guardCommentHistory(new Array(LIMITS.MAX_COMMENT_HISTORY + 1).fill({})),
+      InternalCommentGuardError,
+    );
+  });
+});
+
+describe("validateCommentInput", () => {
+  for (const comment of fixture.validComments) {
+    it(`${comment.id} validates`, () => {
+      const result = validateCommentInput(comment, fixture.teamMembers);
+
+      assert.equal(result.author, comment.author);
+      assert.equal(result.body, comment.body);
+      assert.equal(result.visibility, "team-only");
+    });
+  }
+
+  it("rejects hostile fixture inputs", () => {
+    const [badTarget, badKind, badAuthor, outsider, emptyBody] = fixture.hostileInputs;
+
+    assert.throws(() => validateTarget(badTarget.value), InternalCommentGuardError);
+    assert.throws(() => validateTarget(badKind.value), InternalCommentGuardError);
+    assert.throws(() => validateAuthor(badAuthor.value), InternalCommentGuardError);
+    assert.throws(() => validateAuthor(outsider.value, fixture.teamMembers), InternalCommentGuardError);
+    assert.throws(
+      () =>
+        validateCommentInput(
+          {
+            target: { kind: "message", id: "msg-001" },
+            author: "alice@example.test",
+            body: emptyBody.value,
+          },
+          fixture.teamMembers,
+        ),
+      InternalCommentGuardError,
+    );
+  });
+});
+
+describe("external payload leakage guard", () => {
+  it("allows reply payloads that omit internal comments", () => {
+    const payload = buildExternalReplyPayload(
+      fixture.leakScenario.message,
+      fixture.leakScenario.replyBody,
+    );
+
+    assert.equal(payload.to, "customer@example.test");
+    assert.equal(
+      assertExternalPayloadDoesNotLeakComment(payload, fixture.leakScenario.comments),
+      true,
+    );
+  });
+
+  it("rejects payloads that include internal comment body text", () => {
+    assert.throws(
+      () =>
+        assertExternalPayloadDoesNotLeakComment(
+          fixture.leakScenario.unsafePayload,
+          fixture.leakScenario.comments,
+        ),
+      InternalCommentGuardError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add folder-local validation, sanitization, and performance guards for internal comments
- add synthetic fixtures covering target, author, body, roster, history, and leakage scenarios
- document the security/performance boundary and the external payload no-leak invariant
- add standalone Node coverage for the guard contract

## Validation
- node tools\v1\team\internal-comment-thread\tests\comment-guards.test.mjs
- git diff --check

Closes 