### PR TITLE
test: add legal review docs and fixture checks

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/README.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/README.md
@@ -1,15 +1,109 @@
 # Legal and Compliance Review Flag
 
-This folder is the isolated workspace for the Legal and Compliance Review Flag tool.
+Folder-local review kit for the V2 team Legal and Compliance Review Flag tool.
+This contribution documents the independent test surface for the tool while the
+runtime implementation is still pending.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\legal-and-compliance-review-flag\
-`
+```
+tools/v2/team/legal-and-compliance-review-flag/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet core,
+Stellar integration, database schema, or design system unless a future integration
+issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Structure
+
+```
+legal-and-compliance-review-flag/
+  docs/
+    test-plan.md                     Independent automated and manual test plan
+    review-notes.md                  OSS reviewer guide and boundaries
+  fixtures/
+    legal-review-items.json          Synthetic legal/compliance review examples
+  tests/
+    legal-review-fixtures.test.mjs   Executable fixture and contract checks
+  README.md                          Setup, usage, fixtures, limitations
+  specs.md                           Scope and contributor expectations
+```
+
+## Setup
+
+No package install is required for the current review kit. The executable tests use
+only Node built-ins.
+
+Requirements:
+
+- Node 18 or later.
+- Run commands from the repository root, or from this tool folder as noted below.
+
+## Running the Tests
+
+From the repository root:
+
+```
+node --test tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
+```
+
+From this folder:
+
+```
+node --test tests/legal-review-fixtures.test.mjs
+```
+
+The tests validate that fixture records are complete, use only reserved example
+domains, cover the expected legal/compliance risk areas, and keep review routing
+values inside the documented contract.
+
+## Reviewing This Tool Independently
+
+1. Confirm every changed file lives under this folder.
+2. Run the fixture test command above.
+3. Read `docs/test-plan.md` for the manual review checklist.
+4. Read `docs/review-notes.md` for the expected boundaries and future integration
+   points.
+5. Confirm the fixture data is synthetic and does not contain real customers,
+   credentials, wallet values, or legal advice.
+
+## Fixture Contract
+
+`fixtures/legal-review-items.json` contains synthetic examples for messages that
+should be routed to legal or compliance review before a team acts on them.
+
+Each review item includes:
+
+- Stable IDs for the review item, email, and thread.
+- Synthetic sender/requester addresses using reserved example domains.
+- A `riskArea` such as `privacy`, `contract`, `regulatory`, or `marketing`.
+- A severity tier: `critical`, `high`, `medium`, or `low`.
+- A review status such as `needs-legal-review`, `needs-compliance-review`,
+  `approved-with-notes`, `blocked`, or `monitoring`.
+- Human-readable signals and a recommended action for reviewers.
+
+The fixture also includes routing rules so future service tests can assert that
+specific risk areas map to the right review owner.
+
+## Known Limitations
+
+- This is a documentation and fixture validation contribution. It does not add the
+  future service, hook, UI component, persistence layer, or app integration.
+- The current tests validate review data shape and review-contract safety. They do
+  not classify live email content.
+- Fixture examples are not legal advice and should not be treated as a compliance
+  policy source.
+- No external API calls, LLM calls, sender reputation checks, or jurisdictional
+  rule engines are included.
+- Authentication, authorization, audit logging, and durable storage belong to
+  future integration issues.
+
+## Acceptance Checklist
+
+- [x] Tests and test plan live inside this folder.
+- [x] Documentation explains independent setup and review.
+- [x] Fixtures are folder-local and synthetic.
+- [x] No files outside `tools/v2/team/legal-and-compliance-review-flag/` are needed.
+- [x] The contribution is reviewable as a self-contained mini-product change.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/review-notes.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/review-notes.md
@@ -1,0 +1,71 @@
+# Review Notes - Legal and Compliance Review Flag
+
+This contribution adds folder-local testing and documentation for the Legal and
+Compliance Review Flag tool. It is intentionally scoped to review fixtures,
+independent test coverage, setup notes, and future implementation boundaries.
+
+## What Changed
+
+- Rewrote `README.md` with setup, usage, fixture shape, review steps, and known
+  limitations.
+- Repaired `specs.md` so it describes the V2 team tool scope without template
+  placeholders.
+- Added `fixtures/legal-review-items.json` with synthetic legal/compliance review
+  examples and routing rules.
+- Added `tests/legal-review-fixtures.test.mjs`, a zero-dependency Node test that
+  validates the fixture contract.
+- Added this review guide and a fuller `docs/test-plan.md`.
+
+## What To Review
+
+### Scope
+
+- Every changed file should live under
+  `tools/v2/team/legal-and-compliance-review-flag/`.
+- There should be no imports from the main app, design system, wallet code,
+  Stellar integration, database layer, routing, or inbox architecture.
+- No workflow, package, or root configuration files are required.
+
+### Fixtures
+
+- `fixtures/legal-review-items.json` uses synthetic data only.
+- Sender and requester addresses use reserved example domains.
+- Review items cover privacy, contract, regulatory, marketing, employment, and
+  finance scenarios.
+- High-risk items include at least two human-readable signals.
+- Routing rules describe the intended future mapping to legal or compliance
+  owners without calling any external service.
+
+### Tests
+
+- Run:
+
+  ```
+  node --test tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
+  ```
+
+- The test should pass without installing dependencies.
+- The test validates fixture shape, uniqueness, enum values, reserved domains,
+  high-risk context, risk-area coverage, and routing rule coverage.
+
+## What Is Intentionally Not Included
+
+- No React UI, hook, service implementation, app route, or Storybook story.
+- No live inbox integration or database persistence.
+- No authentication, authorization, audit log, or escalation notification.
+- No external legal/compliance API, LLM classifier, sender reputation lookup, or
+  jurisdiction-specific policy engine.
+- No legal advice or compliance decision automation.
+
+## Follow-Up Shape
+
+Future implementation issues can add these files inside this same folder:
+
+- `services/legal-review-service.mjs` for deterministic validation and routing.
+- `components/legal-review-flag-panel.tsx` for an isolated review queue UI.
+- `hooks/use-legal-review-flag.ts` for local state around review items.
+- Additional tests under `tests/` for service behavior, UI accessibility, and
+  status transitions.
+
+The first integration issue should decide how this tool receives real mail/thread
+events and where approved review decisions are persisted.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/test-plan.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/test-plan.md
@@ -1,0 +1,99 @@
+# Test Plan - Legal and Compliance Review Flag
+
+This issue covers testing and documentation for the isolated V2 team tool. The
+runtime service and UI are not implemented yet, so the current automated coverage
+validates the fixture contract and review boundaries that future code should keep.
+
+## Automated Test
+
+Run from the repository root:
+
+```
+node --test tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
+```
+
+Run from this tool folder:
+
+```
+node --test tests/legal-review-fixtures.test.mjs
+```
+
+No install step is required. The test uses Node built-ins only.
+
+### Automated Coverage
+
+The fixture test verifies:
+
+1. Metadata identifies this tool as `legal-and-compliance-review-flag` and keeps
+   scope folder-local.
+2. Each review item has required fields, stable IDs, and unique email/thread
+   references.
+3. Risk areas, severity values, statuses, and review owners stay inside the
+   documented allow-lists.
+4. Sender and requester addresses use reserved `example.com`, `example.net`, or
+   `example.org` domains.
+5. High-risk review items include at least two explanatory signals and remain in
+   a review queue status.
+6. Fixture examples cover privacy, contract, regulatory, and marketing review
+   areas.
+7. Routing rules map to at least one covered fixture item.
+
+## Manual Review Checklist
+
+1. Confirm all changed files live under:
+
+   ```
+   tools/v2/team/legal-and-compliance-review-flag/
+   ```
+
+2. Open `README.md` and confirm it documents:
+
+   - Setup requirements.
+   - Test command.
+   - Fixture purpose and shape.
+   - Known limitations.
+   - Independent review steps.
+
+3. Open `fixtures/legal-review-items.json` and confirm:
+
+   - Examples are synthetic and use reserved domains.
+   - No real customer, employee, credential, wallet, contract, or legal advice is
+     included.
+   - High-risk examples explain why the item needs legal or compliance review.
+
+4. Open `docs/review-notes.md` and confirm:
+
+   - The contribution does not claim app integration.
+   - Future implementation seams are documented as follow-up work.
+   - The issue remains reviewable without running the main app.
+
+## Future Service Test Plan
+
+When `services/` is added in a future issue, add executable tests for:
+
+| Behavior | Expected coverage |
+| --- | --- |
+| `createReviewItem(input)` | Accepts well-formed data and rejects missing IDs, invalid enum values, and empty signals. |
+| `routeReviewItem(item)` | Maps privacy/contract items to legal and regulatory/marketing items to compliance. |
+| `canResolveReview(status)` | Allows terminal decisions only from review queue statuses. |
+| `sanitizeReviewText(value)` | Trims whitespace and rejects control characters or script-like payloads. |
+| `validateSyntheticFixture(item)` | Keeps fixture safety checks reusable from tests. |
+
+## Future UI and Accessibility Test Plan
+
+When `components/` is added in a future issue, review:
+
+1. Keyboard access for filter controls and decision buttons.
+2. Visible labels for status, severity, risk area, and review owner.
+3. `role="alert"` or equivalent announcement for validation errors.
+4. Clear empty, loading, success, and blocked states.
+5. No color-only indication for severity or review status.
+
+## Known Limitations
+
+- Current automated tests cover fixture and review-contract quality, not live
+  classification logic.
+- No app route, inbox data source, persistence layer, or permission model exists
+  in this contribution.
+- Jurisdiction values are illustrative and do not encode legal obligations.
+- The fixture is intentionally small so reviewers can inspect it by hand.

--- a/tools/v2/team/legal-and-compliance-review-flag/fixtures/legal-review-items.json
+++ b/tools/v2/team/legal-and-compliance-review-flag/fixtures/legal-review-items.json
@@ -1,0 +1,147 @@
+{
+  "metadata": {
+    "tool": "legal-and-compliance-review-flag",
+    "fixtureVersion": 1,
+    "scope": "folder-local",
+    "dataPolicy": [
+      "Synthetic review examples only.",
+      "No real customers, contracts, credentials, wallets, or legal advice.",
+      "All email addresses use reserved example domains."
+    ]
+  },
+  "reviewItems": [
+    {
+      "id": "legal-review-001",
+      "threadId": "thread-vendor-dpa-001",
+      "emailId": "email-vendor-dpa-001",
+      "subject": "Vendor DPA update for approval",
+      "sender": "contracts@example.com",
+      "requester": "ops-lead@example.com",
+      "jurisdiction": "US",
+      "riskArea": "privacy",
+      "severity": "high",
+      "status": "needs-legal-review",
+      "signals": [
+        "Mentions a data processing addendum before vendor onboarding.",
+        "Requests approval before customer data can be shared."
+      ],
+      "recommendedAction": "Route to legal review before the vendor onboarding thread continues."
+    },
+    {
+      "id": "legal-review-002",
+      "threadId": "thread-regulatory-disclosure-002",
+      "emailId": "email-regulatory-disclosure-002",
+      "subject": "Question about required product disclosure",
+      "sender": "program-manager@example.net",
+      "requester": "product-owner@example.com",
+      "jurisdiction": "EU",
+      "riskArea": "regulatory",
+      "severity": "critical",
+      "status": "needs-compliance-review",
+      "signals": [
+        "Mentions a required disclosure deadline.",
+        "Asks whether a user-facing notice can be omitted.",
+        "References a market launch date in the same thread."
+      ],
+      "recommendedAction": "Escalate to compliance review and block launch approval until the decision is recorded."
+    },
+    {
+      "id": "legal-review-003",
+      "threadId": "thread-contract-redline-003",
+      "emailId": "email-contract-redline-003",
+      "subject": "Customer redlines to liability terms",
+      "sender": "sales@example.org",
+      "requester": "account-owner@example.com",
+      "jurisdiction": "US",
+      "riskArea": "contract",
+      "severity": "medium",
+      "status": "needs-legal-review",
+      "signals": [
+        "Customer proposes changes to liability language.",
+        "Deal team asks whether the change can be accepted."
+      ],
+      "recommendedAction": "Ask legal to review the redline before the account owner replies."
+    },
+    {
+      "id": "legal-review-004",
+      "threadId": "thread-marketing-claims-004",
+      "emailId": "email-marketing-claims-004",
+      "subject": "Homepage copy using guaranteed results claim",
+      "sender": "marketing@example.com",
+      "requester": "campaign-owner@example.net",
+      "jurisdiction": "Global",
+      "riskArea": "marketing",
+      "severity": "high",
+      "status": "needs-compliance-review",
+      "signals": [
+        "Uses a guaranteed results claim.",
+        "Requests same-day publication without review."
+      ],
+      "recommendedAction": "Send to compliance review and require approved replacement wording before publication."
+    },
+    {
+      "id": "legal-review-005",
+      "threadId": "thread-employment-records-005",
+      "emailId": "email-employment-records-005",
+      "subject": "Retention question for hiring records",
+      "sender": "people-team@example.org",
+      "requester": "recruiting-lead@example.com",
+      "jurisdiction": "US",
+      "riskArea": "employment",
+      "severity": "medium",
+      "status": "monitoring",
+      "signals": [
+        "Asks how long hiring notes should be retained.",
+        "Mentions internal candidate records."
+      ],
+      "recommendedAction": "Track for legal review if the team proposes deletion or external sharing."
+    },
+    {
+      "id": "legal-review-006",
+      "threadId": "thread-finance-terms-006",
+      "emailId": "email-finance-terms-006",
+      "subject": "Unusual payment term request",
+      "sender": "finance@example.net",
+      "requester": "vendor-manager@example.com",
+      "jurisdiction": "US",
+      "riskArea": "finance",
+      "severity": "low",
+      "status": "approved-with-notes",
+      "signals": [
+        "Payment timing differs from the standard template.",
+        "No personal data, regulated claim, or contract redline is included."
+      ],
+      "recommendedAction": "Allow the team to continue after finance notes are attached to the thread."
+    }
+  ],
+  "routingRules": [
+    {
+      "id": "privacy-high-to-legal",
+      "riskArea": "privacy",
+      "minimumSeverity": "high",
+      "reviewOwner": "legal",
+      "expectedStatus": "needs-legal-review"
+    },
+    {
+      "id": "regulatory-critical-to-compliance",
+      "riskArea": "regulatory",
+      "minimumSeverity": "critical",
+      "reviewOwner": "compliance",
+      "expectedStatus": "needs-compliance-review"
+    },
+    {
+      "id": "contract-medium-to-legal",
+      "riskArea": "contract",
+      "minimumSeverity": "medium",
+      "reviewOwner": "legal",
+      "expectedStatus": "needs-legal-review"
+    },
+    {
+      "id": "marketing-high-to-compliance",
+      "riskArea": "marketing",
+      "minimumSeverity": "high",
+      "reviewOwner": "compliance",
+      "expectedStatus": "needs-compliance-review"
+    }
+  ]
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/specs.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/specs.md
@@ -1,41 +1,65 @@
-# Legal and Compliance Review Flag
-
-Compliance workflow.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/legal-and-compliance-review-flag/README.md"
-  @"
-
 # Legal and Compliance Review Flag Specs
 
 ## Purpose
 
-Compliance workflow.
+Provide a folder-local foundation for a team workflow that marks inbound mail or
+thread events requiring legal or compliance review before the team proceeds.
 
-## Contributor boundary
+The tool is intended for review routing and contributor-facing validation only at
+this stage. It must not provide legal advice or make final compliance decisions.
+
+## Scope
+
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/legal-and-compliance-review-flag/`
+
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar integration, database
+schema, or design system unless a future integration issue explicitly allows it.
+
+## Contributor Boundary
 
 All work for this tool should stay in:
 
-$dir/
+```
+tools/v2/team/legal-and-compliance-review-flag/
+```
 
-## Required issue categories
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Recommended Internal Structure
+
+- `components/` for future isolated UI pieces.
+- `services/` for deterministic review routing and validation logic.
+- `hooks/` for future React state wrappers.
+- `fixtures/` for synthetic review examples.
+- `tests/` for folder-local executable checks.
+- `docs/` for setup, test plans, and review notes.
+
+## Review Contract
+
+Future implementation work should keep these behaviors testable without the main
+application:
+
+- Review items have stable IDs, email/thread references, risk area, severity,
+  status, signals, and recommended action.
+- Routing rules map legal and compliance risk areas to named review owners.
+- Fixtures use reserved example domains and contain no real personal data.
+- High-risk records include enough signals for a reviewer to understand why they
+  were flagged.
+- Terminal review statuses such as `blocked` and `approved-with-notes` are clearly
+  distinguishable from queue statuses.
+
+## Out of Scope
+
+- Main app routes, navigation, dashboard layout, or inbox wiring.
+- Wallet, Stellar, payment, or database changes.
+- Legal advice, policy generation, or jurisdiction-specific decision automation.
+- External API calls, LLM classification, or sender reputation lookups.

--- a/tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(__dir, "..", "fixtures", "legal-review-items.json");
+
+const ALLOWED_RISK_AREAS = new Set([
+  "privacy",
+  "contract",
+  "regulatory",
+  "marketing",
+  "employment",
+  "finance",
+  "other",
+]);
+
+const ALLOWED_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
+const ALLOWED_STATUSES = new Set([
+  "needs-legal-review",
+  "needs-compliance-review",
+  "approved-with-notes",
+  "blocked",
+  "monitoring",
+]);
+const ALLOWED_REVIEW_OWNERS = new Set(["legal", "compliance", "security", "finance", "ops"]);
+
+async function loadFixture() {
+  return JSON.parse(await readFile(fixturePath, "utf8"));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function assertReservedExampleEmail(value, fieldName) {
+  assert.match(
+    value,
+    /^[^@\s]+@(?:[a-z0-9-]+\.)*example\.(?:com|net|org)$/i,
+    `${fieldName} must use a reserved example domain`,
+  );
+}
+
+test("fixture metadata describes the isolated tool", async () => {
+  const data = await loadFixture();
+
+  assert.equal(data.metadata.tool, "legal-and-compliance-review-flag");
+  assert.equal(data.metadata.scope, "folder-local");
+  assert.equal(data.metadata.fixtureVersion, 1);
+  assert.ok(Array.isArray(data.metadata.dataPolicy));
+  assert.ok(
+    data.metadata.dataPolicy.some((entry) => entry.includes("Synthetic")),
+    "data policy should identify the examples as synthetic",
+  );
+});
+
+test("review items have stable IDs, required fields, and unique references", async () => {
+  const { reviewItems } = await loadFixture();
+
+  assert.ok(Array.isArray(reviewItems));
+  assert.ok(reviewItems.length >= 6, "expected broad enough review coverage");
+
+  const ids = new Set();
+  const threadIds = new Set();
+  const emailIds = new Set();
+
+  for (const item of reviewItems) {
+    for (const field of [
+      "id",
+      "threadId",
+      "emailId",
+      "subject",
+      "sender",
+      "requester",
+      "jurisdiction",
+      "riskArea",
+      "severity",
+      "status",
+      "recommendedAction",
+    ]) {
+      assert.ok(isNonEmptyString(item[field]), `${item.id ?? "item"} missing ${field}`);
+    }
+
+    assert.match(item.id, /^legal-review-\d{3}$/);
+    assert.match(item.threadId, /^thread-[a-z0-9-]+-\d{3}$/);
+    assert.match(item.emailId, /^email-[a-z0-9-]+-\d{3}$/);
+
+    assert.equal(ids.has(item.id), false, `duplicate id ${item.id}`);
+    assert.equal(threadIds.has(item.threadId), false, `duplicate threadId ${item.threadId}`);
+    assert.equal(emailIds.has(item.emailId), false, `duplicate emailId ${item.emailId}`);
+
+    ids.add(item.id);
+    threadIds.add(item.threadId);
+    emailIds.add(item.emailId);
+  }
+});
+
+test("review item enums stay inside the documented contract", async () => {
+  const { reviewItems } = await loadFixture();
+
+  for (const item of reviewItems) {
+    assert.ok(ALLOWED_RISK_AREAS.has(item.riskArea), `${item.id} has unknown riskArea`);
+    assert.ok(ALLOWED_SEVERITIES.has(item.severity), `${item.id} has unknown severity`);
+    assert.ok(ALLOWED_STATUSES.has(item.status), `${item.id} has unknown status`);
+  }
+});
+
+test("fixture examples use reserved domains and avoid real addresses", async () => {
+  const { reviewItems } = await loadFixture();
+
+  for (const item of reviewItems) {
+    assertReservedExampleEmail(item.sender, `${item.id}.sender`);
+    assertReservedExampleEmail(item.requester, `${item.id}.requester`);
+  }
+});
+
+test("high-risk review items include enough reviewer context", async () => {
+  const { reviewItems } = await loadFixture();
+
+  for (const item of reviewItems) {
+    assert.ok(Array.isArray(item.signals), `${item.id} signals must be an array`);
+    assert.ok(item.signals.every(isNonEmptyString), `${item.id} signals must be non-empty`);
+
+    if (item.severity === "critical" || item.severity === "high") {
+      assert.ok(item.signals.length >= 2, `${item.id} needs at least two review signals`);
+      assert.match(
+        item.status,
+        /^needs-(legal|compliance)-review$/,
+        `${item.id} high-risk item should stay in a review queue status`,
+      );
+    }
+  }
+});
+
+test("fixtures cover expected legal and compliance review areas", async () => {
+  const { reviewItems } = await loadFixture();
+  const areas = new Set(reviewItems.map((item) => item.riskArea));
+
+  for (const requiredArea of ["privacy", "contract", "regulatory", "marketing"]) {
+    assert.ok(areas.has(requiredArea), `missing ${requiredArea} fixture coverage`);
+  }
+});
+
+test("routing rules are valid and map to covered fixture statuses", async () => {
+  const { reviewItems, routingRules } = await loadFixture();
+
+  assert.ok(Array.isArray(routingRules));
+  assert.ok(routingRules.length >= 4, "expected legal/compliance routing coverage");
+
+  for (const rule of routingRules) {
+    assert.ok(isNonEmptyString(rule.id), "routing rule needs an id");
+    assert.ok(ALLOWED_RISK_AREAS.has(rule.riskArea), `${rule.id} has unknown riskArea`);
+    assert.ok(ALLOWED_SEVERITIES.has(rule.minimumSeverity), `${rule.id} has unknown severity`);
+    assert.ok(ALLOWED_REVIEW_OWNERS.has(rule.reviewOwner), `${rule.id} has unknown owner`);
+    assert.ok(ALLOWED_STATUSES.has(rule.expectedStatus), `${rule.id} has unknown status`);
+
+    const matchingItem = reviewItems.find(
+      (item) => item.riskArea === rule.riskArea && item.status === rule.expectedStatus,
+    );
+    assert.ok(matchingItem, `${rule.id} should be backed by at least one fixture item`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add folder-local README/spec cleanup, test plan, and review notes for the Legal and Compliance Review Flag tool.
- Add synthetic legal/compliance review fixtures and zero-dependency Node fixture tests.
- Keep all changes inside tools/v2/team/legal-and-compliance-review-flag/.

## Validation
- node --test tools/v2/team/legal-and-compliance-review-flag/tests/legal-review-fixtures.test.mjs
- git diff --check

Closes 