### PR TITLE
Add mail-to-ticket converter core engine

### DIFF
--- a/tools/v2/team/mail-to-ticket-converter/README.md
+++ b/tools/v2/team/mail-to-ticket-converter/README.md
@@ -1,15 +1,49 @@
 # Mail-to-Ticket Converter
 
-This folder is the isolated workspace for the Mail-to-Ticket Converter tool.
+This folder contains the isolated core engine for the Mail-to-Ticket Converter
+tool. It converts local mail-like inputs into deterministic ticket candidates
+that future UI work can inspect before any main-app integration exists.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\mail-to-ticket-converter\
-`
+`tools/v2/team/mail-to-ticket-converter/`
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder API
+
+```js
+import { createTicketConversionReport } from "./index.mjs";
+
+const report = createTicketConversionReport({
+  messages: [
+    {
+      id: "mail-001",
+      subject: "Urgent: production login outage",
+      body: "Users cannot sign in after the latest deployment.",
+      senderEmail: "ops@example.com",
+      receivedAt: "2026-07-01T09:00:00.000Z",
+    },
+  ],
+});
+```
+
+The service returns one of four states:
+
+- `loading`: future UI callers can render a pending state while local mail data
+  is prepared.
+- `empty`: the message list is valid but has no items to convert.
+- `success`: messages were converted into ticket candidates with category,
+  priority, queue, SLA, tags, and source metadata.
+- `error`: the input shape is invalid and includes validation messages.
+
+## Local Files
+
+- `services/ticket-converter.service.mjs` contains the pure conversion logic.
+- `fixtures/sample-mail-items.json` provides deterministic local examples.
+- `tests/ticket-converter.test.mjs` verifies the folder-local API.
+- `docs/` documents reviewer notes and the test plan.
+
+No live network calls, secrets, production data, or app integration are included.

--- a/tools/v2/team/mail-to-ticket-converter/docs/review-notes.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/review-notes.md
@@ -1,0 +1,35 @@
+# Review Notes
+
+## Reviewer Intent
+
+The folder-local service prepares ticket candidates from local message records.
+It does not create tickets in any external system and does not integrate with
+the main inbox. The output is shaped for future UI review: title, description,
+category, priority, queue, SLA hours, tags, confidence, and source metadata.
+
+## Rule Coverage
+
+- Security queue: breach, phishing, suspicious login, security incident, or
+  production outage language.
+- Billing queue: invoice, charge, payment, refund, subscription, or billing
+  wording.
+- Access queue: login, password, permissions, locked-out, sign-in, or access
+  blockers.
+- Product support: bug, broken flow, error, exception, failing, or regression
+  language.
+- Product feedback: feature request, roadmap, improvement, or suggestion
+  language.
+- Customer support: routine messages that do not match a stronger category.
+
+## State Model
+
+- `loading`: local mail data is not ready yet.
+- `empty`: the input is valid but has no messages.
+- `success`: all messages were converted into reviewable ticket candidates.
+- `error`: invalid local input shape; no conversion is attempted.
+
+## Data Safety
+
+Fixtures are invented and deterministic. The service does not read production
+mail, persist records, call APIs, fetch remote resources, use secrets, or submit
+tickets to an external system.

--- a/tools/v2/team/mail-to-ticket-converter/docs/test-plan.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/test-plan.md
@@ -1,0 +1,21 @@
+# Test Plan
+
+Run from the repository root:
+
+```sh
+node tools/v2/team/mail-to-ticket-converter/tests/ticket-converter.test.mjs
+node -e "import('./tools/v2/team/mail-to-ticket-converter/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
+git diff --check
+```
+
+Expected coverage:
+
+- Loading state returns `state: loading` and no tickets.
+- Empty state returns `state: empty` and zero counts.
+- Invalid message input returns `state: error` with local validation messages.
+- Fixture report converts five local messages into ticket candidates.
+- Security outage mail routes to `Security Response` with critical priority.
+- Reply prefixes are normalized and source metadata is preserved.
+- Local configuration can override ticket IDs and queue names.
+
+No dependency install or network access is required for this tool.

--- a/tools/v2/team/mail-to-ticket-converter/fixtures/sample-mail-items.json
+++ b/tools/v2/team/mail-to-ticket-converter/fixtures/sample-mail-items.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "mail-001",
+    "threadId": "thread-access-001",
+    "subject": "Re: Urgent login access blocked",
+    "body": "A VIP customer cannot access the admin portal after password reset. They are blocked before a launch deadline.",
+    "senderName": "Jordan Lee",
+    "senderEmail": "jordan@example.com",
+    "receivedAt": "2026-07-01T09:00:00.000Z",
+    "labels": ["VIP", "Customer Support"],
+    "isVip": true
+  },
+  {
+    "id": "mail-002",
+    "threadId": "thread-security-002",
+    "subject": "Production down after suspected security incident",
+    "body": "The team reports a production down outage and possible breach after suspicious login activity.",
+    "senderName": "Ops Desk",
+    "senderEmail": "ops@example.com",
+    "receivedAt": "2026-07-01T09:15:00.000Z",
+    "labels": ["Incident"],
+    "attachments": [
+      {
+        "name": "incident-notes.txt",
+        "type": "text/plain"
+      }
+    ]
+  },
+  {
+    "id": "mail-003",
+    "threadId": "thread-billing-003",
+    "subject": "Invoice refund question",
+    "body": "The customer asks whether a duplicate invoice charge can be refunded this week.",
+    "senderName": "Billing Contact",
+    "senderEmail": "billing@example.com",
+    "receivedAt": "2026-07-01T10:00:00.000Z",
+    "labels": ["Billing"]
+  },
+  {
+    "id": "mail-004",
+    "threadId": "thread-feature-004",
+    "subject": "Feature request for export filters",
+    "body": "Can the roadmap include an improvement for saved export filters?",
+    "senderName": "Product User",
+    "senderEmail": "product@example.com",
+    "receivedAt": "2026-07-01T10:30:00.000Z",
+    "labels": ["Product Feedback"]
+  },
+  {
+    "id": "mail-005",
+    "threadId": "thread-routine-005",
+    "subject": "Weekly partner update",
+    "body": "Sharing the weekly partner update for visibility.",
+    "senderName": "Partner Team",
+    "senderEmail": "partners@example.com",
+    "receivedAt": "2026-07-01T11:00:00.000Z",
+    "labels": ["FYI"]
+  }
+]

--- a/tools/v2/team/mail-to-ticket-converter/index.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/index.mjs
@@ -1,0 +1,6 @@
+export {
+  DEFAULT_CONVERTER_CONFIG,
+  TICKET_CONVERTER_STATES,
+  convertMailToTicket,
+  createTicketConversionReport,
+} from "./services/ticket-converter.service.mjs";

--- a/tools/v2/team/mail-to-ticket-converter/services/ticket-converter.service.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/services/ticket-converter.service.mjs
@@ -1,0 +1,341 @@
+export const TICKET_CONVERTER_STATES = Object.freeze({
+  LOADING: "loading",
+  EMPTY: "empty",
+  SUCCESS: "success",
+  ERROR: "error",
+});
+
+export const DEFAULT_CONVERTER_CONFIG = Object.freeze({
+  ticketIdPrefix: "ticket",
+  titleMaxLength: 96,
+  descriptionMaxLength: 320,
+  slaHours: Object.freeze({
+    critical: 4,
+    high: 24,
+    medium: 72,
+    low: 168,
+  }),
+  queues: Object.freeze({
+    access: "Access Support",
+    billing: "Billing Operations",
+    bug: "Product Support",
+    feature: "Product Feedback",
+    security: "Security Response",
+    support: "Customer Support",
+  }),
+});
+
+const PRIORITY_RANK = Object.freeze({
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+});
+
+const CATEGORY_RULES = Object.freeze({
+  security: ["breach", "compromised", "phishing", "security incident", "suspicious login"],
+  billing: ["billing", "charge", "invoice", "payment", "refund", "subscription"],
+  access: ["access", "locked out", "login", "password", "permission", "sign in"],
+  bug: ["bug", "broken", "error", "exception", "failing", "regression"],
+  feature: ["feature request", "improvement", "roadmap", "suggestion"],
+});
+
+const PRIORITY_RULES = Object.freeze({
+  critical: ["breach", "data loss", "outage", "production down", "security incident", "severity 1"],
+  high: ["asap", "blocked", "cannot access", "deadline", "urgent", "vip"],
+  medium: [
+    "billing",
+    "bug",
+    "customer question",
+    "feature request",
+    "follow up",
+    "help",
+    "invoice",
+    "issue",
+    "payment",
+    "refund",
+  ],
+});
+
+export function createTicketConversionReport(input = {}) {
+  if (input?.isLoading) {
+    return {
+      state: TICKET_CONVERTER_STATES.LOADING,
+      status: "pending",
+      tickets: [],
+      errors: [],
+      summary: createEmptySummary(),
+    };
+  }
+
+  const messages = input?.messages;
+  if (!Array.isArray(messages)) {
+    return createErrorReport("messages must be an array");
+  }
+
+  if (messages.length === 0) {
+    return {
+      state: TICKET_CONVERTER_STATES.EMPTY,
+      status: "ready",
+      tickets: [],
+      errors: [],
+      summary: createEmptySummary(),
+    };
+  }
+
+  const errors = validateMessages(messages);
+  if (errors.length > 0) {
+    return createErrorReport(errors);
+  }
+
+  const config = normalizeConfig(input.config);
+  const tickets = messages.map((message, index) => convertMailToTicket(message, {
+    ...config,
+    index,
+  }));
+
+  return {
+    state: TICKET_CONVERTER_STATES.SUCCESS,
+    status: "converted",
+    tickets,
+    errors: [],
+    summary: summarizeTickets(tickets),
+  };
+}
+
+export function convertMailToTicket(message, config = DEFAULT_CONVERTER_CONFIG) {
+  const normalizedConfig = normalizeConfig(config);
+  const text = normalizeSearchText(message);
+  const category = detectCategory(text);
+  const priority = detectPriority(text, message);
+  const title = normalizeTitle(message.subject ?? message.title, normalizedConfig.titleMaxLength);
+  const description = buildDescription(message, normalizedConfig.descriptionMaxLength);
+  const queue = normalizedConfig.queues[category] ?? normalizedConfig.queues.support;
+  const tags = buildTags(message, category, priority);
+
+  return {
+    id: `${normalizedConfig.ticketIdPrefix}-${message.id}`,
+    title,
+    description,
+    category,
+    priority,
+    queue,
+    status: "ready_for_review",
+    confidence: calculateConfidence(category, priority, text),
+    slaHours: normalizedConfig.slaHours[priority],
+    tags,
+    source: {
+      messageId: message.id,
+      threadId: message.threadId ?? null,
+      senderName: message.senderName ?? null,
+      senderEmail: message.senderEmail ?? null,
+      receivedAt: message.receivedAt ?? null,
+      attachmentsCount: Array.isArray(message.attachments) ? message.attachments.length : 0,
+    },
+  };
+}
+
+function normalizeConfig(config = {}) {
+  return {
+    ...DEFAULT_CONVERTER_CONFIG,
+    ...config,
+    slaHours: {
+      ...DEFAULT_CONVERTER_CONFIG.slaHours,
+      ...(config.slaHours ?? {}),
+    },
+    queues: {
+      ...DEFAULT_CONVERTER_CONFIG.queues,
+      ...(config.queues ?? {}),
+    },
+  };
+}
+
+function validateMessages(messages) {
+  const errors = [];
+  messages.forEach((message, index) => {
+    if (!message || typeof message !== "object") {
+      errors.push(`messages[${index}] must be an object`);
+      return;
+    }
+
+    if (!isNonEmptyString(message.id)) {
+      errors.push(`messages[${index}].id is required`);
+    }
+
+    if (!isNonEmptyString(message.subject) && !isNonEmptyString(message.title)) {
+      errors.push(`messages[${index}].subject or messages[${index}].title is required`);
+    }
+  });
+
+  return errors;
+}
+
+function detectCategory(text) {
+  for (const [category, terms] of Object.entries(CATEGORY_RULES)) {
+    if (findMatches(text, terms).length > 0) {
+      return category;
+    }
+  }
+
+  return "support";
+}
+
+function detectPriority(text, message) {
+  if (message.isVip === true || hasLabel(message, "vip")) {
+    return "high";
+  }
+
+  for (const priority of ["critical", "high", "medium"]) {
+    if (findMatches(text, PRIORITY_RULES[priority]).length > 0) {
+      return priority;
+    }
+  }
+
+  return "low";
+}
+
+function normalizeTitle(value, maxLength) {
+  const cleaned = value
+    .replace(/^\s*(re|fw|fwd):\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (cleaned.length <= maxLength) {
+    return cleaned;
+  }
+
+  return `${cleaned.slice(0, maxLength - 1).trim()}...`;
+}
+
+function buildDescription(message, maxLength) {
+  const body = isNonEmptyString(message.body) ? message.body : "No message body provided.";
+  const cleaned = body.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= maxLength) {
+    return cleaned;
+  }
+
+  return `${cleaned.slice(0, maxLength - 1).trim()}...`;
+}
+
+function buildTags(message, category, priority) {
+  const tags = new Set([category, priority, "mail-import"]);
+  if (Array.isArray(message.labels)) {
+    message.labels
+      .filter(isNonEmptyString)
+      .map((label) => label.trim().toLowerCase().replace(/\s+/g, "-"))
+      .forEach((label) => tags.add(label));
+  }
+
+  if (Array.isArray(message.attachments) && message.attachments.length > 0) {
+    tags.add("has-attachments");
+  }
+
+  if (message.isVip === true) {
+    tags.add("vip");
+  }
+
+  return [...tags].sort();
+}
+
+function calculateConfidence(category, priority, text) {
+  const categoryMatched = category !== "support";
+  const priorityMatched = priority !== "low";
+  if (priority === "critical" && categoryMatched) {
+    return 0.95;
+  }
+
+  if (categoryMatched && priorityMatched) {
+    return 0.9;
+  }
+
+  if (categoryMatched || priorityMatched || text.length > 80) {
+    return 0.8;
+  }
+
+  return 0.65;
+}
+
+function summarizeTickets(tickets) {
+  const summary = {
+    totalMessages: tickets.length,
+    convertedTickets: tickets.length,
+    highestPriority: highestPriority(tickets.map((ticket) => ticket.priority)),
+    categories: {},
+    priorities: {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+    },
+  };
+
+  for (const ticket of tickets) {
+    summary.categories[ticket.category] = (summary.categories[ticket.category] ?? 0) + 1;
+    summary.priorities[ticket.priority] += 1;
+  }
+
+  summary.categories = Object.fromEntries(Object.entries(summary.categories).sort());
+  return summary;
+}
+
+function createEmptySummary() {
+  return {
+    totalMessages: 0,
+    convertedTickets: 0,
+    highestPriority: "low",
+    categories: {},
+    priorities: {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+    },
+  };
+}
+
+function createErrorReport(messages) {
+  return {
+    state: TICKET_CONVERTER_STATES.ERROR,
+    status: "blocked",
+    tickets: [],
+    errors: Array.isArray(messages) ? messages : [messages],
+    summary: createEmptySummary(),
+  };
+}
+
+function highestPriority(priorities) {
+  return priorities.reduce((highest, priority) => (
+    PRIORITY_RANK[priority] > PRIORITY_RANK[highest] ? priority : highest
+  ), "low");
+}
+
+function normalizeSearchText(message) {
+  return [
+    message.subject,
+    message.title,
+    message.body,
+    message.senderEmail,
+    message.senderName,
+    Array.isArray(message.labels) ? message.labels.join(" ") : "",
+  ].filter(Boolean).join(" ").toLowerCase();
+}
+
+function findMatches(text, terms) {
+  return terms.filter((term) => {
+    const pattern = new RegExp(`\\b${escapeRegex(term).replace(/\s+/g, "\\s+")}\\b`, "i");
+    return pattern.test(text);
+  });
+}
+
+function hasLabel(message, label) {
+  return Array.isArray(message.labels)
+    && message.labels.some((entry) => entry.toLowerCase() === label.toLowerCase());
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/tools/v2/team/mail-to-ticket-converter/specs.md
+++ b/tools/v2/team/mail-to-ticket-converter/specs.md
@@ -1,41 +1,50 @@
 # Mail-to-Ticket Converter
 
-Convert mail into tickets.
+The Mail-to-Ticket Converter is a V2 team tool that turns local mail or thread
+records into reviewable ticket candidates for support, operations, security,
+billing, access, and product queues.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/mail-to-ticket-converter/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
+## Core Inputs
 
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/mail-to-ticket-converter/README.md"
-  @"
+- `messages`: an array of local mail-like items.
+- `isLoading`: optional boolean used by future UI callers to request a loading
+  report.
+- Each message should include `id`, `subject` or `title`, and optional context
+  such as `body`, `senderName`, `senderEmail`, `receivedAt`, `threadId`,
+  `labels`, `attachments`, `isVip`, or `requestedBy`.
 
-# Mail-to-Ticket Converter Specs
+## Core Outputs
 
-## Purpose
+- `state`: `loading`, `empty`, `success`, or `error`.
+- `status`: `pending`, `ready`, `converted`, or `blocked`.
+- `tickets`: ticket candidates with title, description, category, priority,
+  queue, SLA hours, confidence, tags, and source metadata.
+- `summary`: counts by category and priority plus highest detected priority.
+- `errors`: validation messages for invalid input.
 
-Convert mail into tickets.
+## Conversion Rules
 
-## Contributor boundary
+- Critical priority: outage, breach, security incident, data loss, severity 1,
+  or production-down language.
+- High priority: urgent access failures, VIP requests, billing/payment blockers,
+  or time-sensitive customer issues.
+- Medium priority: bugs, broken flows, feature requests, customer questions, and
+  normal operational requests.
+- Low priority: FYI or routine informational messages.
+- Queue selection is derived from category first, then urgency signals.
 
-All work for this tool should stay in:
+## Non-Goals
 
-$dir/
-
-## Required issue categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+- No main app routing, inbox rendering, database writes, ticket-system API calls,
+  wallet, Stellar, or design-system changes.
+- No production mail, secrets, live network calls, or third-party integrations.
+- No automatic ticket creation. The engine only prepares local ticket candidates
+  for future human review.

--- a/tools/v2/team/mail-to-ticket-converter/tests/ticket-converter.test.mjs
+++ b/tools/v2/team/mail-to-ticket-converter/tests/ticket-converter.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  TICKET_CONVERTER_STATES,
+  convertMailToTicket,
+  createTicketConversionReport,
+} from "../index.mjs";
+
+const sampleMessages = JSON.parse(
+  readFileSync(new URL("../fixtures/sample-mail-items.json", import.meta.url), "utf-8"),
+);
+
+describe("Mail-to-Ticket Converter", () => {
+  it("returns loading state for pending callers", () => {
+    const report = createTicketConversionReport({ isLoading: true });
+
+    assert.equal(report.state, TICKET_CONVERTER_STATES.LOADING);
+    assert.equal(report.status, "pending");
+    assert.deepEqual(report.tickets, []);
+  });
+
+  it("returns empty state for a valid empty message list", () => {
+    const report = createTicketConversionReport({ messages: [] });
+
+    assert.equal(report.state, TICKET_CONVERTER_STATES.EMPTY);
+    assert.equal(report.status, "ready");
+    assert.equal(report.summary.totalMessages, 0);
+  });
+
+  it("returns error state for invalid messages", () => {
+    const report = createTicketConversionReport({ messages: [{ body: "Missing id and title" }] });
+
+    assert.equal(report.state, TICKET_CONVERTER_STATES.ERROR);
+    assert.equal(report.status, "blocked");
+    assert.ok(report.errors.some((message) => message.includes("id is required")));
+  });
+
+  it("converts fixtures into deterministic ticket candidates", () => {
+    const report = createTicketConversionReport({ messages: sampleMessages });
+
+    assert.equal(report.state, TICKET_CONVERTER_STATES.SUCCESS);
+    assert.equal(report.status, "converted");
+    assert.equal(report.tickets.length, 5);
+    assert.equal(report.summary.highestPriority, "critical");
+    assert.deepEqual(report.summary.priorities, {
+      critical: 1,
+      high: 1,
+      medium: 2,
+      low: 1,
+    });
+  });
+
+  it("routes security outage mail to the security response queue", () => {
+    const report = createTicketConversionReport({ messages: sampleMessages });
+    const securityTicket = report.tickets.find((ticket) => ticket.id === "ticket-mail-002");
+
+    assert.equal(securityTicket.category, "security");
+    assert.equal(securityTicket.priority, "critical");
+    assert.equal(securityTicket.queue, "Security Response");
+    assert.equal(securityTicket.slaHours, 4);
+    assert.ok(securityTicket.tags.includes("has-attachments"));
+  });
+
+  it("normalizes reply prefixes and keeps source mail metadata", () => {
+    const accessTicket = convertMailToTicket(sampleMessages[0]);
+
+    assert.equal(accessTicket.title, "Urgent login access blocked");
+    assert.equal(accessTicket.category, "access");
+    assert.equal(accessTicket.priority, "high");
+    assert.equal(accessTicket.source.threadId, "thread-access-001");
+    assert.equal(accessTicket.source.senderEmail, "jordan@example.com");
+    assert.ok(accessTicket.tags.includes("vip"));
+  });
+
+  it("allows local caller configuration without touching global defaults", () => {
+    const ticket = convertMailToTicket(sampleMessages[4], {
+      ticketIdPrefix: "case",
+      queues: {
+        support: "Triage",
+      },
+    });
+
+    assert.equal(ticket.id, "case-mail-005");
+    assert.equal(ticket.category, "support");
+    assert.equal(ticket.priority, "low");
+    assert.equal(ticket.queue, "Triage");
+  });
+});


### PR DESCRIPTION
## Summary
- add a folder-local mail-to-ticket converter for V2 team contexts
- convert local mail-like inputs into ticket candidates with category, priority, queue, SLA, tags, confidence, and source metadata
- add deterministic fixtures, Node tests, and docs for loading, empty, success, and error states

## Scope and safety
- changes are limited to `tools/v2/team/mail-to-ticket-converter/`
- no main app integration, routing, inbox rendering, wallet, Stellar core, database, or design-system changes
- no live network calls, secrets, production data, or external ticket-system writes

## Validation
- `node tools\v2\team\mail-to-ticket-converter\tests\ticket-converter.test.mjs`
- `node -e "import('./tools/v2/team/mail-to-ticket-converter/index.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
- `git diff --check`

Closes #620
