### PR TITLE
Add SLA deadline tracker architecture contract

### DIFF
--- a/tools/v1/team/sla-deadline-tracker/README.md
+++ b/tools/v1/team/sla-deadline-tracker/README.md
@@ -1,15 +1,29 @@
 # SLA Deadline Tracker
 
-This folder is the isolated workspace for the SLA Deadline Tracker tool.
+SLA Deadline Tracker is a folder-local team tool for monitoring response deadlines on shared
+mail workflows. It is not mounted in the main application and does not touch routing, wallet,
+mail rendering, database, Stellar core, or the shared design system.
 
 ## Ownership Boundary
 
-All work for this tool must stay inside:
+All source, docs, tests, fixtures, and future local configuration for this tool must stay under:
 
-`text
-.\tools\v1\team\sla-deadline-tracker\
-`
+```text
+tools/v1/team/sla-deadline-tracker/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Future integration work must be handled by a separate issue before this tool can call main app
+services, read production inbox state, or write to shared application stores.
 
-See specs.md for the issue categories and contributor expectations.
+## Local Architecture Contract
+
+- `components/` may render deadline queues, filters, empty/loading/error states, and escalation
+  controls using props from folder-local hooks or services only.
+- `services/` owns pure deadline calculation, validation, and in-memory reference behavior.
+- `hooks/` may adapt service outputs for React state, but must not call global app stores.
+- `fixtures/` stores synthetic deadline records and SLA policies for deterministic tests.
+- `tests/` contains folder-local unit, contract, and fixture tests.
+- `docs/` records architecture, ownership, safety, performance, and future integration notes.
+
+See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) and
+[docs/CONTRIBUTOR_BOUNDARY.md](./docs/CONTRIBUTOR_BOUNDARY.md) for the detailed contract.

--- a/tools/v1/team/sla-deadline-tracker/docs/ARCHITECTURE.md
+++ b/tools/v1/team/sla-deadline-tracker/docs/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# SLA Deadline Tracker Architecture
+
+## Module Boundaries
+
+```text
+tools/v1/team/sla-deadline-tracker/
+  components/   UI-only views for queues, filters, deadline cards, and local states
+  services/     Pure SLA policy parsing, deadline calculation, sorting, and validation
+  hooks/        React adapters over local services and fixture-backed state
+  fixtures/     Synthetic deadline records and policies for local tests and demos
+  tests/        Folder-local unit, fixture, and architecture contract tests
+  docs/         Architecture, contributor boundaries, safety, and integration notes
+```
+
+No module in this tool may import from `src/`, sibling tools, `tools/v2/`, or application shell
+modules. Shared dependencies must come from the existing package graph or from a future local
+tool package file reviewed in a separate dependency-focused change.
+
+## Data Flow
+
+1. A future integration adapter may pass sanitized message metadata into the tool.
+2. `services/` validates each deadline record and normalizes timestamps.
+3. `services/` computes deadline state using deterministic clock input from the caller.
+4. `hooks/` may hold local UI state such as selected status filters or optimistic action feedback.
+5. `components/` render read-only derived SLA state and emit local action callbacks.
+
+The core service layer must remain pure: no live network calls, timers, local storage, IndexedDB,
+wallet access, or direct mail engine calls.
+
+## Public Folder API
+
+Future contributors may expose a small folder-local API from an `index.ts` or `index.mjs` file.
+That export should contain typed service helpers, React components, and fixtures that are safe for
+review. It must not mount the tool, register routes, or mutate global app state.
+
+## Failure Model
+
+- Malformed timestamps are rejected by services before rendering.
+- Unknown SLA policies fall back to an explicit validation error instead of an inferred deadline.
+- Empty message lists render an empty state rather than querying the main inbox.
+- Oversized histories are paged, filtered, or summarized before rendering.
+
+## Review Checklist
+
+- Files changed are limited to `tools/v1/team/sla-deadline-tracker/`.
+- Docs explain what future contributors may and may not change.
+- Any future services are deterministic and testable without network access.
+- Any future UI is accessible by keyboard and does not rely on color alone for deadline state.

--- a/tools/v1/team/sla-deadline-tracker/docs/CONTRIBUTOR_BOUNDARY.md
+++ b/tools/v1/team/sla-deadline-tracker/docs/CONTRIBUTOR_BOUNDARY.md
@@ -1,0 +1,34 @@
+# Contributor Boundary
+
+## Contributors May Change
+
+- Folder-local docs, tests, fixtures, services, hooks, and components.
+- Synthetic SLA policies and deadline records used for deterministic tests.
+- Pure helpers for timestamp normalization, deadline calculation, sorting, and status derivation.
+- Local accessibility and visual notes for a future UI surface.
+
+## Contributors Must Not Change
+
+- Main application shell, dashboard layout, navigation, routing, or global providers.
+- Existing inbox architecture, message rendering, wallet core, Stellar core, or database schema.
+- Root package dependencies, repository-wide build settings, or shared design system tokens.
+- Production data, secrets, user credentials, payment details, or private mailbox contents.
+
+## Dependency Rules
+
+- Prefer TypeScript or JavaScript standard library APIs for time arithmetic and validation.
+- Keep services pure and dependency-light; add dependencies only through a future local package file.
+- Do not introduce live network calls, telemetry, cron jobs, or background workers in this folder.
+- Fixtures must use `.test` domains and synthetic IDs.
+
+## Integration Constraints
+
+This tool can be integrated only after a future issue defines:
+
+- the sanitized message metadata contract supplied by the main mail app
+- the clock source used for deterministic deadline calculation
+- the escalation delivery path and permission checks
+- the accessibility review path for mounted UI
+- the storage ownership boundary for durable SLA records
+
+Until then, the tool remains a self-contained mini-product with local tests and docs only.

--- a/tools/v1/team/sla-deadline-tracker/specs.md
+++ b/tools/v1/team/sla-deadline-tracker/specs.md
@@ -1,38 +1,48 @@
-# SLA Deadline Tracker
-
-Response deadline monitoring.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/sla-deadline-tracker/README.md"
-  @"
-
 # SLA Deadline Tracker Specs
 
 ## Purpose
 
-Response deadline monitoring.
+SLA Deadline Tracker helps teams monitor shared inbox response deadlines, identify messages that
+are approaching breach, and prepare future escalation workflows without connecting to production
+mail or notification systems.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V1
+- Audience: team
+- Folder ownership: `tools/v1/team/sla-deadline-tracker/`
+- Work mode: isolated mini-product until a future integration issue links it into the app.
 
-$dir/
+## In Scope
 
-## Required issue categories
+- Define local module boundaries for components, services, hooks, tests, docs, and fixtures.
+- Document data ownership and the shape of deadline records future contributors may introduce.
+- Describe dependency limits and integration constraints.
+- Keep all architecture notes and validation inside this folder.
+
+## Out of Scope
+
+- Main app shell, navigation, routing, or dashboard changes.
+- Existing inbox architecture, wallet core, Stellar core, mail rendering, or database schema changes.
+- Live network calls, production mail data, credentials, or external notification delivery.
+- Global design system edits or root dependency changes.
+
+## Data Ownership
+
+The tool owns derived SLA metadata only:
+
+- message reference ID
+- shared inbox identity
+- received timestamp
+- SLA policy name and target duration
+- computed due timestamp
+- deadline state: `ok`, `due-soon`, `breached`, or `resolved`
+- optional assignee and escalation note
+
+The tool must not become the source of truth for message bodies, wallet identities, sender
+credentials, delivery proofs, or permanent audit logs.
+
+## Required Issue Categories
 
 - Architecture
 - Feature

--- a/tools/v1/team/sla-deadline-tracker/tests/architecture-contract.test.mjs
+++ b/tools/v1/team/sla-deadline-tracker/tests/architecture-contract.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function listFiles(dir = toolRoot) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolute = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(absolute) : absolute;
+    }),
+  );
+
+  return files.flat();
+}
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("architecture docs define the folder-local module map", async () => {
+  const readme = await readToolFile("README.md");
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+
+  for (const folder of ["components/", "services/", "hooks/", "fixtures/", "tests/", "docs/"]) {
+    assert.match(readme, new RegExp(folder.replace("/", "\\/")));
+    assert.match(architecture, new RegExp(folder.replace("/", "\\/")));
+  }
+
+  assert.match(readme, /tools\/v1\/team\/sla-deadline-tracker\//);
+  assert.match(architecture, /No module in this tool may import from `src\/`/);
+});
+
+test("specs describe ownership, future contributor limits, and SLA data ownership", async () => {
+  const specs = await readToolFile("specs.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+
+  for (const term of [
+    "Release tier: V1",
+    "Audience: team",
+    "Data Ownership",
+    "deadline state",
+    "Out of Scope",
+  ]) {
+    assert.match(specs, new RegExp(term));
+  }
+
+  for (const term of [
+    "Contributors May Change",
+    "Contributors Must Not Change",
+    "Dependency Rules",
+    "Integration Constraints",
+  ]) {
+    assert.match(boundary, new RegExp(term));
+  }
+});
+
+test("architecture contract rejects generated template residue", async () => {
+  const files = await listFiles();
+  const textFiles = files.filter((file) => /\.(md|json)$/.test(file));
+  const combined = (
+    await Promise.all(textFiles.map((file) => readFile(file, "utf8")))
+  ).join("\n");
+
+  assert.doesNotMatch(combined, /System\.Collections|Set-Content|@\s*\||\$dir|\$\(.*\)/);
+  assert.doesNotMatch(combined, /components\/\n- services\/\n- hooks\/\n-\s+ests\//);
+});
+
+test("tool docs keep integration and dependency boundaries explicit", async () => {
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+  const combined = `${architecture}\n${boundary}`;
+
+  for (const forbiddenArea of [
+    "routing",
+    "wallet core",
+    "Stellar core",
+    "database schema",
+    "shared design system",
+    "production data",
+    "secrets",
+  ]) {
+    assert.match(combined, new RegExp(forbiddenArea, "i"));
+  }
+
+  assert.match(combined, /no live network calls/i);
+  assert.match(combined, /\.test` domains/);
+});
+
+test("all current files stay under the SLA Deadline Tracker tool root", async () => {
+  const files = await listFiles();
+
+  assert.ok(files.length >= 5, "expected README, specs, docs, and tests");
+
+  for (const file of files) {
+    assert.ok(file.startsWith(toolRoot), `file escaped the tool root: ${file}`);
+  }
+});


### PR DESCRIPTION
## Summary
- replace generated template residue in the SLA Deadline Tracker README/specs with a clear folder-local architecture contract
- document module boundaries, data ownership, dependency limits, and future integration constraints
- add an architecture contract test covering module map, boundary language, and template residue checks

Closes #44

## Tests
- node tools\\v1\\team\\sla-deadline-tracker\\tests\\architecture-contract.test.mjs
- git diff --cached --check