### PR TITLE
fix: add read receipt payload validation and route tests

### DIFF
--- a/src/routes/api/v1/receipts/$messageId/read.ts
+++ b/src/routes/api/v1/receipts/$messageId/read.ts
@@ -1,10 +1,17 @@
+import { z } from "zod";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema } from "@/server/api/domain";
+import { ApiError } from "@/server/api/errors";
 import { getReceipt, markReceiptRead } from "@/server/api/receipt-service";
+import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const payloadSchema = z.object({
+  readAt: z.string().datetime(),
+});
 
 export const Route = createFileRoute("/api/v1/receipts/$messageId/read")({
   server: {
@@ -13,9 +20,22 @@ export const Route = createFileRoute("/api/v1/receipts/$messageId/read")({
         handleApiRequest(request, async () => {
           const repository = getApiContext().repository;
           const messageId = hash32Schema.parse(params.messageId);
+
+          const payload = await parseJsonBody(request, payloadSchema);
+          const readAt = new Date(payload.readAt);
+
           const current = await getReceipt(repository, messageId);
           requireActorMatches(request, current.recipient);
-          const receipt = await markReceiptRead(repository, messageId);
+
+          if (readAt.getTime() < new Date(current.deliveredAt).getTime()) {
+            throw new ApiError(
+              400,
+              "bad_request",
+              "Read timestamp cannot be before delivery timestamp",
+            );
+          }
+
+          const receipt = await markReceiptRead(repository, messageId, readAt);
           return apiSuccess(request, receipt);
         }),
     },

--- a/tests/unit/api/read-receipt-route.test.ts
+++ b/tests/unit/api/read-receipt-route.test.ts
@@ -27,7 +27,11 @@ describe("POST /api/v1/receipts/:messageId/read", () => {
 
   it("marks a receipt as read when requested by the recipient", async () => {
     const repository = getApiContext().repository;
-    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+    await createDeliveryReceipt(
+      repository,
+      { messageId, recipient, sender },
+      new Date("2026-07-17T12:00:00Z"),
+    );
 
     const request = createRequest({ readAt: "2026-07-17T12:05:00Z" });
     const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
@@ -47,7 +51,11 @@ describe("POST /api/v1/receipts/:messageId/read", () => {
 
   it("rejects unauthorized actors", async () => {
     const repository = getApiContext().repository;
-    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+    await createDeliveryReceipt(
+      repository,
+      { messageId, recipient, sender },
+      new Date("2026-07-17T12:00:00Z"),
+    );
 
     const request = createRequest({ readAt: "2026-07-17T12:05:00Z" }, sender); // unauthorized, sender can't mark read
     const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
@@ -59,7 +67,11 @@ describe("POST /api/v1/receipts/:messageId/read", () => {
 
   it("rejects invalid payloads", async () => {
     const repository = getApiContext().repository;
-    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+    await createDeliveryReceipt(
+      repository,
+      { messageId, recipient, sender },
+      new Date("2026-07-17T12:00:00Z"),
+    );
 
     const request = createRequest({ readAt: "not-a-date" });
     const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
@@ -71,13 +83,20 @@ describe("POST /api/v1/receipts/:messageId/read", () => {
 
   it("rejects duplicate read receipts deterministically", async () => {
     const repository = getApiContext().repository;
-    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+    await createDeliveryReceipt(
+      repository,
+      { messageId, recipient, sender },
+      new Date("2026-07-17T12:00:00Z"),
+    );
 
     const request1 = createRequest({ readAt: "2026-07-17T12:05:00Z" });
     await Route.options.server.handlers.POST({ request: request1, params: { messageId } });
 
     const request2 = createRequest({ readAt: "2026-07-17T12:06:00Z" });
-    const response2 = await Route.options.server.handlers.POST({ request: request2, params: { messageId } });
+    const response2 = await Route.options.server.handlers.POST({
+      request: request2,
+      params: { messageId },
+    });
 
     expect(response2.status).toBe(409);
     const body = await response2.json();
@@ -86,7 +105,11 @@ describe("POST /api/v1/receipts/:messageId/read", () => {
 
   it("rejects stale timestamps (before delivery)", async () => {
     const repository = getApiContext().repository;
-    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+    await createDeliveryReceipt(
+      repository,
+      { messageId, recipient, sender },
+      new Date("2026-07-17T12:00:00Z"),
+    );
 
     const request = createRequest({ readAt: "2026-07-17T11:00:00Z" }); // before delivery
     const response = await Route.options.server.handlers.POST({ request, params: { messageId } });

--- a/tests/unit/api/read-receipt-route.test.ts
+++ b/tests/unit/api/read-receipt-route.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { Route } from "../../../src/routes/api/v1/receipts/$messageId/read";
+import { getApiContext } from "../../../src/server/api/context";
+import { createDeliveryReceipt } from "../../../src/server/api/receipt-service";
+
+const messageId = "a".repeat(64);
+const recipient = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+
+describe("POST /api/v1/receipts/:messageId/read", () => {
+  beforeEach(() => {
+    getApiContext().repository.reset?.();
+  });
+
+  const createRequest = (body: unknown, actor: string = recipient) => {
+    return new Request(`https://stealth.test/api/v1/receipts/${messageId}/read`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-stealth-address": actor,
+      },
+      body: JSON.stringify(body),
+    });
+  };
+
+  it("marks a receipt as read when requested by the recipient", async () => {
+    const repository = getApiContext().repository;
+    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+
+    const request = createRequest({ readAt: "2026-07-17T12:05:00Z" });
+    const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      messageId,
+      recipient,
+      sender,
+      readAt: "2026-07-17T12:05:00.000Z",
+    });
+
+    const stored = await repository.getReceipt(messageId);
+    expect(stored?.readAt).toBe("2026-07-17T12:05:00.000Z");
+  });
+
+  it("rejects unauthorized actors", async () => {
+    const repository = getApiContext().repository;
+    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+
+    const request = createRequest({ readAt: "2026-07-17T12:05:00Z" }, sender); // unauthorized, sender can't mark read
+    const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("forbidden");
+  });
+
+  it("rejects invalid payloads", async () => {
+    const repository = getApiContext().repository;
+    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+
+    const request = createRequest({ readAt: "not-a-date" });
+    const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("validation_error");
+  });
+
+  it("rejects duplicate read receipts deterministically", async () => {
+    const repository = getApiContext().repository;
+    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+
+    const request1 = createRequest({ readAt: "2026-07-17T12:05:00Z" });
+    await Route.options.server.handlers.POST({ request: request1, params: { messageId } });
+
+    const request2 = createRequest({ readAt: "2026-07-17T12:06:00Z" });
+    const response2 = await Route.options.server.handlers.POST({ request: request2, params: { messageId } });
+
+    expect(response2.status).toBe(409);
+    const body = await response2.json();
+    expect(body.error.code).toBe("conflict");
+  });
+
+  it("rejects stale timestamps (before delivery)", async () => {
+    const repository = getApiContext().repository;
+    await createDeliveryReceipt(repository, { messageId, recipient, sender }, new Date("2026-07-17T12:00:00Z"));
+
+    const request = createRequest({ readAt: "2026-07-17T11:00:00Z" }); // before delivery
+    const response = await Route.options.server.handlers.POST({ request, params: { messageId } });
+
+    expect(response.status).toBe(400); // 400 Bad Request
+    const body = await response.json();
+    expect(body.error.code).toBe("bad_request");
+  });
+});


### PR DESCRIPTION
# Add receipt read-state validation tests

## Description
This PR addresses the issue of improving the reliability and security of the read receipt publishing route `src/routes/api/v1/receipts/$messageId/read.ts` by ensuring it properly rejects invalid actors, malformed payloads, deterministic duplicates, and stale timestamps. 

## Proposed Changes
- **Payload Validation**: Added JSON body parsing in the read route to extract and validate the `readAt` timestamp, rejecting invalid payloads with a `422 Unprocessable Entity` (`validation_error`) response.
- **Timestamp Validation**: Implemented logic to reject stale read receipt timestamps (i.e. timestamps occurring before the original delivery timestamp) with a `400 Bad Request`.
- **Route Tests**: Created a new route-level test file `tests/unit/api/read-receipt-route.test.ts` to fully cover:
  - Valid payloads and successful operations
  - Invalid payloads
  - Unauthorized actors (e.g. non-recipients) rejecting with `403 Forbidden`
  - Deterministic rejection of duplicate read receipts with `409 Conflict`
  - Stale timestamps

Closes 