### PR TITLE
Add shared team inbox input guards

### DIFF
--- a/tools/v1/team/shared-team-inbox/docs/SECURITY_AND_PERFORMANCE.md
+++ b/tools/v1/team/shared-team-inbox/docs/SECURITY_AND_PERFORMANCE.md
@@ -1,0 +1,42 @@
+# Shared Team Inbox Security And Performance Notes
+
+## Threat Assumptions
+
+- Sender fields, subjects, previews, comments, reply bodies, attachment metadata, and timestamps are
+  untrusted until validated by folder-local guards.
+- The shared inbox UI should render derived previews and metadata, not raw message bodies.
+- Internal comments are team-only and must not be copied into external reply drafts automatically.
+- Delivery proof hashes are references only; this tool must not verify or mutate protocol state.
+
+## Unsafe Inputs
+
+- malformed email-like addresses
+- invalid or missing timestamps
+- unsupported status values
+- oversized subjects, previews, comments, replies, histories, or attachment sets
+- control characters in user-visible text
+- attachment metadata with missing or negative size values
+
+## Guard Helpers
+
+`services/shared-inbox-guards.mjs` provides:
+
+- message normalization with address, timestamp, status, proof hash, and text guards
+- queue building with a configurable batch cap and newest-first sorting
+- internal comment draft preparation with team-only visibility
+- reply draft preparation with explicit shared inbox sender and recipient validation
+- attachment preview deferral for large attachment counts or total byte size
+
+## Performance Constraints
+
+- Default message batches are capped at 500 records before normalization work begins.
+- Message bodies are not accepted by the guard surface; callers provide bounded previews.
+- Attachment previews are deferred above 10 attachments or 10 MiB of aggregate metadata size.
+- Queue sorting happens after validation and should be paged by a future integration adapter for
+  histories larger than the local batch limit.
+
+## Integration Notes
+
+Future integration must keep these guards between raw inbox data and UI rendering. Main app routing,
+mail rendering, wallet, Stellar core, database, and shared design system code remain out of scope
+for this local hardening layer.

--- a/tools/v1/team/shared-team-inbox/fixtures/sample-guard-inputs.json
+++ b/tools/v1/team/shared-team-inbox/fixtures/sample-guard-inputs.json
@@ -1,0 +1,51 @@
+{
+  "messages": [
+    {
+      "id": "msg-newer-001",
+      "senderAddress": "Customer.One@Example.Test",
+      "sharedInboxAddress": "support@team.test",
+      "subject": "Cannot open encrypted message",
+      "preview": "The customer reports that the encrypted body opens but the attached receipt does not.",
+      "receivedAt": "2026-06-23T10:10:00.000Z",
+      "deliveryProofHash": "proof_guard_newer_001",
+      "status": "unassigned",
+      "internalCommentCount": 0,
+      "replyCount": 0
+    },
+    {
+      "id": "msg-older-002",
+      "senderAddress": "vendor.ops@example.test",
+      "sharedInboxAddress": "support@team.test",
+      "subject": "Relay status follow-up",
+      "preview": "Vendor asks whether the team has a new relay status update.",
+      "receivedAt": "2026-06-23T09:00:00.000Z",
+      "deliveryProofHash": "proof_guard_older_002",
+      "status": "claimed",
+      "assigneeAddress": "riley@team.test",
+      "internalCommentCount": 2,
+      "replyCount": 1
+    }
+  ],
+  "commentDraft": {
+    "messageId": "msg-newer-001",
+    "authorAddress": "alice@team.test",
+    "body": "Known receipt issue. Keep the note internal."
+  },
+  "replyDraft": {
+    "messageId": "msg-newer-001",
+    "fromSharedInboxAddress": "support@team.test",
+    "toAddress": "customer.one@example.test",
+    "subject": "Re: Cannot open encrypted message",
+    "body": "Thanks for the report. We are checking the encrypted receipt path now."
+  },
+  "attachments": [
+    {
+      "filename": "receipt-metadata.json",
+      "sizeBytes": 1024
+    },
+    {
+      "filename": "debug-log.txt",
+      "sizeBytes": 2048
+    }
+  ]
+}

--- a/tools/v1/team/shared-team-inbox/services/shared-inbox-guards.mjs
+++ b/tools/v1/team/shared-team-inbox/services/shared-inbox-guards.mjs
@@ -1,0 +1,180 @@
+export const SHARED_INBOX_LIMITS = Object.freeze({
+  maxMessagesPerBatch: 500,
+  maxSubjectLength: 180,
+  maxPreviewLength: 280,
+  maxCommentLength: 2_000,
+  maxReplyLength: 10_000,
+  maxAttachmentCountForPreview: 10,
+  maxAttachmentBytesForPreview: 10 * 1024 * 1024,
+});
+
+const VALID_STATUSES = new Set([
+  "unassigned",
+  "claimed",
+  "in-progress",
+  "awaiting-reply",
+  "resolved",
+]);
+
+export class SharedInboxGuardError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "SharedInboxGuardError";
+    this.details = details;
+  }
+}
+
+export function sanitizeText(value, fieldName, options = {}) {
+  const { maxLength = 1_000, required = true } = options;
+
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new SharedInboxGuardError(`${fieldName} is required`, { fieldName });
+    }
+
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new SharedInboxGuardError(`${fieldName} must be a string`, { fieldName });
+  }
+
+  const withoutControlCharacters = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+  const trimmed = withoutControlCharacters.trim();
+
+  if (required && trimmed === "") {
+    throw new SharedInboxGuardError(`${fieldName} cannot be empty`, { fieldName });
+  }
+
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 1)}…` : trimmed;
+}
+
+export function normalizeEmailAddress(value, fieldName) {
+  const address = sanitizeText(value, fieldName, { maxLength: 320 }).toLowerCase();
+
+  if (!/^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(address)) {
+    throw new SharedInboxGuardError(`${fieldName} must be a valid email-like address`, {
+      fieldName,
+    });
+  }
+
+  return address;
+}
+
+function parseIsoDate(value, fieldName) {
+  const timestamp = sanitizeText(value, fieldName, { maxLength: 64 });
+  const parsed = new Date(timestamp);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SharedInboxGuardError(`${fieldName} must be a valid ISO timestamp`, { fieldName });
+  }
+
+  return parsed.toISOString();
+}
+
+export function normalizeSharedInboxMessage(message) {
+  if (!message || typeof message !== "object") {
+    throw new SharedInboxGuardError("message must be an object");
+  }
+
+  const status = sanitizeText(message.status ?? "unassigned", "status", { maxLength: 32 });
+
+  if (!VALID_STATUSES.has(status)) {
+    throw new SharedInboxGuardError("status is not supported", { status });
+  }
+
+  return {
+    id: sanitizeText(message.id, "id", { maxLength: 120 }),
+    senderAddress: normalizeEmailAddress(message.senderAddress, "senderAddress"),
+    sharedInboxAddress: normalizeEmailAddress(message.sharedInboxAddress, "sharedInboxAddress"),
+    subject: sanitizeText(message.subject, "subject", {
+      maxLength: SHARED_INBOX_LIMITS.maxSubjectLength,
+    }),
+    preview: sanitizeText(message.preview, "preview", {
+      maxLength: SHARED_INBOX_LIMITS.maxPreviewLength,
+    }),
+    receivedAt: parseIsoDate(message.receivedAt, "receivedAt"),
+    deliveryProofHash: sanitizeText(message.deliveryProofHash, "deliveryProofHash", {
+      maxLength: 160,
+    }),
+    status,
+    assigneeAddress: message.assigneeAddress
+      ? normalizeEmailAddress(message.assigneeAddress, "assigneeAddress")
+      : "",
+    internalCommentCount: Number.isSafeInteger(message.internalCommentCount)
+      ? Math.max(0, message.internalCommentCount)
+      : 0,
+    replyCount: Number.isSafeInteger(message.replyCount) ? Math.max(0, message.replyCount) : 0,
+  };
+}
+
+export function buildSharedInboxQueue(messages, options = {}) {
+  if (!Array.isArray(messages)) {
+    throw new SharedInboxGuardError("messages must be an array");
+  }
+
+  const maxMessages = options.maxMessagesPerBatch ?? SHARED_INBOX_LIMITS.maxMessagesPerBatch;
+
+  if (messages.length > maxMessages) {
+    throw new SharedInboxGuardError("message batch is too large", {
+      maxMessages,
+      receivedMessages: messages.length,
+    });
+  }
+
+  return messages
+    .map((message) => normalizeSharedInboxMessage(message))
+    .sort((a, b) => new Date(b.receivedAt).getTime() - new Date(a.receivedAt).getTime());
+}
+
+export function prepareInternalCommentDraft(input) {
+  if (!input || typeof input !== "object") {
+    throw new SharedInboxGuardError("comment input must be an object");
+  }
+
+  return {
+    messageId: sanitizeText(input.messageId, "messageId", { maxLength: 120 }),
+    authorAddress: normalizeEmailAddress(input.authorAddress, "authorAddress"),
+    body: sanitizeText(input.body, "body", {
+      maxLength: SHARED_INBOX_LIMITS.maxCommentLength,
+    }),
+    visibility: "team-only",
+  };
+}
+
+export function prepareReplyDraft(input) {
+  if (!input || typeof input !== "object") {
+    throw new SharedInboxGuardError("reply input must be an object");
+  }
+
+  return {
+    messageId: sanitizeText(input.messageId, "messageId", { maxLength: 120 }),
+    fromSharedInboxAddress: normalizeEmailAddress(
+      input.fromSharedInboxAddress,
+      "fromSharedInboxAddress",
+    ),
+    toAddress: normalizeEmailAddress(input.toAddress, "toAddress"),
+    subject: sanitizeText(input.subject, "subject", {
+      maxLength: SHARED_INBOX_LIMITS.maxSubjectLength,
+    }),
+    body: sanitizeText(input.body, "body", {
+      maxLength: SHARED_INBOX_LIMITS.maxReplyLength,
+    }),
+  };
+}
+
+export function shouldDeferAttachmentPreview(attachments, limits = SHARED_INBOX_LIMITS) {
+  if (!Array.isArray(attachments)) {
+    throw new SharedInboxGuardError("attachments must be an array");
+  }
+
+  const totalBytes = attachments.reduce((sum, attachment) => {
+    const sizeBytes = Number.isFinite(attachment?.sizeBytes) ? attachment.sizeBytes : 0;
+    return sum + Math.max(0, sizeBytes);
+  }, 0);
+
+  return (
+    attachments.length > limits.maxAttachmentCountForPreview ||
+    totalBytes > limits.maxAttachmentBytesForPreview
+  );
+}

--- a/tools/v1/team/shared-team-inbox/tests/shared-inbox-guards.test.mjs
+++ b/tools/v1/team/shared-team-inbox/tests/shared-inbox-guards.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  SHARED_INBOX_LIMITS,
+  SharedInboxGuardError,
+  buildSharedInboxQueue,
+  normalizeEmailAddress,
+  normalizeSharedInboxMessage,
+  prepareInternalCommentDraft,
+  prepareReplyDraft,
+  sanitizeText,
+  shouldDeferAttachmentPreview,
+} from "../services/shared-inbox-guards.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(__dirname, "../fixtures/sample-guard-inputs.json");
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+
+test("sanitizes control characters and truncates bounded text", () => {
+  assert.equal(sanitizeText("  hello\u0000 world  ", "subject"), "hello world");
+  assert.equal(sanitizeText("abcdef", "preview", { maxLength: 4 }), "abc…");
+});
+
+test("rejects malformed email-like addresses", () => {
+  assert.throws(() => normalizeEmailAddress("not-an-address", "senderAddress"), SharedInboxGuardError);
+});
+
+test("normalizes shared inbox message input", () => {
+  const normalized = normalizeSharedInboxMessage(fixture.messages[0]);
+
+  assert.equal(normalized.senderAddress, "customer.one@example.test");
+  assert.equal(normalized.sharedInboxAddress, "support@team.test");
+  assert.equal(normalized.status, "unassigned");
+  assert.equal(normalized.receivedAt, "2026-06-23T10:10:00.000Z");
+});
+
+test("rejects unsupported message status", () => {
+  assert.throws(
+    () => normalizeSharedInboxMessage({ ...fixture.messages[0], status: "archived" }),
+    SharedInboxGuardError,
+  );
+});
+
+test("builds newest-first queue after validation", () => {
+  const queue = buildSharedInboxQueue(fixture.messages);
+
+  assert.deepEqual(
+    queue.map((message) => message.id),
+    ["msg-newer-001", "msg-older-002"],
+  );
+});
+
+test("rejects oversized message batches before normalizing", () => {
+  assert.throws(
+    () => buildSharedInboxQueue(fixture.messages, { maxMessagesPerBatch: 1 }),
+    SharedInboxGuardError,
+  );
+});
+
+test("prepares internal comments as team-only drafts", () => {
+  const draft = prepareInternalCommentDraft(fixture.commentDraft);
+
+  assert.equal(draft.visibility, "team-only");
+  assert.equal(draft.authorAddress, "alice@team.test");
+  assert.equal(draft.body, "Known receipt issue. Keep the note internal.");
+});
+
+test("prepares explicit shared-inbox reply drafts", () => {
+  const draft = prepareReplyDraft(fixture.replyDraft);
+
+  assert.equal(draft.fromSharedInboxAddress, "support@team.test");
+  assert.equal(draft.toAddress, "customer.one@example.test");
+  assert.equal(draft.subject, "Re: Cannot open encrypted message");
+});
+
+test("truncates oversized comments and replies", () => {
+  const longComment = "a".repeat(SHARED_INBOX_LIMITS.maxCommentLength + 50);
+  const longReply = "b".repeat(SHARED_INBOX_LIMITS.maxReplyLength + 50);
+
+  assert.equal(
+    prepareInternalCommentDraft({ ...fixture.commentDraft, body: longComment }).body.length,
+    SHARED_INBOX_LIMITS.maxCommentLength,
+  );
+  assert.equal(
+    prepareReplyDraft({ ...fixture.replyDraft, body: longReply }).body.length,
+    SHARED_INBOX_LIMITS.maxReplyLength,
+  );
+});
+
+test("defers large attachment previews", () => {
+  assert.equal(shouldDeferAttachmentPreview(fixture.attachments), false);
+  assert.equal(
+    shouldDeferAttachmentPreview([
+      { filename: "large.bin", sizeBytes: SHARED_INBOX_LIMITS.maxAttachmentBytesForPreview + 1 },
+    ]),
+    true,
+  );
+});
+
+test("fixture stays synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readFile(fixturePath, "utf8");
+
+  assert.equal(
+    fixture.messages.every((message) => message.senderAddress.toLowerCase().endsWith(".test")),
+    true,
+  );
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});


### PR DESCRIPTION
## Summary
- add folder-local Shared Team Inbox guard helpers for text cleanup, email validation, message normalization, queue batch limits, comment/reply drafts, and attachment preview deferral
- add synthetic guard fixtures and security/performance notes for unsafe inputs, large histories, and attachment limits
- add local tests covering malformed input, hostile status values, batch limits, draft preparation, attachment limits, and fixture safety

Closes #l

## Tests
- node tools\v1\team\shared-team-inbox\tests\shared-inbox-guards.test.mjs
- node -e "import('./tools/v1/team/shared-team-inbox/services/shared-inbox-guards.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --cached --check