### PR TITLE
Add invoice approval workflow test documentation

### DIFF
--- a/tools/v2/team/invoice-approval-workflow/README.md
+++ b/tools/v2/team/invoice-approval-workflow/README.md
@@ -1,15 +1,46 @@
 # Invoice Approval Workflow
 
-This folder is the isolated workspace for the Invoice Approval Workflow tool.
+Invoice Approval Workflow is an isolated V2 team workspace for reviewing
+invoice-like email requests before any future approval routing or accounting
+integration is added.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\invoice-approval-workflow\
-`
+```text
+tools/v2/team/invoice-approval-workflow/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Reviewer Setup
+
+This issue adds folder-local documentation, synthetic fixtures, and a
+zero-dependency Node contract test. Run from the repository root:
+
+```bash
+node --test tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs
+```
+
+The test validates the local fixture and documentation contract without using
+main app test helpers.
+
+## Documentation Map
+
+- `specs.md` defines the status model, fixture contract, and contributor
+  boundary.
+- `docs/test-plan.md` lists automated and manual review checks.
+- `docs/review-notes.md` summarizes reviewer expectations and limitations.
+- `fixtures/sample-approval-cases.json` provides synthetic invoice approval
+  scenarios.
+- `tests/invoice-approval-docs.test.mjs` validates the fixture and documentation
+  contract.
+
+## Current Limitations
+
+- No inbox ingestion, payment execution, vendor update, accounting export, or
+  database persistence is included.
+- No app routing, dashboard registration, wallet, Stellar, auth, or shared
+  design-system integration is included.
+- Fixture content is synthetic and should remain folder-local.

--- a/tools/v2/team/invoice-approval-workflow/docs/review-notes.md
+++ b/tools/v2/team/invoice-approval-workflow/docs/review-notes.md
@@ -1,0 +1,44 @@
+# Invoice Approval Workflow Review Notes
+
+## What This Contribution Covers
+
+This contribution adds contributor-facing documentation and fixture coverage for
+the isolated Invoice Approval Workflow folder. It gives reviewers a local
+validation path without connecting to production invoices, payment systems, or
+the main application.
+
+Reviewers should expect:
+
+- a repaired README and specs file for the folder-local workflow.
+- a deterministic synthetic fixture with representative approval statuses.
+- a local Node test that validates fixture and documentation requirements.
+- clear limitations for future payment, accounting, inbox, and routing work.
+
+## What Is Out Of Scope
+
+This issue does not add:
+
+- payment execution, deposits, trades, or wallet signing.
+- Stellar transaction behavior or contract calls.
+- database schema changes or accounting exports.
+- inbox reads, mailbox writes, or mail rendering changes.
+- app routing, dashboard placement, authentication, or shared design-system
+  changes.
+- production vendor, customer, invoice, or payment data.
+
+## Reviewer Flow
+
+1. Run the local Node test from the repository root.
+2. Inspect `fixtures/sample-approval-cases.json` and confirm all cases are
+   synthetic.
+3. Compare fixture statuses with the rules in `specs.md`.
+4. Confirm `docs/test-plan.md` names both current checks and future coverage
+   gaps.
+5. Confirm the PR changes only files inside this tool folder.
+
+## Known Limitations
+
+The fixture documents the review contract before this folder has a production
+approval service. A future feature issue should implement scoring and approval
+state logic inside this folder first; main app integration should remain a
+separate follow-up after the isolated model is accepted.

--- a/tools/v2/team/invoice-approval-workflow/docs/test-plan.md
+++ b/tools/v2/team/invoice-approval-workflow/docs/test-plan.md
@@ -1,0 +1,43 @@
+# Invoice Approval Workflow Test Plan
+
+## Automated Checks
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs
+```
+
+The local test checks that:
+
+- synthetic fixture cases use stable identifiers and contain no production data.
+- all documented approval statuses are represented.
+- blocked cases require missing details to be supplied before approval.
+- rejected cases have a rejection reason in their risk flags.
+- ready-for-approval cases do not require manual review.
+- documentation includes setup, fixture, limitation, and review guidance.
+
+## Manual Review Checklist
+
+- Confirm all changes stay under `tools/v2/team/invoice-approval-workflow/`.
+- Confirm fixture content is synthetic and avoids real vendor, customer, invoice,
+  or payment data.
+- Confirm the status rules in `specs.md` match the fixture vocabulary.
+- Confirm no live network calls, secrets, database writes, payment execution,
+  wallet behavior, Stellar behavior, inbox writes, or app routing changes are
+  introduced.
+- Confirm future integration boundaries are documented instead of implemented.
+
+## Future Code Coverage
+
+When folder-local core logic is added or reconciled with future implementation
+work, extend coverage for:
+
+- amount and currency normalization.
+- purchase order and receipt matching.
+- duplicate invoice checks.
+- department approval threshold rules.
+- loading, empty, error, and success states for future UI work.
+
+Keep future tests folder-local unless a separate integration issue explicitly
+allows app-wide coverage.

--- a/tools/v2/team/invoice-approval-workflow/fixtures/sample-approval-cases.json
+++ b/tools/v2/team/invoice-approval-workflow/fixtures/sample-approval-cases.json
@@ -1,0 +1,65 @@
+{
+  "tool": "invoice-approval-workflow",
+  "runContext": {
+    "now": "2026-07-01T00:00:00.000Z",
+    "source": "synthetic-folder-local-fixture"
+  },
+  "cases": [
+    {
+      "id": "approval-001",
+      "invoiceId": "INV-SYN-1001",
+      "vendor": "Northstar Supplies",
+      "amount": 1850,
+      "currency": "USD",
+      "department": "Operations",
+      "requestedBy": "Jordan Lee",
+      "riskFlags": [],
+      "approvalStatus": "ready-for-approval",
+      "reviewRequired": false,
+      "nextAction": "Queue the invoice for department approval.",
+      "containsProductionData": false
+    },
+    {
+      "id": "approval-002",
+      "invoiceId": "INV-SYN-1002",
+      "vendor": "Harbor Design Studio",
+      "amount": 9200,
+      "currency": "USD",
+      "department": "Marketing",
+      "requestedBy": "Mira Patel",
+      "riskFlags": ["large-amount", "manager-threshold"],
+      "approvalStatus": "needs-review",
+      "reviewRequired": true,
+      "nextAction": "Route to a marketing manager before approving.",
+      "containsProductionData": false
+    },
+    {
+      "id": "approval-003",
+      "invoiceId": "INV-SYN-1003",
+      "vendor": "Summit Hosting",
+      "amount": 4100,
+      "currency": "USD",
+      "department": "Engineering",
+      "requestedBy": "Noah Kim",
+      "riskFlags": ["missing-purchase-order", "missing-receipt"],
+      "approvalStatus": "blocked",
+      "reviewRequired": true,
+      "nextAction": "Request the purchase order and receipt before review.",
+      "containsProductionData": false
+    },
+    {
+      "id": "approval-004",
+      "invoiceId": "INV-SYN-1004",
+      "vendor": "Northstar Supplies",
+      "amount": 1850,
+      "currency": "USD",
+      "department": "Operations",
+      "requestedBy": "Jordan Lee",
+      "riskFlags": ["duplicate-invoice"],
+      "approvalStatus": "rejected",
+      "reviewRequired": true,
+      "nextAction": "Reject the duplicate invoice and reference the approved copy.",
+      "containsProductionData": false
+    }
+  ]
+}

--- a/tools/v2/team/invoice-approval-workflow/specs.md
+++ b/tools/v2/team/invoice-approval-workflow/specs.md
@@ -1,36 +1,64 @@
 # Invoice Approval Workflow
 
-Invoice review process.
+Review invoice-like requests and classify them for approval, follow-up, or
+rejection before a future integration writes to any payment or accounting
+system.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/invoice-approval-workflow/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
+## Recommended Internal Structure
 
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/invoice-approval-workflow/README.md"
-  @"
 
-# Invoice Approval Workflow Specs
+## Fixture Contract
 
-## Purpose
+Synthetic approval cases should include:
 
-Invoice review process.
+- `id`: stable fixture-local identifier.
+- `invoiceId`: synthetic invoice identifier.
+- `vendor`: synthetic vendor name.
+- `amount`: numeric invoice amount.
+- `currency`: ISO-like currency code for display.
+- `department`: team requesting approval.
+- `requestedBy`: synthetic requester name.
+- `riskFlags`: local review reasons such as missing purchase order or duplicate
+  invoice warning.
+- `approvalStatus`: `ready-for-approval`, `needs-review`, `blocked`, or
+  `rejected`.
+- `reviewRequired`: true unless the invoice is ready for approval.
+- `nextAction`: reviewable guidance for the team.
+- `containsProductionData`: false for all local fixtures.
 
-## Contributor boundary
+## Status Rules
+
+- `ready-for-approval`: invoice has enough clean metadata for a future approval
+  queue.
+- `needs-review`: invoice needs human verification but is not blocked.
+- `blocked`: invoice cannot proceed until required details are supplied.
+- `rejected`: invoice should not proceed because it is duplicate, invalid, or
+  out of policy.
+
+## Contributor Boundary
 
 All work for this tool should stay in:
 
-$dir/
+```text
+tools/v2/team/invoice-approval-workflow/
+```
+
+Do not add payment execution, wallet behavior, Stellar behavior, inbox writes,
+database persistence, accounting exports, app routes, or shared design system
+changes in this issue.
 
 ## Required issue categories
 

--- a/tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs
+++ b/tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const toolDir = join(currentDir, "..");
+const fixturePath = join(toolDir, "fixtures", "sample-approval-cases.json");
+const readmePath = join(toolDir, "README.md");
+const specsPath = join(toolDir, "specs.md");
+const testPlanPath = join(toolDir, "docs", "test-plan.md");
+const reviewNotesPath = join(toolDir, "docs", "review-notes.md");
+
+const allowedStatuses = new Set(["ready-for-approval", "needs-review", "blocked", "rejected"]);
+const requiredStatuses = ["ready-for-approval", "needs-review", "blocked", "rejected"];
+
+async function readJson(path) {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample invoice approval fixture follows the documented contract", async () => {
+  const fixture = await readJson(fixturePath);
+
+  assert.equal(fixture.tool, "invoice-approval-workflow");
+  assert.match(fixture.runContext.now, /^\d{4}-\d{2}-\d{2}T/);
+  assert.ok(Array.isArray(fixture.cases), "fixture cases must be an array");
+  assert.ok(fixture.cases.length >= requiredStatuses.length);
+
+  const seenStatuses = new Set();
+  const seenIds = new Set();
+
+  for (const approvalCase of fixture.cases) {
+    assert.ok(approvalCase.id, "case needs a stable id");
+    assert.equal(seenIds.has(approvalCase.id), false, `${approvalCase.id} is duplicated`);
+    assert.ok(approvalCase.invoiceId, `${approvalCase.id} needs an invoice id`);
+    assert.ok(approvalCase.vendor, `${approvalCase.id} needs a vendor`);
+    assert.ok(approvalCase.department, `${approvalCase.id} needs a department`);
+    assert.ok(approvalCase.requestedBy, `${approvalCase.id} needs a requester`);
+    assert.equal(
+      approvalCase.containsProductionData,
+      false,
+      `${approvalCase.id} must stay synthetic`,
+    );
+    assert.equal(typeof approvalCase.amount, "number", `${approvalCase.id} amount is numeric`);
+    assert.ok(approvalCase.amount > 0, `${approvalCase.id} amount must be positive`);
+    assert.match(approvalCase.currency, /^[A-Z]{3}$/, `${approvalCase.id} uses currency code`);
+    assert.ok(
+      allowedStatuses.has(approvalCase.approvalStatus),
+      `${approvalCase.id} status is invalid`,
+    );
+    assert.ok(Array.isArray(approvalCase.riskFlags), `${approvalCase.id} risk flags are listed`);
+    assert.equal(typeof approvalCase.reviewRequired, "boolean");
+    assert.ok(approvalCase.nextAction, `${approvalCase.id} needs a next action`);
+
+    if (approvalCase.approvalStatus === "ready-for-approval") {
+      assert.equal(
+        approvalCase.reviewRequired,
+        false,
+        `${approvalCase.id} ready approvals should not require review`,
+      );
+      assert.equal(approvalCase.riskFlags.length, 0, `${approvalCase.id} should have no flags`);
+    }
+
+    if (approvalCase.approvalStatus === "blocked") {
+      assert.equal(
+        approvalCase.riskFlags.some((flag) => flag.startsWith("missing-")),
+        true,
+        `${approvalCase.id} blocked cases need missing detail flags`,
+      );
+      assert.equal(approvalCase.reviewRequired, true);
+    }
+
+    if (approvalCase.approvalStatus === "rejected") {
+      assert.equal(
+        approvalCase.riskFlags.includes("duplicate-invoice") ||
+          approvalCase.riskFlags.includes("policy-violation"),
+        true,
+        `${approvalCase.id} rejected cases need a rejection reason`,
+      );
+      assert.equal(approvalCase.reviewRequired, true);
+    }
+
+    if (approvalCase.riskFlags.includes("manager-threshold")) {
+      assert.equal(
+        approvalCase.approvalStatus,
+        "needs-review",
+        `${approvalCase.id} manager threshold cases should need review`,
+      );
+    }
+
+    seenStatuses.add(approvalCase.approvalStatus);
+    seenIds.add(approvalCase.id);
+  }
+
+  for (const status of requiredStatuses) {
+    assert.ok(seenStatuses.has(status), `fixture must include ${status}`);
+  }
+});
+
+test("documentation exposes setup, limitations, and review boundaries", async () => {
+  const [readme, specs, testPlan, reviewNotes] = await Promise.all([
+    readFile(readmePath, "utf8"),
+    readFile(specsPath, "utf8"),
+    readFile(testPlanPath, "utf8"),
+    readFile(reviewNotesPath, "utf8"),
+  ]);
+
+  assert.ok(
+    readme.includes(
+      "node --test tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs",
+    ),
+  );
+  assert.ok(readme.includes("tools/v2/team/invoice-approval-workflow/"));
+  assert.ok(specs.includes("ready-for-approval"));
+  assert.ok(specs.includes("Do not add payment execution"));
+  assert.ok(testPlan.includes("Manual Review Checklist"));
+  assert.ok(testPlan.includes("no production data"));
+  assert.ok(reviewNotes.includes("Out Of Scope"));
+  assert.ok(reviewNotes.toLowerCase().includes("integration"));
+});


### PR DESCRIPTION
Closes 

## Summary
- repair the folder-local Invoice Approval Workflow README and specs placeholders
- add a contributor-facing test plan and review notes
- add synthetic invoice approval fixture cases covering ready-for-approval, needs-review, blocked, and rejected states
- add a zero-dependency Node documentation/fixture contract test

## Scope
- only touches tools/v2/team/invoice-approval-workflow/
- no app shell, routing, auth, wallet, Stellar, database, inbox, mail rendering, payment execution, accounting export, or design-system integration
- no live network calls, secrets, production data, persistence, or side effects

## Validation
- node --test tools/v2/team/invoice-approval-workflow/tests/invoice-approval-docs.test.mjs
- npx --yes prettier --check on the changed Invoice Approval Workflow files
- git diff --check
- ASCII scan over tools/v2/team/invoice-approval-workflow