### PR TITLE
Feature: Create demo dataset schema validators 

### DIFF
--- a/src/features/demo-admin-dashboard/utils/__tests__/validators.test.ts
+++ b/src/features/demo-admin-dashboard/utils/__tests__/validators.test.ts
@@ -1,0 +1,56 @@
+import { validateDemoDataset } from '../validators';
+import { DemoDataValidationError, formatValidationErrors } from '../validation-errors';
+
+describe('Demo Dataset Validators', () => {
+  it('should accept a valid demo dataset', () => {
+    const validData = {
+      version: '1.0.0',
+      emails: [
+        {
+          id: 'msg_001',
+          subject: 'Test Email',
+          sender: 'demo@stellar-mail.fake',
+          body: 'Hello world'
+        }
+      ]
+    };
+
+    expect(() => validateDemoDataset(validData)).not.toThrow();
+    const result = validateDemoDataset(validData);
+    expect(result.version).toBe('1.0.0');
+  });
+
+  it('should reject malformed structures and aggregate errors', () => {
+    const invalidData = {
+      version: '1', // Invalid semver
+      emails: [
+        {
+          id: '', // Empty ID
+          subject: 123, // Should be string
+          sender: 'not-an-email', // No @ symbol
+          // missing body
+        }
+      ]
+    };
+
+    try {
+      validateDemoDataset(invalidData);
+      fail('Should have thrown DemoDataValidationError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(DemoDataValidationError);
+      const e = error as DemoDataValidationError;
+      
+      expect(e.issues).toContain("Missing or invalid 'version' (expected semantic version string like '1.0.0').");
+      expect(e.issues).toContain("Email at index 0 has missing or invalid 'id'.");
+      expect(e.issues).toContain("Email at index 0 has missing or invalid 'subject'.");
+      expect(e.issues).toContain("Email at index 0 has missing or invalid 'sender' email address.");
+      expect(e.issues).toContain("Email at index 0 has missing or invalid 'body'.");
+    }
+  });
+
+  it('should format errors correctly', () => {
+    const issues = ['Error 1', 'Error 2'];
+    const formatted = formatValidationErrors(issues);
+    expect(formatted).toBe('Validation failed with 2 issue(s):\n  1. Error 1\n  2. Error 2');
+  });
+});

--- a/src/features/demo-admin-dashboard/utils/validation-errors.ts
+++ b/src/features/demo-admin-dashboard/utils/validation-errors.ts
@@ -1,0 +1,20 @@
+// Custom error type for demo data validation
+export class DemoDataValidationError extends Error {
+  public readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super('Demo dataset validation failed');
+    this.name = 'DemoDataValidationError';
+    this.issues = issues;
+  }
+}
+
+// Error formatter to make logs readable in the admin UI
+export function formatValidationErrors(issues: string[]): string {
+  if (issues.length === 0) return 'No validation errors.';
+  
+  const header = `Validation failed with ${issues.length} issue(s):\n`;
+  const formattedIssues = issues.map((issue, index) => `  ${index + 1}. ${issue}`).join('\n');
+  
+  return header + formattedIssues;
+}

--- a/src/features/demo-admin-dashboard/utils/validators.ts
+++ b/src/features/demo-admin-dashboard/utils/validators.ts
@@ -1,0 +1,65 @@
+import { DemoDataValidationError } from './validation-errors';
+
+// Define the expected shape of the demo dataset
+export interface DemoEmail {
+  id: string;
+  subject: string;
+  sender: string;
+  body: string;
+}
+
+export interface DemoDataset {
+  version: string;
+  emails: DemoEmail[];
+}
+
+// Helper for type-checking plain objects
+const isPlainObject = (val: unknown): val is Record<string, unknown> => {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+};
+
+// Runtime Validator
+export function validateDemoDataset(data: unknown): DemoDataset {
+  const issues: string[] = [];
+
+  if (!isPlainObject(data)) {
+    throw new DemoDataValidationError(['Dataset must be a valid JSON object.']);
+  }
+
+  // Validate version
+  if (typeof data.version !== 'string' || !/^\d+\.\d+\.\d+$/.test(data.version)) {
+    issues.push("Missing or invalid 'version' (expected semantic version string like '1.0.0').");
+  }
+
+  // Validate emails array
+  if (!Array.isArray(data.emails)) {
+    issues.push("Missing or invalid 'emails' property (expected an array).");
+  } else {
+    data.emails.forEach((email: unknown, index: number) => {
+      if (!isPlainObject(email)) {
+        issues.push(`Email at index ${index} must be an object.`);
+        return;
+      }
+      
+      if (typeof email.id !== 'string' || email.id.trim() === '') {
+        issues.push(`Email at index ${index} has missing or invalid 'id'.`);
+      }
+      if (typeof email.subject !== 'string') {
+        issues.push(`Email at index ${index} has missing or invalid 'subject'.`);
+      }
+      if (typeof email.sender !== 'string' || !email.sender.includes('@')) {
+        issues.push(`Email at index ${index} has missing or invalid 'sender' email address.`);
+      }
+      if (typeof email.body !== 'string') {
+        issues.push(`Email at index ${index} has missing or invalid 'body'.`);
+      }
+    });
+  }
+
+  if (issues.length > 0) {
+    throw new DemoDataValidationError(issues);
+  }
+
+  // If we pass, cast safely
+  return data as DemoDataset;
+}


### PR DESCRIPTION
Closes #169 

🎯 Context

This PR introduces pure TypeScript runtime validators to catch malformed demo data before it reaches the preview or publish flows. To ensure zero risk to the core product, all validation logic, custom error types, and tests have been strictly isolated to the demo admin tooling, completely bypassing production mail flows.

🛠️ Key Changes

    Created DemoDataValidationError as a custom error type to cleanly aggregate validation failures.

    Built formatValidationErrors to transform arrays of validation issues into readable logs for the admin UI.

    Implemented validateDemoDataset, a dependency-free runtime schema validator that enforces the expected structure of mock emails and versioning.

    Added a comprehensive local test suite (validators.test.ts) using deterministic mock data to verify acceptance and rejection behaviors.

    Confirmed all files are scoped exclusively to src/features/demo-admin-dashboard/.
