### PR TITLE
docs(team-workload-balancer): link and close issue #713

### DIFF
--- a/tools/v2/team/team-workload-balancer/docs/review-notes.md
+++ b/tools/v2/team/team-workload-balancer/docs/review-notes.md
@@ -35,3 +35,10 @@
 ## Files changed are limited to $rel/
 
 All work is contained within `tools/v2/team/team-workload-balancer/`.
+
+## Issue linkage note
+
+The original delivery PR (#767) merged the folder-local tests, fixtures, and docs, but
+its description referenced the issue without a GitHub closing keyword, so the issue was
+not auto-closed or linked on merge. This follow-up records the completed linkage so that
+issue #713 is closed by a merged pull request.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #767, which delivered the Team Workload Balancer folder-local tests, fixtures, and docs but referenced the issue without a closing keyword. As a result, issue #713 was never auto-closed or linked to a merged PR.

This PR adds a short **Issue linkage note** to the tool's `docs/review-notes.md` and uses the closing keyword so the issue is closed by a merged pull request.

## Changes

- `tools/v2/team/team-workload-balancer/docs/review-notes.md` — add issue linkage note.

## Scope

- Single file changed, entirely within `tools/v2/team/team-workload-balancer/`.
- No changes to the main app shell, routing, design system, or any shared infrastructure.
- Documentation-only; no code or behavior changes. Folder-local tests still pass.

Closes #713