### PR TITLE
Add email ownership tracker test documentation

### DIFF
--- a/tools/v1/team/email-ownership-tracker/docs/KNOWN_LIMITATIONS.md
+++ b/tools/v1/team/email-ownership-tracker/docs/KNOWN_LIMITATIONS.md
@@ -1,0 +1,12 @@
+# Email Ownership Tracker Known Limitations
+
+- No main application integration is included.
+- No durable storage adapter is included.
+- No conflict resolver is included for simultaneous claim attempts.
+- No role-based permission model is included.
+- No external notification, escalation delivery, or SLA engine is included.
+- No production inbox data, message body rendering, attachment processing, or wallet access is used.
+- Fixtures are synthetic and intended for local review only.
+
+Future issues should define these behaviors explicitly before mounting the tool or connecting it to
+live inbox data.

--- a/tools/v1/team/email-ownership-tracker/docs/TEST_PLAN.md
+++ b/tools/v1/team/email-ownership-tracker/docs/TEST_PLAN.md
@@ -1,0 +1,53 @@
+# Email Ownership Tracker Test Plan
+
+## Scope
+
+This test plan covers the isolated Email Ownership Tracker tool under:
+
+```text
+tools/v1/team/email-ownership-tracker/
+```
+
+The tool is reviewed independently. Tests must not require the main app shell, routing, wallet,
+Stellar core, database, production inbox data, or shared design system integration.
+
+## Core Behavior Coverage
+
+When services are present, folder-local tests should cover:
+
+- ownership event validation for required IDs, actors, owners, actions, and timestamps
+- chronological timeline construction from unordered events
+- current owner derivation after claim, release, reassignment, and escalation events
+- duplicate or conflicting ownership attempts
+- malformed addresses, unsupported actions, invalid timestamps, and oversized notes
+- empty histories and large-history batch limits
+
+## UI And Accessibility Coverage
+
+When components are present, folder-local tests or manual review notes should cover:
+
+- empty, loading, error, and success states
+- keyboard access for claim, release, reassign, open message, and escalation controls
+- accessible labels for repeated action buttons
+- visible focus states on message rows and action groups
+- ownership state represented by text, not color alone
+
+## Documentation Contract Coverage
+
+The documentation contract test verifies that:
+
+- setup, usage, fixtures, known limitations, and review checklist docs exist
+- fixture data is synthetic and uses `.test` addresses
+- docs state that app-wide integration is out of scope
+- docs include contributor commands for local validation
+- docs avoid generated template residue and sensitive-field examples
+
+## Contributor Validation Commands
+
+```bash
+node tools/v1/team/email-ownership-tracker/tests/documentation-contract.test.mjs
+git diff --check
+git diff --name-only
+```
+
+If service or UI tests are added later, include their exact commands in this document.

--- a/tools/v1/team/email-ownership-tracker/docs/USAGE.md
+++ b/tools/v1/team/email-ownership-tracker/docs/USAGE.md
@@ -1,0 +1,38 @@
+# Email Ownership Tracker Usage Notes
+
+## Local Setup
+
+No app-wide setup is required for this isolated documentation and fixture slice. Reviewers can read
+the tool docs and run the folder-local Node test directly from the repository root:
+
+```bash
+node tools/v1/team/email-ownership-tracker/tests/documentation-contract.test.mjs
+```
+
+Future service or UI work may add local package scripts, but it must stay inside this tool folder.
+
+## Review Fixture
+
+The fixture at `fixtures/sample-ownership-history.json` models a synthetic shared inbox history:
+
+- one message is claimed and reassigned
+- one message is claimed and escalated
+- one message is claimed and released
+- all addresses use `.test` domains
+- no production mail, credentials, secrets, payment data, or local user data is included
+
+## Expected Workflow
+
+1. Load sanitized ownership events from a future integration adapter or local fixture.
+2. Validate event IDs, message IDs, actors, owners, timestamps, and actions.
+3. Build a chronological ownership history per message.
+4. Derive the current owner and handoff count for each message.
+5. Render or review the derived state without mutating source mail records.
+
+## Review Checklist
+
+- All changed files stay under `tools/v1/team/email-ownership-tracker/`.
+- Tests or test plans are folder-local.
+- Fixtures are deterministic and synthetic.
+- Known limitations are documented before integration.
+- No main app shell, routing, wallet, Stellar core, database, or shared design system files change.

--- a/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-history.json
+++ b/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-history.json
@@ -1,0 +1,74 @@
+{
+  "messages": [
+    {
+      "messageId": "msg-history-001",
+      "sharedInboxAddress": "support@team.test",
+      "subject": "Account recovery request",
+      "events": [
+        {
+          "eventId": "event-history-001-a",
+          "action": "claimed",
+          "actorAddress": "alice@team.test",
+          "ownerAddress": "alice@team.test",
+          "occurredAt": "2026-06-23T08:00:00.000Z",
+          "note": "Initial owner from support queue."
+        },
+        {
+          "eventId": "event-history-001-b",
+          "action": "reassigned",
+          "actorAddress": "alice@team.test",
+          "previousOwnerAddress": "alice@team.test",
+          "ownerAddress": "riley@team.test",
+          "occurredAt": "2026-06-23T08:45:00.000Z",
+          "note": "Handoff to recovery specialist."
+        }
+      ]
+    },
+    {
+      "messageId": "msg-history-002",
+      "sharedInboxAddress": "ops@team.test",
+      "subject": "Relay configuration question",
+      "events": [
+        {
+          "eventId": "event-history-002-a",
+          "action": "claimed",
+          "actorAddress": "jordan@team.test",
+          "ownerAddress": "jordan@team.test",
+          "occurredAt": "2026-06-23T09:10:00.000Z",
+          "note": "Operations owner assigned."
+        },
+        {
+          "eventId": "event-history-002-b",
+          "action": "escalated",
+          "actorAddress": "jordan@team.test",
+          "ownerAddress": "jordan@team.test",
+          "occurredAt": "2026-06-23T09:25:00.000Z",
+          "note": "Needs rotation review."
+        }
+      ]
+    },
+    {
+      "messageId": "msg-history-003",
+      "sharedInboxAddress": "billing@team.test",
+      "subject": "Billing contact update",
+      "events": [
+        {
+          "eventId": "event-history-003-a",
+          "action": "claimed",
+          "actorAddress": "taylor@team.test",
+          "ownerAddress": "taylor@team.test",
+          "occurredAt": "2026-06-23T07:30:00.000Z",
+          "note": "Billing owner assigned."
+        },
+        {
+          "eventId": "event-history-003-b",
+          "action": "released",
+          "actorAddress": "taylor@team.test",
+          "previousOwnerAddress": "taylor@team.test",
+          "occurredAt": "2026-06-23T08:05:00.000Z",
+          "note": "Resolved; owner released."
+        }
+      ]
+    }
+  ]
+}

--- a/tools/v1/team/email-ownership-tracker/tests/documentation-contract.test.mjs
+++ b/tools/v1/team/email-ownership-tracker/tests/documentation-contract.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("documentation covers setup, usage, fixtures, limitations, and review commands", async () => {
+  const testPlan = await readToolFile("docs/TEST_PLAN.md");
+  const usage = await readToolFile("docs/USAGE.md");
+  const limitations = await readToolFile("docs/KNOWN_LIMITATIONS.md");
+
+  for (const term of ["Core Behavior Coverage", "UI And Accessibility Coverage", "Contributor Validation Commands"]) {
+    assert.match(testPlan, new RegExp(term));
+  }
+
+  for (const term of ["Local Setup", "Review Fixture", "Expected Workflow", "Review Checklist"]) {
+    assert.match(usage, new RegExp(term));
+  }
+
+  assert.match(limitations, /No main application integration is included/);
+  assert.match(limitations, /No production inbox data/);
+});
+
+test("fixture models claim, release, reassignment, and escalation scenarios", async () => {
+  const fixture = JSON.parse(await readToolFile("fixtures/sample-ownership-history.json"));
+  const actions = new Set(
+    fixture.messages.flatMap((message) => message.events.map((event) => event.action)),
+  );
+
+  for (const action of ["claimed", "released", "reassigned", "escalated"]) {
+    assert.ok(actions.has(action), `fixture should include ${action}`);
+  }
+
+  assert.equal(fixture.messages.length, 3);
+});
+
+test("fixture remains synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readToolFile("fixtures/sample-ownership-history.json");
+  const fixture = JSON.parse(fixtureText);
+
+  assert.equal(
+    fixture.messages.every((message) => message.sharedInboxAddress.endsWith(".test")),
+    true,
+  );
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});
+
+test("documentation states isolation from app-wide systems", async () => {
+  const combined = [
+    await readToolFile("docs/TEST_PLAN.md"),
+    await readToolFile("docs/USAGE.md"),
+    await readToolFile("docs/KNOWN_LIMITATIONS.md"),
+  ].join("\n");
+
+  for (const boundary of [
+    "main app shell",
+    "routing",
+    "wallet",
+    "Stellar core",
+    "database",
+    "shared design system",
+  ]) {
+    assert.match(combined, new RegExp(boundary, "i"));
+  }
+});
+
+test("documentation avoids generated template residue", async () => {
+  const combined = [
+    await readToolFile("docs/TEST_PLAN.md"),
+    await readToolFile("docs/USAGE.md"),
+    await readToolFile("docs/KNOWN_LIMITATIONS.md"),
+  ].join("\n");
+
+  assert.doesNotMatch(combined, /System\.Collections|Set-Content|@\s*\||\$dir|\$\(.*\)/);
+});


### PR DESCRIPTION
## Summary
- add folder-local Email Ownership Tracker test plan, usage notes, known limitations, and synthetic ownership history fixture
- document independent review steps, fixture expectations, and app-wide isolation constraints
- add a documentation contract test covering setup, usage, fixtures, limitations, review commands, and synthetic data safety

Closes #

## Tests
- node tools\v1\team\email-ownership-tracker\tests\documentation-contract.test.mjs
- git diff --cached --check