### PR TITLE
feat(demo-admin-dashboard): campaign taxonomy types, fixtures, and docs

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/campaignTaxonomy.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/campaignTaxonomy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUDIENCE_SEGMENTS_BY_ID,
+} from "../fixtures/audienceSegmentFixtures";
+import {
+  CAMPAIGN_GROUPS_BY_ID,
+  CAMPAIGN_RECORDS_BY_ID,
+  campaignGroups,
+  campaignMessageLinks,
+  campaignRecords,
+  campaignRelationshipExamples,
+} from "../fixtures/campaignTaxonomyFixtures";
+
+describe("campaignGroups fixture", () => {
+  it("has unique IDs", () => {
+    const ids = campaignGroups.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every campaignId in a group exists in campaignRecords", () => {
+    for (const group of campaignGroups) {
+      for (const campaignId of group.campaignIds) {
+        expect(CAMPAIGN_RECORDS_BY_ID[campaignId]).toBeDefined();
+      }
+    }
+  });
+
+  it("has a non-empty name and description for each group", () => {
+    for (const group of campaignGroups) {
+      expect(group.name.trim().length).toBeGreaterThan(0);
+      expect(group.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("campaignRecords fixture", () => {
+  it("has unique IDs", () => {
+    const ids = campaignRecords.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every record references a valid groupId", () => {
+    for (const record of campaignRecords) {
+      expect(CAMPAIGN_GROUPS_BY_ID[record.groupId]).toBeDefined();
+    }
+  });
+
+  it("every record references a valid audienceId", () => {
+    for (const record of campaignRecords) {
+      expect(AUDIENCE_SEGMENTS_BY_ID[record.audienceId]).toBeDefined();
+    }
+  });
+
+  it("every record has at least one messageId", () => {
+    for (const record of campaignRecords) {
+      expect(record.messageIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every record has an ISO 8601 createdAt and updatedAt", () => {
+    const iso = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+    for (const record of campaignRecords) {
+      expect(record.createdAt).toMatch(iso);
+      expect(record.updatedAt).toMatch(iso);
+    }
+  });
+
+  it("every record belongs to a group that lists it", () => {
+    for (const record of campaignRecords) {
+      const group = CAMPAIGN_GROUPS_BY_ID[record.groupId];
+      expect(group.campaignIds).toContain(record.id);
+    }
+  });
+});
+
+describe("campaignMessageLinks fixture", () => {
+  it("every link references a valid campaignId", () => {
+    for (const link of campaignMessageLinks) {
+      expect(CAMPAIGN_RECORDS_BY_ID[link.campaignId]).toBeDefined();
+    }
+  });
+
+  it("every campaignRecord messageId has a corresponding link", () => {
+    for (const record of campaignRecords) {
+      for (const messageId of record.messageIds) {
+        const link = campaignMessageLinks.find(
+          (l) => l.campaignId === record.id && l.messageId === messageId,
+        );
+        expect(link).toBeDefined();
+      }
+    }
+  });
+
+  it("sequenceIndex values are non-negative integers", () => {
+    for (const link of campaignMessageLinks) {
+      expect(link.sequenceIndex).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(link.sequenceIndex)).toBe(true);
+    }
+  });
+
+  it("each campaign's links have unique sequenceIndex values", () => {
+    const byCampaign: Record<string, number[]> = {};
+    for (const link of campaignMessageLinks) {
+      (byCampaign[link.campaignId] ??= []).push(link.sequenceIndex);
+    }
+    for (const [campaignId, indices] of Object.entries(byCampaign)) {
+      expect(new Set(indices).size).toBe(indices.length);
+      void campaignId;
+    }
+  });
+});
+
+describe("campaignRelationshipExamples fixture", () => {
+  it("every example has a valid campaign, group, and non-empty audienceLabel", () => {
+    for (const example of campaignRelationshipExamples) {
+      expect(CAMPAIGN_RECORDS_BY_ID[example.campaign.id]).toBeDefined();
+      expect(CAMPAIGN_GROUPS_BY_ID[example.group.id]).toBeDefined();
+      expect(example.audienceLabel.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every example audienceSize is a positive integer", () => {
+    for (const example of campaignRelationshipExamples) {
+      expect(example.audienceSize).toBeGreaterThan(0);
+      expect(Number.isInteger(example.audienceSize)).toBe(true);
+    }
+  });
+
+  it("campaign and group IDs are consistent within each example", () => {
+    for (const example of campaignRelationshipExamples) {
+      expect(example.campaign.groupId).toBe(example.group.id);
+    }
+  });
+
+  it("message links in each example belong to the correct campaign", () => {
+    for (const example of campaignRelationshipExamples) {
+      for (const link of example.messageLinks) {
+        expect(link.campaignId).toBe(example.campaign.id);
+      }
+    }
+  });
+});

--- a/src/features/demo-admin-dashboard/docs/CAMPAIGN_TAXONOMY.md
+++ b/src/features/demo-admin-dashboard/docs/CAMPAIGN_TAXONOMY.md
@@ -1,0 +1,129 @@
+# Campaign Taxonomy
+
+Describes how campaign records, campaign groups, audiences, and demo messages
+relate inside the demo admin dashboard.
+
+All data is fake, deterministic, and safe for public repository review.
+
+---
+
+## Entity model
+
+```
+CampaignGroup
+  └── CampaignRecord (many per group)
+        ├── AudienceSegment (one per record, via audienceId)
+        └── CampaignMessageLink (one per message)
+              └── Demo message draft (identified by messageId)
+```
+
+### CampaignGroup
+
+A logical container for campaigns that share a common goal.
+
+| Field         | Type                    | Description                                      |
+|---------------|-------------------------|--------------------------------------------------|
+| `id`          | `string`                | Stable identifier (`group-onboarding`, etc.)     |
+| `name`        | `string`                | Display name shown in the admin dashboard        |
+| `description` | `string`                | Short summary of what this group covers          |
+| `category`    | `CampaignGroupCategory` | `onboarding \| newsletter \| security \| events \| operations` |
+| `campaignIds` | `string[]`              | Ordered IDs of the campaigns in this group       |
+
+### CampaignRecord
+
+The canonical demo campaign entity. One record per distinct campaign story.
+
+| Field         | Type                | Description                                           |
+|---------------|---------------------|-------------------------------------------------------|
+| `id`          | `string`            | Stable identifier (`camp-welcome`, etc.)              |
+| `name`        | `string`            | Display name shown in the campaign list               |
+| `description` | `string`            | Short summary of the campaign's purpose               |
+| `groupId`     | `string`            | ID of the parent `CampaignGroup`                      |
+| `audienceId`  | `AudienceSegmentId` | ID of the target `AudienceSegment`                    |
+| `status`      | `CampaignStatus`    | `active \| draft \| needs-review \| archived`         |
+| `tags`        | `string[]`          | Free-form labels for filtering (matches `CampaignTag` slugs) |
+| `messageIds`  | `string[]`          | Ordered draft message IDs attached to this campaign   |
+| `createdAt`   | `string`            | ISO 8601 timestamp (fake, deterministic)              |
+| `updatedAt`   | `string`            | ISO 8601 timestamp (fake, deterministic)              |
+
+Each `CampaignRecord` belongs to **exactly one** `CampaignGroup` and targets
+**exactly one** `AudienceSegment`. The group lists it in `campaignIds` and the
+record references back via `groupId` — both sides must agree.
+
+### AudienceSegment
+
+Defined in `types/audienceSegment.ts` and `fixtures/audienceSegmentFixtures.ts`.
+Campaigns reference segments by `AudienceSegmentId`:
+
+| ID                | Label             | Estimated size |
+|-------------------|-------------------|---------------|
+| `investors`       | Investors         | 340           |
+| `founders`        | Founders          | 210           |
+| `events`          | Event Attendees   | 580           |
+| `relay-operators` | Relay Operators   | 95            |
+| `unknown-senders` | Unknown Senders   | 1 200         |
+
+### CampaignMessageLink
+
+An explicit join between a `CampaignRecord` and a demo message draft.
+
+| Field           | Type                   | Description                                         |
+|-----------------|------------------------|-----------------------------------------------------|
+| `campaignId`    | `string`               | ID of the parent `CampaignRecord`                   |
+| `messageId`     | `string`               | ID of the demo message draft                        |
+| `role`          | `CampaignMessageRole`  | `primary \| followup \| notification`               |
+| `sequenceIndex` | `number`               | Zero-based position in the campaign message sequence|
+
+Message roles:
+- **primary** — the main campaign message (typically the first send).
+- **followup** — a subsequent message in a multi-step sequence.
+- **notification** — a transactional or triggered notice (not a marketing send).
+
+### CampaignRelationshipMap
+
+A pre-resolved snapshot that combines a campaign with its group, audience
+label, audience size, and message links. Used by admin panels to display
+the full picture without repeated lookups.
+
+---
+
+## Example relationship
+
+```
+CampaignGroup: "Onboarding Series" (group-onboarding)
+  │
+  ├── CampaignRecord: "Welcome Onboarding" (camp-welcome)
+  │     audienceId: founders  →  AudienceSegment "Founders" (est. 210)
+  │     messageIds: [msg-welcome-1, msg-welcome-2]
+  │       CampaignMessageLink { role: primary,   sequenceIndex: 0 } → msg-welcome-1
+  │       CampaignMessageLink { role: followup,  sequenceIndex: 1 } → msg-welcome-2
+  │
+  └── CampaignRecord: "Wallet Setup Prompt" (camp-wallet-setup)
+        audienceId: founders  →  AudienceSegment "Founders" (est. 210)
+        messageIds: [msg-wallet-1]
+          CampaignMessageLink { role: notification, sequenceIndex: 0 } → msg-wallet-1
+```
+
+---
+
+## Source files
+
+| Purpose              | File                                              |
+|----------------------|---------------------------------------------------|
+| Types                | `types/campaignTaxonomy.ts`                       |
+| Fixtures             | `fixtures/campaignTaxonomyFixtures.ts`            |
+| Tests                | `__tests__/campaignTaxonomy.test.ts`              |
+| Audience segments    | `types/audienceSegment.ts`, `fixtures/audienceSegmentFixtures.ts` |
+| Campaign status      | `types/campaignSnapshot.ts`                       |
+| Public exports       | `index.ts`                                        |
+
+---
+
+## Safety notes
+
+- All `messageId` values in fixtures are demo identifiers.
+  They do not reference real inbox messages or production mail records.
+- All recipient hints in associated message drafts use reserved domains
+  (`*.stealth.demo`, `example.com`, `example.org`).
+- `audienceSize` values are fake estimates for display only.
+- No live network calls, real wallet addresses, or real user data appear here.

--- a/src/features/demo-admin-dashboard/fixtures/campaignTaxonomyFixtures.ts
+++ b/src/features/demo-admin-dashboard/fixtures/campaignTaxonomyFixtures.ts
@@ -1,0 +1,189 @@
+import type {
+  CampaignGroup,
+  CampaignMessageLink,
+  CampaignRecord,
+  CampaignRelationshipMap,
+} from "../types/campaignTaxonomy";
+
+// ---------------------------------------------------------------------------
+// Campaign Groups
+// ---------------------------------------------------------------------------
+
+export const campaignGroups: CampaignGroup[] = [
+  {
+    id: "group-onboarding",
+    name: "Onboarding Series",
+    description:
+      "Campaigns sent to newly registered accounts to introduce Stealth features and Stellar wallet setup.",
+    category: "onboarding",
+    campaignIds: ["camp-welcome", "camp-wallet-setup"],
+  },
+  {
+    id: "group-newsletter",
+    name: "Protocol Newsletter",
+    description:
+      "Monthly and quarterly digests keeping investors, founders, and relay operators up to date on protocol progress.",
+    category: "newsletter",
+    campaignIds: ["camp-investor-q3", "camp-relay-digest"],
+  },
+  {
+    id: "group-security",
+    name: "Security Notices",
+    description:
+      "Transactional security alerts triggered by policy changes, new-device logins, or passphrase confirmation requests.",
+    category: "security",
+    campaignIds: ["camp-passphrase-confirm", "camp-cold-outreach-notice"],
+  },
+  {
+    id: "group-events",
+    name: "Event Outreach",
+    description:
+      "Pre-event and post-event communication for Stellar ecosystem conferences and Stealth booth presence.",
+    category: "events",
+    campaignIds: ["camp-summit-invite"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Campaign Records
+// ---------------------------------------------------------------------------
+
+export const campaignRecords: CampaignRecord[] = [
+  {
+    id: "camp-welcome",
+    name: "Welcome Onboarding",
+    description: "Two-message intro sequence sent to every new Stealth account on signup.",
+    groupId: "group-onboarding",
+    audienceId: "founders",
+    status: "active",
+    tags: ["onboarding", "welcome"],
+    messageIds: ["msg-welcome-1", "msg-welcome-2"],
+    createdAt: "2026-06-01T08:00:00Z",
+    updatedAt: "2026-06-17T10:00:00Z",
+  },
+  {
+    id: "camp-wallet-setup",
+    name: "Wallet Setup Prompt",
+    description: "Follow-up message sent 48 hours after signup if the user has not linked a Stellar wallet.",
+    groupId: "group-onboarding",
+    audienceId: "founders",
+    status: "draft",
+    tags: ["onboarding", "stellar"],
+    messageIds: ["msg-wallet-1"],
+    createdAt: "2026-06-01T08:30:00Z",
+    updatedAt: "2026-06-14T09:00:00Z",
+  },
+  {
+    id: "camp-investor-q3",
+    name: "Q3 Investor Update",
+    description: "Quarterly progress report covering relay expansion, postage latency improvements, and mailbox growth.",
+    groupId: "group-newsletter",
+    audienceId: "investors",
+    status: "draft",
+    tags: ["newsletter", "announcement"],
+    messageIds: ["msg-investor-q3-1"],
+    createdAt: "2026-06-10T09:00:00Z",
+    updatedAt: "2026-06-17T10:00:00Z",
+  },
+  {
+    id: "camp-relay-digest",
+    name: "Relay Operator Digest",
+    description: "Monthly operational summary for active relay node operators covering uptime, earnings, and protocol changes.",
+    groupId: "group-newsletter",
+    audienceId: "relay-operators",
+    status: "needs-review",
+    tags: ["newsletter", "stellar", "announcement"],
+    messageIds: ["msg-relay-digest-1"],
+    createdAt: "2026-06-05T08:00:00Z",
+    updatedAt: "2026-06-15T08:00:00Z",
+  },
+  {
+    id: "camp-passphrase-confirm",
+    name: "Passphrase Confirmation",
+    description: "Security alert requesting passphrase confirmation when a new device login is detected.",
+    groupId: "group-security",
+    audienceId: "founders",
+    status: "active",
+    tags: ["security", "alert"],
+    messageIds: ["msg-passphrase-1"],
+    createdAt: "2026-06-01T07:00:00Z",
+    updatedAt: "2026-06-15T09:30:00Z",
+  },
+  {
+    id: "camp-cold-outreach-notice",
+    name: "Cold Outreach Policy Notice",
+    description: "Automated notice sent to unknown senders explaining postage verification requirements.",
+    groupId: "group-security",
+    audienceId: "unknown-senders",
+    status: "draft",
+    tags: ["security", "alert"],
+    messageIds: ["msg-cold-outreach-1"],
+    createdAt: "2026-06-01T07:30:00Z",
+    updatedAt: "2026-06-14T16:00:00Z",
+  },
+  {
+    id: "camp-summit-invite",
+    name: "Stellar Summit Invite",
+    description: "Event invitation and logistics digest for registered Stellar Summit 2026 attendees.",
+    groupId: "group-events",
+    audienceId: "events",
+    status: "active",
+    tags: ["announcement", "marketing"],
+    messageIds: ["msg-summit-1"],
+    createdAt: "2026-06-08T10:00:00Z",
+    updatedAt: "2026-06-16T14:00:00Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Campaign Message Links
+// ---------------------------------------------------------------------------
+
+export const campaignMessageLinks: CampaignMessageLink[] = [
+  { campaignId: "camp-welcome", messageId: "msg-welcome-1", role: "primary", sequenceIndex: 0 },
+  { campaignId: "camp-welcome", messageId: "msg-welcome-2", role: "followup", sequenceIndex: 1 },
+  { campaignId: "camp-wallet-setup", messageId: "msg-wallet-1", role: "notification", sequenceIndex: 0 },
+  { campaignId: "camp-investor-q3", messageId: "msg-investor-q3-1", role: "primary", sequenceIndex: 0 },
+  { campaignId: "camp-relay-digest", messageId: "msg-relay-digest-1", role: "primary", sequenceIndex: 0 },
+  { campaignId: "camp-passphrase-confirm", messageId: "msg-passphrase-1", role: "notification", sequenceIndex: 0 },
+  { campaignId: "camp-cold-outreach-notice", messageId: "msg-cold-outreach-1", role: "notification", sequenceIndex: 0 },
+  { campaignId: "camp-summit-invite", messageId: "msg-summit-1", role: "primary", sequenceIndex: 0 },
+];
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+export const CAMPAIGN_GROUPS_BY_ID: Record<string, CampaignGroup> = Object.fromEntries(
+  campaignGroups.map((g) => [g.id, g]),
+);
+
+export const CAMPAIGN_RECORDS_BY_ID: Record<string, CampaignRecord> = Object.fromEntries(
+  campaignRecords.map((r) => [r.id, r]),
+);
+
+// ---------------------------------------------------------------------------
+// Relationship map examples
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-resolved relationship maps for the two primary active campaigns.
+ * These illustrate how campaign records, groups, audiences, and messages
+ * connect without requiring a runtime join.
+ */
+export const campaignRelationshipExamples: CampaignRelationshipMap[] = [
+  {
+    campaign: CAMPAIGN_RECORDS_BY_ID["camp-welcome"],
+    group: CAMPAIGN_GROUPS_BY_ID["group-onboarding"],
+    audienceLabel: "Founders",
+    audienceSize: 210,
+    messageLinks: campaignMessageLinks.filter((l) => l.campaignId === "camp-welcome"),
+  },
+  {
+    campaign: CAMPAIGN_RECORDS_BY_ID["camp-summit-invite"],
+    group: CAMPAIGN_GROUPS_BY_ID["group-events"],
+    audienceLabel: "Event Attendees",
+    audienceSize: 580,
+    messageLinks: campaignMessageLinks.filter((l) => l.campaignId === "camp-summit-invite"),
+  },
+];

--- a/src/features/demo-admin-dashboard/index.ts
+++ b/src/features/demo-admin-dashboard/index.ts
@@ -48,6 +48,24 @@ export type {
 export type { CampaignSnapshot } from "./types/campaignSnapshot";
 export type { CampaignTag, TagColorKey } from "./types/campaignTag";
 
+// Campaign taxonomy: records, groups, audiences, message links (issue #252)
+export type {
+  CampaignGroup,
+  CampaignGroupCategory,
+  CampaignMessageLink,
+  CampaignMessageRole,
+  CampaignRecord,
+  CampaignRelationshipMap,
+} from "./types/campaignTaxonomy";
+export {
+  CAMPAIGN_GROUPS_BY_ID,
+  CAMPAIGN_RECORDS_BY_ID,
+  campaignGroups,
+  campaignMessageLinks,
+  campaignRecords,
+  campaignRelationshipExamples,
+} from "./fixtures/campaignTaxonomyFixtures";
+
 export type {
   DemoAttachment,
   DemoCalendarEvent,

--- a/src/features/demo-admin-dashboard/types/campaignTaxonomy.ts
+++ b/src/features/demo-admin-dashboard/types/campaignTaxonomy.ts
@@ -1,0 +1,75 @@
+import type { AudienceSegmentId } from "./audienceSegment";
+import type { CampaignStatus } from "./campaignSnapshot";
+
+/** Top-level categories used to classify demo campaign groups. */
+export type CampaignGroupCategory =
+  | "onboarding"
+  | "newsletter"
+  | "security"
+  | "events"
+  | "operations";
+
+/**
+ * A logical grouping of related demo campaigns.
+ * Groups collect campaigns that share a common goal so maintainers
+ * can review related campaign records side by side.
+ */
+export interface CampaignGroup {
+  id: string;
+  name: string;
+  description: string;
+  category: CampaignGroupCategory;
+  /** Ordered campaign IDs belonging to this group. */
+  campaignIds: string[];
+}
+
+/**
+ * The canonical demo campaign record.
+ * Represents a single distinct campaign story in the admin dashboard.
+ * A campaign belongs to exactly one group and targets one audience segment.
+ */
+export interface CampaignRecord {
+  id: string;
+  name: string;
+  description: string;
+  /** References the CampaignGroup this campaign belongs to. */
+  groupId: string;
+  /** References the AudienceSegment this campaign targets. */
+  audienceId: AudienceSegmentId;
+  status: CampaignStatus;
+  tags: string[];
+  /** Ordered IDs of demo message drafts attached to this campaign. */
+  messageIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Describes the role a demo message plays within a campaign sequence. */
+export type CampaignMessageRole = "primary" | "followup" | "notification";
+
+/**
+ * An explicit link between a campaign record and a demo message draft.
+ * Captures why the message was attached and its position in the sequence.
+ */
+export interface CampaignMessageLink {
+  campaignId: string;
+  messageId: string;
+  role: CampaignMessageRole;
+  /** Zero-based position within the campaign message sequence. */
+  sequenceIndex: number;
+}
+
+/**
+ * The fully resolved relationship view for a single campaign.
+ * Used by admin panels to render a campaign alongside its group,
+ * audience, and messages without repeated lookups.
+ */
+export interface CampaignRelationshipMap {
+  campaign: CampaignRecord;
+  group: CampaignGroup;
+  /** Human-readable audience label resolved from the AudienceSegment. */
+  audienceLabel: string;
+  /** Estimated audience size for display purposes. */
+  audienceSize: number;
+  messageLinks: CampaignMessageLink[];
+}


### PR DESCRIPTION
## Summary

- Adds `CampaignGroup`, `CampaignRecord`, `CampaignMessageLink`, and `CampaignRelationshipMap` types under `types/campaignTaxonomy.ts`
- Adds deterministic fixtures covering 4 campaign groups, 7 campaign records across 5 audience segments, and 8 message links in `fixtures/campaignTaxonomyFixtures.ts`
- Adds 17 relationship-integrity tests in `__tests__/campaignTaxonomy.test.ts` (all passing)
- Adds `docs/CAMPAIGN_TAXONOMY.md` with entity model, field tables, and an example relationship tree
- Exports all new types and fixtures from `index.ts`

All data is fake, deterministic, and safe for public review. No files outside `src/features/demo-admin-dashboard/` were changed.

## Test plan

- [x] `npx vitest run src/features/demo-admin-dashboard/__tests__/campaignTaxonomy.test.ts` — 17/17 pass
- [x] No modifications to inbox, reader, calendar, sender policy, protocol, or API files

Closes #252