### PR TITLE
Add customer support macro guard boundaries

### DIFF
--- a/tools/v1/team/customer-support-macro-tool/docs/SECURITY_AND_PERFORMANCE.md
+++ b/tools/v1/team/customer-support-macro-tool/docs/SECURITY_AND_PERFORMANCE.md
@@ -1,0 +1,114 @@
+# Customer Support Macro Tool - Security and Performance Notes
+
+This document records the local security assumptions, unsafe input handling,
+and performance limits for the isolated Customer Support Macro Tool.
+
+## Scope
+
+All guidance applies only to:
+
+```text
+tools/v1/team/customer-support-macro-tool/
+```
+
+The tool does not read a live inbox, insert into compose windows, send mail,
+call providers, call AI services, write server records, notify users, touch
+wallet or Stellar state, or connect to the app shell. Future integration must
+add an explicit adapter issue before using real customer or mailbox data.
+
+## Threat Assumptions
+
+- Macro titles, bodies, tags, variables, stored macro records, import/export
+  payloads, attachment metadata, and history windows are untrusted input.
+- Macro output is suggested text only; this folder must not send, save, or
+  insert it into compose automatically.
+- Attachment contents are out of scope for this folder; only bounded metadata
+  may be accepted by guard helpers.
+- Large macro libraries, team histories, and import/export batches can create
+  avoidable CPU and memory work even when each record is valid.
+- Fixtures must remain synthetic and must not contain real customer replies,
+  tickets, order ids, secrets, API keys, access tokens, wallet data, or provider
+  credentials.
+
+## Guard Helpers
+
+`guards/macro-guards.mjs` owns folder-local validation and sanitization:
+
+- `sanitizeMacroText()` removes HTML-like tags, control characters, zero-width
+  characters, leading/trailing whitespace, and oversized text.
+- `validateMacroId()` rejects empty ids, path traversal, whitespace, and
+  unsupported characters.
+- `validateMacroCategory()` allowlists the six local macro categories.
+- `validateTags()` bounds tag counts, strips unsafe text, and normalizes tags.
+- `sanitizeMacroInput()` validates create/update-shaped macro input.
+- `validateVariableMap()` validates interpolation variables before rendering a
+  macro preview.
+- `sanitizeStoredMacro()` validates stored macro records before import or
+  storage hydration.
+- `guardMacroBatch()` caps the number of macros processed in one pass.
+- `guardSearchOptions()` bounds search and filter input.
+- `guardAttachmentMetadata()` accepts metadata only and rejects embedded file
+  contents.
+- `guardHistoryWindow()` caps future audit/history scans.
+
+These guards are pure and synchronous. They do not perform network calls,
+storage writes, mailbox reads, compose writes, notification delivery, provider
+calls, AI calls, or background jobs.
+
+## Unsafe Inputs
+
+| Input                             | Risk                                   | Handling                              |
+| --------------------------------- | -------------------------------------- | ------------------------------------- |
+| Path-like macro ids               | Path traversal or confusing audit ids  | Rejected by `validateMacroId()`       |
+| HTML-like text in title/body/tags | Accidental markup or script display    | Stripped before use                   |
+| Control or zero-width characters  | Hidden content or rendering surprises  | Removed by `sanitizeMacroText()`      |
+| Unsupported categories            | Undefined behavior or broken filters   | Rejected by `validateMacroCategory()` |
+| Oversized variable maps           | Excess interpolation work              | Rejected by `validateVariableMap()`   |
+| Oversized macro libraries         | Slow full-library scans                | Rejected with a pagination hint       |
+| Attachment contents               | File parsing, malware, memory pressure | Rejected; metadata only               |
+| Oversized histories               | Avoidable scan cost                    | Rejected with a smaller-window hint   |
+
+## Performance Limits
+
+The current guard constants are intentionally conservative:
+
+| Limit                    | Value                           |
+| ------------------------ | ------------------------------- |
+| Macro batch size         | 500 macros                      |
+| Title length             | 120 characters                  |
+| Body length              | 4,000 characters                |
+| Tag count                | 20 tags                         |
+| Variable count           | 50 variables                    |
+| Variable value length    | 1,000 characters                |
+| Search query length      | 120 characters                  |
+| Attachment count         | 25 metadata rows                |
+| Attachment size metadata | 10,000,000 bytes per attachment |
+| History events           | 500 rows                        |
+
+Future integrations should paginate large macro libraries, import files, team
+histories, and attachment lists before calling search, interpolation, or export
+logic. The tool should operate on a bounded, user-confirmed slice rather than
+scanning full organizations or long-running support histories.
+
+## Review Commands
+
+Run from the repository root:
+
+```bash
+node --test tools/v1/team/customer-support-macro-tool/tests/macro-guards.test.mjs
+```
+
+The guard test uses `fixtures/hostile-macro-inputs.json` to verify malformed
+input rejection, text sanitization, variable-map boundaries, attachment
+metadata boundaries, and oversized collection guards.
+
+## Future Adapter Checklist
+
+- Normalize real support data into folder-local macro shapes.
+- Run guard helpers before create, update, import, export, search, and
+  interpolation paths.
+- Keep compose insertion and send behavior behind explicit user confirmation.
+- Avoid logging raw macro bodies, customer names, ticket ids, or order ids.
+- Paginate large macro libraries, histories, and attachment metadata.
+- Keep provider, AI, database, notification, wallet, and Stellar integrations
+  outside this folder unless a future issue explicitly allows them.

--- a/tools/v1/team/customer-support-macro-tool/fixtures/hostile-macro-inputs.json
+++ b/tools/v1/team/customer-support-macro-tool/fixtures/hostile-macro-inputs.json
@@ -1,0 +1,94 @@
+{
+  "tool": "customer-support-macro-tool",
+  "version": 1,
+  "validMacro": {
+    "id": "macro_safe_001",
+    "title": "Refund status update",
+    "body": "Hi {{customer_name}}, your refund for order {{order_id}} is being reviewed.",
+    "category": "refund",
+    "tags": ["Refund", " Status "],
+    "createdAt": "2026-06-18T09:00:00.000Z",
+    "updatedAt": "2026-06-18T09:00:00.000Z",
+    "usageCount": 3,
+    "isFavorite": false
+  },
+  "hostileMacros": [
+    {
+      "id": "bad-id-path",
+      "field": "id",
+      "reason": "path traversal in macro id",
+      "patch": {
+        "id": "../../macros"
+      }
+    },
+    {
+      "id": "bad-category",
+      "field": "category",
+      "reason": "unsupported category",
+      "patch": {
+        "category": "live-inbox"
+      }
+    },
+    {
+      "id": "bad-title-empty",
+      "field": "title",
+      "reason": "title has no visible text",
+      "patch": {
+        "title": "   "
+      }
+    },
+    {
+      "id": "bad-tags-shape",
+      "field": "tags",
+      "reason": "tags must be an array",
+      "patch": {
+        "tags": "urgent"
+      }
+    },
+    {
+      "id": "bad-created-at",
+      "field": "createdAt",
+      "reason": "invalid timestamp",
+      "patch": {
+        "createdAt": "not-a-date"
+      }
+    },
+    {
+      "id": "bad-usage-count",
+      "field": "usageCount",
+      "reason": "usage count must be finite and non-negative",
+      "patch": {
+        "usageCount": -1
+      }
+    },
+    {
+      "id": "bad-favorite",
+      "field": "isFavorite",
+      "reason": "favorite flag must be boolean",
+      "patch": {
+        "isFavorite": "false"
+      }
+    }
+  ],
+  "sanitizationCases": [
+    {
+      "field": "title",
+      "input": "  <script>alert(1)</script> Refund\u0000 update\u200b  ",
+      "expected": "alert(1) Refund update"
+    },
+    {
+      "field": "body",
+      "input": "<b>Hi</b> {{customer_name}}\u0007, refund is approved.",
+      "expected": "Hi {{customer_name}}, refund is approved."
+    },
+    {
+      "field": "attachmentName",
+      "input": "<img src=x>macro-export.csv\u0000",
+      "expected": "macro-export.csv"
+    }
+  ],
+  "validVariables": {
+    "customer_name": "Avery\u0000 Stone",
+    "order_id": "ORD-123"
+  }
+}

--- a/tools/v1/team/customer-support-macro-tool/guards/macro-guards.mjs
+++ b/tools/v1/team/customer-support-macro-tool/guards/macro-guards.mjs
@@ -1,0 +1,284 @@
+/**
+ * Security and performance guards for Customer Support Macro Tool.
+ *
+ * These helpers are pure and folder-local. Future app adapters should run them
+ * before creating, updating, searching, importing, exporting, or interpolating
+ * macros sourced from users, storage, or mailbox context.
+ */
+
+const ALLOWED_CATEGORIES = new Set([
+  "greeting",
+  "billing",
+  "technical",
+  "shipping",
+  "refund",
+  "general",
+]);
+
+const MACRO_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export const MACRO_GUARD_LIMITS = {
+  MAX_MACRO_ID_LENGTH: 96,
+  MAX_TITLE_LENGTH: 120,
+  MAX_BODY_LENGTH: 4_000,
+  MAX_TAG_COUNT: 20,
+  MAX_TAG_LENGTH: 48,
+  MAX_VARIABLE_COUNT: 50,
+  MAX_VARIABLE_NAME_LENGTH: 64,
+  MAX_VARIABLE_VALUE_LENGTH: 1_000,
+  MAX_SEARCH_QUERY_LENGTH: 120,
+  MAX_MACRO_BATCH_SIZE: 500,
+  MAX_ATTACHMENT_COUNT: 25,
+  MAX_ATTACHMENT_NAME_LENGTH: 180,
+  MAX_ATTACHMENT_BYTES: 10_000_000,
+  MAX_HISTORY_EVENTS: 500,
+};
+
+const CONTROL_CHARACTERS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g;
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+const HTML_TAGS = /<[^>]*>/g;
+
+export class MacroGuardError extends Error {
+  constructor(message, field) {
+    super(message);
+    this.name = "MacroGuardError";
+    this.field = field;
+  }
+}
+
+export function sanitizeMacroText(value, maxLength = MACRO_GUARD_LIMITS.MAX_BODY_LENGTH) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .normalize("NFC")
+    .replace(HTML_TAGS, "")
+    .replace(CONTROL_CHARACTERS, "")
+    .replace(INVISIBLE_CHARACTERS, "")
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function validateMacroId(id) {
+  if (typeof id !== "string" || id.length === 0) {
+    throw new MacroGuardError("macro id must be a non-empty string", "id");
+  }
+  if (id.length > MACRO_GUARD_LIMITS.MAX_MACRO_ID_LENGTH) {
+    throw new MacroGuardError(
+      `macro id exceeds ${MACRO_GUARD_LIMITS.MAX_MACRO_ID_LENGTH} characters`,
+      "id",
+    );
+  }
+  if (!MACRO_ID_PATTERN.test(id)) {
+    throw new MacroGuardError(
+      "macro id may contain only letters, numbers, underscore, and dash",
+      "id",
+    );
+  }
+  return id;
+}
+
+export function validateMacroCategory(category) {
+  if (typeof category !== "string" || category.length === 0) {
+    throw new MacroGuardError("category must be a non-empty string", "category");
+  }
+  if (!ALLOWED_CATEGORIES.has(category)) {
+    throw new MacroGuardError(`unsupported macro category: ${category}`, "category");
+  }
+  return category;
+}
+
+export function validateTags(tags = []) {
+  if (!Array.isArray(tags)) {
+    throw new MacroGuardError("tags must be an array", "tags");
+  }
+  if (tags.length > MACRO_GUARD_LIMITS.MAX_TAG_COUNT) {
+    throw new MacroGuardError(
+      `tag count ${tags.length} exceeds ${MACRO_GUARD_LIMITS.MAX_TAG_COUNT}`,
+      "tags",
+    );
+  }
+
+  const sanitized = [];
+  for (const tag of tags) {
+    const cleaned = sanitizeMacroText(tag, MACRO_GUARD_LIMITS.MAX_TAG_LENGTH).toLowerCase();
+    if (cleaned.length === 0) {
+      throw new MacroGuardError("tags must contain visible text", "tags");
+    }
+    sanitized.push(cleaned);
+  }
+  return sanitized;
+}
+
+export function sanitizeMacroInput(input) {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new MacroGuardError("macro input must be a plain object", "input");
+  }
+
+  const title = sanitizeMacroText(input.title, MACRO_GUARD_LIMITS.MAX_TITLE_LENGTH);
+  const body = sanitizeMacroText(input.body, MACRO_GUARD_LIMITS.MAX_BODY_LENGTH);
+
+  if (title.length === 0) {
+    throw new MacroGuardError("title must contain visible text", "title");
+  }
+  if (body.length === 0) {
+    throw new MacroGuardError("body must contain visible text", "body");
+  }
+
+  return {
+    title,
+    body,
+    category: validateMacroCategory(input.category),
+    tags: validateTags(input.tags ?? []),
+  };
+}
+
+export function validateVariableMap(variables = {}) {
+  if (variables === null || typeof variables !== "object" || Array.isArray(variables)) {
+    throw new MacroGuardError("variables must be a plain object", "variables");
+  }
+
+  const entries = Object.entries(variables);
+  if (entries.length > MACRO_GUARD_LIMITS.MAX_VARIABLE_COUNT) {
+    throw new MacroGuardError(
+      `variable count ${entries.length} exceeds ${MACRO_GUARD_LIMITS.MAX_VARIABLE_COUNT}`,
+      "variables",
+    );
+  }
+
+  const sanitized = {};
+  for (const [key, value] of entries) {
+    if (
+      key.length > MACRO_GUARD_LIMITS.MAX_VARIABLE_NAME_LENGTH ||
+      !VARIABLE_NAME_PATTERN.test(key)
+    ) {
+      throw new MacroGuardError(`invalid variable name: ${key}`, "variables");
+    }
+    sanitized[key] = sanitizeMacroText(value, MACRO_GUARD_LIMITS.MAX_VARIABLE_VALUE_LENGTH);
+  }
+  return sanitized;
+}
+
+export function sanitizeStoredMacro(macro) {
+  if (macro === null || typeof macro !== "object" || Array.isArray(macro)) {
+    throw new MacroGuardError("stored macro must be a plain object", "macro");
+  }
+  if (
+    typeof macro.usageCount !== "number" ||
+    macro.usageCount < 0 ||
+    !Number.isFinite(macro.usageCount)
+  ) {
+    throw new MacroGuardError("usageCount must be a non-negative finite number", "usageCount");
+  }
+  if (typeof macro.isFavorite !== "boolean") {
+    throw new MacroGuardError("isFavorite must be boolean", "isFavorite");
+  }
+
+  const input = sanitizeMacroInput(macro);
+  return {
+    id: validateMacroId(macro.id),
+    ...input,
+    createdAt: validateIsoTimestamp(macro.createdAt, "createdAt"),
+    updatedAt: validateIsoTimestamp(macro.updatedAt, "updatedAt"),
+    usageCount: macro.usageCount,
+    isFavorite: macro.isFavorite,
+  };
+}
+
+export function validateIsoTimestamp(value, field) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    throw new MacroGuardError(`${field} must be an ISO timestamp string`, field);
+  }
+  if (Number.isNaN(Date.parse(value))) {
+    throw new MacroGuardError(`${field} must be parseable as a date`, field);
+  }
+  return value;
+}
+
+export function guardMacroBatch(macros) {
+  if (!Array.isArray(macros)) {
+    throw new MacroGuardError("macros must be an array", "macros");
+  }
+  if (macros.length > MACRO_GUARD_LIMITS.MAX_MACRO_BATCH_SIZE) {
+    throw new MacroGuardError(
+      `macro batch size ${macros.length} exceeds ${MACRO_GUARD_LIMITS.MAX_MACRO_BATCH_SIZE}; paginate before scanning`,
+      "macros",
+    );
+  }
+  return macros.map((macro) => sanitizeStoredMacro(macro));
+}
+
+export function guardSearchOptions(options = {}) {
+  if (options === null || typeof options !== "object" || Array.isArray(options)) {
+    throw new MacroGuardError("search options must be a plain object", "search");
+  }
+
+  const query =
+    options.query === undefined
+      ? ""
+      : sanitizeMacroText(options.query, MACRO_GUARD_LIMITS.MAX_SEARCH_QUERY_LENGTH);
+
+  return {
+    query,
+    category: options.category === undefined ? undefined : validateMacroCategory(options.category),
+    tags: validateTags(options.tags ?? []),
+    favoritesOnly: Boolean(options.favoritesOnly),
+  };
+}
+
+export function guardAttachmentMetadata(attachments = []) {
+  if (!Array.isArray(attachments)) {
+    throw new MacroGuardError("attachments must be an array", "attachments");
+  }
+  if (attachments.length > MACRO_GUARD_LIMITS.MAX_ATTACHMENT_COUNT) {
+    throw new MacroGuardError(
+      `attachment count ${attachments.length} exceeds ${MACRO_GUARD_LIMITS.MAX_ATTACHMENT_COUNT}`,
+      "attachments",
+    );
+  }
+
+  return attachments.map((attachment, index) => {
+    if (attachment === null || typeof attachment !== "object" || Array.isArray(attachment)) {
+      throw new MacroGuardError(`attachment ${index} must be a plain object`, "attachments");
+    }
+    if ("content" in attachment || "bytes" in attachment || "buffer" in attachment) {
+      throw new MacroGuardError(
+        "attachment content is out of scope; pass metadata only",
+        "attachments",
+      );
+    }
+    const name = sanitizeMacroText(attachment.name, MACRO_GUARD_LIMITS.MAX_ATTACHMENT_NAME_LENGTH);
+    if (name.length === 0) {
+      throw new MacroGuardError("attachment name must contain visible text", "attachments");
+    }
+    if (!Number.isInteger(attachment.sizeBytes) || attachment.sizeBytes < 0) {
+      throw new MacroGuardError(
+        "attachment sizeBytes must be a non-negative integer",
+        "attachments",
+      );
+    }
+    if (attachment.sizeBytes > MACRO_GUARD_LIMITS.MAX_ATTACHMENT_BYTES) {
+      throw new MacroGuardError(
+        `attachment exceeds ${MACRO_GUARD_LIMITS.MAX_ATTACHMENT_BYTES} bytes`,
+        "attachments",
+      );
+    }
+    return { name, sizeBytes: attachment.sizeBytes };
+  });
+}
+
+export function guardHistoryWindow(events = []) {
+  if (!Array.isArray(events)) {
+    throw new MacroGuardError("history events must be an array", "history");
+  }
+  if (events.length > MACRO_GUARD_LIMITS.MAX_HISTORY_EVENTS) {
+    throw new MacroGuardError(
+      `history size ${events.length} exceeds ${MACRO_GUARD_LIMITS.MAX_HISTORY_EVENTS}; request a smaller window`,
+      "history",
+    );
+  }
+  return true;
+}
+
+export { ALLOWED_CATEGORIES };

--- a/tools/v1/team/customer-support-macro-tool/tests/macro-guards.test.mjs
+++ b/tools/v1/team/customer-support-macro-tool/tests/macro-guards.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  MACRO_GUARD_LIMITS,
+  MacroGuardError,
+  guardAttachmentMetadata,
+  guardHistoryWindow,
+  guardMacroBatch,
+  guardSearchOptions,
+  sanitizeMacroInput,
+  sanitizeMacroText,
+  sanitizeStoredMacro,
+  validateMacroCategory,
+  validateMacroId,
+  validateTags,
+  validateVariableMap,
+} from "../guards/macro-guards.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(join(currentDir, "..", "fixtures", "hostile-macro-inputs.json"), "utf8"),
+);
+
+const baseMacro = fixture.validMacro;
+
+function assertGuardError(fn, field) {
+  assert.throws(
+    fn,
+    (error) => error instanceof MacroGuardError && error.field === field,
+    `expected MacroGuardError for ${field}`,
+  );
+}
+
+describe("Customer Support Macro guards - text sanitization", () => {
+  for (const entry of fixture.sanitizationCases) {
+    it(`sanitizes ${entry.field}`, () => {
+      assert.equal(sanitizeMacroText(entry.input), entry.expected);
+    });
+  }
+
+  it("returns an empty string for non-string text", () => {
+    assert.equal(sanitizeMacroText(null), "");
+    assert.equal(sanitizeMacroText(42), "");
+  });
+
+  it("truncates text to the provided limit", () => {
+    assert.equal(sanitizeMacroText("abcdef", 3), "abc");
+  });
+});
+
+describe("Customer Support Macro guards - field validators", () => {
+  it("accepts safe macro ids", () => {
+    assert.equal(validateMacroId("macro_safe-001"), "macro_safe-001");
+  });
+
+  it("rejects path-like ids", () => {
+    assertGuardError(() => validateMacroId("../../macros"), "id");
+  });
+
+  it("accepts allowlisted categories", () => {
+    assert.equal(validateMacroCategory("refund"), "refund");
+    assert.equal(validateMacroCategory("technical"), "technical");
+  });
+
+  it("rejects unsupported categories", () => {
+    assertGuardError(() => validateMacroCategory("live-inbox"), "category");
+  });
+
+  it("normalizes safe tags", () => {
+    assert.deepEqual(validateTags([" Billing ", "<b>Urgent</b>"]), ["billing", "urgent"]);
+  });
+
+  it("rejects too many tags", () => {
+    const tags = Array.from({ length: MACRO_GUARD_LIMITS.MAX_TAG_COUNT + 1 }, (_, index) => {
+      return `tag-${index}`;
+    });
+    assertGuardError(() => validateTags(tags), "tags");
+  });
+});
+
+describe("Customer Support Macro guards - macro input", () => {
+  it("returns a sanitized copy without mutating input", () => {
+    const input = {
+      title: " <b>Refund</b>\u0000 update ",
+      body: "Hi\u200b {{customer_name}}, refund approved.",
+      category: "refund",
+      tags: [" Billing "],
+    };
+
+    const sanitized = sanitizeMacroInput(input);
+    assert.equal(sanitized.title, "Refund update");
+    assert.equal(sanitized.body, "Hi {{customer_name}}, refund approved.");
+    assert.deepEqual(sanitized.tags, ["billing"]);
+    assert.equal(input.title, " <b>Refund</b>\u0000 update ");
+  });
+
+  for (const entry of fixture.hostileMacros) {
+    it(`rejects ${entry.id}: ${entry.reason}`, () => {
+      assertGuardError(() => sanitizeStoredMacro({ ...baseMacro, ...entry.patch }), entry.field);
+    });
+  }
+
+  it("rejects non-object macro input", () => {
+    assertGuardError(() => sanitizeMacroInput(null), "input");
+    assertGuardError(() => sanitizeMacroInput([]), "input");
+  });
+
+  it("guards and sanitizes a bounded macro batch", () => {
+    const result = guardMacroBatch([baseMacro]);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, baseMacro.id);
+    assert.deepEqual(result[0].tags, ["refund", "status"]);
+  });
+
+  it("rejects oversized macro batches before scanning", () => {
+    const macros = Array.from(
+      { length: MACRO_GUARD_LIMITS.MAX_MACRO_BATCH_SIZE + 1 },
+      (_, index) => ({
+        ...baseMacro,
+        id: `macro_${index}`,
+      }),
+    );
+
+    assertGuardError(() => guardMacroBatch(macros), "macros");
+  });
+});
+
+describe("Customer Support Macro guards - variables and search", () => {
+  it("sanitizes variable values", () => {
+    const variables = validateVariableMap(fixture.validVariables);
+    assert.equal(variables.customer_name, "Avery Stone");
+    assert.equal(variables.order_id, "ORD-123");
+  });
+
+  it("rejects invalid variable names", () => {
+    assertGuardError(() => validateVariableMap({ "../customer": "Avery" }), "variables");
+  });
+
+  it("rejects too many variables", () => {
+    const variables = Object.fromEntries(
+      Array.from({ length: MACRO_GUARD_LIMITS.MAX_VARIABLE_COUNT + 1 }, (_, index) => [
+        `var_${index}`,
+        "value",
+      ]),
+    );
+    assertGuardError(() => validateVariableMap(variables), "variables");
+  });
+
+  it("guards search options", () => {
+    const options = guardSearchOptions({
+      query: "<b>refund</b>\u0000",
+      category: "refund",
+      tags: [" Billing "],
+      favoritesOnly: true,
+    });
+
+    assert.equal(options.query, "refund");
+    assert.equal(options.category, "refund");
+    assert.deepEqual(options.tags, ["billing"]);
+    assert.equal(options.favoritesOnly, true);
+  });
+});
+
+describe("Customer Support Macro guards - collection limits", () => {
+  it("rejects attachment content and accepts metadata", () => {
+    const metadata = guardAttachmentMetadata([
+      {
+        name: fixture.sanitizationCases[2].input,
+        sizeBytes: 1024,
+      },
+    ]);
+
+    assert.equal(metadata[0].name, fixture.sanitizationCases[2].expected);
+    assertGuardError(
+      () => guardAttachmentMetadata([{ name: "macro.csv", sizeBytes: 10, content: "raw" }]),
+      "attachments",
+    );
+  });
+
+  it("rejects oversized attachment lists", () => {
+    const attachments = Array.from(
+      { length: MACRO_GUARD_LIMITS.MAX_ATTACHMENT_COUNT + 1 },
+      (_, index) => ({
+        name: `file-${index}.csv`,
+        sizeBytes: 100,
+      }),
+    );
+
+    assertGuardError(() => guardAttachmentMetadata(attachments), "attachments");
+  });
+
+  it("rejects oversized history windows", () => {
+    const history = Array.from(
+      { length: MACRO_GUARD_LIMITS.MAX_HISTORY_EVENTS + 1 },
+      (_, index) => ({
+        id: `event-${index}`,
+      }),
+    );
+
+    assertGuardError(() => guardHistoryWindow(history), "history");
+  });
+});


### PR DESCRIPTION
Closes #4

## Summary
- add folder-local Customer Support Macro guard helpers for macro input, stored macro records, variables, search options, attachment metadata, histories, and oversized batches
- add hostile input fixtures covering path-like ids, unsupported categories, malformed timestamps, bad stored flags, unsafe text, and invalid shapes
- document security assumptions, unsafe input handling, performance limits, and future adapter requirements

## Scope
- only touches `tools/v1/team/customer-support-macro-tool/`
- no app shell, dashboard, routing, inbox, compose, auth, wallet, Stellar, database, notification, provider, AI provider, or design-system integration
- no production data, live network calls, server persistence, secrets, webhooks, background jobs, send actions, save actions, compose insertion, or mailbox mutation

## Validation
- `node --test tools/v1/team/customer-support-macro-tool/tests/macro-guards.test.mjs`
- `npx --yes prettier --check tools/v1/team/customer-support-macro-tool/guards/macro-guards.mjs tools/v1/team/customer-support-macro-tool/fixtures/hostile-macro-inputs.json tools/v1/team/customer-support-macro-tool/docs/SECURITY_AND_PERFORMANCE.md tools/v1/team/customer-support-macro-tool/tests/macro-guards.test.mjs`
- `git diff --cached --check`
- ASCII scan over changed Customer Support Macro Tool files

## Existing suite note
- attempted `npx --yes vitest run --config tools/v1/team/customer-support-macro-tool/vitest.config.ts tools/v1/team/customer-support-macro-tool/tests/macro.service.test.ts tools/v1/team/customer-support-macro-tool/tests/storage.service.test.ts tools/v1/team/customer-support-macro-tool/tests/macro.helpers.test.ts`
- blocked before tests ran because local project dependencies are unavailable from the tool config: `vitest/config`
- runtime services, hooks, fixtures, and existing Vitest tests were not changed
