### PR TITLE
Add deadline detector architecture contract

### DIFF
--- a/tools/v2/individual/deadline-detector/README.md
+++ b/tools/v2/individual/deadline-detector/README.md
@@ -69,9 +69,14 @@ No real sender, mailbox, or personal data is used.
 ## Documentation Map
 
 - `specs.md` defines scope, status rules, and the local detection contract.
+- `docs/ARCHITECTURE.md` defines module boundaries, dependency rules, and
+  future integration constraints.
+- `docs/DATA_OWNERSHIP.md` defines fixture ownership, runtime state, privacy
+  rules, and adapter boundaries.
 - `docs/ACCESSIBILITY.md` documents keyboard, focus, and screen-reader behavior.
 - `docs/VISUAL_STYLE.md` documents the local visual treatment.
 - `docs/TEST_PLAN.md` lists automated and manual review checks.
+- `tests/architecture-contract.test.mjs` validates the architecture contract.
 - `tests/deadline-fixtures.test.mjs` validates the fixture contract.
 
 ## Known Limitations

--- a/tools/v2/individual/deadline-detector/docs/ARCHITECTURE.md
+++ b/tools/v2/individual/deadline-detector/docs/ARCHITECTURE.md
@@ -1,0 +1,223 @@
+# Deadline Detector - Architecture Contract
+
+This document defines the folder-local architecture, dependency rules, data
+flow, and future integration constraints for the Deadline Detector. The tool is
+a self-contained V2 individual mini-product and must remain isolated in
+`tools/v2/individual/deadline-detector/`.
+
+## Ownership Boundary
+
+All source, fixtures, tests, and docs for this issue stay inside:
+
+```text
+tools/v2/individual/deadline-detector/
+```
+
+This tool does not modify or depend on the main application shell, dashboard
+layout, routing, inbox architecture, mail rendering engine, authentication,
+wallet core, Stellar core, database schema, reminder scheduling, calendar
+providers, notification delivery, or shared design system.
+
+## Folder Structure
+
+```text
+tools/v2/individual/deadline-detector/
+|-- index.ts
+|-- README.md
+|-- specs.md
+|-- components/
+|   |-- DeadlineDetectorEmptyState.tsx
+|   |-- DeadlineDetectorErrorState.tsx
+|   |-- DeadlineDetectorLoadingState.tsx
+|   |-- DeadlineDetectorSummary.tsx
+|   |-- DeadlineDetectorTool.tsx
+|   |-- DeadlineResultCard.tsx
+|   `-- index.ts
+|-- docs/
+|   |-- ACCESSIBILITY.md
+|   |-- ARCHITECTURE.md
+|   |-- DATA_OWNERSHIP.md
+|   |-- TEST_PLAN.md
+|   `-- VISUAL_STYLE.md
+|-- fixtures/
+|   `-- sample-deadline-messages.json
+|-- services/
+|   |-- deadline-detector.service.ts
+|   `-- index.ts
+|-- tests/
+|   |-- architecture-contract.test.mjs
+|   `-- deadline-fixtures.test.mjs
+`-- types/
+    |-- deadline.ts
+    `-- index.ts
+```
+
+A future `hooks/` module may be added inside this folder by a UI/state issue,
+but this architecture issue does not require one.
+
+## Module Boundaries
+
+### Public API: `index.ts`
+
+`index.ts` is the folder-local public import surface. It exports:
+
+- `DeadlineDetectorTool`
+- `detectDeadlines`
+- `sortDetectedDeadlines`
+- Deadline domain types from `types/`
+
+It must not re-export fixtures as stable API, expose provider SDKs, or import
+from app routing, inbox, reminder, calendar, wallet, Stellar, or database
+modules.
+
+### Types: `types/`
+
+`types/deadline.ts` owns the stable domain contracts:
+
+- `DeadlineMessage`
+- `DetectedDeadline`
+- `DeadlineDetectionResult`
+- `DeadlineDetectionSummary`
+- `DeadlineDetectorServiceOptions`
+- status, urgency, source, and id aliases
+
+Types are plain TypeScript definitions. They must not import runtime code,
+application auth state, database entities, mailbox thread models, calendar
+provider records, or reminder scheduler models.
+
+### Service Layer: `services/`
+
+`deadline-detector.service.ts` owns the deterministic detection engine:
+
+- Normalizes ISO dates, US dates, simple relative phrases, and 24-hour times.
+- Classifies rows as `detected`, `needs-review`, `missed`, or `ignored`.
+- Computes urgency and confidence from local message text and the supplied
+  `now` option.
+- Sorts urgent and overdue rows before lower-priority rows.
+
+Service rules:
+
+- No network calls.
+- No persistence writes.
+- No production mailbox reads.
+- No calendar, reminder, notification, or scheduling side effects.
+- No mutation of input arrays or fixture files.
+- No imports from `src/`, app routes, inbox modules, reminder modules, calendar
+  modules, wallet modules, Stellar modules, database modules, or sibling tools.
+
+### Component Layer: `components/`
+
+Components own local presentation only:
+
+- `DeadlineDetectorTool` orchestrates local view state and filtering.
+- Empty, loading, error, summary, and result card components render accessible
+  states.
+- Reminder and review actions are callback props and do not perform writes by
+  themselves.
+
+Component rules:
+
+- Components may use React, lucide icons, local services, and local types.
+- Components must not import app routes, inbox stores, reminder writers,
+  calendars, auth, wallet, Stellar, or database clients.
+- Components must not create reminders, mutate messages, schedule jobs, or
+  persist data directly.
+
+### Fixture Layer: `fixtures/`
+
+Fixtures are synthetic examples for tests and local review. They must not
+contain real senders, production mailbox content, API keys, tokens, secrets, or
+personal data.
+
+### Test Layer: `tests/`
+
+Tests verify:
+
+- Fixture schema and expected deadline outcomes.
+- Required docs, module boundary claims, relative import isolation, and absence
+  of forbidden integration imports.
+- No broken generation/template leftovers in docs.
+
+Node-compatible tests are preferred for lightweight contributor review.
+
+### Documentation Layer: `docs/`
+
+Docs own contributor guidance, data boundaries, accessibility notes, visual
+style notes, and test guidance. Future integration details belong in docs until
+a separate integration issue explicitly allows code wiring.
+
+## Data Flow
+
+```text
+Synthetic fixtures or caller-provided DeadlineMessage[]
+    -> detectDeadlines(messages, options)
+    -> normalize date and time signals from local text
+    -> classify status, urgency, confidence, and review requirement
+    -> sortDetectedDeadlines()
+    -> DeadlineDetectionResult { deadlines[], summary }
+    -> DeadlineDetectorTool renders reviewable candidates
+```
+
+The current flow does not perform real fetches, writes, background jobs,
+notifications, reminders, calendar updates, mailbox mutations, or provider
+calls.
+
+## Dependency Rules
+
+Allowed:
+
+- Relative imports that resolve inside `tools/v2/individual/deadline-detector/`.
+- React and lucide icon imports in component files.
+- Node built-ins in tests.
+- TypeScript type-only imports inside this folder.
+
+Not allowed:
+
+- `src/` imports or aliases such as `@/`.
+- Imports from sibling tools or parent directories that escape this folder.
+- Main app routing, dashboard, inbox, reminder, calendar, auth, wallet, Stellar,
+  database, or design-system modules.
+- New npm dependencies for this architecture issue.
+- Live network calls, secrets, production credentials, or provider SDKs.
+
+## Future Contributor Contract
+
+Contributors may:
+
+- Add local tests, fixtures, and docs.
+- Refine deterministic parsing rules while preserving documented output shapes.
+- Extend components inside this folder when behavior remains callback-driven.
+- Add a future folder-local `hooks/` module for UI state if a scoped issue asks
+  for it.
+
+Contributors may not:
+
+- Wire this tool into application routes, navigation, inbox views, or dashboards.
+- Persist deadline outputs to a database, browser storage, calendar, or reminder
+  scheduler.
+- Connect to live inbox APIs, calendar providers, notification providers,
+  authentication, wallet flows, or Stellar transactions.
+- Change shared design-system files or global app state.
+- Modify files outside this folder for this issue.
+
+## Review Checklist
+
+- [ ] All changed files are under `tools/v2/individual/deadline-detector/`.
+- [ ] `README.md`, `specs.md`, `docs/ARCHITECTURE.md`, and
+      `docs/DATA_OWNERSHIP.md` agree on the folder boundary.
+- [ ] No relative imports resolve outside this folder.
+- [ ] No main app routing, inbox, reminder, calendar, auth, wallet, Stellar,
+      database, provider, or design-system wiring is introduced.
+- [ ] `node --test tools/v2/individual/deadline-detector/tests/architecture-contract.test.mjs`
+      passes.
+- [ ] Existing fixture tests still pass.
+
+## Acceptance Criteria Mapping
+
+| Issue Requirement                                                                | Evidence                                                                        |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Clear folder-local architecture plan                                             | This document and `specs.md`                                                    |
+| No main app, routing, inbox, wallet, Stellar, database, or design-system changes | Dependency rules and contract test                                              |
+| Specs explain future contributor boundaries                                      | `specs.md` and Future Contributor Contract                                      |
+| Files changed are limited to this folder                                         | Git diff and contract test                                                      |
+| Self-contained mini-product review                                               | README, docs, fixtures, services, components, types, and tests are folder-local |

--- a/tools/v2/individual/deadline-detector/docs/DATA_OWNERSHIP.md
+++ b/tools/v2/individual/deadline-detector/docs/DATA_OWNERSHIP.md
@@ -1,0 +1,114 @@
+# Deadline Detector - Data Ownership
+
+This document defines owned data, runtime state, privacy expectations, and
+future adapter boundaries for the folder-local Deadline Detector.
+
+## Owned Data
+
+| Data                             | Owner                                  | Source                                                  | Mutation Rule                                                                 |
+| -------------------------------- | -------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `DeadlineMessage`                | `types/deadline.ts`                    | Caller data or `fixtures/sample-deadline-messages.json` | Service reads message fields and does not mutate the source array or objects. |
+| `DetectedDeadline`               | `types/deadline.ts` and service output | Created by `detectDeadlines()`                          | Returned to caller and not persisted by this tool.                            |
+| `DeadlineDetectionSummary`       | `types/deadline.ts` and service output | Reduced from detection results                          | Returned to caller and not persisted by this tool.                            |
+| `DeadlineDetectorServiceOptions` | `types/deadline.ts`                    | Caller-provided options                                 | Used only to set deterministic `now` and fallback timezone.                   |
+| UI filter/view state             | `components/DeadlineDetectorTool.tsx`  | Local React state                                       | Lives only in memory while the component is mounted.                          |
+
+## Runtime State
+
+The current tool owns only transient in-memory state:
+
+- Local detection arrays created inside `detectDeadlines()`.
+- Local urgency ranking inside `sortDetectedDeadlines()`.
+- Local component view state for loading, error, ready, and status filtering.
+- Local synthetic fixture data read by tests.
+
+The tool does not own:
+
+- Live inbox messages.
+- Reminder records.
+- Calendar events.
+- Notification delivery state.
+- User accounts or authentication sessions.
+- Wallet accounts.
+- Stellar transactions.
+- Database rows.
+- Audit logs.
+
+## Lifecycle
+
+```text
+DeadlineMessage[] input
+    -> text normalization in the service
+    -> deadline status, urgency, confidence, and reviewRequired calculation
+    -> sorted DeadlineDetectionResult
+    -> component rendering or caller handling
+    -> discarded unless a future integration adapter stores it
+```
+
+No step writes to disk, localStorage, cookies, remote APIs, queues, databases,
+inbox state, calendar providers, reminder schedulers, notification services,
+wallet state, or Stellar ledgers.
+
+## Fixture Rules
+
+- Fixture messages are synthetic and use `.test` senders.
+- Fixture data must set `containsPersonalData` to `false`.
+- Fixture bodies must not contain real email content, private names, account
+  numbers, tokens, API keys, secrets, or production identifiers.
+- Tests may read fixtures but must not write back to them.
+- New fixture rows should be small enough for quick review and local test
+  execution.
+
+## Detection Ownership
+
+`services/deadline-detector.service.ts` owns deterministic local parsing:
+
+- ISO date detection.
+- US date detection.
+- Simple relative phrase detection for today, tomorrow, and next week.
+- 24-hour time extraction.
+- Deadline signal and ignore signal classification.
+- Urgency, confidence, and review requirement calculations.
+
+The detector does not authorize users, resolve sender identity, contact mailbox
+providers, write reminders, update calendars, schedule jobs, or deliver
+notifications.
+
+## Component State Ownership
+
+`DeadlineDetectorTool` owns presentation-only state:
+
+- `viewState`: local loading, error, or ready state.
+- `filter`: local result filter state.
+- Derived `result` and `filteredDeadlines` memoized from caller-provided
+  messages.
+
+Callback props such as `onCreateReminder`, `onReviewDeadline`, and
+`onRequestMessages` are external extension points. The component calls them but
+does not implement persistence, mailbox mutation, or scheduling.
+
+## Future Integration Adapter Boundary
+
+If a later issue connects this tool to real app data, it must add an adapter
+layer separate from the pure detection service. That adapter must be reviewed
+for:
+
+- User consent before scanning live mailbox content.
+- Reminder-write permission prompts.
+- Calendar provider permissions and failure handling.
+- Duplicate deadline suppression.
+- Privacy-preserving evidence snippets.
+- Audit history and retention rules.
+- Rate limits and provider error handling.
+
+The current architecture issue documents those boundaries but does not implement
+the adapter.
+
+## Privacy and Security Constraints
+
+- Do not log raw message bodies from live mailboxes.
+- Keep fixture senders and message bodies synthetic.
+- Do not persist detection output.
+- Do not include secrets, tokens, API keys, wallet data, production IDs, or
+  private meeting/email content in fixtures.
+- Keep future error messages structural and non-sensitive.

--- a/tools/v2/individual/deadline-detector/specs.md
+++ b/tools/v2/individual/deadline-detector/specs.md
@@ -12,6 +12,18 @@ content and presenting reviewable reminder candidates.
 - Folder ownership: `tools/v2/individual/deadline-detector/`
 - Integration status: isolated mini-product workspace
 
+## Module Boundaries
+
+| Module        | Purpose                                                                           | Change Rules                                                                                     |
+| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `index.ts`    | Public barrel export for the folder-local API                                     | Keep external imports pointed at this file; do not export fixtures as stable API.                |
+| `types/`      | Deadline message, detection result, status, urgency, and service option contracts | Add fields only with matching docs, fixtures, and tests.                                         |
+| `services/`   | Deterministic detection and sorting logic                                         | Keep the detector pure, synchronous, and free of mailbox or calendar writes.                     |
+| `components/` | Folder-local React presentation for loading, empty, error, and success states     | Accept callbacks through props; do not mutate app routing, mailbox, calendar, or database state. |
+| `fixtures/`   | Synthetic message examples and expected deadline outcomes                         | Do not include personal data, production senders, tokens, or real mailbox content.               |
+| `tests/`      | Fixture and architecture contract checks                                          | Use local fixtures and Node-compatible contract tests for contributor review.                    |
+| `docs/`       | Architecture, data ownership, accessibility, visual style, and test guidance      | Document future integration requirements instead of implementing them in this issue.             |
+
 ## In-Scope Behavior
 
 - Model message-like inputs with sender, subject, body, received time, and user
@@ -86,6 +98,24 @@ Each expected deadline should include:
 
 ## Contributor Boundary
 
-Keep all changes for this issue in this folder. Future integration issues should
-define consent, reminder-write permissions, privacy handling, and audit behavior
-before this tool touches a real mailbox or calendar.
+Future contributors may change:
+
+- Folder-local docs, tests, fixtures, and deterministic detector rules.
+- Components and component props when callback-driven behavior stays isolated.
+- Type definitions when fixtures, docs, and tests are updated together.
+- Future `hooks/` files inside this folder when a scoped UI or state issue adds
+  them.
+
+Future contributors may not change in this issue:
+
+- Main application shell, dashboard layout, navigation, or routing.
+- Existing inbox architecture, mail rendering engine, or mailbox mutation flows.
+- Reminder writes, calendar writes, notification delivery, or scheduling side
+  effects.
+- Authentication, wallet core, Stellar core, payment flows, or database schema.
+- Shared design system files or global style tokens.
+- Files outside `tools/v2/individual/deadline-detector/`.
+
+Future integration issues should define consent, reminder-write permissions,
+privacy handling, duplicate suppression, and audit behavior before this tool
+touches a real mailbox or calendar.

--- a/tools/v2/individual/deadline-detector/tests/architecture-contract.test.mjs
+++ b/tools/v2/individual/deadline-detector/tests/architecture-contract.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const toolRoot = fileURLToPath(new URL("..", import.meta.url));
+const toolPath = "tools/v2/individual/deadline-detector/";
+
+const requiredDocs = [
+  "README.md",
+  "specs.md",
+  "docs/ARCHITECTURE.md",
+  "docs/DATA_OWNERSHIP.md",
+  "docs/TEST_PLAN.md",
+  "docs/ACCESSIBILITY.md",
+  "docs/VISUAL_STYLE.md",
+];
+
+const markdownFiles = listFiles(toolRoot).filter((file) => extname(file) === ".md");
+const codeFiles = listFiles(toolRoot).filter((file) =>
+  [".js", ".mjs", ".ts", ".tsx"].includes(extname(file)),
+);
+
+describe("Deadline Detector - architecture contract", () => {
+  it("keeps required architecture documents folder-local", () => {
+    for (const doc of requiredDocs) {
+      const absolute = resolve(toolRoot, doc);
+      assert.ok(existsSync(absolute), `${doc} must exist`);
+      assert.ok(isPathInside(toolRoot, absolute), `${doc} must stay inside ${toolPath}`);
+    }
+  });
+
+  it("documents module boundaries, data ownership, and integration constraints", () => {
+    assertDocIncludes("docs/ARCHITECTURE.md", [
+      toolPath,
+      "Module Boundaries",
+      "Dependency Rules",
+      "Future Contributor Contract",
+      "No network calls",
+      "No persistence writes",
+      "reminder",
+      "calendar",
+    ]);
+
+    assertDocIncludes("docs/DATA_OWNERSHIP.md", [
+      "DeadlineMessage",
+      "DetectedDeadline",
+      "DeadlineDetectionSummary",
+      "Fixture Rules",
+      "Future Integration Adapter Boundary",
+      "No step writes to disk",
+    ]);
+
+    assertDocIncludes("specs.md", [
+      "Module Boundaries",
+      "Future contributors may change",
+      "Future contributors may not change",
+      "Files outside",
+      toolPath,
+    ]);
+  });
+
+  it("removes broken generation/template leftovers from markdown docs", () => {
+    const forbidden = ["$(", "$dir", "Set-Content", "System.Collections.Hashtable", "@ |"];
+
+    for (const file of markdownFiles) {
+      const text = readFileSync(file, "utf8");
+      for (const token of forbidden) {
+        assert.ok(!text.includes(token), `${relative(toolRoot, file)} still contains ${token}`);
+      }
+    }
+  });
+
+  it("keeps relative imports inside the tool folder", () => {
+    for (const file of codeFiles) {
+      const imports = extractImportSpecifiers(readFileSync(file, "utf8"));
+
+      for (const specifier of imports) {
+        if (!specifier.startsWith(".")) continue;
+        const resolved = resolve(dirname(file), specifier);
+        assert.ok(
+          isPathInside(toolRoot, resolved),
+          `${relative(toolRoot, file)} imports outside the tool folder: ${specifier}`,
+        );
+      }
+    }
+  });
+
+  it("does not import forbidden main app or provider modules", () => {
+    const forbiddenImportFragments = [
+      "@/",
+      "src/",
+      "routes/",
+      "router",
+      "inbox",
+      "mailbox",
+      "calendar",
+      "reminder",
+      "notification",
+      "wallet",
+      "stellar",
+      "database",
+      "components/ui",
+      "design-system",
+    ];
+
+    for (const file of codeFiles) {
+      const imports = extractImportSpecifiers(readFileSync(file, "utf8"));
+      for (const specifier of imports) {
+        for (const fragment of forbiddenImportFragments) {
+          assert.ok(
+            !specifier.toLowerCase().includes(fragment),
+            `${relative(toolRoot, file)} imports forbidden module fragment ${fragment}`,
+          );
+        }
+      }
+    }
+  });
+});
+
+function assertDocIncludes(relativePath, expectedPhrases) {
+  const text = readFileSync(resolve(toolRoot, relativePath), "utf8");
+  for (const phrase of expectedPhrases) {
+    assert.ok(text.includes(phrase), `${relativePath} must mention "${phrase}"`);
+  }
+}
+
+function extractImportSpecifiers(source) {
+  const specifiers = [];
+  const patterns = [
+    /\bfrom\s+["']([^"']+)["']/g,
+    /\bimport\s+["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.push(match[1]);
+    }
+  }
+
+  return specifiers;
+}
+
+function listFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root)) {
+    const fullPath = resolve(root, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...listFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function isPathInside(root, target) {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}


### PR DESCRIPTION
Closes 

## Summary
- add a folder-local architecture contract for Deadline Detector
- document data ownership, fixture/runtime boundaries, dependency rules, and future reminder/calendar adapter constraints
- add a zero-dependency Node architecture contract test for required docs, template cleanup, import isolation, and forbidden app/provider imports

## Scope
- only touches `tools/v2/individual/deadline-detector/`
- no app shell, dashboard, routing, inbox, auth, wallet, Stellar, database, reminder, calendar, notification, provider, or design-system integration
- no production data, live network calls, persistence, secrets, or side effects

## Validation
- `node --test tools/v2/individual/deadline-detector/tests/architecture-contract.test.mjs`
- `node --test tools/v2/individual/deadline-detector/tests/deadline-fixtures.test.mjs`
- `npx --yes prettier --check` on changed Deadline Detector files
- `git diff --check`
- ASCII scan over `tools/v2/individual/deadline-detector`