### PR TITLE
test: add calendar regression coverage for issue 1062

### DIFF
--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -155,7 +155,7 @@ export function useCalendar() {
   };
 }
 
-function to24HourTime(value: string) {
+export function to24HourTime(value: string) {
   const match = value.match(/(\d{1,2}):(\d{2})\s*(AM|PM)?/i);
   if (!match) return "09:00";
   let hour = Number(match[1]);
@@ -164,7 +164,8 @@ function to24HourTime(value: string) {
   return `${String(hour).padStart(2, "0")}:${match[2]}`;
 }
 
-function addOneHour(value: string) {
+export function addOneHour(value: string) {
   const [hours, minutes] = value.split(":").map(Number);
   return `${String((hours + 1) % 24).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
+

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -168,4 +168,3 @@ export function addOneHour(value: string) {
   const [hours, minutes] = value.split(":").map(Number);
   return `${String((hours + 1) % 24).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
-

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -43,4 +43,23 @@ test.describe("calendar linking", () => {
       page.getByRole("heading", { level: 1, name: "TOKEN2049 Abu Dhabi - founder pass ready" }),
     ).toBeVisible();
   });
+  test("calendar workspace handles manual event creation and deletion", async ({ page }) => {
+    await page.getByRole("button", { name: "Verified 1" }).click();
+    await page.getByRole("button", { name: /Add to calendar/i }).click();
+    await page.getByRole("button", { name: /Open calendar/i }).click();
+
+    // Create a new event
+    await page.getByRole("button", { name: /New event/i }).click();
+    await page.getByPlaceholder("What is happening?").fill("My Custom Meeting");
+    await page.getByRole("button", { name: /Save event/i }).click();
+
+    await expect(page.getByText("My Custom Meeting")).toBeVisible();
+    await expect(page.getByText("Event created")).toBeVisible();
+
+    // Delete the event
+    await page.getByText("My Custom Meeting").first().click();
+    await page.getByRole("button", { name: /Delete/i }).click();
+    await expect(page.getByText("Event deleted")).toBeVisible();
+    await expect(page.getByText("My Custom Meeting")).not.toBeVisible();
+  });
 });

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -51,7 +51,7 @@ test.describe("calendar linking", () => {
     // Create a new event
     await page.getByRole("button", { name: /New event/i }).click();
     await page.getByPlaceholder("What is happening?").fill("My Custom Meeting");
-    await page.getByRole("button", { name: /Save event/i }).click();
+    await page.getByRole("button", { name: /Create event/i }).click();
 
     await expect(page.getByText("My Custom Meeting")).toBeVisible();
     await expect(page.getByText("Event created")).toBeVisible();

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -53,13 +53,12 @@ test.describe("calendar linking", () => {
     await page.getByPlaceholder("What is happening?").fill("My Custom Meeting");
     await page.getByRole("button", { name: /Create event/i }).click();
 
-    await expect(page.getByText("My Custom Meeting")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "My Custom Meeting" })).toBeVisible();
     await expect(page.getByText("Event created")).toBeVisible();
 
     // Delete the event
-    await page.getByText("My Custom Meeting").first().click();
     await page.getByRole("button", { name: /Delete/i }).click();
     await expect(page.getByText("Event deleted")).toBeVisible();
-    await expect(page.getByText("My Custom Meeting")).not.toBeVisible();
+    await expect(page.getByText("My Custom Meeting")).toHaveCount(0);
   });
 });

--- a/tests/unit/calendar/dateUtils.test.ts
+++ b/tests/unit/calendar/dateUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getReferenceNow, getAppToday, getLocalTimeZone } from '../../../src/features/calendar/dateUtils';
+import { startOfDay } from 'date-fns';
+
+describe('dateUtils', () => {
+  it('getReferenceNow returns the fixed seed time', () => {
+    const now = getReferenceNow();
+    expect(now).toEqual(new Date(2026, 5, 13, 9, 41, 0, 0));
+  });
+
+  it('getAppToday returns the start of the reference day', () => {
+    const today = getAppToday();
+    expect(today).toEqual(startOfDay(new Date(2026, 5, 13, 9, 41, 0, 0)));
+  });
+
+  it('getLocalTimeZone returns a timezone string', () => {
+    const tz = getLocalTimeZone();
+    expect(typeof tz).toBe('string');
+  });
+
+  it('getLocalTimeZone fallback when Intl fails', () => {
+    const originalIntl = global.Intl;
+    // Replace Intl with undefined to trigger the catch block
+    Object.defineProperty(global, 'Intl', { value: undefined, writable: true, configurable: true });
+    
+    expect(getLocalTimeZone()).toBe('local time');
+    
+    // Restore Intl
+    Object.defineProperty(global, 'Intl', { value: originalIntl, writable: true, configurable: true });
+  });
+});

--- a/tests/unit/calendar/dateUtils.test.ts
+++ b/tests/unit/calendar/dateUtils.test.ts
@@ -1,31 +1,39 @@
-import { describe, it, expect } from 'vitest';
-import { getReferenceNow, getAppToday, getLocalTimeZone } from '../../../src/features/calendar/dateUtils';
-import { startOfDay } from 'date-fns';
+import { describe, it, expect } from "vitest";
+import {
+  getReferenceNow,
+  getAppToday,
+  getLocalTimeZone,
+} from "../../../src/features/calendar/dateUtils";
+import { startOfDay } from "date-fns";
 
-describe('dateUtils', () => {
-  it('getReferenceNow returns the fixed seed time', () => {
+describe("dateUtils", () => {
+  it("getReferenceNow returns the fixed seed time", () => {
     const now = getReferenceNow();
     expect(now).toEqual(new Date(2026, 5, 13, 9, 41, 0, 0));
   });
 
-  it('getAppToday returns the start of the reference day', () => {
+  it("getAppToday returns the start of the reference day", () => {
     const today = getAppToday();
     expect(today).toEqual(startOfDay(new Date(2026, 5, 13, 9, 41, 0, 0)));
   });
 
-  it('getLocalTimeZone returns a timezone string', () => {
+  it("getLocalTimeZone returns a timezone string", () => {
     const tz = getLocalTimeZone();
-    expect(typeof tz).toBe('string');
+    expect(typeof tz).toBe("string");
   });
 
-  it('getLocalTimeZone fallback when Intl fails', () => {
+  it("getLocalTimeZone fallback when Intl fails", () => {
     const originalIntl = global.Intl;
     // Replace Intl with undefined to trigger the catch block
-    Object.defineProperty(global, 'Intl', { value: undefined, writable: true, configurable: true });
-    
-    expect(getLocalTimeZone()).toBe('local time');
-    
+    Object.defineProperty(global, "Intl", { value: undefined, writable: true, configurable: true });
+
+    expect(getLocalTimeZone()).toBe("local time");
+
     // Restore Intl
-    Object.defineProperty(global, 'Intl', { value: originalIntl, writable: true, configurable: true });
+    Object.defineProperty(global, "Intl", {
+      value: originalIntl,
+      writable: true,
+      configurable: true,
+    });
   });
 });

--- a/tests/unit/calendar/useCalendar.test.ts
+++ b/tests/unit/calendar/useCalendar.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { to24HourTime, addOneHour } from '../../../src/features/calendar/useCalendar';
+
+describe('useCalendar pure helpers', () => {
+  describe('to24HourTime', () => {
+    it('parses AM times correctly', () => {
+      expect(to24HourTime('9:30 AM')).toBe('09:30');
+      expect(to24HourTime('11:00 AM')).toBe('11:00');
+    });
+
+    it('parses PM times correctly', () => {
+      expect(to24HourTime('2:15 PM')).toBe('14:15');
+      expect(to24HourTime('11:59 PM')).toBe('23:59');
+    });
+
+    it('handles 12 AM and 12 PM correctly', () => {
+      expect(to24HourTime('12:00 AM')).toBe('00:00');
+      expect(to24HourTime('12:30 PM')).toBe('12:30');
+    });
+
+    it('parses 24-hour times without AM/PM', () => {
+      expect(to24HourTime('14:00')).toBe('14:00');
+      expect(to24HourTime('08:45')).toBe('08:45');
+    });
+
+    it('returns default 09:00 for invalid formats', () => {
+      expect(to24HourTime('invalid time')).toBe('09:00');
+      expect(to24HourTime('')).toBe('09:00');
+    });
+  });
+
+  describe('addOneHour', () => {
+    it('adds an hour to a standard morning time', () => {
+      expect(addOneHour('09:30')).toBe('10:30');
+    });
+
+    it('adds an hour and wraps around midnight correctly', () => {
+      expect(addOneHour('23:15')).toBe('00:15');
+    });
+
+    it('handles single digit hours padded with zero', () => {
+      expect(addOneHour('08:05')).toBe('09:05');
+    });
+  });
+});

--- a/tests/unit/calendar/useCalendar.test.ts
+++ b/tests/unit/calendar/useCalendar.test.ts
@@ -1,45 +1,45 @@
-import { describe, it, expect } from 'vitest';
-import { to24HourTime, addOneHour } from '../../../src/features/calendar/useCalendar';
+import { describe, it, expect } from "vitest";
+import { to24HourTime, addOneHour } from "../../../src/features/calendar/useCalendar";
 
-describe('useCalendar pure helpers', () => {
-  describe('to24HourTime', () => {
-    it('parses AM times correctly', () => {
-      expect(to24HourTime('9:30 AM')).toBe('09:30');
-      expect(to24HourTime('11:00 AM')).toBe('11:00');
+describe("useCalendar pure helpers", () => {
+  describe("to24HourTime", () => {
+    it("parses AM times correctly", () => {
+      expect(to24HourTime("9:30 AM")).toBe("09:30");
+      expect(to24HourTime("11:00 AM")).toBe("11:00");
     });
 
-    it('parses PM times correctly', () => {
-      expect(to24HourTime('2:15 PM')).toBe('14:15');
-      expect(to24HourTime('11:59 PM')).toBe('23:59');
+    it("parses PM times correctly", () => {
+      expect(to24HourTime("2:15 PM")).toBe("14:15");
+      expect(to24HourTime("11:59 PM")).toBe("23:59");
     });
 
-    it('handles 12 AM and 12 PM correctly', () => {
-      expect(to24HourTime('12:00 AM')).toBe('00:00');
-      expect(to24HourTime('12:30 PM')).toBe('12:30');
+    it("handles 12 AM and 12 PM correctly", () => {
+      expect(to24HourTime("12:00 AM")).toBe("00:00");
+      expect(to24HourTime("12:30 PM")).toBe("12:30");
     });
 
-    it('parses 24-hour times without AM/PM', () => {
-      expect(to24HourTime('14:00')).toBe('14:00');
-      expect(to24HourTime('08:45')).toBe('08:45');
+    it("parses 24-hour times without AM/PM", () => {
+      expect(to24HourTime("14:00")).toBe("14:00");
+      expect(to24HourTime("08:45")).toBe("08:45");
     });
 
-    it('returns default 09:00 for invalid formats', () => {
-      expect(to24HourTime('invalid time')).toBe('09:00');
-      expect(to24HourTime('')).toBe('09:00');
+    it("returns default 09:00 for invalid formats", () => {
+      expect(to24HourTime("invalid time")).toBe("09:00");
+      expect(to24HourTime("")).toBe("09:00");
     });
   });
 
-  describe('addOneHour', () => {
-    it('adds an hour to a standard morning time', () => {
-      expect(addOneHour('09:30')).toBe('10:30');
+  describe("addOneHour", () => {
+    it("adds an hour to a standard morning time", () => {
+      expect(addOneHour("09:30")).toBe("10:30");
     });
 
-    it('adds an hour and wraps around midnight correctly', () => {
-      expect(addOneHour('23:15')).toBe('00:15');
+    it("adds an hour and wraps around midnight correctly", () => {
+      expect(addOneHour("23:15")).toBe("00:15");
     });
 
-    it('handles single digit hours padded with zero', () => {
-      expect(addOneHour('08:05')).toBe('09:05');
+    it("handles single digit hours padded with zero", () => {
+      expect(addOneHour("08:05")).toBe("09:05");
     });
   });
 });


### PR DESCRIPTION

### Description
**Closes #924**

This PR adds focused regression coverage for the existing Calendar Workspace behavior so future contributors can modify this surface with confidence. It is strictly scoped to test coverage without introducing any new features, tools, or dependencies.

### Changes Made
* **Pure Helper Coverage:** Extracted `to24HourTime` and `addOneHour` as pure functions from `useCalendar.ts` to allow for side-effect-free testing. Added comprehensive vitest suites for these time parsers and `dateUtils.ts`.
* **Playwright Coverage:** Added an end-to-end user flow in `tests/e2e/calendar.spec.ts` covering manual event creation and deletion within the workspace, which asserts user-visible UI outcomes without relying on implementation details.

### Validation & Environment Notes
* ✅ Unit tests ran successfully via `npm run test` (Vitest). 