### PR TITLE
Add email ownership tracker architecture contract

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -1,15 +1,32 @@
 # Email Ownership Tracker
 
-This folder is the isolated workspace for the Email Ownership Tracker tool.
+Email Ownership Tracker is a folder-local team tool for tracking who currently owns a shared
+inbox message and how ownership changed over time. The tool is isolated until a future integration
+issue explicitly connects it to the main mail application.
 
 ## Ownership Boundary
 
-All work for this tool must stay inside:
+All source, docs, tests, fixtures, and future local configuration for this tool must stay under:
 
-`text
-.\tools\v1\team\email-ownership-tracker\
-`
+```text
+tools/v1/team/email-ownership-tracker/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app shell, routing, inbox architecture, wallet core, Stellar
+core, database schema, or shared design system unless a future integration issue explicitly allows
+that work.
 
-See specs.md for the issue categories and contributor expectations.
+## Local Architecture Contract
+
+- `components/` may render ownership queues, ownership history, empty/loading/error states, and
+  handoff controls using folder-local props only.
+- `services/` owns validation, ownership event normalization, timeline construction, and summary
+  derivation.
+- `hooks/` may adapt folder-local services into React state, but must not call global stores or
+  live mail APIs.
+- `fixtures/` stores synthetic ownership events and histories for deterministic tests.
+- `tests/` contains folder-local unit, fixture, and architecture contract tests.
+- `docs/` records architecture, contributor boundaries, safety assumptions, and integration notes.
+
+See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) and
+[docs/CONTRIBUTOR_BOUNDARY.md](./docs/CONTRIBUTOR_BOUNDARY.md) for the detailed contract.

--- a/tools/v1/team/email-ownership-tracker/docs/ARCHITECTURE.md
+++ b/tools/v1/team/email-ownership-tracker/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Email Ownership Tracker Architecture
+
+## Module Boundaries
+
+```text
+tools/v1/team/email-ownership-tracker/
+  components/   UI-only views for ownership queues, details, history, and local states
+  services/     Pure validation, event normalization, timeline building, and summaries
+  hooks/        React adapters over folder-local services and fixture-backed state
+  fixtures/     Synthetic ownership events and histories for demos and tests
+  tests/        Folder-local unit, fixture, and architecture contract tests
+  docs/         Architecture, contributor boundaries, safety, and integration notes
+```
+
+No module in this tool may import from `src/`, sibling tools, `tools/v2/`, main app routing,
+wallet code, Stellar core, database code, or shared design system internals.
+
+## Data Flow
+
+1. A future integration adapter may pass sanitized message metadata into the tool.
+2. `services/` validates ownership events and normalizes timestamps and addresses.
+3. `services/` builds a chronological timeline and derives current owner summaries.
+4. `hooks/` may manage local selected-message, filter, and optimistic feedback state.
+5. `components/` render derived state and emit local action callbacks.
+
+The core service layer must remain pure: no live network calls, timers, local storage, IndexedDB,
+wallet access, or direct mail engine calls.
+
+## Ownership State Model
+
+- `claimed`: a team member takes ownership of an unowned message.
+- `released`: the current owner clears ownership after resolution or handoff cancellation.
+- `reassigned`: ownership moves from one team member to another.
+- `escalated`: ownership remains visible while the message is flagged for manager or rotation review.
+
+The tool derives current owner state from events; it does not mutate source mail records.
+
+## Public Folder API
+
+Future contributors may expose a small folder-local API from an `index.ts` or `index.mjs` file.
+That export should include typed service helpers, UI components, and synthetic fixtures that are
+safe for review. It must not mount the tool, register routes, or mutate global app state.
+
+## Review Checklist
+
+- Files changed are limited to `tools/v1/team/email-ownership-tracker/`.
+- Specs explain what future contributors may and may not change.
+- Any future services are deterministic and testable without network access.
+- Any future UI is keyboard accessible and does not rely on color alone for ownership state.

--- a/tools/v1/team/email-ownership-tracker/docs/CONTRIBUTOR_BOUNDARY.md
+++ b/tools/v1/team/email-ownership-tracker/docs/CONTRIBUTOR_BOUNDARY.md
@@ -1,0 +1,34 @@
+# Contributor Boundary
+
+## Contributors May Change
+
+- Folder-local docs, tests, fixtures, services, hooks, and components.
+- Synthetic ownership histories for deterministic tests and demos.
+- Pure helpers for event validation, timeline construction, filtering, and summary derivation.
+- Local accessibility and visual notes for a future UI surface.
+
+## Contributors Must Not Change
+
+- Main application shell, dashboard layout, navigation, routing, or global providers.
+- Existing inbox architecture, message rendering, wallet core, Stellar core, or database schema.
+- Root package dependencies, repository-wide build settings, or shared design system tokens.
+- Production data, user credentials, private mailbox contents, secrets, or payment details.
+
+## Dependency Rules
+
+- Prefer JavaScript or TypeScript standard library APIs for timestamp and string validation.
+- Keep services pure and dependency-light.
+- Do not introduce live network calls, telemetry, cron jobs, local storage, or background workers.
+- Fixtures must use `.test` domains and synthetic IDs.
+
+## Integration Constraints
+
+This tool can be integrated only after a future issue defines:
+
+- the sanitized message metadata contract supplied by the main mail app
+- the permission model for claiming, releasing, reassigning, and escalating ownership
+- the storage ownership boundary for durable ownership history
+- the UI accessibility review path for a mounted route or panel
+- the conflict behavior when two team members try to claim the same message
+
+Until then, the tool remains a self-contained mini-product with local tests and docs only.

--- a/tools/v1/team/email-ownership-tracker/specs.md
+++ b/tools/v1/team/email-ownership-tracker/specs.md
@@ -1,38 +1,47 @@
-# Email Ownership Tracker
-
-Track ownership history.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v1/team/email-ownership-tracker/README.md"
-  @"
-
 # Email Ownership Tracker Specs
 
 ## Purpose
 
-Track ownership history.
+Email Ownership Tracker helps teams avoid duplicate replies and dropped handoffs by maintaining a
+derived record of message ownership in shared inbox workflows.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V1
+- Audience: team
+- Folder ownership: `tools/v1/team/email-ownership-tracker/`
+- Work mode: isolated mini-product until a future integration issue links it into the app.
 
-$dir/
+## In Scope
 
-## Required issue categories
+- Define folder-local module boundaries for components, services, hooks, tests, docs, and fixtures.
+- Document ownership event data, derived state, and current-owner summary responsibilities.
+- Describe dependency limits and future integration constraints.
+- Keep all architecture notes and validation inside this folder.
+
+## Out of Scope
+
+- Main app shell, navigation, routing, dashboard layout, or global providers.
+- Existing inbox architecture, wallet core, Stellar core, mail rendering, or database schema changes.
+- Live network calls, production mail data, credentials, private mailbox contents, or payment data.
+- Global design system edits or root dependency changes.
+
+## Data Ownership
+
+The tool owns derived ownership metadata only:
+
+- message reference ID
+- shared inbox address
+- subject preview label
+- ownership action: `claimed`, `released`, `reassigned`, or `escalated`
+- actor, current owner, and previous owner addresses
+- action timestamp
+- optional team-only handoff note
+
+The tool must not become the source of truth for message bodies, wallet identities, sender
+credentials, delivery proofs, payment details, or permanent audit logs.
+
+## Required Issue Categories
 
 - Architecture
 - Feature

--- a/tools/v1/team/email-ownership-tracker/tests/architecture-contract.test.mjs
+++ b/tools/v1/team/email-ownership-tracker/tests/architecture-contract.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function listFiles(dir = toolRoot) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolute = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(absolute) : absolute;
+    }),
+  );
+
+  return files.flat();
+}
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("architecture docs define folder-local module boundaries", async () => {
+  const readme = await readToolFile("README.md");
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+
+  for (const folder of ["components/", "services/", "hooks/", "fixtures/", "tests/", "docs/"]) {
+    assert.match(readme, new RegExp(folder.replace("/", "\\/")));
+    assert.match(architecture, new RegExp(folder.replace("/", "\\/")));
+  }
+
+  assert.match(readme, /tools\/v1\/team\/email-ownership-tracker\//);
+  assert.match(architecture, /No module in this tool may import from `src\/`/);
+});
+
+test("specs describe scope, data ownership, and contributor limits", async () => {
+  const specs = await readToolFile("specs.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+
+  for (const term of [
+    "Release tier: V1",
+    "Audience: team",
+    "Data Ownership",
+    "ownership action",
+    "Out of Scope",
+  ]) {
+    assert.match(specs, new RegExp(term));
+  }
+
+  for (const term of [
+    "Contributors May Change",
+    "Contributors Must Not Change",
+    "Dependency Rules",
+    "Integration Constraints",
+  ]) {
+    assert.match(boundary, new RegExp(term));
+  }
+});
+
+test("architecture contract rejects generated template residue", async () => {
+  const files = await listFiles();
+  const textFiles = files.filter((file) => /\.(md|json)$/.test(file));
+  const combined = (
+    await Promise.all(textFiles.map((file) => readFile(file, "utf8")))
+  ).join("\n");
+
+  assert.doesNotMatch(combined, /System\.Collections|Set-Content|@\s*\||\$dir|\$\(.*\)/);
+  assert.doesNotMatch(combined, /components\/\n- services\/\n- hooks\/\n-\s+ests\//);
+});
+
+test("integration and dependency boundaries remain explicit", async () => {
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+  const combined = `${architecture}\n${boundary}`;
+
+  for (const forbiddenArea of [
+    "routing",
+    "wallet core",
+    "Stellar core",
+    "database schema",
+    "shared design system",
+    "production data",
+    "secrets",
+  ]) {
+    assert.match(combined, new RegExp(forbiddenArea, "i"));
+  }
+
+  assert.match(combined, /no live network calls/i);
+  assert.match(combined, /\.test` domains/);
+});
+
+test("all current files stay under the Email Ownership Tracker root", async () => {
+  const files = await listFiles();
+
+  assert.ok(files.length >= 5, "expected README, specs, docs, and tests");
+
+  for (const file of files) {
+    assert.ok(file.startsWith(toolRoot), `file escaped the tool root: ${file}`);
+  }
+});


### PR DESCRIPTION
## Summary
- replace generated template residue in the Email Ownership Tracker README/specs with a clear folder-local architecture contract
- document module boundaries, ownership event data, dependency limits, and future integration constraints
- add an architecture contract test covering module map, boundary language, and template residue checks

Closes #

## Tests
- node tools\v1\team\email-ownership-tracker\tests\architecture-contract.test.mjs
- git diff --cached --check