### PR TITLE
feat(task-extractor): add typed non-UI execution contract

### DIFF
--- a/tools/v2/individual/task-extractor/README.md
+++ b/tools/v2/individual/task-extractor/README.md
@@ -1,15 +1,58 @@
 # Task Extractor
 
-This folder is the isolated workspace for the Task Extractor tool.
+This folder is the isolated workspace for the Task Extractor tool. It extracts
+action items from a message's subject and body and returns a typed,
+deterministic result.
+
+## Execution contract
+
+The non-UI entry point is exported from `index.ts`:
+
+```ts
+import { safeExtractTasks } from "tools/v2/individual/task-extractor";
+
+const outcome = safeExtractTasks({
+  messageId: "msg-1",
+  subject: "Sprint prep",
+  body: "- [ ] Update the roadmap deck\nPlease send the notes by tomorrow.",
+  receivedAt: "2026-07-03T08:00:00.000Z",
+});
+
+if (outcome.status === "ok") {
+  outcome.result.tasks; // ExtractedTask[] with priority, confidence, due hints
+}
+```
+
+- `safeExtractTasks` — guarded entry point for untrusted input; validates,
+  sanitizes, enforces limits, and never throws.
+- `extractTasks` — pure engine for pre-validated input.
+- Full contract (types, error codes, extraction rules): `docs/contract.md`.
+- Fixtures for success and failure paths: `services/fixtures.ts`.
+
+## Layout
+
+- `index.ts` — public barrel export (no UI code)
+- `types/` — typed input/output contract and error codes
+- `services/` — extraction engine, guards, fixtures
+- `tests/` — vitest suites for the engine and guards
+- `docs/` — contract documentation
+
+## Testing
+
+From the repository root:
+
+```sh
+npx vitest run --config tools/v2/individual/task-extractor/vitest.config.ts
+```
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\task-extractor\
-`
+`tools/v2/individual/task-extractor/`
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.

--- a/tools/v2/individual/task-extractor/docs/contract.md
+++ b/tools/v2/individual/task-extractor/docs/contract.md
@@ -1,0 +1,123 @@
+# Task Extractor — Execution Contract
+
+Stable backend-facing contract for extracting action items from a message
+independently of any presentation layer. All types live in
+`types/taskExtractor.ts` and are re-exported from the folder root `index.ts`.
+
+## Entry points
+
+| Export | Kind | Use when |
+| --- | --- | --- |
+| `safeExtractTasks(input: unknown, options?: unknown): SafeTaskExtractionResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
+| `extractTasks(input: TaskExtractionInput, options?: TaskExtractionOptions): TaskExtractionResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+
+Both functions are pure and deterministic: no network calls, no mailbox access,
+no randomness, no clock reads, and no mutation of caller-supplied objects.
+Identical input always produces an identical result. Relative due phrases
+("today", "tomorrow", "eod") only resolve to dates when the caller supplies
+`receivedAt` — the engine never reads the system clock.
+
+## Input
+
+```ts
+interface TaskExtractionInput {
+  messageId: string;      // required, non-empty; echoed back and used in task ids
+  subject: string;        // may be empty when body is not
+  body: string;           // plain text; may be empty when subject is not
+  senderAddress?: string; // correlation only — never analyzed
+  receivedAt?: string;    // ISO 8601; enables relative due-date resolution
+  language?: string;      // BCP 47; only "en" / "en-*" supported
+}
+
+interface TaskExtractionOptions {
+  maxTasks?: number;                          // 1–50, default 10
+  minConfidence?: "low" | "medium" | "high";  // default "low" (keep all)
+}
+```
+
+## Output
+
+```ts
+interface TaskExtractionResult {
+  messageId: string;
+  tasks: ExtractedTask[];      // order of appearance, truncated to maxTasks
+  stats: TaskExtractionStats;  // lineCount, candidateCount, extractedCount, truncated
+}
+
+interface ExtractedTask {
+  id: string;             // deterministic: `<messageId>-task-<n>`
+  text: string;           // trimmed, whitespace-collapsed, ≤ 200 chars
+  source: "subject" | "body";
+  trigger: "checkbox" | "request-phrase" | "bullet-action" | "imperative-line";
+  priority: "low" | "normal" | "high";
+  confidence: "low" | "medium" | "high";
+  dueAtHint?: string;     // YYYY-MM-DD when resolvable
+  dueTextHint?: string;   // raw phrase (e.g. "friday") when not resolvable
+}
+```
+
+An empty `tasks` array is a valid success outcome, not an error.
+
+The guarded entry point wraps this in a discriminated union:
+
+```ts
+type SafeTaskExtractionResult =
+  | { status: "ok"; result: TaskExtractionResult }
+  | { status: "error"; code: TaskExtractionErrorCode; message: string; issues: TaskExtractionIssue[] };
+```
+
+## Error codes
+
+| Code | Trigger |
+| --- | --- |
+| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options` | `maxTasks` outside 1–50, or `minConfidence` not low/medium/high. |
+| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
+| `empty-content` | Subject and body are both empty after sanitization. |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+
+## Extraction rules
+
+Rule-based and folder-local; scanned per line, in order of appearance:
+
+| Trigger | Matches | Confidence |
+| --- | --- | --- |
+| `checkbox` | `- [ ] <task>` style items | high |
+| `request-phrase` | "please …", "can/could/would you …", "make sure to …", "remember / don't forget to …", "action required: …", "we/you need to …" | high |
+| `bullet-action` | Bullet or numbered item starting with an action verb (`ACTION_VERBS`) | medium |
+| `imperative-line` | A whole line starting with an action verb | low |
+
+- **Priority**: "urgent", "asap", "critical", "high priority", … → `high`;
+  "no rush", "when you get a chance", … → `low`; otherwise `normal`.
+- **Due hints**: explicit `YYYY-MM-DD` dates (validated as real calendar days)
+  become `dueAtHint`. "today"/"eod" and "tomorrow" resolve against
+  `receivedAt` when present; weekdays and other phrases stay as `dueTextHint`.
+- **Dedup**: repeated task texts (case-insensitive) collapse to the first hit.
+- **Truncation**: extraction stops at `maxTasks`; `stats.truncated` reports it.
+
+## Sanitization
+
+`safeExtractTasks` normalizes text to NFC and strips ASCII control characters
+and zero-width characters (U+200B–U+200D, U+2060, U+FEFF) before extraction,
+so hidden characters cannot mask request phrases.
+
+## Fixtures
+
+`services/fixtures.ts` exports:
+
+- `successFixtures` — explicit requests, checkbox/bullet lists, urgent
+  requests with relative due dates, and a no-tasks case with their expected
+  task texts.
+- `failureFixtures` — one payload per error path with its expected error code.
+
+Tests in `tests/` replay both sets through the public entry points.
+
+## Boundaries
+
+This tool is a self-contained workspace. It has no imports from the main app,
+routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system, and exports no UI. Run its tests from the repository root with:
+
+```sh
+npx vitest run --config tools/v2/individual/task-extractor/vitest.config.ts
+```

--- a/tools/v2/individual/task-extractor/docs/contract.md
+++ b/tools/v2/individual/task-extractor/docs/contract.md
@@ -6,10 +6,10 @@ independently of any presentation layer. All types live in
 
 ## Entry points
 
-| Export | Kind | Use when |
-| --- | --- | --- |
-| `safeExtractTasks(input: unknown, options?: unknown): SafeTaskExtractionResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
-| `extractTasks(input: TaskExtractionInput, options?: TaskExtractionOptions): TaskExtractionResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+| Export                                                                                            | Kind                        | Use when                                                                                |
+| ------------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| `safeExtractTasks(input: unknown, options?: unknown): SafeTaskExtractionResult`                   | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws.                |
+| `extractTasks(input: TaskExtractionInput, options?: TaskExtractionOptions): TaskExtractionResult` | Pure engine                 | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
 
 Both functions are pure and deterministic: no network calls, no mailbox access,
 no randomness, no clock reads, and no mutation of caller-supplied objects.
@@ -21,17 +21,17 @@ Identical input always produces an identical result. Relative due phrases
 
 ```ts
 interface TaskExtractionInput {
-  messageId: string;      // required, non-empty; echoed back and used in task ids
-  subject: string;        // may be empty when body is not
-  body: string;           // plain text; may be empty when subject is not
+  messageId: string; // required, non-empty; echoed back and used in task ids
+  subject: string; // may be empty when body is not
+  body: string; // plain text; may be empty when subject is not
   senderAddress?: string; // correlation only — never analyzed
-  receivedAt?: string;    // ISO 8601; enables relative due-date resolution
-  language?: string;      // BCP 47; only "en" / "en-*" supported
+  receivedAt?: string; // ISO 8601; enables relative due-date resolution
+  language?: string; // BCP 47; only "en" / "en-*" supported
 }
 
 interface TaskExtractionOptions {
-  maxTasks?: number;                          // 1–50, default 10
-  minConfidence?: "low" | "medium" | "high";  // default "low" (keep all)
+  maxTasks?: number; // 1–50, default 10
+  minConfidence?: "low" | "medium" | "high"; // default "low" (keep all)
 }
 ```
 
@@ -40,19 +40,19 @@ interface TaskExtractionOptions {
 ```ts
 interface TaskExtractionResult {
   messageId: string;
-  tasks: ExtractedTask[];      // order of appearance, truncated to maxTasks
-  stats: TaskExtractionStats;  // lineCount, candidateCount, extractedCount, truncated
+  tasks: ExtractedTask[]; // order of appearance, truncated to maxTasks
+  stats: TaskExtractionStats; // lineCount, candidateCount, extractedCount, truncated
 }
 
 interface ExtractedTask {
-  id: string;             // deterministic: `<messageId>-task-<n>`
-  text: string;           // trimmed, whitespace-collapsed, ≤ 200 chars
+  id: string; // deterministic: `<messageId>-task-<n>`
+  text: string; // trimmed, whitespace-collapsed, ≤ 200 chars
   source: "subject" | "body";
   trigger: "checkbox" | "request-phrase" | "bullet-action" | "imperative-line";
   priority: "low" | "normal" | "high";
   confidence: "low" | "medium" | "high";
-  dueAtHint?: string;     // YYYY-MM-DD when resolvable
-  dueTextHint?: string;   // raw phrase (e.g. "friday") when not resolvable
+  dueAtHint?: string; // YYYY-MM-DD when resolvable
+  dueTextHint?: string; // raw phrase (e.g. "friday") when not resolvable
 }
 ```
 
@@ -63,29 +63,34 @@ The guarded entry point wraps this in a discriminated union:
 ```ts
 type SafeTaskExtractionResult =
   | { status: "ok"; result: TaskExtractionResult }
-  | { status: "error"; code: TaskExtractionErrorCode; message: string; issues: TaskExtractionIssue[] };
+  | {
+      status: "error";
+      code: TaskExtractionErrorCode;
+      message: string;
+      issues: TaskExtractionIssue[];
+    };
 ```
 
 ## Error codes
 
-| Code | Trigger |
-| --- | --- |
-| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
-| `invalid-options` | `maxTasks` outside 1–50, or `minConfidence` not low/medium/high. |
-| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
-| `empty-content` | Subject and body are both empty after sanitization. |
-| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+| Code                   | Trigger                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid-input`        | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options`      | `maxTasks` outside 1–50, or `minConfidence` not low/medium/high.                                                                                     |
+| `input-too-large`      | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`).                                  |
+| `empty-content`        | Subject and body are both empty after sanitization.                                                                                                  |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag.                                                                                         |
 
 ## Extraction rules
 
 Rule-based and folder-local; scanned per line, in order of appearance:
 
-| Trigger | Matches | Confidence |
-| --- | --- | --- |
-| `checkbox` | `- [ ] <task>` style items | high |
-| `request-phrase` | "please …", "can/could/would you …", "make sure to …", "remember / don't forget to …", "action required: …", "we/you need to …" | high |
-| `bullet-action` | Bullet or numbered item starting with an action verb (`ACTION_VERBS`) | medium |
-| `imperative-line` | A whole line starting with an action verb | low |
+| Trigger           | Matches                                                                                                                         | Confidence |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `checkbox`        | `- [ ] <task>` style items                                                                                                      | high       |
+| `request-phrase`  | "please …", "can/could/would you …", "make sure to …", "remember / don't forget to …", "action required: …", "we/you need to …" | high       |
+| `bullet-action`   | Bullet or numbered item starting with an action verb (`ACTION_VERBS`)                                                           | medium     |
+| `imperative-line` | A whole line starting with an action verb                                                                                       | low        |
 
 - **Priority**: "urgent", "asap", "critical", "high priority", … → `high`;
   "no rush", "when you get a chance", … → `low`; otherwise `normal`.

--- a/tools/v2/individual/task-extractor/index.ts
+++ b/tools/v2/individual/task-extractor/index.ts
@@ -1,0 +1,40 @@
+// Task Extractor — non-UI execution entry point.
+//
+// Everything a backend caller needs: the pure engine, the guarded service
+// entry point, the typed contract, and fixtures. No UI code is exported.
+
+export {
+  extractTasks,
+  resolveMaxTasks,
+  DEFAULT_MAX_TASKS,
+  MAX_TASKS_LIMIT,
+  MAX_TASK_TEXT_CHARS,
+  ACTION_VERBS,
+  HIGH_PRIORITY_TERMS,
+  LOW_PRIORITY_TERMS,
+} from "./services/taskExtractor";
+export {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeExtractTasks,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "./services/guards";
+export { successFixtures, failureFixtures } from "./services/fixtures";
+export type { SuccessFixture, FailureFixture } from "./services/fixtures";
+export type {
+  ExtractedTask,
+  SafeTaskExtractionResult,
+  TaskConfidence,
+  TaskExtractionErrorCode,
+  TaskExtractionInput,
+  TaskExtractionIssue,
+  TaskExtractionOptions,
+  TaskExtractionResult,
+  TaskExtractionStats,
+  TaskPriority,
+  TaskSource,
+  TaskTrigger,
+} from "./types/taskExtractor";

--- a/tools/v2/individual/task-extractor/services/fixtures.ts
+++ b/tools/v2/individual/task-extractor/services/fixtures.ts
@@ -1,0 +1,130 @@
+// Task Extractor — typed fixtures for the execution contract.
+//
+// Deterministic sample payloads used by tests and by consumers who want a
+// known-good reference for wiring the service. Success fixtures pass the
+// guarded entry point; failure fixtures each trigger a specific error code.
+
+import { GUARD_LIMITS } from "./guards";
+import type { TaskExtractionErrorCode, TaskExtractionInput } from "../types/taskExtractor";
+
+export interface SuccessFixture {
+  name: string;
+  input: TaskExtractionInput;
+  /** Task texts the engine is expected to extract, in order. */
+  expectedTaskTexts: string[];
+}
+
+export interface FailureFixture {
+  name: string;
+  /** Intentionally loosely typed — failure fixtures model bad payloads. */
+  input: unknown;
+  expectedCode: TaskExtractionErrorCode;
+}
+
+export const successFixtures: SuccessFixture[] = [
+  {
+    name: "explicit-requests",
+    input: {
+      messageId: "msg-requests-001",
+      subject: "Two things before the launch",
+      body: [
+        "Hi team,",
+        "Please review the launch checklist and flag anything missing.",
+        "Could you send the final pricing sheet to legal?",
+        "Thanks!",
+      ].join("\n"),
+      senderAddress: "amina@example.com",
+      receivedAt: "2026-07-01T09:15:00.000Z",
+      language: "en",
+    },
+    expectedTaskTexts: [
+      "review the launch checklist and flag anything missing",
+      "send the final pricing sheet to legal",
+    ],
+  },
+  {
+    name: "checkbox-and-bullet-list",
+    input: {
+      messageId: "msg-list-001",
+      subject: "Sprint prep",
+      body: [
+        "Before Monday standup:",
+        "- [ ] Update the roadmap deck",
+        "- review open pull requests by 2026-07-10",
+        "- lunch menu ideas",
+      ].join("\n"),
+      receivedAt: "2026-07-02T14:30:00.000Z",
+    },
+    expectedTaskTexts: ["Update the roadmap deck", "review open pull requests by 2026-07-10"],
+  },
+  {
+    name: "urgent-request-with-relative-due",
+    input: {
+      messageId: "msg-urgent-001",
+      subject: "Action required: contract signature",
+      body: "Please sign the vendor contract by tomorrow, this is urgent.",
+      receivedAt: "2026-07-03T08:00:00.000Z",
+    },
+    expectedTaskTexts: [
+      "contract signature",
+      "sign the vendor contract by tomorrow, this is urgent",
+    ],
+  },
+  {
+    name: "no-tasks-found",
+    input: {
+      messageId: "msg-none-001",
+      subject: "Weekly notes",
+      body: "It was a quiet week. The office closes early on the holiday.",
+    },
+    expectedTaskTexts: [],
+  },
+];
+
+export const failureFixtures: FailureFixture[] = [
+  {
+    name: "missing-body",
+    input: {
+      messageId: "msg-invalid-001",
+      subject: "No body field on this payload",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "blank-message-id",
+    input: {
+      messageId: "   ",
+      subject: "Hello",
+      body: "Please review this",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "oversized-body",
+    input: {
+      messageId: "msg-oversized-001",
+      subject: "Huge payload",
+      body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1),
+    },
+    expectedCode: "input-too-large",
+  },
+  {
+    name: "empty-content",
+    input: {
+      messageId: "msg-empty-001",
+      subject: "   ",
+      body: "\u200b\u200b",
+    },
+    expectedCode: "empty-content",
+  },
+  {
+    name: "unsupported-language",
+    input: {
+      messageId: "msg-lang-001",
+      subject: "Bonjour",
+      body: "Merci de relire le document.",
+      language: "fr",
+    },
+    expectedCode: "unsupported-language",
+  },
+];

--- a/tools/v2/individual/task-extractor/services/guards.ts
+++ b/tools/v2/individual/task-extractor/services/guards.ts
@@ -1,0 +1,200 @@
+// Task Extractor — validation, sanitization, and the safe entry point.
+//
+// Folder-local hardening layer that runs before the core engine to reject
+// hostile or oversized input and to strip characters that could hide content
+// or break downstream processing. Pure and deterministic: no network calls,
+// no eval, and no mutation of caller-supplied objects.
+
+import { extractTasks, MAX_TASKS_LIMIT } from "./taskExtractor";
+import type {
+  SafeTaskExtractionResult,
+  TaskExtractionInput,
+  TaskExtractionIssue,
+  TaskExtractionOptions,
+} from "../types/taskExtractor";
+
+export const GUARD_LIMITS = {
+  maxMessageIdChars: 256,
+  maxSubjectChars: 500,
+  maxBodyChars: 50000,
+  maxBodyWords: 10000,
+} as const;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+
+const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+
+/** Normalize to NFC and strip control and zero-width characters. */
+export function sanitizeText(text: string): string {
+  return text.normalize("NFC").replace(CONTROL_CHARACTERS, "").replace(INVISIBLE_CHARACTERS, "");
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+  return trimmed.split(/\s+/).length;
+}
+
+/** Structural type check — true when value is a usable TaskExtractionInput. */
+export function validateInput(value: unknown): value is TaskExtractionInput {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.messageId !== "string" || v.messageId.trim().length === 0) {
+    return false;
+  }
+  if (typeof v.subject !== "string" || typeof v.body !== "string") {
+    return false;
+  }
+  if (v.senderAddress !== undefined && typeof v.senderAddress !== "string") {
+    return false;
+  }
+  if (v.receivedAt !== undefined) {
+    if (typeof v.receivedAt !== "string" || Number.isNaN(new Date(v.receivedAt).getTime())) {
+      return false;
+    }
+  }
+  if (v.language !== undefined && typeof v.language !== "string") {
+    return false;
+  }
+  return true;
+}
+
+/** Structural type check for options. */
+export function validateOptions(value: unknown): value is TaskExtractionOptions {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (v.maxTasks !== undefined) {
+    if (
+      typeof v.maxTasks !== "number" ||
+      !Number.isFinite(v.maxTasks) ||
+      v.maxTasks < 1 ||
+      v.maxTasks > MAX_TASKS_LIMIT
+    ) {
+      return false;
+    }
+  }
+  if (v.minConfidence !== undefined && !CONFIDENCE_LEVELS.includes(v.minConfidence as string)) {
+    return false;
+  }
+  return true;
+}
+
+/** Size checks against GUARD_LIMITS. Empty array means within limits. */
+export function checkInputLimits(input: TaskExtractionInput): TaskExtractionIssue[] {
+  const issues: TaskExtractionIssue[] = [];
+  if (input.messageId.length > GUARD_LIMITS.maxMessageIdChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "messageId",
+      message: `messageId exceeds ${GUARD_LIMITS.maxMessageIdChars} characters`,
+    });
+  }
+  if (input.subject.length > GUARD_LIMITS.maxSubjectChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "subject",
+      message: `subject exceeds ${GUARD_LIMITS.maxSubjectChars} characters`,
+    });
+  }
+  if (input.body.length > GUARD_LIMITS.maxBodyChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyChars} characters`,
+    });
+  } else if (countWords(input.body) > GUARD_LIMITS.maxBodyWords) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyWords} words`,
+    });
+  }
+  return issues;
+}
+
+function isSupportedLanguage(language: string | undefined): boolean {
+  if (language === undefined) {
+    return true;
+  }
+  const normalized = language.toLowerCase();
+  return normalized === "en" || normalized.startsWith("en-");
+}
+
+/** Return a sanitized copy of the input without mutating the original. */
+export function sanitizeInput(input: TaskExtractionInput): TaskExtractionInput {
+  return {
+    ...input,
+    messageId: input.messageId.trim(),
+    subject: sanitizeText(input.subject),
+    body: sanitizeText(input.body),
+  };
+}
+
+/**
+ * Guarded, non-throwing entry point for untrusted callers.
+ *
+ * Validates, sanitizes, and enforces limits before delegating to
+ * extractTasks. Always returns a discriminated SafeTaskExtractionResult.
+ */
+export function safeExtractTasks(input: unknown, options?: unknown): SafeTaskExtractionResult {
+  if (!validateInput(input)) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: "Input must include a non-empty messageId and string subject and body.",
+      issues: [{ code: "invalid-input", message: "Input failed structural validation." }],
+    };
+  }
+  if (!validateOptions(options)) {
+    return {
+      status: "error",
+      code: "invalid-options",
+      message: `Options must use a maxTasks between 1 and ${MAX_TASKS_LIMIT} and a minConfidence of low, medium, or high.`,
+      issues: [{ code: "invalid-options", message: "Options failed structural validation." }],
+    };
+  }
+  if (!isSupportedLanguage(input.language)) {
+    return {
+      status: "error",
+      code: "unsupported-language",
+      message: `Language "${input.language}" is not supported; only English ("en") is available.`,
+      issues: [
+        {
+          code: "unsupported-language",
+          field: "language",
+          message: "Only English content can be analyzed.",
+        },
+      ],
+    };
+  }
+  const limitIssues = checkInputLimits(input);
+  if (limitIssues.length > 0) {
+    return {
+      status: "error",
+      code: "input-too-large",
+      message: limitIssues.map((issue) => issue.message).join("; "),
+      issues: limitIssues,
+    };
+  }
+  const sanitized = sanitizeInput(input);
+  if (sanitized.subject.trim().length === 0 && sanitized.body.trim().length === 0) {
+    return {
+      status: "error",
+      code: "empty-content",
+      message: "Subject and body are both empty after sanitization; nothing to analyze.",
+      issues: [{ code: "empty-content", message: "No analyzable content present." }],
+    };
+  }
+  return { status: "ok", result: extractTasks(sanitized, options) };
+}

--- a/tools/v2/individual/task-extractor/services/taskExtractor.ts
+++ b/tools/v2/individual/task-extractor/services/taskExtractor.ts
@@ -1,0 +1,308 @@
+// Task Extractor — core extraction engine.
+//
+// Rule-based extraction of action items from subject and body text. Pure and
+// deterministic: no network calls, no mailbox access, no randomness, no clock
+// reads, and no mutation of caller-supplied objects. Relative due phrases only
+// resolve to dates when the caller supplies receivedAt.
+
+import type {
+  ExtractedTask,
+  TaskConfidence,
+  TaskExtractionInput,
+  TaskExtractionOptions,
+  TaskExtractionResult,
+  TaskPriority,
+  TaskSource,
+  TaskTrigger,
+} from "../types/taskExtractor";
+
+export const DEFAULT_MAX_TASKS = 10;
+export const MAX_TASKS_LIMIT = 50;
+/** Task text longer than this is cut at the last word boundary. */
+export const MAX_TASK_TEXT_CHARS = 200;
+
+export const HIGH_PRIORITY_TERMS: ReadonlySet<string> = new Set([
+  "urgent",
+  "urgently",
+  "asap",
+  "immediately",
+  "critical",
+  "blocker",
+  "blocking",
+]);
+
+export const LOW_PRIORITY_TERMS: readonly string[] = [
+  "no rush",
+  "no hurry",
+  "whenever you can",
+  "when you get a chance",
+  "when you have time",
+  "low priority",
+];
+
+export const ACTION_VERBS: ReadonlySet<string> = new Set([
+  "add",
+  "approve",
+  "book",
+  "call",
+  "cancel",
+  "check",
+  "complete",
+  "confirm",
+  "deploy",
+  "draft",
+  "email",
+  "finish",
+  "fix",
+  "follow",
+  "order",
+  "pay",
+  "prepare",
+  "renew",
+  "reply",
+  "review",
+  "schedule",
+  "send",
+  "share",
+  "sign",
+  "submit",
+  "test",
+  "update",
+  "upload",
+  "verify",
+]);
+
+const CHECKBOX_PATTERN = /^[-*]\s*\[\s?\]\s*(.+)$/;
+const BULLET_PATTERN = /^(?:[-*•]|\d+[.)])\s+(.+)$/;
+
+const REQUEST_PATTERNS: readonly RegExp[] = [
+  /\bplease\s+([a-z].+)/i,
+  /\b(?:can|could|would)\s+you\s+(?:please\s+)?(.+)/i,
+  /\b(?:make|be)\s+sure\s+(?:to\s+)?(.+)/i,
+  /\b(?:remember|don't\s+forget|do\s+not\s+forget)\s+to\s+(.+)/i,
+  /\baction\s+required:?\s+(.+)/i,
+  /\b(?:we|you)\s+need\s+to\s+(.+)/i,
+  /\bneeds?\s+you\s+to\s+(.+)/i,
+];
+
+const ISO_DATE_PATTERN = /\b(\d{4})-(\d{2})-(\d{2})\b/;
+const DUE_PHRASE_PATTERN =
+  /\b(?:by|before|due(?:\s+on)?|until)\s+(end\s+of\s+(?:day|week)|eod|eow|today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday|next\s+week)\b/i;
+
+const CONFIDENCE_RANK: Record<TaskConfidence, number> = { low: 0, medium: 1, high: 2 };
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function normalizeTaskText(text: string): string {
+  let cleaned = collapseWhitespace(text).replace(/[.,;:!?\s]+$/, "");
+  if (cleaned.length > MAX_TASK_TEXT_CHARS) {
+    const cut = cleaned.slice(0, MAX_TASK_TEXT_CHARS);
+    const lastSpace = cut.lastIndexOf(" ");
+    cleaned = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd();
+  }
+  return cleaned;
+}
+
+function firstWord(text: string): string {
+  const match = /^[a-z']+/i.exec(text.trim());
+  return match ? match[0].toLowerCase() : "";
+}
+
+function isValidCalendarDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    return false;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function toIsoDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+interface DueHints {
+  dueAtHint?: string;
+  dueTextHint?: string;
+}
+
+function detectDueHints(text: string, receivedAt: string | undefined): DueHints {
+  const isoMatch = ISO_DATE_PATTERN.exec(text);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    if (isValidCalendarDate(Number(year), Number(month), Number(day))) {
+      return { dueAtHint: `${year}-${month}-${day}` };
+    }
+  }
+  const phraseMatch = DUE_PHRASE_PATTERN.exec(text);
+  if (!phraseMatch) {
+    return {};
+  }
+  const phrase = collapseWhitespace(phraseMatch[1].toLowerCase());
+  if (
+    receivedAt !== undefined &&
+    (phrase === "today" || phrase === "end of day" || phrase === "eod")
+  ) {
+    return { dueAtHint: toIsoDate(new Date(receivedAt).getTime()) };
+  }
+  if (receivedAt !== undefined && phrase === "tomorrow") {
+    return { dueAtHint: toIsoDate(new Date(receivedAt).getTime() + MILLISECONDS_PER_DAY) };
+  }
+  return { dueTextHint: phrase };
+}
+
+function detectPriority(taskText: string, contextLine: string): TaskPriority {
+  const haystack = `${taskText} ${contextLine}`.toLowerCase();
+  for (const phrase of LOW_PRIORITY_TERMS) {
+    if (haystack.includes(phrase)) {
+      return "low";
+    }
+  }
+  if (haystack.includes("high priority")) {
+    return "high";
+  }
+  for (const token of haystack.split(/[^a-z]+/)) {
+    if (HIGH_PRIORITY_TERMS.has(token)) {
+      return "high";
+    }
+  }
+  return "normal";
+}
+
+interface Candidate {
+  text: string;
+  source: TaskSource;
+  trigger: TaskTrigger;
+  confidence: TaskConfidence;
+  contextLine: string;
+}
+
+function matchLine(line: string, source: TaskSource): Candidate | undefined {
+  const checkbox = CHECKBOX_PATTERN.exec(line);
+  if (checkbox) {
+    return {
+      text: checkbox[1],
+      source,
+      trigger: "checkbox",
+      confidence: "high",
+      contextLine: line,
+    };
+  }
+  for (const pattern of REQUEST_PATTERNS) {
+    const request = pattern.exec(line);
+    if (request) {
+      return {
+        text: request[1],
+        source,
+        trigger: "request-phrase",
+        confidence: "high",
+        contextLine: line,
+      };
+    }
+  }
+  const bullet = BULLET_PATTERN.exec(line);
+  if (bullet && ACTION_VERBS.has(firstWord(bullet[1]))) {
+    return {
+      text: bullet[1],
+      source,
+      trigger: "bullet-action",
+      confidence: "medium",
+      contextLine: line,
+    };
+  }
+  if (ACTION_VERBS.has(firstWord(line))) {
+    return { text: line, source, trigger: "imperative-line", confidence: "low", contextLine: line };
+  }
+  return undefined;
+}
+
+/** Clamp caller-supplied maxTasks into the supported range. */
+export function resolveMaxTasks(maxTasks: number | undefined): number {
+  if (maxTasks === undefined) {
+    return DEFAULT_MAX_TASKS;
+  }
+  return Math.min(Math.max(Math.trunc(maxTasks), 1), MAX_TASKS_LIMIT);
+}
+
+/**
+ * Extract action items from a message.
+ *
+ * Assumes input has already been validated and sanitized — use
+ * safeExtractTasks from services/guards for untrusted callers.
+ */
+export function extractTasks(
+  input: TaskExtractionInput,
+  options: TaskExtractionOptions = {},
+): TaskExtractionResult {
+  const lines: Array<{ text: string; source: TaskSource }> = [];
+  if (input.subject.trim().length > 0) {
+    lines.push({ text: collapseWhitespace(input.subject), source: "subject" });
+  }
+  for (const rawLine of input.body.split(/\r?\n/)) {
+    const line = collapseWhitespace(rawLine);
+    if (line.length > 0) {
+      lines.push({ text: line, source: "body" });
+    }
+  }
+
+  const candidates: Candidate[] = [];
+  for (const line of lines) {
+    const candidate = matchLine(line.text, line.source);
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  const minConfidence = CONFIDENCE_RANK[options.minConfidence ?? "low"];
+  const maxTasks = resolveMaxTasks(options.maxTasks);
+  const seen = new Set<string>();
+  const tasks: ExtractedTask[] = [];
+  let truncated = false;
+  for (const candidate of candidates) {
+    if (CONFIDENCE_RANK[candidate.confidence] < minConfidence) {
+      continue;
+    }
+    const text = normalizeTaskText(candidate.text);
+    if (text.length === 0) {
+      continue;
+    }
+    const dedupKey = text.toLowerCase();
+    if (seen.has(dedupKey)) {
+      continue;
+    }
+    if (tasks.length >= maxTasks) {
+      truncated = true;
+      break;
+    }
+    seen.add(dedupKey);
+    const due = detectDueHints(candidate.contextLine, input.receivedAt);
+    tasks.push({
+      id: `${input.messageId}-task-${tasks.length + 1}`,
+      text,
+      source: candidate.source,
+      trigger: candidate.trigger,
+      priority: detectPriority(text, candidate.contextLine),
+      confidence: candidate.confidence,
+      ...(due.dueAtHint !== undefined ? { dueAtHint: due.dueAtHint } : {}),
+      ...(due.dueTextHint !== undefined ? { dueTextHint: due.dueTextHint } : {}),
+    });
+  }
+
+  return {
+    messageId: input.messageId,
+    tasks,
+    stats: {
+      lineCount: lines.length,
+      candidateCount: candidates.length,
+      extractedCount: tasks.length,
+      truncated,
+    },
+  };
+}

--- a/tools/v2/individual/task-extractor/specs.md
+++ b/tools/v2/individual/task-extractor/specs.md
@@ -1,25 +1,3 @@
-# Task Extractor
-
-Extract tasks from emails.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/task-extractor/README.md"
-  @"
-
 # Task Extractor Specs
 
 ## Purpose
@@ -30,7 +8,29 @@ Extract tasks from emails.
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v2/individual/task-extractor/`
+
+This is a self-contained tooling workspace. Do not wire this tool into the
+main app, routing, inbox architecture, wallet core, Stellar core, or design
+system unless a future integration issue explicitly allows it.
+
+## Internal structure
+
+- `index.ts` — non-UI execution entry point (barrel export)
+- `types/` — typed input/output contract and error codes
+- `services/` — extraction engine, validation guards, fixtures
+- `tests/` — vitest suites
+- `docs/` — contract documentation
+
+## Execution contract
+
+The backend-facing contract is documented in `docs/contract.md`:
+
+- Typed inputs (`TaskExtractionInput`, `TaskExtractionOptions`) and outputs
+  (`TaskExtractionResult`, `SafeTaskExtractionResult`).
+- Machine-readable error codes (`invalid-input`, `invalid-options`,
+  `input-too-large`, `empty-content`, `unsupported-language`).
+- Fixtures covering success and failure cases in `services/fixtures.ts`.
 
 ## Required issue categories
 

--- a/tools/v2/individual/task-extractor/tests/guards.test.ts
+++ b/tools/v2/individual/task-extractor/tests/guards.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeExtractTasks,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "../services/guards";
+import { failureFixtures, successFixtures } from "../services/fixtures";
+import type { TaskExtractionInput } from "../types/taskExtractor";
+
+function makeInput(overrides: Partial<TaskExtractionInput> = {}): TaskExtractionInput {
+  return {
+    messageId: "msg-guard-001",
+    subject: "Hello",
+    body: "Please review the update.",
+    ...overrides,
+  };
+}
+
+describe("sanitizeText", () => {
+  it("strips control and zero-width characters", () => {
+    expect(sanitizeText("he\u0000llo\u200b world\u2060")).toBe("hello world");
+  });
+
+  it("normalizes composed characters to NFC", () => {
+    expect(sanitizeText("cafe\u0301")).toBe("café");
+  });
+});
+
+describe("validateInput", () => {
+  it("accepts a minimal valid input", () => {
+    expect(validateInput(makeInput())).toBe(true);
+  });
+
+  it("rejects non-objects, null, and arrays", () => {
+    expect(validateInput("text")).toBe(false);
+    expect(validateInput(null)).toBe(false);
+    expect(validateInput([makeInput()])).toBe(false);
+  });
+
+  it("rejects a missing or blank messageId", () => {
+    expect(validateInput({ ...makeInput(), messageId: undefined })).toBe(false);
+    expect(validateInput(makeInput({ messageId: "   " }))).toBe(false);
+  });
+
+  it("rejects non-string subject or body", () => {
+    expect(validateInput({ ...makeInput(), subject: 5 })).toBe(false);
+    expect(validateInput({ ...makeInput(), body: undefined })).toBe(false);
+  });
+
+  it("rejects an unparseable receivedAt", () => {
+    expect(validateInput(makeInput({ receivedAt: "not-a-date" }))).toBe(false);
+    expect(validateInput(makeInput({ receivedAt: "2026-07-01T00:00:00.000Z" }))).toBe(true);
+  });
+});
+
+describe("validateOptions", () => {
+  it("accepts undefined and valid shapes", () => {
+    expect(validateOptions(undefined)).toBe(true);
+    expect(validateOptions({})).toBe(true);
+    expect(validateOptions({ maxTasks: 5, minConfidence: "medium" })).toBe(true);
+  });
+
+  it("rejects wrong types and out-of-range values", () => {
+    expect(validateOptions({ maxTasks: 0 })).toBe(false);
+    expect(validateOptions({ maxTasks: Number.NaN })).toBe(false);
+    expect(validateOptions({ maxTasks: 51 })).toBe(false);
+    expect(validateOptions({ minConfidence: "urgent" })).toBe(false);
+  });
+});
+
+describe("checkInputLimits", () => {
+  it("returns no issues within limits", () => {
+    expect(checkInputLimits(makeInput())).toEqual([]);
+  });
+
+  it("flags each oversized field with input-too-large", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        messageId: "x".repeat(GUARD_LIMITS.maxMessageIdChars + 1),
+        subject: "y".repeat(GUARD_LIMITS.maxSubjectChars + 1),
+        body: "z".repeat(GUARD_LIMITS.maxBodyChars + 1),
+      }),
+    );
+    expect(issues).toHaveLength(3);
+    expect(issues.every((issue) => issue.code === "input-too-large")).toBe(true);
+    expect(issues.map((issue) => issue.field)).toEqual(["messageId", "subject", "body"]);
+  });
+
+  it("flags a body with too many words even under the char limit", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        body: Array(GUARD_LIMITS.maxBodyWords + 1)
+          .fill("w")
+          .join(" "),
+      }),
+    );
+    expect(issues).toEqual([expect.objectContaining({ code: "input-too-large", field: "body" })]);
+  });
+});
+
+describe("sanitizeInput", () => {
+  it("returns a cleaned copy without mutating the original", () => {
+    const input = makeInput({ messageId: "  msg-1  ", subject: "Hi\u200b", body: "ok" });
+    const cleaned = sanitizeInput(input);
+    expect(cleaned).toMatchObject({ messageId: "msg-1", subject: "Hi", body: "ok" });
+    expect(input.messageId).toBe("  msg-1  ");
+  });
+});
+
+describe("safeExtractTasks", () => {
+  it("returns ok with the expected tasks for every success fixture", () => {
+    for (const fixture of successFixtures) {
+      const outcome = safeExtractTasks(fixture.input);
+      expect(outcome.status, fixture.name).toBe("ok");
+      if (outcome.status === "ok") {
+        expect(
+          outcome.result.tasks.map((task) => task.text),
+          fixture.name,
+        ).toEqual(fixture.expectedTaskTexts);
+      }
+    }
+  });
+
+  it("returns the expected error code for every failure fixture", () => {
+    for (const fixture of failureFixtures) {
+      const outcome = safeExtractTasks(fixture.input);
+      expect(outcome.status, fixture.name).toBe("error");
+      if (outcome.status === "error") {
+        expect(outcome.code, fixture.name).toBe(fixture.expectedCode);
+        expect(outcome.issues.length, fixture.name).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("rejects invalid options with invalid-options", () => {
+    const outcome = safeExtractTasks(makeInput(), { maxTasks: -5 });
+    expect(outcome).toMatchObject({ status: "error", code: "invalid-options" });
+  });
+
+  it("accepts regional English language tags", () => {
+    const outcome = safeExtractTasks(makeInput({ language: "en-GB" }));
+    expect(outcome.status).toBe("ok");
+  });
+
+  it("extracts from sanitized text so hidden characters cannot mask requests", () => {
+    const outcome = safeExtractTasks(
+      makeInput({ subject: "", body: "Plea\u200bse review the security report" }),
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status === "ok") {
+      expect(outcome.result.tasks.map((task) => task.text)).toEqual(["review the security report"]);
+    }
+  });
+
+  it("never throws on hostile payloads", () => {
+    const hostile = [null, 42, "text", [], { messageId: 1 }, { __proto__: { subject: "x" } }];
+    for (const payload of hostile) {
+      expect(() => safeExtractTasks(payload)).not.toThrow();
+      expect(safeExtractTasks(payload).status).toBe("error");
+    }
+  });
+});

--- a/tools/v2/individual/task-extractor/tests/taskExtractor.test.ts
+++ b/tools/v2/individual/task-extractor/tests/taskExtractor.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractTasks,
+  DEFAULT_MAX_TASKS,
+  MAX_TASKS_LIMIT,
+  MAX_TASK_TEXT_CHARS,
+  resolveMaxTasks,
+} from "../services/taskExtractor";
+import { successFixtures } from "../services/fixtures";
+import type { TaskExtractionInput } from "../types/taskExtractor";
+
+function makeInput(overrides: Partial<TaskExtractionInput> = {}): TaskExtractionInput {
+  return {
+    messageId: "msg-test-001",
+    subject: "",
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("extractTasks", () => {
+  it("extracts the expected tasks from each success fixture", () => {
+    for (const fixture of successFixtures) {
+      const result = extractTasks(fixture.input);
+      expect(
+        result.tasks.map((task) => task.text),
+        fixture.name,
+      ).toEqual(fixture.expectedTaskTexts);
+      expect(result.messageId).toBe(fixture.input.messageId);
+    }
+  });
+
+  it("assigns deterministic sequential task ids", () => {
+    const result = extractTasks(
+      makeInput({ body: "Please review the deck.\nPlease send the notes." }),
+    );
+    expect(result.tasks.map((task) => task.id)).toEqual([
+      "msg-test-001-task-1",
+      "msg-test-001-task-2",
+    ]);
+  });
+
+  it("treats checkbox items as high-confidence tasks", () => {
+    const result = extractTasks(makeInput({ body: "- [ ] Book the venue" }));
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      text: "Book the venue",
+      trigger: "checkbox",
+      confidence: "high",
+      source: "body",
+    });
+  });
+
+  it("captures the requested action from request phrases", () => {
+    const result = extractTasks(
+      makeInput({ body: "Could you please share the meeting notes with the team?" }),
+    );
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      text: "share the meeting notes with the team",
+      trigger: "request-phrase",
+      confidence: "high",
+    });
+  });
+
+  it("keeps action-verb bullets and drops non-action bullets", () => {
+    const result = extractTasks(makeInput({ body: "- schedule the retro\n- cake for the party" }));
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      text: "schedule the retro",
+      trigger: "bullet-action",
+      confidence: "medium",
+    });
+  });
+
+  it("flags bare imperative lines with low confidence", () => {
+    const result = extractTasks(makeInput({ body: "Send the invoice to the client" }));
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      trigger: "imperative-line",
+      confidence: "low",
+    });
+  });
+
+  it("filters below minConfidence without changing stronger tasks", () => {
+    const body = "Send the invoice to the client\n- [ ] Book the venue";
+    const all = extractTasks(makeInput({ body }));
+    const filtered = extractTasks(makeInput({ body }), { minConfidence: "medium" });
+    expect(all.tasks).toHaveLength(2);
+    expect(filtered.tasks).toHaveLength(1);
+    expect(filtered.tasks[0].text).toBe("Book the venue");
+    expect(filtered.stats.candidateCount).toBe(2);
+  });
+
+  it("detects high and low priority from surrounding language", () => {
+    const urgent = extractTasks(makeInput({ body: "Please fix the login bug, it is urgent." }));
+    const relaxed = extractTasks(makeInput({ body: "Please update the wiki, no rush at all." }));
+    const plain = extractTasks(makeInput({ body: "Please confirm the booking." }));
+    expect(urgent.tasks[0].priority).toBe("high");
+    expect(relaxed.tasks[0].priority).toBe("low");
+    expect(plain.tasks[0].priority).toBe("normal");
+  });
+
+  it("resolves ISO dates into dueAtHint and rejects impossible dates", () => {
+    const dated = extractTasks(makeInput({ body: "Please submit the report by 2026-08-15." }));
+    const bogus = extractTasks(makeInput({ body: "Please submit the report by 2026-13-40." }));
+    expect(dated.tasks[0].dueAtHint).toBe("2026-08-15");
+    expect(bogus.tasks[0].dueAtHint).toBeUndefined();
+  });
+
+  it("resolves relative due phrases only when receivedAt is present", () => {
+    const withReceived = extractTasks(
+      makeInput({
+        body: "Please pay the invoice by tomorrow.",
+        receivedAt: "2026-07-03T08:00:00.000Z",
+      }),
+    );
+    const withoutReceived = extractTasks(
+      makeInput({ body: "Please pay the invoice by tomorrow." }),
+    );
+    expect(withReceived.tasks[0].dueAtHint).toBe("2026-07-04");
+    expect(withReceived.tasks[0].dueTextHint).toBeUndefined();
+    expect(withoutReceived.tasks[0].dueAtHint).toBeUndefined();
+    expect(withoutReceived.tasks[0].dueTextHint).toBe("tomorrow");
+  });
+
+  it("keeps weekday due phrases as text hints", () => {
+    const result = extractTasks(
+      makeInput({
+        body: "Please draft the summary by Friday.",
+        receivedAt: "2026-07-03T08:00:00.000Z",
+      }),
+    );
+    expect(result.tasks[0].dueAtHint).toBeUndefined();
+    expect(result.tasks[0].dueTextHint).toBe("friday");
+  });
+
+  it("deduplicates repeated task texts case-insensitively", () => {
+    const result = extractTasks(
+      makeInput({ body: "Please review the deck.\nplease Review The Deck." }),
+    );
+    expect(result.tasks).toHaveLength(1);
+    expect(result.stats.candidateCount).toBe(2);
+  });
+
+  it("truncates to maxTasks and reports it in stats", () => {
+    const body = [
+      "Please review the deck.",
+      "Please send the notes.",
+      "Please book the room.",
+    ].join("\n");
+    const result = extractTasks(makeInput({ body }), { maxTasks: 2 });
+    expect(result.tasks).toHaveLength(2);
+    expect(result.stats).toMatchObject({
+      candidateCount: 3,
+      extractedCount: 2,
+      truncated: true,
+    });
+  });
+
+  it("cuts overlong task text at a word boundary", () => {
+    const longTail = "review " + "spreadsheet ".repeat(40);
+    const result = extractTasks(makeInput({ body: `Please ${longTail}` }));
+    const text = result.tasks[0].text;
+    expect(text.length).toBeLessThanOrEqual(MAX_TASK_TEXT_CHARS);
+    expect(text.endsWith("spreadsheet")).toBe(true);
+  });
+
+  it("returns an empty task list with stats when nothing matches", () => {
+    const result = extractTasks(
+      makeInput({ subject: "Weekly notes", body: "It was a quiet week." }),
+    );
+    expect(result.tasks).toEqual([]);
+    expect(result.stats).toEqual({
+      lineCount: 2,
+      candidateCount: 0,
+      extractedCount: 0,
+      truncated: false,
+    });
+  });
+
+  it("is deterministic for identical input", () => {
+    const input = makeInput({
+      subject: "Action required: renew the certificate",
+      body: "Please renew the TLS certificate by 2026-08-01.",
+      receivedAt: "2026-07-03T08:00:00.000Z",
+    });
+    expect(extractTasks(input)).toEqual(extractTasks(input));
+  });
+
+  it("does not mutate the caller's input", () => {
+    const input = makeInput({ subject: "Sprint prep", body: "- [ ] Update the roadmap deck" });
+    const snapshot = JSON.parse(JSON.stringify(input));
+    extractTasks(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("resolveMaxTasks", () => {
+  it("defaults when undefined and clamps out-of-range values", () => {
+    expect(resolveMaxTasks(undefined)).toBe(DEFAULT_MAX_TASKS);
+    expect(resolveMaxTasks(0)).toBe(1);
+    expect(resolveMaxTasks(7.9)).toBe(7);
+    expect(resolveMaxTasks(1000)).toBe(MAX_TASKS_LIMIT);
+  });
+});

--- a/tools/v2/individual/task-extractor/types/taskExtractor.ts
+++ b/tools/v2/individual/task-extractor/types/taskExtractor.ts
@@ -1,0 +1,115 @@
+// Task Extractor — typed execution contract.
+//
+// Backend-facing types for the task-extractor tool. These types define the
+// stable, non-UI contract between callers (services, jobs, tests) and the
+// extraction engine. No presentation concerns belong here.
+
+/** Urgency inferred from the language around a task. */
+export type TaskPriority = "low" | "normal" | "high";
+
+/** How much trust callers should place in an extracted task. */
+export type TaskConfidence = "low" | "medium" | "high";
+
+/** Which part of the message a task was found in. */
+export type TaskSource = "subject" | "body";
+
+/** Which rule produced a task candidate. */
+export type TaskTrigger = "checkbox" | "request-phrase" | "bullet-action" | "imperative-line";
+
+/** Input accepted by the extraction engine. */
+export interface TaskExtractionInput {
+  /** Stable caller-supplied identifier echoed back in the result. */
+  messageId: string;
+  /** Message subject line. May be empty when the body is not. */
+  subject: string;
+  /** Plain-text message body. May be empty when the subject is not. */
+  body: string;
+  /** Optional sender address, kept for correlation only — never analyzed. */
+  senderAddress?: string;
+  /**
+   * Optional ISO 8601 timestamp of when the message was received. When
+   * present, relative due phrases ("today", "tomorrow") resolve to dates.
+   */
+  receivedAt?: string;
+  /**
+   * Optional BCP 47 language tag. Only English ("en" or "en-*") is
+   * supported; other values are rejected with "unsupported-language".
+   */
+  language?: string;
+}
+
+/** Tuning options for a single extraction call. */
+export interface TaskExtractionOptions {
+  /** Upper bound on returned tasks (1–50). Defaults to 10. */
+  maxTasks?: number;
+  /** Drop tasks below this confidence. Defaults to "low" (keep all). */
+  minConfidence?: TaskConfidence;
+}
+
+/** One extracted action item. */
+export interface ExtractedTask {
+  /** Deterministic id: `<messageId>-task-<n>` in order of appearance. */
+  id: string;
+  /** The task text, trimmed and whitespace-collapsed. */
+  text: string;
+  /** Where the task was found. */
+  source: TaskSource;
+  /** Which rule matched. */
+  trigger: TaskTrigger;
+  /** Urgency inferred from surrounding language. */
+  priority: TaskPriority;
+  /** Trust level derived from the strength of the matching rule. */
+  confidence: TaskConfidence;
+  /** Resolved due date (YYYY-MM-DD) when one could be determined. */
+  dueAtHint?: string;
+  /** Raw due phrase (e.g. "by friday", "eod") when a date could not be resolved. */
+  dueTextHint?: string;
+}
+
+/** Deterministic counters describing how the extraction ran. */
+export interface TaskExtractionStats {
+  /** Non-empty lines scanned across subject and body. */
+  lineCount: number;
+  /** Candidates matched by any rule before filtering and dedup. */
+  candidateCount: number;
+  /** Tasks returned after confidence filtering, dedup, and truncation. */
+  extractedCount: number;
+  /** True when maxTasks cut off further tasks. */
+  truncated: boolean;
+}
+
+/** Successful extraction output. An empty task list is a valid outcome. */
+export interface TaskExtractionResult {
+  /** Echo of the input messageId. */
+  messageId: string;
+  /** Extracted tasks in order of appearance, truncated to maxTasks. */
+  tasks: ExtractedTask[];
+  /** Counters describing the extraction. */
+  stats: TaskExtractionStats;
+}
+
+/** Machine-readable failure codes for the safe entry point. */
+export type TaskExtractionErrorCode =
+  | "invalid-input"
+  | "invalid-options"
+  | "input-too-large"
+  | "empty-content"
+  | "unsupported-language";
+
+/** One validation problem, tied to a field when known. */
+export interface TaskExtractionIssue {
+  code: TaskExtractionErrorCode;
+  /** Input field the issue applies to, when identifiable. */
+  field?: string;
+  message: string;
+}
+
+/** Discriminated result of the guarded entry point — never throws. */
+export type SafeTaskExtractionResult =
+  | { status: "ok"; result: TaskExtractionResult }
+  | {
+      status: "error";
+      code: TaskExtractionErrorCode;
+      message: string;
+      issues: TaskExtractionIssue[];
+    };

--- a/tools/v2/individual/task-extractor/vitest.config.ts
+++ b/tools/v2/individual/task-extractor/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    root: path.resolve(__dirname),
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements the non-UI execution contract for `tools/v2/individual/task-extractor` (#1383). The tool now exposes a stable, backend-facing API that extracts action items from a message independently of any presentation concerns.

- **Typed contract** — `types/taskExtractor.ts` defines `TaskExtractionInput`, `TaskExtractionOptions`, `TaskExtractionResult`, `ExtractedTask`, `SafeTaskExtractionResult`, and the error-code union; documented in `docs/contract.md`.
- **Non-UI service entry point** — `index.ts` exports `safeExtractTasks` (guarded, never throws, returns a discriminated ok/error result) and `extractTasks` (pure engine for pre-validated input). Both are deterministic: no network, no randomness, no clock reads, no input mutation — relative due phrases ("tomorrow", "eod") only resolve to dates when the caller supplies `receivedAt`.
- **Extraction rules** — checkbox items, request phrases ("please …", "could you …", "action required: …"), action-verb bullets, and bare imperative lines, each with a trigger tag and confidence tier; plus priority inference (urgent/no-rush language), ISO and relative due-date hints, case-insensitive dedup, and `maxTasks` truncation reported in stats. An empty task list is a valid success outcome.
- **Error codes** — `invalid-input`, `invalid-options`, `input-too-large`, `empty-content`, `unsupported-language`, enforced by a folder-local guard layer (`services/guards.ts`) with size limits and control/zero-width character sanitization.
- **Fixtures** — `services/fixtures.ts` covers success cases (explicit requests, checkbox/bullet lists, urgent + relative due date, no-tasks) and failure cases (one per error path).
- **Tests** — 37 vitest cases across engine and guards, replaying every fixture through the public entry points.

No styling or layout files are changed; all work stays inside the tool's ownership boundary. Follows the same contract structure as the merged follow-up-sequence-builder contract (#1406) and the sentiment-detector contract (#1413).

## Test plan

```sh
npx vitest run --config tools/v2/individual/task-extractor/vitest.config.ts
```

- [x] 37/37 tests pass
- [x] `tsc --noEmit --strict` clean on the tool's files
- [x] `eslint` clean on the folder

Closes #1383