### PR TITLE
Add knowledge base suggestion architecture contract

### DIFF
--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,15 +1,46 @@
 # Knowledge Base Suggestion
 
-This folder is the isolated workspace for the Knowledge Base Suggestion tool.
+Knowledge Base Suggestion is a V2 team tool for proposing internal help-center
+or runbook articles from repeated email themes, support gaps, and team review
+signals. This issue defines the isolated architecture contract only; it does not
+wire the tool into the main app yet.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\knowledge-base-suggestion\
-`
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Architecture Map
+
+- `specs.md` defines the release tier, contributor boundary, and required
+  module categories.
+- `docs/ARCHITECTURE.md` defines component, service, hook, test, and docs
+  boundaries.
+- `docs/DATA_OWNERSHIP.md` documents local data ownership, dependency rules,
+  and future integration constraints.
+- `tests/architecture-contract.test.mjs` validates that the architecture docs
+  keep the required boundary language in place.
+
+## Local Validation
+
+Run from the repository root:
+
+```bash
+node --test tools/v2/team/knowledge-base-suggestion/tests/architecture-contract.test.mjs
+```
+
+The test is intentionally zero-dependency and does not import the main app.
+
+## Current Limitations
+
+- No inbox ingestion, support-ticket sync, knowledge base write, notification,
+  database persistence, or approval workflow is implemented.
+- No app shell, routing, dashboard, auth, wallet, Stellar, or shared
+  design-system integration is included.
+- Future feature work should build inside this folder first and leave app-level
+  wiring to a separate integration issue.

--- a/tools/v2/team/knowledge-base-suggestion/docs/ARCHITECTURE.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/ARCHITECTURE.md
@@ -1,0 +1,154 @@
+# Knowledge Base Suggestion Architecture Contract
+
+## Purpose
+
+Knowledge Base Suggestion is a self-contained V2 team mini-product. It helps a
+team identify repeated support questions, policy gaps, and workflow patterns
+that may deserve internal documentation. The architecture keeps suggestion
+logic local to this folder and leaves main-app wiring for a future integration
+issue.
+
+## Ownership Boundary
+
+All implementation, fixtures, tests, and docs for this tool must remain inside:
+
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
+
+No file outside this folder is required for this architecture issue.
+
+## Module Boundaries
+
+### `components/`
+
+Responsibility: render the review surface for suggestion candidates.
+
+Planned components:
+
+- `KnowledgeBaseSuggestionShell`: local root component that receives candidate
+  inputs or fixture data and coordinates the review surface.
+- `SuggestionCandidateList`: renders candidate article ideas, confidence, and
+  status.
+- `SuggestionEvidencePanel`: shows the local evidence summary that supports a
+  candidate without exposing production email bodies.
+- `SuggestionReviewActions`: presents reviewer actions such as accept, defer,
+  reject, or mark-needs-more-evidence.
+
+Rules:
+
+- Components receive data from hooks or props.
+- Components do not read the inbox, database, wallet, Stellar, or auth state.
+- Components do not mutate production knowledge base records.
+
+### `services/`
+
+Responsibility: hold pure business logic and deterministic helpers.
+
+Planned services:
+
+- `suggestionDetector`: groups repeated themes and identifies candidate
+  knowledge base topics.
+- `suggestionScorer`: computes local confidence and evidence strength.
+- `suggestionNormalizer`: converts local input records into a consistent
+  candidate shape for the UI.
+- `reviewStateService`: models local reviewer states and transition rules.
+
+Rules:
+
+- Services do not import React.
+- Services do not make live network calls.
+- Services use injected data or local fixtures instead of fetching from the
+  main app.
+
+### `hooks/`
+
+Responsibility: bridge component state to local services.
+
+Planned hooks:
+
+- `useKnowledgeBaseSuggestions`: manages candidate loading, filtering, review
+  state, and service calls.
+- `useSuggestionFilters`: owns local filter state for department, status,
+  confidence, and topic area.
+- `useSuggestionReview`: exposes local reviewer actions without publishing or
+  persisting records outside this folder.
+
+Rules:
+
+- Hooks call services instead of duplicating business logic.
+- Hooks do not write to global stores or app contexts.
+- Hooks do not register routes, navigation items, or mail actions.
+
+### `tests/`
+
+Responsibility: provide local confidence without requiring the main app.
+
+Expected coverage:
+
+- Architecture and documentation contract tests.
+- Service tests for grouping, scoring, normalization, and review transitions.
+- Fixture tests proving all sample data is synthetic.
+- Hook and component tests after implementation exists.
+
+Rules:
+
+- Tests must stay folder-local.
+- Tests may use local fixtures and standard test utilities already present in
+  the repository.
+- Tests must not require a live inbox, production database, wallet, Stellar
+  account, or external knowledge base service.
+
+### `docs/`
+
+Responsibility: explain the tool contract for future contributors.
+
+Expected contents:
+
+- Architecture and dependency boundaries.
+- Data ownership and privacy rules.
+- Review notes and test plans for future implementation issues.
+- Future integration notes that describe, but do not implement, app wiring.
+
+## Dependency Graph
+
+```text
+components/ -> hooks/ -> services/
+tests/ -> docs/, fixtures/, components/, hooks/, services/
+docs/ -> descriptive only
+```
+
+Components should not import services directly once hooks exist. Services should
+not import components or hooks. Docs should not be imported at runtime.
+
+## Integration Constraints
+
+This architecture issue must not:
+
+- Modify the main app shell, dashboard, routing, navigation, or shared layout.
+- Connect to the existing inbox architecture or mail rendering engine.
+- Add database schema, persistence, or production knowledge base writes.
+- Add authentication, wallet, Stellar, or payment behavior.
+- Add notifications, ticketing sync, or external provider calls.
+- Change the shared design system.
+
+Future integration should pass prepared evidence and callbacks into the
+folder-local shell through a thin adapter. The tool should remain the source of
+truth for suggestion logic, while the main app owns routing, authorization, live
+mail access, persistence, and publishing.
+
+## Contributor Rules
+
+May change inside this folder:
+
+- Local components, services, hooks, tests, fixtures, and docs.
+- Internal types and local data contracts.
+- Architecture docs when module boundaries evolve.
+
+Must not change in this issue:
+
+- Files outside `tools/v2/team/knowledge-base-suggestion/`.
+- Main app shell, routing, inbox, wallet, Stellar, auth, database, or shared
+  design-system code.
+- Production data access, production knowledge base publishing, or live network
+  integrations.

--- a/tools/v2/team/knowledge-base-suggestion/docs/DATA_OWNERSHIP.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/DATA_OWNERSHIP.md
@@ -1,0 +1,70 @@
+# Knowledge Base Suggestion Data Ownership
+
+## Local Data Model
+
+This tool owns only folder-local, review-oriented data shapes:
+
+- `SuggestionCandidate`: a proposed article or runbook topic.
+- `SuggestionEvidence`: synthetic or injected evidence summary that explains
+  why the candidate exists.
+- `SuggestionScore`: confidence, recurrence count, risk, and freshness signals.
+- `SuggestionReviewState`: local reviewer status such as `new`, `accepted`,
+  `deferred`, `rejected`, or `needs-more-evidence`.
+- `SuggestionFilterState`: local UI filters for team, topic, confidence, and
+  status.
+
+These models are internal contracts. They do not imply database ownership or
+production publishing rights.
+
+## Data This Tool Does Not Own
+
+The tool must not own or mutate:
+
+- Live inbox threads, rendered email bodies, attachments, or mailbox metadata.
+- User, teammate, department, auth, role, or permission records.
+- Wallet, Stellar, payment, or blockchain state.
+- Main application database rows or migrations.
+- Production knowledge base articles, slugs, publishing workflows, or audit
+  trails.
+- Notification, ticketing, CRM, or analytics provider records.
+
+## Source Data Rules
+
+Before integration exists, data should come from local fixtures or inputs
+provided by the caller. Fixtures must be synthetic and must not include real
+sender, recipient, customer, mailbox, teammate, account, or organization data.
+
+After a future integration issue is approved, the main app should prepare and
+sanitize evidence before passing it into this tool. This folder should not fetch
+or scrape the inbox directly.
+
+## Storage Rules
+
+- Architecture-only work does not persist data.
+- Future local prototypes may keep state in memory or local fixtures.
+- Production persistence must be handled by a separate integration issue.
+- Publishing to a knowledge base must be a separate issue with explicit review,
+  authorization, validation, and rollback behavior.
+
+## Dependency Ownership
+
+- `components/` own rendering and local user intent.
+- `hooks/` own local state orchestration.
+- `services/` own grouping, scoring, normalization, and transition logic.
+- `tests/` own local verification.
+- `docs/` own contributor guidance and architecture constraints.
+
+No layer owns main-app data access, production persistence, wallet behavior, or
+Stellar behavior.
+
+## Future Adapter Contract
+
+A future integration should provide this tool with:
+
+- sanitized evidence summaries.
+- optional topic metadata.
+- reviewer identity already authorized by the main app.
+- callbacks for previewing or publishing suggestions.
+
+That adapter should live outside this folder and should be reviewed in its own
+issue. This architecture issue only defines the local contract.

--- a/tools/v2/team/knowledge-base-suggestion/specs.md
+++ b/tools/v2/team/knowledge-base-suggestion/specs.md
@@ -1,36 +1,63 @@
 # Knowledge Base Suggestion
 
-Suggest internal documentation.
+Suggest internal documentation from repeated team email patterns while keeping
+the tool isolated from the main mail app until a future integration issue.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: team
+- Folder ownership: `tools/v2/team/knowledge-base-suggestion/`
 
 This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
+## Recommended Internal Structure
 
 - components/
 - services/
 - hooks/
--     ests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/knowledge-base-suggestion/README.md"
-  @"
+- tests/
 
-# Knowledge Base Suggestion Specs
+## Module Boundary Summary
 
-## Purpose
+- `components/`: presentational and container UI for reviewing suggestion
+  candidates, evidence summaries, confidence, and reviewer actions.
+- `services/`: pure business logic for detecting suggestion candidates,
+  scoring repeated themes, normalizing evidence, and preparing review payloads.
+- `hooks/`: local React state adapters that bridge components to services
+  without reaching into app-wide stores.
+- `tests/`: folder-local contract, fixture, service, hook, and component tests.
+- `docs/`: architecture notes, data ownership rules, review plans, and future
+  integration notes.
 
-Suggest internal documentation.
+## Data Ownership
 
-## Contributor boundary
+This tool may own local suggestion drafts, review states, scoring metadata,
+source evidence references, and synthetic fixtures inside this folder. It must
+not own or mutate live inbox threads, rendered mail, user profiles, wallet
+state, Stellar data, database rows, or production knowledge base records.
+
+## Dependency Rules
+
+- Components may depend on hooks and local types.
+- Hooks may depend on services and local types.
+- Services may depend on local fixtures, local types, and standard JavaScript
+  utilities.
+- Tests may import local modules and read local docs or fixtures.
+- Docs must remain descriptive and must not require runtime integration.
+
+Components should not call services directly once hooks exist. Services should
+not import React, app shell modules, route modules, auth, wallet, Stellar, inbox,
+mail rendering, or database code.
+
+## Contributor Boundary
 
 All work for this tool should stay in:
 
-$dir/
+```text
+tools/v2/team/knowledge-base-suggestion/
+```
 
 ## Required issue categories
 
@@ -39,3 +66,11 @@ $dir/
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Future Integration Constraints
+
+Future app integration must be a separate issue. That follow-up should pass
+mail evidence into this tool through an adapter instead of letting this folder
+read the inbox directly. It should also keep knowledge base publishing,
+database persistence, notifications, approval workflows, routing, and auth
+checks outside this architecture-only contribution until explicitly approved.

--- a/tools/v2/team/knowledge-base-suggestion/tests/architecture-contract.test.mjs
+++ b/tools/v2/team/knowledge-base-suggestion/tests/architecture-contract.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const toolDir = join(currentDir, "..");
+
+const docs = {
+  readme: join(toolDir, "README.md"),
+  specs: join(toolDir, "specs.md"),
+  architecture: join(toolDir, "docs", "ARCHITECTURE.md"),
+  dataOwnership: join(toolDir, "docs", "DATA_OWNERSHIP.md"),
+};
+
+async function readDoc(path) {
+  return readFile(path, "utf8");
+}
+
+test("architecture docs define folder-local module boundaries", async () => {
+  const [readme, specs, architecture] = await Promise.all([
+    readDoc(docs.readme),
+    readDoc(docs.specs),
+    readDoc(docs.architecture),
+  ]);
+
+  const combined = `${readme}\n${specs}\n${architecture}`;
+
+  assert.ok(combined.includes("tools/v2/team/knowledge-base-suggestion/"));
+  assert.ok(readme.includes("docs/ARCHITECTURE.md"));
+  assert.ok(readme.includes("docs/DATA_OWNERSHIP.md"));
+
+  for (const boundary of ["components/", "services/", "hooks/", "tests/", "docs/"]) {
+    assert.ok(combined.includes(boundary), `${boundary} boundary must be documented`);
+  }
+
+  assert.ok(architecture.includes("components/ -> hooks/ -> services/"));
+  assert.ok(specs.includes("Components should not call services directly"));
+});
+
+test("data ownership and integration constraints are explicit", async () => {
+  const [specs, architecture, dataOwnership] = await Promise.all([
+    readDoc(docs.specs),
+    readDoc(docs.architecture),
+    readDoc(docs.dataOwnership),
+  ]);
+
+  assert.ok(specs.includes("Release tier: V2"));
+  assert.ok(specs.includes("Audience: team"));
+  assert.ok(dataOwnership.includes("Fixtures must be synthetic"));
+  assert.ok(dataOwnership.includes("must not own or mutate"));
+
+  for (const forbidden of [
+    "main app shell",
+    "routing",
+    "inbox architecture",
+    "wallet",
+    "Stellar",
+    "database",
+    "design system",
+  ]) {
+    assert.ok(
+      architecture.toLowerCase().includes(forbidden.toLowerCase()),
+      `${forbidden} constraint must be documented`,
+    );
+  }
+});
+
+test("template placeholders are removed from contributor-facing docs", async () => {
+  const [readme, specs] = await Promise.all([readDoc(docs.readme), readDoc(docs.specs)]);
+  const combined = `${readme}\n${specs}`;
+
+  for (const residue of ["$dir", "Set-Content", "System.Collections", '@"']) {
+    assert.equal(combined.includes(residue), false, `${residue} template residue remains`);
+  }
+});


### PR DESCRIPTION
Closes 

## Summary
- repair the Knowledge Base Suggestion README/specs placeholders for the V2 team tool
- add a folder-local architecture contract covering components, services, hooks, tests, and docs
- document data ownership, dependency rules, prohibited production ownership, and future adapter constraints
- add a zero-dependency Node documentation contract test for the architecture boundary

## Scope
- only touches tools/v2/team/knowledge-base-suggestion/
- no app shell, dashboard, routing, auth, wallet, Stellar, database, inbox, mail rendering, knowledge base publishing, notification, ticketing, or design-system integration
- no production data, live network calls, persistence, secrets, or side effects

## Validation
- node --test tools/v2/team/knowledge-base-suggestion/tests/architecture-contract.test.mjs
- npx --yes prettier --check on the changed Knowledge Base Suggestion files
- git diff --check
- ASCII scan over tools/v2/team/knowledge-base-suggestion