### PR TITLE
feat(onboarding): accessible modal - dialog semantics, focus trap, progressbar, reduced motion (#932)

### DIFF
--- a/src/features/onboarding/OnboardingModal.tsx
+++ b/src/features/onboarding/OnboardingModal.tsx
@@ -1,4 +1,5 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useRef } from "react";
+import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import { useOnboarding } from "./useOnboarding";
 import { useFreighter } from "./useFreighter";
 import { IdentityStep } from "./steps/IdentityStep";
@@ -28,7 +29,14 @@ const stepVariants = {
 
 function ProgressBar({ stepIndex, totalSteps }: { stepIndex: number; totalSteps: number }) {
   return (
-    <div className="flex items-center gap-3 px-6 pt-5 pb-1">
+    <div
+      className="flex items-center gap-3 px-6 pt-5 pb-1"
+      role="progressbar"
+      aria-valuemin={1}
+      aria-valuemax={totalSteps}
+      aria-valuenow={stepIndex + 1}
+      aria-label={"Step " + (stepIndex + 1) + " of " + totalSteps}
+    >
       <div className="flex flex-1 gap-1">
         {Array.from({ length: totalSteps }).map((_, i) => (
           <div
@@ -40,7 +48,7 @@ function ProgressBar({ stepIndex, totalSteps }: { stepIndex: number; totalSteps:
           />
         ))}
       </div>
-      <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+      <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums" aria-live="polite">
         {stepIndex + 1} / {totalSteps}
       </span>
     </div>
@@ -133,6 +141,47 @@ export function OnboardingModal({ open, onComplete }: Props) {
   const freighter = useFreighter();
   const onboarding = useOnboarding({ onComplete });
 
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Keyboard accessibility: while the modal is open, move initial focus into the
+  // panel and trap Tab focus inside it. The modal is intentionally
+  // non-dismissible, so there is deliberately no Escape-to-close handler.
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const focusableSelector =
+      "a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+    function getFocusable(): HTMLElement[] {
+      return Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        (el) => el.offsetParent !== null,
+      );
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Tab") return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    panel.addEventListener("keydown", handleKeyDown);
+    getFocusable()[0]?.focus();
+
+    return () => panel.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
   const stepProps: StepProps = {
     freighter,
     draft: onboarding.draft,
@@ -145,47 +194,54 @@ export function OnboardingModal({ open, onComplete }: Props) {
   };
 
   return (
-    <AnimatePresence>
-      {open && (
-        <>
-          {/* Non-dismissible backdrop */}
-          <motion.div
-            key="onboarding-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-40 bg-black/70 backdrop-blur-md"
-          />
+    <MotionConfig reducedMotion="user">
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* Non-dismissible backdrop */}
+            <motion.div
+              key="onboarding-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 z-40 bg-black/70 backdrop-blur-md"
+            />
 
-          {/* Modal panel */}
-          <motion.div
-            key="onboarding-panel"
-            initial={{ opacity: 0, scale: 0.96, y: 12 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: 8 }}
-            transition={{ type: "spring", stiffness: 300, damping: 28 }}
-            className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(480px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
-          >
-            <ProgressBar stepIndex={onboarding.stepIndex} totalSteps={onboarding.totalSteps} />
+            {/* Modal panel */}
+            <motion.div
+              key="onboarding-panel"
+              ref={panelRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Account setup"
+              tabIndex={-1}
+              initial={{ opacity: 0, scale: 0.96, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96, y: 8 }}
+              transition={{ type: "spring", stiffness: 300, damping: 28 }}
+              className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(480px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
+            >
+              <ProgressBar stepIndex={onboarding.stepIndex} totalSteps={onboarding.totalSteps} />
 
-            {/* Step content area with direction-aware slide transition */}
-            <div className="overflow-hidden px-6 pb-6 pt-4">
-              <AnimatePresence mode="wait" custom={onboarding.direction}>
-                <motion.div
-                  key={onboarding.step}
-                  custom={onboarding.direction}
-                  variants={stepVariants}
-                  initial="enter"
-                  animate="center"
-                  exit="exit"
-                >
-                  {renderStep(onboarding.step, stepProps)}
-                </motion.div>
-              </AnimatePresence>
-            </div>
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+              {/* Step content area with direction-aware slide transition */}
+              <div className="overflow-hidden px-6 pb-6 pt-4">
+                <AnimatePresence mode="wait" custom={onboarding.direction}>
+                  <motion.div
+                    key={onboarding.step}
+                    custom={onboarding.direction}
+                    variants={stepVariants}
+                    initial="enter"
+                    animate="center"
+                    exit="exit"
+                  >
+                    {renderStep(onboarding.step, stepProps)}
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </MotionConfig>
   );
 }

--- a/src/features/onboarding/steps/IdentityStep.tsx
+++ b/src/features/onboarding/steps/IdentityStep.tsx
@@ -38,7 +38,7 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
 
       <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 space-y-3">
         <div className="flex items-start gap-3">
-          <Wallet className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <Wallet className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <div className="space-y-1">
             <p className="text-sm font-medium text-foreground">What Stealth will read</p>
             <p className="text-xs text-muted-foreground">
@@ -59,7 +59,7 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
             rel="noreferrer"
             className="mt-2 inline-flex items-center gap-1.5 text-xs text-amber-300 underline underline-offset-2 hover:text-amber-200"
           >
-            Get Freighter <ExternalLink className="h-3 w-3" />
+            Get Freighter <ExternalLink className="h-3 w-3" aria-hidden="true" />
           </a>
         </div>
       )}
@@ -90,14 +90,14 @@ export function IdentityStep({ freighter, onAdvance }: Props) {
       >
         {isConnecting ? (
           <>
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             Waiting for Freighter…
           </>
         ) : state.status === "connected" ? (
           "Connected"
         ) : (
           <>
-            <Wallet className="h-4 w-4" />
+            <Wallet className="h-4 w-4" aria-hidden="true" />
             Connect with Freighter
           </>
         )}

--- a/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
+++ b/src/features/onboarding/steps/UnknownSenderRulesStep.tsx
@@ -60,6 +60,7 @@ export function UnknownSenderRulesStep({ draft, onUpdate, onAdvance, onRetreat }
             <button
               key={policy.value}
               onClick={() => onUpdate({ unknownSenderRule: policy.value })}
+              aria-pressed={isSelected}
               className={cn(
                 "relative rounded-xl border p-4 text-left transition",
                 isSelected


### PR DESCRIPTION
## What
Improves accessibility of the onboarding modal (#932).

- Modal panel now exposes proper dialog semantics: `role="dialog"`, `aria-modal="true"`, `aria-label`, and is programmatically focusable (`tabIndex={-1}`).
- Keyboard focus trap: Tab / Shift+Tab cycle within the panel, and initial focus moves into the dialog on open. The modal is intentionally non-dismissible, so there is deliberately no Escape-to-close.
- Step progress indicator is now a semantic `role="progressbar"` with `aria-valuemin/max/now`, plus an `aria-live="polite"` step counter for screen-reader announcements.
- Honors reduced-motion preferences via framer-motion `<MotionConfig reducedMotion="user">`.
- Sender-policy options expose selected state via `aria-pressed`; decorative wallet/loader/link icons are marked `aria-hidden`.

## Testing
- `prettier --check` clean on all touched files.
- Type-check / lint run in CI.

Closes #932