### PR TITLE
Add meeting assignment architecture contract

### DIFF
--- a/tools/v2/team/meeting-assignment-tool/README.md
+++ b/tools/v2/team/meeting-assignment-tool/README.md
@@ -1,12 +1,12 @@
 # Meeting Assignment Tool
 
-Assign meeting responsibilities to team members based on skills, workload, and capacity.
+Assign meeting responsibilities to team members based on skills, workload, priority, and capacity.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-```
+```text
 tools/v2/team/meeting-assignment-tool/
 ```
 
@@ -14,49 +14,52 @@ Do not wire this tool into the main app, routing, inbox architecture, wallet cor
 
 ## Structure
 
-```
-fixtures/           Deterministic local data (team members, sample meetings)
-services/           Core pure-function logic + async service factory
-tests/              node:test suite (no external runner required)
-docs/               Review notes and contributor context
-types.ts            All domain types
+```text
+fixtures/           Deterministic local data for team members and sample meetings
+services/           Core pure-function logic plus async service factory
+helpers/            Folder-local validation and performance guards
+tests/              Local contract and behavior tests
+docs/               Architecture, data ownership, security, and reviewer notes
+types.ts            Domain types for inputs, outputs, and load states
 index.ts            Folder-local public API
+specs.md            Contributor-facing scope and implementation contract
 ```
+
+The current release does not create app shell routes, shared UI components, auth bindings, persistence adapters, wallet calls, Stellar calls, or inbox integrations.
 
 ## Run Tests
 
 ```bash
 node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment.test.mjs
+node --test tools/v2/team/meeting-assignment-tool/tests/architecture-contract.test.mjs
 ```
-
-17 tests, no external dependencies.
 
 ## Public API
 
 ```ts
 import { assignMeetings, createMeetingAssignmentService } from "./index";
 
-// Pure function — deterministic, synchronous
+// Pure function: deterministic and synchronous.
 const result = assignMeetings({ teamMembers, meetings });
-// result.assignments[]  — per-meeting assignment with reason
-// result.summary        — totals, coverage %, per-member effort delta
+// result.assignments[]: per-meeting assignment with reason
+// result.summary: totals, coverage %, per-member effort delta
 
-// Async service wrapper — simulates delay/failure for UI dev
+// Async service wrapper: simulates delay/failure for UI development.
 const svc = createMeetingAssignmentService({ simulateDelay: false });
 const data = await svc.assign();
 ```
 
 ## Assignment Algorithm
 
-1. Sort meetings by priority (desc), then effort (asc).
+1. Sort meetings by priority descending, then effort ascending.
 2. Find members whose skill set covers all `requiredSkills`.
-3. Filter by remaining capacity (`weeklyCapacity − currentLoad ≥ effort`).
-4. Pick the least-loaded eligible member; ties broken by higher capacity.
-5. Unassigned reason is one of: `"matched"` / `"capacity"` / `"skill_mismatch"`.
+3. Filter by remaining capacity (`weeklyCapacity - currentLoad >= effort`).
+4. Pick the least-loaded eligible member; ties are broken by higher capacity.
+5. Report unassigned reason as `"capacity"` or `"skill_mismatch"` when no match can be made.
 
-## Inputs & Outputs
+## Inputs and Outputs
 
-**Input — `TeamMember`**
+**Input: `TeamMember`**
 
 | Field                | Type       | Description                         |
 | -------------------- | ---------- | ----------------------------------- |
@@ -64,23 +67,23 @@ const data = await svc.assign();
 | `name`               | `string`   | Display name                        |
 | `skills`             | `string[]` | Skill tags                          |
 | `currentMeetingLoad` | `number`   | Meetings already assigned this week |
-| `weeklyCapacity`     | `number`   | Max meetings per week               |
+| `weeklyCapacity`     | `number`   | Max effort capacity per week        |
 
-**Input — `Meeting`**
+**Input: `Meeting`**
 
-| Field            | Type          | Description                        |
-| ---------------- | ------------- | ---------------------------------- |
-| `id`             | `string`      | Unique identifier                  |
-| `requiredSkills` | `string[]`    | Skills needed (empty = any member) |
-| `effort`         | `1 \| 2 \| 3` | Weight consumed from capacity      |
-| `priority`       | `number`      | Higher = processed first           |
+| Field            | Type          | Description                           |
+| ---------------- | ------------- | ------------------------------------- |
+| `id`             | `string`      | Unique identifier                     |
+| `requiredSkills` | `string[]`    | Skills needed; empty means any member |
+| `effort`         | `1 \| 2 \| 3` | Weight consumed from capacity         |
+| `priority`       | `number`      | Higher values are processed first     |
 
-**Output — `MeetingAssignment`**
+**Output: `MeetingAssignment`**
 
 | Field        | Type                                          | Description                 |
 | ------------ | --------------------------------------------- | --------------------------- |
 | `assigneeId` | `string \| null`                              | Assigned member id, or null |
-| `status`     | `"assigned" \| "unassigned"`                  |                             |
+| `status`     | `"assigned" \| "unassigned"`                  | Assignment outcome          |
 | `reason`     | `"matched" \| "capacity" \| "skill_mismatch"` | Why assigned or not         |
 
-See `types.ts` for full type definitions and `docs/review-notes.md` for contributor notes.
+See `types.ts`, `docs/ARCHITECTURE.md`, and `docs/DATA_OWNERSHIP.md` for the full architecture contract.

--- a/tools/v2/team/meeting-assignment-tool/docs/ARCHITECTURE.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/ARCHITECTURE.md
@@ -1,0 +1,178 @@
+# Meeting Assignment Tool - Architecture Contract
+
+This document defines the module boundaries, dependency rules, data flow, and future integration constraints for the Meeting Assignment Tool. The tool is a self-contained V2 team mini-product and must remain isolated in `tools/v2/team/meeting-assignment-tool/`.
+
+## Ownership Boundary
+
+All source, fixtures, tests, and docs for this issue stay inside:
+
+```text
+tools/v2/team/meeting-assignment-tool/
+```
+
+This tool does not modify or depend on the main application shell, dashboard layout, routing, inbox architecture, mail rendering engine, authentication, wallet core, Stellar core, database schema, or shared design system.
+
+## Folder Structure
+
+```text
+tools/v2/team/meeting-assignment-tool/
+|-- index.ts
+|-- types.ts
+|-- specs.md
+|-- README.md
+|-- fixtures/
+|   |-- sample-meetings.json
+|   `-- team-members.json
+|-- helpers/
+|   |-- performance.ts
+|   `-- validation.ts
+|-- services/
+|   `-- meetingAssignmentService.ts
+|-- tests/
+|   |-- architecture-contract.test.mjs
+|   |-- meeting-assignment.test.mjs
+|   `-- validation.test.ts
+`-- docs/
+    |-- ARCHITECTURE.md
+    |-- DATA_OWNERSHIP.md
+    |-- SECURITY_AND_PERFORMANCE.md
+    `-- review-notes.md
+```
+
+Potential future `components/` and `hooks/` modules must be added inside this folder only, and only by a UI-specific issue.
+
+## Module Boundaries
+
+### Public API: `index.ts`
+
+`index.ts` is the only intended import surface for other folder-local experiments. It exports:
+
+- `assignMeetings`
+- `createMeetingAssignmentService`
+- `MeetingAssignmentService`
+- `MeetingAssignmentServiceConfig`
+- Domain types from `types.ts`
+
+It must not re-export fixtures, helper internals, app modules, or external providers as stable API.
+
+### Domain Types: `types.ts`
+
+`types.ts` owns the stable data contracts:
+
+- `TeamMember`
+- `Meeting`
+- `MeetingAssignment`
+- `AssignmentSummary`
+- `AssignmentResult`
+- `LoadState<T>`
+
+Types are plain TypeScript contracts. They must not import runtime code, application auth state, database entities, wallet models, or live inbox types.
+
+### Service Layer: `services/meetingAssignmentService.ts`
+
+The service layer owns assignment behavior:
+
+- `assignMeetings()` is the deterministic pure function.
+- `createMeetingAssignmentService()` is an async wrapper for local UI development and simulated loading or error states.
+- Fixture fallback data comes from this folder only.
+
+Service rules:
+
+- No network calls.
+- No persistence writes.
+- No production data reads.
+- No mutations of input arrays or fixture modules.
+- No imports from `src/`, app routes, inbox modules, wallet modules, Stellar modules, or other tools.
+
+### Helper Layer: `helpers/`
+
+Helpers are folder-local guard utilities:
+
+- `validation.ts` sanitizes and validates meeting payloads.
+- `performance.ts` keeps assignee arrays within local processing limits and chunks large lists.
+
+Helpers may be shared inside this folder but are not the public API for external app integration.
+
+### Fixture Layer: `fixtures/`
+
+Fixtures provide deterministic local data for tests and demos. They are not production data and must not be mutated at runtime.
+
+### Test Layer: `tests/`
+
+Tests verify:
+
+- Assignment behavior and fixture shape.
+- Architecture contract, required docs, and isolation boundaries.
+- Guard behavior for validation and performance helpers.
+
+Node-compatible tests are preferred for lightweight contributor review. If a future Vitest suite remains, it must stay folder-local and avoid global app setup.
+
+### Documentation Layer: `docs/`
+
+Docs own contributor guidance, data boundaries, security constraints, and review checklists. Future integration details belong here until a separate integration issue explicitly allows code wiring.
+
+## Data Flow
+
+```text
+Folder-local fixtures or caller-provided arrays
+    -> assignMeetings()
+    -> sorted planning pass by priority and effort
+    -> skill match and capacity filter
+    -> local load counter update
+    -> AssignmentResult { assignments[], summary }
+```
+
+The async service wrapper adds simulated delay or simulated failure only after caller opt-in. It does not perform real fetches, writes, background jobs, notifications, or external provider calls.
+
+## Dependency Rules
+
+Allowed:
+
+- Relative imports that resolve inside `tools/v2/team/meeting-assignment-tool/`.
+- Node built-ins in tests.
+- TypeScript type-only imports inside this folder.
+- Test runner imports already scoped to local tests.
+
+Not allowed:
+
+- `src/` imports or aliases such as `@/`.
+- Imports from sibling tools or parent directories that escape this folder.
+- Main app routing, dashboard, inbox, wallet, Stellar, database, or design-system modules.
+- New npm dependencies for this architecture issue.
+- Live network calls, secrets, production credentials, or provider SDKs.
+
+## Future Contributor Contract
+
+Contributors may:
+
+- Add local tests, fixtures, and docs.
+- Add future `components/` or `hooks/` modules inside this folder when scoped to a UI issue.
+- Refine the assignment algorithm while keeping result shape and documented reasons compatible.
+- Update validation or performance limits with matching docs and tests.
+
+Contributors may not:
+
+- Wire this tool into application routes, navigation, inbox views, or dashboards.
+- Persist assignments to a database or browser storage.
+- Connect to calendars, inbox APIs, authentication, wallet flows, Stellar transactions, or notification providers.
+- Change shared design-system files or global app state.
+- Modify files outside this folder for this issue.
+
+## Review Checklist
+
+- [ ] All changed files are under `tools/v2/team/meeting-assignment-tool/`.
+- [ ] `README.md`, `specs.md`, `docs/ARCHITECTURE.md`, and `docs/DATA_OWNERSHIP.md` agree on the folder boundary.
+- [ ] No imports resolve outside this folder.
+- [ ] No main app routing, inbox, auth, wallet, Stellar, database, provider, or design-system wiring is introduced.
+- [ ] `node --test tools/v2/team/meeting-assignment-tool/tests/architecture-contract.test.mjs` passes.
+- [ ] Existing assignment behavior tests still pass.
+
+## Acceptance Criteria Mapping
+
+| Issue Requirement                                                                | Evidence                                                              |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Clear folder-local architecture plan                                             | This document and `specs.md`                                          |
+| No main app, routing, inbox, wallet, Stellar, database, or design-system changes | Dependency rules and contract test                                    |
+| Specs explain future contributor boundaries                                      | `specs.md` and Future Contributor Contract                            |
+| Files changed are limited to this folder                                         | Git diff and contract test                                            |
+| Self-contained mini-product review                                               | README, docs, fixtures, services, helpers, and tests are folder-local |

--- a/tools/v2/team/meeting-assignment-tool/docs/DATA_OWNERSHIP.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/DATA_OWNERSHIP.md
@@ -1,0 +1,93 @@
+# Meeting Assignment Tool - Data Ownership
+
+This document defines which module owns each data shape, how data moves through the tool, and what this isolated V2 tool must not read or mutate.
+
+## Owned Data
+
+| Data                | Owner                         | Source                                           | Mutation Rule                                                                    |
+| ------------------- | ----------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `TeamMember`        | `types.ts`                    | Caller data or `fixtures/team-members.json`      | Service copies member load into a local counter; source arrays remain unchanged. |
+| `Meeting`           | `types.ts`                    | Caller data or `fixtures/sample-meetings.json`   | Service sorts a copied array; source arrays remain unchanged.                    |
+| `MeetingAssignment` | `types.ts` and service output | Created by `assignMeetings()`                    | Output is returned to the caller and not persisted.                              |
+| `AssignmentSummary` | `types.ts` and service output | Built from assignment pass and local load deltas | Output is returned to the caller and not persisted.                              |
+| `MeetingPayload`    | `helpers/validation.ts`       | Future form or integration payloads              | Validation is local and throws on unsafe structure.                              |
+
+## Runtime State
+
+The tool owns only transient in-memory state:
+
+- Local `memberLoad` counters inside `assignMeetings()`.
+- Optional simulated loading or failure state inside `createMeetingAssignmentService()`.
+- Local test fixtures loaded from this folder.
+
+The tool does not own:
+
+- Live inbox messages.
+- Calendar provider records.
+- Team directory profiles.
+- Authentication sessions.
+- Wallet accounts.
+- Stellar transactions.
+- Database rows.
+- Notification delivery state.
+
+## Lifecycle
+
+```text
+Input arrays
+    -> shallow copied by assignment service
+    -> sorted planning pass
+    -> local load counter adjusted
+    -> AssignmentResult returned
+    -> caller decides what to display or discard
+```
+
+No step writes to disk, localStorage, cookies, remote APIs, queues, databases, inbox state, calendar services, wallet state, or Stellar ledgers.
+
+## Fixture Rules
+
+- Fixtures are deterministic examples for tests and local development.
+- Fixtures must not contain production names, emails, tokens, secrets, or private meeting content.
+- Tests may read fixtures but must not write back to them.
+- New fixtures should be small enough for quick review and local test execution.
+
+## Validation Ownership
+
+`helpers/validation.ts` owns structural validation for basic meeting payloads:
+
+- Required `meetingId` and `title` fields.
+- Assignee email shape checks.
+- Meeting title sanitization.
+- Description type and length checks.
+
+Validation helpers do not authorize users, check team membership, contact mail providers, or resolve identities. Those concerns require a future integration issue and a separate adapter boundary.
+
+## Performance Ownership
+
+`helpers/performance.ts` owns local guardrails:
+
+- Maximum assignee count per payload.
+- Chunking helper for future batch-style UI work.
+
+Performance helpers do not create background jobs, worker queues, polling loops, or event subscriptions.
+
+## Future Integration Adapter Boundary
+
+If a later issue connects this tool to real app data, it must add a new adapter layer that sits outside the current pure assignment engine. That adapter must be reviewed separately for:
+
+- Authentication and authorization.
+- Data minimization.
+- Persistence and audit requirements.
+- Provider rate limits.
+- Error handling.
+- Privacy and retention rules.
+
+The current architecture issue documents those boundaries but does not implement the adapter.
+
+## Privacy and Security Constraints
+
+- Do not log raw meeting descriptions beyond local test fixtures.
+- Do not include secrets, tokens, API keys, wallet data, or production identifiers in fixtures.
+- Do not persist assignment outputs.
+- Do not connect to external providers from this folder-local service.
+- Keep future error messages structural and non-sensitive.

--- a/tools/v2/team/meeting-assignment-tool/docs/review-notes.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/review-notes.md
@@ -1,66 +1,80 @@
-# Review Notes — Meeting Assignment Tool
+# Review Notes - Meeting Assignment Tool
 
 ## Validated in This Contribution
 
 ### Folder-Local Scope
 
 - All source files are inside `tools/v2/team/meeting-assignment-tool/`.
-- No imports from `@/components/ui/*`, `@/features/*`, or any main-app module.
-- No live network calls, secrets, or production data introduced.
+- No imports from `@/components/ui/*`, `@/features/*`, `src/`, or any main-app module.
+- No live network calls, secrets, production data, persistence, wallet calls, or Stellar calls are introduced.
 
-### TypeScript & Build
+### Architecture Contract
 
-- `types.ts` compiles with strict TypeScript (project uses `strict: true`).
-- `services/meetingAssignmentService.ts` imports only folder-local fixtures and
-  its own types.
-- Barrel export via `index.ts` exposes the public API without leaking internals.
+- `docs/ARCHITECTURE.md` defines module boundaries, dependency rules, and future integration constraints.
+- `docs/DATA_OWNERSHIP.md` defines owned data, fixture rules, runtime state, and adapter boundaries.
+- `specs.md` explains what future contributors may and may not change.
+- `tests/architecture-contract.test.mjs` verifies required docs, isolation claims, and missing template leftovers.
+
+### TypeScript and Build
+
+- `types.ts` declares the domain contract for team members, meetings, assignments, summaries, and load states.
+- `services/meetingAssignmentService.ts` imports only folder-local fixtures and its own types.
+- `index.ts` exposes the public API without leaking fixtures or helper internals as stable app API.
 
 ### Core Logic
 
 `assignMeetings()` is a pure function that:
 
-1. Sorts meetings by priority (desc) then effort (asc).
+1. Sorts meetings by priority descending, then effort ascending.
 2. Matches members whose skill set is a superset of `requiredSkills`.
-3. Filters by remaining capacity (`weeklyCapacity − currentLoad ≥ effort`).
-4. Picks the least-loaded eligible member; ties broken by higher capacity.
+3. Filters by remaining capacity (`weeklyCapacity - currentLoad >= effort`).
+4. Picks the least-loaded eligible member; ties are broken by higher capacity.
 5. Mutates a local load counter so each subsequent meeting sees updated loads.
 
 Unassigned reasons are machine-readable:
 
-- `"skill_mismatch"` — no member has the required skills.
-- `"capacity"` — skill match found but all eligible members were at capacity.
+- `"skill_mismatch"` means no member has the required skills.
+- `"capacity"` means a skill match exists but all eligible members are at capacity.
 
 ### State Coverage
 
-| State             | Where handled                                                                     |
-| ----------------- | --------------------------------------------------------------------------------- |
-| Loading           | `createMeetingAssignmentService()` async wrapper with configurable delay          |
-| Error (simulated) | `failureRate` option throws `Error("... simulated")`                              |
-| Error (bad input) | `assignMeetings()` throws `TypeError` for non-array arguments                     |
-| Empty             | `meetings: []` → `{ assignments: [], summary: { total: 0, coveragePercent: 0 } }` |
-| Success           | Full `AssignmentResult` with `assignments[]` and `summary`                        |
+| State             | Where handled                                                            |
+| ----------------- | ------------------------------------------------------------------------ |
+| Loading           | `createMeetingAssignmentService()` async wrapper with configurable delay |
+| Error (simulated) | `failureRate` option throws `Error("... simulated")`                     |
+| Error (bad input) | `assignMeetings()` throws `TypeError` for non-array arguments            |
+| Empty             | `meetings: []` returns empty assignments and zero coverage               |
+| Success           | Full `AssignmentResult` with `assignments[]` and `summary`               |
 
 ### Fixtures
 
 - 4 team members with varied roles, skills, loads, and capacities.
-- 7 meetings spanning all assignment outcomes (matched, capacity-blocked, skill-mismatch).
+- 7 meetings spanning matched and capacity-blocked outcomes.
 
 ### Test Coverage
 
-17 assertions via `node:test` (no external test runner):
+Behavior tests via `node:test` cover:
 
-- Per-meeting assignment verification (all 7 meetings).
+- Per-meeting assignment verification.
 - Output order preservation.
-- Summary statistics (covered %, member effort delta).
-- Error/edge-case handling (TypeError, empty input, unknown skill).
+- Summary statistics.
+- Error and edge-case handling.
 - Fixture schema validation.
 
-## Out of Scope (Future Issues)
+Architecture tests via `node:test` cover:
 
-- Main-app integration (mounting in a route or sidebar).
-- Live calendar or inbox data connection.
-- Authentication / authorization.
-- UI components and hooks.
-- Export (CSV, iCal) functionality.
-- Conflict detection (overlapping time slots).
+- Required architecture docs.
+- Folder path and forbidden integration statements.
+- Relative import isolation.
+- Removal of broken template tokens in docs.
+
+## Out of Scope
+
+- Main-app integration or route mounting.
+- Live calendar, inbox, or team directory data.
+- Authentication and authorization.
+- Shared design-system adoption.
+- Database or browser persistence.
+- Export workflows such as CSV or iCal.
+- Conflict detection for overlapping time slots.
 - Real-time re-assignment on member availability changes.

--- a/tools/v2/team/meeting-assignment-tool/services/meetingAssignmentService.ts
+++ b/tools/v2/team/meeting-assignment-tool/services/meetingAssignmentService.ts
@@ -22,7 +22,7 @@ import sampleMembers from "../fixtures/team-members.json";
  *   2. For each meeting find members whose skill set is a superset of the
  *      meeting's requiredSkills.
  *   3. Among skill-matching members, discard those whose remaining capacity
- *      (weeklyCapacity − currentMeetingLoad) is less than the meeting effort.
+ *      (weeklyCapacity - currentMeetingLoad) is less than the meeting effort.
  *   4. Pick the eligible member with the lowest current load; on a tie prefer
  *      the one with the higher capacity.
  *   5. Mutate a local load counter so subsequent meetings see updated loads.
@@ -30,8 +30,8 @@ import sampleMembers from "../fixtures/team-members.json";
  * Inputs, outputs, and error states
  * ----------------------------------
  * Input:
- *   - `teamMembers` — snapshot of team members with current loads.
- *   - `meetings`    — list of meetings that need to be assigned.
+ *   - `teamMembers` - snapshot of team members with current loads.
+ *   - `meetings`    - list of meetings that need to be assigned.
  *
  * Output:  AssignmentResult { assignments[], summary }
  *
@@ -154,7 +154,7 @@ export interface MeetingAssignmentServiceConfig {
   simulateDelay?: boolean;
   /** Delay in ms. Default: 600. */
   delayMs?: number;
-  /** Probability (0–1) of a simulated failure. Default: 0. */
+  /** Probability (0-1) of a simulated failure. Default: 0. */
   failureRate?: number;
 }
 

--- a/tools/v2/team/meeting-assignment-tool/specs.md
+++ b/tools/v2/team/meeting-assignment-tool/specs.md
@@ -1,41 +1,59 @@
-# Meeting Assignment Tool
-
-Assign meeting responsibilities.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/meeting-assignment-tool/README.md"
-  @"
-
 # Meeting Assignment Tool Specs
 
 ## Purpose
 
-Assign meeting responsibilities.
+The Meeting Assignment Tool assigns meeting responsibilities to available team members using folder-local fixtures, deterministic workload balancing, and explicit unassigned reasons.
 
-## Contributor boundary
+## Scope
 
-All work for this tool should stay in:
+- Release tier: V2 later-release tool
+- Audience: team
+- Folder ownership: `tools/v2/team/meeting-assignment-tool/`
+- Integration status: isolated mini-product, not wired into the main app
 
-$dir/
+This issue defines the architecture and folder contract around the existing local service, helpers, fixtures, docs, and tests. It does not add application routing, shared UI adoption, production data access, persistence, or external provider calls.
 
-## Required issue categories
+## Module Boundaries
+
+| Module      | Purpose                                                                     | Change Rules                                                                      |
+| ----------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `index.ts`  | Public barrel export for the folder-local API                               | Keep external imports pointed at this file; do not export fixtures as stable API. |
+| `types.ts`  | Domain types for members, meetings, assignments, summaries, and load states | Add fields only with matching docs and tests.                                     |
+| `services/` | Assignment engine and async service wrapper                                 | Keep deterministic core logic pure and side-effect free.                          |
+| `helpers/`  | Validation and performance guard helpers                                    | Keep guards folder-local and independent from app services.                       |
+| `fixtures/` | Deterministic sample team and meeting data                                  | Do not mutate fixtures at runtime or treat them as production data.               |
+| `tests/`    | Behavior, fixture, and architecture contract checks                         | Use local fixtures and Node-compatible tests for contributor review.              |
+| `docs/`     | Architecture, data ownership, security, and review notes                    | Document future integration instead of implementing it in this issue.             |
+
+## Contributor Boundary
+
+Future contributors may change:
+
+- Folder-local docs, fixtures, tests, and helper utilities.
+- Service internals when the public assignment result contract stays compatible.
+- Future `components/` or `hooks/` files inside this folder when a UI issue adds them.
+- Validation and performance limits when the docs and tests are updated together.
+
+Future contributors may not change in this issue:
+
+- Main application shell, dashboard layout, navigation, or routing.
+- Existing inbox architecture or mail rendering engine.
+- Authentication, wallet core, Stellar core, payment flows, or database schema.
+- Shared design system files or global style tokens.
+- Files outside `tools/v2/team/meeting-assignment-tool/`.
+
+## Required Issue Categories
 
 - Architecture
 - Feature
 - UI and accessibility
 - Security and performance
 - Testing and documentation
+
+## Acceptance Checklist
+
+- The tool has a clear folder-local architecture plan.
+- The specs explain what future contributors may and may not change.
+- The data ownership document separates fixture data, service state, helper validation, and future integration adapters.
+- Tests can verify the architecture contract without main app wiring.
+- All files changed by this issue stay inside `tools/v2/team/meeting-assignment-tool/`.

--- a/tools/v2/team/meeting-assignment-tool/tests/architecture-contract.test.mjs
+++ b/tools/v2/team/meeting-assignment-tool/tests/architecture-contract.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toolRoot = fileURLToPath(new URL("..", import.meta.url));
+const toolPath = "tools/v2/team/meeting-assignment-tool/";
+
+const requiredDocs = [
+  "README.md",
+  "specs.md",
+  "docs/ARCHITECTURE.md",
+  "docs/DATA_OWNERSHIP.md",
+  "docs/review-notes.md",
+];
+
+const markdownFiles = listFiles(toolRoot).filter((file) => extname(file) === ".md");
+const codeFiles = listFiles(toolRoot).filter((file) =>
+  [".js", ".mjs", ".ts", ".tsx"].includes(extname(file)),
+);
+
+describe("Meeting Assignment Tool - architecture contract", () => {
+  it("keeps required architecture documents folder-local", () => {
+    for (const doc of requiredDocs) {
+      const absolute = resolve(toolRoot, doc);
+      assert.ok(existsSync(absolute), `${doc} must exist`);
+      assert.ok(
+        isPathInside(toolRoot, absolute),
+        `${doc} must stay inside the meeting assignment tool folder`,
+      );
+    }
+  });
+
+  it("documents the issue ownership boundary and module contract", () => {
+    assertDocIncludes("docs/ARCHITECTURE.md", [
+      toolPath,
+      "Module Boundaries",
+      "Dependency Rules",
+      "Future Contributor Contract",
+      "No network calls",
+      "No persistence writes",
+    ]);
+
+    assertDocIncludes("docs/DATA_OWNERSHIP.md", [
+      "TeamMember",
+      "Meeting",
+      "AssignmentResult",
+      "Fixture Rules",
+      "Future Integration Adapter Boundary",
+      "No step writes to disk",
+    ]);
+
+    assertDocIncludes("specs.md", [
+      "Future contributors may change",
+      "Future contributors may not change",
+      "Files outside",
+      toolPath,
+    ]);
+  });
+
+  it("removes broken generation/template leftovers from markdown docs", () => {
+    const forbidden = ["$(", "$dir", "Set-Content", "System.Collections.Hashtable", "@ |"];
+
+    for (const file of markdownFiles) {
+      const text = readFileSync(file, "utf8");
+      for (const token of forbidden) {
+        assert.ok(!text.includes(token), `${relative(toolRoot, file)} still contains ${token}`);
+      }
+    }
+  });
+
+  it("keeps relative imports inside the tool folder", () => {
+    for (const file of codeFiles) {
+      const source = readFileSync(file, "utf8");
+      const imports = extractImportSpecifiers(source);
+
+      for (const specifier of imports) {
+        if (!specifier.startsWith(".")) continue;
+        const resolved = resolve(dirname(file), specifier);
+        assert.ok(
+          isPathInside(toolRoot, resolved),
+          `${relative(toolRoot, file)} imports outside the tool folder: ${specifier}`,
+        );
+      }
+    }
+  });
+
+  it("does not import main app, routing, inbox, wallet, Stellar, or design-system modules", () => {
+    const forbiddenImportFragments = [
+      "@/",
+      "src/",
+      "routes/",
+      "router",
+      "wallet",
+      "stellar",
+      "inbox",
+      "components/ui",
+      "design-system",
+    ];
+
+    for (const file of codeFiles) {
+      const imports = extractImportSpecifiers(readFileSync(file, "utf8"));
+      for (const specifier of imports) {
+        for (const fragment of forbiddenImportFragments) {
+          assert.ok(
+            !specifier.toLowerCase().includes(fragment),
+            `${relative(toolRoot, file)} imports forbidden module fragment ${fragment}`,
+          );
+        }
+      }
+    }
+  });
+});
+
+function assertDocIncludes(relativePath, expectedPhrases) {
+  const text = readFileSync(resolve(toolRoot, relativePath), "utf8");
+  for (const phrase of expectedPhrases) {
+    assert.ok(text.includes(phrase), `${relativePath} must mention "${phrase}"`);
+  }
+}
+
+function extractImportSpecifiers(source) {
+  const specifiers = [];
+  const patterns = [
+    /\bfrom\s+["']([^"']+)["']/g,
+    /\bimport\s+["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.push(match[1]);
+    }
+  }
+
+  return specifiers;
+}
+
+function listFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root)) {
+    const fullPath = resolve(root, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...listFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function isPathInside(root, target) {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}

--- a/tools/v2/team/meeting-assignment-tool/tests/meeting-assignment.test.mjs
+++ b/tools/v2/team/meeting-assignment-tool/tests/meeting-assignment.test.mjs
@@ -97,7 +97,7 @@ function assignMeetings({ teamMembers: members, meetings }) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("Meeting Assignment Tool — assignMeetings()", () => {
+describe("Meeting Assignment Tool - assignMeetings()", () => {
   it("returns 7 assignments for 7 fixture meetings", () => {
     const { assignments, summary } = assignMeetings({ teamMembers, meetings: sampleMeetings });
     assert.strictEqual(assignments.length, 7);
@@ -216,7 +216,7 @@ describe("Meeting Assignment Tool — assignMeetings()", () => {
   });
 });
 
-describe("Meeting Assignment Tool — fixtures", () => {
+describe("Meeting Assignment Tool - fixtures", () => {
   it("team-members.json has 4 members with required fields", () => {
     assert.strictEqual(teamMembers.length, 4);
     for (const m of teamMembers) {

--- a/tools/v2/team/meeting-assignment-tool/types.ts
+++ b/tools/v2/team/meeting-assignment-tool/types.ts
@@ -38,9 +38,9 @@ export interface MeetingAssignment {
   status: "assigned" | "unassigned";
   /**
    * Short machine-readable reason:
-   *   "matched"        — member had the skills and capacity
-   *   "capacity"       — skill match found but all eligible members were at capacity
-   *   "skill_mismatch" — no member had the required skills
+   *   "matched"        - member had the skills and capacity
+   *   "capacity"       - skill match found but all eligible members were at capacity
+   *   "skill_mismatch" - no member had the required skills
    */
   reason: "matched" | "capacity" | "skill_mismatch";
   scheduledAt: string;
@@ -54,7 +54,7 @@ export interface AssignmentSummary {
   total: number;
   assigned: number;
   unassigned: number;
-  /** Percentage of meetings that were successfully assigned (0–100). */
+  /** Percentage of meetings that were successfully assigned (0-100). */
   coveragePercent: number;
   /** Per-member breakdown of how many meetings were assigned. */
   memberLoad: Record<string, number>;


### PR DESCRIPTION


## Summary
- add a folder-local architecture contract for Meeting Assignment Tool
- document data ownership, fixture/runtime boundaries, dependency constraints, and future integration adapter rules
- repair the generated specs template residue and add a zero-dependency Node contract test for required docs and import isolation

## Scope
- only touches `tools/v2/team/meeting-assignment-tool/`
- no app shell, dashboard, routing, auth, wallet, Stellar, database, inbox, mail rendering, notification, provider, or design-system integration
- no production data, live network calls, persistence, secrets, or side effects

## Validation
- `node --test tools/v2/team/meeting-assignment-tool/tests/architecture-contract.test.mjs`
- `node --test tools/v2/team/meeting-assignment-tool/tests/meeting-assignment.test.mjs`
- `npx --yes prettier --check` on changed Meeting Assignment Tool files
- `git diff --check`
- ASCII scan over `tools/v2/team/meeting-assignment-tool`