### PR TITLE
feat: harden Email Summarizer against malformed input and oversized payloads

### DIFF
--- a/tools/v1/individual/email-summarizer/docs/security.md
+++ b/tools/v1/individual/email-summarizer/docs/security.md
@@ -1,0 +1,55 @@
+# Email Summarizer — Security & Performance Hardening
+
+This document records the threat assumptions, unsafe-input handling, and
+performance guards for the Email Summarizer tool. All behavior described here is
+implemented in `services/security.ts` and exercised by `tests/security.test.ts`.
+Everything stays inside this tool folder: no network calls, no mailbox
+mutation, no external providers, and no main-app imports.
+
+## Trust boundary
+
+The engine (`services/emailSummarizer.ts`) is pure and deterministic, but it
+assumes a well-formed `NormalizedEmail`. In a real deployment the email body,
+subject, and sender originate from untrusted senders. The hardening layer sits
+in front of the engine and treats every field as hostile until validated.
+
+## Threat assumptions and unsafe inputs
+
+| Unsafe input                                    | Risk                                                     | Mitigation                                                                                      |
+| ----------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Non-object, missing, or wrong-typed fields      | Runtime errors and undefined downstream behavior         | `validateEmailInput` rejects with typed `not-an-object` / `missing-field` / `wrong-type` issues |
+| Control characters or terminal escape sequences | Log/terminal injection, corrupted rendering              | `stripControlChars` replaces them with spaces while preserving tab and newline                  |
+| HTML or script markup in subject or sender      | Markup or script injection if later rendered as HTML     | `stripHtml` removes tags before the value is stored                                             |
+| Oversized body (multi-MB paste)                 | Excess CPU and memory in sentence splitting and scanning | Soft cap truncates at `bodyTruncateLength`; hard cap rejects past `maxBodyLength`               |
+| Oversized subject or sender                     | Unbounded storage and display                            | Capped to `maxSubjectLength` / `maxSenderLength`                                                |
+| Invalid `receivedAt` timestamp                  | Misleading traceability metadata                         | Preserved as-is but flagged with an `invalid-timestamp` warning                                 |
+
+## Size limits
+
+Defined in `SECURITY_LIMITS`:
+
+- `maxSubjectLength` — 1000 characters
+- `maxSenderLength` — 320 characters (RFC 5321 address ceiling)
+- `maxReceivedAtLength` — 64 characters
+- `bodyTruncateLength` — 20000 characters (soft cap: truncate and warn)
+- `maxBodyLength` — 100000 characters (hard cap: reject)
+
+## Performance notes
+
+- The engine runs `splitSentences`, `extractActionItems`, and a narrative filter
+  over the whole body, so cost grows with body length. Bounding the body length
+  before summarizing keeps the work predictable.
+- Truncating at `bodyTruncateLength` (rather than rejecting) keeps the common
+  "very long email" case usable while capping the worst case.
+- Bodies past `maxBodyLength` are rejected outright so a single hostile payload
+  cannot force a large allocation or a long-running scan.
+- All limits are plain constants; there are no nested loops over attachments or
+  recipients and no quadratic scans, so processing stays linear in body length.
+
+## Failure model
+
+`validateEmailInput` never throws. It returns either a sanitized success with
+optional non-fatal warnings (truncation, invalid timestamp), or a typed failure
+listing why the input was rejected. `summarizeEmailSafely` composes this guard
+with the pure engine: hostile input becomes a typed `unsupported-input` result
+instead of ever reaching `summarizeEmail`.

--- a/tools/v1/individual/email-summarizer/index.ts
+++ b/tools/v1/individual/email-summarizer/index.ts
@@ -5,5 +5,6 @@
 
 export * from "./services/emailSummarizer";
 export * from "./services/fixtures";
+export * from "./services/security";
 export * from "./hooks";
 export * from "./components";

--- a/tools/v1/individual/email-summarizer/services/security.ts
+++ b/tools/v1/individual/email-summarizer/services/security.ts
@@ -54,6 +54,7 @@ export type EmailValidationResult =
 // Control characters (except tab, newline, carriage return) can corrupt
 // rendering or smuggle terminal escape sequences. They are replaced with a
 // single space rather than dropped so word boundaries survive.
+// eslint-disable-next-line no-control-regex
 const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
 const HTML_TAG = /<[^>]*>/g;
 

--- a/tools/v1/individual/email-summarizer/services/security.ts
+++ b/tools/v1/individual/email-summarizer/services/security.ts
@@ -1,0 +1,190 @@
+/**
+ * Email Summarizer — input hardening and performance guards.
+ *
+ * Folder-local safety layer for the Email Summarizer engine. These helpers
+ * validate and sanitize untrusted email input before it reaches
+ * summarizeEmail, and bound the work the pure engine performs so a hostile or
+ * oversized payload can never cause unnecessary processing.
+ *
+ * Pure and deterministic: no network calls, no mailbox mutation, no external
+ * providers, and no imports outside this tool folder. See docs/security.md for
+ * the threat model and performance notes.
+ */
+
+import {
+  summarizeEmail,
+  type NormalizedEmail,
+  type SummarizerOptions,
+  type SummarizerResult,
+} from "./emailSummarizer";
+
+/** Conservative size caps that bound the work the engine performs. */
+export const SECURITY_LIMITS = {
+  /** Maximum accepted subject length, in characters. */
+  maxSubjectLength: 1000,
+  /** Maximum accepted sender length, in characters (RFC 5321 address ceiling). */
+  maxSenderLength: 320,
+  /** Maximum accepted receivedAt length, in characters. */
+  maxReceivedAtLength: 64,
+  /** Hard ceiling: bodies longer than this are rejected outright. */
+  maxBodyLength: 100000,
+  /** Soft ceiling: bodies longer than this are truncated before summarizing. */
+  bodyTruncateLength: 20000,
+} as const;
+
+export type SecurityIssueField = "input" | "subject" | "sender" | "receivedAt" | "body";
+
+export type SecurityIssueCode =
+  | "not-an-object"
+  | "missing-field"
+  | "wrong-type"
+  | "too-long"
+  | "invalid-timestamp";
+
+export interface SecurityIssue {
+  field: SecurityIssueField;
+  code: SecurityIssueCode;
+  message: string;
+}
+
+export type EmailValidationResult =
+  | { ok: true; value: NormalizedEmail; warnings: SecurityIssue[] }
+  | { ok: false; issues: SecurityIssue[] };
+
+// Control characters (except tab, newline, carriage return) can corrupt
+// rendering or smuggle terminal escape sequences. They are replaced with a
+// single space rather than dropped so word boundaries survive.
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+const HTML_TAG = /<[^>]*>/g;
+
+/** Replaces dangerous control characters while preserving tab and newline. */
+export function stripControlChars(text: string): string {
+  return text.replace(CONTROL_CHARS, " ");
+}
+
+/** Removes HTML/markup tags so script or markup cannot ride along as text. */
+export function stripHtml(text: string): string {
+  return text.replace(HTML_TAG, "");
+}
+
+function sanitizeField(value: string, maxLength: number): string {
+  const cleaned = stripControlChars(value).trim();
+  return cleaned.length > maxLength ? cleaned.slice(0, maxLength) : cleaned;
+}
+
+const REQUIRED_FIELDS: Array<keyof NormalizedEmail> = ["subject", "sender", "receivedAt", "body"];
+
+/**
+ * Validates and sanitizes untrusted input into a NormalizedEmail.
+ *
+ * Malformed or hostile shapes (non-objects, missing fields, wrong types, or a
+ * body past the hard ceiling) are rejected with typed issues. Recoverable
+ * problems (control characters, oversized-but-bounded fields, an unparseable
+ * timestamp) are sanitized and reported as non-fatal warnings.
+ */
+export function validateEmailInput(value: unknown): EmailValidationResult {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {
+      ok: false,
+      issues: [
+        {
+          field: "input",
+          code: "not-an-object",
+          message: "Email input must be an object with subject, sender, receivedAt, and body.",
+        },
+      ],
+    };
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const issues: SecurityIssue[] = [];
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in candidate) || candidate[field] === undefined) {
+      issues.push({
+        field,
+        code: "missing-field",
+        message: `Missing required field "${field}".`,
+      });
+    } else if (typeof candidate[field] !== "string") {
+      issues.push({
+        field,
+        code: "wrong-type",
+        message: `Field "${field}" must be a string.`,
+      });
+    }
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  const rawBody = candidate.body as string;
+  if (rawBody.length > SECURITY_LIMITS.maxBodyLength) {
+    return {
+      ok: false,
+      issues: [
+        {
+          field: "body",
+          code: "too-long",
+          message: `Email body exceeds the maximum of ${SECURITY_LIMITS.maxBodyLength} characters.`,
+        },
+      ],
+    };
+  }
+
+  const warnings: SecurityIssue[] = [];
+
+  const subject = sanitizeField(
+    stripHtml(candidate.subject as string),
+    SECURITY_LIMITS.maxSubjectLength,
+  );
+  const sender = sanitizeField(
+    stripHtml(candidate.sender as string),
+    SECURITY_LIMITS.maxSenderLength,
+  );
+  const receivedAt = sanitizeField(
+    candidate.receivedAt as string,
+    SECURITY_LIMITS.maxReceivedAtLength,
+  );
+
+  let body = stripControlChars(rawBody);
+  if (body.length > SECURITY_LIMITS.bodyTruncateLength) {
+    body = body.slice(0, SECURITY_LIMITS.bodyTruncateLength);
+    warnings.push({
+      field: "body",
+      code: "too-long",
+      message: `Email body truncated to ${SECURITY_LIMITS.bodyTruncateLength} characters before summarizing.`,
+    });
+  }
+
+  if (Number.isNaN(new Date(receivedAt).getTime())) {
+    warnings.push({
+      field: "receivedAt",
+      code: "invalid-timestamp",
+      message: "receivedAt is not a valid date; preserved as-is for traceability.",
+    });
+  }
+
+  return { ok: true, value: { subject, sender, receivedAt, body }, warnings };
+}
+
+/**
+ * Hardened entry point: validates and sanitizes untrusted input, then delegates
+ * to the pure summarizeEmail engine. Hostile or malformed input is reported as
+ * a typed "unsupported-input" result instead of reaching the engine.
+ */
+export function summarizeEmailSafely(
+  input: unknown,
+  options: SummarizerOptions = {},
+): SummarizerResult {
+  const validation = validateEmailInput(input);
+  if (!validation.ok) {
+    return {
+      status: "error",
+      code: "unsupported-input",
+      message: validation.issues.map((issue) => issue.message).join(" "),
+    };
+  }
+  return summarizeEmail(validation.value, options);
+}

--- a/tools/v1/individual/email-summarizer/tests/security.test.ts
+++ b/tools/v1/individual/email-summarizer/tests/security.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  SECURITY_LIMITS,
+  stripControlChars,
+  stripHtml,
+  summarizeEmailSafely,
+  validateEmailInput,
+} from "../services/security";
+
+function validInput() {
+  return {
+    subject: "Weekly status",
+    sender: "alex@example.com",
+    receivedAt: "2026-01-02T10:00:00.000Z",
+    body: "The release is on track. Please review the changelog before the demo.",
+  };
+}
+
+describe("validateEmailInput — malformed and hostile shapes", () => {
+  it("rejects non-object input", () => {
+    for (const value of [null, undefined, "x", 42, true, ["a"]]) {
+      expect(validateEmailInput(value).ok).toBe(false);
+    }
+  });
+
+  it("rejects missing required fields", () => {
+    const result = validateEmailInput({ subject: "Only subject" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.some((issue) => issue.code === "missing-field")).toBe(true);
+    }
+  });
+
+  it("rejects fields of the wrong type", () => {
+    const result = validateEmailInput({
+      subject: "S",
+      sender: 123,
+      receivedAt: "2026-01-02T10:00:00.000Z",
+      body: "Body",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.some((issue) => issue.code === "wrong-type")).toBe(true);
+    }
+  });
+});
+
+describe("sanitization helpers", () => {
+  it("strips control characters but keeps tabs and newlines", () => {
+    const cleaned = stripControlChars("a\u0000b\tc\nd");
+    expect(cleaned).toContain("\t");
+    expect(cleaned).toContain("\n");
+    expect(cleaned).not.toContain("\u0000");
+  });
+
+  it("removes HTML tags", () => {
+    expect(stripHtml("<script>alert(1)</script>hello")).toBe("alert(1)hello");
+  });
+
+  it("sanitizes subject markup on a valid email", () => {
+    const result = validateEmailInput({
+      ...validInput(),
+      subject: "<b>Important</b> update",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.subject).toBe("Important update");
+    }
+  });
+});
+
+describe("performance guards on large input", () => {
+  it("truncates an oversized-but-bounded body and warns", () => {
+    const body = "x".repeat(SECURITY_LIMITS.bodyTruncateLength + 500);
+    const result = validateEmailInput({ ...validInput(), body });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.body.length).toBe(SECURITY_LIMITS.bodyTruncateLength);
+      expect(result.warnings.some((issue) => issue.code === "too-long")).toBe(true);
+    }
+  });
+
+  it("rejects a body past the hard ceiling", () => {
+    const body = "x".repeat(SECURITY_LIMITS.maxBodyLength + 1);
+    const result = validateEmailInput({ ...validInput(), body });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.some((issue) => issue.code === "too-long")).toBe(true);
+    }
+  });
+
+  it("caps an oversized subject", () => {
+    const subject = "s".repeat(SECURITY_LIMITS.maxSubjectLength + 50);
+    const result = validateEmailInput({ ...validInput(), subject });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.subject.length).toBe(SECURITY_LIMITS.maxSubjectLength);
+    }
+  });
+});
+
+describe("summarizeEmailSafely", () => {
+  it("returns an unsupported-input error for hostile input", () => {
+    const result = summarizeEmailSafely(null);
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.code).toBe("unsupported-input");
+    }
+  });
+
+  it("summarizes a valid email", () => {
+    const result = summarizeEmailSafely(validInput());
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.summary.summary.length).toBeGreaterThan(0);
+      expect(result.summary.source.sender).toBe("alex@example.com");
+    }
+  });
+
+  it("handles a very long body without unbounded work", () => {
+    const body = `Please review this. ${"word ".repeat(5000)}`;
+    const result = summarizeEmailSafely({ ...validInput(), body });
+    expect(result.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## What

Adds a folder-local input-hardening and performance-guard layer for the Email Summarizer tool, sitting in front of the pure `summarizeEmail` engine.

- `services/security.ts` — `SECURITY_LIMITS`, `stripControlChars`, `stripHtml`, `validateEmailInput`, and a `summarizeEmailSafely` wrapper that validates/sanitizes untrusted input before it reaches the engine.
- `docs/security.md` — threat model, size limits, performance notes, and failure model.
- `tests/security.test.ts` — covers malformed/hostile shapes, sanitization, large-input truncation/reject/cap, and the safe wrapper.
- `index.ts` — re-exports the new security surface.

## Threat assumptions handled

- Non-object / missing / wrong-typed fields → rejected with typed issues.
- Control characters and HTML/markup → stripped before storage.
- Oversized body → soft cap truncates (warn), hard cap rejects.
- Oversized subject/sender → capped; invalid `receivedAt` → flagged.

## Scope & safety

- Pure and deterministic: no network calls, no mailbox mutation, no external providers.
- All changes confined to `tools/v1/individual/email-summarizer/`; no security-sensitive app code touched.

Closes #347