### PR TITLE
Feature: Add avatar color and initials generator #177

### DIFF
--- a/src/features/demo-admin-dashboard/components/AvatarPreview.tsx
+++ b/src/features/demo-admin-dashboard/components/AvatarPreview.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { getInitials, getAvatarColor } from '../utils/avatar-helpers';
+
+export interface AvatarPreviewProps {
+  name: string;
+  size?: number;
+}
+
+/**
+ * Visual preview component for demo dashboard maintainers to verify
+ * the generated initials and colors for fake personas.
+ */
+export const AvatarPreview: React.FC<AvatarPreviewProps> = ({ name, size = 40 }) => {
+  const initials = getInitials(name);
+  const backgroundColor = getAvatarColor(name);
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        backgroundColor,
+        color: '#ffffff',
+        borderRadius: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontWeight: 'bold',
+        fontSize: size * 0.4,
+        fontFamily: 'sans-serif',
+        userSelect: 'none',
+      }}
+      title={name}
+      aria-label={`Avatar for ${name}`}
+    >
+      {initials}
+    </div>
+  );
+};

--- a/src/features/demo-admin-dashboard/utils/__tests__/avatar-helpers.test.ts
+++ b/src/features/demo-admin-dashboard/utils/__tests__/avatar-helpers.test.ts
@@ -1,0 +1,43 @@
+import { getInitials, getAvatarColor } from '../avatar-helpers';
+
+describe('Avatar Helpers', () => {
+  describe('getInitials', () => {
+    it('should extract two initials for a first and last name', () => {
+      expect(getInitials('John Doe')).toBe('JD');
+    });
+
+    it('should handle single names by taking the first two letters', () => {
+      expect(getInitials('Alice')).toBe('AL');
+    });
+
+    it('should handle multiple names by taking first and last initials', () => {
+      expect(getInitials('John Jacob Jingleheimer Schmidt')).toBe('JS');
+    });
+
+    it('should handle empty or malformed input gracefully', () => {
+      expect(getInitials('')).toBe('??');
+      expect(getInitials('   ')).toBe('??');
+    });
+  });
+
+  describe('getAvatarColor', () => {
+    it('should return a consistent color for the same input', () => {
+      const color1 = getAvatarColor('Demo User');
+      const color2 = getAvatarColor('Demo User');
+      expect(color1).toBe(color2);
+    });
+
+    it('should return a fallback gray for empty inputs', () => {
+      expect(getAvatarColor('')).toBe('#9CA3AF');
+    });
+
+    it('should distribute colors for different inputs', () => {
+      const color1 = getAvatarColor('Alice');
+      const color2 = getAvatarColor('Bob');
+      // Statistically unlikely to hash to the exact same index, 
+      // but strictly testing that it returns a valid hex from our array
+      expect(color1).toMatch(/^#[0-9A-F]{6}$/i);
+      expect(color2).toMatch(/^#[0-9A-F]{6}$/i);
+    });
+  });
+});

--- a/src/features/demo-admin-dashboard/utils/avatar-helpers.ts
+++ b/src/features/demo-admin-dashboard/utils/avatar-helpers.ts
@@ -1,0 +1,44 @@
+/**
+ * Extracts up to two initials from a given name string.
+ * Example: "John Doe" -> "JD", "Alice" -> "A", "  spaces  " -> "S"
+ */
+export function getInitials(name: string): string {
+  if (!name || typeof name !== 'string') return '??';
+
+  const cleanName = name.trim().replace(/\s+/g, ' ');
+  if (!cleanName) return '??';
+
+  const parts = cleanName.split(' ');
+  if (parts.length === 1) {
+    return parts[0].substring(0, 2).toUpperCase();
+  }
+
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+const AVATAR_COLORS = [
+  '#EF4444', // Red
+  '#F97316', // Orange
+  '#F59E0B', // Amber
+  '#10B981', // Emerald
+  '#3B82F6', // Blue
+  '#6366F1', // Indigo
+  '#8B5CF6', // Violet
+  '#EC4899', // Pink
+];
+
+/**
+ * Deterministically generates a hex color based on a string input.
+ * Ensures the same sender name always gets the same color in the demo UI.
+ */
+export function getAvatarColor(name: string): string {
+  if (!name || typeof name !== 'string') return '#9CA3AF'; // Default gray for empty
+
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const index = Math.abs(hash) % AVATAR_COLORS.length;
+  return AVATAR_COLORS[index];
+}


### PR DESCRIPTION
Closes #177 

🎯 Context

This PR introduces utilities to generate consistent sender avatar colors and initials for demo personas. To ensure zero risk to the core product, these utilities and their preview components have been strictly isolated to the demo admin tooling, bypassing all production app-shell and UI components.

🛠️ Key Changes

    Implemented getAvatarColor as a deterministic seed helper to hash a string (like a sender name) into a consistent hex color from a predefined palette.

    Built the AvatarPreview component to allow dashboard maintainers to easily visualize and verify the generated avatars for fake personas.

    Added a robust local test suite (avatar-helpers.test.ts) to guarantee the color hashing and initial extraction remain completely deterministic.

    Confirmed all files are scoped exclusively to src/features/demo-admin-dashboard/.