### PR TITLE
Add legal compliance review flag service

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/README.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/README.md
@@ -1,15 +1,49 @@
 # Legal and Compliance Review Flag
 
-This folder is the isolated workspace for the Legal and Compliance Review Flag tool.
+This folder contains the isolated core engine for the Legal and Compliance
+Review Flag tool. It evaluates team mail or workflow items and returns a
+deterministic review report that future UI work can consume without wiring into
+the main application.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\legal-and-compliance-review-flag\
-`
+`tools/v2/team/legal-and-compliance-review-flag/`
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder API
+
+```js
+import { createReviewFlagReport } from "./index.mjs";
+
+const report = createReviewFlagReport({
+  items: [
+    {
+      id: "thread-001",
+      subject: "Vendor DPA for review",
+      body: "The vendor asks us to approve the data processing addendum.",
+      containsExternalData: true,
+      contractValue: 125000,
+    },
+  ],
+});
+```
+
+The service returns one of four states:
+
+- `loading`: future UI can show a pending state before local data is ready.
+- `empty`: the input list is valid but has no items to review.
+- `success`: items were evaluated and include flags, severity, and reviewer
+  suggestions.
+- `error`: the input shape is invalid and includes local validation messages.
+
+## Local Files
+
+- `services/review-flag.service.mjs` contains the pure deterministic logic.
+- `fixtures/sample-review-items.json` provides local, non-production examples.
+- `tests/review-flag.test.mjs` verifies the folder-local API.
+- `docs/` documents reviewer notes and the test plan.
+
+No live network calls, secrets, production data, or app integration are included.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/review-notes.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/review-notes.md
@@ -1,0 +1,34 @@
+# Review Notes
+
+## Reviewer Intent
+
+The folder-local service is designed for future UI integration while staying
+fully isolated from the main app. It does not make legal decisions. It only
+surfaces deterministic review signals so a human team member can decide whether
+Legal, Compliance, Finance Operations, or the Team Owner should handle the item.
+
+## Rule Coverage
+
+- Legal review required: contract, NDA, MSA, DPA, addendum, liability, terms, or
+  procurement language.
+- Compliance risk: PII, personal data, regulated data, privacy, GDPR, HIPAA, or
+  external customer data.
+- Sanctions or export review: sanctions, embargo, restricted country, dual-use,
+  or export-control wording.
+- Finance review required: refund, chargeback, invoice, tax, or payment
+  exception wording.
+- Missing approval: high-value or external-data items without an assigned
+  reviewer, legal owner, compliance owner, or approval marker.
+
+## State Model
+
+- `loading`: future UI can render a waiting state while local data is prepared.
+- `empty`: callers passed an empty list and there is nothing to evaluate.
+- `success`: each item has status, severity, flags, metadata, and reviewer
+  suggestion.
+- `error`: invalid local input shape; no item evaluation is attempted.
+
+## Data Safety
+
+Fixtures are invented and deterministic. The service does not read production
+mail, call APIs, fetch remote resources, use secrets, or persist user data.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/test-plan.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/test-plan.md
@@ -1,0 +1,20 @@
+# Test Plan
+
+Run from the repository root:
+
+```sh
+node tools/v2/team/legal-and-compliance-review-flag/tests/review-flag.test.mjs
+node -e "import('./tools/v2/team/legal-and-compliance-review-flag/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
+git diff --check
+```
+
+Expected coverage:
+
+- Loading state returns `state: loading` and no items.
+- Empty state returns `state: empty` and zero counts.
+- Invalid item input returns `state: error` with local validation messages.
+- Fixture report flags legal, compliance, export, and approval concerns.
+- Routine fixture item remains clear with low severity.
+- Flag summary order is deterministic.
+
+No dependency install or network access is required for this tool.

--- a/tools/v2/team/legal-and-compliance-review-flag/fixtures/sample-review-items.json
+++ b/tools/v2/team/legal-and-compliance-review-flag/fixtures/sample-review-items.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "mail-legal-001",
+    "subject": "Vendor DPA and contract addendum",
+    "body": "The vendor asks us to approve the data processing addendum before renewal terms are finalized.",
+    "requestedAction": "Approve updated contract language",
+    "containsExternalData": true,
+    "contractValue": 125000,
+    "attachments": [
+      {
+        "name": "vendor-dpa.pdf",
+        "type": "application/pdf"
+      }
+    ]
+  },
+  {
+    "id": "mail-compliance-002",
+    "subject": "Customer export with PII",
+    "body": "Support needs to send a customer export that may include personal data and GDPR regulated data.",
+    "requestedAction": "Confirm whether export can be shared",
+    "containsExternalData": true,
+    "complianceOwner": "Avery Singh",
+    "contractValue": 0
+  },
+  {
+    "id": "mail-export-003",
+    "subject": "Restricted country resale question",
+    "body": "A reseller asks whether our dual-use component can be sent to a restricted country under export control rules.",
+    "requestedAction": "Reply to reseller",
+    "containsExternalData": false,
+    "contractValue": 35000
+  },
+  {
+    "id": "mail-clear-004",
+    "subject": "Team lunch schedule",
+    "body": "Please confirm the team lunch headcount for Friday.",
+    "requestedAction": "Confirm attendance",
+    "containsExternalData": false,
+    "contractValue": 0,
+    "reviewer": "Team Coordinator"
+  }
+]

--- a/tools/v2/team/legal-and-compliance-review-flag/index.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/index.mjs
@@ -1,0 +1,6 @@
+export {
+  DEFAULT_REVIEW_CONFIG,
+  REVIEW_FLAG_STATES,
+  createReviewFlagReport,
+  evaluateReviewItem,
+} from "./services/review-flag.service.mjs";

--- a/tools/v2/team/legal-and-compliance-review-flag/services/review-flag.service.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/services/review-flag.service.mjs
@@ -1,0 +1,395 @@
+export const REVIEW_FLAG_STATES = Object.freeze({
+  LOADING: "loading",
+  EMPTY: "empty",
+  SUCCESS: "success",
+  ERROR: "error",
+});
+
+export const DEFAULT_REVIEW_CONFIG = Object.freeze({
+  highValueThreshold: 100000,
+  reviewers: Object.freeze({
+    legal: "Legal",
+    compliance: "Compliance",
+    finance: "Finance Operations",
+    combined: "Legal and Compliance",
+    owner: "Team Owner",
+  }),
+});
+
+const SEVERITY_RANK = Object.freeze({
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+});
+
+const LEGAL_TERMS = [
+  "addendum",
+  "contract",
+  "data processing",
+  "dpa",
+  "indemnity",
+  "liability",
+  "msa",
+  "nda",
+  "procurement",
+  "renewal terms",
+  "termination",
+  "terms of service",
+];
+
+const COMPLIANCE_TERMS = [
+  "customer export",
+  "gdpr",
+  "health data",
+  "hipaa",
+  "passport",
+  "personal data",
+  "pii",
+  "privacy",
+  "regulated data",
+  "ssn",
+];
+
+const SANCTIONS_TERMS = [
+  "dual-use",
+  "embargo",
+  "export control",
+  "restricted country",
+  "sanction",
+  "trade restriction",
+];
+
+const FINANCE_TERMS = [
+  "chargeback",
+  "invoice",
+  "payment exception",
+  "refund",
+  "tax",
+];
+
+export function createReviewFlagReport(input = {}) {
+  if (input?.isLoading) {
+    return {
+      state: REVIEW_FLAG_STATES.LOADING,
+      status: "pending",
+      items: [],
+      flags: [],
+      errors: [],
+      summary: createEmptySummary(),
+    };
+  }
+
+  const items = input?.items;
+  if (!Array.isArray(items)) {
+    return createErrorReport("items must be an array");
+  }
+
+  if (items.length === 0) {
+    return {
+      state: REVIEW_FLAG_STATES.EMPTY,
+      status: "ready",
+      items: [],
+      flags: [],
+      errors: [],
+      summary: createEmptySummary(),
+    };
+  }
+
+  const config = {
+    ...DEFAULT_REVIEW_CONFIG,
+    ...(input.config ?? {}),
+    reviewers: {
+      ...DEFAULT_REVIEW_CONFIG.reviewers,
+      ...(input.config?.reviewers ?? {}),
+    },
+  };
+
+  const errors = validateItems(items);
+  if (errors.length > 0) {
+    return createErrorReport(errors);
+  }
+
+  const evaluatedItems = items.map((item) => evaluateReviewItem(item, config));
+  const summary = summarizeEvaluations(evaluatedItems);
+
+  return {
+    state: REVIEW_FLAG_STATES.SUCCESS,
+    status: summary.criticalCount > 0
+      ? "blocked"
+      : summary.flaggedItems > 0
+        ? "review_required"
+        : "clear",
+    items: evaluatedItems,
+    flags: summarizeFlags(evaluatedItems),
+    errors: [],
+    summary,
+  };
+}
+
+export function evaluateReviewItem(item, config = DEFAULT_REVIEW_CONFIG) {
+  const normalizedConfig = {
+    ...DEFAULT_REVIEW_CONFIG,
+    ...config,
+    reviewers: {
+      ...DEFAULT_REVIEW_CONFIG.reviewers,
+      ...(config.reviewers ?? {}),
+    },
+  };
+
+  const searchableText = normalizeSearchText(item);
+  const contractValue = normalizeMoney(item.contractValue);
+  const hasExternalData = item.containsExternalData === true;
+  const hasAssignedReviewer = hasAnyValue(item, [
+    "reviewer",
+    "legalOwner",
+    "complianceOwner",
+    "approvedBy",
+  ]);
+
+  const flags = [];
+  const legalMatches = findMatches(searchableText, LEGAL_TERMS);
+  if (legalMatches.length > 0) {
+    flags.push(createFlag({
+      code: "legal_review_required",
+      label: "Legal review required",
+      severity: contractValue >= normalizedConfig.highValueThreshold ? "high" : "medium",
+      reason: "The item references contract or legal terms that should be reviewed before response.",
+      evidence: legalMatches,
+    }));
+  }
+
+  const complianceMatches = findMatches(searchableText, COMPLIANCE_TERMS);
+  if (hasExternalData || complianceMatches.length > 0) {
+    flags.push(createFlag({
+      code: "compliance_risk",
+      label: "Compliance risk",
+      severity: "high",
+      reason: "The item may involve regulated, personal, or external customer data.",
+      evidence: hasExternalData ? ["containsExternalData"] : complianceMatches,
+    }));
+  }
+
+  const sanctionsMatches = findMatches(searchableText, SANCTIONS_TERMS);
+  if (sanctionsMatches.length > 0) {
+    flags.push(createFlag({
+      code: "sanctions_export_review",
+      label: "Sanctions or export review",
+      severity: "critical",
+      reason: "The item references sanctions, restricted jurisdictions, or export-control concerns.",
+      evidence: sanctionsMatches,
+    }));
+  }
+
+  const financeMatches = findMatches(searchableText, FINANCE_TERMS);
+  if (financeMatches.length > 0) {
+    flags.push(createFlag({
+      code: "finance_review_required",
+      label: "Finance review required",
+      severity: "medium",
+      reason: "The item references payment, tax, invoice, refund, or chargeback handling.",
+      evidence: financeMatches,
+    }));
+  }
+
+  if ((contractValue >= normalizedConfig.highValueThreshold || hasExternalData) && !hasAssignedReviewer) {
+    flags.push(createFlag({
+      code: "missing_approval",
+      label: "Missing owner or reviewer",
+      severity: contractValue >= normalizedConfig.highValueThreshold && hasExternalData
+        ? "critical"
+        : "high",
+      reason: "The item needs an accountable reviewer before the team responds.",
+      evidence: [
+        contractValue >= normalizedConfig.highValueThreshold ? "highValueContract" : null,
+        hasExternalData ? "externalData" : null,
+      ].filter(Boolean),
+    }));
+  }
+
+  const severity = flags.length > 0 ? highestSeverity(flags.map((flag) => flag.severity)) : "low";
+
+  return {
+    id: item.id,
+    title: item.subject ?? item.title,
+    status: flags.length > 0 ? "needs_review" : "clear",
+    severity,
+    recommendedReviewer: chooseReviewer(flags, normalizedConfig.reviewers),
+    flags,
+    metadata: {
+      contractValue,
+      containsExternalData: hasExternalData,
+      requestedAction: item.requestedAction ?? null,
+    },
+  };
+}
+
+function createFlag({ code, label, severity, reason, evidence }) {
+  return {
+    code,
+    label,
+    severity,
+    reason,
+    evidence: [...new Set(evidence)].sort(),
+  };
+}
+
+function createEmptySummary() {
+  return {
+    totalItems: 0,
+    flaggedItems: 0,
+    clearItems: 0,
+    highestSeverity: "low",
+    criticalCount: 0,
+    highCount: 0,
+    mediumCount: 0,
+    lowCount: 0,
+  };
+}
+
+function createErrorReport(messages) {
+  return {
+    state: REVIEW_FLAG_STATES.ERROR,
+    status: "blocked",
+    items: [],
+    flags: [],
+    errors: Array.isArray(messages) ? messages : [messages],
+    summary: createEmptySummary(),
+  };
+}
+
+function validateItems(items) {
+  const errors = [];
+  items.forEach((item, index) => {
+    if (!item || typeof item !== "object") {
+      errors.push(`items[${index}] must be an object`);
+      return;
+    }
+
+    if (!isNonEmptyString(item.id)) {
+      errors.push(`items[${index}].id is required`);
+    }
+
+    if (!isNonEmptyString(item.subject) && !isNonEmptyString(item.title)) {
+      errors.push(`items[${index}].subject or items[${index}].title is required`);
+    }
+  });
+
+  return errors;
+}
+
+function summarizeEvaluations(items) {
+  const severityCounts = items.reduce((counts, item) => {
+    counts[item.severity] += 1;
+    return counts;
+  }, { critical: 0, high: 0, medium: 0, low: 0 });
+
+  return {
+    totalItems: items.length,
+    flaggedItems: items.filter((item) => item.flags.length > 0).length,
+    clearItems: items.filter((item) => item.flags.length === 0).length,
+    highestSeverity: highestSeverity(items.map((item) => item.severity)),
+    criticalCount: severityCounts.critical,
+    highCount: severityCounts.high,
+    mediumCount: severityCounts.medium,
+    lowCount: severityCounts.low,
+  };
+}
+
+function summarizeFlags(items) {
+  const counts = new Map();
+  for (const item of items) {
+    for (const flag of item.flags) {
+      const current = counts.get(flag.code) ?? {
+        code: flag.code,
+        label: flag.label,
+        severity: flag.severity,
+        count: 0,
+      };
+      current.count += 1;
+      current.severity = highestSeverity([current.severity, flag.severity]);
+      counts.set(flag.code, current);
+    }
+  }
+
+  return [...counts.values()].sort((a, b) => {
+    if (SEVERITY_RANK[b.severity] !== SEVERITY_RANK[a.severity]) {
+      return SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    }
+    return a.code.localeCompare(b.code);
+  });
+}
+
+function chooseReviewer(flags, reviewers) {
+  const codes = new Set(flags.map((flag) => flag.code));
+  if (codes.has("sanctions_export_review")) {
+    return reviewers.combined;
+  }
+
+  if (codes.has("compliance_risk") && codes.has("legal_review_required")) {
+    return reviewers.combined;
+  }
+
+  if (codes.has("compliance_risk")) {
+    return reviewers.compliance;
+  }
+
+  if (codes.has("legal_review_required") || codes.has("missing_approval")) {
+    return reviewers.legal;
+  }
+
+  if (codes.has("finance_review_required")) {
+    return reviewers.finance;
+  }
+
+  return reviewers.owner;
+}
+
+function highestSeverity(severities) {
+  return severities.reduce((highest, severity) => (
+    SEVERITY_RANK[severity] > SEVERITY_RANK[highest] ? severity : highest
+  ), "low");
+}
+
+function normalizeSearchText(item) {
+  return [
+    item.subject,
+    item.title,
+    item.body,
+    item.requestedAction,
+    Array.isArray(item.tags) ? item.tags.join(" ") : "",
+    Array.isArray(item.attachments) ? item.attachments.map((attachment) => attachment.name).join(" ") : "",
+  ].filter(Boolean).join(" ").toLowerCase();
+}
+
+function findMatches(text, terms) {
+  return terms.filter((term) => {
+    const pattern = new RegExp(`\\b${escapeRegex(term).replace(/\s+/g, "\\s+")}\\b`, "i");
+    return pattern.test(text);
+  });
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeMoney(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = Number(value.replace(/[^0-9.-]/g, ""));
+    return Number.isFinite(normalized) ? normalized : 0;
+  }
+
+  return 0;
+}
+
+function hasAnyValue(item, keys) {
+  return keys.some((key) => isNonEmptyString(item[key]));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/specs.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/specs.md
@@ -1,41 +1,49 @@
 # Legal and Compliance Review Flag
 
-Compliance workflow.
+The Legal and Compliance Review Flag is a V2 team tool that identifies mail or
+workflow items needing legal, compliance, finance, or ownership review before
+the team responds.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/legal-and-compliance-review-flag/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
+## Core Inputs
 
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/legal-and-compliance-review-flag/README.md"
-  @"
+- `items`: an array of mail or workflow review items.
+- `isLoading`: optional boolean used by future UI callers to request a loading
+  report.
+- Each item should include `id`, `subject` or `title`, and optional context such
+  as `body`, `requestedAction`, `attachments`, `containsExternalData`,
+  `contractValue`, `reviewer`, `legalOwner`, or `complianceOwner`.
 
-# Legal and Compliance Review Flag Specs
+## Core Outputs
 
-## Purpose
+- `state`: `loading`, `empty`, `success`, or `error`.
+- `status`: `pending`, `ready`, `clear`, `review_required`, or `blocked`.
+- `items`: per-item evaluations with `flags`, `severity`, `status`, and
+  `recommendedReviewer`.
+- `summary`: counts by severity and overall highest severity.
+- `errors`: validation messages for invalid input.
 
-Compliance workflow.
+## Flag Categories
 
-## Contributor boundary
+- Legal review: contract, NDA, MSA, DPA, terms, addendum, liability, or
+  procurement language.
+- Compliance risk: PII, personal data, privacy regulation, customer export, or
+  regulated data language.
+- Sanctions and export control: sanctions, embargo, restricted country,
+  dual-use, or export-control language.
+- Finance review: invoice, refund, chargeback, tax, or payment language.
+- Approval gap: high-value or external-data items without an owner or reviewer.
 
-All work for this tool should stay in:
+## Non-Goals
 
-$dir/
-
-## Required issue categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+- No main application routing, navigation, mail rendering, wallet, Stellar,
+  database, or design-system changes.
+- No production data, live network calls, secrets, or third-party service calls.
+- No final legal judgment. The engine only flags review needs for humans.

--- a/tools/v2/team/legal-and-compliance-review-flag/tests/review-flag.test.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/tests/review-flag.test.mjs
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  REVIEW_FLAG_STATES,
+  createReviewFlagReport,
+  evaluateReviewItem,
+} from "../index.mjs";
+
+const sampleItems = JSON.parse(
+  readFileSync(new URL("../fixtures/sample-review-items.json", import.meta.url), "utf-8"),
+);
+
+describe("Legal and Compliance Review Flag", () => {
+  it("returns a loading state for pending callers", () => {
+    const report = createReviewFlagReport({ isLoading: true });
+
+    assert.equal(report.state, REVIEW_FLAG_STATES.LOADING);
+    assert.equal(report.status, "pending");
+    assert.deepEqual(report.items, []);
+  });
+
+  it("returns an empty state for a valid empty list", () => {
+    const report = createReviewFlagReport({ items: [] });
+
+    assert.equal(report.state, REVIEW_FLAG_STATES.EMPTY);
+    assert.equal(report.status, "ready");
+    assert.equal(report.summary.totalItems, 0);
+  });
+
+  it("returns an error state for invalid input", () => {
+    const report = createReviewFlagReport({ items: [{ body: "No id or title" }] });
+
+    assert.equal(report.state, REVIEW_FLAG_STATES.ERROR);
+    assert.equal(report.status, "blocked");
+    assert.ok(report.errors.some((message) => message.includes("id is required")));
+  });
+
+  it("flags legal, compliance, approval, and export concerns from fixtures", () => {
+    const report = createReviewFlagReport({ items: sampleItems });
+
+    assert.equal(report.state, REVIEW_FLAG_STATES.SUCCESS);
+    assert.equal(report.status, "blocked");
+    assert.equal(report.summary.totalItems, 4);
+    assert.equal(report.summary.flaggedItems, 3);
+    assert.equal(report.summary.clearItems, 1);
+    assert.equal(report.summary.highestSeverity, "critical");
+
+    const legalItem = report.items.find((item) => item.id === "mail-legal-001");
+    assert.deepEqual(
+      legalItem.flags.map((flag) => flag.code).sort(),
+      ["compliance_risk", "legal_review_required", "missing_approval"].sort(),
+    );
+    assert.equal(legalItem.recommendedReviewer, "Legal and Compliance");
+
+    const exportItem = report.items.find((item) => item.id === "mail-export-003");
+    assert.equal(exportItem.severity, "critical");
+    assert.ok(exportItem.flags.some((flag) => flag.code === "sanctions_export_review"));
+  });
+
+  it("marks routine messages as clear and low severity", () => {
+    const routine = evaluateReviewItem(sampleItems.find((item) => item.id === "mail-clear-004"));
+
+    assert.equal(routine.status, "clear");
+    assert.equal(routine.severity, "low");
+    assert.deepEqual(routine.flags, []);
+    assert.equal(routine.recommendedReviewer, "Team Owner");
+  });
+
+  it("summarizes flag counts in deterministic severity order", () => {
+    const report = createReviewFlagReport({ items: sampleItems });
+
+    assert.deepEqual(
+      report.flags.map((flag) => flag.code),
+      [
+        "missing_approval",
+        "sanctions_export_review",
+        "compliance_risk",
+        "legal_review_required",
+      ],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a folder-local legal/compliance review flag engine for V2 team contexts
- add deterministic local fixtures for legal, compliance, export-control, approval-gap, and clear-item scenarios
- document inputs, outputs, loading, empty, success, and error states for future UI work

## Scope and safety
- changes are limited to `tools/v2/team/legal-and-compliance-review-flag/`
- no main app integration, routing, wallet, Stellar core, database, or design-system changes
- no live network calls, secrets, or production data

## Validation
- `node tools\v2\team\legal-and-compliance-review-flag\tests\review-flag.test.mjs`
- `node -e "import('./tools/v2/team/legal-and-compliance-review-flag/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`

Closes 