### PR TITLE
Add customer support macro UI surface

### DIFF
--- a/tools/v1/team/customer-support-macro-tool/README.md
+++ b/tools/v1/team/customer-support-macro-tool/README.md
@@ -41,6 +41,7 @@ This tool provides:
 
 ```
 customer-support-macro-tool/
+├── components/        # Folder-local React UI surface
 ├── services/
 │   ├── macro.service.ts        # Pure CRUD / search / validation functions
 │   └── storage.service.ts      # localStorage + in-memory adapters
@@ -53,7 +54,9 @@ customer-support-macro-tool/
 │   ├── storage.service.test.ts # Unit tests — persistence layer
 │   └── TEST_PLAN.md            # Full test strategy document
 ├── docs/
-│   └── SETUP.md                # Dev setup guide
+│   ├── ACCESSIBILITY.md        # Keyboard and screen-reader notes
+│   ├── SETUP.md                # Dev setup guide
+│   └── VISUAL_STYLE.md         # Local visual style notes
 ├── README.md                   ← you are here
 └── specs.md                    # Issue categories and contributor expectations
 ```
@@ -156,6 +159,9 @@ import { FIXTURE_MACROS } from "./fixtures/macros.fixture";
 ## 6. Running tests
 
 ```bash
+# Run UI contract checks without package install
+node tools/v1/team/customer-support-macro-tool/tests/ui-contract.test.mjs
+
 # Run only this tool's tests (from repo root)
 npx vitest run tools/v1/team/customer-support-macro-tool/tests
 
@@ -178,7 +184,7 @@ coverage targets, and a description of every test case.
 | localStorage only           | No sync across tabs. Tab isolation is fine for V1.                                                                                  |
 | No server-side storage      | Macros are local to the browser. Cloud sync is a V2 concern.                                                                        |
 | Hook not unit-tested        | `useMacros.ts` wraps the fully-tested service layer. Full hook tests require `@testing-library/react`, which is not in devDeps yet. |
-| No UI component             | The component layer is planned in a separate issue.                                                                                 |
+| No app-mounted UI           | The component layer is folder-local and intentionally not mounted in the main app yet.                                               |
 | No conflict resolution      | If two agents edit the same macro name, last write wins.                                                                            |
 | Max body length 4,000 chars | Enforced by `validateMacroInput`. Configurable in a future issue.                                                                   |
 

--- a/tools/v1/team/customer-support-macro-tool/components/MacroCard.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroCard.tsx
@@ -1,0 +1,93 @@
+import { Edit3, Play, Star } from "lucide-react";
+import type { Macro } from "../services/macro.service";
+
+interface MacroCardProps {
+  macro: Macro;
+  onEdit?: (macro: Macro) => void;
+  onToggleFavorite?: (macro: Macro) => void;
+  onUse?: (macro: Macro) => void;
+}
+
+const categoryStyles: Record<Macro["category"], string> = {
+  greeting: "border-blue-200 bg-blue-50 text-blue-800",
+  billing: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  technical: "border-violet-200 bg-violet-50 text-violet-800",
+  shipping: "border-cyan-200 bg-cyan-50 text-cyan-800",
+  refund: "border-amber-200 bg-amber-50 text-amber-800",
+  general: "border-slate-200 bg-slate-50 text-slate-700",
+};
+
+export function MacroCard({ macro, onEdit, onToggleFavorite, onUse }: MacroCardProps) {
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-slate-950">{macro.title}</h3>
+            <span
+              className={`rounded-md border px-2 py-1 text-xs font-medium ${categoryStyles[macro.category]}`}
+            >
+              {macro.category}
+            </span>
+            {macro.isFavorite ? (
+              <span className="rounded-md bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
+                favorite
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-3 line-clamp-3 whitespace-pre-wrap text-sm leading-6 text-slate-600">
+            {macro.body}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-600">
+            {macro.tags.map((tag) => (
+              <span className="rounded-md bg-slate-100 px-2 py-1" key={tag}>
+                {tag}
+              </span>
+            ))}
+            <span className="rounded-md bg-slate-100 px-2 py-1">
+              used {macro.usageCount} times
+            </span>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap gap-2 md:flex-col">
+          {onUse ? (
+            <button
+              aria-label={`Apply macro ${macro.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onUse(macro)}
+              type="button"
+            >
+              <Play aria-hidden="true" className="size-4" />
+              Apply
+            </button>
+          ) : null}
+          {onToggleFavorite ? (
+            <button
+              aria-label={`${macro.isFavorite ? "Remove favorite from" : "Favorite"} ${macro.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={() => onToggleFavorite(macro)}
+              type="button"
+            >
+              <Star aria-hidden="true" className="size-4" />
+              Favorite
+            </button>
+          ) : null}
+          {onEdit ? (
+            <button
+              aria-label={`Edit macro ${macro.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-slate-950"
+              onClick={() => onEdit(macro)}
+              type="button"
+            >
+              <Edit3 aria-hidden="true" className="size-4" />
+              Edit
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export type { MacroCardProps };

--- a/tools/v1/team/customer-support-macro-tool/components/MacroSummary.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroSummary.tsx
@@ -1,0 +1,35 @@
+import type { MacroCategory } from "../services/macro.service";
+
+interface MacroSummaryProps {
+  favorites: number;
+  total: number;
+  totalUsage: number;
+  visibleCategories: MacroCategory[];
+}
+
+export function MacroSummary({
+  favorites,
+  total,
+  totalUsage,
+  visibleCategories,
+}: MacroSummaryProps) {
+  const items = [
+    ["Total", total],
+    ["Favorites", favorites],
+    ["Categories", visibleCategories.length],
+    ["Uses", totalUsage],
+  ] as const;
+
+  return (
+    <dl aria-label="Support macro summary" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {items.map(([label, value]) => (
+        <div className="rounded-lg border border-slate-200 bg-white p-4" key={label}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-1 text-2xl font-semibold text-slate-950">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export type { MacroSummaryProps };

--- a/tools/v1/team/customer-support-macro-tool/components/MacroToolEmptyState.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroToolEmptyState.tsx
@@ -1,0 +1,41 @@
+import { FileText, Plus } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface MacroToolEmptyStateProps {
+  action?: ReactNode;
+  description?: string;
+  title?: string;
+}
+
+export function MacroToolEmptyState({
+  action,
+  description = "Create or import support macros to preview the team response workflow.",
+  title = "No support macros",
+}: MacroToolEmptyStateProps) {
+  return (
+    <section
+      aria-label="No support macros"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="status"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-blue-200 bg-blue-50 text-blue-800"
+      >
+        <FileText className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      {action ? (
+        <div className="mt-6">{action}</div>
+      ) : (
+        <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-slate-500">
+          <Plus aria-hidden="true" className="size-4" />
+          Awaiting macro data
+        </div>
+      )}
+    </section>
+  );
+}
+
+export type { MacroToolEmptyStateProps };

--- a/tools/v1/team/customer-support-macro-tool/components/MacroToolErrorState.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroToolErrorState.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+interface MacroToolErrorStateProps {
+  details?: string;
+  onRetry?: () => void;
+  title?: string;
+}
+
+export function MacroToolErrorState({
+  details = "Support macros could not be prepared. Retry with the same local input or review manually.",
+  onRetry,
+  title = "Macro tool failed",
+}: MacroToolErrorStateProps) {
+  return (
+    <section
+      aria-label="Customer support macro tool error"
+      className="mx-auto flex max-w-lg flex-col items-center justify-center px-4 py-12 text-center"
+      role="alert"
+    >
+      <div
+        aria-hidden="true"
+        className="mb-5 flex size-14 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-red-700"
+      >
+        <AlertTriangle className="size-7" />
+      </div>
+      <h2 className="text-xl font-semibold text-red-900">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{details}</p>
+      {onRetry ? (
+        <button
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+          onClick={onRetry}
+          type="button"
+        >
+          <RotateCcw aria-hidden="true" className="size-4" />
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+export type { MacroToolErrorStateProps };

--- a/tools/v1/team/customer-support-macro-tool/components/MacroToolLoadingState.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroToolLoadingState.tsx
@@ -1,0 +1,34 @@
+interface MacroToolLoadingStateProps {
+  message?: string;
+  rowCount?: number;
+}
+
+export function MacroToolLoadingState({
+  message = "Loading support macros...",
+  rowCount = 3,
+}: MacroToolLoadingStateProps) {
+  return (
+    <section aria-busy="true" aria-live="polite" className="space-y-4" role="status">
+      <span className="sr-only">{message}</span>
+      {Array.from({ length: rowCount }).map((_, index) => (
+        <div
+          aria-hidden="true"
+          className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          key={index}
+        >
+          <div className="flex items-start gap-4">
+            <div className="size-10 animate-pulse rounded-md bg-slate-200" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-full animate-pulse rounded bg-slate-100" />
+            </div>
+            <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200" />
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export type { MacroToolLoadingStateProps };

--- a/tools/v1/team/customer-support-macro-tool/components/MacroToolPanel.tsx
+++ b/tools/v1/team/customer-support-macro-tool/components/MacroToolPanel.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from "react";
+import { Filter, Plus } from "lucide-react";
+import type { Macro, MacroCategory } from "../services/macro.service";
+import { MacroCard } from "./MacroCard";
+import { MacroSummary } from "./MacroSummary";
+import { MacroToolEmptyState } from "./MacroToolEmptyState";
+import { MacroToolErrorState } from "./MacroToolErrorState";
+import { MacroToolLoadingState } from "./MacroToolLoadingState";
+
+type MacroToolViewState = "loading" | "error" | "ready";
+type CategoryFilter = "all" | MacroCategory;
+
+interface MacroToolPanelProps {
+  errorMessage?: string;
+  initialState?: MacroToolViewState;
+  macros?: Macro[];
+  onCreateMacro?: () => void;
+  onEditMacro?: (macro: Macro) => void;
+  onRetry?: () => void;
+  onToggleFavorite?: (macro: Macro) => void;
+  onUseMacro?: (macro: Macro) => void;
+}
+
+const categoryOptions: Array<{ label: string; value: CategoryFilter }> = [
+  { label: "All", value: "all" },
+  { label: "Greeting", value: "greeting" },
+  { label: "Billing", value: "billing" },
+  { label: "Technical", value: "technical" },
+  { label: "Shipping", value: "shipping" },
+  { label: "Refund", value: "refund" },
+  { label: "General", value: "general" },
+];
+
+function includesQuery(macro: Macro, query: string): boolean {
+  const haystack = [macro.title, macro.body, ...macro.tags].join(" ").toLowerCase();
+  return haystack.includes(query.toLowerCase().trim());
+}
+
+export function MacroToolPanel({
+  errorMessage,
+  initialState = "ready",
+  macros = [],
+  onCreateMacro,
+  onEditMacro,
+  onRetry,
+  onToggleFavorite,
+  onUseMacro,
+}: MacroToolPanelProps) {
+  const [viewState, setViewState] = useState<MacroToolViewState>(initialState);
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [query, setQuery] = useState("");
+
+  const filteredMacros = useMemo(
+    () =>
+      macros.filter((macro) => {
+        const categoryMatch = category === "all" || macro.category === category;
+        const queryMatch = !query || includesQuery(macro, query);
+        return categoryMatch && queryMatch;
+      }),
+    [category, macros, query],
+  );
+
+  const summary = useMemo(() => {
+    const visibleCategories = [...new Set(macros.map((macro) => macro.category))];
+    const totalUsage = macros.reduce((total, macro) => total + macro.usageCount, 0);
+    const favorites = macros.filter((macro) => macro.isFavorite).length;
+    return { favorites, totalUsage, visibleCategories };
+  }, [macros]);
+
+  if (viewState === "loading") {
+    return <MacroToolLoadingState />;
+  }
+
+  if (viewState === "error") {
+    return (
+      <MacroToolErrorState
+        details={errorMessage}
+        onRetry={onRetry ?? (() => setViewState("ready"))}
+      />
+    );
+  }
+
+  if (macros.length === 0) {
+    return (
+      <MacroToolEmptyState
+        action={
+          onCreateMacro ? (
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+              onClick={onCreateMacro}
+              type="button"
+            >
+              <Plus aria-hidden="true" className="size-4" />
+              New macro
+            </button>
+          ) : null
+        }
+      />
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="support-macro-tool-title"
+      className="mx-auto w-full max-w-5xl space-y-6 rounded-lg border border-slate-200 bg-slate-50 p-4 md:p-6"
+    >
+      <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-slate-500">Team V1 tool</p>
+          <h1 className="mt-1 text-2xl font-semibold text-slate-950" id="support-macro-tool-title">
+            Customer Support Macro Tool
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            Search reusable replies, apply customer variables, and keep frequent responses
+            consistent across the support team.
+          </p>
+        </div>
+        {onCreateMacro ? (
+          <button
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+            onClick={onCreateMacro}
+            type="button"
+          >
+            <Plus aria-hidden="true" className="size-4" />
+            New macro
+          </button>
+        ) : null}
+      </header>
+
+      <MacroSummary
+        favorites={summary.favorites}
+        total={macros.length}
+        totalUsage={summary.totalUsage}
+        visibleCategories={summary.visibleCategories}
+      />
+
+      <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+        <div>
+          <label className="text-sm font-medium text-slate-800" htmlFor="macro-search">
+            Search macros
+          </label>
+          <input
+            className="mt-2 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-950"
+            id="macro-search"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search title, body, or tag"
+            type="search"
+            value={query}
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+            <Filter aria-hidden="true" className="size-4" />
+            Filter category
+          </div>
+          <fieldset className="flex flex-wrap gap-2">
+            <legend className="sr-only">Macro category filter</legend>
+            {categoryOptions.map((option) => (
+              <label
+                className={`cursor-pointer rounded-md border px-3 py-2 text-sm font-medium transition-colors ${
+                  category === option.value
+                    ? "border-slate-950 bg-slate-950 text-white"
+                    : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+                }`}
+                key={option.value}
+              >
+                <input
+                  checked={category === option.value}
+                  className="sr-only"
+                  name="macro-category-filter"
+                  onChange={() => setCategory(option.value)}
+                  type="radio"
+                  value={option.value}
+                />
+                {option.label}
+              </label>
+            ))}
+          </fieldset>
+        </div>
+      </div>
+
+      {filteredMacros.length > 0 ? (
+        <div aria-label="Customer support macros" className="space-y-3" role="list">
+          {filteredMacros.map((macro) => (
+            <div key={macro.id} role="listitem">
+              <MacroCard
+                macro={macro}
+                onEdit={onEditMacro}
+                onToggleFavorite={onToggleFavorite}
+                onUse={onUseMacro}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <MacroToolEmptyState
+          description="No macros match the current search or category filter."
+          title="No matching macros"
+        />
+      )}
+    </section>
+  );
+}
+
+export type { MacroToolPanelProps };

--- a/tools/v1/team/customer-support-macro-tool/components/index.ts
+++ b/tools/v1/team/customer-support-macro-tool/components/index.ts
@@ -1,0 +1,12 @@
+export { MacroCard } from "./MacroCard";
+export { MacroSummary } from "./MacroSummary";
+export { MacroToolEmptyState } from "./MacroToolEmptyState";
+export { MacroToolErrorState } from "./MacroToolErrorState";
+export { MacroToolLoadingState } from "./MacroToolLoadingState";
+export { MacroToolPanel } from "./MacroToolPanel";
+export type { MacroCardProps } from "./MacroCard";
+export type { MacroSummaryProps } from "./MacroSummary";
+export type { MacroToolEmptyStateProps } from "./MacroToolEmptyState";
+export type { MacroToolErrorStateProps } from "./MacroToolErrorState";
+export type { MacroToolLoadingStateProps } from "./MacroToolLoadingState";
+export type { MacroToolPanelProps } from "./MacroToolPanel";

--- a/tools/v1/team/customer-support-macro-tool/docs/ACCESSIBILITY.md
+++ b/tools/v1/team/customer-support-macro-tool/docs/ACCESSIBILITY.md
@@ -1,0 +1,32 @@
+# Accessibility Notes
+
+## State Announcements
+
+- `MacroToolLoadingState` uses `role="status"`, `aria-live="polite"`, and
+  `aria-busy="true"` so assistive technology can announce loading progress.
+- `MacroToolErrorState` uses `role="alert"` for immediate failure announcement.
+- `MacroToolEmptyState` uses `role="status"` with a scoped `aria-label`.
+- The ready view is labelled by `support-macro-tool-title`.
+
+## Keyboard Behavior
+
+- Search uses a native `input type="search"` with a visible label.
+- Category filters are native radio inputs wrapped by labels.
+- Apply, favorite, edit, retry, and create actions are native buttons.
+- Focus indicators use `focus-visible` outlines with sufficient offset.
+
+## Screen Reader Names
+
+- Decorative icons use `aria-hidden="true"`.
+- Apply, favorite, and edit buttons include the macro title in `aria-label`.
+- The macro list uses `role="list"` and `role="listitem"` wrappers.
+- Category and favorite chips use visible text labels; color is never the only
+  signal.
+
+## Manual Checklist
+
+- Tab through search, category filters, create, apply, favorite, edit, and retry
+  controls.
+- Confirm focus outlines remain visible at each stop.
+- Confirm loading and error states announce with screen-reader tooling.
+- Confirm macro actions have readable accessible names.

--- a/tools/v1/team/customer-support-macro-tool/docs/VISUAL_STYLE.md
+++ b/tools/v1/team/customer-support-macro-tool/docs/VISUAL_STYLE.md
@@ -1,0 +1,28 @@
+# Visual Style Notes
+
+## Layout
+
+- The ready state uses a constrained `max-w-5xl` tool surface.
+- Search and category filters are grouped in one control band.
+- Macro cards use one card layer with action buttons wrapping on narrow screens.
+
+## Color System
+
+- Macro categories use distinct chip colors for quick scanning.
+- Favorite state uses amber with a text label.
+- Primary apply/create actions use dark filled buttons.
+- Edit and favorite actions use bordered secondary buttons.
+
+## Typography
+
+- Tool title uses `text-2xl`.
+- Macro titles use `text-base` so long templates wrap cleanly.
+- Macro bodies use `text-sm`, `leading-6`, and `whitespace-pre-wrap` to preserve
+  readable response structure.
+
+## Interaction Treatment
+
+- Search preserves stable height while filtering.
+- Category filter labels use the same selected/unselected treatment as adjacent
+  isolated tool workspaces.
+- All controls use the same focus-visible outline treatment.

--- a/tools/v1/team/customer-support-macro-tool/specs.md
+++ b/tools/v1/team/customer-support-macro-tool/specs.md
@@ -20,7 +20,7 @@ unless a future integration issue explicitly allows it.
 
 ```
 customer-support-macro-tool/
-├── components/   # React UI (future issue)
+├── components/   # React UI (implemented locally)
 ├── services/     # Pure business logic (implemented)
 ├── hooks/        # React hooks (implemented)
 ├── tests/        # Unit tests + test plan (implemented)
@@ -34,7 +34,7 @@ customer-support-macro-tool/
 | ------------------------- | ------------------------------------------------------------------------- |
 | Architecture              | Addressed — service layer, storage adapter pattern, hook interface        |
 | Feature                   | Addressed — CRUD, search, sort, interpolation, validation, usage tracking |
-| UI and accessibility      | Deferred — separate UI issue                                              |
+| UI and accessibility      | Addressed — folder-local components and accessibility docs                |
 | Security and performance  | Addressed — input validation, no external deps, immutable patterns        |
 | Testing and documentation | ✅ Completed — this issue                                                 |
 

--- a/tools/v1/team/customer-support-macro-tool/tests/ui-contract.test.mjs
+++ b/tools/v1/team/customer-support-macro-tool/tests/ui-contract.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(currentDir, "..");
+
+async function readLocal(relativePath) {
+  return readFile(join(rootDir, relativePath), "utf8");
+}
+
+test("loading, error, and empty states expose screen-reader roles", async () => {
+  const loadingState = await readLocal("components/MacroToolLoadingState.tsx");
+  const errorState = await readLocal("components/MacroToolErrorState.tsx");
+  const emptyState = await readLocal("components/MacroToolEmptyState.tsx");
+
+  assert.match(loadingState, /role="status"/);
+  assert.match(loadingState, /aria-live="polite"/);
+  assert.match(loadingState, /aria-busy="true"/);
+  assert.match(errorState, /role="alert"/);
+  assert.match(errorState, /type="button"/);
+  assert.match(emptyState, /role="status"/);
+  assert.match(emptyState, /aria-label="No support macros"/);
+});
+
+test("macro panel uses labelled search, native filters, and labelled result list", async () => {
+  const panel = await readLocal("components/MacroToolPanel.tsx");
+
+  assert.match(panel, /aria-labelledby="support-macro-tool-title"/);
+  assert.match(panel, /htmlFor="macro-search"/);
+  assert.match(panel, /type="search"/);
+  assert.match(panel, /<fieldset/);
+  assert.match(panel, /<legend className="sr-only">Macro category filter<\/legend>/);
+  assert.match(panel, /type="radio"/);
+  assert.match(panel, /name="macro-category-filter"/);
+  assert.match(panel, /role="list"/);
+  assert.match(panel, /role="listitem"/);
+});
+
+test("macro card labels icon-backed controls", async () => {
+  const card = await readLocal("components/MacroCard.tsx");
+
+  assert.match(card, /aria-label=\{`Apply macro \$\{macro\.title\}`\}/);
+  assert.match(card, /aria-label=\{`\$\{macro\.isFavorite \? "Remove favorite from" : "Favorite"\} \$\{macro\.title\}`\}/);
+  assert.match(card, /aria-label=\{`Edit macro \$\{macro\.title\}`\}/);
+  assert.match(card, /aria-hidden="true"/);
+  assert.match(card, /type="button"/);
+});
+
+test("component barrel exports the local UI surface", async () => {
+  const index = await readLocal("components/index.ts");
+
+  for (const exportName of [
+    "MacroCard",
+    "MacroSummary",
+    "MacroToolEmptyState",
+    "MacroToolErrorState",
+    "MacroToolLoadingState",
+    "MacroToolPanel",
+  ]) {
+    assert.match(index, new RegExp(`\\b${exportName}\\b`));
+  }
+});
+
+test("documentation covers focus, keyboard, screen-reader, and visual states", async () => {
+  const accessibility = await readLocal("docs/ACCESSIBILITY.md");
+  const visualStyle = await readLocal("docs/VISUAL_STYLE.md");
+
+  assert.match(accessibility, /Keyboard Behavior/);
+  assert.match(accessibility, /Screen Reader Names/);
+  assert.match(accessibility, /focus/i);
+  assert.match(visualStyle, /Color System/);
+  assert.match(visualStyle, /Favorite/);
+});


### PR DESCRIPTION
## Summary
- add a folder-local React UI surface for customer support macros
- cover empty, loading, error, ready, filtered, and macro-card states
- add keyboard/screen-reader-focused accessibility docs and local visual style notes
- add standalone Node contract tests for the UI surface

## Validation
- node tools\v1\team\customer-support-macro-tool\tests\ui-contract.test.mjs
- git diff --check

Closes 