### PR TITLE
Add legal review security performance guards

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/docs/performance-notes.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/performance-notes.md
@@ -1,0 +1,40 @@
+# Legal and Compliance Review Flag Performance Notes
+
+## Local Budgets
+
+The current folder-local guard helper applies these default bounds:
+
+- review body text: 12,000 characters.
+- attachment metadata rows: 25 items.
+- history rows: 50 items.
+
+These numbers are intentionally conservative for a V2 later-release tool that
+does not yet have pagination, virtualization, or backend streaming.
+
+## Large Email Strategy
+
+Future service or UI code should avoid parsing full production email payloads in
+render paths. Prefer this sequence:
+
+1. sanitize and truncate text in the service layer.
+2. compute review warnings once per input payload.
+3. pass bounded, already-normalized data into components.
+4. defer attachment body inspection to a separate future issue.
+5. add pagination or virtualization before displaying large histories.
+
+## Attachment Strategy
+
+Attachment content should not be read in this tool during the isolated phase.
+Only bounded metadata should be accepted. A future integration may add provider
+adapters, but those adapters should live outside this folder and pass sanitized
+metadata inward.
+
+## Regression Checks
+
+The local test suite validates:
+
+- malformed input returns a controlled error.
+- secret-like values are redacted.
+- control characters are removed from text fields.
+- large bodies, attachment lists, and histories are bounded.
+- documentation continues to name the security and performance constraints.

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/security-and-performance.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/security-and-performance.md
@@ -1,0 +1,55 @@
+# Legal and Compliance Review Flag Security and Performance Notes
+
+## Threat Assumptions
+
+Inputs for this isolated tool may eventually come from email bodies, attachment
+metadata, reviewer notes, or imported history. Until a future integration issue
+defines the live data path, every caller-provided value should be treated as
+untrusted.
+
+The tool must defend against:
+
+- malformed payloads such as null, arrays, or primitive values.
+- hostile control characters in subject lines, body text, attachment names, or
+  history fields.
+- accidental secret exposure in review text, including token, password, secret,
+  private key, or API key assignments.
+- large email bodies that could slow review rendering.
+- large attachment lists or long audit histories that could create unnecessary
+  work before pagination exists.
+- production data leakage through fixtures or test snapshots.
+
+## Guard Helper
+
+`services/review-safety-guards.mjs` provides zero-dependency helpers for this
+folder:
+
+- `sanitizeReviewText` removes unsafe control characters, redacts secret-like
+  assignments, and truncates oversized text.
+- `normalizeAttachmentList` keeps attachment metadata synthetic and bounded.
+- `normalizeHistoryItems` keeps history entries bounded.
+- `evaluateLegalReviewInput` validates a full review payload and reports errors,
+  warnings, sanitized output, and performance counters.
+
+These helpers are intentionally local and do not import the main app, inbox,
+database, wallet, Stellar, auth, or design-system code.
+
+## Required Handling
+
+- Invalid payloads should return `input-must-be-object` instead of throwing.
+- Empty required fields should report `subject-required` or `body-required`.
+- Secret-like assignments should be redacted before rendering or snapshotting.
+- Oversized body text should be truncated and flagged with `body-truncated`.
+- Oversized attachment and history arrays should be bounded before any future
+  UI work renders them.
+
+## Out of Scope
+
+This contribution does not add:
+
+- live inbox reads, mailbox writes, or mail rendering changes.
+- database schema changes or persistence.
+- notification delivery or reviewer assignment writes.
+- auth, wallet, Stellar, or payment behavior.
+- external legal, compliance, ticketing, or storage provider calls.
+- app shell, routing, dashboard, or shared design-system integration.

--- a/tools/v2/team/legal-and-compliance-review-flag/fixtures/hostile-review-inputs.json
+++ b/tools/v2/team/legal-and-compliance-review-flag/fixtures/hostile-review-inputs.json
@@ -1,0 +1,34 @@
+{
+  "tool": "legal-and-compliance-review-flag",
+  "source": "synthetic-security-performance-fixtures",
+  "cases": [
+    {
+      "id": "malformed-input",
+      "input": "not-an-object",
+      "expectedErrors": ["input-must-be-object"]
+    },
+    {
+      "id": "secret-redaction",
+      "input": {
+        "subject": "Vendor contract password=plain-text-secret",
+        "body": "Please review this clause. apiKey=abc123 should never leak.",
+        "attachments": [],
+        "history": []
+      },
+      "expectedWarnings": ["secret-like-values-redacted"]
+    },
+    {
+      "id": "large-email",
+      "input": {
+        "subject": "Large regulatory review",
+        "bodyRepeat": {
+          "value": "Long compliance paragraph. ",
+          "count": 900
+        },
+        "attachmentsRepeat": 40,
+        "historyRepeat": 80
+      },
+      "expectedWarnings": ["body-truncated", "attachments-truncated", "history-truncated"]
+    }
+  ]
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/services/review-safety-guards.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/services/review-safety-guards.mjs
@@ -1,0 +1,142 @@
+const DEFAULT_TEXT_LIMIT = 12000;
+const DEFAULT_ATTACHMENT_LIMIT = 25;
+const DEFAULT_HISTORY_LIMIT = 50;
+
+const CONTROL_CHARS_EXCEPT_TABS_AND_NEWLINES = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const SECRET_ASSIGNMENT =
+  /\b(api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*([^\s,;]+)/gi;
+
+export const REVIEW_SAFETY_LIMITS = Object.freeze({
+  maxTextChars: DEFAULT_TEXT_LIMIT,
+  maxAttachments: DEFAULT_ATTACHMENT_LIMIT,
+  maxHistoryItems: DEFAULT_HISTORY_LIMIT,
+});
+
+export function sanitizeReviewText(value, options = {}) {
+  const limit = Number.isInteger(options.limit) ? options.limit : DEFAULT_TEXT_LIMIT;
+  const rawText = typeof value === "string" ? value : "";
+  const withoutControls = rawText.replace(CONTROL_CHARS_EXCEPT_TABS_AND_NEWLINES, " ");
+  let redactions = 0;
+  const withoutSecrets = withoutControls.replace(SECRET_ASSIGNMENT, (_match, label) => {
+    redactions += 1;
+    return `${label}=[redacted]`;
+  });
+
+  const text = withoutSecrets.length > limit ? withoutSecrets.slice(0, limit) : withoutSecrets;
+
+  return {
+    text,
+    originalLength: rawText.length,
+    sanitizedLength: text.length,
+    truncated: withoutSecrets.length > limit,
+    redactions,
+  };
+}
+
+export function normalizeAttachmentList(attachments, options = {}) {
+  const limit = Number.isInteger(options.limit) ? options.limit : DEFAULT_ATTACHMENT_LIMIT;
+  const source = Array.isArray(attachments) ? attachments : [];
+  const normalized = source.slice(0, limit).map((attachment, index) => ({
+    id: String(attachment?.id || `attachment-${index + 1}`),
+    name: sanitizeReviewText(attachment?.name, { limit: 160 }).text || "unnamed-attachment",
+    sizeBytes: Math.max(0, Number(attachment?.sizeBytes) || 0),
+    mimeType:
+      sanitizeReviewText(attachment?.mimeType, { limit: 120 }).text || "application/octet-stream",
+  }));
+
+  return {
+    attachments: normalized,
+    originalCount: source.length,
+    truncated: source.length > limit,
+  };
+}
+
+export function normalizeHistoryItems(history, options = {}) {
+  const limit = Number.isInteger(options.limit) ? options.limit : DEFAULT_HISTORY_LIMIT;
+  const source = Array.isArray(history) ? history : [];
+  const items = source.slice(0, limit).map((item, index) => ({
+    id: String(item?.id || `history-${index + 1}`),
+    action: sanitizeReviewText(item?.action, { limit: 120 }).text || "unknown",
+    actor: sanitizeReviewText(item?.actor, { limit: 120 }).text || "unknown",
+    occurredAt: sanitizeReviewText(item?.occurredAt, { limit: 80 }).text || "",
+  }));
+
+  return {
+    history: items,
+    originalCount: source.length,
+    truncated: source.length > limit,
+  };
+}
+
+export function evaluateLegalReviewInput(input, options = {}) {
+  const errors = [];
+  const warnings = [];
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      errors: ["input-must-be-object"],
+      warnings,
+      sanitized: null,
+      performance: {
+        skipped: true,
+        reason: "invalid-input",
+      },
+    };
+  }
+
+  const subject = sanitizeReviewText(input.subject, { limit: 240 });
+  const body = sanitizeReviewText(input.body, {
+    limit: options.maxTextChars || DEFAULT_TEXT_LIMIT,
+  });
+  const attachments = normalizeAttachmentList(input.attachments, {
+    limit: options.maxAttachments || DEFAULT_ATTACHMENT_LIMIT,
+  });
+  const history = normalizeHistoryItems(input.history, {
+    limit: options.maxHistoryItems || DEFAULT_HISTORY_LIMIT,
+  });
+
+  if (!subject.text) {
+    errors.push("subject-required");
+  }
+
+  if (!body.text) {
+    errors.push("body-required");
+  }
+
+  if (body.truncated) {
+    warnings.push("body-truncated");
+  }
+
+  if (body.redactions > 0 || subject.redactions > 0) {
+    warnings.push("secret-like-values-redacted");
+  }
+
+  if (attachments.truncated) {
+    warnings.push("attachments-truncated");
+  }
+
+  if (history.truncated) {
+    warnings.push("history-truncated");
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    sanitized: {
+      subject: subject.text,
+      body: body.text,
+      attachments: attachments.attachments,
+      history: history.history,
+    },
+    performance: {
+      bodyChars: body.sanitizedLength,
+      originalBodyChars: body.originalLength,
+      attachmentCount: attachments.attachments.length,
+      originalAttachmentCount: attachments.originalCount,
+      historyCount: history.history.length,
+      originalHistoryCount: history.originalCount,
+    },
+  };
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/tests/security-performance-guards.test.mjs
+++ b/tools/v2/team/legal-and-compliance-review-flag/tests/security-performance-guards.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  REVIEW_SAFETY_LIMITS,
+  evaluateLegalReviewInput,
+  sanitizeReviewText,
+} from "../services/review-safety-guards.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const toolDir = join(currentDir, "..");
+const fixturePath = join(toolDir, "fixtures", "hostile-review-inputs.json");
+const securityDocPath = join(toolDir, "docs", "security-and-performance.md");
+const performanceDocPath = join(toolDir, "docs", "performance-notes.md");
+
+async function readJson(path) {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw);
+}
+
+function expandFixtureInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+
+  const expanded = { ...input };
+
+  if (expanded.bodyRepeat) {
+    expanded.body = expanded.bodyRepeat.value.repeat(expanded.bodyRepeat.count);
+    delete expanded.bodyRepeat;
+  }
+
+  if (expanded.attachmentsRepeat) {
+    expanded.attachments = Array.from({ length: expanded.attachmentsRepeat }, (_, index) => ({
+      id: `attachment-${index + 1}`,
+      name: `contract-evidence-${index + 1}.pdf`,
+      sizeBytes: 1024 + index,
+      mimeType: "application/pdf",
+    }));
+    delete expanded.attachmentsRepeat;
+  }
+
+  if (expanded.historyRepeat) {
+    expanded.history = Array.from({ length: expanded.historyRepeat }, (_, index) => ({
+      id: `history-${index + 1}`,
+      action: "review-note",
+      actor: "synthetic-reviewer",
+      occurredAt: `2026-07-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+    }));
+    delete expanded.historyRepeat;
+  }
+
+  return expanded;
+}
+
+test("review safety guard handles malformed and hostile inputs", async () => {
+  const fixture = await readJson(fixturePath);
+
+  assert.equal(fixture.tool, "legal-and-compliance-review-flag");
+  assert.ok(Array.isArray(fixture.cases));
+
+  for (const reviewCase of fixture.cases) {
+    const result = evaluateLegalReviewInput(expandFixtureInput(reviewCase.input));
+
+    for (const expectedError of reviewCase.expectedErrors || []) {
+      assert.ok(result.errors.includes(expectedError), `${reviewCase.id} missing ${expectedError}`);
+    }
+
+    for (const expectedWarning of reviewCase.expectedWarnings || []) {
+      assert.ok(
+        result.warnings.includes(expectedWarning),
+        `${reviewCase.id} missing ${expectedWarning}`,
+      );
+    }
+  }
+});
+
+test("sanitization removes control characters and redacts secret-like assignments", () => {
+  const result = sanitizeReviewText("Line\u0000 one token=abc123\nprivate_key=super-secret");
+
+  assert.equal(result.redactions, 2);
+  assert.equal(result.text.includes("\u0000"), false);
+  assert.equal(result.text.includes("abc123"), false);
+  assert.equal(result.text.includes("super-secret"), false);
+  assert.ok(result.text.includes("token=[redacted]"));
+  assert.ok(result.text.includes("private_key=[redacted]"));
+});
+
+test("large review payloads are bounded before future UI rendering", () => {
+  const input = {
+    subject: "Large compliance review",
+    body: "x".repeat(REVIEW_SAFETY_LIMITS.maxTextChars + 500),
+    attachments: Array.from({ length: REVIEW_SAFETY_LIMITS.maxAttachments + 5 }, (_, index) => ({
+      name: `evidence-${index}.pdf`,
+    })),
+    history: Array.from({ length: REVIEW_SAFETY_LIMITS.maxHistoryItems + 5 }, (_, index) => ({
+      action: `review-${index}`,
+    })),
+  };
+
+  const result = evaluateLegalReviewInput(input);
+
+  assert.equal(result.ok, true);
+  assert.ok(result.warnings.includes("body-truncated"));
+  assert.ok(result.warnings.includes("attachments-truncated"));
+  assert.ok(result.warnings.includes("history-truncated"));
+  assert.equal(result.sanitized.body.length, REVIEW_SAFETY_LIMITS.maxTextChars);
+  assert.equal(result.sanitized.attachments.length, REVIEW_SAFETY_LIMITS.maxAttachments);
+  assert.equal(result.sanitized.history.length, REVIEW_SAFETY_LIMITS.maxHistoryItems);
+});
+
+test("security and performance documentation names the isolated constraints", async () => {
+  const [securityDoc, performanceDoc] = await Promise.all([
+    readFile(securityDocPath, "utf8"),
+    readFile(performanceDocPath, "utf8"),
+  ]);
+
+  assert.ok(securityDoc.includes("malformed payloads"));
+  assert.ok(securityDoc.includes("Secret-like assignments") || securityDoc.includes("Secret"));
+  assert.ok(securityDoc.includes("Out of Scope"));
+  assert.ok(performanceDoc.includes("12,000 characters"));
+  assert.ok(performanceDoc.includes("pagination or virtualization"));
+});


### PR DESCRIPTION
Closes #617

## Summary
- add folder-local security and performance guard helpers for Legal and Compliance Review Flag inputs
- add synthetic hostile/large review fixtures covering malformed input, secret-like redaction, truncation, attachment limits, and history limits
- document threat assumptions, unsafe input handling, performance budgets, and out-of-scope integrations
- add a zero-dependency Node test suite for the guard behavior and documentation constraints

## Scope
- only touches tools/v2/team/legal-and-compliance-review-flag/
- no app shell, routing, auth, wallet, Stellar, database, inbox, mail rendering, notification, assignment write, external legal/compliance provider, ticketing, storage provider, or design-system integration
- no production data, live network calls, persistence, secrets, or side effects

## Validation
- node --test tools/v2/team/legal-and-compliance-review-flag/tests/security-performance-guards.test.mjs
- npx --yes prettier --check on the changed Legal and Compliance Review Flag files
- git diff --check
- ASCII scan over tools/v2/team/legal-and-compliance-review-flag