### PR TITLE
Add email translator test documentation

### DIFF
--- a/tools/v2/individual/email-translator/docs/review-notes.md
+++ b/tools/v2/individual/email-translator/docs/review-notes.md
@@ -1,0 +1,42 @@
+# Email Translator Review Notes
+
+## What This Contribution Covers
+
+This contribution adds contributor-facing documentation and fixture coverage for
+the isolated Email Translator workspace. It gives reviewers a local validation
+path before this tool is connected to a real translation provider or the main
+mail app.
+
+Reviewers should expect:
+
+- a deterministic synthetic fixture with representative translation scenarios.
+- a local Node test that validates the fixture and documentation contract.
+- a test plan that covers current review steps and future service/UI coverage.
+- explicit limitations for inbox, provider, routing, persistence, and secret
+  handling.
+
+## What Is Out Of Scope
+
+This issue does not add:
+
+- live translation API calls, LLM calls, or provider credentials.
+- inbox reads, mailbox writes, or mail rendering changes.
+- database schema changes or persistence.
+- app routing, dashboard placement, authentication, wallet, Stellar, or shared
+  design-system changes.
+- production sender, recipient, mailbox, or customer data.
+
+## Reviewer Flow
+
+1. Run the local Node test from the repository root.
+2. Inspect `fixtures/review-scenarios.json` and confirm all cases are synthetic.
+3. Confirm risky or unsupported scenarios require manual review.
+4. Confirm `docs/test-plan.md` names both current checks and future coverage
+   gaps.
+5. Confirm the PR changes only files inside this tool folder.
+
+## Known Limitations
+
+The fixture documents expected review behavior before a production translation
+provider is approved. Future integration should pass email body text into this
+tool as caller-owned input instead of letting the tool read from a mailbox.

--- a/tools/v2/individual/email-translator/docs/test-plan.md
+++ b/tools/v2/individual/email-translator/docs/test-plan.md
@@ -1,0 +1,45 @@
+# Email Translator Test Plan
+
+## Automated Checks
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/individual/email-translator/tests/email-translator-docs.test.mjs
+```
+
+The local test checks that:
+
+- review scenarios use stable ids and contain no production email data.
+- each scenario names a supported source and target language.
+- every scenario documents an expected review state.
+- unsupported or risky translation cases require manual review.
+- documentation includes setup, fixture, limitation, and integration-boundary
+  guidance.
+
+## Manual Review Checklist
+
+- Confirm all changed files stay under `tools/v2/individual/email-translator/`.
+- Confirm review fixtures contain no production data.
+- Confirm fixtures are synthetic and avoid real mailbox, sender, recipient, or
+  customer data.
+- Confirm source text is treated as caller-provided content, not fetched from
+  the inbox.
+- Confirm the review notes keep live translation providers, API keys, secrets,
+  inbox integration, persistence, and main app routing out of scope.
+- Confirm future service or UI work can reuse the fixture statuses without
+  changing this issue's review vocabulary.
+
+## Future Code Coverage
+
+When a folder-local translator service or UI surface is available on the target
+branch, extend coverage for:
+
+- source language auto-detection behavior.
+- supported and unsupported language pairs.
+- loading, empty, error, and success states.
+- copy-to-clipboard affordances.
+- provider errors, timeout handling, and unsafe markup warnings.
+
+Keep future tests folder-local unless a separate integration issue explicitly
+allows app-wide coverage.

--- a/tools/v2/individual/email-translator/fixtures/review-scenarios.json
+++ b/tools/v2/individual/email-translator/fixtures/review-scenarios.json
@@ -1,0 +1,49 @@
+{
+  "tool": "email-translator",
+  "runContext": {
+    "now": "2026-07-01T00:00:00.000Z",
+    "source": "synthetic-folder-local-fixture"
+  },
+  "scenarios": [
+    {
+      "id": "translate-review-001",
+      "sourceLanguage": "en",
+      "targetLanguage": "es",
+      "sourceText": "Hello team, please review the project update before Friday.",
+      "expectedState": "ready-for-translation",
+      "reviewRequired": false,
+      "riskFlags": [],
+      "containsProductionData": false
+    },
+    {
+      "id": "translate-review-002",
+      "sourceLanguage": "auto",
+      "targetLanguage": "fr",
+      "sourceText": "Good morning, please confirm the invoice note and next steps.",
+      "expectedState": "needs-source-review",
+      "reviewRequired": true,
+      "riskFlags": ["auto-detect-source"],
+      "containsProductionData": false
+    },
+    {
+      "id": "translate-review-003",
+      "sourceLanguage": "en",
+      "targetLanguage": "zz",
+      "sourceText": "Please translate this internal update for a future locale.",
+      "expectedState": "unsupported-language",
+      "reviewRequired": true,
+      "riskFlags": ["unsupported-target-language"],
+      "containsProductionData": false
+    },
+    {
+      "id": "translate-review-004",
+      "sourceLanguage": "en",
+      "targetLanguage": "de",
+      "sourceText": "Please review this message before sending: javascript:alert test marker.",
+      "expectedState": "blocked-input",
+      "reviewRequired": true,
+      "riskFlags": ["active-content-marker"],
+      "containsProductionData": false
+    }
+  ]
+}

--- a/tools/v2/individual/email-translator/tests/email-translator-docs.test.mjs
+++ b/tools/v2/individual/email-translator/tests/email-translator-docs.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const toolDir = join(currentDir, "..");
+const fixturePath = join(toolDir, "fixtures", "review-scenarios.json");
+const testPlanPath = join(toolDir, "docs", "test-plan.md");
+const reviewNotesPath = join(toolDir, "docs", "review-notes.md");
+
+const supportedLanguages = new Set(["auto", "en", "es", "fr", "de", "pt"]);
+const allowedStates = new Set([
+  "ready-for-translation",
+  "needs-source-review",
+  "unsupported-language",
+  "blocked-input",
+]);
+const requiredStates = [
+  "ready-for-translation",
+  "needs-source-review",
+  "unsupported-language",
+  "blocked-input",
+];
+
+async function readJson(path) {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw);
+}
+
+test("email translator review scenarios follow the fixture contract", async () => {
+  const fixture = await readJson(fixturePath);
+
+  assert.equal(fixture.tool, "email-translator");
+  assert.match(fixture.runContext.now, /^\d{4}-\d{2}-\d{2}T/);
+  assert.ok(Array.isArray(fixture.scenarios), "scenarios must be an array");
+  assert.ok(fixture.scenarios.length >= requiredStates.length);
+
+  const seenIds = new Set();
+  const seenStates = new Set();
+
+  for (const scenario of fixture.scenarios) {
+    assert.ok(scenario.id, "scenario needs a stable id");
+    assert.equal(seenIds.has(scenario.id), false, `${scenario.id} is duplicated`);
+    assert.ok(supportedLanguages.has(scenario.sourceLanguage), `${scenario.id} source invalid`);
+    assert.ok(scenario.targetLanguage, `${scenario.id} target is required`);
+    assert.ok(scenario.sourceText, `${scenario.id} source text is required`);
+    assert.equal(scenario.containsProductionData, false, `${scenario.id} must stay synthetic`);
+    assert.ok(allowedStates.has(scenario.expectedState), `${scenario.id} state is invalid`);
+    assert.equal(typeof scenario.reviewRequired, "boolean");
+    assert.ok(Array.isArray(scenario.riskFlags), `${scenario.id} risk flags are listed`);
+
+    if (scenario.expectedState === "ready-for-translation") {
+      assert.equal(scenario.reviewRequired, false, `${scenario.id} should be ready`);
+      assert.equal(scenario.riskFlags.length, 0, `${scenario.id} should have no risk flags`);
+    }
+
+    if (scenario.expectedState === "needs-source-review") {
+      assert.equal(scenario.sourceLanguage, "auto", `${scenario.id} uses auto detection`);
+      assert.equal(scenario.reviewRequired, true);
+      assert.ok(scenario.riskFlags.includes("auto-detect-source"));
+    }
+
+    if (scenario.expectedState === "unsupported-language") {
+      assert.equal(
+        supportedLanguages.has(scenario.targetLanguage),
+        false,
+        `${scenario.id} target should be unsupported`,
+      );
+      assert.equal(scenario.reviewRequired, true);
+    }
+
+    if (scenario.expectedState === "blocked-input") {
+      assert.ok(
+        scenario.riskFlags.includes("active-content-marker"),
+        `${scenario.id} needs active content flag`,
+      );
+      assert.equal(scenario.reviewRequired, true);
+    }
+
+    seenIds.add(scenario.id);
+    seenStates.add(scenario.expectedState);
+  }
+
+  for (const state of requiredStates) {
+    assert.ok(seenStates.has(state), `fixture must include ${state}`);
+  }
+});
+
+test("email translator documentation exposes setup and isolation boundaries", async () => {
+  const [testPlan, reviewNotes] = await Promise.all([
+    readFile(testPlanPath, "utf8"),
+    readFile(reviewNotesPath, "utf8"),
+  ]);
+
+  assert.ok(
+    testPlan.includes(
+      "node --test tools/v2/individual/email-translator/tests/email-translator-docs.test.mjs",
+    ),
+  );
+  assert.ok(testPlan.includes("Manual Review Checklist"));
+  assert.ok(testPlan.includes("no production data"));
+  assert.ok(testPlan.includes("Future Code Coverage"));
+  assert.ok(reviewNotes.includes("Out Of Scope"));
+  assert.ok(reviewNotes.includes("live translation API calls"));
+  assert.ok(reviewNotes.toLowerCase().includes("integration"));
+  assert.ok(reviewNotes.includes("tool read from a mailbox"));
+});


### PR DESCRIPTION
Closes #498

## Summary
- add a contributor-facing Email Translator test plan and review notes
- add synthetic review scenarios covering ready, source-review, unsupported-language, and blocked-input states
- add a zero-dependency Node documentation/fixture contract test

## Scope
- only touches new docs, fixture, and test files under tools/v2/individual/email-translator/
- intentionally avoids README/specs and existing core/security paths to reduce conflicts with open PRs
- no app shell, routing, auth, wallet, Stellar, database, inbox, mail rendering, live provider, LLM, or design-system integration
- no live network calls, secrets, production data, persistence, or side effects

## Validation
- node --test tools/v2/individual/email-translator/tests/email-translator-docs.test.mjs
- npx --yes prettier --check on the new Email Translator docs, fixture, and test files
- git diff --check
- ASCII scan over the changed docs, fixtures, and tests