### PR TITLE
Add email ownership tracker input guards

### DIFF
--- a/tools/v1/team/email-ownership-tracker/docs/SECURITY_AND_PERFORMANCE.md
+++ b/tools/v1/team/email-ownership-tracker/docs/SECURITY_AND_PERFORMANCE.md
@@ -1,0 +1,46 @@
+# Email Ownership Tracker Security And Performance Notes
+
+## Threat Assumptions
+
+- Ownership events can arrive from UI actions, future inbox adapters, or replayed local fixtures and
+  must be treated as untrusted until normalized.
+- Message subjects, notes, actor addresses, owner addresses, timestamps, and actions are unsafe
+  inputs.
+- The tracker stores derived ownership metadata only. It must not store full message bodies,
+  credentials, delivery proofs, private mailbox data, or payment details.
+
+## Guard Surface
+
+`services/ownership-guards.mjs` provides folder-local guards for:
+
+- stripping control characters from user-visible text
+- validating email-like actor, owner, previous owner, and shared inbox addresses
+- validating ISO timestamps before timeline sorting
+- rejecting unsupported ownership actions
+- requiring owners for claim and reassignment events
+- requiring previous owners for reassignment events
+- capping batch size before normalization work starts
+- building chronological timelines and current ownership summaries
+
+## Unsafe Inputs
+
+- malformed addresses
+- unsupported actions such as `archive`, `delete`, or arbitrary workflow names
+- invalid timestamps or future adapter placeholders
+- ownership assignment events without an owner
+- reassignment events without a previous owner
+- oversized subjects, notes, message IDs, or event batches
+- control characters in subjects or notes
+
+## Performance Constraints
+
+- Event batches default to a 1,000-event cap before normalization and sorting.
+- Summaries are computed with one pass over the normalized timeline.
+- The guard layer does not fetch mail, inspect attachments, start timers, or write durable storage.
+- Future integration should page large histories before passing data into these helpers.
+
+## Integration Boundary
+
+These guards are safe to use before any future UI or service integration. They do not import from
+the main app shell, routing, inbox architecture, wallet core, Stellar core, database, or shared
+design system.

--- a/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-guard-inputs.json
+++ b/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-guard-inputs.json
@@ -1,0 +1,76 @@
+{
+  "events": [
+    {
+      "eventId": "own-event-001",
+      "messageId": "msg-owner-001",
+      "sharedInboxAddress": "support@team.test",
+      "subject": "Account recovery request",
+      "action": "claimed",
+      "actorAddress": "Alice@Team.Test",
+      "ownerAddress": "Alice@Team.Test",
+      "occurredAt": "2026-06-23T09:00:00.000Z",
+      "note": "Initial claim from support queue."
+    },
+    {
+      "eventId": "own-event-002",
+      "messageId": "msg-owner-001",
+      "sharedInboxAddress": "support@team.test",
+      "subject": "Account recovery request",
+      "action": "reassigned",
+      "actorAddress": "alice@team.test",
+      "previousOwnerAddress": "alice@team.test",
+      "ownerAddress": "riley@team.test",
+      "occurredAt": "2026-06-23T09:30:00.000Z",
+      "note": "Handoff to recovery specialist."
+    },
+    {
+      "eventId": "own-event-003",
+      "messageId": "msg-owner-002",
+      "sharedInboxAddress": "ops@team.test",
+      "subject": "Relay configuration issue",
+      "action": "claimed",
+      "actorAddress": "jordan@team.test",
+      "ownerAddress": "jordan@team.test",
+      "occurredAt": "2026-06-23T08:45:00.000Z",
+      "note": ""
+    },
+    {
+      "eventId": "own-event-004",
+      "messageId": "msg-owner-002",
+      "sharedInboxAddress": "ops@team.test",
+      "subject": "Relay configuration issue",
+      "action": "escalated",
+      "actorAddress": "jordan@team.test",
+      "ownerAddress": "jordan@team.test",
+      "occurredAt": "2026-06-23T09:10:00.000Z",
+      "note": "Escalated to operations rotation."
+    },
+    {
+      "eventId": "own-event-005",
+      "messageId": "msg-owner-003",
+      "sharedInboxAddress": "billing@team.test",
+      "subject": "Billing contact update",
+      "action": "claimed",
+      "actorAddress": "taylor@team.test",
+      "ownerAddress": "taylor@team.test",
+      "occurredAt": "2026-06-23T07:45:00.000Z",
+      "note": "Billing queue triage."
+    },
+    {
+      "eventId": "own-event-006",
+      "messageId": "msg-owner-003",
+      "sharedInboxAddress": "billing@team.test",
+      "subject": "Billing contact update",
+      "action": "released",
+      "actorAddress": "taylor@team.test",
+      "previousOwnerAddress": "taylor@team.test",
+      "occurredAt": "2026-06-23T08:20:00.000Z",
+      "note": "Resolved externally; release ownership."
+    }
+  ],
+  "claimDraft": {
+    "messageId": "msg-owner-004",
+    "actorAddress": "sam@team.test",
+    "note": "Claiming from shared support queue."
+  }
+}

--- a/tools/v1/team/email-ownership-tracker/services/ownership-guards.mjs
+++ b/tools/v1/team/email-ownership-tracker/services/ownership-guards.mjs
@@ -1,0 +1,218 @@
+export const OWNERSHIP_LIMITS = Object.freeze({
+  maxEventsPerBatch: 1_000,
+  maxSubjectLength: 180,
+  maxNoteLength: 1_500,
+  maxMessageIdLength: 160,
+});
+
+export const OWNERSHIP_ACTIONS = Object.freeze({
+  CLAIMED: "claimed",
+  RELEASED: "released",
+  REASSIGNED: "reassigned",
+  ESCALATED: "escalated",
+});
+
+const VALID_ACTIONS = new Set(Object.values(OWNERSHIP_ACTIONS));
+
+export class OwnershipGuardError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "OwnershipGuardError";
+    this.details = details;
+  }
+}
+
+export function sanitizeOwnershipText(value, fieldName, options = {}) {
+  const { maxLength = 1_000, required = true } = options;
+
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new OwnershipGuardError(`${fieldName} is required`, { fieldName });
+    }
+
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new OwnershipGuardError(`${fieldName} must be a string`, { fieldName });
+  }
+
+  const normalized = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trim();
+
+  if (required && normalized === "") {
+    throw new OwnershipGuardError(`${fieldName} cannot be empty`, { fieldName });
+  }
+
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
+}
+
+export function normalizeOwnershipAddress(value, fieldName) {
+  const address = sanitizeOwnershipText(value, fieldName, { maxLength: 320 }).toLowerCase();
+
+  if (!/^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(address)) {
+    throw new OwnershipGuardError(`${fieldName} must be a valid email-like address`, {
+      fieldName,
+    });
+  }
+
+  return address;
+}
+
+function normalizeOptionalAddress(value, fieldName) {
+  if (value === undefined || value === null || value === "") {
+    return "";
+  }
+
+  return normalizeOwnershipAddress(value, fieldName);
+}
+
+export function parseOwnershipTimestamp(value, fieldName = "occurredAt") {
+  const timestamp = sanitizeOwnershipText(value, fieldName, { maxLength: 64 });
+  const parsed = new Date(timestamp);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new OwnershipGuardError(`${fieldName} must be a valid ISO timestamp`, { fieldName });
+  }
+
+  return parsed.toISOString();
+}
+
+export function normalizeOwnershipEvent(event) {
+  if (!event || typeof event !== "object") {
+    throw new OwnershipGuardError("ownership event must be an object");
+  }
+
+  const action = sanitizeOwnershipText(event.action, "action", { maxLength: 32 });
+
+  if (!VALID_ACTIONS.has(action)) {
+    throw new OwnershipGuardError("ownership action is not supported", { action });
+  }
+
+  const ownerAddress = normalizeOptionalAddress(event.ownerAddress, "ownerAddress");
+  const previousOwnerAddress = normalizeOptionalAddress(
+    event.previousOwnerAddress,
+    "previousOwnerAddress",
+  );
+
+  if (
+    (action === OWNERSHIP_ACTIONS.CLAIMED || action === OWNERSHIP_ACTIONS.REASSIGNED) &&
+    ownerAddress === ""
+  ) {
+    throw new OwnershipGuardError("ownerAddress is required for ownership assignment", {
+      action,
+    });
+  }
+
+  if (action === OWNERSHIP_ACTIONS.REASSIGNED && previousOwnerAddress === "") {
+    throw new OwnershipGuardError("previousOwnerAddress is required for reassignment", {
+      action,
+    });
+  }
+
+  return {
+    eventId: sanitizeOwnershipText(event.eventId, "eventId", { maxLength: 160 }),
+    messageId: sanitizeOwnershipText(event.messageId, "messageId", {
+      maxLength: OWNERSHIP_LIMITS.maxMessageIdLength,
+    }),
+    sharedInboxAddress: normalizeOwnershipAddress(event.sharedInboxAddress, "sharedInboxAddress"),
+    subject: sanitizeOwnershipText(event.subject, "subject", {
+      maxLength: OWNERSHIP_LIMITS.maxSubjectLength,
+    }),
+    action,
+    actorAddress: normalizeOwnershipAddress(event.actorAddress, "actorAddress"),
+    ownerAddress,
+    previousOwnerAddress,
+    occurredAt: parseOwnershipTimestamp(event.occurredAt),
+    note: sanitizeOwnershipText(event.note, "note", {
+      maxLength: OWNERSHIP_LIMITS.maxNoteLength,
+      required: false,
+    }),
+  };
+}
+
+export function buildOwnershipTimeline(events, options = {}) {
+  if (!Array.isArray(events)) {
+    throw new OwnershipGuardError("ownership events must be an array");
+  }
+
+  const maxEvents = options.maxEventsPerBatch ?? OWNERSHIP_LIMITS.maxEventsPerBatch;
+
+  if (events.length > maxEvents) {
+    throw new OwnershipGuardError("ownership event batch is too large", {
+      maxEvents,
+      receivedEvents: events.length,
+    });
+  }
+
+  return events
+    .map((event) => normalizeOwnershipEvent(event))
+    .sort((a, b) => new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime());
+}
+
+export function summarizeCurrentOwnership(timeline) {
+  if (!Array.isArray(timeline)) {
+    throw new OwnershipGuardError("ownership timeline must be an array");
+  }
+
+  const byMessage = new Map();
+
+  for (const event of timeline) {
+    const current = byMessage.get(event.messageId) ?? {
+      messageId: event.messageId,
+      subject: event.subject,
+      sharedInboxAddress: event.sharedInboxAddress,
+      ownerAddress: "",
+      lastAction: "",
+      lastActorAddress: "",
+      updatedAt: "",
+      handoffCount: 0,
+      escalationCount: 0,
+    };
+
+    if (event.action === OWNERSHIP_ACTIONS.CLAIMED) {
+      current.ownerAddress = event.ownerAddress;
+    }
+
+    if (event.action === OWNERSHIP_ACTIONS.REASSIGNED) {
+      current.ownerAddress = event.ownerAddress;
+      current.handoffCount += 1;
+    }
+
+    if (event.action === OWNERSHIP_ACTIONS.RELEASED) {
+      current.ownerAddress = "";
+    }
+
+    if (event.action === OWNERSHIP_ACTIONS.ESCALATED) {
+      current.escalationCount += 1;
+    }
+
+    current.subject = event.subject;
+    current.sharedInboxAddress = event.sharedInboxAddress;
+    current.lastAction = event.action;
+    current.lastActorAddress = event.actorAddress;
+    current.updatedAt = event.occurredAt;
+    byMessage.set(event.messageId, current);
+  }
+
+  return [...byMessage.values()].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+}
+
+export function prepareOwnershipClaim(input) {
+  if (!input || typeof input !== "object") {
+    throw new OwnershipGuardError("claim input must be an object");
+  }
+
+  return {
+    messageId: sanitizeOwnershipText(input.messageId, "messageId", {
+      maxLength: OWNERSHIP_LIMITS.maxMessageIdLength,
+    }),
+    actorAddress: normalizeOwnershipAddress(input.actorAddress, "actorAddress"),
+    ownerAddress: normalizeOwnershipAddress(input.ownerAddress ?? input.actorAddress, "ownerAddress"),
+    note: sanitizeOwnershipText(input.note, "note", {
+      maxLength: OWNERSHIP_LIMITS.maxNoteLength,
+      required: false,
+    }),
+  };
+}

--- a/tools/v1/team/email-ownership-tracker/tests/ownership-guards.test.mjs
+++ b/tools/v1/team/email-ownership-tracker/tests/ownership-guards.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  OWNERSHIP_ACTIONS,
+  OWNERSHIP_LIMITS,
+  OwnershipGuardError,
+  buildOwnershipTimeline,
+  normalizeOwnershipAddress,
+  normalizeOwnershipEvent,
+  prepareOwnershipClaim,
+  sanitizeOwnershipText,
+  summarizeCurrentOwnership,
+} from "../services/ownership-guards.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(__dirname, "../fixtures/sample-ownership-guard-inputs.json");
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+
+test("sanitizes control characters and truncates bounded ownership text", () => {
+  assert.equal(sanitizeOwnershipText("  hello\u0000 owner  ", "note"), "hello owner");
+  assert.equal(sanitizeOwnershipText("abcdef", "note", { maxLength: 4 }), "abc…");
+});
+
+test("normalizes email-like ownership addresses", () => {
+  assert.equal(normalizeOwnershipAddress("Alice@Team.Test", "ownerAddress"), "alice@team.test");
+});
+
+test("rejects malformed ownership addresses", () => {
+  assert.throws(
+    () => normalizeOwnershipAddress("not-an-address", "ownerAddress"),
+    OwnershipGuardError,
+  );
+});
+
+test("normalizes claim ownership events", () => {
+  const event = normalizeOwnershipEvent(fixture.events[0]);
+
+  assert.equal(event.action, OWNERSHIP_ACTIONS.CLAIMED);
+  assert.equal(event.actorAddress, "alice@team.test");
+  assert.equal(event.ownerAddress, "alice@team.test");
+  assert.equal(event.occurredAt, "2026-06-23T09:00:00.000Z");
+});
+
+test("rejects unsupported ownership actions", () => {
+  assert.throws(
+    () => normalizeOwnershipEvent({ ...fixture.events[0], action: "archived" }),
+    OwnershipGuardError,
+  );
+});
+
+test("requires owner for claim and previous owner for reassignment", () => {
+  assert.throws(
+    () => normalizeOwnershipEvent({ ...fixture.events[0], ownerAddress: "" }),
+    OwnershipGuardError,
+  );
+  assert.throws(
+    () => normalizeOwnershipEvent({ ...fixture.events[1], previousOwnerAddress: "" }),
+    OwnershipGuardError,
+  );
+});
+
+test("builds chronological timeline after validation", () => {
+  const timeline = buildOwnershipTimeline(fixture.events);
+
+  assert.deepEqual(
+    timeline.map((event) => event.eventId),
+    [
+      "own-event-005",
+      "own-event-006",
+      "own-event-003",
+      "own-event-001",
+      "own-event-004",
+      "own-event-002",
+    ],
+  );
+});
+
+test("rejects oversized event batches before normalizing", () => {
+  assert.throws(
+    () => buildOwnershipTimeline(fixture.events, { maxEventsPerBatch: 2 }),
+    OwnershipGuardError,
+  );
+});
+
+test("summarizes current ownership by message", () => {
+  const summary = summarizeCurrentOwnership(buildOwnershipTimeline(fixture.events));
+  const byMessage = Object.fromEntries(summary.map((record) => [record.messageId, record]));
+
+  assert.equal(byMessage["msg-owner-001"].ownerAddress, "riley@team.test");
+  assert.equal(byMessage["msg-owner-001"].handoffCount, 1);
+  assert.equal(byMessage["msg-owner-002"].ownerAddress, "jordan@team.test");
+  assert.equal(byMessage["msg-owner-002"].escalationCount, 1);
+  assert.equal(byMessage["msg-owner-003"].ownerAddress, "");
+  assert.equal(byMessage["msg-owner-003"].lastAction, OWNERSHIP_ACTIONS.RELEASED);
+});
+
+test("prepares safe ownership claim drafts", () => {
+  const claim = prepareOwnershipClaim(fixture.claimDraft);
+
+  assert.equal(claim.messageId, "msg-owner-004");
+  assert.equal(claim.actorAddress, "sam@team.test");
+  assert.equal(claim.ownerAddress, "sam@team.test");
+  assert.equal(claim.note, "Claiming from shared support queue.");
+});
+
+test("truncates oversized ownership notes", () => {
+  const longNote = "a".repeat(OWNERSHIP_LIMITS.maxNoteLength + 20);
+  const claim = prepareOwnershipClaim({ ...fixture.claimDraft, note: longNote });
+
+  assert.equal(claim.note.length, OWNERSHIP_LIMITS.maxNoteLength);
+});
+
+test("fixture stays synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readFile(fixturePath, "utf8");
+
+  assert.equal(
+    fixture.events.every((event) => event.sharedInboxAddress.toLowerCase().endsWith(".test")),
+    true,
+  );
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});


### PR DESCRIPTION
## Summary
- add folder-local Email Ownership Tracker guards for text cleanup, address validation, ownership action validation, timeline building, current-owner summaries, and claim drafts
- add synthetic ownership event fixtures and security/performance notes for unsafe inputs and large ownership histories
- add local tests covering malformed input, unsupported actions, assignment invariants, batch limits, summaries, and fixture safety

Closes 

## Tests
- node tools\v1\team\email-ownership-tracker\tests\ownership-guards.test.mjs
- node -e "import('./tools/v1/team/email-ownership-tracker/services/ownership-guards.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --cached --check