### PR TITLE
Add internal comment thread test documentation

### DIFF
--- a/tools/v1/team/internal-comment-thread/docs/KNOWN_LIMITATIONS.md
+++ b/tools/v1/team/internal-comment-thread/docs/KNOWN_LIMITATIONS.md
@@ -1,0 +1,12 @@
+# Internal Comment Thread Known Limitations
+
+- No main application integration is included.
+- No durable storage adapter is included.
+- No role-based permission model beyond a flat team roster is included.
+- No nested replies, rich formatting, attachments, mentions, or notifications are included.
+- No search or full-text indexing is included.
+- No production inbox data, external delivery, wallet access, or protocol mutation is used.
+- Fixtures are synthetic and intended for local review only.
+
+Future issues should define these behaviors explicitly before mounting the tool or connecting it to
+live inbox data.

--- a/tools/v1/team/internal-comment-thread/docs/TEST_PLAN.md
+++ b/tools/v1/team/internal-comment-thread/docs/TEST_PLAN.md
@@ -1,0 +1,57 @@
+# Internal Comment Thread Test Plan
+
+## Scope
+
+This test plan covers the isolated Internal Comment Thread tool under:
+
+```text
+tools/v1/team/internal-comment-thread/
+```
+
+Tests must stay folder-local and must not require the main app shell, routing, wallet, Stellar core,
+database, production inbox data, or shared design system integration.
+
+## Core Behavior Coverage
+
+When services are present, folder-local tests should cover:
+
+- creating comments for authorized team members only
+- rejecting empty, malformed, or oversized comment bodies
+- listing comments by exact message or thread target
+- preserving target isolation between message-level and thread-level comments
+- allowing authors to update and delete their own comments
+- rejecting update and delete attempts from other team members
+- proving that external-safe summaries never include comment body text
+
+## UI And Accessibility Coverage
+
+When components are present, tests or manual review notes should cover:
+
+- empty, loading, error, and success states
+- labelled composer controls
+- keyboard access for submit, edit, delete, cancel, and retry actions
+- visible focus states on comment actions
+- delete confirmation with clear accessible text
+- no comment body rendered in external-sender previews
+
+## Visibility Contract Coverage
+
+Every change must preserve the firm rule:
+
+```text
+Internal comment body text must never be included in an external reply, forward, notification,
+header, log, or payload.
+```
+
+Fixture and contract tests should include a phrase that appears in internal comments and assert that
+the phrase does not appear in any external-facing payload sample.
+
+## Contributor Validation Commands
+
+```bash
+node tools/v1/team/internal-comment-thread/tests/documentation-contract.test.mjs
+git diff --check
+git diff --name-only
+```
+
+Add exact service or UI test commands here when those layers are introduced.

--- a/tools/v1/team/internal-comment-thread/docs/USAGE.md
+++ b/tools/v1/team/internal-comment-thread/docs/USAGE.md
@@ -1,0 +1,40 @@
+# Internal Comment Thread Usage Notes
+
+## Local Setup
+
+No app-wide setup is required for this isolated documentation and fixture slice. Reviewers can run
+the folder-local documentation test from the repository root:
+
+```bash
+node tools/v1/team/internal-comment-thread/tests/documentation-contract.test.mjs
+```
+
+Future service or UI work may add local package scripts, but those scripts must stay inside this
+tool folder.
+
+## Review Fixture
+
+The fixture at `fixtures/sample-internal-comment-thread.json` models synthetic internal comments:
+
+- one message-level target with two internal comments
+- one thread-level target with one internal comment
+- an external-facing payload sample that includes counts and timestamps only
+- all addresses use `.test` domains
+- no production mail, credentials, secrets, payment data, or local user data is included
+
+## Expected Workflow
+
+1. Load a message or thread target selected from a future shared inbox adapter.
+2. Validate that the current author belongs to the team roster.
+3. Add or list internal comments for that exact target.
+4. Build external-facing reply or summary data without comment body text.
+5. Review generated payloads to ensure internal notes remain team-only.
+
+## Review Checklist
+
+- All changed files stay under `tools/v1/team/internal-comment-thread/`.
+- Tests or test plans are folder-local.
+- Fixtures are deterministic and synthetic.
+- Known limitations are documented before integration.
+- The no-leak visibility rule is called out in tests and docs.
+- No main app shell, routing, wallet, Stellar core, database, or shared design system files change.

--- a/tools/v1/team/internal-comment-thread/fixtures/sample-internal-comment-thread.json
+++ b/tools/v1/team/internal-comment-thread/fixtures/sample-internal-comment-thread.json
@@ -1,0 +1,46 @@
+{
+  "teamRoster": [
+    "alice@team.test",
+    "bob@team.test",
+    "carol@team.test"
+  ],
+  "targets": [
+    {
+      "kind": "message",
+      "id": "msg-internal-doc-001",
+      "comments": [
+        {
+          "id": "comment-doc-001",
+          "author": "alice@team.test",
+          "body": "Internal only: customer used the retired migration path.",
+          "createdAt": "2026-06-23T09:00:00.000Z"
+        },
+        {
+          "id": "comment-doc-002",
+          "author": "bob@team.test",
+          "body": "Internal only: verify the old plan flag before replying.",
+          "createdAt": "2026-06-23T09:05:00.000Z"
+        }
+      ]
+    },
+    {
+      "kind": "thread",
+      "id": "thread-internal-doc-001",
+      "comments": [
+        {
+          "id": "comment-doc-003",
+          "author": "carol@team.test",
+          "body": "Internal only: include this in the weekly ops review.",
+          "createdAt": "2026-06-23T09:10:00.000Z"
+        }
+      ]
+    }
+  ],
+  "externalPayloadSample": {
+    "to": "customer@example.test",
+    "subject": "Re: Migration question",
+    "internalCommentCount": 2,
+    "latestInternalCommentAt": "2026-06-23T09:05:00.000Z",
+    "commentBodiesIncluded": false
+  }
+}

--- a/tools/v1/team/internal-comment-thread/tests/documentation-contract.test.mjs
+++ b/tools/v1/team/internal-comment-thread/tests/documentation-contract.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("documentation covers setup, usage, fixtures, limitations, and review commands", async () => {
+  const testPlan = await readToolFile("docs/TEST_PLAN.md");
+  const usage = await readToolFile("docs/USAGE.md");
+  const limitations = await readToolFile("docs/KNOWN_LIMITATIONS.md");
+
+  for (const term of ["Core Behavior Coverage", "UI And Accessibility Coverage", "Contributor Validation Commands"]) {
+    assert.match(testPlan, new RegExp(term));
+  }
+
+  for (const term of ["Local Setup", "Review Fixture", "Expected Workflow", "Review Checklist"]) {
+    assert.match(usage, new RegExp(term));
+  }
+
+  assert.match(limitations, /No main application integration is included/);
+  assert.match(limitations, /No production inbox data/);
+});
+
+test("fixture models message and thread internal comments", async () => {
+  const fixture = JSON.parse(await readToolFile("fixtures/sample-internal-comment-thread.json"));
+  const targetKinds = new Set(fixture.targets.map((target) => target.kind));
+  const commentCount = fixture.targets.reduce((sum, target) => sum + target.comments.length, 0);
+
+  assert.ok(targetKinds.has("message"));
+  assert.ok(targetKinds.has("thread"));
+  assert.equal(commentCount, 3);
+});
+
+test("external payload sample excludes internal comment body text", async () => {
+  const fixture = JSON.parse(await readToolFile("fixtures/sample-internal-comment-thread.json"));
+  const internalBodies = fixture.targets.flatMap((target) =>
+    target.comments.map((comment) => comment.body),
+  );
+  const externalPayload = JSON.stringify(fixture.externalPayloadSample);
+
+  assert.equal(fixture.externalPayloadSample.commentBodiesIncluded, false);
+
+  for (const body of internalBodies) {
+    assert.doesNotMatch(externalPayload, new RegExp(body.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
+test("fixture remains synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readToolFile("fixtures/sample-internal-comment-thread.json");
+  const fixture = JSON.parse(fixtureText);
+
+  assert.equal(fixture.teamRoster.every((address) => address.endsWith(".test")), true);
+  assert.equal(fixture.externalPayloadSample.to.endsWith(".test"), true);
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});
+
+test("documentation states isolation from app-wide systems", async () => {
+  const combined = [
+    await readToolFile("docs/TEST_PLAN.md"),
+    await readToolFile("docs/USAGE.md"),
+    await readToolFile("docs/KNOWN_LIMITATIONS.md"),
+  ].join("\n");
+
+  for (const boundary of [
+    "main app shell",
+    "routing",
+    "wallet",
+    "Stellar core",
+    "database",
+    "shared design system",
+  ]) {
+    assert.match(combined, new RegExp(boundary, "i"));
+  }
+});
+
+test("documentation avoids generated template residue", async () => {
+  const combined = [
+    await readToolFile("docs/TEST_PLAN.md"),
+    await readToolFile("docs/USAGE.md"),
+    await readToolFile("docs/KNOWN_LIMITATIONS.md"),
+  ].join("\n");
+
+  assert.doesNotMatch(combined, /System\.Collections|Set-Content|@\s*\||\$dir|\$\(.*\)/);
+});


### PR DESCRIPTION
## Summary
- add folder-local Internal Comment Thread test plan, usage notes, known limitations, and synthetic comment-thread fixture
- document independent review steps, visibility contract checks, fixture expectations, and app-wide isolation constraints
- add a documentation contract test covering setup, usage, fixtures, limitations, external payload safety, and template residue checks

Closes #443.

## Tests
- node tools\v1\team\internal-comment-thread\tests\documentation-contract.test.mjs
- git diff --cached --check