### PR TITLE
Add email tone rewriter architecture contract

### DIFF
--- a/tools/v1/individual/email-tone-rewriter/README.md
+++ b/tools/v1/individual/email-tone-rewriter/README.md
@@ -6,38 +6,52 @@ This folder is the isolated workspace for the Email Tone Rewriter tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v1\individual\email-tone-rewriter\
-`
+```text
+tools/v1/individual/email-tone-rewriter/
+```
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, compose
+flow, wallet core, Stellar core, database schema, notification system, provider
+SDKs, AI providers, or existing design system unless a future integration issue
+explicitly allows it.
 
 ## Contributor Setup
 
-The folder now includes a reviewable, folder-local core service for the V1
-feature issue:
+The folder includes a reviewable, folder-local V1 surface:
 
-- `services.ts` exposes the pure rewrite API, validation helpers, and preserved
-  key-point extraction.
-- `services.test.ts` covers supported tones, validation errors, key-point
-  preservation, disabled send/save flags, and length constraints.
-- `specs.md` defines the behavior and ownership boundary.
-- `docs/test-plan.md` lists the acceptance scenarios future component tests
-  should cover.
-- `docs/fixtures.md` describes synthetic rewrite requests and expected outputs.
-- `REVIEW_NOTES.md` gives reviewers a quick checklist for this isolated work.
+- `index.ts` exposes the folder-local public API.
+- `services/emailToneRewriter.ts` exposes the pure rewrite engine, validation
+  helpers, key-point extraction, and UI-ready state mapping.
+- `services/guards.ts` sanitizes input and rejects oversized or invalid work
+  before the engine runs.
+- `services/fixtures.ts` contains synthetic examples for tests and local
+  review.
+- `components/` contains the idle, loading, error, and success review UI
+  surfaces.
+- `specs.md` defines behavior, ownership boundaries, module boundaries, and
+  contributor rules.
+- `docs/ARCHITECTURE.md` documents module boundaries, dependency rules, and
+  future integration constraints.
+- `docs/DATA_OWNERSHIP.md` documents transient draft ownership, result
+  ownership, fixture rules, and privacy limits.
+- `docs/test-plan.md`, `docs/threat-model.md`, `docs/performance.md`,
+  `docs/fixtures.md`, and `docs/visual-style.md` record local review guidance.
+- `tests/architecture-contract.test.mjs` verifies required docs and import
+  isolation with Node built-ins.
 
 ## Intended Usage
 
 The tool helps an individual user rewrite a draft email into a selected tone,
-such as concise, friendly, formal, or apologetic. A future implementation should
-accept a draft, requested tone, and optional constraints, then return a
-reviewable rewrite without sending or saving anything automatically.
+such as concise, friendly, formal, or apologetic. It accepts a draft, requested
+tone, and optional length constraint, then returns a reviewable rewrite without
+sending or saving anything automatically.
 
 ## Known Limitations
 
-- This issue adds the pure core service only; UI, integration, send actions, and
-  persistence are intentionally out of scope until a future integration issue
-  allows them.
-- The rewrite is deterministic and local. It does not call external AI providers,
-  production APIs, or mailbox data.
+- App integration, route wiring, compose insertion, send actions, persistence,
+  and mailbox mutation are intentionally out of scope until a future integration
+  issue allows them.
+- The rewrite is deterministic and local. It does not call external AI
+  providers, production APIs, provider SDKs, or mailbox data.
+- The current UI surface is folder-local and should not be treated as mounted in
+  the main application.

--- a/tools/v1/individual/email-tone-rewriter/docs/ARCHITECTURE.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# Email Tone Rewriter - Architecture Contract
+
+This document defines the module boundaries, dependency rules, data flow, and
+future integration constraints for the Email Tone Rewriter. The tool is a
+self-contained V1 individual mini-product and must remain isolated in
+`tools/v1/individual/email-tone-rewriter/`.
+
+## Ownership Boundary
+
+All source, fixtures, tests, and docs for this issue stay inside:
+
+```text
+tools/v1/individual/email-tone-rewriter/
+```
+
+This tool does not modify or depend on the main application shell, dashboard
+layout, routing, inbox architecture, mail rendering engine, compose-send flow,
+authentication, wallet core, Stellar core, database schema, notification
+delivery, provider SDKs, AI providers, or shared design system.
+
+## Folder Structure
+
+```text
+tools/v1/individual/email-tone-rewriter/
+|-- README.md
+|-- REVIEW_NOTES.md
+|-- index.ts
+|-- services.ts
+|-- services.test.ts
+|-- specs.md
+|-- styles.css
+|-- components/
+|   |-- EmailToneRewriter.tsx
+|   |-- EmailToneRewriterEmpty.tsx
+|   |-- EmailToneRewriterError.tsx
+|   |-- EmailToneRewriterLoading.tsx
+|   |-- EmailToneRewriterSuccess.tsx
+|   `-- index.ts
+|-- docs/
+|   |-- ARCHITECTURE.md
+|   |-- DATA_OWNERSHIP.md
+|   |-- fixtures.md
+|   |-- performance.md
+|   |-- test-plan.md
+|   |-- threat-model.md
+|   `-- visual-style.md
+|-- services/
+|   |-- emailToneRewriter.ts
+|   |-- fixtures.ts
+|   `-- guards.ts
+`-- tests/
+    |-- architecture-contract.test.mjs
+    |-- components.test.ts
+    |-- emailToneRewriter.test.ts
+    `-- guards.test.ts
+```
+
+## Module Boundaries
+
+### Public API: `index.ts`
+
+The public API exports only folder-local service and component modules.
+
+Rules:
+
+- Export the pure engine, guards, fixtures, and components from this folder.
+- Keep future app calls behind an explicit adapter or wrapper issue.
+- Do not export app shell, routing, inbox, compose, auth, wallet, Stellar,
+  database, notification, provider, AI provider, or design-system modules.
+
+### Core Engine: `services/emailToneRewriter.ts`
+
+The core engine owns deterministic rewrite behavior:
+
+- Supported tone ids.
+- Request and result types.
+- Sentence splitting, tidying, capitalization, and key-point extraction.
+- Tone transforms.
+- Empty-body, unsupported-tone, and unsupported-input errors.
+- Disabled send/save/mutate action flags.
+- UI-ready state mapping.
+
+Engine rules:
+
+- No React imports.
+- No network calls.
+- No persistence writes.
+- No mailbox, inbox, compose, auth, wallet, Stellar, database, notification, or
+  provider access.
+- No external AI provider calls.
+- No mutation of caller-supplied objects.
+
+### Guard Layer: `services/guards.ts`
+
+The guard layer owns local hardening before the engine runs:
+
+- Text sanitation for control, invisible, and decomposed characters.
+- Subject, body, word-count, and maxWords bounds.
+- Guard-specific typed errors for oversized and invalid length requests.
+- Delegation to the core engine after input is sanitized and bounded.
+
+Guard rules:
+
+- Guards are pure and deterministic.
+- Guards do not perform network work, storage writes, mailbox reads, or app
+  integration.
+- Guards may reject work before the engine runs but may not change ownership of
+  the draft data.
+
+### Fixture Layer: `services/fixtures.ts`
+
+Fixtures provide synthetic review examples for tests and local development.
+
+Rules:
+
+- Fixtures must be fake and small.
+- Fixtures must not contain real emails, production mailbox content, secrets,
+  API keys, access tokens, wallet data, provider credentials, or private user
+  information.
+- Tests may read fixtures but must not write back to fixture modules.
+
+### Component Layer: `components/`
+
+Components own folder-local rendering for the idle, loading, error, and success
+states:
+
+- `EmailToneRewriterEmpty` renders labelled draft and tone controls.
+- `EmailToneRewriterLoading` announces in-progress review work.
+- `EmailToneRewriterError` renders deterministic validation errors.
+- `EmailToneRewriterSuccess` renders the rewritten body and preserved facts for
+  user review.
+- `EmailToneRewriter` routes UI states to the matching component.
+
+Component rules:
+
+- Components may import React types and folder-local services.
+- Components must not send, save, persist, or mutate a draft.
+- Components must not import shared design-system modules, app routes, inbox
+  modules, compose modules, auth state, wallet state, Stellar modules, database
+  clients, notification systems, provider SDKs, AI clients, or sibling tools.
+
+### Test Layer: `tests/`
+
+Tests verify:
+
+- Core rewrite behavior, deterministic output, validation errors, preserved key
+  points, and disabled actions.
+- Guard sanitation, hard limits, and deterministic delegation.
+- Component semantics for labelled controls, status, alert, and review states.
+- Architecture contract, required docs, import isolation, and forbidden
+  integration imports.
+
+## Data Flow
+
+```text
+Caller-supplied draft request
+    -> safeRewriteEmailTone()
+    -> sanitizeRewriteRequest()
+    -> checkRequestLimits()
+    -> rewriteEmailTone()
+    -> ToneRewrite result with disabled actions
+    -> folder-local component renders review state
+```
+
+The current flow does not send mail, save drafts, mutate inbox threads, create
+database records, notify users, call providers, call AI services, run background
+jobs, or touch wallet/Stellar state.
+
+## Dependency Rules
+
+Allowed:
+
+- Relative imports that resolve inside
+  `tools/v1/individual/email-tone-rewriter/`.
+- React type imports and JSX in `components/`.
+- Vitest imports in existing Vitest tests.
+- Node built-ins in contract tests.
+- TypeScript type-only imports inside this folder.
+
+Not allowed:
+
+- `src/` imports or aliases such as `@/`.
+- Imports from sibling tools or parent directories that escape this folder.
+- Main app routing, dashboard, inbox, compose, auth, wallet, Stellar, database,
+  notification, provider, AI provider, or design-system modules.
+- New npm dependencies for this architecture issue.
+- Live network calls, secrets, production credentials, provider SDKs, AI
+  clients, webhooks, queues, scheduled jobs, or server persistence.
+
+## Future Contributor Contract
+
+Contributors may:
+
+- Add local tests, fixtures, and docs.
+- Refine deterministic rewrite rules with matching behavior tests.
+- Adjust guard limits with a documented rationale.
+- Improve folder-local component accessibility and review-state rendering.
+- Add adapter notes inside docs for a future integration issue.
+
+Contributors may not:
+
+- Wire this tool into application routes, navigation, inbox views, compose
+  surfaces, or dashboard layouts.
+- Send mail, save drafts, mutate mailbox state, persist rewrite history, deliver
+  notifications, call provider SDKs, call AI providers, or run background sync.
+- Connect to authentication, wallet flows, Stellar transactions, payment
+  features, or database schemas.
+- Change shared design-system files or global app state.
+- Modify files outside this folder for this issue.
+
+## Review Checklist
+
+- [ ] All changed files are under `tools/v1/individual/email-tone-rewriter/`.
+- [ ] `specs.md`, `docs/ARCHITECTURE.md`, and `docs/DATA_OWNERSHIP.md` agree
+      on the folder boundary.
+- [ ] No relative imports resolve outside this folder.
+- [ ] No main app routing, inbox, compose, auth, wallet, Stellar, database,
+      provider, AI provider, notification, or design-system wiring is
+      introduced.
+- [ ] `node --test tools/v1/individual/email-tone-rewriter/tests/architecture-contract.test.mjs`
+      passes.
+- [ ] Existing Vitest suites still pass when project dependencies are installed.
+
+## Acceptance Criteria Mapping
+
+| Issue Requirement                                                                | Evidence                                                                 |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Clear folder-local architecture plan                                             | This document and `specs.md`                                             |
+| No main app, routing, inbox, wallet, Stellar, database, or design-system changes | Dependency rules and contract test                                       |
+| Specs explain future contributor boundaries                                      | `specs.md` and Future Contributor Contract                               |
+| Files changed are limited to this folder                                         | Git diff and contract test                                               |
+| Self-contained mini-product review                                               | README, docs, services, components, fixtures, and tests are folder-local |

--- a/tools/v1/individual/email-tone-rewriter/docs/DATA_OWNERSHIP.md
+++ b/tools/v1/individual/email-tone-rewriter/docs/DATA_OWNERSHIP.md
@@ -1,0 +1,123 @@
+# Email Tone Rewriter - Data Ownership
+
+This document defines owned data, runtime state, fixture rules, and future
+adapter boundaries for the folder-local Email Tone Rewriter.
+
+## Owned Data
+
+| Data                 | Owner                           | Source                           | Mutation Rule                                                     |
+| -------------------- | ------------------------------- | -------------------------------- | ----------------------------------------------------------------- |
+| `RewriteRequest`     | `services/emailToneRewriter.ts` | Caller input or local fixtures   | Read-only input; the engine returns a new result object.          |
+| `ToneId`             | `services/emailToneRewriter.ts` | Folder-local supported tone list | Changes require matching tests and specs updates.                 |
+| `ToneRewrite`        | `services/emailToneRewriter.ts` | Deterministic rewrite output     | Returned to caller for review; never auto-sent or persisted.      |
+| `preservedKeyPoints` | `services/emailToneRewriter.ts` | Source draft body                | Extracted as review metadata; not stored externally.              |
+| `RewriteActionFlags` | `services/emailToneRewriter.ts` | Constant disabled action policy  | `canSend`, `canSave`, and `canMutate` remain false in this issue. |
+| `GUARD_LIMITS`       | `services/guards.ts`            | Folder-local hardening constants | Bounds work before the engine runs.                               |
+| Sanitized draft copy | `services/guards.ts`            | Caller input                     | New copied request; caller object is not mutated.                 |
+| Fixture drafts       | `services/fixtures.ts`          | Synthetic local examples         | Used by tests and review only.                                    |
+| UI state props       | `components/`                   | Caller state and rewrite results | Rendered locally; no persistence or mailbox mutation.             |
+
+## Runtime State
+
+The current tool owns only transient local state:
+
+- caller-supplied subject and body text while a rewrite is requested;
+- sanitized copies of the same text;
+- deterministic rewrite results;
+- preserved key-point arrays;
+- UI-ready idle, loading, ready, and error states;
+- synthetic fixture drafts for tests.
+
+The tool does not own:
+
+- live inbox messages;
+- compose drafts outside this folder;
+- sent mail;
+- rewrite history stored on a server;
+- user accounts;
+- authentication sessions;
+- wallet accounts;
+- Stellar transactions;
+- database rows;
+- notification delivery state;
+- provider credentials;
+- AI prompts sent to external services;
+- external model responses.
+
+## Lifecycle
+
+```text
+Caller draft input
+    -> sanitizeRewriteRequest()
+    -> checkRequestLimits()
+    -> rewriteEmailTone()
+    -> ToneRewrite review result
+    -> component renders output with send/save/mutate disabled
+```
+
+No step writes to server APIs, shared app stores, queues, databases, inbox
+state, compose state, notification services, provider services, AI providers,
+wallet state, or Stellar ledgers.
+
+## Fixture Rules
+
+- Fixture drafts are synthetic examples for tests and local development.
+- Fixture text must not include real inbox content, customer details, private
+  user messages, secrets, API keys, access tokens, wallet data, provider
+  credentials, production URLs, or production email addresses.
+- Tests may import fixtures but must not write back to fixture files.
+- New fixtures should stay small, deterministic, and reviewable.
+
+## Draft Privacy Rules
+
+- Treat every caller-supplied draft as private untrusted text.
+- Do not log raw draft content in production integrations.
+- Do not send draft content to external AI providers or provider SDKs in this
+  issue.
+- Do not store draft content or rewrite history in this issue.
+- Do not include production drafts in snapshots, fixtures, docs, or review
+  notes.
+
+## Result Ownership
+
+The rewrite result is review metadata, not a send instruction:
+
+- `rewrittenBody` is suggested text for user review.
+- `preservedKeyPoints` are local review anchors.
+- `wordCount`, `truncated`, and `changed` are local display metadata.
+- `actions.canSend`, `actions.canSave`, and `actions.canMutate` remain false.
+
+A future integration may copy a reviewed rewrite into a compose surface only
+through an explicit adapter issue. That adapter must define user confirmation,
+audit, retention, and error-handling rules before any send or save behavior is
+enabled.
+
+## Future Integration Adapter Boundary
+
+If a later issue connects this tool to live app data, it must add an explicit
+adapter or wrapper layer and review:
+
+- user authentication and authorization;
+- compose insertion behavior;
+- inbox and mailbox read rules;
+- draft save and send confirmation;
+- privacy limits for draft text;
+- retention and deletion behavior for rewrite history;
+- audit logging without raw private content;
+- provider and AI service boundaries if any remote rewrite is introduced;
+- rate limits, retries, and failure display;
+- accessibility and review-state requirements for mounted UI.
+
+The current architecture issue documents those boundaries but does not
+implement the adapter.
+
+## Security Constraints
+
+- Do not include secrets, tokens, API keys, wallet data, production IDs, or real
+  user data in fixtures.
+- Do not send, save, enqueue, persist, or mutate rewrite output automatically.
+- Do not call external AI providers, provider SDKs, production APIs, webhooks,
+  background jobs, or queues.
+- Keep validation and guard errors structural and non-sensitive.
+- Keep all changed files for this issue inside
+  `tools/v1/individual/email-tone-rewriter/`.

--- a/tools/v1/individual/email-tone-rewriter/specs.md
+++ b/tools/v1/individual/email-tone-rewriter/specs.md
@@ -1,66 +1,206 @@
-# Email Tone Rewriter
-
-Rewrite email tone for different contexts.
-
-## Scope
-
-- Release tier: V1
-- Audience: individual
-- Folder ownership: `tools/v1/individual/email-tone-rewriter/`
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- tests/
-- docs/
-
 # Email Tone Rewriter Specs
 
 ## Purpose
 
-Rewrite a draft email into a requested tone while preserving the user's meaning
-and keeping the result reviewable before any send action.
+Email Tone Rewriter is a V1 individual productivity tool that rewrites a draft
+email into a requested tone while preserving the user's meaning, factual
+anchors, and review control. The tool stays isolated in:
 
-## Contributor boundary
+```text
+tools/v1/individual/email-tone-rewriter/
+```
 
-All work for this tool should stay in:
+This folder is a self-contained mini-product. It must not be wired into the
+main application shell, dashboard layout, navigation, routing, inbox
+architecture, compose/send flow, authentication, wallet core, Stellar core,
+database schema, notification system, provider SDKs, AI providers, or shared
+design system unless a future integration issue explicitly allows it.
 
-`tools/v1/individual/email-tone-rewriter/`
+## Release Scope
 
-Do not add imports from the main inbox, routing, wallet, Stellar, database, or
-design-system layers until a later integration issue explicitly allows it.
-
-## Required issue categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+- Release tier: V1
+- Audience: individual
+- Owner folder: `tools/v1/individual/email-tone-rewriter/`
+- Current implementation style: deterministic, local, rule-based rewrite
+- Current persistence model: none
+- Current network model: none
 
 ## Core Behavior Contract
 
-The future implementation should:
+The tool accepts a normalized draft request with:
 
-- accept a normalized draft input with `subject`, `bodyText`, target `tone`, and
-  optional length constraints;
-- support a bounded set of tones such as `concise`, `friendly`, `formal`, and
-  `apologetic`;
-- preserve factual claims, dates, names, and requested actions from the source
-  draft;
-- return a reviewable rewritten body and a list of preserved key points;
-- reject empty drafts or unsupported tone values with deterministic validation
-  errors;
-- never send, save, or mutate the mailbox before explicit user confirmation.
+- `subject`
+- `bodyText`
+- `tone`
+- optional `maxWords`
+
+The supported tones are:
+
+- `concise`
+- `friendly`
+- `formal`
+- `apologetic`
+
+The rewriter must:
+
+- preserve factual claims, names, dates, links, emails, amounts, quarters, and
+  requested actions from the source draft;
+- return a reviewable rewritten body and preserved key points;
+- produce deterministic output for the same input;
+- reject empty drafts, malformed input, unsupported tones, oversized drafts, and
+  invalid length constraints with typed error results;
+- keep send, save, and mutate action flags disabled;
+- never send, save, persist, enqueue, notify, or mutate mailbox state.
+
+## Module Boundaries
+
+### Public API: `index.ts`
+
+`index.ts` is the folder-local public export surface. Future callers should
+import from this file or from explicitly documented folder-local modules only.
+
+Rules:
+
+- Export only modules that live under this folder.
+- Do not export app shell, route, inbox, compose, wallet, Stellar, database,
+  notification, provider, AI provider, or design-system dependencies.
+- Keep cross-folder integration in a future wrapper issue.
+
+### Service Layer: `services/`
+
+The service layer owns pure rewrite logic, fixtures, and hardening guards.
+
+Rules:
+
+- `services/emailToneRewriter.ts` owns tone transformation, key-point
+  extraction, deterministic validation, and UI-ready result states.
+- `services/guards.ts` owns input sanitation and hard size limits before the
+  engine runs.
+- `services/fixtures.ts` owns synthetic examples for tests and local review.
+- Services must not import React, routes, app stores, inbox state, compose
+  state, wallet, Stellar, database, notification, provider SDKs, AI providers,
+  or sibling tools.
+- Services must not perform network calls, persistence writes, mailbox reads,
+  sends, background jobs, or timers.
+
+### Component Layer: `components/`
+
+The component layer owns the folder-local review UI surface for idle, loading,
+error, and success states.
+
+Rules:
+
+- Components may import React types and folder-local services.
+- Components must render reviewable output without sending or saving drafts.
+- Components must keep send/save/mutate actions visibly disabled until a future
+  integration issue defines an explicit adapter.
+- Components must not import shared design-system components, app shell routes,
+  inbox modules, compose modules, auth state, wallet state, Stellar modules,
+  database clients, notification systems, provider SDKs, AI clients, or sibling
+  tools.
+
+### Test Layer: `tests/`
+
+The test layer owns local behavior, guard, component, and architecture checks.
+
+Rules:
+
+- Behavior tests should use local fixtures and deterministic expectations.
+- Contract tests should use Node built-ins where possible so reviewers can run
+  architecture checks without project dependency installation.
+- Tests must not call live services, send mail, mutate mailbox state, persist to
+  production stores, or require secrets.
+
+### Documentation Layer: `docs/`
+
+The docs layer owns architecture, data ownership, threat model, performance,
+fixture, visual-style, and test-plan notes for this folder only.
+
+Rules:
+
+- Docs may describe future integration constraints.
+- Docs must not imply current app integration where none exists.
+- Future app wiring belongs in a new issue and should point back to these
+  folder-local boundaries.
+
+## Data Ownership
+
+The tool owns only transient caller-supplied draft data and deterministic
+rewrite results inside this folder. It does not own:
+
+- live inbox messages;
+- compose drafts outside this folder;
+- sent mail;
+- user accounts;
+- authentication sessions;
+- wallet accounts;
+- Stellar transactions;
+- database rows;
+- notification state;
+- provider credentials;
+- AI prompts or external model responses.
+
+See `docs/DATA_OWNERSHIP.md` for the detailed data and fixture contract.
+
+## Dependency Rules
+
+Allowed:
+
+- relative imports that resolve inside
+  `tools/v1/individual/email-tone-rewriter/`;
+- React type imports in components;
+- Vitest imports in existing Vitest tests;
+- Node built-ins in architecture contract tests;
+- TypeScript type-only imports inside this folder.
+
+Not allowed:
+
+- imports from `src/`, app aliases such as `@/`, parent folders, or sibling
+  tools;
+- main app routing, dashboard, inbox, compose, auth, wallet, Stellar, database,
+  notification, provider, AI provider, or design-system modules;
+- new npm dependencies for this architecture issue;
+- live network calls, secrets, production credentials, provider SDKs, webhooks,
+  background jobs, or server persistence.
+
+## Future Contributor Contract
+
+Future contributors may change:
+
+- folder-local docs, tests, and fixtures;
+- deterministic rewrite rules with matching tests;
+- validation and guard limits with documented rationale;
+- component accessibility and review-state rendering;
+- adapter interfaces documented in this folder for a later integration issue.
+
+Future contributors may not change:
+
+- files outside `tools/v1/individual/email-tone-rewriter/` for this issue;
+- main app shell, routes, navigation, dashboard, inbox, compose, auth, wallet,
+  Stellar, database, notification, provider, AI provider, or design-system code;
+- send/save/mutate behavior without explicit user confirmation and a separate
+  integration issue;
+- fixtures to include real user emails, production mailbox content, secrets,
+  API keys, wallet data, or provider credentials;
+- deterministic local behavior into live network behavior inside this issue.
 
 ## Out of Scope
 
-- sending emails;
-- mutating mailbox state;
-- adding routes, dashboard widgets, or navigation links;
-- calling external AI providers from this folder;
-- persisting rewrite history outside this folder.
+- Sending emails.
+- Saving drafts or rewrite history.
+- Mutating mailbox, inbox, compose, routing, auth, wallet, Stellar, database, or
+  notification state.
+- Calling external AI providers or provider SDKs.
+- Adding app shell, dashboard, route, navigation, or shared design-system
+  integration.
+- Running background jobs, queues, webhooks, or scheduled sync.
+
+## Acceptance Criteria Mapping
+
+| Issue requirement                                                                | Evidence                                                                        |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Clear folder-local architecture plan                                             | `docs/ARCHITECTURE.md` and this file                                            |
+| No main app, routing, inbox, wallet, Stellar, database, or design-system changes | Dependency rules and `tests/architecture-contract.test.mjs`                     |
+| Specs explain what contributors may and may not change                           | Future Contributor Contract                                                     |
+| Files changed are limited to this folder                                         | Git diff and contract test                                                      |
+| Self-contained mini-product review                                               | README, specs, docs, services, components, fixtures, and tests are folder-local |

--- a/tools/v1/individual/email-tone-rewriter/tests/architecture-contract.test.mjs
+++ b/tools/v1/individual/email-tone-rewriter/tests/architecture-contract.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const toolRoot = fileURLToPath(new URL("..", import.meta.url));
+const toolPath = "tools/v1/individual/email-tone-rewriter/";
+
+const requiredDocs = [
+  "README.md",
+  "specs.md",
+  "docs/ARCHITECTURE.md",
+  "docs/DATA_OWNERSHIP.md",
+  "docs/test-plan.md",
+  "docs/threat-model.md",
+  "docs/performance.md",
+  "docs/fixtures.md",
+  "docs/visual-style.md",
+  "REVIEW_NOTES.md",
+];
+
+const contractDocs = ["README.md", "specs.md", "docs/ARCHITECTURE.md", "docs/DATA_OWNERSHIP.md"];
+const codeFiles = listFiles(toolRoot).filter((file) =>
+  [".js", ".mjs", ".ts", ".tsx"].includes(extname(file)),
+);
+
+describe("Email Tone Rewriter - architecture contract", () => {
+  it("keeps required architecture documents folder-local", () => {
+    for (const doc of requiredDocs) {
+      const absolute = resolve(toolRoot, doc);
+      assert.ok(existsSync(absolute), `${doc} must exist`);
+      assert.ok(isPathInside(toolRoot, absolute), `${doc} must stay inside ${toolPath}`);
+    }
+  });
+
+  it("documents module boundaries, data ownership, and integration constraints", () => {
+    assertDocIncludes("docs/ARCHITECTURE.md", [
+      toolPath,
+      "Module Boundaries",
+      "Dependency Rules",
+      "Future Contributor Contract",
+      "No network calls",
+      "No persistence writes",
+      "compose",
+      "inbox",
+      "AI providers",
+    ]);
+
+    assertDocIncludes("docs/DATA_OWNERSHIP.md", [
+      "RewriteRequest",
+      "ToneRewrite",
+      "RewriteActionFlags",
+      "Fixture Rules",
+      "Future Integration Adapter Boundary",
+      "No step writes to server APIs",
+    ]);
+
+    assertDocIncludes("specs.md", [
+      "Module Boundaries",
+      "Future contributors may change",
+      "Future contributors may not change",
+      "Files changed are limited to this folder",
+      toolPath,
+    ]);
+  });
+
+  it("removes broken generation/template leftovers from contract docs", () => {
+    const forbidden = ["$(", "$dir", "Set-Content", "System.Collections.Hashtable", "@ |"];
+
+    for (const relativePath of contractDocs) {
+      const text = readFileSync(resolve(toolRoot, relativePath), "utf8");
+      for (const token of forbidden) {
+        assert.ok(!text.includes(token), `${relativePath} still contains ${token}`);
+      }
+    }
+  });
+
+  it("keeps relative imports inside the tool folder", () => {
+    for (const file of codeFiles) {
+      const imports = extractImportSpecifiers(readFileSync(file, "utf8"));
+
+      for (const specifier of imports) {
+        if (!specifier.startsWith(".")) continue;
+        const resolved = resolve(dirname(file), specifier);
+        assert.ok(
+          isPathInside(toolRoot, resolved),
+          `${relative(toolRoot, file)} imports outside the tool folder: ${specifier}`,
+        );
+      }
+    }
+  });
+
+  it("does not import forbidden main app or provider modules", () => {
+    const forbiddenImportFragments = [
+      "@/",
+      "src/",
+      "routes/",
+      "router",
+      "inbox",
+      "mailbox",
+      "compose",
+      "notification",
+      "provider",
+      "openai",
+      "anthropic",
+      "wallet",
+      "stellar",
+      "database",
+      "components/ui",
+      "design-system",
+    ];
+
+    for (const file of codeFiles) {
+      const imports = extractImportSpecifiers(readFileSync(file, "utf8"));
+      for (const specifier of imports) {
+        for (const fragment of forbiddenImportFragments) {
+          assert.ok(
+            !specifier.toLowerCase().includes(fragment),
+            `${relative(toolRoot, file)} imports forbidden module fragment ${fragment}`,
+          );
+        }
+      }
+    }
+  });
+});
+
+function assertDocIncludes(relativePath, expectedPhrases) {
+  const text = readFileSync(resolve(toolRoot, relativePath), "utf8");
+  for (const phrase of expectedPhrases) {
+    assert.ok(text.includes(phrase), `${relativePath} must mention "${phrase}"`);
+  }
+}
+
+function extractImportSpecifiers(source) {
+  const specifiers = [];
+  const patterns = [
+    /\bfrom\s+["']([^"']+)["']/g,
+    /\bimport\s+["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specifiers.push(match[1]);
+    }
+  }
+
+  return specifiers;
+}
+
+function listFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root)) {
+    const fullPath = resolve(root, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...listFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function isPathInside(root, target) {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}


### PR DESCRIPTION
Closes 

## Summary
- add a folder-local architecture contract for Email Tone Rewriter
- document service, guard, component, fixture, test, data ownership, and future integration boundaries
- add a zero-dependency Node architecture contract test for required docs and import isolation

## Scope
- only touches `tools/v1/individual/email-tone-rewriter/`
- no app shell, dashboard, routing, inbox, compose, auth, wallet, Stellar, database, notification, provider, AI provider, or design-system integration
- no production data, live network calls, server persistence, secrets, webhooks, background jobs, send actions, save actions, or mailbox mutation

## Validation
- `node --test tools/v1/individual/email-tone-rewriter/tests/architecture-contract.test.mjs`
- `npx --yes prettier --check tools/v1/individual/email-tone-rewriter/README.md tools/v1/individual/email-tone-rewriter/specs.md tools/v1/individual/email-tone-rewriter/docs/ARCHITECTURE.md tools/v1/individual/email-tone-rewriter/docs/DATA_OWNERSHIP.md tools/v1/individual/email-tone-rewriter/tests/architecture-contract.test.mjs`
- `git diff --check`
- ASCII scan over changed Email Tone Rewriter files

## Existing suite note
- attempted `npx --yes vitest run tools/v1/individual/email-tone-rewriter/tests/emailToneRewriter.test.ts tools/v1/individual/email-tone-rewriter/tests/guards.test.ts tools/v1/individual/email-tone-rewriter/tests/components.test.ts tools/v1/individual/email-tone-rewriter/services.test.ts`
- blocked before tests ran because local project dependencies are unavailable from `vite.config.ts`: `@cloudflare/vite-plugin`, `@tailwindcss/vite`, `@tanstack/react-start/plugin/vite`, `@vitejs/plugin-react`, `vite`, and `vite-tsconfig-paths`
- runtime files were not changed
