### PR TITLE
feat(sentiment-detector): add typed non-UI execution contract

### DIFF
--- a/tools/v2/individual/sentiment-detector/README.md
+++ b/tools/v2/individual/sentiment-detector/README.md
@@ -1,15 +1,57 @@
 # Sentiment Detector
 
-This folder is the isolated workspace for the Sentiment Detector tool.
+This folder is the isolated workspace for the Sentiment Detector tool. It
+analyzes sender sentiment from a message's subject and body and returns a
+typed, deterministic result.
+
+## Execution contract
+
+The non-UI entry point is exported from `index.ts`:
+
+```ts
+import { safeAnalyzeSentiment } from "tools/v2/individual/sentiment-detector";
+
+const outcome = safeAnalyzeSentiment({
+  messageId: "msg-1",
+  subject: "Great news",
+  body: "Really appreciate the quick fix!",
+});
+
+if (outcome.status === "ok") {
+  outcome.result.sentiment; // "positive" | "negative" | "neutral" | "mixed"
+}
+```
+
+- `safeAnalyzeSentiment` — guarded entry point for untrusted input; validates,
+  sanitizes, enforces limits, and never throws.
+- `analyzeSentiment` — pure engine for pre-validated input.
+- Full contract (types, error codes, scoring model): `docs/contract.md`.
+- Fixtures for success and failure paths: `services/fixtures.ts`.
+
+## Layout
+
+- `index.ts` — public barrel export (no UI code)
+- `types/` — typed input/output contract and error codes
+- `services/` — detection engine, guards, fixtures
+- `tests/` — vitest suites for the engine and guards
+- `docs/` — contract documentation
+
+## Testing
+
+From the repository root:
+
+```sh
+npx vitest run --config tools/v2/individual/sentiment-detector/vitest.config.ts
+```
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\sentiment-detector\
-`
+`tools/v2/individual/sentiment-detector/`
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.

--- a/tools/v2/individual/sentiment-detector/docs/contract.md
+++ b/tools/v2/individual/sentiment-detector/docs/contract.md
@@ -1,0 +1,108 @@
+# Sentiment Detector — Execution Contract
+
+Stable backend-facing contract for running sentiment analysis independently of
+any presentation layer. All types live in `types/sentimentDetector.ts` and are
+re-exported from the folder root `index.ts`.
+
+## Entry points
+
+| Export | Kind | Use when |
+| --- | --- | --- |
+| `safeAnalyzeSentiment(input: unknown, options?: unknown): SafeSentimentResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
+| `analyzeSentiment(input: SentimentAnalysisInput, options?: SentimentAnalysisOptions): SentimentAnalysisResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+
+Both functions are pure and deterministic: no network calls, no mailbox access,
+no randomness, no clock reads, and no mutation of caller-supplied objects.
+Identical input always produces an identical result.
+
+## Input
+
+```ts
+interface SentimentAnalysisInput {
+  messageId: string;      // required, non-empty; echoed back in the result
+  subject: string;        // may be empty when body is not
+  body: string;           // plain text; may be empty when subject is not
+  senderAddress?: string; // correlation only — never analyzed
+  receivedAt?: string;    // ISO 8601 when present
+  language?: string;      // BCP 47; only "en" / "en-*" supported
+}
+
+interface SentimentAnalysisOptions {
+  includeSignals?: boolean; // default true
+  maxSignals?: number;      // 1–100, default 25
+}
+```
+
+## Output
+
+```ts
+interface SentimentAnalysisResult {
+  messageId: string;
+  sentiment: "positive" | "negative" | "neutral" | "mixed";
+  score: number;                          // [-1, 1]; 0 = neutral / no evidence
+  confidence: "low" | "medium" | "high";  // from matched-evidence count
+  signals: SentimentSignal[];             // strongest first, truncated to maxSignals
+  stats: SentimentStats;                  // deterministic counters
+}
+```
+
+The guarded entry point wraps this in a discriminated union:
+
+```ts
+type SafeSentimentResult =
+  | { status: "ok"; result: SentimentAnalysisResult }
+  | { status: "error"; code: SentimentErrorCode; message: string; issues: SentimentIssue[] };
+```
+
+## Error codes
+
+| Code | Trigger |
+| --- | --- |
+| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options` | `includeSignals` not a boolean, or `maxSignals` outside 1–100. |
+| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
+| `empty-content` | Subject and body are both empty after sanitization. |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+
+## Scoring model
+
+Lexicon-based and folder-local:
+
+- Positive and negative term weights come from `POSITIVE_TERMS` / `NEGATIVE_TERMS`.
+- Subject matches are weighted 1.5× body matches.
+- A negation (`not`, `never`, `isn't`, …) within 2 tokens before a term flips
+  its polarity.
+- An intensifier (`very`, `extremely`, …) directly before a term boosts its
+  weight 1.5×.
+- `score = (positiveWeight − negativeWeight) / (positiveWeight + negativeWeight)`,
+  rounded to 3 decimals; 0 when nothing matches.
+- Labels: `mixed` when both polarities are present and the minority is ≥ 50% of
+  the majority; otherwise `positive`/`negative` outside the ±0.2 neutral band,
+  else `neutral`.
+- Confidence: `high` ≥ 5 matches, `medium` ≥ 2, else `low`.
+
+## Sanitization
+
+`safeAnalyzeSentiment` normalizes text to NFC and strips ASCII control
+characters and zero-width characters (U+200B–U+200D, U+2060, U+FEFF) before
+scoring, so hidden characters cannot mask lexicon terms.
+
+## Fixtures
+
+`services/fixtures.ts` exports:
+
+- `successFixtures` — positive, negative, mixed, neutral, and negation cases
+  with their expected labels.
+- `failureFixtures` — one payload per error path with its expected error code.
+
+Tests in `tests/` replay both sets through the public entry points.
+
+## Boundaries
+
+This tool is a self-contained workspace. It has no imports from the main app,
+routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system, and exports no UI. Run its tests from the repository root with:
+
+```sh
+npx vitest run --config tools/v2/individual/sentiment-detector/vitest.config.ts
+```

--- a/tools/v2/individual/sentiment-detector/docs/contract.md
+++ b/tools/v2/individual/sentiment-detector/docs/contract.md
@@ -6,10 +6,10 @@ re-exported from the folder root `index.ts`.
 
 ## Entry points
 
-| Export | Kind | Use when |
-| --- | --- | --- |
-| `safeAnalyzeSentiment(input: unknown, options?: unknown): SafeSentimentResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
-| `analyzeSentiment(input: SentimentAnalysisInput, options?: SentimentAnalysisOptions): SentimentAnalysisResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+| Export                                                                                                         | Kind                        | Use when                                                                                |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| `safeAnalyzeSentiment(input: unknown, options?: unknown): SafeSentimentResult`                                 | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws.                |
+| `analyzeSentiment(input: SentimentAnalysisInput, options?: SentimentAnalysisOptions): SentimentAnalysisResult` | Pure engine                 | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
 
 Both functions are pure and deterministic: no network calls, no mailbox access,
 no randomness, no clock reads, and no mutation of caller-supplied objects.
@@ -19,17 +19,17 @@ Identical input always produces an identical result.
 
 ```ts
 interface SentimentAnalysisInput {
-  messageId: string;      // required, non-empty; echoed back in the result
-  subject: string;        // may be empty when body is not
-  body: string;           // plain text; may be empty when subject is not
+  messageId: string; // required, non-empty; echoed back in the result
+  subject: string; // may be empty when body is not
+  body: string; // plain text; may be empty when subject is not
   senderAddress?: string; // correlation only — never analyzed
-  receivedAt?: string;    // ISO 8601 when present
-  language?: string;      // BCP 47; only "en" / "en-*" supported
+  receivedAt?: string; // ISO 8601 when present
+  language?: string; // BCP 47; only "en" / "en-*" supported
 }
 
 interface SentimentAnalysisOptions {
   includeSignals?: boolean; // default true
-  maxSignals?: number;      // 1–100, default 25
+  maxSignals?: number; // 1–100, default 25
 }
 ```
 
@@ -39,10 +39,10 @@ interface SentimentAnalysisOptions {
 interface SentimentAnalysisResult {
   messageId: string;
   sentiment: "positive" | "negative" | "neutral" | "mixed";
-  score: number;                          // [-1, 1]; 0 = neutral / no evidence
-  confidence: "low" | "medium" | "high";  // from matched-evidence count
-  signals: SentimentSignal[];             // strongest first, truncated to maxSignals
-  stats: SentimentStats;                  // deterministic counters
+  score: number; // [-1, 1]; 0 = neutral / no evidence
+  confidence: "low" | "medium" | "high"; // from matched-evidence count
+  signals: SentimentSignal[]; // strongest first, truncated to maxSignals
+  stats: SentimentStats; // deterministic counters
 }
 ```
 
@@ -56,13 +56,13 @@ type SafeSentimentResult =
 
 ## Error codes
 
-| Code | Trigger |
-| --- | --- |
-| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
-| `invalid-options` | `includeSignals` not a boolean, or `maxSignals` outside 1–100. |
-| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
-| `empty-content` | Subject and body are both empty after sanitization. |
-| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+| Code                   | Trigger                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid-input`        | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options`      | `includeSignals` not a boolean, or `maxSignals` outside 1–100.                                                                                       |
+| `input-too-large`      | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`).                                  |
+| `empty-content`        | Subject and body are both empty after sanitization.                                                                                                  |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag.                                                                                         |
 
 ## Scoring model
 

--- a/tools/v2/individual/sentiment-detector/index.ts
+++ b/tools/v2/individual/sentiment-detector/index.ts
@@ -1,0 +1,45 @@
+// Sentiment Detector — non-UI execution entry point.
+//
+// Everything a backend caller needs: the pure engine, the guarded service
+// entry point, the typed contract, and fixtures. No UI code is exported.
+
+export {
+  analyzeSentiment,
+  resolveMaxSignals,
+  DEFAULT_MAX_SIGNALS,
+  MAX_SIGNALS_LIMIT,
+  SUBJECT_WEIGHT_MULTIPLIER,
+  INTENSIFIER_MULTIPLIER,
+  NEGATION_WINDOW,
+  NEUTRAL_BAND,
+  MIXED_RATIO,
+  POSITIVE_TERMS,
+  NEGATIVE_TERMS,
+  NEGATION_TERMS,
+  INTENSIFIER_TERMS,
+} from "./services/sentimentDetector";
+export {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeAnalyzeSentiment,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "./services/guards";
+export { successFixtures, failureFixtures } from "./services/fixtures";
+export type { SuccessFixture, FailureFixture } from "./services/fixtures";
+export type {
+  SafeSentimentResult,
+  SentimentAnalysisInput,
+  SentimentAnalysisOptions,
+  SentimentAnalysisResult,
+  SentimentConfidence,
+  SentimentErrorCode,
+  SentimentIssue,
+  SentimentLabel,
+  SentimentSignal,
+  SentimentStats,
+  SignalPolarity,
+  SignalSource,
+} from "./types/sentimentDetector";

--- a/tools/v2/individual/sentiment-detector/services/fixtures.ts
+++ b/tools/v2/individual/sentiment-detector/services/fixtures.ts
@@ -1,0 +1,127 @@
+// Sentiment Detector — typed fixtures for the execution contract.
+//
+// Deterministic sample payloads used by tests and by consumers who want a
+// known-good reference for wiring the service. Success fixtures pass the
+// guarded entry point; failure fixtures each trigger a specific error code.
+
+import { GUARD_LIMITS } from "./guards";
+import type {
+  SentimentAnalysisInput,
+  SentimentErrorCode,
+  SentimentLabel,
+} from "../types/sentimentDetector";
+
+export interface SuccessFixture {
+  name: string;
+  input: SentimentAnalysisInput;
+  expectedSentiment: SentimentLabel;
+}
+
+export interface FailureFixture {
+  name: string;
+  /** Intentionally loosely typed — failure fixtures model bad payloads. */
+  input: unknown;
+  expectedCode: SentimentErrorCode;
+}
+
+export const successFixtures: SuccessFixture[] = [
+  {
+    name: "positive-reply",
+    input: {
+      messageId: "msg-positive-001",
+      subject: "Great news, thank you!",
+      body: "Really appreciate the quick turnaround. The fix works and I am very happy with the result.",
+      senderAddress: "amina@example.com",
+      receivedAt: "2026-07-01T09:15:00.000Z",
+      language: "en",
+    },
+    expectedSentiment: "positive",
+  },
+  {
+    name: "negative-complaint",
+    input: {
+      messageId: "msg-negative-001",
+      subject: "Urgent problem with my order",
+      body: "This is unacceptable. The delivery failed twice and support has been terrible. I am extremely frustrated and want a refund.",
+      senderAddress: "colin@example.com",
+      receivedAt: "2026-07-02T14:30:00.000Z",
+    },
+    expectedSentiment: "negative",
+  },
+  {
+    name: "mixed-feedback",
+    input: {
+      messageId: "msg-mixed-001",
+      subject: "Feedback on the new release",
+      body: "The new dashboard is excellent and I love the search, but the export is broken and the sync problem is still there.",
+      receivedAt: "2026-07-03T08:00:00.000Z",
+    },
+    expectedSentiment: "mixed",
+  },
+  {
+    name: "neutral-notice",
+    input: {
+      messageId: "msg-neutral-001",
+      subject: "Meeting moved to Thursday",
+      body: "The weekly sync now starts at 10:00 in the same room. Agenda unchanged.",
+    },
+    expectedSentiment: "neutral",
+  },
+  {
+    name: "negated-positive-reads-negative",
+    input: {
+      messageId: "msg-negated-001",
+      subject: "Order update",
+      body: "I am not happy with this experience and the packaging was not good either.",
+    },
+    expectedSentiment: "negative",
+  },
+];
+
+export const failureFixtures: FailureFixture[] = [
+  {
+    name: "missing-body",
+    input: {
+      messageId: "msg-invalid-001",
+      subject: "No body field on this payload",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "blank-message-id",
+    input: {
+      messageId: "   ",
+      subject: "Hello",
+      body: "Some text",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "oversized-body",
+    input: {
+      messageId: "msg-oversized-001",
+      subject: "Huge payload",
+      body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1),
+    },
+    expectedCode: "input-too-large",
+  },
+  {
+    name: "empty-content",
+    input: {
+      messageId: "msg-empty-001",
+      subject: "   ",
+      body: "\u200b\u200b",
+    },
+    expectedCode: "empty-content",
+  },
+  {
+    name: "unsupported-language",
+    input: {
+      messageId: "msg-lang-001",
+      subject: "Bonjour",
+      body: "Merci beaucoup pour votre aide.",
+      language: "fr",
+    },
+    expectedCode: "unsupported-language",
+  },
+];

--- a/tools/v2/individual/sentiment-detector/services/guards.ts
+++ b/tools/v2/individual/sentiment-detector/services/guards.ts
@@ -1,0 +1,198 @@
+// Sentiment Detector — validation, sanitization, and the safe entry point.
+//
+// Folder-local hardening layer that runs before the core engine to reject
+// hostile or oversized input and to strip characters that could hide content
+// or break downstream processing. Pure and deterministic: no network calls,
+// no eval, and no mutation of caller-supplied objects.
+
+import { analyzeSentiment, MAX_SIGNALS_LIMIT } from "./sentimentDetector";
+import type {
+  SafeSentimentResult,
+  SentimentAnalysisInput,
+  SentimentAnalysisOptions,
+  SentimentIssue,
+} from "../types/sentimentDetector";
+
+export const GUARD_LIMITS = {
+  maxMessageIdChars: 256,
+  maxSubjectChars: 500,
+  maxBodyChars: 50000,
+  maxBodyWords: 10000,
+} as const;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+
+/** Normalize to NFC and strip control and zero-width characters. */
+export function sanitizeText(text: string): string {
+  return text.normalize("NFC").replace(CONTROL_CHARACTERS, "").replace(INVISIBLE_CHARACTERS, "");
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+  return trimmed.split(/\s+/).length;
+}
+
+/** Structural type check — true when value is a usable SentimentAnalysisInput. */
+export function validateInput(value: unknown): value is SentimentAnalysisInput {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.messageId !== "string" || v.messageId.trim().length === 0) {
+    return false;
+  }
+  if (typeof v.subject !== "string" || typeof v.body !== "string") {
+    return false;
+  }
+  if (v.senderAddress !== undefined && typeof v.senderAddress !== "string") {
+    return false;
+  }
+  if (v.receivedAt !== undefined) {
+    if (typeof v.receivedAt !== "string" || Number.isNaN(new Date(v.receivedAt).getTime())) {
+      return false;
+    }
+  }
+  if (v.language !== undefined && typeof v.language !== "string") {
+    return false;
+  }
+  return true;
+}
+
+/** Structural type check for options. */
+export function validateOptions(value: unknown): value is SentimentAnalysisOptions {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (v.includeSignals !== undefined && typeof v.includeSignals !== "boolean") {
+    return false;
+  }
+  if (v.maxSignals !== undefined) {
+    if (
+      typeof v.maxSignals !== "number" ||
+      !Number.isFinite(v.maxSignals) ||
+      v.maxSignals < 1 ||
+      v.maxSignals > MAX_SIGNALS_LIMIT
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Size checks against GUARD_LIMITS. Empty array means within limits. */
+export function checkInputLimits(input: SentimentAnalysisInput): SentimentIssue[] {
+  const issues: SentimentIssue[] = [];
+  if (input.messageId.length > GUARD_LIMITS.maxMessageIdChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "messageId",
+      message: `messageId exceeds ${GUARD_LIMITS.maxMessageIdChars} characters`,
+    });
+  }
+  if (input.subject.length > GUARD_LIMITS.maxSubjectChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "subject",
+      message: `subject exceeds ${GUARD_LIMITS.maxSubjectChars} characters`,
+    });
+  }
+  if (input.body.length > GUARD_LIMITS.maxBodyChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyChars} characters`,
+    });
+  } else if (countWords(input.body) > GUARD_LIMITS.maxBodyWords) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyWords} words`,
+    });
+  }
+  return issues;
+}
+
+function isSupportedLanguage(language: string | undefined): boolean {
+  if (language === undefined) {
+    return true;
+  }
+  const normalized = language.toLowerCase();
+  return normalized === "en" || normalized.startsWith("en-");
+}
+
+/** Return a sanitized copy of the input without mutating the original. */
+export function sanitizeInput(input: SentimentAnalysisInput): SentimentAnalysisInput {
+  return {
+    ...input,
+    messageId: input.messageId.trim(),
+    subject: sanitizeText(input.subject),
+    body: sanitizeText(input.body),
+  };
+}
+
+/**
+ * Guarded, non-throwing entry point for untrusted callers.
+ *
+ * Validates, sanitizes, and enforces limits before delegating to
+ * analyzeSentiment. Always returns a discriminated SafeSentimentResult.
+ */
+export function safeAnalyzeSentiment(input: unknown, options?: unknown): SafeSentimentResult {
+  if (!validateInput(input)) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: "Input must include a non-empty messageId and string subject and body.",
+      issues: [{ code: "invalid-input", message: "Input failed structural validation." }],
+    };
+  }
+  if (!validateOptions(options)) {
+    return {
+      status: "error",
+      code: "invalid-options",
+      message: `Options must use a boolean includeSignals and a maxSignals between 1 and ${MAX_SIGNALS_LIMIT}.`,
+      issues: [{ code: "invalid-options", message: "Options failed structural validation." }],
+    };
+  }
+  if (!isSupportedLanguage(input.language)) {
+    return {
+      status: "error",
+      code: "unsupported-language",
+      message: `Language "${input.language}" is not supported; only English ("en") is available.`,
+      issues: [
+        {
+          code: "unsupported-language",
+          field: "language",
+          message: "Only English content can be analyzed.",
+        },
+      ],
+    };
+  }
+  const limitIssues = checkInputLimits(input);
+  if (limitIssues.length > 0) {
+    return {
+      status: "error",
+      code: "input-too-large",
+      message: limitIssues.map((issue) => issue.message).join("; "),
+      issues: limitIssues,
+    };
+  }
+  const sanitized = sanitizeInput(input);
+  if (sanitized.subject.trim().length === 0 && sanitized.body.trim().length === 0) {
+    return {
+      status: "error",
+      code: "empty-content",
+      message: "Subject and body are both empty after sanitization; nothing to analyze.",
+      issues: [{ code: "empty-content", message: "No analyzable content present." }],
+    };
+  }
+  return { status: "ok", result: analyzeSentiment(sanitized, options) };
+}

--- a/tools/v2/individual/sentiment-detector/services/sentimentDetector.ts
+++ b/tools/v2/individual/sentiment-detector/services/sentimentDetector.ts
@@ -1,0 +1,282 @@
+// Sentiment Detector — core detection engine.
+//
+// Lexicon-based scoring over subject and body text. Pure and deterministic:
+// no network calls, no mailbox access, no randomness, no clock reads, and no
+// mutation of caller-supplied objects. Presentation concerns stay out of this
+// module — callers receive plain data and decide how to render it.
+
+import type {
+  SentimentAnalysisInput,
+  SentimentAnalysisOptions,
+  SentimentAnalysisResult,
+  SentimentConfidence,
+  SentimentLabel,
+  SentimentSignal,
+  SentimentStats,
+  SignalSource,
+} from "../types/sentimentDetector";
+
+export const DEFAULT_MAX_SIGNALS = 25;
+export const MAX_SIGNALS_LIMIT = 100;
+
+/** Subject terms carry more intent than body terms. */
+export const SUBJECT_WEIGHT_MULTIPLIER = 1.5;
+/** Boost applied when an intensifier directly precedes a term. */
+export const INTENSIFIER_MULTIPLIER = 1.5;
+/** How many tokens back a negation may sit and still flip a term. */
+export const NEGATION_WINDOW = 2;
+
+/** Score magnitude required before leaving the neutral band. */
+export const NEUTRAL_BAND = 0.2;
+/** Minority/majority weight ratio at which both polarities read as mixed. */
+export const MIXED_RATIO = 0.5;
+
+export const POSITIVE_TERMS: Readonly<Record<string, number>> = {
+  amazing: 2,
+  appreciate: 2,
+  appreciated: 2,
+  awesome: 2,
+  congratulations: 2,
+  delighted: 2,
+  excellent: 2,
+  excited: 1,
+  fantastic: 2,
+  glad: 1,
+  good: 1,
+  great: 1,
+  happy: 1,
+  helpful: 1,
+  impressed: 2,
+  love: 2,
+  loved: 2,
+  perfect: 2,
+  pleased: 1,
+  resolved: 1,
+  thank: 1,
+  thanks: 1,
+  thrilled: 2,
+  wonderful: 2,
+};
+
+export const NEGATIVE_TERMS: Readonly<Record<string, number>> = {
+  angry: 2,
+  annoyed: 1,
+  awful: 2,
+  bad: 1,
+  broken: 1,
+  complaint: 2,
+  confused: 1,
+  disappointed: 2,
+  disappointing: 2,
+  error: 1,
+  fail: 1,
+  failed: 1,
+  frustrated: 2,
+  frustrating: 2,
+  hate: 2,
+  horrible: 2,
+  issue: 1,
+  late: 1,
+  poor: 1,
+  problem: 1,
+  refund: 1,
+  terrible: 2,
+  unacceptable: 2,
+  unhappy: 2,
+  urgent: 1,
+  worst: 2,
+  wrong: 1,
+};
+
+export const NEGATION_TERMS: ReadonlySet<string> = new Set([
+  "not",
+  "no",
+  "never",
+  "hardly",
+  "without",
+  "isn't",
+  "wasn't",
+  "aren't",
+  "don't",
+  "doesn't",
+  "didn't",
+  "can't",
+  "cannot",
+  "couldn't",
+  "won't",
+  "wouldn't",
+]);
+
+export const INTENSIFIER_TERMS: ReadonlySet<string> = new Set([
+  "very",
+  "really",
+  "extremely",
+  "incredibly",
+  "absolutely",
+  "so",
+  "truly",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z']+/)
+    .map((token) => token.replace(/^'+|'+$/g, ""))
+    .filter((token) => token.length > 0);
+}
+
+interface ScanAccumulator {
+  signals: SentimentSignal[];
+  tokenCount: number;
+  negationFlips: number;
+  intensifierBoosts: number;
+}
+
+function scanSource(text: string, source: SignalSource, acc: ScanAccumulator): void {
+  const tokens = tokenize(text);
+  acc.tokenCount += tokens.length;
+  const sourceMultiplier = source === "subject" ? SUBJECT_WEIGHT_MULTIPLIER : 1;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    const positiveWeight = POSITIVE_TERMS[token];
+    const negativeWeight = NEGATIVE_TERMS[token];
+    if (positiveWeight === undefined && negativeWeight === undefined) {
+      continue;
+    }
+
+    let polarity: SentimentSignal["polarity"] =
+      positiveWeight !== undefined ? "positive" : "negative";
+    const baseWeight = positiveWeight ?? negativeWeight ?? 0;
+
+    let negated = false;
+    for (let back = 1; back <= NEGATION_WINDOW && i - back >= 0; back += 1) {
+      if (NEGATION_TERMS.has(tokens[i - back])) {
+        negated = true;
+        break;
+      }
+    }
+    if (negated) {
+      polarity = polarity === "positive" ? "negative" : "positive";
+      acc.negationFlips += 1;
+    }
+
+    let weight = baseWeight * sourceMultiplier;
+    if (i > 0 && INTENSIFIER_TERMS.has(tokens[i - 1])) {
+      weight *= INTENSIFIER_MULTIPLIER;
+      acc.intensifierBoosts += 1;
+    }
+
+    acc.signals.push({
+      term: token,
+      polarity,
+      weight: roundTo(weight, 3),
+      source,
+      negated,
+    });
+  }
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function classify(score: number, positiveWeight: number, negativeWeight: number): SentimentLabel {
+  if (positiveWeight === 0 && negativeWeight === 0) {
+    return "neutral";
+  }
+  if (positiveWeight > 0 && negativeWeight > 0) {
+    const ratio =
+      Math.min(positiveWeight, negativeWeight) / Math.max(positiveWeight, negativeWeight);
+    if (ratio >= MIXED_RATIO) {
+      return "mixed";
+    }
+  }
+  if (score >= NEUTRAL_BAND) {
+    return "positive";
+  }
+  if (score <= -NEUTRAL_BAND) {
+    return "negative";
+  }
+  return "neutral";
+}
+
+function deriveConfidence(totalMatches: number): SentimentConfidence {
+  if (totalMatches >= 5) {
+    return "high";
+  }
+  if (totalMatches >= 2) {
+    return "medium";
+  }
+  return "low";
+}
+
+/** Clamp caller-supplied maxSignals into the supported range. */
+export function resolveMaxSignals(maxSignals: number | undefined): number {
+  if (maxSignals === undefined) {
+    return DEFAULT_MAX_SIGNALS;
+  }
+  return Math.min(Math.max(Math.trunc(maxSignals), 1), MAX_SIGNALS_LIMIT);
+}
+
+/**
+ * Analyze the sentiment of a message.
+ *
+ * Assumes input has already been validated and sanitized — use
+ * safeAnalyzeSentiment from services/guards for untrusted callers.
+ */
+export function analyzeSentiment(
+  input: SentimentAnalysisInput,
+  options: SentimentAnalysisOptions = {},
+): SentimentAnalysisResult {
+  const acc: ScanAccumulator = {
+    signals: [],
+    tokenCount: 0,
+    negationFlips: 0,
+    intensifierBoosts: 0,
+  };
+  scanSource(input.subject, "subject", acc);
+  scanSource(input.body, "body", acc);
+
+  let positiveWeight = 0;
+  let negativeWeight = 0;
+  let positiveMatches = 0;
+  let negativeMatches = 0;
+  for (const signal of acc.signals) {
+    if (signal.polarity === "positive") {
+      positiveWeight += signal.weight;
+      positiveMatches += 1;
+    } else {
+      negativeWeight += signal.weight;
+      negativeMatches += 1;
+    }
+  }
+
+  const totalWeight = positiveWeight + negativeWeight;
+  const score = totalWeight === 0 ? 0 : roundTo((positiveWeight - negativeWeight) / totalWeight, 3);
+
+  const stats: SentimentStats = {
+    tokenCount: acc.tokenCount,
+    positiveMatches,
+    negativeMatches,
+    negationFlips: acc.negationFlips,
+    intensifierBoosts: acc.intensifierBoosts,
+  };
+
+  const includeSignals = options.includeSignals !== false;
+  const signals = includeSignals
+    ? [...acc.signals]
+        .sort((a, b) => b.weight - a.weight || a.term.localeCompare(b.term))
+        .slice(0, resolveMaxSignals(options.maxSignals))
+    : [];
+
+  return {
+    messageId: input.messageId,
+    sentiment: classify(score, positiveWeight, negativeWeight),
+    score,
+    confidence: deriveConfidence(positiveMatches + negativeMatches),
+    signals,
+    stats,
+  };
+}

--- a/tools/v2/individual/sentiment-detector/specs.md
+++ b/tools/v2/individual/sentiment-detector/specs.md
@@ -1,25 +1,3 @@
-# Sentiment Detector
-
-Analyze sender sentiment.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/sentiment-detector/README.md"
-  @"
-
 # Sentiment Detector Specs
 
 ## Purpose
@@ -30,7 +8,29 @@ Analyze sender sentiment.
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v2/individual/sentiment-detector/`
+
+This is a self-contained tooling workspace. Do not wire this tool into the
+main app, routing, inbox architecture, wallet core, Stellar core, or design
+system unless a future integration issue explicitly allows it.
+
+## Internal structure
+
+- `index.ts` — non-UI execution entry point (barrel export)
+- `types/` — typed input/output contract and error codes
+- `services/` — detection engine, validation guards, fixtures
+- `tests/` — vitest suites
+- `docs/` — contract documentation
+
+## Execution contract
+
+The backend-facing contract is documented in `docs/contract.md`:
+
+- Typed inputs (`SentimentAnalysisInput`, `SentimentAnalysisOptions`) and
+  outputs (`SentimentAnalysisResult`, `SafeSentimentResult`).
+- Machine-readable error codes (`invalid-input`, `invalid-options`,
+  `input-too-large`, `empty-content`, `unsupported-language`).
+- Fixtures covering success and failure cases in `services/fixtures.ts`.
 
 ## Required issue categories
 

--- a/tools/v2/individual/sentiment-detector/tests/guards.test.ts
+++ b/tools/v2/individual/sentiment-detector/tests/guards.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeAnalyzeSentiment,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "../services/guards";
+import { failureFixtures, successFixtures } from "../services/fixtures";
+import type { SentimentAnalysisInput } from "../types/sentimentDetector";
+
+function makeInput(overrides: Partial<SentimentAnalysisInput> = {}): SentimentAnalysisInput {
+  return {
+    messageId: "msg-guard-001",
+    subject: "Hello",
+    body: "Thanks for the update.",
+    ...overrides,
+  };
+}
+
+describe("sanitizeText", () => {
+  it("strips control and zero-width characters", () => {
+    expect(sanitizeText("he\u0000llo\u200b world\u2060")).toBe("hello world");
+  });
+
+  it("normalizes composed characters to NFC", () => {
+    expect(sanitizeText("cafe\u0301")).toBe("café");
+  });
+});
+
+describe("validateInput", () => {
+  it("accepts a minimal valid input", () => {
+    expect(validateInput(makeInput())).toBe(true);
+  });
+
+  it("rejects non-objects, null, and arrays", () => {
+    expect(validateInput("text")).toBe(false);
+    expect(validateInput(null)).toBe(false);
+    expect(validateInput([makeInput()])).toBe(false);
+  });
+
+  it("rejects a missing or blank messageId", () => {
+    expect(validateInput({ ...makeInput(), messageId: undefined })).toBe(false);
+    expect(validateInput(makeInput({ messageId: "   " }))).toBe(false);
+  });
+
+  it("rejects non-string subject or body", () => {
+    expect(validateInput({ ...makeInput(), subject: 5 })).toBe(false);
+    expect(validateInput({ ...makeInput(), body: undefined })).toBe(false);
+  });
+
+  it("rejects an unparseable receivedAt", () => {
+    expect(validateInput(makeInput({ receivedAt: "not-a-date" }))).toBe(false);
+    expect(validateInput(makeInput({ receivedAt: "2026-07-01T00:00:00.000Z" }))).toBe(true);
+  });
+});
+
+describe("validateOptions", () => {
+  it("accepts undefined and valid shapes", () => {
+    expect(validateOptions(undefined)).toBe(true);
+    expect(validateOptions({})).toBe(true);
+    expect(validateOptions({ includeSignals: false, maxSignals: 10 })).toBe(true);
+  });
+
+  it("rejects wrong types and out-of-range maxSignals", () => {
+    expect(validateOptions({ includeSignals: "yes" })).toBe(false);
+    expect(validateOptions({ maxSignals: 0 })).toBe(false);
+    expect(validateOptions({ maxSignals: Number.NaN })).toBe(false);
+    expect(validateOptions({ maxSignals: 101 })).toBe(false);
+  });
+});
+
+describe("checkInputLimits", () => {
+  it("returns no issues within limits", () => {
+    expect(checkInputLimits(makeInput())).toEqual([]);
+  });
+
+  it("flags each oversized field with input-too-large", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        messageId: "x".repeat(GUARD_LIMITS.maxMessageIdChars + 1),
+        subject: "y".repeat(GUARD_LIMITS.maxSubjectChars + 1),
+        body: "z".repeat(GUARD_LIMITS.maxBodyChars + 1),
+      }),
+    );
+    expect(issues).toHaveLength(3);
+    expect(issues.every((issue) => issue.code === "input-too-large")).toBe(true);
+    expect(issues.map((issue) => issue.field)).toEqual(["messageId", "subject", "body"]);
+  });
+
+  it("flags a body with too many words even under the char limit", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        body: Array(GUARD_LIMITS.maxBodyWords + 1)
+          .fill("w")
+          .join(" "),
+      }),
+    );
+    expect(issues).toEqual([expect.objectContaining({ code: "input-too-large", field: "body" })]);
+  });
+});
+
+describe("sanitizeInput", () => {
+  it("returns a cleaned copy without mutating the original", () => {
+    const input = makeInput({ messageId: "  msg-1  ", subject: "Hi\u200b", body: "ok" });
+    const cleaned = sanitizeInput(input);
+    expect(cleaned).toMatchObject({ messageId: "msg-1", subject: "Hi", body: "ok" });
+    expect(input.messageId).toBe("  msg-1  ");
+  });
+});
+
+describe("safeAnalyzeSentiment", () => {
+  it("returns ok for every success fixture", () => {
+    for (const fixture of successFixtures) {
+      const outcome = safeAnalyzeSentiment(fixture.input);
+      expect(outcome.status, fixture.name).toBe("ok");
+      if (outcome.status === "ok") {
+        expect(outcome.result.sentiment, fixture.name).toBe(fixture.expectedSentiment);
+      }
+    }
+  });
+
+  it("returns the expected error code for every failure fixture", () => {
+    for (const fixture of failureFixtures) {
+      const outcome = safeAnalyzeSentiment(fixture.input);
+      expect(outcome.status, fixture.name).toBe("error");
+      if (outcome.status === "error") {
+        expect(outcome.code, fixture.name).toBe(fixture.expectedCode);
+        expect(outcome.issues.length, fixture.name).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("rejects invalid options with invalid-options", () => {
+    const outcome = safeAnalyzeSentiment(makeInput(), { maxSignals: -5 });
+    expect(outcome).toMatchObject({ status: "error", code: "invalid-options" });
+  });
+
+  it("accepts regional English language tags", () => {
+    const outcome = safeAnalyzeSentiment(makeInput({ language: "en-GB" }));
+    expect(outcome.status).toBe("ok");
+  });
+
+  it("analyzes sanitized text so hidden characters cannot mask terms", () => {
+    const outcome = safeAnalyzeSentiment(
+      makeInput({ subject: "", body: "ter\u200brible experience" }),
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status === "ok") {
+      expect(outcome.result.sentiment).toBe("negative");
+    }
+  });
+
+  it("never throws on hostile payloads", () => {
+    const hostile = [null, 42, "text", [], { messageId: 1 }, { __proto__: { subject: "x" } }];
+    for (const payload of hostile) {
+      expect(() => safeAnalyzeSentiment(payload)).not.toThrow();
+      expect(safeAnalyzeSentiment(payload).status).toBe("error");
+    }
+  });
+});

--- a/tools/v2/individual/sentiment-detector/tests/sentimentDetector.test.ts
+++ b/tools/v2/individual/sentiment-detector/tests/sentimentDetector.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeSentiment,
+  DEFAULT_MAX_SIGNALS,
+  MAX_SIGNALS_LIMIT,
+  resolveMaxSignals,
+} from "../services/sentimentDetector";
+import { successFixtures } from "../services/fixtures";
+import type { SentimentAnalysisInput } from "../types/sentimentDetector";
+
+function makeInput(overrides: Partial<SentimentAnalysisInput> = {}): SentimentAnalysisInput {
+  return {
+    messageId: "msg-test-001",
+    subject: "",
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("analyzeSentiment", () => {
+  it("classifies each success fixture as expected", () => {
+    for (const fixture of successFixtures) {
+      const result = analyzeSentiment(fixture.input);
+      expect(result.sentiment, fixture.name).toBe(fixture.expectedSentiment);
+      expect(result.messageId).toBe(fixture.input.messageId);
+    }
+  });
+
+  it("returns a neutral zero-score result when nothing matches", () => {
+    const result = analyzeSentiment(
+      makeInput({ subject: "Schedule", body: "The meeting is on Tuesday." }),
+    );
+    expect(result.sentiment).toBe("neutral");
+    expect(result.score).toBe(0);
+    expect(result.confidence).toBe("low");
+    expect(result.signals).toEqual([]);
+    expect(result.stats.positiveMatches).toBe(0);
+    expect(result.stats.negativeMatches).toBe(0);
+  });
+
+  it("keeps the score inside [-1, 1]", () => {
+    const positive = analyzeSentiment(
+      makeInput({ body: "great great great wonderful excellent perfect" }),
+    );
+    const negative = analyzeSentiment(
+      makeInput({ body: "terrible awful horrible worst unacceptable" }),
+    );
+    expect(positive.score).toBe(1);
+    expect(negative.score).toBe(-1);
+  });
+
+  it("flips polarity when a negation precedes a term", () => {
+    const result = analyzeSentiment(makeInput({ body: "The update is not good." }));
+    expect(result.sentiment).toBe("negative");
+    expect(result.stats.negationFlips).toBe(1);
+    expect(result.signals[0]).toMatchObject({ term: "good", polarity: "negative", negated: true });
+  });
+
+  it("handles contraction negations within the lookback window", () => {
+    const result = analyzeSentiment(makeInput({ body: "This isn't very helpful." }));
+    expect(result.sentiment).toBe("negative");
+    expect(result.stats.negationFlips).toBe(1);
+  });
+
+  it("weights subject matches more than body matches", () => {
+    const fromSubject = analyzeSentiment(makeInput({ subject: "great" }));
+    const fromBody = analyzeSentiment(makeInput({ body: "great" }));
+    expect(fromSubject.signals[0].weight).toBeGreaterThan(fromBody.signals[0].weight);
+  });
+
+  it("boosts terms preceded by an intensifier", () => {
+    const plain = analyzeSentiment(makeInput({ body: "happy" }));
+    const boosted = analyzeSentiment(makeInput({ body: "very happy" }));
+    expect(boosted.signals[0].weight).toBeGreaterThan(plain.signals[0].weight);
+    expect(boosted.stats.intensifierBoosts).toBe(1);
+  });
+
+  it("raises confidence with more matched evidence", () => {
+    const low = analyzeSentiment(makeInput({ body: "good" }));
+    const medium = analyzeSentiment(makeInput({ body: "good great" }));
+    const high = analyzeSentiment(makeInput({ body: "good great happy glad pleased" }));
+    expect(low.confidence).toBe("low");
+    expect(medium.confidence).toBe("medium");
+    expect(high.confidence).toBe("high");
+  });
+
+  it("truncates signals to maxSignals, strongest first", () => {
+    const result = analyzeSentiment(makeInput({ body: "good great happy glad pleased helpful" }), {
+      maxSignals: 3,
+    });
+    expect(result.signals).toHaveLength(3);
+    const weights = result.signals.map((signal) => signal.weight);
+    expect([...weights].sort((a, b) => b - a)).toEqual(weights);
+    expect(result.stats.positiveMatches).toBe(6);
+  });
+
+  it("omits signals when includeSignals is false without changing the score", () => {
+    const withSignals = analyzeSentiment(makeInput({ body: "great news, thanks" }));
+    const withoutSignals = analyzeSentiment(makeInput({ body: "great news, thanks" }), {
+      includeSignals: false,
+    });
+    expect(withoutSignals.signals).toEqual([]);
+    expect(withoutSignals.score).toBe(withSignals.score);
+    expect(withoutSignals.sentiment).toBe(withSignals.sentiment);
+  });
+
+  it("is deterministic for identical input", () => {
+    const input = makeInput({
+      subject: "Problem",
+      body: "The export failed but support was great.",
+    });
+    expect(analyzeSentiment(input)).toEqual(analyzeSentiment(input));
+  });
+
+  it("does not mutate the caller's input", () => {
+    const input = makeInput({ subject: "Great", body: "Thanks a lot" });
+    const snapshot = JSON.parse(JSON.stringify(input));
+    analyzeSentiment(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("resolveMaxSignals", () => {
+  it("defaults when undefined and clamps out-of-range values", () => {
+    expect(resolveMaxSignals(undefined)).toBe(DEFAULT_MAX_SIGNALS);
+    expect(resolveMaxSignals(0)).toBe(1);
+    expect(resolveMaxSignals(10.9)).toBe(10);
+    expect(resolveMaxSignals(1000)).toBe(MAX_SIGNALS_LIMIT);
+  });
+});

--- a/tools/v2/individual/sentiment-detector/types/sentimentDetector.ts
+++ b/tools/v2/individual/sentiment-detector/types/sentimentDetector.ts
@@ -1,0 +1,114 @@
+// Sentiment Detector — typed execution contract.
+//
+// Backend-facing types for the sentiment-detector tool. These types define the
+// stable, non-UI contract between callers (services, jobs, tests) and the
+// detection engine. No presentation concerns belong here.
+
+/** Overall sentiment classification for a message. */
+export type SentimentLabel = "positive" | "negative" | "neutral" | "mixed";
+
+/** How much trust callers should place in the classification. */
+export type SentimentConfidence = "low" | "medium" | "high";
+
+/** Polarity contributed by a single matched term. */
+export type SignalPolarity = "positive" | "negative";
+
+/** Which part of the message a signal was found in. */
+export type SignalSource = "subject" | "body";
+
+/** Input accepted by the detection engine. */
+export interface SentimentAnalysisInput {
+  /** Stable caller-supplied identifier echoed back in the result. */
+  messageId: string;
+  /** Message subject line. May be empty when the body is not. */
+  subject: string;
+  /** Plain-text message body. May be empty when the subject is not. */
+  body: string;
+  /** Optional sender address, kept for correlation only — never analyzed. */
+  senderAddress?: string;
+  /** Optional ISO 8601 timestamp of when the message was received. */
+  receivedAt?: string;
+  /**
+   * Optional BCP 47 language tag. Only English ("en" or "en-*") is
+   * supported; other values are rejected with "unsupported-language".
+   */
+  language?: string;
+}
+
+/** Tuning options for a single analysis call. */
+export interface SentimentAnalysisOptions {
+  /** Include per-term signals in the result. Defaults to true. */
+  includeSignals?: boolean;
+  /** Upper bound on returned signals (1–100). Defaults to 25. */
+  maxSignals?: number;
+}
+
+/** One matched lexicon term and its contribution to the score. */
+export interface SentimentSignal {
+  /** The lexicon term that matched, lowercased. */
+  term: string;
+  /** Effective polarity after negation handling. */
+  polarity: SignalPolarity;
+  /** Effective weight after source and intensifier multipliers. */
+  weight: number;
+  /** Where the term was found. */
+  source: SignalSource;
+  /** True when a nearby negation flipped the term's base polarity. */
+  negated: boolean;
+}
+
+/** Deterministic counters describing how the score was produced. */
+export interface SentimentStats {
+  /** Total tokens scanned across subject and body. */
+  tokenCount: number;
+  /** Matches contributing positive weight (after negation). */
+  positiveMatches: number;
+  /** Matches contributing negative weight (after negation). */
+  negativeMatches: number;
+  /** How many matches had their polarity flipped by a negation. */
+  negationFlips: number;
+  /** How many matches were boosted by an intensifier. */
+  intensifierBoosts: number;
+}
+
+/** Successful analysis output. */
+export interface SentimentAnalysisResult {
+  /** Echo of the input messageId. */
+  messageId: string;
+  /** Overall classification. */
+  sentiment: SentimentLabel;
+  /** Normalized score in [-1, 1]; 0 means neutral or no evidence. */
+  score: number;
+  /** Trust level derived from the amount of matched evidence. */
+  confidence: SentimentConfidence;
+  /** Matched signals, strongest first, truncated to maxSignals. */
+  signals: SentimentSignal[];
+  /** Counters describing the analysis. */
+  stats: SentimentStats;
+}
+
+/** Machine-readable failure codes for the safe entry point. */
+export type SentimentErrorCode =
+  | "invalid-input"
+  | "invalid-options"
+  | "input-too-large"
+  | "empty-content"
+  | "unsupported-language";
+
+/** One validation problem, tied to a field when known. */
+export interface SentimentIssue {
+  code: SentimentErrorCode;
+  /** Input field the issue applies to, when identifiable. */
+  field?: string;
+  message: string;
+}
+
+/** Discriminated result of the guarded entry point — never throws. */
+export type SafeSentimentResult =
+  | { status: "ok"; result: SentimentAnalysisResult }
+  | {
+      status: "error";
+      code: SentimentErrorCode;
+      message: string;
+      issues: SentimentIssue[];
+    };

--- a/tools/v2/individual/sentiment-detector/vitest.config.ts
+++ b/tools/v2/individual/sentiment-detector/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    root: path.resolve(__dirname),
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements the non-UI execution contract for `tools/v2/individual/sentiment-detector` (#1384). The tool now exposes a stable, backend-facing API that runs independently of any presentation concerns.

- **Typed contract** — `types/sentimentDetector.ts` defines `SentimentAnalysisInput`, `SentimentAnalysisOptions`, `SentimentAnalysisResult`, `SafeSentimentResult`, and the error-code union; documented in `docs/contract.md`.
- **Non-UI service entry point** — `index.ts` exports `safeAnalyzeSentiment` (guarded, never throws, returns a discriminated ok/error result) and `analyzeSentiment` (pure engine for pre-validated input). Both are deterministic: no network, no randomness, no clock reads, no input mutation.
- **Error codes** — `invalid-input`, `invalid-options`, `input-too-large`, `empty-content`, `unsupported-language`, enforced by a folder-local guard layer (`services/guards.ts`) with size limits and control/zero-width character sanitization.
- **Fixtures** — `services/fixtures.ts` covers success cases (positive, negative, mixed, neutral, negation) and failure cases (one per error code).
- **Tests** — 32 vitest cases across engine and guards, replaying every fixture through the public entry points.

No styling or layout files are changed; all work stays inside the tool's ownership boundary.

Closes #1384

## Test plan

```sh
npx vitest run --config tools/v2/individual/sentiment-detector/vitest.config.ts
```

- [x] 32/32 tests pass
- [x] `tsc --noEmit --strict` clean on the tool's files
- [x] `eslint` clean on the folder
