### PR TITLE
Add email ownership tracker UI surface

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -1,15 +1,50 @@
 # Email Ownership Tracker
 
-This folder is the isolated workspace for the Email Ownership Tracker tool.
+Email Ownership Tracker is an isolated V1 team tool workspace for viewing and
+changing message ownership across a shared team inbox workflow.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\team\email-ownership-tracker\
-`
+```text
+tools/v1/team/email-ownership-tracker/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+Run the folder-local contract test from the repository root:
+
+```bash
+node tools/v1/team/email-ownership-tracker/tests/ui-contract.test.mjs
+```
+
+No app mount, live inbox data, or package installation is required for this
+review.
+
+## UI Workflow
+
+1. Show empty, loading, error, and ready ownership states.
+2. Summarize unassigned, owned, stale, and resolved messages.
+3. Let reviewers filter ownership rows by state.
+4. Provide keyboard-accessible claim, transfer, and release actions.
+5. Keep all UI code folder-local until a future integration issue wires the tool.
+
+## Documentation Map
+
+- `components/` contains the isolated React UI surface.
+- `fixtures/sample-ownership.json` contains deterministic synthetic examples.
+- `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
+- `docs/VISUAL_STYLE.md` documents the local visual treatment.
+- `tests/ui-contract.test.mjs` validates fixture and accessibility contracts.
+
+## Known Limitations
+
+- This contribution does not connect to the main shared inbox.
+- Ownership actions are exposed as callbacks only.
+- Persistence, notifications, auth, wallet, Stellar, and mailbox integration are
+  out of scope.

--- a/tools/v1/team/email-ownership-tracker/components/EmailOwnershipTracker.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/EmailOwnershipTracker.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from "react";
+import { Filter, MailPlus } from "lucide-react";
+import type {
+  OwnershipRecord,
+  OwnershipStatus,
+  OwnershipSummary as Summary,
+} from "../types";
+import { OwnershipEmptyState } from "./OwnershipEmptyState";
+import { OwnershipErrorState } from "./OwnershipErrorState";
+import { OwnershipLoadingState } from "./OwnershipLoadingState";
+import { OwnershipRecordCard } from "./OwnershipRecordCard";
+import { OwnershipSummary } from "./OwnershipSummary";
+
+type TrackerViewState = "loading" | "error" | "ready";
+type FilterValue = "all" | OwnershipStatus;
+
+interface EmailOwnershipTrackerProps {
+  errorMessage?: string;
+  initialState?: TrackerViewState;
+  onClaim?: (record: OwnershipRecord) => void;
+  onRelease?: (record: OwnershipRecord) => void;
+  onRequestRecords?: () => void;
+  onTransfer?: (record: OwnershipRecord) => void;
+  records?: OwnershipRecord[];
+}
+
+const filterOptions: Array<{ label: string; value: FilterValue }> = [
+  { label: "All", value: "all" },
+  { label: "Unassigned", value: "unassigned" },
+  { label: "Owned", value: "owned" },
+  { label: "Stale", value: "stale" },
+  { label: "Resolved", value: "resolved" },
+];
+
+function summarizeOwnership(records: OwnershipRecord[]): Summary {
+  return records.reduce(
+    (summary, record) => {
+      summary.totalMessages += 1;
+      summary[record.status] += 1;
+      return summary;
+    },
+    {
+      totalMessages: 0,
+      unassigned: 0,
+      owned: 0,
+      stale: 0,
+      resolved: 0,
+    },
+  );
+}
+
+export function EmailOwnershipTracker({
+  errorMessage,
+  initialState = "ready",
+  onClaim,
+  onRelease,
+  onRequestRecords,
+  onTransfer,
+  records = [],
+}: EmailOwnershipTrackerProps) {
+  const [viewState, setViewState] = useState<TrackerViewState>(initialState);
+  const [filter, setFilter] = useState<FilterValue>("all");
+
+  const summary = useMemo(() => summarizeOwnership(records), [records]);
+  const filteredRecords = useMemo(
+    () => (filter === "all" ? records : records.filter((record) => record.status === filter)),
+    [filter, records],
+  );
+
+  if (viewState === "loading") {
+    return <OwnershipLoadingState />;
+  }
+
+  if (viewState === "error") {
+    return <OwnershipErrorState details={errorMessage} onRetry={() => setViewState("ready")} />;
+  }
+
+  if (records.length === 0) {
+    return (
+      <OwnershipEmptyState
+        action={
+          onRequestRecords ? (
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={onRequestRecords}
+              type="button"
+            >
+              <MailPlus aria-hidden="true" className="size-4" />
+              Add ownership sample
+            </button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="email-ownership-title"
+      className="mx-auto w-full max-w-5xl space-y-6 rounded-lg border border-slate-200 bg-slate-50 p-4 md:p-6"
+    >
+      <header>
+        <p className="text-sm font-medium uppercase tracking-wide text-slate-500">Team V1 tool</p>
+        <h1 className="mt-1 text-2xl font-semibold text-slate-950" id="email-ownership-title">
+          Email Ownership Tracker
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+          Track message ownership, spot stale handoffs, and keep shared inbox work from being
+          duplicated.
+        </p>
+      </header>
+
+      <OwnershipSummary summary={summary} />
+
+      <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <Filter aria-hidden="true" className="size-4" />
+          Filter ownership
+        </div>
+        <fieldset className="flex flex-wrap gap-2">
+          <legend className="sr-only">Ownership status filter</legend>
+          {filterOptions.map((option) => (
+            <label
+              className={`cursor-pointer rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                filter === option.value
+                  ? "border-slate-950 bg-slate-950 text-white"
+                  : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+              }`}
+              key={option.value}
+            >
+              <input
+                checked={filter === option.value}
+                className="sr-only"
+                name="email-ownership-filter"
+                onChange={() => setFilter(option.value)}
+                type="radio"
+                value={option.value}
+              />
+              {option.label}
+            </label>
+          ))}
+        </fieldset>
+      </div>
+
+      {filteredRecords.length > 0 ? (
+        <div aria-label="Email ownership records" className="space-y-3" role="list">
+          {filteredRecords.map((record) => (
+            <div key={record.id} role="listitem">
+              <OwnershipRecordCard
+                onClaim={onClaim}
+                onRelease={onRelease}
+                onTransfer={onTransfer}
+                record={record}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <OwnershipEmptyState
+          description="No ownership records match the current filter. Choose another status to continue reviewing."
+          title="No matching ownership records"
+        />
+      )}
+    </section>
+  );
+}
+
+export { summarizeOwnership };
+export type { EmailOwnershipTrackerProps };

--- a/tools/v1/team/email-ownership-tracker/components/OwnershipEmptyState.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/OwnershipEmptyState.tsx
@@ -1,0 +1,41 @@
+import { Inbox, UserPlus } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface OwnershipEmptyStateProps {
+  action?: ReactNode;
+  description?: string;
+  title?: string;
+}
+
+export function OwnershipEmptyState({
+  action,
+  description = "Add a shared inbox sample to preview ownership tracking.",
+  title = "No ownership records",
+}: OwnershipEmptyStateProps) {
+  return (
+    <section
+      aria-label="No ownership records"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="status"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-blue-200 bg-blue-50 text-blue-800"
+      >
+        <Inbox className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      {action ? (
+        <div className="mt-6">{action}</div>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-slate-500">
+          <UserPlus aria-hidden="true" className="size-4" />
+          Awaiting shared inbox data
+        </div>
+      )}
+    </section>
+  );
+}
+
+export type { OwnershipEmptyStateProps };

--- a/tools/v1/team/email-ownership-tracker/components/OwnershipErrorState.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/OwnershipErrorState.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface OwnershipErrorStateProps {
+  details?: string;
+  onRetry?: () => void;
+  title?: string;
+}
+
+export function OwnershipErrorState({
+  details = "Ownership records could not be prepared. Retry with the same local input or review manually.",
+  onRetry,
+  title = "Ownership tracker failed",
+}: OwnershipErrorStateProps) {
+  return (
+    <section
+      aria-label="Email ownership tracker error"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="alert"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-red-700"
+      >
+        <AlertTriangle className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-red-900">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{details}</p>
+      {onRetry ? (
+        <button
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          onClick={onRetry}
+          type="button"
+        >
+          <RotateCcw aria-hidden="true" className="size-4" />
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+export type { OwnershipErrorStateProps };

--- a/tools/v1/team/email-ownership-tracker/components/OwnershipLoadingState.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/OwnershipLoadingState.tsx
@@ -1,0 +1,34 @@
+interface OwnershipLoadingStateProps {
+  message?: string;
+  rowCount?: number;
+}
+
+export function OwnershipLoadingState({
+  message = "Loading ownership records...",
+  rowCount = 3,
+}: OwnershipLoadingStateProps) {
+  return (
+    <section aria-busy="true" aria-live="polite" className="space-y-4" role="status">
+      <span className="sr-only">{message}</span>
+      {Array.from({ length: rowCount }).map((_, index) => (
+        <div
+          aria-hidden="true"
+          className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          key={index}
+        >
+          <div className="flex items-start gap-4">
+            <div className="size-10 animate-pulse rounded-md bg-slate-200" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-full animate-pulse rounded bg-slate-100" />
+            </div>
+            <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export type { OwnershipLoadingStateProps };

--- a/tools/v1/team/email-ownership-tracker/components/OwnershipRecordCard.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/OwnershipRecordCard.tsx
@@ -1,0 +1,103 @@
+import { CheckCircle2, Clock3, RotateCcw, UserCheck, UserPlus } from "lucide-react";
+import type { OwnershipRecord } from "../types";
+
+interface OwnershipRecordCardProps {
+  onClaim?: (record: OwnershipRecord) => void;
+  onRelease?: (record: OwnershipRecord) => void;
+  onTransfer?: (record: OwnershipRecord) => void;
+  record: OwnershipRecord;
+}
+
+const statusStyles: Record<OwnershipRecord["status"], string> = {
+  unassigned: "border-blue-200 bg-blue-50 text-blue-800",
+  owned: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  stale: "border-amber-200 bg-amber-50 text-amber-800",
+  resolved: "border-slate-200 bg-slate-50 text-slate-700",
+};
+
+const statusIcons = {
+  unassigned: UserPlus,
+  owned: UserCheck,
+  stale: Clock3,
+  resolved: CheckCircle2,
+};
+
+export function OwnershipRecordCard({
+  onClaim,
+  onRelease,
+  onTransfer,
+  record,
+}: OwnershipRecordCardProps) {
+  const StatusIcon = statusIcons[record.status];
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        <div
+          aria-hidden="true"
+          className={`flex size-10 shrink-0 items-center justify-center rounded-md border ${statusStyles[record.status]}`}
+        >
+          <StatusIcon className="size-5" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-slate-950">
+              {record.subject}
+            </h3>
+            <span
+              className={`rounded-md border px-2 py-1 text-xs font-medium ${statusStyles[record.status]}`}
+            >
+              {record.status}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-slate-700">
+            {record.senderLabel} · {record.team}
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            {record.owner ? `Owned by ${record.owner}` : "No owner assigned"} · Updated{" "}
+            {record.ageMinutes} minutes ago
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">{record.lastAction}</p>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap gap-2 md:flex-col">
+          {record.status === "unassigned" && onClaim ? (
+            <button
+              aria-label={`Claim ownership of ${record.subject}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onClaim(record)}
+              type="button"
+            >
+              <UserPlus aria-hidden="true" className="size-4" />
+              Claim
+            </button>
+          ) : null}
+          {record.status !== "unassigned" && record.status !== "resolved" && onTransfer ? (
+            <button
+              aria-label={`Transfer ownership of ${record.subject}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onTransfer(record)}
+              type="button"
+            >
+              <RotateCcw aria-hidden="true" className="size-4" />
+              Transfer
+            </button>
+          ) : null}
+          {record.status !== "unassigned" && record.status !== "resolved" && onRelease ? (
+            <button
+              aria-label={`Release ownership of ${record.subject}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onRelease(record)}
+              type="button"
+            >
+              Release
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export type { OwnershipRecordCardProps };

--- a/tools/v1/team/email-ownership-tracker/components/OwnershipSummary.tsx
+++ b/tools/v1/team/email-ownership-tracker/components/OwnershipSummary.tsx
@@ -1,0 +1,27 @@
+import type { OwnershipSummary as Summary } from "../types";
+
+interface OwnershipSummaryProps {
+  summary: Summary;
+}
+
+const summaryItems = [
+  ["unassigned", "Unassigned"],
+  ["owned", "Owned"],
+  ["stale", "Stale"],
+  ["resolved", "Resolved"],
+] as const;
+
+export function OwnershipSummary({ summary }: OwnershipSummaryProps) {
+  return (
+    <dl aria-label="Email ownership summary" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {summaryItems.map(([key, label]) => (
+        <div className="rounded-lg border border-slate-200 bg-white p-4" key={key}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-1 text-2xl font-semibold text-slate-950">{summary[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export type { OwnershipSummaryProps };

--- a/tools/v1/team/email-ownership-tracker/components/index.ts
+++ b/tools/v1/team/email-ownership-tracker/components/index.ts
@@ -1,0 +1,12 @@
+export { EmailOwnershipTracker, summarizeOwnership } from "./EmailOwnershipTracker";
+export { OwnershipEmptyState } from "./OwnershipEmptyState";
+export { OwnershipErrorState } from "./OwnershipErrorState";
+export { OwnershipLoadingState } from "./OwnershipLoadingState";
+export { OwnershipRecordCard } from "./OwnershipRecordCard";
+export { OwnershipSummary } from "./OwnershipSummary";
+export type { EmailOwnershipTrackerProps } from "./EmailOwnershipTracker";
+export type { OwnershipEmptyStateProps } from "./OwnershipEmptyState";
+export type { OwnershipErrorStateProps } from "./OwnershipErrorState";
+export type { OwnershipLoadingStateProps } from "./OwnershipLoadingState";
+export type { OwnershipRecordCardProps } from "./OwnershipRecordCard";
+export type { OwnershipSummaryProps } from "./OwnershipSummary";

--- a/tools/v1/team/email-ownership-tracker/docs/ACCESSIBILITY.md
+++ b/tools/v1/team/email-ownership-tracker/docs/ACCESSIBILITY.md
@@ -1,0 +1,31 @@
+# Accessibility Notes
+
+## State Announcements
+
+- `OwnershipLoadingState` uses `role="status"`, `aria-live="polite"`, and
+  `aria-busy="true"` so assistive technology can announce loading progress.
+- `OwnershipErrorState` uses `role="alert"` for immediate failure announcement.
+- `OwnershipEmptyState` uses `role="status"` with a scoped `aria-label`.
+- The ready view is labelled by `email-ownership-title`.
+
+## Keyboard Behavior
+
+- Ownership filters are native radio inputs wrapped by labels.
+- Claim, transfer, release, retry, and add-sample actions are native buttons.
+- Focus indicators use `focus-visible` outlines with sufficient offset.
+- The UI does not trap focus or create hidden modal states.
+
+## Screen Reader Names
+
+- Decorative icons use `aria-hidden="true"`.
+- Claim, transfer, and release buttons include the message subject in
+  `aria-label`.
+- The result list uses `role="list"` and `role="listitem"` wrappers.
+- Status chips use visible text labels; color is never the only signal.
+
+## Manual Checklist
+
+- Tab through add-sample, filter, claim, transfer, release, and retry controls.
+- Confirm focus outlines remain visible at each stop.
+- Confirm loading and error states announce with screen-reader tooling.
+- Confirm icon-backed controls have neighboring text or accessible names.

--- a/tools/v1/team/email-ownership-tracker/docs/VISUAL_STYLE.md
+++ b/tools/v1/team/email-ownership-tracker/docs/VISUAL_STYLE.md
@@ -1,0 +1,30 @@
+# Visual Style Notes
+
+## Layout
+
+- The ready state uses a constrained `max-w-5xl` tool surface matching adjacent
+  isolated tool workspaces.
+- Summary metrics use a compact responsive definition list.
+- Ownership cards use a single card layer with actions aligned to the side on
+  wider screens and wrapping on narrow screens.
+
+## Color System
+
+- `unassigned` uses blue for unclaimed work.
+- `owned` uses emerald for active ownership.
+- `stale` uses amber for handoffs that need attention.
+- `resolved` uses slate for completed work.
+
+## Typography
+
+- Tool title uses `text-2xl`.
+- Card titles use `text-base` so long subjects wrap cleanly.
+- Supporting metadata uses `text-sm` and `leading-6` for scan-friendly review.
+
+## Interaction Treatment
+
+- Claim uses a dark filled button.
+- Transfer, release, retry, and add-sample actions use bordered or secondary
+  button styles.
+- All controls use the same focus-visible outline treatment as sibling tool
+  components.

--- a/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership.json
+++ b/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership.json
@@ -1,0 +1,52 @@
+{
+  "tool": "email-ownership-tracker",
+  "records": [
+    {
+      "id": "own-unassigned-001",
+      "messageId": "msg-001",
+      "subject": "Login help",
+      "senderLabel": "customer.one@example.test",
+      "status": "unassigned",
+      "team": "Support",
+      "updatedAt": "2026-06-20T09:00:00.000Z",
+      "ageMinutes": 18,
+      "lastAction": "Message entered the shared inbox."
+    },
+    {
+      "id": "own-owned-001",
+      "messageId": "msg-002",
+      "subject": "Billing question",
+      "senderLabel": "customer.two@example.test",
+      "status": "owned",
+      "owner": "alice@example.test",
+      "team": "Support",
+      "updatedAt": "2026-06-20T10:00:00.000Z",
+      "ageMinutes": 42,
+      "lastAction": "Alice claimed the message."
+    },
+    {
+      "id": "own-stale-001",
+      "messageId": "msg-003",
+      "subject": "Contract review",
+      "senderLabel": "customer.three@example.test",
+      "status": "stale",
+      "owner": "bob@example.test",
+      "team": "Legal",
+      "updatedAt": "2026-06-19T15:00:00.000Z",
+      "ageMinutes": 960,
+      "lastAction": "Ownership has not changed since yesterday."
+    },
+    {
+      "id": "own-resolved-001",
+      "messageId": "msg-004",
+      "subject": "Resolved setup question",
+      "senderLabel": "customer.four@example.test",
+      "status": "resolved",
+      "owner": "carol@example.test",
+      "team": "Customer Success",
+      "updatedAt": "2026-06-20T11:00:00.000Z",
+      "ageMinutes": 5,
+      "lastAction": "Carol resolved the conversation."
+    }
+  ]
+}

--- a/tools/v1/team/email-ownership-tracker/specs.md
+++ b/tools/v1/team/email-ownership-tracker/specs.md
@@ -1,41 +1,34 @@
-# Email Ownership Tracker
-
-Track ownership history.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/email-ownership-tracker/README.md"
-  @"
-
 # Email Ownership Tracker Specs
 
 ## Purpose
 
-Track ownership history.
+Track who owns each shared inbox message, surface stale ownership, and expose
+safe local controls for claim, transfer, release, and review workflows.
 
-## Contributor boundary
+## Contributor Boundary
 
-All work for this tool should stay in:
+All work for this tool must stay inside:
 
-$dir/
+```text
+tools/v1/team/email-ownership-tracker/
+```
 
-## Required issue categories
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or shared design system unless a future
+integration issue explicitly allows it.
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+## Required Local Behavior
+
+- Provide empty, loading, error, and success UI states.
+- Expose folder-local components for the primary ownership workflow.
+- Include native keyboard support for filters and ownership actions.
+- Provide accessible names for icon-backed controls.
+- Document focus, screen-reader, and visual treatment.
+- Use synthetic fixtures only.
+
+## Recommended Internal Structure
+
+- `components/` for folder-local UI components.
+- `fixtures/` for deterministic ownership examples.
+- `tests/` for standalone contract checks.
+- `docs/` for accessibility and local visual style notes.

--- a/tools/v1/team/email-ownership-tracker/tests/ui-contract.test.mjs
+++ b/tools/v1/team/email-ownership-tracker/tests/ui-contract.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+async function loadFixture() {
+  const raw = await readLocal("fixtures/sample-ownership.json");
+  return JSON.parse(raw);
+}
+
+test("sample ownership fixture follows the local UI contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "email-ownership-tracker");
+  assert.ok(Array.isArray(fixture.records));
+  assert.equal(fixture.records.length, 4);
+
+  const statuses = new Set();
+
+  for (const record of fixture.records) {
+    assert.ok(record.id, "record needs a stable id");
+    assert.ok(record.messageId, `${record.id} needs message id`);
+    assert.ok(record.subject, `${record.id} needs subject`);
+    assert.ok(record.senderLabel, `${record.id} needs sender label`);
+    assert.ok(["unassigned", "owned", "stale", "resolved"].includes(record.status));
+    assert.ok(record.team, `${record.id} needs team`);
+    assert.equal(typeof record.ageMinutes, "number");
+    assert.ok(record.lastAction, `${record.id} needs last action`);
+
+    if (record.owner) {
+      assert.match(record.owner, /\.test$/);
+    }
+
+    statuses.add(record.status);
+  }
+
+  for (const status of ["unassigned", "owned", "stale", "resolved"]) {
+    assert.ok(statuses.has(status), `fixture must include ${status}`);
+  }
+});
+
+test("loading, error, and empty states expose screen-reader roles", async () => {
+  const loadingState = await readLocal("components/OwnershipLoadingState.tsx");
+  const errorState = await readLocal("components/OwnershipErrorState.tsx");
+  const emptyState = await readLocal("components/OwnershipEmptyState.tsx");
+
+  assert.match(loadingState, /role="status"/);
+  assert.match(loadingState, /aria-live="polite"/);
+  assert.match(loadingState, /aria-busy="true"/);
+  assert.match(errorState, /role="alert"/);
+  assert.match(errorState, /type="button"/);
+  assert.match(emptyState, /role="status"/);
+  assert.match(emptyState, /aria-label="No ownership records"/);
+});
+
+test("tracker uses native filters and labelled result list", async () => {
+  const tracker = await readLocal("components/EmailOwnershipTracker.tsx");
+
+  assert.match(tracker, /aria-labelledby="email-ownership-title"/);
+  assert.match(tracker, /<fieldset/);
+  assert.match(tracker, /<legend className="sr-only">Ownership status filter<\/legend>/);
+  assert.match(tracker, /type="radio"/);
+  assert.match(tracker, /name="email-ownership-filter"/);
+  assert.match(tracker, /role="list"/);
+  assert.match(tracker, /role="listitem"/);
+});
+
+test("ownership cards label icon-backed controls", async () => {
+  const card = await readLocal("components/OwnershipRecordCard.tsx");
+
+  assert.match(card, /aria-label=\{`Claim ownership of \$\{record\.subject\}`\}/);
+  assert.match(card, /aria-label=\{`Transfer ownership of \$\{record\.subject\}`\}/);
+  assert.match(card, /aria-label=\{`Release ownership of \$\{record\.subject\}`\}/);
+  assert.match(card, /aria-hidden="true"/);
+  assert.match(card, /type="button"/);
+});
+
+test("component barrel exports the local UI surface", async () => {
+  const index = await readLocal("components/index.ts");
+
+  for (const exportName of [
+    "EmailOwnershipTracker",
+    "OwnershipEmptyState",
+    "OwnershipErrorState",
+    "OwnershipLoadingState",
+    "OwnershipRecordCard",
+    "OwnershipSummary",
+  ]) {
+    assert.match(index, new RegExp(`\\b${exportName}\\b`));
+  }
+});
+
+test("documentation covers focus, keyboard, screen-reader, and status colors", async () => {
+  const accessibility = await readLocal("docs/ACCESSIBILITY.md");
+  const visualStyle = await readLocal("docs/VISUAL_STYLE.md");
+
+  assert.match(accessibility, /Keyboard Behavior/);
+  assert.match(accessibility, /Screen Reader Names/);
+  assert.match(accessibility, /focus/i);
+  assert.match(visualStyle, /unassigned/);
+  assert.match(visualStyle, /owned/);
+  assert.match(visualStyle, /stale/);
+  assert.match(visualStyle, /resolved/);
+});

--- a/tools/v1/team/email-ownership-tracker/types.ts
+++ b/tools/v1/team/email-ownership-tracker/types.ts
@@ -1,0 +1,22 @@
+export type OwnershipStatus = "unassigned" | "owned" | "stale" | "resolved";
+
+export interface OwnershipRecord {
+  id: string;
+  messageId: string;
+  subject: string;
+  senderLabel: string;
+  status: OwnershipStatus;
+  owner?: string;
+  team: string;
+  updatedAt: string;
+  ageMinutes: number;
+  lastAction: string;
+}
+
+export interface OwnershipSummary {
+  totalMessages: number;
+  unassigned: number;
+  owned: number;
+  stale: number;
+  resolved: number;
+}


### PR DESCRIPTION
## Summary
- add a folder-local React UI surface for email ownership tracking
- cover empty, loading, error, ready, filtered, and record-card states
- add synthetic ownership fixtures plus accessibility and visual style documentation
- add standalone Node contract tests for fixture shape and UI accessibility hooks

## Validation
- node tools\v1\team\email-ownership-tracker\tests\ui-contract.test.mjs
- git diff --check

Closes 