### PR TITLE
Add SLA deadline tracker core service

### DIFF
--- a/tools/v1/team/sla-deadline-tracker/docs/SERVICE_CONTRACT.md
+++ b/tools/v1/team/sla-deadline-tracker/docs/SERVICE_CONTRACT.md
@@ -1,0 +1,47 @@
+# SLA Deadline Tracker Service Contract
+
+## Inputs
+
+The core service accepts synthetic or sanitized deadline records with:
+
+- `id`: local deadline record ID
+- `messageId`: reference to the source message, not the message body
+- `sharedInboxId`: shared inbox identifier
+- `subject`: display subject for future UI work
+- `receivedAt`: ISO timestamp used to compute the deadline
+- `resolvedAt`: optional ISO timestamp that marks the record resolved
+- `policy`: `{ name, targetMinutes, dueSoonWindowMinutes }`
+- `assignee`: optional synthetic team member identifier
+- `escalationNote`: optional local note for future escalation workflows
+
+## Outputs
+
+`evaluateDeadlineState` returns the normalized input plus:
+
+- `dueAt`: computed ISO timestamp
+- `state`: `ok`, `due-soon`, `breached`, or `resolved`
+- `minutesUntilDue`: integer minutes until breach, or `null` for resolved records
+- `isActionable`: true for `due-soon` and `breached` records
+
+`buildDeadlineQueue` returns records sorted by soonest due time, keeping resolved records last.
+`filterDeadlineQueue` filters by state, assignee, or shared inbox.
+`summarizeDeadlineQueue` returns total, state counts, and actionable count.
+
+## Loading and Error States
+
+The service is synchronous and pure. Future UI hooks should represent these states:
+
+- `loading`: caller is fetching sanitized records from a future integration adapter
+- `ready`: records were normalized and evaluated successfully
+- `empty`: no records were supplied
+- `error`: validation failed with `SlaDeadlineValidationError`
+
+Validation errors include a message and optional `details` object. The service does not retry,
+fetch, persist, or schedule background work.
+
+## Safety and Performance
+
+- No live network calls, production data, secrets, payment data, or mailbox credentials are used.
+- Batch size defaults to 500 records to prevent accidental large-history work.
+- Date calculation uses deterministic `now` injection in tests and future callers.
+- Fixtures use `.test` domains and synthetic IDs only.

--- a/tools/v1/team/sla-deadline-tracker/fixtures/sample-sla-deadlines.json
+++ b/tools/v1/team/sla-deadline-tracker/fixtures/sample-sla-deadlines.json
@@ -1,0 +1,62 @@
+{
+  "now": "2026-06-23T10:00:00.000Z",
+  "records": [
+    {
+      "id": "deadline-ok-001",
+      "messageId": "msg-ok-001",
+      "sharedInboxId": "support@team.test",
+      "subject": "Product onboarding question",
+      "receivedAt": "2026-06-23T09:30:00.000Z",
+      "policy": {
+        "name": "Standard support response",
+        "targetMinutes": 120,
+        "dueSoonWindowMinutes": 30
+      },
+      "assignee": "alice@team.test",
+      "escalationNote": ""
+    },
+    {
+      "id": "deadline-due-soon-002",
+      "messageId": "msg-due-soon-002",
+      "sharedInboxId": "support@team.test",
+      "subject": "Encrypted attachment cannot be opened",
+      "receivedAt": "2026-06-23T08:20:00.000Z",
+      "policy": {
+        "name": "Standard support response",
+        "targetMinutes": 120,
+        "dueSoonWindowMinutes": 30
+      },
+      "assignee": "riley@team.test",
+      "escalationNote": "Ask support lead to review before breach."
+    },
+    {
+      "id": "deadline-breached-003",
+      "messageId": "msg-breached-003",
+      "sharedInboxId": "ops@team.test",
+      "subject": "Partner relay outage report",
+      "receivedAt": "2026-06-23T06:00:00.000Z",
+      "policy": {
+        "name": "Operations urgent response",
+        "targetMinutes": 90,
+        "dueSoonWindowMinutes": 20
+      },
+      "assignee": "jordan@team.test",
+      "escalationNote": "Escalate to operations rotation."
+    },
+    {
+      "id": "deadline-resolved-004",
+      "messageId": "msg-resolved-004",
+      "sharedInboxId": "billing@team.test",
+      "subject": "Billing address confirmation",
+      "receivedAt": "2026-06-23T07:00:00.000Z",
+      "resolvedAt": "2026-06-23T07:40:00.000Z",
+      "policy": {
+        "name": "Billing response",
+        "targetMinutes": 180,
+        "dueSoonWindowMinutes": 45
+      },
+      "assignee": "taylor@team.test",
+      "escalationNote": ""
+    }
+  ]
+}

--- a/tools/v1/team/sla-deadline-tracker/index.mjs
+++ b/tools/v1/team/sla-deadline-tracker/index.mjs
@@ -1,0 +1,11 @@
+export {
+  DEADLINE_STATES,
+  SlaDeadlineValidationError,
+  buildDeadlineQueue,
+  evaluateDeadlineState,
+  filterDeadlineQueue,
+  normalizeDeadlineRecord,
+  normalizeSlaPolicy,
+  parseIsoDate,
+  summarizeDeadlineQueue,
+} from "./services/sla-deadline-service.mjs";

--- a/tools/v1/team/sla-deadline-tracker/services/sla-deadline-service.mjs
+++ b/tools/v1/team/sla-deadline-tracker/services/sla-deadline-service.mjs
@@ -1,0 +1,195 @@
+export const DEADLINE_STATES = Object.freeze({
+  OK: "ok",
+  DUE_SOON: "due-soon",
+  BREACHED: "breached",
+  RESOLVED: "resolved",
+});
+
+const DEFAULT_DUE_SOON_WINDOW_MINUTES = 30;
+const MAX_RECORDS = 500;
+
+export class SlaDeadlineValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "SlaDeadlineValidationError";
+    this.details = details;
+  }
+}
+
+export function parseIsoDate(value, fieldName) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new SlaDeadlineValidationError(`${fieldName} must be a non-empty ISO timestamp`, {
+      fieldName,
+    });
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SlaDeadlineValidationError(`${fieldName} must be a valid ISO timestamp`, {
+      fieldName,
+      value,
+    });
+  }
+
+  return parsed;
+}
+
+export function normalizeSlaPolicy(policy) {
+  if (!policy || typeof policy !== "object") {
+    throw new SlaDeadlineValidationError("SLA policy is required");
+  }
+
+  if (typeof policy.name !== "string" || policy.name.trim() === "") {
+    throw new SlaDeadlineValidationError("SLA policy name is required", { fieldName: "name" });
+  }
+
+  if (!Number.isFinite(policy.targetMinutes) || policy.targetMinutes <= 0) {
+    throw new SlaDeadlineValidationError("SLA targetMinutes must be a positive number", {
+      fieldName: "targetMinutes",
+    });
+  }
+
+  const dueSoonWindowMinutes =
+    policy.dueSoonWindowMinutes === undefined
+      ? DEFAULT_DUE_SOON_WINDOW_MINUTES
+      : policy.dueSoonWindowMinutes;
+
+  if (!Number.isFinite(dueSoonWindowMinutes) || dueSoonWindowMinutes < 0) {
+    throw new SlaDeadlineValidationError("SLA dueSoonWindowMinutes must be zero or positive", {
+      fieldName: "dueSoonWindowMinutes",
+    });
+  }
+
+  return {
+    name: policy.name.trim(),
+    targetMinutes: policy.targetMinutes,
+    dueSoonWindowMinutes,
+  };
+}
+
+export function normalizeDeadlineRecord(record) {
+  if (!record || typeof record !== "object") {
+    throw new SlaDeadlineValidationError("Deadline record is required");
+  }
+
+  for (const fieldName of ["id", "messageId", "sharedInboxId", "subject", "receivedAt"]) {
+    if (typeof record[fieldName] !== "string" || record[fieldName].trim() === "") {
+      throw new SlaDeadlineValidationError(`${fieldName} is required`, { fieldName });
+    }
+  }
+
+  const policy = normalizeSlaPolicy(record.policy);
+  const receivedAt = parseIsoDate(record.receivedAt, "receivedAt");
+  const resolvedAt = record.resolvedAt ? parseIsoDate(record.resolvedAt, "resolvedAt") : null;
+  const dueAt = new Date(receivedAt.getTime() + policy.targetMinutes * 60_000);
+
+  return {
+    id: record.id.trim(),
+    messageId: record.messageId.trim(),
+    sharedInboxId: record.sharedInboxId.trim(),
+    subject: record.subject.trim(),
+    receivedAt: receivedAt.toISOString(),
+    dueAt: dueAt.toISOString(),
+    resolvedAt: resolvedAt ? resolvedAt.toISOString() : null,
+    policy,
+    assignee: typeof record.assignee === "string" ? record.assignee.trim() : "",
+    escalationNote: typeof record.escalationNote === "string" ? record.escalationNote.trim() : "",
+  };
+}
+
+export function evaluateDeadlineState(record, options = {}) {
+  const normalized = normalizeDeadlineRecord(record);
+
+  if (normalized.resolvedAt) {
+    return {
+      ...normalized,
+      state: DEADLINE_STATES.RESOLVED,
+      minutesUntilDue: null,
+      isActionable: false,
+    };
+  }
+
+  const now = options.now ? parseIsoDate(options.now, "now") : new Date();
+  const dueAt = parseIsoDate(normalized.dueAt, "dueAt");
+  const minutesUntilDue = Math.ceil((dueAt.getTime() - now.getTime()) / 60_000);
+  const state =
+    minutesUntilDue < 0
+      ? DEADLINE_STATES.BREACHED
+      : minutesUntilDue <= normalized.policy.dueSoonWindowMinutes
+        ? DEADLINE_STATES.DUE_SOON
+        : DEADLINE_STATES.OK;
+
+  return {
+    ...normalized,
+    state,
+    minutesUntilDue,
+    isActionable: state === DEADLINE_STATES.DUE_SOON || state === DEADLINE_STATES.BREACHED,
+  };
+}
+
+export function buildDeadlineQueue(records, options = {}) {
+  if (!Array.isArray(records)) {
+    throw new SlaDeadlineValidationError("Deadline records must be an array");
+  }
+
+  if (records.length > (options.maxRecords ?? MAX_RECORDS)) {
+    throw new SlaDeadlineValidationError("Deadline record batch is too large", {
+      maxRecords: options.maxRecords ?? MAX_RECORDS,
+      receivedRecords: records.length,
+    });
+  }
+
+  return records
+    .map((record) => evaluateDeadlineState(record, options))
+    .sort((a, b) => {
+      if (a.state === DEADLINE_STATES.RESOLVED && b.state !== DEADLINE_STATES.RESOLVED) {
+        return 1;
+      }
+
+      if (b.state === DEADLINE_STATES.RESOLVED && a.state !== DEADLINE_STATES.RESOLVED) {
+        return -1;
+      }
+
+      return new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime();
+    });
+}
+
+export function filterDeadlineQueue(queue, filters = {}) {
+  if (!Array.isArray(queue)) {
+    throw new SlaDeadlineValidationError("Deadline queue must be an array");
+  }
+
+  return queue.filter((item) => {
+    const matchesState = filters.state ? item.state === filters.state : true;
+    const matchesAssignee = filters.assignee ? item.assignee === filters.assignee : true;
+    const matchesInbox = filters.sharedInboxId ? item.sharedInboxId === filters.sharedInboxId : true;
+
+    return matchesState && matchesAssignee && matchesInbox;
+  });
+}
+
+export function summarizeDeadlineQueue(queue) {
+  if (!Array.isArray(queue)) {
+    throw new SlaDeadlineValidationError("Deadline queue must be an array");
+  }
+
+  const summary = {
+    total: queue.length,
+    ok: 0,
+    dueSoon: 0,
+    breached: 0,
+    resolved: 0,
+    actionable: 0,
+  };
+
+  for (const item of queue) {
+    if (item.state === DEADLINE_STATES.OK) summary.ok += 1;
+    if (item.state === DEADLINE_STATES.DUE_SOON) summary.dueSoon += 1;
+    if (item.state === DEADLINE_STATES.BREACHED) summary.breached += 1;
+    if (item.state === DEADLINE_STATES.RESOLVED) summary.resolved += 1;
+    if (item.isActionable) summary.actionable += 1;
+  }
+
+  return summary;
+}

--- a/tools/v1/team/sla-deadline-tracker/tests/sla-deadline-service.test.mjs
+++ b/tools/v1/team/sla-deadline-tracker/tests/sla-deadline-service.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  DEADLINE_STATES,
+  SlaDeadlineValidationError,
+  buildDeadlineQueue,
+  evaluateDeadlineState,
+  filterDeadlineQueue,
+  normalizeDeadlineRecord,
+  normalizeSlaPolicy,
+  summarizeDeadlineQueue,
+} from "../index.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(__dirname, "../fixtures/sample-sla-deadlines.json");
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+
+test("normalizes SLA policy defaults", () => {
+  assert.deepEqual(normalizeSlaPolicy({ name: " Support ", targetMinutes: 60 }), {
+    name: "Support",
+    targetMinutes: 60,
+    dueSoonWindowMinutes: 30,
+  });
+});
+
+test("rejects malformed SLA policies", () => {
+  assert.throws(
+    () => normalizeSlaPolicy({ name: "Broken", targetMinutes: 0 }),
+    SlaDeadlineValidationError,
+  );
+});
+
+test("normalizes deadline records and computes dueAt", () => {
+  const normalized = normalizeDeadlineRecord(fixture.records[0]);
+
+  assert.equal(normalized.id, "deadline-ok-001");
+  assert.equal(normalized.dueAt, "2026-06-23T11:30:00.000Z");
+  assert.equal(normalized.resolvedAt, null);
+});
+
+test("evaluates ok deadline state", () => {
+  const result = evaluateDeadlineState(fixture.records[0], { now: fixture.now });
+
+  assert.equal(result.state, DEADLINE_STATES.OK);
+  assert.equal(result.minutesUntilDue, 90);
+  assert.equal(result.isActionable, false);
+});
+
+test("evaluates due-soon deadline state", () => {
+  const result = evaluateDeadlineState(fixture.records[1], { now: fixture.now });
+
+  assert.equal(result.state, DEADLINE_STATES.DUE_SOON);
+  assert.equal(result.minutesUntilDue, 20);
+  assert.equal(result.isActionable, true);
+});
+
+test("evaluates breached deadline state", () => {
+  const result = evaluateDeadlineState(fixture.records[2], { now: fixture.now });
+
+  assert.equal(result.state, DEADLINE_STATES.BREACHED);
+  assert.equal(result.minutesUntilDue, -150);
+  assert.equal(result.isActionable, true);
+});
+
+test("evaluates resolved deadline state without actionable work", () => {
+  const result = evaluateDeadlineState(fixture.records[3], { now: fixture.now });
+
+  assert.equal(result.state, DEADLINE_STATES.RESOLVED);
+  assert.equal(result.minutesUntilDue, null);
+  assert.equal(result.isActionable, false);
+});
+
+test("builds queue sorted by due date with resolved records last", () => {
+  const queue = buildDeadlineQueue(fixture.records, { now: fixture.now });
+
+  assert.deepEqual(
+    queue.map((item) => item.id),
+    ["deadline-breached-003", "deadline-due-soon-002", "deadline-ok-001", "deadline-resolved-004"],
+  );
+});
+
+test("filters deadline queue by state and assignee", () => {
+  const queue = buildDeadlineQueue(fixture.records, { now: fixture.now });
+
+  assert.deepEqual(
+    filterDeadlineQueue(queue, { state: DEADLINE_STATES.BREACHED }).map((item) => item.id),
+    ["deadline-breached-003"],
+  );
+  assert.deepEqual(
+    filterDeadlineQueue(queue, { assignee: "riley@team.test" }).map((item) => item.id),
+    ["deadline-due-soon-002"],
+  );
+});
+
+test("summarizes deadline queue state counts", () => {
+  const queue = buildDeadlineQueue(fixture.records, { now: fixture.now });
+
+  assert.deepEqual(summarizeDeadlineQueue(queue), {
+    total: 4,
+    ok: 1,
+    dueSoon: 1,
+    breached: 1,
+    resolved: 1,
+    actionable: 2,
+  });
+});
+
+test("rejects oversized batches before doing queue work", () => {
+  assert.throws(
+    () => buildDeadlineQueue(fixture.records, { now: fixture.now, maxRecords: 2 }),
+    SlaDeadlineValidationError,
+  );
+});
+
+test("fixture remains synthetic and free of sensitive fields", async () => {
+  const fixtureText = await readFile(fixturePath, "utf8");
+
+  assert.equal(fixture.records.every((record) => record.sharedInboxId.endsWith(".test")), true);
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});


### PR DESCRIPTION
## Summary
- add a folder-local pure SLA deadline service for validation, due-time calculation, state evaluation, sorting, filtering, and summaries
- add deterministic synthetic fixtures covering ok, due-soon, breached, and resolved deadline states
- expose a local API surface from index.mjs and document service inputs, outputs, loading states, error states, and safety limits

Closes 

## Tests
- node tools\v1\team\sla-deadline-tracker\tests\sla-deadline-service.test.mjs
- node -e "import('./tools/v1/team/sla-deadline-tracker/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --cached --check