### PR TITLE
V1]individual] grammar cleaner

### DIFF
--- a/tools/v1/individual/grammar-cleaner/services/grammarCleaner.ts
+++ b/tools/v1/individual/grammar-cleaner/services/grammarCleaner.ts
@@ -66,6 +66,25 @@ const HOMOPHONE_RULES: ReplacementRule[] = [
     explanation: "Use 'it's' as a contraction of 'it is' or 'it has'.",
   },
   {
+    pattern:
+      /\byour\s+(ready|done|finished|late|early|here|there|back|not|also|still|already|always|never|just|only|even|all|going|coming|working|happy|sorry|right|wrong|welcome|aware|concerned|interested|the\b)/gi,
+    replacement: "you're $1",
+    type: "spelling",
+    explanation: "Use 'you're' as a contraction of 'you are' before a description.",
+  },
+  {
+    pattern: /\btheirs\s+(a|an|alot|a lot|many|much|no|not)\b/gi,
+    replacement: "there's $1",
+    type: "spelling",
+    explanation: "Use 'there's' when you mean 'there is'.",
+  },
+  {
+    pattern: /\baccidently\b/gi,
+    replacement: "accidentally",
+    type: "spelling",
+    explanation: "'Accidentally' includes the '-ally' ending.",
+  },
+  {
     pattern: /\baffect\b/gi,
     replacement: "effect",
     type: "spelling",
@@ -158,14 +177,14 @@ const HOMOPHONE_RULES: ReplacementRule[] = [
   {
     pattern:
       /\bthere\s+(going|coming|doing|making|getting|having|working|taking|bringing|leaving|heading|arriving|planning|trying|looking|waiting|checking|reviewing|sending|preparing|meeting|starting|finishing|leading|running|building|creating|setting)\b/gi,
-    replacement: "they're",
+    replacement: "they're $1",
     type: "spelling",
     explanation: "Use 'they're' as a contraction of 'they are' before a verb.",
   },
   {
     pattern:
       /\btheir\s+(ready|done|finished|late|early|here|there|back|not|also|still|already|always|never|just|only|even|all|both|each|going|coming|working|happy|sorry|thankful|grateful|aware|concerned|interested)\b/gi,
-    replacement: "they're",
+    replacement: "they're $1",
     type: "spelling",
     explanation: "Use 'they're' (they are) instead of 'their' (possessive) before a description.",
   },

--- a/tools/v1/individual/grammar-cleaner/tests/grammarCleaner.test.ts
+++ b/tools/v1/individual/grammar-cleaner/tests/grammarCleaner.test.ts
@@ -13,14 +13,16 @@ import {
 const sampleText = SAMPLE_TEXTS[0].input;
 
 describe("cleanGrammar", () => {
-  it("detects and corrects homophone errors", () => {
+  it("detects and corrects homophone errors without dropping following words", () => {
     const result = cleanGrammar(sampleText);
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
     expect(result.result.changed).toBe(true);
     expect(result.result.issueCount).toBeGreaterThan(0);
-    expect(result.result.correctedText).toContain("they're");
-    expect(result.result.correctedText).not.toContain("teh");
+    expect(result.result.correctedText).toContain("they're going");
+    expect(result.result.correctedText).toContain("You're the best");
+    expect(result.result.correctedText).toContain("it's important");
+    expect(result.result.correctedText).not.toContain("there going");
   });
 
   it("capitalizes 'i' to 'I'", () => {
@@ -40,6 +42,17 @@ describe("cleanGrammar", () => {
     expect(result.result.correctedText).not.toContain("just");
     expect(result.result.correctedText).not.toContain("basically");
     expect(result.result.changed).toBe(true);
+  });
+
+  it("preserves captured words in their/there/your corrections", () => {
+    const result = cleanGrammar({
+      bodyText: "Their ready now. There working late. Your welcome to join.",
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.result.correctedText).toBe(
+      "They're ready now. They're working late. You're welcome to join.",
+    );
   });
 
   it("fixes punctuation spacing", () => {


### PR DESCRIPTION
### Motivation
- Fix cases where homophone replacements (`there`, `their`, `your`) dropped the following verb or descriptor during replacement and add a few common misspelling corrections.
- Make the engine more robust for phrase-level corrections while keeping the service deterministic and folder-local.

### Description
- Add new folder-local replacement rules for `your` → `you're` with captured continuation, `theirs` → `there's`, and `accidently` → `accidentally` inside `tools/v1/individual/grammar-cleaner/services/grammarCleaner.ts`.
- Preserve captured follow-up words in existing `there ...` and `their ...` rules by changing the replacements to include the capture (`"they're $1"` and similar) so verbs/descriptors are not dropped.
- Expand unit tests in `tools/v1/individual/grammar-cleaner/tests/grammarCleaner.test.ts` to assert phrase-preserving corrections and verify the new rules produce expected corrected text.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and validated the diff of modified files under `tools/v1/individual/grammar-cleaner/`.
- Attempted to run unit tests with `bunx vitest run --config tools/v1/individual/grammar-cleaner/vitest.config.ts` but execution was blocked because the environment has no local `node_modules` and resolving `vitest` from the npm registry returned HTTP 403, so tests could not complete in this environment.

------

Closes #365