### PR TITLE
Add shared team inbox architecture contract

### DIFF
--- a/tools/v1/team/shared-team-inbox/docs/ARCHITECTURE.md
+++ b/tools/v1/team/shared-team-inbox/docs/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Shared Team Inbox Architecture
+
+## Folder Contract
+
+```text
+tools/v1/team/shared-team-inbox/
+  components/   UI-only views for message queues, filters, ownership, comments, and local states
+  services/     Pure message, assignment, status, comment, and reply workflow helpers
+  hooks/        React adapters over folder-local services and fixture-backed state
+  fixtures/     Synthetic shared inbox messages, assignments, comments, replies, and rosters
+  tests/        Folder-local unit, fixture, documentation, and architecture contract tests
+  docs/         Architecture, contributor boundaries, safety, and integration notes
+```
+
+No module in this tool may import from `src/`, sibling tools, `tools/v2/`, main app routing,
+wallet code, Stellar core, database code, existing inbox internals, mail rendering, or shared
+design system internals.
+
+## Data Ownership
+
+The tool owns derived collaboration metadata only:
+
+- shared inbox ID or address
+- message reference ID and bounded preview metadata
+- assignment owner and handoff metadata
+- internal comment metadata owned by the team-only surface
+- status value: `unassigned`, `claimed`, `in-progress`, `awaiting-reply`, or `resolved`
+- reply draft metadata for future shared-identity sending
+
+The tool must not become the source of truth for full message bodies, private mailbox contents,
+wallet identities, sender credentials, delivery proof verification, payment details, or permanent
+audit logs.
+
+## Dependency Rules
+
+- Prefer JavaScript or TypeScript standard library APIs for local validation and sorting.
+- Keep services pure and deterministic unless a future integration issue defines an adapter.
+- Do not add root dependencies or repository-wide build settings from this tool.
+- No live network calls, telemetry, cron jobs, local storage, or background workers are allowed.
+- Fixtures must use `.test` domains and synthetic IDs.
+
+## Data Flow
+
+1. A future integration adapter may pass sanitized shared inbox metadata into the tool.
+2. `services/` validate and normalize message, assignment, comment, and reply data.
+3. `hooks/` may manage local UI state such as active filters, optimistic status changes, and retry
+   messages.
+4. `components/` render derived state and emit folder-local action callbacks.
+5. External delivery, durable persistence, and app mounting remain outside this tool until separate
+   integration issues define them.
+
+## Review Checklist
+
+- Files changed are limited to `tools/v1/team/shared-team-inbox/`.
+- Specs explain what future contributors may and may not change.
+- New behavior is reviewable without app-wide routes, database, wallet, or mail engine changes.
+- Future UI remains accessible by keyboard and does not rely on color alone for state.
+- Team-only data is never included in external-facing payloads.

--- a/tools/v1/team/shared-team-inbox/docs/CONTRIBUTOR_BOUNDARY.md
+++ b/tools/v1/team/shared-team-inbox/docs/CONTRIBUTOR_BOUNDARY.md
@@ -1,0 +1,28 @@
+# Shared Team Inbox Contributor Boundary
+
+## Contributors May Change
+
+- Folder-local docs, tests, fixtures, services, hooks, and components.
+- Synthetic messages, assignments, comments, replies, and team rosters used for local tests.
+- Pure helpers for validation, status transitions, assignment summaries, and fixture-backed state.
+- Local accessibility and visual notes for a future UI surface.
+
+## Contributors Must Not Change
+
+- Main application shell, dashboard layout, navigation, routing, or global providers.
+- Existing inbox architecture, mail rendering, wallet core, Stellar core, or database schema.
+- Root package dependencies, repository-wide build settings, or shared design system tokens.
+- Production data, user credentials, private mailbox contents, secrets, or payment details.
+
+## Integration Constraints
+
+This tool can be integrated only after a future issue defines:
+
+- the sanitized shared inbox metadata contract supplied by the main mail app
+- the permission model for claims, releases, internal comments, and replies
+- the shared identity reply path and audit requirements
+- the storage ownership boundary for durable team state
+- the accessibility review path for a mounted route or panel
+- the conflict behavior when multiple members act on the same message
+
+Until then, the tool remains a self-contained mini-product with local tests and docs only.

--- a/tools/v1/team/shared-team-inbox/tests/architecture-contract.test.mjs
+++ b/tools/v1/team/shared-team-inbox/tests/architecture-contract.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function listFiles(dir = toolRoot) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolute = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(absolute) : absolute;
+    }),
+  );
+
+  return files.flat();
+}
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("architecture docs define folder-local module boundaries", async () => {
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+
+  for (const folder of ["components/", "services/", "hooks/", "fixtures/", "tests/", "docs/"]) {
+    assert.match(architecture, new RegExp(folder.replace("/", "\\/")));
+  }
+
+  assert.match(architecture, /tools\/v1\/team\/shared-team-inbox\//);
+  assert.match(architecture, /No module in this tool may import from `src\/`/);
+  assert.match(boundary, /Contributors May Change/);
+  assert.match(boundary, /Contributors Must Not Change/);
+});
+
+test("architecture docs describe data ownership and contributor limits", async () => {
+  const architecture = await readToolFile("docs/ARCHITECTURE.md");
+  const boundary = await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md");
+
+  for (const term of [
+    "Data Ownership",
+    "shared inbox ID",
+    "message reference ID",
+    "assignment owner",
+    "internal comment metadata",
+    "reply draft metadata",
+  ]) {
+    assert.match(architecture, new RegExp(term));
+  }
+
+  for (const term of ["Dependency Rules", "Integration Constraints", "Production data"]) {
+    assert.match(`${architecture}\n${boundary}`, new RegExp(term, "i"));
+  }
+});
+
+test("architecture contract rejects generated template residue", async () => {
+  const files = await listFiles();
+  const textFiles = files.filter((file) => /\.(md|json)$/.test(file));
+  const combined = (
+    await Promise.all(textFiles.map((file) => readFile(file, "utf8")))
+  ).join("\n");
+
+  assert.doesNotMatch(combined, /System\.Collections|Set-Content|@\s*\||\$dir|\$\(.*\)/);
+  assert.doesNotMatch(combined, /components\/\n- services\/\n- hooks\/\n-\s+ests\//);
+});
+
+test("integration boundaries remain explicit", async () => {
+  const combined = [
+    await readToolFile("docs/ARCHITECTURE.md"),
+    await readToolFile("docs/CONTRIBUTOR_BOUNDARY.md"),
+  ].join("\n");
+
+  for (const forbiddenArea of [
+    "routing",
+    "wallet core",
+    "Stellar core",
+    "database schema",
+    "shared design system",
+    "production data",
+    "secrets",
+  ]) {
+    assert.match(combined, new RegExp(forbiddenArea, "i"));
+  }
+
+  assert.match(combined, /no live network calls/i);
+  assert.match(combined, /\.test` domains/);
+});
+
+test("all current files stay under the Shared Team Inbox root", async () => {
+  const files = await listFiles();
+
+  assert.ok(files.length >= 5, "expected existing docs plus architecture contract files");
+
+  for (const file of files) {
+    assert.ok(file.startsWith(toolRoot), `file escaped the tool root: ${file}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add folder-local Shared Team Inbox architecture and contributor boundary docs
- document module boundaries, derived data ownership, dependency rules, and future integration constraints
- add an architecture contract test covering module map, data ownership, app-wide boundaries, and template residue checks

Closes 

## Tests
- node tools\v1\team\shared-team-inbox\tests\architecture-contract.test.mjs
- git diff --cached --check