### PR TITLE
Polish onboarding interaction and focus states

### DIFF
--- a/src/features/onboarding/steps/AddressStep.tsx
+++ b/src/features/onboarding/steps/AddressStep.tsx
@@ -45,8 +45,9 @@ export function AddressStep({ walletAddress, onAdvance, onRetreat }: Props) {
           {walletAddress}
         </p>
         <button
+          type="button"
           onClick={handleCopy}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground transition hover:text-foreground"
+          className="flex items-center gap-1.5 rounded-sm text-xs text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
         >
           {copied ? (
             <>
@@ -80,14 +81,16 @@ export function AddressStep({ walletAddress, onAdvance, onRetreat }: Props) {
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]"
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onAdvance}
-          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]"
         >
           Continue
         </button>

--- a/src/features/onboarding/steps/IdentityStep.tsx
+++ b/src/features/onboarding/steps/IdentityStep.tsx
@@ -49,7 +49,10 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
       </div>
 
       {state.status === "unavailable" && (
-        <div role="status" className="rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+        <div
+          role="status"
+          className="rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4"
+        >
           <p className="text-sm text-amber-300">
             Freighter wallet extension not found. Install it, then return here.
           </p>
@@ -72,7 +75,10 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
       )}
 
       {state.status === "connected" && (
-        <div role="status" className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4">
+        <div
+          role="status"
+          className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4"
+        >
           <p className="text-xs font-mono text-emerald-300 break-all">{state.address}</p>
           <p className="mt-1 text-xs text-muted-foreground">Wallet connected. Continuing…</p>
         </div>

--- a/src/features/onboarding/steps/IdentityStep.tsx
+++ b/src/features/onboarding/steps/IdentityStep.tsx
@@ -49,7 +49,7 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
       </div>
 
       {state.status === "unavailable" && (
-        <div className="rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+        <div role="status" className="rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
           <p className="text-sm text-amber-300">
             Freighter wallet extension not found. Install it, then return here.
           </p>
@@ -57,7 +57,7 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
             href="https://freighter.app"
             target="_blank"
             rel="noreferrer"
-            className="mt-2 inline-flex items-center gap-1.5 text-xs text-amber-300 underline underline-offset-2 hover:text-amber-200"
+            className="mt-2 inline-flex items-center gap-1.5 rounded-sm text-xs text-amber-300 underline underline-offset-2 hover:text-amber-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/50"
           >
             Get Freighter <ExternalLink className="h-3 w-3" />
           </a>
@@ -65,24 +65,26 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
       )}
 
       {state.status === "error" && (
-        <div className="rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
+        <div role="alert" className="rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
           <p className="text-sm text-red-300">{state.message}</p>
           <p className="mt-1 text-xs text-muted-foreground">You can try again below.</p>
         </div>
       )}
 
       {state.status === "connected" && (
-        <div className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4">
+        <div role="status" className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4">
           <p className="text-xs font-mono text-emerald-300 break-all">{state.address}</p>
           <p className="mt-1 text-xs text-muted-foreground">Wallet connected. Continuing…</p>
         </div>
       )}
 
       <button
+        type="button"
         onClick={handleConnect}
         disabled={isConnecting || state.status === "connected"}
+        aria-busy={isConnecting}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold transition",
+          "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]",
           isConnecting || state.status === "connected"
             ? "cursor-not-allowed bg-white/10 text-muted-foreground"
             : "bg-foreground text-background hover:opacity-90",

--- a/src/features/onboarding/steps/MinimumPostageStep.tsx
+++ b/src/features/onboarding/steps/MinimumPostageStep.tsx
@@ -63,11 +63,15 @@ export function MinimumPostageStep({ draft, onUpdate, onAdvance, onRetreat }: Pr
           return (
             <button
               key={preset.value}
+              type="button"
+              aria-pressed={isSelected}
               onClick={() => handlePreset(preset.value)}
               className={cn(
                 "rounded-xl border p-3 text-left transition",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60",
+                "active:scale-[0.99]",
                 isSelected
-                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  ? "border-emerald-400/30 bg-emerald-400/[0.06] ring-1 ring-emerald-400/30"
                   : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
               )}
             >
@@ -80,8 +84,9 @@ export function MinimumPostageStep({ draft, onUpdate, onAdvance, onRetreat }: Pr
 
       <div className="space-y-2">
         <button
+          type="button"
           onClick={() => setCustom(true)}
-          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition"
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
         >
           Enter custom amount
         </button>
@@ -118,16 +123,18 @@ export function MinimumPostageStep({ draft, onUpdate, onAdvance, onRetreat }: Pr
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]"
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onAdvance}
           disabled={!canAdvance}
           className={cn(
-            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]",
             canAdvance
               ? "bg-foreground text-background hover:opacity-90"
               : "cursor-not-allowed bg-white/10 text-muted-foreground",

--- a/src/features/onboarding/steps/PolicyReviewStep.tsx
+++ b/src/features/onboarding/steps/PolicyReviewStep.tsx
@@ -55,7 +55,10 @@ export function PolicyReviewStep({ draft, isSubmitting, submitError, onSubmit, o
       </div>
 
       {submitError && (
-        <div role="alert" className="flex items-start gap-2 rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4"
+        >
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
           <div className="space-y-1">
             <p className="text-sm text-red-300">{submitError}</p>

--- a/src/features/onboarding/steps/PolicyReviewStep.tsx
+++ b/src/features/onboarding/steps/PolicyReviewStep.tsx
@@ -55,7 +55,7 @@ export function PolicyReviewStep({ draft, isSubmitting, submitError, onSubmit, o
       </div>
 
       {submitError && (
-        <div className="flex items-start gap-2 rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
+        <div role="alert" className="flex items-start gap-2 rounded-xl border border-red-400/20 bg-red-400/[0.06] p-4">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
           <div className="space-y-1">
             <p className="text-sm text-red-300">{submitError}</p>
@@ -76,20 +76,23 @@ export function PolicyReviewStep({ draft, isSubmitting, submitError, onSubmit, o
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
           disabled={isSubmitting}
           className={cn(
-            "flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition",
+            "flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]",
             isSubmitting ? "opacity-40" : "hover:bg-white/[0.04] hover:text-foreground",
           )}
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onSubmit}
           disabled={isSubmitting}
+          aria-busy={isSubmitting}
           className={cn(
-            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]",
             isSubmitting
               ? "cursor-not-allowed bg-white/10 text-muted-foreground"
               : "bg-foreground text-background hover:opacity-90",

--- a/src/features/onboarding/steps/ReceiptPreferenceStep.tsx
+++ b/src/features/onboarding/steps/ReceiptPreferenceStep.tsx
@@ -49,11 +49,15 @@ export function ReceiptPreferenceStep({ draft, onUpdate, onAdvance, onRetreat }:
           return (
             <button
               key={String(value)}
+              type="button"
+              aria-pressed={isSelected}
               onClick={() => onUpdate({ receiptOnDelivery: value })}
               className={cn(
                 "flex items-start gap-3 rounded-xl border p-4 text-left transition",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60",
+                "active:scale-[0.99]",
                 isSelected
-                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  ? "border-emerald-400/30 bg-emerald-400/[0.06] ring-1 ring-emerald-400/30"
                   : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
               )}
             >
@@ -85,14 +89,16 @@ export function ReceiptPreferenceStep({ draft, onUpdate, onAdvance, onRetreat }:
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]"
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onAdvance}
-          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]"
         >
           Continue
         </button>

--- a/src/features/onboarding/steps/RecoveryStep.tsx
+++ b/src/features/onboarding/steps/RecoveryStep.tsx
@@ -49,11 +49,15 @@ export function RecoveryStep({ onAdvance, onRetreat }: Props) {
         {ACKNOWLEDGMENTS.map((label, index) => (
           <button
             key={index}
+            type="button"
+            aria-pressed={checked[index]}
             onClick={() => toggle(index)}
             className={cn(
               "flex w-full items-start gap-3 rounded-xl border p-3 text-left transition",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60",
+              "active:scale-[0.99]",
               checked[index]
-                ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                ? "border-emerald-400/30 bg-emerald-400/[0.06] ring-1 ring-emerald-400/30"
                 : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
             )}
           >
@@ -78,16 +82,18 @@ export function RecoveryStep({ onAdvance, onRetreat }: Props) {
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]"
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onAdvance}
           disabled={!allChecked}
           className={cn(
-            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition",
+            "flex-1 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]",
             allChecked
               ? "bg-foreground text-background hover:opacity-90"
               : "cursor-not-allowed bg-white/10 text-muted-foreground",

--- a/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
+++ b/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
@@ -59,11 +59,15 @@ export function UnknownSenderRulesStep({ draft, onUpdate, onAdvance, onRetreat }
           return (
             <button
               key={policy.value}
+              type="button"
+              aria-pressed={isSelected}
               onClick={() => onUpdate({ unknownSenderRule: policy.value })}
               className={cn(
                 "relative rounded-xl border p-4 text-left transition",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60",
+                "active:scale-[0.99]",
                 isSelected
-                  ? "border-emerald-400/20 bg-emerald-400/[0.06]"
+                  ? "border-emerald-400/30 bg-emerald-400/[0.06] ring-1 ring-emerald-400/30"
                   : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05]",
               )}
             >
@@ -90,14 +94,16 @@ export function UnknownSenderRulesStep({ draft, onUpdate, onAdvance, onRetreat }
 
       <div className="flex gap-3">
         <button
+          type="button"
           onClick={onRetreat}
-          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
+          className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 active:scale-[0.99]"
         >
           Back
         </button>
         <button
+          type="button"
           onClick={onAdvance}
-          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+          className="flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 active:scale-[0.99]"
         >
           Continue
         </button>

--- a/tools/v1/individual/grammar-cleaner/tests/components.test.ts
+++ b/tools/v1/individual/grammar-cleaner/tests/components.test.ts
@@ -14,16 +14,23 @@ const sampleInput = SAMPLE_TEXTS[0].input;
 const onChange = () => {};
 const onSubmit = () => {};
 
-function isElement(n: unknown): n is ReactElement {
+/** Local typed shape so `props` is accessible as Record<string, unknown>. */
+type TypedElement = Omit<ReactElement, "props"> & { props: Record<string, unknown> };
+
+function isElement(n: unknown): n is TypedElement {
   return (
-    typeof n === "object" && n !== null && "type" in n && "props" in (n as Record<string, unknown>)
+    typeof n === "object" &&
+    n !== null &&
+    "type" in n &&
+    "props" in (n as Record<string, unknown>) &&
+    typeof (n as Record<string, unknown>).props === "object"
   );
 }
 
 function findInTree(
   node: ReactNode,
-  predicate: (el: ReactElement) => boolean,
-): ReactElement | null {
+  predicate: (el: TypedElement) => boolean,
+): TypedElement | null {
   if (!isElement(node)) return null;
   if (predicate(node)) return node;
   const children = node.props.children;
@@ -36,7 +43,7 @@ function findInTree(
   return null;
 }
 
-function hasElement(node: ReactNode, predicate: (el: ReactElement) => boolean): boolean {
+function hasElement(node: ReactNode, predicate: (el: TypedElement) => boolean): boolean {
   return findInTree(node, predicate) !== null;
 }
 

--- a/tools/v1/team/collision-detection/tests/components.test.ts
+++ b/tools/v1/team/collision-detection/tests/components.test.ts
@@ -13,16 +13,23 @@ import { scanActiveReplies } from "../services/collisionDetection";
 
 const sampleReplies = COLLISION_FIXTURES[0].replies;
 
-function isElement(n: unknown): n is ReactElement {
+/** Local typed shape so `props` is accessible as Record<string, unknown>. */
+type TypedElement = Omit<ReactElement, "props"> & { props: Record<string, unknown> };
+
+function isElement(n: unknown): n is TypedElement {
   return (
-    typeof n === "object" && n !== null && "type" in n && "props" in (n as Record<string, unknown>)
+    typeof n === "object" &&
+    n !== null &&
+    "type" in n &&
+    "props" in (n as Record<string, unknown>) &&
+    typeof (n as Record<string, unknown>).props === "object"
   );
 }
 
 function findInTree(
   node: ReactNode,
-  predicate: (el: ReactElement) => boolean,
-): ReactElement | null {
+  predicate: (el: TypedElement) => boolean,
+): TypedElement | null {
   if (!isElement(node)) return null;
   if (predicate(node)) return node;
   const children = node.props.children;
@@ -35,7 +42,7 @@ function findInTree(
   return null;
 }
 
-function hasElement(node: ReactNode, predicate: (el: ReactElement) => boolean): boolean {
+function hasElement(node: ReactNode, predicate: (el: TypedElement) => boolean): boolean {
   return findInTree(node, predicate) !== null;
 }
 


### PR DESCRIPTION
Add visible focus-visible rings and active press feedback to every onboarding button, mark selection cards with aria-pressed plus a clearer selected ring, add aria-busy on the wallet-connect and activate actions, and give the wallet/submit status messages role=status/alert. Also set type=button on non-submit buttons so they don't accidentally submit. Behavior is unchanged; only existing design tokens are used.

Closes #931