### PR TITLE
docs(team-payment-approval): link and close issue #696

### DIFF
--- a/tools/v2/team/team-payment-approval/DELIVERY.md
+++ b/tools/v2/team/team-payment-approval/DELIVERY.md
@@ -439,3 +439,12 @@ These will be handled by **separate follow-up issues** after this UI work is val
 ✅ **Ready for review and testing!**
 
 The Team Payment Approval tool is now a **complete, self-contained, accessible UI** ready for isolated validation and future integration.
+
+---
+
+## Issue Linkage Note
+
+The original delivery PR (#781) merged the full tool, but its description referenced the
+issue with `for #696` rather than a GitHub closing keyword, so the issue was not
+auto-closed or linked on merge. This follow-up records the completed linkage so that
+issue #696 is closed by a merged pull request.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #781, which delivered the Team Payment Approval UI and accessibility surface but referenced the issue with `for #696` instead of a closing keyword. As a result, issue #696 was never auto-closed or linked to a merged PR.

This PR adds a short **Issue Linkage Note** to the tool's `DELIVERY.md` and uses the closing keyword so the issue is closed by a merged pull request.

## Changes

- `tools/v2/team/team-payment-approval/DELIVERY.md` — add issue linkage note.

## Scope

- Single file changed, entirely within `tools/v2/team/team-payment-approval/`.
- No changes to the main app shell, routing, design system, or any shared infrastructure.
- Documentation-only; no code or behavior changes.

Closes #696