### PR TITLE
Add unit tests for schema validation (#228)

### DIFF
--- a/src/features/demo-admin-dashboard/__tests__/proofFormatting.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/proofFormatting.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  truncateHash,
+  formatLatency,
+  formatPostageStatus,
+  isValidMockHash,
+  isValidDiagnosticId,
+  formatProofSummary,
+  validateProofRecord,
+} from "../proofFormatting";
+import { demoProofRecords } from "../fixtures/proofRecordFixtures";
+import type { ProofRecord } from "../types/proofRecord";
+
+describe("truncateHash", () => {
+  it("truncates standard hex hash with default prefix/suffix lengths", () => {
+    const hash = "0xabcdef1234567890abcdef1234567890abcdef";
+    expect(truncateHash(hash)).toBe("0xabcdef\u2026cdef");
+  });
+
+  it("handles hashes without 0x prefix by adding it in the result", () => {
+    const hash = "abcdef1234567890abcdef1234567890abcdef";
+    expect(truncateHash(hash)).toBe("0xabcdef\u2026cdef");
+  });
+
+  it("returns original hash if body length is less than or equal to prefix + suffix", () => {
+    const shortHash = "0x123456";
+    expect(truncateHash(shortHash, 4, 4)).toBe("0x123456");
+  });
+
+  it("supports custom prefix and suffix lengths", () => {
+    const hash = "0xabcdef1234567890";
+    expect(truncateHash(hash, 4, 2)).toBe("0xabcd\u202690");
+  });
+});
+
+describe("formatLatency", () => {
+  it("normalises latency strings to lowercase and trims whitespace", () => {
+    expect(formatLatency("  42MS  ")).toBe("42ms");
+    expect(formatLatency("15ms")).toBe("15ms");
+  });
+});
+
+describe("formatPostageStatus", () => {
+  it("returns human-readable labels for each postage status", () => {
+    expect(formatPostageStatus("pending")).toBe("Pending");
+    expect(formatPostageStatus("settled")).toBe("Settled");
+    expect(formatPostageStatus("refunded")).toBe("Refunded");
+  });
+});
+
+describe("isValidMockHash", () => {
+  it("returns true for valid hex strings starting with 0x", () => {
+    expect(isValidMockHash("0x1234567890abcdef")).toBe(true);
+    expect(isValidMockHash("0xABCDEF")).toBe(true);
+    expect(isValidMockHash(" 0x12ab  ")).toBe(true); // trims whitespace
+  });
+
+  it("returns false for non-hex, empty, or missing 0x prefix", () => {
+    expect(isValidMockHash("1234567890abcdef")).toBe(false);
+    expect(isValidMockHash("0x123g")).toBe(false);
+    expect(isValidMockHash("")).toBe(false);
+  });
+});
+
+describe("isValidDiagnosticId", () => {
+  it("returns true for valid UUID format", () => {
+    expect(isValidDiagnosticId("12345678-abcd-1234-abcd-1234567890ab")).toBe(true);
+    expect(isValidDiagnosticId(" 12345678-abcd-1234-abcd-1234567890ab ")).toBe(true); // trims
+  });
+
+  it("returns false for invalid UUID formatting", () => {
+    expect(isValidDiagnosticId("12345678-abcd-1234-abcd")).toBe(false);
+    expect(isValidDiagnosticId("invalid-uuid-string")).toBe(false);
+    expect(isValidDiagnosticId("")).toBe(false);
+  });
+});
+
+describe("formatProofSummary", () => {
+  it("builds a formatted one-line summary", () => {
+    const record: ProofRecord = demoProofRecords[0];
+    const summary = formatProofSummary(record);
+    // msg=0xabc…1234 | pay=0xdef…5678 | settled | 42ms
+    expect(summary).toContain("msg=");
+    expect(summary).toContain("pay=");
+    expect(summary).toContain("Settled");
+    expect(summary).toContain("42ms");
+  });
+});
+
+describe("validateProofRecord", () => {
+  it("returns empty array for valid proof record fixture", () => {
+    const errors = validateProofRecord(demoProofRecords[0]);
+    expect(errors).toEqual([]);
+  });
+
+  it("identifies invalid messageHash path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      messageHash: "invalid_hash",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "messageHash",
+      message: "Must be a hex string starting with 0x.",
+    });
+  });
+
+  it("identifies invalid paymentHash path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      paymentHash: "invalid_hash",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "paymentHash",
+      message: "Must be a hex string starting with 0x.",
+    });
+  });
+
+  it("identifies invalid diagnosticId path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      diagnosticId: "not-a-uuid",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "diagnosticId",
+      message: "Must be a valid UUID (8-4-4-4-12).",
+    });
+  });
+
+  it("identifies missing/invalid contractAddress path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      contractAddress: "short",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "contractAddress",
+      message: "Contract address is required.",
+    });
+  });
+
+  it("identifies missing signature path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      signature: "  ",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "signature",
+      message: "Signature is required.",
+    });
+  });
+
+  it("identifies invalid latency path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      latency: "42",
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "latency",
+      message: 'Latency must be in the format "42ms".',
+    });
+  });
+
+  it("identifies invalid postageStatus path", () => {
+    const invalidRecord: Partial<ProofRecord> = {
+      ...demoProofRecords[0],
+      postageStatus: "unknown-status" as any,
+    };
+    const errors = validateProofRecord(invalidRecord);
+    expect(errors).toContainEqual({
+      field: "postageStatus",
+      message: "Must be pending, settled, or refunded.",
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/__tests__/seedDatasetValidation.test.ts
+++ b/src/features/demo-admin-dashboard/__tests__/seedDatasetValidation.test.ts
@@ -87,4 +87,95 @@ describe("validateInboxSeedDataset", () => {
     const issues = validateInboxSeedDataset(dataset);
     expect(issues.some((i) => i.id?.includes("empty"))).toBe(true);
   });
+
+  it("reports warning for message with no subject", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      messages: [{ ...inboxSeedMessages[0], subject: "" }],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const subjectIssue = issues.find((i) => i.fieldPath === "messages[0].subject");
+    expect(subjectIssue).toBeDefined();
+    expect(subjectIssue!.severity).toBe("warning");
+    expect(subjectIssue!.message).toContain("has no subject");
+  });
+
+  it("reports error for invalid message date format", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      messages: [{ ...inboxSeedMessages[0], date: "invalid-date-format" }],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const dateIssue = issues.find((i) => i.fieldPath === "messages[0].date");
+    expect(dateIssue).toBeDefined();
+    expect(dateIssue!.severity).toBe("error");
+    expect(dateIssue!.message).toContain("invalid date");
+  });
+
+  it("reports warning for unsafe recipient domain", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      messages: [{ ...inboxSeedMessages[0], recipients: ["eve@unverified.com"] }],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const recipientIssue = issues.find((i) => i.fieldPath === "messages[0].recipients[0]");
+    expect(recipientIssue).toBeDefined();
+    expect(recipientIssue!.severity).toBe("warning");
+    expect(recipientIssue!.message).toContain("uses an unsafe domain");
+  });
+
+  it("reports error for potential secret pattern in message body", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      messages: [
+        {
+          ...inboxSeedMessages[0],
+          body: "Here is my Stellar secret key: SAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        },
+      ],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const bodyIssue = issues.find((i) => i.fieldPath === "messages[0].body");
+    expect(bodyIssue).toBeDefined();
+    expect(bodyIssue!.severity).toBe("error");
+    expect(bodyIssue!.message).toContain("may contain a secret");
+  });
+
+  it("reports error for invalid proof record timestamp", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      messages: [
+        {
+          ...inboxSeedMessages[0],
+          proofRecord: {
+            ...inboxSeedMessages[0].proofRecord!,
+            timestamp: "not-iso-date",
+          },
+        },
+      ],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const proofTimeIssue = issues.find((i) => i.fieldPath === "messages[0].proofRecord.timestamp");
+    expect(proofTimeIssue).toBeDefined();
+    expect(proofTimeIssue!.severity).toBe("error");
+    expect(proofTimeIssue!.message).toContain("is not ISO 8601");
+  });
+
+  it("reports warning for unsafe sender domain in senders list", () => {
+    const dataset: DemoDataset = {
+      ...inboxSeedDataset,
+      senders: [
+        {
+          address: "unsafe@malicious.domain.com",
+          name: "Unsafe Sender",
+          isTrusted: false,
+        },
+      ],
+    };
+    const issues = validateInboxSeedDataset(dataset);
+    const senderIssue = issues.find((i) => i.fieldPath === "senders[0].address");
+    expect(senderIssue).toBeDefined();
+    expect(senderIssue!.severity).toBe("warning");
+    expect(senderIssue!.message).toContain("uses an unsafe domain");
+  });
 });


### PR DESCRIPTION
## Goal
This PR introduces robust unit tests for demo dataset validators and error formatting within the Demo Admin Dashboard to ensure schema consistency and stable validation reporting.

Closes #228

## Proposed Changes
All changes are fully isolated inside the `src/features/demo-admin-dashboard/` implementation directory:
- **`__tests__/proofFormatting.test.ts` (NEW)**: Implemented tests for proof record validators and formatting helpers:
  - Tested hash truncation, latency normalisation, and postage status resolution.
  - Verified lightweight validators for mock hashes and diagnostic UUIDs.
  - Added invalid field path tests targeting messages and signatures using the existing `demoProofRecords` valid fixture.
- **`__tests__/seedDatasetValidation.test.ts` (MODIFIED)**: Expanded coverage to fully validate all validator logic branches:
  - Added tests for missing subjects (warnings).
  - Added tests for malformed ISO dates (errors).
  - Added tests for unsafe domains in recipient lists (warnings).
  - Added tests checking for secret patterns in message bodies (errors).
  - Added tests for invalid proof timestamps (errors).
  - Added tests for unsafe domains in sender configurations (warnings).

## Verification Results
Verified locally using `bun test`. All new and modified tests pass cleanly:
- `bun test seedDatasetValidation.test.ts` (14/14 passed)
- `bun test proofFormatting.test.ts` (19/19 passed)
