### PR TITLE
Add shared team inbox UI surface

### DIFF
--- a/tools/v1/team/shared-team-inbox/components/SharedInboxEmptyState.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxEmptyState.tsx
@@ -1,0 +1,19 @@
+interface SharedInboxEmptyStateProps {
+  activeFilter?: string;
+}
+
+export function SharedInboxEmptyState({ activeFilter = "all messages" }: SharedInboxEmptyStateProps) {
+  return (
+    <section
+      aria-labelledby="shared-inbox-empty-title"
+      className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center"
+    >
+      <h2 id="shared-inbox-empty-title" className="text-lg font-semibold text-slate-950">
+        No shared inbox messages
+      </h2>
+      <p className="mt-2 text-sm text-slate-600">
+        There are no {activeFilter} to triage. New shared inbox mail will appear here.
+      </p>
+    </section>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedInboxErrorState.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxErrorState.tsx
@@ -1,0 +1,29 @@
+interface SharedInboxErrorStateProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function SharedInboxErrorState({ message, onRetry }: SharedInboxErrorStateProps) {
+  return (
+    <section
+      role="alert"
+      aria-labelledby="shared-inbox-error-title"
+      className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-950"
+    >
+      <h2 id="shared-inbox-error-title" className="text-base font-semibold">
+        Shared inbox could not load
+      </h2>
+      <p className="mt-2 text-sm">{message}</p>
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2"
+          aria-label="Retry loading shared team inbox"
+        >
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedInboxLoadingState.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxLoadingState.tsx
@@ -1,0 +1,21 @@
+export function SharedInboxLoadingState() {
+  return (
+    <section
+      aria-labelledby="shared-inbox-loading-title"
+      aria-live="polite"
+      className="rounded-lg border border-slate-200 bg-white p-6"
+    >
+      <h2 id="shared-inbox-loading-title" className="text-base font-semibold text-slate-950">
+        Loading shared inbox
+      </h2>
+      <p className="mt-2 text-sm text-slate-600">
+        Checking the shared message feed, assignments, and internal comments.
+      </p>
+      <div className="mt-5 space-y-3" aria-hidden="true">
+        <div className="h-4 w-2/3 rounded bg-slate-200" />
+        <div className="h-4 w-1/2 rounded bg-slate-200" />
+        <div className="h-20 rounded bg-slate-100" />
+      </div>
+    </section>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedInboxMessageCard.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxMessageCard.tsx
@@ -1,0 +1,124 @@
+import type { SharedInboxActionHandlers, SharedInboxMessage } from "../types";
+
+interface SharedInboxMessageCardProps extends SharedInboxActionHandlers {
+  message: SharedInboxMessage;
+}
+
+const statusLabels = {
+  unassigned: "Unassigned",
+  claimed: "Claimed",
+  "in-progress": "In progress",
+  "awaiting-reply": "Awaiting reply",
+  resolved: "Resolved",
+} as const;
+
+const statusClasses = {
+  unassigned: "border-slate-300 bg-slate-50 text-slate-700",
+  claimed: "border-sky-300 bg-sky-50 text-sky-800",
+  "in-progress": "border-violet-300 bg-violet-50 text-violet-800",
+  "awaiting-reply": "border-amber-300 bg-amber-50 text-amber-900",
+  resolved: "border-emerald-300 bg-emerald-50 text-emerald-800",
+} as const;
+
+function formatReceivedAt(receivedAt: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(receivedAt));
+}
+
+export function SharedInboxMessageCard({
+  message,
+  onClaim,
+  onRelease,
+  onOpenMessage,
+  onReply,
+}: SharedInboxMessageCardProps) {
+  const titleId = `shared-inbox-message-${message.id}-title`;
+  const statusLabel = statusLabels[message.status];
+  const hasAssignee = Boolean(message.assignee);
+
+  return (
+    <article
+      aria-labelledby={titleId}
+      className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm focus-within:ring-2 focus-within:ring-slate-900"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded-full border px-2.5 py-1 text-xs font-medium ${statusClasses[message.status]}`}
+              aria-label={`Message status: ${statusLabel}`}
+            >
+              {statusLabel}
+            </span>
+            <span className="text-xs font-medium text-slate-500">{message.team}</span>
+          </div>
+
+          <h3 id={titleId} className="mt-3 text-lg font-semibold text-slate-950">
+            {message.subject}
+          </h3>
+          <p className="mt-1 text-sm text-slate-600">{message.preview}</p>
+
+          <dl className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-slate-800">Sender</dt>
+              <dd>{message.senderAddress}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-slate-800">Received</dt>
+              <dd>
+                <time dateTime={message.receivedAt}>{formatReceivedAt(message.receivedAt)}</time>
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-slate-800">Owner</dt>
+              <dd>
+                {message.assignee
+                  ? `${message.assignee.displayName} (${message.assignee.stealthAddress})`
+                  : "No owner yet"}
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-slate-800">Activity</dt>
+              <dd>
+                {message.internalCommentCount} internal comments, {message.replyCount} replies
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          className="grid min-w-40 gap-2 sm:grid-cols-3 lg:grid-cols-1"
+          role="group"
+          aria-label={`Actions for ${message.subject}`}
+        >
+          <button
+            type="button"
+            onClick={() => (hasAssignee ? onRelease?.(message.id) : onClaim?.(message.id))}
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`${hasAssignee ? "Release" : "Claim"} shared inbox message ${message.subject}`}
+          >
+            {hasAssignee ? "Release" : "Claim"}
+          </button>
+          <button
+            type="button"
+            onClick={() => onOpenMessage?.(message.id)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`Open shared inbox message ${message.subject}`}
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            onClick={() => onReply?.(message.id)}
+            className="rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`Reply to ${message.subject} as shared inbox`}
+          >
+            Reply
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedInboxSuccessState.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxSuccessState.tsx
@@ -1,0 +1,34 @@
+interface SharedInboxSuccessStateProps {
+  message: string;
+  onDismiss?: () => void;
+}
+
+export function SharedInboxSuccessState({ message, onDismiss }: SharedInboxSuccessStateProps) {
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-labelledby="shared-inbox-success-title"
+      className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-emerald-950"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 id="shared-inbox-success-title" className="text-sm font-semibold">
+            Shared inbox updated
+          </h2>
+          <p className="mt-1 text-sm">{message}</p>
+        </div>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md px-2 py-1 text-sm font-medium text-emerald-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2"
+            aria-label="Dismiss shared inbox update"
+          >
+            Dismiss
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedInboxSummary.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedInboxSummary.tsx
@@ -1,0 +1,30 @@
+import type { SharedInboxSummary as SharedInboxSummaryModel } from "../types";
+
+interface SharedInboxSummaryProps {
+  summary: SharedInboxSummaryModel;
+}
+
+const summaryItems = [
+  ["total", "Total"],
+  ["unassigned", "Unassigned"],
+  ["claimed", "Claimed"],
+  ["inProgress", "In progress"],
+  ["awaitingReply", "Awaiting reply"],
+  ["resolved", "Resolved"],
+] as const;
+
+export function SharedInboxSummary({ summary }: SharedInboxSummaryProps) {
+  return (
+    <dl
+      className="grid gap-3 sm:grid-cols-3 lg:grid-cols-6"
+      aria-label="Shared inbox message summary"
+    >
+      {summaryItems.map(([key, label]) => (
+        <div key={key} className="rounded-lg border border-slate-200 bg-white p-4">
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-950">{summary[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/SharedTeamInbox.tsx
+++ b/tools/v1/team/shared-team-inbox/components/SharedTeamInbox.tsx
@@ -1,0 +1,132 @@
+import type {
+  SharedInboxActionHandlers,
+  SharedInboxMessage,
+  SharedInboxMessageStatus,
+  SharedInboxSummary,
+} from "../types";
+import { SharedInboxEmptyState } from "./SharedInboxEmptyState";
+import { SharedInboxErrorState } from "./SharedInboxErrorState";
+import { SharedInboxLoadingState } from "./SharedInboxLoadingState";
+import { SharedInboxMessageCard } from "./SharedInboxMessageCard";
+import { SharedInboxSuccessState } from "./SharedInboxSuccessState";
+import { SharedInboxSummary as SharedInboxSummaryView } from "./SharedInboxSummary";
+
+interface SharedTeamInboxProps extends SharedInboxActionHandlers {
+  messages: SharedInboxMessage[];
+  summary: SharedInboxSummary;
+  activeStatus?: SharedInboxMessageStatus | "all";
+  isLoading?: boolean;
+  error?: string | null;
+  successMessage?: string | null;
+  onRetry?: () => void;
+  onDismissSuccess?: () => void;
+}
+
+const filters: Array<{ value: SharedInboxMessageStatus | "all"; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "unassigned", label: "Unassigned" },
+  { value: "claimed", label: "Claimed" },
+  { value: "in-progress", label: "In progress" },
+  { value: "awaiting-reply", label: "Awaiting reply" },
+  { value: "resolved", label: "Resolved" },
+];
+
+export function SharedTeamInbox({
+  messages,
+  summary,
+  activeStatus = "all",
+  isLoading = false,
+  error = null,
+  successMessage = null,
+  onRetry,
+  onDismissSuccess,
+  onStatusFilterChange,
+  onClaim,
+  onRelease,
+  onOpenMessage,
+  onReply,
+}: SharedTeamInboxProps) {
+  if (isLoading) {
+    return <SharedInboxLoadingState />;
+  }
+
+  if (error) {
+    return <SharedInboxErrorState message={error} onRetry={onRetry} />;
+  }
+
+  const visibleMessages =
+    activeStatus === "all"
+      ? messages
+      : messages.filter((message) => message.status === activeStatus);
+
+  const activeFilterLabel =
+    filters.find((filter) => filter.value === activeStatus)?.label.toLowerCase() ?? "messages";
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-6" aria-labelledby="shared-team-inbox-title">
+      <header className="space-y-2">
+        <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          Team workflow
+        </p>
+        <h1 id="shared-team-inbox-title" className="text-2xl font-semibold text-slate-950">
+          Shared Team Inbox
+        </h1>
+        <p className="max-w-3xl text-sm text-slate-600">
+          Triage shared mail, claim ownership, review internal activity, and reply through the
+          shared identity without exposing an individual mailbox.
+        </p>
+      </header>
+
+      {successMessage ? (
+        <SharedInboxSuccessState message={successMessage} onDismiss={onDismissSuccess} />
+      ) : null}
+
+      <SharedInboxSummaryView summary={summary} />
+
+      <section aria-labelledby="shared-inbox-filter-title" className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h2 id="shared-inbox-filter-title" className="text-base font-semibold text-slate-950">
+            Message queue
+          </h2>
+          <fieldset className="flex flex-wrap gap-2" aria-label="Filter shared inbox by status">
+            <legend className="sr-only">Filter shared inbox by status</legend>
+            {filters.map((filter) => (
+              <label
+                key={filter.value}
+                className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 focus-within:ring-2 focus-within:ring-slate-900 focus-within:ring-offset-2"
+              >
+                <input
+                  type="radio"
+                  name="shared-inbox-status-filter"
+                  value={filter.value}
+                  checked={activeStatus === filter.value}
+                  onChange={() => onStatusFilterChange?.(filter.value)}
+                  className="sr-only"
+                />
+                {filter.label}
+              </label>
+            ))}
+          </fieldset>
+        </div>
+
+        {visibleMessages.length === 0 ? (
+          <SharedInboxEmptyState activeFilter={activeFilterLabel} />
+        ) : (
+          <div className="space-y-4" role="list" aria-label="Shared inbox messages">
+            {visibleMessages.map((message) => (
+              <div role="listitem" key={message.id}>
+                <SharedInboxMessageCard
+                  message={message}
+                  onClaim={onClaim}
+                  onRelease={onRelease}
+                  onOpenMessage={onOpenMessage}
+                  onReply={onReply}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/tools/v1/team/shared-team-inbox/components/index.ts
+++ b/tools/v1/team/shared-team-inbox/components/index.ts
@@ -1,0 +1,7 @@
+export { SharedInboxEmptyState } from "./SharedInboxEmptyState";
+export { SharedInboxErrorState } from "./SharedInboxErrorState";
+export { SharedInboxLoadingState } from "./SharedInboxLoadingState";
+export { SharedInboxMessageCard } from "./SharedInboxMessageCard";
+export { SharedInboxSuccessState } from "./SharedInboxSuccessState";
+export { SharedInboxSummary } from "./SharedInboxSummary";
+export { SharedTeamInbox } from "./SharedTeamInbox";

--- a/tools/v1/team/shared-team-inbox/docs/ACCESSIBILITY.md
+++ b/tools/v1/team/shared-team-inbox/docs/ACCESSIBILITY.md
@@ -1,0 +1,21 @@
+# Shared Team Inbox Accessibility Notes
+
+## Keyboard Operation
+
+- The status filter uses native radio inputs so arrow-key and Tab behavior follows browser defaults.
+- Message actions are native buttons with visible `focus-visible` rings.
+- Each message card uses `focus-within` styling so keyboard users can keep context while moving across action buttons.
+- The tab order follows the reading order: heading, filters, message content, then message actions.
+
+## Screen Reader Support
+
+- The tool has a single `main` landmark labelled by the page heading.
+- Loading and success states use polite live regions; the error state uses `role="alert"`.
+- Status badges include accessible labels, and the visible text repeats the state so color is not the only cue.
+- Message lists use `role="list"` and `role="listitem"` because the card layout is not a native list element.
+- Action groups are labelled with the message subject so repeated buttons such as Claim, Open, and Reply stay distinguishable.
+
+## Follow-up Integration Notes
+
+- If this UI is mounted in the main app later, the integration should move focus to the top-level heading when opening the tool route.
+- If bulk assignment is added later, use a native checkbox table or an ARIA grid pattern with documented keyboard behavior.

--- a/tools/v1/team/shared-team-inbox/docs/VISUAL_STYLE.md
+++ b/tools/v1/team/shared-team-inbox/docs/VISUAL_STYLE.md
@@ -1,0 +1,32 @@
+# Shared Team Inbox Visual Style
+
+## Principles
+
+- Keep the UI quiet and operational: dense enough for triage, but with clear ownership and status cues.
+- Do not change the shared design system, application shell, navigation, or global styles.
+- Use folder-local components that can be reviewed as a mini-product before integration.
+
+## Layout
+
+- The primary view is a constrained single-column work surface with summary metrics, filters, and message cards.
+- Cards use an 8px radius, subtle borders, and `focus-within` states for keyboard context.
+- Actions stay grouped on the right on large screens and stack under message content on narrow screens.
+
+## Status Treatment
+
+- Every status has both text and color treatment.
+- Colors are semantic and balanced: slate for unassigned, sky for claimed, violet for in progress, amber for awaiting reply, and emerald for resolved.
+- Counts are shown above the queue so reviewers can scan workload distribution without opening a message.
+
+## Responsive Behavior
+
+- Summary metrics move from six columns on desktop to three columns on tablet and one column on narrow screens.
+- Filters wrap instead of shrinking labels.
+- Message metadata uses two columns when space allows and a single column on mobile.
+
+## States
+
+- Empty state explains that the selected filter has no messages.
+- Loading state uses simple skeleton bars and does not require animation.
+- Error state uses a retry button with a clear accessible label.
+- Success state is dismissible and announced politely to assistive technology.

--- a/tools/v1/team/shared-team-inbox/fixtures/sample-shared-inbox-ui.json
+++ b/tools/v1/team/shared-team-inbox/fixtures/sample-shared-inbox-ui.json
@@ -1,0 +1,92 @@
+{
+  "summary": {
+    "total": 5,
+    "unassigned": 1,
+    "claimed": 1,
+    "inProgress": 1,
+    "awaitingReply": 1,
+    "resolved": 1
+  },
+  "messages": [
+    {
+      "id": "msg-unassigned-001",
+      "senderAddress": "pat.customer@example.test",
+      "subject": "Cannot unlock encrypted receipt",
+      "preview": "The customer can open the message but the receipt attachment remains locked.",
+      "status": "unassigned",
+      "team": "Support",
+      "receivedAt": "2026-06-22T08:15:00.000Z",
+      "deliveryProofHash": "proof_ui_unassigned_001",
+      "internalCommentCount": 0,
+      "replyCount": 0
+    },
+    {
+      "id": "msg-claimed-002",
+      "senderAddress": "sam.vendor@example.test",
+      "subject": "Need shared identity confirmation",
+      "preview": "Vendor asks whether the response should come from the shared team address.",
+      "status": "claimed",
+      "team": "Operations",
+      "receivedAt": "2026-06-22T07:20:00.000Z",
+      "deliveryProofHash": "proof_ui_claimed_002",
+      "assignee": {
+        "id": "member-alice",
+        "displayName": "Alice Chen",
+        "stealthAddress": "alice.support@team.test"
+      },
+      "internalCommentCount": 2,
+      "replyCount": 0
+    },
+    {
+      "id": "msg-progress-003",
+      "senderAddress": "morgan.partner@example.test",
+      "subject": "Follow-up on relay outage",
+      "preview": "Partner shared log timestamps and is waiting for an operational update.",
+      "status": "in-progress",
+      "team": "Support",
+      "receivedAt": "2026-06-21T23:45:00.000Z",
+      "deliveryProofHash": "proof_ui_progress_003",
+      "assignee": {
+        "id": "member-riley",
+        "displayName": "Riley Park",
+        "stealthAddress": "riley.ops@team.test"
+      },
+      "internalCommentCount": 3,
+      "replyCount": 1
+    },
+    {
+      "id": "msg-awaiting-004",
+      "senderAddress": "lee.accounting@example.test",
+      "subject": "Billing mailbox verification",
+      "preview": "Accounting team replied with a verification question about the shared mailbox.",
+      "status": "awaiting-reply",
+      "team": "Finance",
+      "receivedAt": "2026-06-21T19:30:00.000Z",
+      "deliveryProofHash": "proof_ui_awaiting_004",
+      "assignee": {
+        "id": "member-jordan",
+        "displayName": "Jordan Smith",
+        "stealthAddress": "jordan.finance@team.test"
+      },
+      "internalCommentCount": 1,
+      "replyCount": 1
+    },
+    {
+      "id": "msg-resolved-005",
+      "senderAddress": "casey.requester@example.test",
+      "subject": "Completed mailbox migration",
+      "preview": "Requester confirmed that messages now route to the shared team inbox.",
+      "status": "resolved",
+      "team": "Operations",
+      "receivedAt": "2026-06-20T15:10:00.000Z",
+      "deliveryProofHash": "proof_ui_resolved_005",
+      "assignee": {
+        "id": "member-taylor",
+        "displayName": "Taylor Reed",
+        "stealthAddress": "taylor.ops@team.test"
+      },
+      "internalCommentCount": 4,
+      "replyCount": 2
+    }
+  ]
+}

--- a/tools/v1/team/shared-team-inbox/tests/ui-contract.test.mjs
+++ b/tools/v1/team/shared-team-inbox/tests/ui-contract.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function listFiles(dir = toolRoot) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolute = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(absolute) : absolute;
+    }),
+  );
+
+  return files.flat();
+}
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("shared team inbox UI remains isolated to the tool folder", async () => {
+  const files = await listFiles();
+  const uiFiles = files.filter((file) => file.includes(`${path.sep}components${path.sep}`));
+
+  assert.ok(uiFiles.length >= 7, "expected folder-local UI components");
+
+  for (const file of files) {
+    assert.ok(
+      file.startsWith(toolRoot),
+      `file escaped the shared team inbox tool folder: ${file}`,
+    );
+  }
+
+  const source = await Promise.all(
+    uiFiles
+      .filter((file) => file.endsWith(".ts") || file.endsWith(".tsx"))
+      .map((file) => readFile(file, "utf8")),
+  );
+  const combined = source.join("\n");
+
+  assert.doesNotMatch(combined, /from\s+["']src\//);
+  assert.doesNotMatch(combined, /from\s+["']\.\.\/\.\.\/\.\./);
+  assert.doesNotMatch(combined, /from\s+["']tools\//);
+});
+
+test("primary UI exposes empty, loading, error, success, and message list states", async () => {
+  const componentIndex = await readToolFile("components/index.ts");
+  const mainComponent = await readToolFile("components/SharedTeamInbox.tsx");
+
+  for (const exportName of [
+    "SharedInboxEmptyState",
+    "SharedInboxLoadingState",
+    "SharedInboxErrorState",
+    "SharedInboxSuccessState",
+    "SharedInboxMessageCard",
+    "SharedInboxSummary",
+    "SharedTeamInbox",
+  ]) {
+    assert.match(componentIndex, new RegExp(`export \\{ ${exportName} \\}`));
+  }
+
+  assert.match(mainComponent, /<SharedInboxLoadingState/);
+  assert.match(mainComponent, /<SharedInboxErrorState/);
+  assert.match(mainComponent, /<SharedInboxSuccessState/);
+  assert.match(mainComponent, /<SharedInboxEmptyState/);
+  assert.match(mainComponent, /role="list"/);
+  assert.match(mainComponent, /role="listitem"/);
+});
+
+test("interactive controls include labels and keyboard-friendly focus behavior", async () => {
+  const mainComponent = await readToolFile("components/SharedTeamInbox.tsx");
+  const cardComponent = await readToolFile("components/SharedInboxMessageCard.tsx");
+  const errorState = await readToolFile("components/SharedInboxErrorState.tsx");
+  const successState = await readToolFile("components/SharedInboxSuccessState.tsx");
+
+  assert.match(mainComponent, /type="radio"/);
+  assert.match(mainComponent, /aria-label="Filter shared inbox by status"/);
+  assert.match(mainComponent, /className="sr-only"/);
+  assert.match(cardComponent, /role="group"/);
+  assert.match(cardComponent, /aria-label=\{`Actions for \$\{message\.subject\}`\}/);
+  assert.match(cardComponent, /aria-label=\{`\$\{hasAssignee \? "Release" : "Claim"\}/);
+  assert.match(cardComponent, /aria-label=\{`Open shared inbox message/);
+  assert.match(cardComponent, /aria-label=\{`Reply to/);
+
+  for (const source of [cardComponent, errorState, successState]) {
+    assert.match(source, /focus-visible:ring-2/);
+  }
+});
+
+test("status presentation is text-labelled and fixture covers every workflow state", async () => {
+  const cardComponent = await readToolFile("components/SharedInboxMessageCard.tsx");
+  const fixture = JSON.parse(await readToolFile("fixtures/sample-shared-inbox-ui.json"));
+  const statuses = new Set(fixture.messages.map((message) => message.status));
+
+  for (const status of ["unassigned", "claimed", "in-progress", "awaiting-reply", "resolved"]) {
+    assert.ok(statuses.has(status), `fixture should include ${status}`);
+  }
+
+  assert.match(cardComponent, /Message status:/);
+  assert.match(cardComponent, /statusLabels/);
+  assert.match(cardComponent, /statusClasses/);
+});
+
+test("fixture data is synthetic and avoids sensitive payment or credential fields", async () => {
+  const fixtureText = await readToolFile("fixtures/sample-shared-inbox-ui.json");
+  const fixture = JSON.parse(fixtureText);
+
+  assert.equal(fixture.summary.total, fixture.messages.length);
+  assert.equal(fixture.messages.every((message) => message.senderAddress.endsWith(".test")), true);
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});
+
+test("accessibility and visual documentation cover review expectations", async () => {
+  const accessibility = await readToolFile("docs/ACCESSIBILITY.md");
+  const visualStyle = await readToolFile("docs/VISUAL_STYLE.md");
+
+  for (const term of ["Keyboard Operation", "Screen Reader Support", "focus-visible", "role=\"alert\""]) {
+    assert.match(accessibility, new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(visualStyle, /Do not change the shared design system/);
+  assert.match(visualStyle, /8px radius/);
+  assert.match(visualStyle, /Status Treatment/);
+  assert.match(visualStyle, /Responsive Behavior/);
+});

--- a/tools/v1/team/shared-team-inbox/types.ts
+++ b/tools/v1/team/shared-team-inbox/types.ts
@@ -1,0 +1,43 @@
+export type SharedInboxMessageStatus =
+  | "unassigned"
+  | "claimed"
+  | "in-progress"
+  | "awaiting-reply"
+  | "resolved";
+
+export interface SharedInboxAssignee {
+  id: string;
+  displayName: string;
+  stealthAddress: string;
+}
+
+export interface SharedInboxMessage {
+  id: string;
+  senderAddress: string;
+  subject: string;
+  preview: string;
+  status: SharedInboxMessageStatus;
+  team: string;
+  receivedAt: string;
+  deliveryProofHash: string;
+  assignee?: SharedInboxAssignee;
+  internalCommentCount: number;
+  replyCount: number;
+}
+
+export interface SharedInboxSummary {
+  total: number;
+  unassigned: number;
+  claimed: number;
+  inProgress: number;
+  awaitingReply: number;
+  resolved: number;
+}
+
+export interface SharedInboxActionHandlers {
+  onClaim?: (messageId: string) => void;
+  onRelease?: (messageId: string) => void;
+  onOpenMessage?: (messageId: string) => void;
+  onReply?: (messageId: string) => void;
+  onStatusFilterChange?: (status: SharedInboxMessageStatus | "all") => void;
+}


### PR DESCRIPTION
## Summary
- add folder-local Shared Team Inbox React/TypeScript UI components for summary, filters, message cards, and empty/loading/error/success states
- add synthetic shared inbox fixture data covering every workflow status
- document accessibility and visual style constraints without mounting the tool in the main app
- add a static UI contract test for isolation, controls, status coverage, and synthetic data safety

Closes 

## Tests
- node tools\\v1\\team\\shared-team-inbox\\tests\\ui-contract.test.mjs
- git diff --cached -