### PR TITLE
Add email template library UI surface

### DIFF
--- a/tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx
+++ b/tools/v2/individual/email-template-library/components/EmailTemplateLibrary.tsx
@@ -1,0 +1,102 @@
+import type {
+  EmailTemplateListItem,
+  TemplateLibraryActionHandlers,
+  TemplateLibraryStats,
+  TemplatePreviewResult,
+} from "../types";
+import { TemplateCard } from "./TemplateCard";
+import { TemplateLibraryEmptyState } from "./TemplateLibraryEmptyState";
+import { TemplateLibraryErrorState } from "./TemplateLibraryErrorState";
+import { TemplateLibraryLoadingState } from "./TemplateLibraryLoadingState";
+import { TemplateLibraryStats as TemplateLibraryStatsView } from "./TemplateLibraryStats";
+import { TemplateLibrarySuccessState } from "./TemplateLibrarySuccessState";
+import { TemplatePreviewPanel } from "./TemplatePreviewPanel";
+
+interface EmailTemplateLibraryProps extends TemplateLibraryActionHandlers {
+  templates: EmailTemplateListItem[];
+  stats: TemplateLibraryStats;
+  preview: TemplatePreviewResult;
+  selectedTemplateId?: string | null;
+  isLoading?: boolean;
+  error?: string | null;
+  successMessage?: string | null;
+  onDismissSuccess?: () => void;
+}
+
+export function EmailTemplateLibrary({
+  templates,
+  stats,
+  preview,
+  selectedTemplateId = null,
+  isLoading = false,
+  error = null,
+  successMessage = null,
+  onDismissSuccess,
+  onCreateTemplate,
+  onRetry,
+  onSelectTemplate,
+  onCopyTemplate,
+  onEditTemplate,
+}: EmailTemplateLibraryProps) {
+  if (isLoading) {
+    return <TemplateLibraryLoadingState />;
+  }
+
+  if (error) {
+    return <TemplateLibraryErrorState message={error} onRetry={onRetry} />;
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-6" aria-labelledby="email-template-library-title">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+            Individual workflow
+          </p>
+          <h1 id="email-template-library-title" className="text-2xl font-semibold text-slate-950">
+            Email Template Library
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm text-slate-600">
+            Organize reusable email templates, preview variable output, and copy draft-ready text
+            without mounting this V2 tool in the main composer.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateTemplate}
+          className="rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+          aria-label="Create new email template"
+        >
+          New template
+        </button>
+      </header>
+
+      {successMessage ? (
+        <TemplateLibrarySuccessState message={successMessage} onDismiss={onDismissSuccess} />
+      ) : null}
+
+      <TemplateLibraryStatsView stats={stats} />
+
+      {templates.length === 0 ? (
+        <TemplateLibraryEmptyState onCreateTemplate={onCreateTemplate} />
+      ) : (
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-4" role="list" aria-label="Email templates">
+            {templates.map((template) => (
+              <div role="listitem" key={template.id}>
+                <TemplateCard
+                  template={template}
+                  selected={template.id === selectedTemplateId}
+                  onSelectTemplate={onSelectTemplate}
+                  onCopyTemplate={onCopyTemplate}
+                  onEditTemplate={onEditTemplate}
+                />
+              </div>
+            ))}
+          </div>
+          <TemplatePreviewPanel result={preview} />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateCard.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateCard.tsx
@@ -1,0 +1,81 @@
+import type { EmailTemplateListItem, TemplateLibraryActionHandlers } from "../types";
+
+interface TemplateCardProps extends TemplateLibraryActionHandlers {
+  template: EmailTemplateListItem;
+  selected?: boolean;
+}
+
+export function TemplateCard({
+  template,
+  selected = false,
+  onSelectTemplate,
+  onCopyTemplate,
+  onEditTemplate,
+}: TemplateCardProps) {
+  const titleId = `email-template-${template.id}-title`;
+
+  return (
+    <article
+      aria-labelledby={titleId}
+      className={`rounded-lg border bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-slate-900 ${
+        selected ? "border-slate-900" : "border-slate-200"
+      }`}
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-slate-300 px-2.5 py-1 text-xs font-medium text-slate-700">
+              {template.category}
+            </span>
+            <span className="text-xs text-slate-500">Used {template.usageCount} times</span>
+          </div>
+          <h3 id={titleId} className="mt-3 text-base font-semibold text-slate-950">
+            {template.name}
+          </h3>
+          <p className="mt-1 text-sm font-medium text-slate-800">{template.subject}</p>
+          <p className="mt-2 text-sm text-slate-600">{template.preview}</p>
+          <p className="mt-3 text-xs text-slate-500">
+            {template.variables.length} variables · Updated{" "}
+            <time dateTime={template.updatedAt}>
+              {new Intl.DateTimeFormat("en", { dateStyle: "medium" }).format(
+                new Date(template.updatedAt),
+              )}
+            </time>
+          </p>
+        </div>
+
+        <div
+          className="grid min-w-32 gap-2 sm:grid-cols-3 lg:grid-cols-1"
+          role="group"
+          aria-label={`Actions for template ${template.name}`}
+        >
+          <button
+            type="button"
+            onClick={() => onSelectTemplate?.(template.id)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`Preview email template ${template.name}`}
+            aria-pressed={selected}
+          >
+            Preview
+          </button>
+          <button
+            type="button"
+            onClick={() => onCopyTemplate?.(template.id)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`Copy email template ${template.name}`}
+          >
+            Copy
+          </button>
+          <button
+            type="button"
+            onClick={() => onEditTemplate?.(template.id)}
+            className="rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+            aria-label={`Edit email template ${template.name}`}
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateLibraryEmptyState.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateLibraryEmptyState.tsx
@@ -1,0 +1,27 @@
+interface TemplateLibraryEmptyStateProps {
+  onCreateTemplate?: () => void;
+}
+
+export function TemplateLibraryEmptyState({ onCreateTemplate }: TemplateLibraryEmptyStateProps) {
+  return (
+    <section
+      aria-labelledby="template-library-empty-title"
+      className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center"
+    >
+      <h2 id="template-library-empty-title" className="text-lg font-semibold text-slate-950">
+        No templates yet
+      </h2>
+      <p className="mt-2 text-sm text-slate-600">
+        Create a reusable email template before connecting this tool to the main composer.
+      </p>
+      <button
+        type="button"
+        onClick={onCreateTemplate}
+        className="mt-5 rounded-md bg-slate-950 px-4 py-2 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+        aria-label="Create first email template"
+      >
+        Create template
+      </button>
+    </section>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateLibraryErrorState.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateLibraryErrorState.tsx
@@ -1,0 +1,29 @@
+interface TemplateLibraryErrorStateProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function TemplateLibraryErrorState({ message, onRetry }: TemplateLibraryErrorStateProps) {
+  return (
+    <section
+      role="alert"
+      aria-labelledby="template-library-error-title"
+      className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-950"
+    >
+      <h2 id="template-library-error-title" className="text-base font-semibold">
+        Template library could not load
+      </h2>
+      <p className="mt-2 text-sm">{message}</p>
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2"
+          aria-label="Retry loading email templates"
+        >
+          Retry
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateLibraryLoadingState.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateLibraryLoadingState.tsx
@@ -1,0 +1,21 @@
+export function TemplateLibraryLoadingState() {
+  return (
+    <section
+      aria-labelledby="template-library-loading-title"
+      aria-live="polite"
+      className="rounded-lg border border-slate-200 bg-white p-6"
+    >
+      <h2 id="template-library-loading-title" className="text-base font-semibold text-slate-950">
+        Loading templates
+      </h2>
+      <p className="mt-2 text-sm text-slate-600">
+        Preparing the local template list, editor, and preview surface.
+      </p>
+      <div className="mt-5 grid gap-3" aria-hidden="true">
+        <div className="h-4 w-2/3 rounded bg-slate-200" />
+        <div className="h-20 rounded bg-slate-100" />
+        <div className="h-20 rounded bg-slate-100" />
+      </div>
+    </section>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateLibraryStats.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateLibraryStats.tsx
@@ -1,0 +1,28 @@
+import type { TemplateLibraryStats as TemplateLibraryStatsModel } from "../types";
+
+interface TemplateLibraryStatsProps {
+  stats: TemplateLibraryStatsModel;
+}
+
+const statItems = [
+  ["totalTemplates", "Templates"],
+  ["categories", "Categories"],
+  ["recentlyUpdated", "Updated"],
+  ["missingVariableTemplates", "Need values"],
+] as const;
+
+export function TemplateLibraryStats({ stats }: TemplateLibraryStatsProps) {
+  return (
+    <dl
+      className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      aria-label="Email template library summary"
+    >
+      {statItems.map(([key, label]) => (
+        <div key={key} className="rounded-lg border border-slate-200 bg-white p-4">
+          <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-950">{stats[key]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplateLibrarySuccessState.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplateLibrarySuccessState.tsx
@@ -1,0 +1,34 @@
+interface TemplateLibrarySuccessStateProps {
+  message: string;
+  onDismiss?: () => void;
+}
+
+export function TemplateLibrarySuccessState({ message, onDismiss }: TemplateLibrarySuccessStateProps) {
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-labelledby="template-library-success-title"
+      className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-emerald-950"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 id="template-library-success-title" className="text-sm font-semibold">
+            Template library updated
+          </h2>
+          <p className="mt-1 text-sm">{message}</p>
+        </div>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md px-2 py-1 text-sm font-medium text-emerald-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2"
+            aria-label="Dismiss template library update"
+          >
+            Dismiss
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/TemplatePreviewPanel.tsx
+++ b/tools/v2/individual/email-template-library/components/TemplatePreviewPanel.tsx
@@ -1,0 +1,33 @@
+import type { TemplatePreviewResult } from "../types";
+
+interface TemplatePreviewPanelProps {
+  result: TemplatePreviewResult;
+}
+
+export function TemplatePreviewPanel({ result }: TemplatePreviewPanelProps) {
+  return (
+    <aside
+      aria-labelledby="email-template-preview-title"
+      className="rounded-lg border border-slate-200 bg-white p-5"
+    >
+      <h2 id="email-template-preview-title" className="text-base font-semibold text-slate-950">
+        Preview
+      </h2>
+      {result.missingVariables.length > 0 ? (
+        <p className="mt-2 text-sm text-amber-800" role="status">
+          Missing values: {result.missingVariables.join(", ")}
+        </p>
+      ) : (
+        <p className="mt-2 text-sm text-emerald-800" role="status">
+          All variables have preview values.
+        </p>
+      )}
+      <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-4">
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Subject</p>
+        <p className="mt-1 text-sm font-semibold text-slate-950">{result.subject}</p>
+        <p className="mt-4 text-xs font-medium uppercase tracking-wide text-slate-500">Body</p>
+        <p className="mt-1 whitespace-pre-line text-sm text-slate-700">{result.body}</p>
+      </div>
+    </aside>
+  );
+}

--- a/tools/v2/individual/email-template-library/components/index.ts
+++ b/tools/v2/individual/email-template-library/components/index.ts
@@ -1,0 +1,8 @@
+export { EmailTemplateLibrary } from "./EmailTemplateLibrary";
+export { TemplateCard } from "./TemplateCard";
+export { TemplateLibraryEmptyState } from "./TemplateLibraryEmptyState";
+export { TemplateLibraryErrorState } from "./TemplateLibraryErrorState";
+export { TemplateLibraryLoadingState } from "./TemplateLibraryLoadingState";
+export { TemplateLibraryStats } from "./TemplateLibraryStats";
+export { TemplateLibrarySuccessState } from "./TemplateLibrarySuccessState";
+export { TemplatePreviewPanel } from "./TemplatePreviewPanel";

--- a/tools/v2/individual/email-template-library/docs/ACCESSIBILITY.md
+++ b/tools/v2/individual/email-template-library/docs/ACCESSIBILITY.md
@@ -1,0 +1,23 @@
+# Email Template Library Accessibility Notes
+
+## Keyboard Operation
+
+- Template actions are native buttons with visible `focus-visible` rings.
+- Template cards use `focus-within` styling so keyboard users can keep list context.
+- The selected template control exposes `aria-pressed` so assistive technology can identify the
+  active preview.
+- Empty, retry, create, preview, copy, edit, and dismiss actions all have explicit labels.
+
+## Screen Reader Support
+
+- The page has one `main` landmark labelled by the visible heading.
+- The template list uses `role="list"` and `role="listitem"` because cards are not native list
+  elements.
+- Loading and success states use polite live regions; the error state uses `role="alert"`.
+- Preview variable completeness is announced with `role="status"`.
+- Missing variables are shown as text, not color alone.
+
+## Integration Notes
+
+If this V2 tool is mounted later, the integration should move focus to the top-level heading when
+opening the tool route and preserve the folder-local labels on repeated template actions.

--- a/tools/v2/individual/email-template-library/docs/VISUAL_STYLE.md
+++ b/tools/v2/individual/email-template-library/docs/VISUAL_STYLE.md
@@ -1,0 +1,26 @@
+# Email Template Library Visual Style
+
+## Principles
+
+- Keep the experience utility-first: fast scanning, clear actions, and no marketing layout.
+- Do not change the shared design system, app shell, navigation, routing, or global styles.
+- Use folder-local components that can be reviewed before integration.
+
+## Layout
+
+- Summary metrics sit above the work area for quick library health scanning.
+- Template cards use an 8px radius, subtle borders, and compact metadata.
+- The preview panel sits beside the template list on desktop and stacks below it on narrow screens.
+
+## State Treatment
+
+- Empty state includes a clear create action.
+- Loading state uses static skeleton bars and no required animation.
+- Error state uses a retry button and alert semantics.
+- Success state is dismissible and announced politely.
+
+## Responsive Behavior
+
+- Summary metrics collapse from four columns to two columns and then one column.
+- Template card actions stack vertically on desktop side rails and wrap on smaller screens.
+- Long template names, subjects, and previews stay inside the card flow.

--- a/tools/v2/individual/email-template-library/fixtures/sample-template-library-ui.json
+++ b/tools/v2/individual/email-template-library/fixtures/sample-template-library-ui.json
@@ -1,0 +1,73 @@
+{
+  "stats": {
+    "totalTemplates": 3,
+    "categories": 3,
+    "recentlyUpdated": 2,
+    "missingVariableTemplates": 1
+  },
+  "selectedTemplateId": "tmpl-follow-up",
+  "templates": [
+    {
+      "id": "tmpl-follow-up",
+      "name": "Polite follow-up",
+      "category": "Follow-up",
+      "subject": "Checking in on {{topic}}",
+      "preview": "A concise follow-up for ongoing conversations that need a gentle nudge.",
+      "variables": [
+        {
+          "key": "firstName",
+          "label": "First name",
+          "value": "Sam"
+        },
+        {
+          "key": "topic",
+          "label": "Topic",
+          "value": "the onboarding checklist"
+        }
+      ],
+      "updatedAt": "2026-06-22T09:00:00.000Z",
+      "usageCount": 14
+    },
+    {
+      "id": "tmpl-support-close",
+      "name": "Support closure",
+      "category": "Support",
+      "subject": "Resolved: {{issue}}",
+      "preview": "A closure message for support cases after the customer confirms resolution.",
+      "variables": [
+        {
+          "key": "issue",
+          "label": "Issue"
+        }
+      ],
+      "updatedAt": "2026-06-21T15:30:00.000Z",
+      "usageCount": 8
+    },
+    {
+      "id": "tmpl-intro",
+      "name": "Warm intro",
+      "category": "Relationship",
+      "subject": "Introducing {{personA}} and {{personB}}",
+      "preview": "A structured introduction template for connecting two contacts.",
+      "variables": [
+        {
+          "key": "personA",
+          "label": "First person",
+          "value": "Avery"
+        },
+        {
+          "key": "personB",
+          "label": "Second person",
+          "value": "Jordan"
+        }
+      ],
+      "updatedAt": "2026-06-20T11:45:00.000Z",
+      "usageCount": 3
+    }
+  ],
+  "preview": {
+    "subject": "Checking in on the onboarding checklist",
+    "body": "Hi Sam,\n\nI wanted to check in on the onboarding checklist and see whether anything is blocking progress.\n\nBest,",
+    "missingVariables": []
+  }
+}

--- a/tools/v2/individual/email-template-library/tests/ui-contract.test.mjs
+++ b/tools/v2/individual/email-template-library/tests/ui-contract.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolRoot = path.resolve(__dirname, "..");
+
+async function listFiles(dir = toolRoot) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolute = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(absolute) : absolute;
+    }),
+  );
+
+  return files.flat();
+}
+
+async function readToolFile(relativePath) {
+  return readFile(path.join(toolRoot, relativePath), "utf8");
+}
+
+test("template library UI remains isolated to the tool folder", async () => {
+  const files = await listFiles();
+  const uiFiles = files.filter((file) => file.includes(`${path.sep}components${path.sep}`));
+
+  assert.ok(uiFiles.length >= 8, "expected folder-local UI components");
+
+  for (const file of files) {
+    assert.ok(file.startsWith(toolRoot), `file escaped the email template tool folder: ${file}`);
+  }
+
+  const source = await Promise.all(
+    uiFiles
+      .filter((file) => file.endsWith(".ts") || file.endsWith(".tsx"))
+      .map((file) => readFile(file, "utf8")),
+  );
+  const combined = source.join("\n");
+
+  assert.doesNotMatch(combined, /from\s+["']src\//);
+  assert.doesNotMatch(combined, /from\s+["']tools\//);
+  assert.doesNotMatch(combined, /from\s+["']\.\.\/\.\.\/\.\./);
+});
+
+test("primary UI exposes empty, loading, error, success, list, and preview states", async () => {
+  const componentIndex = await readToolFile("components/index.ts");
+  const mainComponent = await readToolFile("components/EmailTemplateLibrary.tsx");
+
+  for (const exportName of [
+    "EmailTemplateLibrary",
+    "TemplateCard",
+    "TemplateLibraryEmptyState",
+    "TemplateLibraryLoadingState",
+    "TemplateLibraryErrorState",
+    "TemplateLibrarySuccessState",
+    "TemplatePreviewPanel",
+  ]) {
+    assert.match(componentIndex, new RegExp(`export \\{ ${exportName} \\}`));
+  }
+
+  assert.match(mainComponent, /<TemplateLibraryLoadingState/);
+  assert.match(mainComponent, /<TemplateLibraryErrorState/);
+  assert.match(mainComponent, /<TemplateLibrarySuccessState/);
+  assert.match(mainComponent, /<TemplateLibraryEmptyState/);
+  assert.match(mainComponent, /<TemplatePreviewPanel/);
+  assert.match(mainComponent, /role="list"/);
+  assert.match(mainComponent, /role="listitem"/);
+});
+
+test("interactive controls include labels and keyboard-friendly focus behavior", async () => {
+  const mainComponent = await readToolFile("components/EmailTemplateLibrary.tsx");
+  const cardComponent = await readToolFile("components/TemplateCard.tsx");
+  const emptyState = await readToolFile("components/TemplateLibraryEmptyState.tsx");
+  const errorState = await readToolFile("components/TemplateLibraryErrorState.tsx");
+
+  assert.match(mainComponent, /aria-label="Create new email template"/);
+  assert.match(cardComponent, /role="group"/);
+  assert.match(cardComponent, /aria-label=\{`Actions for template/);
+  assert.match(cardComponent, /aria-pressed=\{selected\}/);
+  assert.match(cardComponent, /aria-label=\{`Preview email template/);
+  assert.match(cardComponent, /aria-label=\{`Copy email template/);
+  assert.match(cardComponent, /aria-label=\{`Edit email template/);
+
+  for (const source of [mainComponent, cardComponent, emptyState, errorState]) {
+    assert.match(source, /focus-visible:ring-2/);
+  }
+});
+
+test("fixture covers template list, variables, stats, and preview output", async () => {
+  const fixture = JSON.parse(await readToolFile("fixtures/sample-template-library-ui.json"));
+  const templateIds = new Set(fixture.templates.map((template) => template.id));
+
+  assert.equal(fixture.stats.totalTemplates, fixture.templates.length);
+  assert.ok(templateIds.has(fixture.selectedTemplateId));
+  assert.equal(fixture.templates.every((template) => template.variables.length > 0), true);
+  assert.equal(typeof fixture.preview.subject, "string");
+  assert.equal(Array.isArray(fixture.preview.missingVariables), true);
+});
+
+test("fixture data is synthetic and avoids sensitive fields", async () => {
+  const fixtureText = await readToolFile("fixtures/sample-template-library-ui.json");
+
+  assert.doesNotMatch(fixtureText, /password|secret|token|bank|card|wallet|seed/i);
+});
+
+test("accessibility and visual documentation cover review expectations", async () => {
+  const accessibility = await readToolFile("docs/ACCESSIBILITY.md");
+  const visualStyle = await readToolFile("docs/VISUAL_STYLE.md");
+
+  for (const term of ["Keyboard Operation", "Screen Reader Support", "focus-visible", "role=\"alert\""]) {
+    assert.match(accessibility, new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(visualStyle, /Do not change the shared design system/);
+  assert.match(visualStyle, /8px radius/);
+  assert.match(visualStyle, /Responsive Behavior/);
+});

--- a/tools/v2/individual/email-template-library/types.ts
+++ b/tools/v2/individual/email-template-library/types.ts
@@ -1,0 +1,37 @@
+export interface TemplateVariable {
+  key: string;
+  label: string;
+  value?: string;
+}
+
+export interface EmailTemplateListItem {
+  id: string;
+  name: string;
+  category: string;
+  subject: string;
+  preview: string;
+  variables: TemplateVariable[];
+  updatedAt: string;
+  usageCount: number;
+}
+
+export interface TemplatePreviewResult {
+  subject: string;
+  body: string;
+  missingVariables: string[];
+}
+
+export interface TemplateLibraryStats {
+  totalTemplates: number;
+  categories: number;
+  recentlyUpdated: number;
+  missingVariableTemplates: number;
+}
+
+export interface TemplateLibraryActionHandlers {
+  onSelectTemplate?: (templateId: string) => void;
+  onCreateTemplate?: () => void;
+  onCopyTemplate?: (templateId: string) => void;
+  onEditTemplate?: (templateId: string) => void;
+  onRetry?: () => void;
+}


### PR DESCRIPTION
## Summary
- add folder-local Email Template Library React/TypeScript UI components for summary metrics, template cards, preview, and empty/loading/error/success states
- add synthetic fixture data plus accessibility and visual style notes without mounting the V2 tool in the main app
- add a static UI contract test for isolation, state coverage, keyboard-accessible controls, fixture coverage, and synthetic data safety

Closes 

## Tests
- node tools\v2\individual\email-template-library\tests\ui-contract.test.mjs
- git diff --cached -