### PR TITLE
Add internal comment thread core service

### DIFF
--- a/tools/v1/team/internal-comment-thread/docs/SERVICE_CONTRACT.md
+++ b/tools/v1/team/internal-comment-thread/docs/SERVICE_CONTRACT.md
@@ -1,0 +1,56 @@
+# Internal Comment Thread Service Contract
+
+## Inputs
+
+The folder-local service accepts:
+
+- `teamRoster`: authorized team addresses
+- `target`: `{ kind: "message" | "thread", id: string }`
+- `author`: authorized team member address
+- `body`: team-only comment text
+- optional `createdAt` timestamp for deterministic tests
+
+All values are treated as untrusted until normalized by the service.
+
+## Outputs
+
+`addComment`, `listComments`, and `updateComment` return internal comment records with:
+
+- `id`
+- `target`
+- `author`
+- `body`
+- `createdAt`
+- `updatedAt`
+- `deletedAt`
+- `visibility: "team-only"`
+
+`deleteComment` soft-deletes a comment so regular lists omit it. `buildExternalSafeSummary`
+returns only target metadata, internal comment count, and latest internal comment timestamp. It
+never includes comment body text.
+
+## Loading and Error States
+
+The service is synchronous and pure. Future hooks should represent:
+
+- `loading`: caller is fetching sanitized target metadata or comments from a future adapter
+- `ready`: comments were normalized and listed successfully
+- `empty`: no comments exist for the selected target
+- `error`: `InternalCommentError` describes validation, authorization, or ownership failure
+
+The service does not fetch, persist, retry, schedule work, write logs, or call external delivery
+paths.
+
+## Non-Negotiable Visibility Rule
+
+Internal comment body text must never appear in any external reply, forward, notification, header,
+log, or payload. External-facing helpers may expose counts and timestamps only.
+
+## Safety And Performance
+
+- Only authorized team roster members can add, update, or delete comments.
+- Authors can update and delete their own comments only.
+- Message and thread targets remain isolated by target kind and ID.
+- Comment bodies are bounded to 4,000 characters.
+- Each target is capped at 500 active comments for the local in-memory reference behavior.
+- Fixtures use `.test` domains and synthetic IDs only.

--- a/tools/v1/team/internal-comment-thread/fixtures/sample-comments.json
+++ b/tools/v1/team/internal-comment-thread/fixtures/sample-comments.json
@@ -1,0 +1,48 @@
+{
+  "teamRoster": [
+    "alice@team.test",
+    "bob@team.test",
+    "carol@team.test"
+  ],
+  "messageTarget": {
+    "kind": "message",
+    "id": "msg-internal-001"
+  },
+  "threadTarget": {
+    "kind": "thread",
+    "id": "thread-internal-001"
+  },
+  "comments": [
+    {
+      "id": "comment-001",
+      "target": {
+        "kind": "message",
+        "id": "msg-internal-001"
+      },
+      "author": "alice@team.test",
+      "body": "Customer mentioned an old support case. Keep this note internal.",
+      "createdAt": "2026-06-23T09:00:00.000Z"
+    },
+    {
+      "id": "comment-002",
+      "target": {
+        "kind": "message",
+        "id": "msg-internal-001"
+      },
+      "author": "bob@team.test",
+      "body": "I checked the team record and the previous workaround still applies.",
+      "createdAt": "2026-06-23T09:05:00.000Z"
+    },
+    {
+      "id": "comment-003",
+      "target": {
+        "kind": "thread",
+        "id": "thread-internal-001"
+      },
+      "author": "carol@team.test",
+      "body": "Thread-level note for the weekly operations review.",
+      "createdAt": "2026-06-23T09:10:00.000Z"
+    }
+  ],
+  "externalSenderAddress": "customer@example.test"
+}

--- a/tools/v1/team/internal-comment-thread/index.mjs
+++ b/tools/v1/team/internal-comment-thread/index.mjs
@@ -1,0 +1,8 @@
+export {
+  COMMENT_LIMITS,
+  InternalCommentError,
+  createInternalCommentService,
+  normalizeCommentTarget,
+  normalizeTeamAddress,
+  sanitizeCommentText,
+} from "./services/internal-comment-service.mjs";

--- a/tools/v1/team/internal-comment-thread/services/internal-comment-service.mjs
+++ b/tools/v1/team/internal-comment-thread/services/internal-comment-service.mjs
@@ -1,0 +1,219 @@
+export const COMMENT_LIMITS = Object.freeze({
+  maxBodyLength: 4_000,
+  maxCommentsPerTarget: 500,
+  maxTargetIdLength: 160,
+});
+
+const TARGET_KINDS = new Set(["message", "thread"]);
+
+export class InternalCommentError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "InternalCommentError";
+    this.details = details;
+  }
+}
+
+export function sanitizeCommentText(value, fieldName, options = {}) {
+  const { maxLength = 1_000, required = true } = options;
+
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new InternalCommentError(`${fieldName} is required`, { fieldName });
+    }
+
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    throw new InternalCommentError(`${fieldName} must be a string`, { fieldName });
+  }
+
+  const normalized = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trim();
+
+  if (required && normalized === "") {
+    throw new InternalCommentError(`${fieldName} cannot be empty`, { fieldName });
+  }
+
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
+}
+
+export function normalizeTeamAddress(value, fieldName) {
+  const address = sanitizeCommentText(value, fieldName, { maxLength: 320 }).toLowerCase();
+
+  if (!/^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(address)) {
+    throw new InternalCommentError(`${fieldName} must be a valid team address`, { fieldName });
+  }
+
+  return address;
+}
+
+export function normalizeCommentTarget(target) {
+  if (!target || typeof target !== "object") {
+    throw new InternalCommentError("comment target is required");
+  }
+
+  const kind = sanitizeCommentText(target.kind, "target.kind", { maxLength: 32 });
+
+  if (!TARGET_KINDS.has(kind)) {
+    throw new InternalCommentError("target kind is not supported", { kind });
+  }
+
+  return {
+    kind,
+    id: sanitizeCommentText(target.id, "target.id", {
+      maxLength: COMMENT_LIMITS.maxTargetIdLength,
+    }),
+  };
+}
+
+function targetKey(target) {
+  return `${target.kind}:${target.id}`;
+}
+
+function normalizeRoster(roster) {
+  if (!Array.isArray(roster)) {
+    throw new InternalCommentError("team roster must be an array");
+  }
+
+  return new Set(roster.map((member) => normalizeTeamAddress(member, "teamRoster[]")));
+}
+
+function assertAuthorized(author, teamRoster) {
+  const normalizedAuthor = normalizeTeamAddress(author, "author");
+
+  if (!teamRoster.has(normalizedAuthor)) {
+    throw new InternalCommentError("author is not authorized for this internal thread", {
+      author: normalizedAuthor,
+    });
+  }
+
+  return normalizedAuthor;
+}
+
+export function createInternalCommentService(options = {}) {
+  const teamRoster = normalizeRoster(options.teamRoster ?? []);
+  const now = options.now ?? (() => new Date().toISOString());
+  const commentsById = new Map();
+  let sequence = 0;
+
+  function nextId() {
+    sequence += 1;
+    return `internal-comment-${String(sequence).padStart(4, "0")}`;
+  }
+
+  function addComment(input) {
+    if (!input || typeof input !== "object") {
+      throw new InternalCommentError("comment input is required");
+    }
+
+    const target = normalizeCommentTarget(input.target);
+    const author = assertAuthorized(input.author, teamRoster);
+    const activeForTarget = listComments(target);
+
+    if (activeForTarget.length >= COMMENT_LIMITS.maxCommentsPerTarget) {
+      throw new InternalCommentError("comment target has reached the local comment limit", {
+        maxCommentsPerTarget: COMMENT_LIMITS.maxCommentsPerTarget,
+      });
+    }
+
+    const createdAt = input.createdAt
+      ? new Date(sanitizeCommentText(input.createdAt, "createdAt", { maxLength: 64 })).toISOString()
+      : now();
+
+    if (Number.isNaN(new Date(createdAt).getTime())) {
+      throw new InternalCommentError("createdAt must be a valid ISO timestamp");
+    }
+
+    const comment = {
+      id: input.id ? sanitizeCommentText(input.id, "id", { maxLength: 160 }) : nextId(),
+      target,
+      author,
+      body: sanitizeCommentText(input.body, "body", {
+        maxLength: COMMENT_LIMITS.maxBodyLength,
+      }),
+      createdAt,
+      updatedAt: null,
+      deletedAt: null,
+      visibility: "team-only",
+    };
+
+    commentsById.set(comment.id, comment);
+    return { ...comment, target: { ...comment.target } };
+  }
+
+  function listComments(target) {
+    const normalizedTarget = normalizeCommentTarget(target);
+    const key = targetKey(normalizedTarget);
+
+    return [...commentsById.values()]
+      .filter((comment) => targetKey(comment.target) === key && !comment.deletedAt)
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      .map((comment) => ({ ...comment, target: { ...comment.target } }));
+  }
+
+  function updateComment(id, body, author) {
+    const commentId = sanitizeCommentText(id, "id", { maxLength: 160 });
+    const normalizedAuthor = assertAuthorized(author, teamRoster);
+    const existing = commentsById.get(commentId);
+
+    if (!existing || existing.deletedAt) {
+      throw new InternalCommentError("comment was not found", { id: commentId });
+    }
+
+    if (existing.author !== normalizedAuthor) {
+      throw new InternalCommentError("only the author can update this comment", {
+        id: commentId,
+      });
+    }
+
+    const updated = {
+      ...existing,
+      body: sanitizeCommentText(body, "body", { maxLength: COMMENT_LIMITS.maxBodyLength }),
+      updatedAt: now(),
+    };
+
+    commentsById.set(commentId, updated);
+    return { ...updated, target: { ...updated.target } };
+  }
+
+  function deleteComment(id, author) {
+    const commentId = sanitizeCommentText(id, "id", { maxLength: 160 });
+    const normalizedAuthor = assertAuthorized(author, teamRoster);
+    const existing = commentsById.get(commentId);
+
+    if (!existing || existing.deletedAt) {
+      throw new InternalCommentError("comment was not found", { id: commentId });
+    }
+
+    if (existing.author !== normalizedAuthor) {
+      throw new InternalCommentError("only the author can delete this comment", {
+        id: commentId,
+      });
+    }
+
+    commentsById.set(commentId, {
+      ...existing,
+      deletedAt: now(),
+    });
+  }
+
+  function buildExternalSafeSummary(target) {
+    const comments = listComments(target);
+
+    return {
+      target: normalizeCommentTarget(target),
+      internalCommentCount: comments.length,
+      latestInternalCommentAt: comments.at(-1)?.createdAt ?? null,
+      commentBodiesIncluded: false,
+    };
+  }
+
+  return {
+    addComment,
+    listComments,
+    updateComment,
+    deleteComment,
+    buildExternalSafeSummary,
+  };
+}

--- a/tools/v1/team/internal-comment-thread/tests/internal-comment-service.test.mjs
+++ b/tools/v1/team/internal-comment-thread/tests/internal-comment-service.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  COMMENT_LIMITS,
+  InternalCommentError,
+  createInternalCommentService,
+  normalizeCommentTarget,
+  normalizeTeamAddress,
+  sanitizeCommentText,
+} from "../index.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(__dirname, "../fixtures/sample-comments.json");
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+
+function createService() {
+  return createInternalCommentService({
+    teamRoster: fixture.teamRoster,
+    now: () => "2026-06-23T10:00:00.000Z",
+  });
+}
+
+test("sanitizes comment text and bounds body length", () => {
+  assert.equal(sanitizeCommentText("  hello\u0000 team  ", "body"), "hello team");
+  assert.equal(sanitizeCommentText("abcdef", "body", { maxLength: 4 }), "abc…");
+});
+
+test("normalizes team addresses and comment targets", () => {
+  assert.equal(normalizeTeamAddress("Alice@Team.Test", "author"), "alice@team.test");
+  assert.deepEqual(normalizeCommentTarget({ kind: "message", id: " msg-1 " }), {
+    kind: "message",
+    id: "msg-1",
+  });
+});
+
+test("rejects unsupported target kinds and unauthorized authors", () => {
+  const service = createService();
+
+  assert.throws(
+    () => normalizeCommentTarget({ kind: "conversation", id: "x" }),
+    InternalCommentError,
+  );
+  assert.throws(
+    () => service.addComment({ ...fixture.comments[0], author: "eve@example.test" }),
+    InternalCommentError,
+  );
+});
+
+test("adds and lists message comments in chronological order", () => {
+  const service = createService();
+
+  service.addComment(fixture.comments[1]);
+  service.addComment(fixture.comments[0]);
+  const comments = service.listComments(fixture.messageTarget);
+
+  assert.deepEqual(
+    comments.map((comment) => comment.id),
+    ["comment-001", "comment-002"],
+  );
+  assert.equal(comments[0].visibility, "team-only");
+});
+
+test("keeps message and thread targets isolated", () => {
+  const service = createService();
+
+  for (const comment of fixture.comments) {
+    service.addComment(comment);
+  }
+
+  assert.deepEqual(
+    service.listComments(fixture.messageTarget).map((comment) => comment.id),
+    ["comment-001", "comment-002"],
+  );
+  assert.deepEqual(
+    service.listComments(fixture.threadTarget).map((comment) => comment.id),
+    ["comment-003"],
+  );
+});
+
+test("allows authors to update their own comments", () => {
+  const service = createService();
+  service.addComment(fixture.comments[0]);
+
+  const updated = service.updateComment("comment-001", "Updated internal note", "alice@team.test");
+
+  assert.equal(updated.body, "Updated internal note");
+  assert.equal(updated.updatedAt, "2026-06-23T10:00:00.000Z");
+});
+
+test("rejects update and delete attempts from other team members", () => {
+  const service = createService();
+  service.addComment(fixture.comments[0]);
+
+  assert.throws(
+    () => service.updateComment("comment-001", "Changed by Bob", "bob@team.test"),
+    InternalCommentError,
+  );
+  assert.throws(() => service.deleteComment("comment-001", "bob@team.test"), InternalCommentError);
+});
+
+test("soft-deletes author comments and omits them from regular lists", () => {
+  const service = createService();
+  service.addComment(fixture.comments[0]);
+  service.deleteComment("comment-001", "alice@team.test");
+
+  assert.deepEqual(service.listComments(fixture.messageTarget), []);
+});
+
+test("external-safe summary never includes comment body text", () => {
+  const service = createService();
+  service.addComment(fixture.comments[0]);
+  const summary = service.buildExternalSafeSummary(fixture.messageTarget);
+  const serialized = JSON.stringify(summary);
+
+  assert.equal(summary.internalCommentCount, 1);
+  assert.equal(summary.commentBodiesIncluded, false);
+  assert.doesNotMatch(serialized, /old support case|Keep this note internal/);
+});
+
+test("rejects empty and oversized comments", () => {
+  const service = createService();
+
+  assert.throws(
+    () => service.addComment({ ...fixture.comments[0], body: "   " }),
+    InternalCommentError,
+  );
+
+  const longBody = "a".repeat(COMMENT_LIMITS.maxBodyLength + 10);
+  const comment = service.addComment({ ...fixture.comments[0], body: longBody });
+  assert.equal(comment.body.length, COMMENT_LIMITS.maxBodyLength);
+});
+
+test("fixture stays synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readFile(fixturePath, "utf8");
+
+  assert.equal(fixture.teamRoster.every((address) => address.endsWith(".test")), true);
+  assert.equal(fixture.externalSenderAddress.endsWith(".test"), true);
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});


### PR DESCRIPTION
## Summary
- add a folder-local pure Internal Comment Thread service for team-only comment creation, listing, update, delete, and external-safe summaries
- add deterministic synthetic fixtures covering message and thread targets with authorized team members
- expose a local API surface from index.mjs and document service inputs, outputs, error states, and the non-negotiable no-leak rule

Closes #4l

## Tests
- node tools\v1\team\internal-comment-thread\tests\internal-comment-service.test.mjs
- node -e "import('./tools/v1/team/internal-comment-thread/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
- git diff --cached --check