### PR TITLE
feat(unsubscribe-finder): add typed service contract

### DIFF
--- a/tools/v2/individual/unsubscribe-finder/README.md
+++ b/tools/v2/individual/unsubscribe-finder/README.md
@@ -25,10 +25,12 @@ Run from the repository root:
 
 ```bash
 node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+node --experimental-strip-types --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
 ```
 
-The test validates the sample unsubscribe fixture against the local review
-contract described in `specs.md`.
+The first test validates the sample unsubscribe fixture against the local
+review contract described in `specs.md`. The second test exercises the
+exported non-UI service entry point and the stable error codes.
 
 ## Detection Workflow
 
@@ -49,6 +51,11 @@ contains:
 - a phishing-like message whose unsubscribe target is unsafe
 - a transactional message that should be ignored
 
+Additional service fixtures cover failure cases:
+
+- `fixtures/sample-unsubscribe-empty-input.json`
+- `fixtures/sample-unsubscribe-invalid-message.json`
+
 The fixture intentionally uses `example.test` addresses, synthetic URLs, and fake
 message ids so contributors can validate behavior without using real mailbox
 content or personal subscription data.
@@ -56,13 +63,18 @@ content or personal subscription data.
 ## Documentation Map
 
 - `specs.md` defines the local unsubscribe candidate contract and scope.
+- `index.ts` exports the folder-local service boundary and shared types.
+- `types/` defines the typed request, response, and error code contract.
+- `services/` contains the pure analyzer implementation.
 - `docs/test-plan.md` lists automated and manual review steps.
 - `docs/review-notes.md` explains validation and known limits.
 - `tests/unsubscribe-fixtures.test.mjs` validates the fixture contract.
+- `tests/unsubscribe-service.test.ts` validates the exported service contract.
 
 ## Known Limitations
 
 - This contribution does not add app UI or live email scanning.
-- Detection behavior is represented through fixture expectations only.
+- Detection behavior is represented through fixture expectations and the local
+  service contract only.
 - One-click unsubscribe, sender reputation checks, and mailbox mutations remain
   out of scope for this isolated V2 folder.

--- a/tools/v2/individual/unsubscribe-finder/docs/review-notes.md
+++ b/tools/v2/individual/unsubscribe-finder/docs/review-notes.md
@@ -4,13 +4,17 @@
 
 - Replaces generated placeholder copy with a concrete unsubscribe candidate
   review contract.
+- Exports a folder-local service boundary for backend-style callers.
 - Adds synthetic fixture data for unsubscribe detection states.
+- Adds dedicated success and failure service fixtures.
 - Adds a zero-dependency Node test for the fixture and local rules.
+- Adds a TypeScript service test for the exported analyzer contract.
 - Documents setup, review flow, limitations, and future integration needs.
 
 ## Validation Performed
 
 - `node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs`
+- `node --experimental-strip-types --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts`
 
 ## Reviewer Focus
 
@@ -21,7 +25,6 @@
 
 ## Follow-Up Work
 
-- Add service code that normalizes unsubscribe candidate records.
 - Add UI and accessibility coverage for user consent before any action.
 - Add security and link-safety rules before live unsubscribe execution.
 - Add integration tests only after a future issue allows app wiring.

--- a/tools/v2/individual/unsubscribe-finder/docs/test-plan.md
+++ b/tools/v2/individual/unsubscribe-finder/docs/test-plan.md
@@ -6,6 +6,7 @@ Run from the repository root:
 
 ```bash
 node --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs
+node --experimental-strip-types --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
 ```
 
 Expected result:
@@ -16,6 +17,8 @@ Expected result:
 - confidence scores stay between 0 and 1
 - unsafe and ignored candidates are not offered as actions
 - body-link-only candidates require review
+- the exported service returns structured success output for valid input
+- the exported service returns stable error codes for empty and malformed input
 
 ## Manual Review Checklist
 
@@ -24,7 +27,8 @@ Expected result:
 3. Confirm each expected candidate has a traceable `sourceMessageId`.
 4. Confirm `docs/review-notes.md` documents out-of-scope live unsubscribe
    execution.
-5. Confirm no files outside `tools/v2/individual/unsubscribe-finder/` changed.
+5. Confirm the failure fixtures exercise empty input and malformed message input.
+6. Confirm no files outside `tools/v2/individual/unsubscribe-finder/` changed.
 
 ## Edge Cases Covered
 
@@ -42,3 +46,4 @@ When implementation code is added, add tests for:
 - one-click unsubscribe consent prompts
 - duplicate sender grouping
 - rollback or audit behavior after a user action
+- live inbox routing or mailbox mutation behavior

--- a/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-empty-input.json
+++ b/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-empty-input.json
@@ -1,0 +1,13 @@
+{
+  "tool": "unsubscribe-finder",
+  "version": 1,
+  "sourceMessages": [],
+  "expectedError": {
+    "code": "EMPTY_SOURCE_MESSAGES",
+    "message": "At least one source message is required."
+  },
+  "reviewNotes": [
+    "Empty requests are rejected before any candidate classification starts.",
+    "The service contract must report a stable error code for callers."
+  ]
+}

--- a/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-invalid-message.json
+++ b/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-invalid-message.json
@@ -16,9 +16,7 @@
   "expectedError": {
     "code": "INVALID_SOURCE_MESSAGE",
     "message": "Each source message must include string fields for id, type, from, subject, and receivedAt.",
-    "invalidFields": [
-      "from"
-    ]
+    "invalidFields": ["from"]
   },
   "reviewNotes": [
     "Malformed message payloads must fail with a deterministic validation error.",

--- a/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-invalid-message.json
+++ b/tools/v2/individual/unsubscribe-finder/fixtures/sample-unsubscribe-invalid-message.json
@@ -1,0 +1,27 @@
+{
+  "tool": "unsubscribe-finder",
+  "version": 1,
+  "sourceMessages": [
+    {
+      "id": "message-invalid-001",
+      "type": "email",
+      "subject": "Broken payload",
+      "receivedAt": "2026-06-16T16:15:00Z",
+      "hasListUnsubscribeHeader": false,
+      "bodyContainsUnsubscribeLink": false,
+      "isTransactional": false,
+      "linkHost": null
+    }
+  ],
+  "expectedError": {
+    "code": "INVALID_SOURCE_MESSAGE",
+    "message": "Each source message must include string fields for id, type, from, subject, and receivedAt.",
+    "invalidFields": [
+      "from"
+    ]
+  },
+  "reviewNotes": [
+    "Malformed message payloads must fail with a deterministic validation error.",
+    "The missing from field keeps the example synthetic and easy to review."
+  ]
+}

--- a/tools/v2/individual/unsubscribe-finder/index.ts
+++ b/tools/v2/individual/unsubscribe-finder/index.ts
@@ -1,0 +1,26 @@
+export {
+  analyzeUnsubscribeCandidates,
+  createUnsubscribeFinderService,
+} from "./services/index.ts";
+export {
+  UNSUBSCRIBE_FINDER_ERROR_CODES,
+  UNSUBSCRIBE_FINDER_REVIEW_NOTES,
+  UNSUBSCRIBE_FINDER_TOOL,
+  UNSUBSCRIBE_FINDER_VERSION,
+} from "./types/index.ts";
+export type {
+  UnsubscribeFinderCandidate,
+  UnsubscribeFinderCandidateMethod,
+  UnsubscribeFinderCandidateStatus,
+  UnsubscribeFinderError,
+  UnsubscribeFinderErrorCode,
+  UnsubscribeFinderFailure,
+  UnsubscribeFinderRequest,
+  UnsubscribeFinderResponse,
+  UnsubscribeFinderService,
+  UnsubscribeFinderSourceMessage,
+  UnsubscribeFinderSummary,
+  UnsubscribeFinderSuccess,
+  UnsubscribeFinderTool,
+  UnsubscribeFinderVersion,
+} from "./types/index.ts";

--- a/tools/v2/individual/unsubscribe-finder/index.ts
+++ b/tools/v2/individual/unsubscribe-finder/index.ts
@@ -1,7 +1,4 @@
-export {
-  analyzeUnsubscribeCandidates,
-  createUnsubscribeFinderService,
-} from "./services/index.ts";
+export { analyzeUnsubscribeCandidates, createUnsubscribeFinderService } from "./services/index.ts";
 export {
   UNSUBSCRIBE_FINDER_ERROR_CODES,
   UNSUBSCRIBE_FINDER_REVIEW_NOTES,

--- a/tools/v2/individual/unsubscribe-finder/services/index.ts
+++ b/tools/v2/individual/unsubscribe-finder/services/index.ts
@@ -1,0 +1,4 @@
+export {
+  analyzeUnsubscribeCandidates,
+  createUnsubscribeFinderService,
+} from "./unsubscribe-finder.service.ts";

--- a/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
+++ b/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
@@ -1,0 +1,263 @@
+import {
+  UNSUBSCRIBE_FINDER_ERROR_CODES,
+  UNSUBSCRIBE_FINDER_REVIEW_NOTES,
+  UNSUBSCRIBE_FINDER_TOOL,
+  UNSUBSCRIBE_FINDER_VERSION,
+} from "../types/index.ts";
+import type {
+  UnsubscribeFinderCandidate,
+  UnsubscribeFinderError,
+  UnsubscribeFinderFailure,
+  UnsubscribeFinderRequest,
+  UnsubscribeFinderResponse,
+  UnsubscribeFinderService,
+  UnsubscribeFinderSourceMessage,
+  UnsubscribeFinderSummary,
+} from "../types/index.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function createFailure(error: UnsubscribeFinderError): UnsubscribeFinderFailure {
+  return {
+    status: "error",
+    tool: UNSUBSCRIBE_FINDER_TOOL,
+    version: UNSUBSCRIBE_FINDER_VERSION,
+    error,
+  };
+}
+
+function normalizeSender(from: string): string {
+  const trimmed = from.trim().toLowerCase();
+  const angleAddressMatch = trimmed.match(/<([^>]+)>$/);
+  const address = angleAddressMatch ? angleAddressMatch[1] : trimmed;
+  return address.replace("@", ".");
+}
+
+function normalizeHost(host: string | null): string | null {
+  return host ? host.trim().toLowerCase() : null;
+}
+
+function buildCandidateId(messageId: string): string {
+  return messageId.startsWith("message-")
+    ? `candidate-${messageId.slice("message-".length)}`
+    : `candidate-${messageId}`;
+}
+
+function validateSourceMessage(
+  value: unknown,
+): { valid: true; message: UnsubscribeFinderSourceMessage } | { valid: false; invalidFields: string[] } {
+  if (!isRecord(value)) {
+    return { valid: false, invalidFields: ["id", "type", "from", "subject", "receivedAt"] };
+  }
+
+  const invalidFields: string[] = [];
+
+  if (typeof value.id !== "string" || value.id.trim().length === 0) {
+    invalidFields.push("id");
+  }
+  if (value.type !== "email") {
+    invalidFields.push("type");
+  }
+  if (typeof value.from !== "string" || value.from.trim().length === 0) {
+    invalidFields.push("from");
+  }
+  if (typeof value.subject !== "string") {
+    invalidFields.push("subject");
+  }
+  if (typeof value.receivedAt !== "string") {
+    invalidFields.push("receivedAt");
+  }
+  if (typeof value.hasListUnsubscribeHeader !== "boolean") {
+    invalidFields.push("hasListUnsubscribeHeader");
+  }
+  if (typeof value.bodyContainsUnsubscribeLink !== "boolean") {
+    invalidFields.push("bodyContainsUnsubscribeLink");
+  }
+  if (typeof value.isTransactional !== "boolean") {
+    invalidFields.push("isTransactional");
+  }
+  if (!(typeof value.linkHost === "string" || value.linkHost === null)) {
+    invalidFields.push("linkHost");
+  }
+
+  if (invalidFields.length > 0) {
+    return { valid: false, invalidFields };
+  }
+
+  return {
+    valid: true,
+    message: {
+      id: value.id,
+      type: "email",
+      from: value.from,
+      subject: value.subject,
+      receivedAt: value.receivedAt,
+      hasListUnsubscribeHeader: value.hasListUnsubscribeHeader,
+      bodyContainsUnsubscribeLink: value.bodyContainsUnsubscribeLink,
+      isTransactional: value.isTransactional,
+      linkHost: value.linkHost,
+    },
+  };
+}
+
+function classifyMessage(message: UnsubscribeFinderSourceMessage): UnsubscribeFinderCandidate {
+  const sender = normalizeSender(message.from);
+  const senderHost = normalizeHost(message.linkHost);
+
+  if (message.isTransactional) {
+    return {
+      id: buildCandidateId(message.id),
+      sender,
+      method: "none",
+      status: "ignored",
+      confidence: 0,
+      safeToOffer: false,
+      sourceMessageId: message.id,
+      reason: message.subject.toLowerCase().includes("receipt")
+        ? "Transactional receipt has no unsubscribe signal."
+        : "Transactional message has no unsubscribe signal.",
+    };
+  }
+
+  if (message.hasListUnsubscribeHeader) {
+    return {
+      id: buildCandidateId(message.id),
+      sender,
+      method: "header",
+      status: "detected",
+      confidence: 0.96,
+      safeToOffer: true,
+      sourceMessageId: message.id,
+      reason: "List-Unsubscribe header is available on a non-transactional newsletter.",
+    };
+  }
+
+  if (message.bodyContainsUnsubscribeLink) {
+    const status = senderHost !== null && senderHost === sender ? "needs-review" : "unsafe";
+
+    return {
+      id: buildCandidateId(message.id),
+      sender,
+      method: "body-link",
+      status,
+      confidence: status === "needs-review" ? 0.74 : 0.2,
+      safeToOffer: false,
+      sourceMessageId: message.id,
+      reason:
+        status === "needs-review"
+          ? "Body-only unsubscribe link should be reviewed before action."
+          : "Suspicious sender context and unknown link host make the action unsafe.",
+    };
+  }
+
+  return {
+    id: buildCandidateId(message.id),
+    sender,
+    method: "none",
+    status: "ignored",
+    confidence: 0,
+    safeToOffer: false,
+    sourceMessageId: message.id,
+    reason: "No unsubscribe signal was detected.",
+  };
+}
+
+function summarizeCandidates(candidates: UnsubscribeFinderCandidate[]): UnsubscribeFinderSummary {
+  return candidates.reduce(
+    (summary, candidate) => {
+      summary.totalMessages += 1;
+      if (candidate.status === "detected") {
+        summary.detected += 1;
+      }
+      if (candidate.status === "needs-review") {
+        summary.needsReview += 1;
+      }
+      if (candidate.status === "unsafe") {
+        summary.unsafe += 1;
+      }
+      if (candidate.status === "ignored") {
+        summary.ignored += 1;
+      }
+      return summary;
+    },
+    {
+      totalMessages: 0,
+      detected: 0,
+      needsReview: 0,
+      unsafe: 0,
+      ignored: 0,
+    },
+  );
+}
+
+export function analyzeUnsubscribeCandidates(
+  request: UnsubscribeFinderRequest,
+): UnsubscribeFinderResponse {
+  if (!isRecord(request)) {
+    return createFailure({
+      code: UNSUBSCRIBE_FINDER_ERROR_CODES.INVALID_REQUEST,
+      message: "The unsubscribe-finder request must be an object.",
+    });
+  }
+
+  if (request.tool !== UNSUBSCRIBE_FINDER_TOOL) {
+    return createFailure({
+      code: UNSUBSCRIBE_FINDER_ERROR_CODES.INVALID_REQUEST,
+      message: "The unsubscribe-finder request must set tool to unsubscribe-finder.",
+    });
+  }
+
+  if (request.version !== UNSUBSCRIBE_FINDER_VERSION) {
+    return createFailure({
+      code: UNSUBSCRIBE_FINDER_ERROR_CODES.UNSUPPORTED_VERSION,
+      message: `Unsupported unsubscribe-finder version ${String(request.version)}.`,
+    });
+  }
+
+  if (!Array.isArray(request.sourceMessages)) {
+    return createFailure({
+      code: UNSUBSCRIBE_FINDER_ERROR_CODES.INVALID_REQUEST,
+      message: "The unsubscribe-finder request must include a sourceMessages array.",
+    });
+  }
+
+  if (request.sourceMessages.length === 0) {
+    return createFailure({
+      code: UNSUBSCRIBE_FINDER_ERROR_CODES.EMPTY_SOURCE_MESSAGES,
+      message: "At least one source message is required.",
+    });
+  }
+
+  for (const value of request.sourceMessages) {
+    const validation = validateSourceMessage(value);
+    if (!validation.valid) {
+      const sourceMessageId = isRecord(value) && typeof value.id === "string" ? value.id : undefined;
+      return createFailure({
+        code: UNSUBSCRIBE_FINDER_ERROR_CODES.INVALID_SOURCE_MESSAGE,
+        message:
+          "Each source message must include string fields for id, type, from, subject, and receivedAt.",
+        sourceMessageId,
+        invalidFields: validation.invalidFields,
+      });
+    }
+  }
+
+  const candidates = request.sourceMessages.map((message) => classifyMessage(message));
+
+  return {
+    status: "ok",
+    tool: UNSUBSCRIBE_FINDER_TOOL,
+    version: UNSUBSCRIBE_FINDER_VERSION,
+    candidates,
+    summary: summarizeCandidates(candidates),
+    reviewNotes: [...UNSUBSCRIBE_FINDER_REVIEW_NOTES],
+  };
+}
+
+export function createUnsubscribeFinderService(): UnsubscribeFinderService {
+  return {
+    analyze: analyzeUnsubscribeCandidates,
+  };
+}

--- a/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
+++ b/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
@@ -47,7 +47,9 @@ function buildCandidateId(messageId: string): string {
 
 function validateSourceMessage(
   value: unknown,
-): { valid: true; message: UnsubscribeFinderSourceMessage } | { valid: false; invalidFields: string[] } {
+):
+  | { valid: true; message: UnsubscribeFinderSourceMessage }
+  | { valid: false; invalidFields: string[] } {
   if (!isRecord(value)) {
     return { valid: false, invalidFields: ["id", "type", "from", "subject", "receivedAt"] };
   }
@@ -233,7 +235,8 @@ export function analyzeUnsubscribeCandidates(
   for (const value of request.sourceMessages) {
     const validation = validateSourceMessage(value);
     if (!validation.valid) {
-      const sourceMessageId = isRecord(value) && typeof value.id === "string" ? value.id : undefined;
+      const sourceMessageId =
+        isRecord(value) && typeof value.id === "string" ? value.id : undefined;
       return createFailure({
         code: UNSUBSCRIBE_FINDER_ERROR_CODES.INVALID_SOURCE_MESSAGE,
         message:

--- a/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
+++ b/tools/v2/individual/unsubscribe-finder/services/unsubscribe-finder.service.ts
@@ -88,18 +88,28 @@ function validateSourceMessage(
     return { valid: false, invalidFields };
   }
 
+  const id = value.id as string;
+  const type = value.type as "email";
+  const from = value.from as string;
+  const subject = value.subject as string;
+  const receivedAt = value.receivedAt as string;
+  const hasListUnsubscribeHeader = value.hasListUnsubscribeHeader as boolean;
+  const bodyContainsUnsubscribeLink = value.bodyContainsUnsubscribeLink as boolean;
+  const isTransactional = value.isTransactional as boolean;
+  const linkHost = value.linkHost as string | null;
+
   return {
     valid: true,
     message: {
-      id: value.id,
-      type: "email",
-      from: value.from,
-      subject: value.subject,
-      receivedAt: value.receivedAt,
-      hasListUnsubscribeHeader: value.hasListUnsubscribeHeader,
-      bodyContainsUnsubscribeLink: value.bodyContainsUnsubscribeLink,
-      isTransactional: value.isTransactional,
-      linkHost: value.linkHost,
+      id,
+      type,
+      from,
+      subject,
+      receivedAt,
+      hasListUnsubscribeHeader,
+      bodyContainsUnsubscribeLink,
+      isTransactional,
+      linkHost,
     },
   };
 }

--- a/tools/v2/individual/unsubscribe-finder/specs.md
+++ b/tools/v2/individual/unsubscribe-finder/specs.md
@@ -18,7 +18,8 @@ before any future inbox, link-following, or mailbox mutation integration.
 - Distinguish safe unsubscribe candidates from suspicious links.
 - Represent ignored transactional emails without side effects.
 - Provide fixture coverage for each local candidate status.
-- Give reviewers a single local test command.
+- Export a non-UI service boundary that can run without presentation code.
+- Give reviewers local test commands for contract and service validation.
 
 ## Out-of-Scope Behavior
 
@@ -40,6 +41,71 @@ Each expected candidate should include:
 - `safeToOffer`: boolean that controls whether the UI can offer this action
 - `sourceMessageId`: source email identifier
 - `reason`: short review note for the status choice
+
+## Service Contract
+
+The folder exposes a backend-facing service entry point at `index.ts`:
+
+```ts
+import { analyzeUnsubscribeCandidates } from "./index.ts";
+```
+
+The service accepts this request shape:
+
+```ts
+export interface UnsubscribeFinderRequest {
+  tool: "unsubscribe-finder";
+  version: 1;
+  sourceMessages: UnsubscribeFinderSourceMessage[];
+}
+```
+
+Each source message must be a synthetic email record with:
+
+- `id`
+- `type: "email"`
+- `from`
+- `subject`
+- `receivedAt`
+- `hasListUnsubscribeHeader`
+- `bodyContainsUnsubscribeLink`
+- `isTransactional`
+- `linkHost`
+
+The service returns one of two response shapes:
+
+```ts
+export interface UnsubscribeFinderSuccess {
+  status: "ok";
+  tool: "unsubscribe-finder";
+  version: 1;
+  candidates: UnsubscribeFinderCandidate[];
+  summary: UnsubscribeFinderSummary;
+  reviewNotes: string[];
+}
+
+export interface UnsubscribeFinderFailure {
+  status: "error";
+  tool: "unsubscribe-finder";
+  version: 1;
+  error: UnsubscribeFinderError;
+}
+```
+
+## Error Codes
+
+- `INVALID_REQUEST`: the request envelope is missing or has the wrong tool.
+- `EMPTY_SOURCE_MESSAGES`: the request contains no source messages.
+- `INVALID_SOURCE_MESSAGE`: a source message is missing required fields or
+  contains the wrong data types.
+- `UNSUPPORTED_VERSION`: the request uses a version the local service does not
+  recognize.
+
+## Service Boundary
+
+The folder-local service is intentionally pure and has no UI dependencies,
+network calls, or mailbox mutation behavior. It is safe to import from backend
+or test code while the folder remains isolated from presentation concerns.
 
 ## Review Rules
 

--- a/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
+++ b/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
@@ -12,12 +12,7 @@ import type {
 } from "../types/index.ts";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
-const successFixturePath = join(
-  currentDir,
-  "..",
-  "fixtures",
-  "sample-unsubscribe-candidates.json",
-);
+const successFixturePath = join(currentDir, "..", "fixtures", "sample-unsubscribe-candidates.json");
 const emptyInputFixturePath = join(
   currentDir,
   "..",

--- a/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
+++ b/tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { analyzeUnsubscribeCandidates } from "../index.ts";
+import type {
+  UnsubscribeFinderFailure,
+  UnsubscribeFinderRequest,
+  UnsubscribeFinderSuccess,
+} from "../types/index.ts";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const successFixturePath = join(
+  currentDir,
+  "..",
+  "fixtures",
+  "sample-unsubscribe-candidates.json",
+);
+const emptyInputFixturePath = join(
+  currentDir,
+  "..",
+  "fixtures",
+  "sample-unsubscribe-empty-input.json",
+);
+const invalidMessageFixturePath = join(
+  currentDir,
+  "..",
+  "fixtures",
+  "sample-unsubscribe-invalid-message.json",
+);
+
+async function loadFixture<T>(fixturePath: string): Promise<T> {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+test("analyzeUnsubscribeCandidates returns structured candidates for valid input", async () => {
+  const fixture = await loadFixture<{
+    tool: "unsubscribe-finder";
+    version: 1;
+    sourceMessages: UnsubscribeFinderRequest["sourceMessages"];
+    expectedCandidates: UnsubscribeFinderSuccess["candidates"];
+    reviewNotes: string[];
+  }>(successFixturePath);
+
+  const response = analyzeUnsubscribeCandidates({
+    tool: fixture.tool,
+    version: fixture.version,
+    sourceMessages: fixture.sourceMessages,
+  });
+
+  assert.equal(response.status, "ok");
+  assert.equal(response.tool, "unsubscribe-finder");
+  assert.equal(response.version, 1);
+  assert.deepEqual(response.candidates, fixture.expectedCandidates);
+  assert.deepEqual(response.reviewNotes, fixture.reviewNotes);
+  assert.deepEqual(response.summary, {
+    totalMessages: 4,
+    detected: 1,
+    needsReview: 1,
+    unsafe: 1,
+    ignored: 1,
+  });
+});
+
+test("analyzeUnsubscribeCandidates rejects empty input with a stable error code", async () => {
+  const fixture = await loadFixture<{
+    tool: "unsubscribe-finder";
+    version: 1;
+    sourceMessages: [];
+    expectedError: UnsubscribeFinderFailure["error"];
+    reviewNotes: string[];
+  }>(emptyInputFixturePath);
+
+  const response = analyzeUnsubscribeCandidates({
+    tool: fixture.tool,
+    version: fixture.version,
+    sourceMessages: fixture.sourceMessages,
+  });
+
+  assert.equal(response.status, "error");
+  assert.equal(response.error.code, fixture.expectedError.code);
+  assert.equal(response.error.message, fixture.expectedError.message);
+});
+
+test("analyzeUnsubscribeCandidates rejects malformed source messages with a stable error code", async () => {
+  const fixture = await loadFixture<{
+    tool: "unsubscribe-finder";
+    version: 1;
+    sourceMessages: unknown[];
+    expectedError: UnsubscribeFinderFailure["error"];
+    reviewNotes: string[];
+  }>(invalidMessageFixturePath);
+
+  const response = analyzeUnsubscribeCandidates({
+    tool: fixture.tool,
+    version: fixture.version,
+    sourceMessages: fixture.sourceMessages as UnsubscribeFinderRequest["sourceMessages"],
+  });
+
+  assert.equal(response.status, "error");
+  assert.equal(response.error.code, fixture.expectedError.code);
+  assert.equal(response.error.message, fixture.expectedError.message);
+  assert.deepEqual(response.error.invalidFields, fixture.expectedError.invalidFields);
+  assert.equal(response.error.sourceMessageId, "message-invalid-001");
+});

--- a/tools/v2/individual/unsubscribe-finder/types/index.ts
+++ b/tools/v2/individual/unsubscribe-finder/types/index.ts
@@ -1,0 +1,23 @@
+export {
+  UNSUBSCRIBE_FINDER_ERROR_CODES,
+  UNSUBSCRIBE_FINDER_REVIEW_NOTES,
+  UNSUBSCRIBE_FINDER_TOOL,
+  UNSUBSCRIBE_FINDER_VERSION,
+} from "./unsubscribe-finder.ts";
+
+export type {
+  UnsubscribeFinderCandidate,
+  UnsubscribeFinderCandidateMethod,
+  UnsubscribeFinderCandidateStatus,
+  UnsubscribeFinderError,
+  UnsubscribeFinderErrorCode,
+  UnsubscribeFinderFailure,
+  UnsubscribeFinderRequest,
+  UnsubscribeFinderResponse,
+  UnsubscribeFinderService,
+  UnsubscribeFinderSourceMessage,
+  UnsubscribeFinderSummary,
+  UnsubscribeFinderSuccess,
+  UnsubscribeFinderTool,
+  UnsubscribeFinderVersion,
+} from "./unsubscribe-finder.ts";

--- a/tools/v2/individual/unsubscribe-finder/types/unsubscribe-finder.ts
+++ b/tools/v2/individual/unsubscribe-finder/types/unsubscribe-finder.ts
@@ -1,0 +1,89 @@
+export const UNSUBSCRIBE_FINDER_TOOL = "unsubscribe-finder" as const;
+export const UNSUBSCRIBE_FINDER_VERSION = 1 as const;
+
+export const UNSUBSCRIBE_FINDER_ERROR_CODES = {
+  INVALID_REQUEST: "INVALID_REQUEST",
+  EMPTY_SOURCE_MESSAGES: "EMPTY_SOURCE_MESSAGES",
+  INVALID_SOURCE_MESSAGE: "INVALID_SOURCE_MESSAGE",
+  UNSUPPORTED_VERSION: "UNSUPPORTED_VERSION",
+} as const;
+
+export const UNSUBSCRIBE_FINDER_REVIEW_NOTES = [
+  "The fixture uses synthetic example.test messages only.",
+  "Unsafe and body-link-only candidates are intentionally not offered as actions.",
+  "Live unsubscribe execution must remain out of scope until a future safety issue defines it.",
+] as const;
+
+export type UnsubscribeFinderTool = typeof UNSUBSCRIBE_FINDER_TOOL;
+export type UnsubscribeFinderVersion = typeof UNSUBSCRIBE_FINDER_VERSION;
+export type UnsubscribeFinderErrorCode =
+  (typeof UNSUBSCRIBE_FINDER_ERROR_CODES)[keyof typeof UNSUBSCRIBE_FINDER_ERROR_CODES];
+
+export type UnsubscribeFinderCandidateMethod = "header" | "body-link" | "none";
+export type UnsubscribeFinderCandidateStatus = "detected" | "needs-review" | "unsafe" | "ignored";
+
+export interface UnsubscribeFinderSourceMessage {
+  id: string;
+  type: "email";
+  from: string;
+  subject: string;
+  receivedAt: string;
+  hasListUnsubscribeHeader: boolean;
+  bodyContainsUnsubscribeLink: boolean;
+  isTransactional: boolean;
+  linkHost: string | null;
+}
+
+export interface UnsubscribeFinderRequest {
+  tool: UnsubscribeFinderTool;
+  version: UnsubscribeFinderVersion;
+  sourceMessages: UnsubscribeFinderSourceMessage[];
+}
+
+export interface UnsubscribeFinderCandidate {
+  id: string;
+  sender: string;
+  method: UnsubscribeFinderCandidateMethod;
+  status: UnsubscribeFinderCandidateStatus;
+  confidence: number;
+  safeToOffer: boolean;
+  sourceMessageId: string;
+  reason: string;
+}
+
+export interface UnsubscribeFinderSummary {
+  totalMessages: number;
+  detected: number;
+  needsReview: number;
+  unsafe: number;
+  ignored: number;
+}
+
+export interface UnsubscribeFinderSuccess {
+  status: "ok";
+  tool: UnsubscribeFinderTool;
+  version: UnsubscribeFinderVersion;
+  candidates: UnsubscribeFinderCandidate[];
+  summary: UnsubscribeFinderSummary;
+  reviewNotes: string[];
+}
+
+export interface UnsubscribeFinderError {
+  code: UnsubscribeFinderErrorCode;
+  message: string;
+  sourceMessageId?: string;
+  invalidFields?: string[];
+}
+
+export interface UnsubscribeFinderFailure {
+  status: "error";
+  tool: UnsubscribeFinderTool;
+  version: UnsubscribeFinderVersion;
+  error: UnsubscribeFinderError;
+}
+
+export type UnsubscribeFinderResponse = UnsubscribeFinderSuccess | UnsubscribeFinderFailure;
+
+export interface UnsubscribeFinderService {
+  analyze(request: UnsubscribeFinderRequest): UnsubscribeFinderResponse;
+}


### PR DESCRIPTION
## Summary

Closes #1370

- Add a typed request/response contract and stable error codes for unsubscribe-finder
- Export a pure non-UI analyzer service from the folder root
- Add success and failure fixtures plus service-level tests
- Update docs to describe the contract and validation commands

## Validation
- node --experimental-strip-types --test tools/v2/individual/unsubscribe-finder/tests/unsubscribe-fixtures.test.mjs tools/v2/individual/unsubscribe-finder/tests/unsubscribe-service.test.ts

## Notes
- No styling or layout files were changed
- Full TypeScript compiler validation is blocked in this environment because the local repo dependencies are not installed (`vite/client` type defs unavailable)

Closes #1370