### PR TITLE
feat(readability-improver): add typed non-UI execution contract

### DIFF
--- a/tools/v2/individual/readability-improver/README.md
+++ b/tools/v2/individual/readability-improver/README.md
@@ -1,15 +1,60 @@
 # Readability Improver
 
-This folder is the isolated workspace for the Readability Improver tool.
+This folder is the isolated workspace for the Readability Improver tool. It
+analyzes a message's subject and body, scores reading ease, and returns
+typed, deterministic improvement suggestions.
+
+## Execution contract
+
+The non-UI entry point is exported from `index.ts`:
+
+```ts
+import { safeImproveReadability } from "tools/v2/individual/readability-improver";
+
+const outcome = safeImproveReadability({
+  messageId: "msg-1",
+  subject: "Process update",
+  body: "We will utilize the new workflow to facilitate onboarding.",
+});
+
+if (outcome.status === "ok") {
+  outcome.result.score;  // Flesch reading ease, 0–100
+  outcome.result.issues; // typed findings with suggestions
+}
+```
+
+- `safeImproveReadability` — guarded entry point for untrusted input;
+  validates, sanitizes, enforces limits, and never throws.
+- `improveReadability` — pure engine for pre-validated input.
+- Full contract (types, error codes, analysis rules): `docs/contract.md`.
+- Fixtures for success and failure paths: `services/fixtures.ts`.
+
+## Layout
+
+- `index.ts` — public barrel export (no UI code)
+- `types/` — typed input/output contract and error codes
+- `services/` — analysis engine, guards, fixtures
+- `tests/` — vitest suites for the engine and guards
+- `docs/` — architecture and contract documentation
+- `components/`, `hooks/` — reserved for future UI work (untouched here)
+
+## Testing
+
+From the repository root:
+
+```sh
+npx vitest run --config tools/v2/individual/readability-improver/vitest.config.ts
+```
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\readability-improver\
-`
+`tools/v2/individual/readability-improver/`
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+See specs.md for the issue categories and contributor expectations, and
+docs/ARCHITECTURE.md for module boundaries.

--- a/tools/v2/individual/readability-improver/README.md
+++ b/tools/v2/individual/readability-improver/README.md
@@ -18,7 +18,7 @@ const outcome = safeImproveReadability({
 });
 
 if (outcome.status === "ok") {
-  outcome.result.score;  // Flesch reading ease, 0–100
+  outcome.result.score; // Flesch reading ease, 0–100
   outcome.result.issues; // typed findings with suggestions
 }
 ```

--- a/tools/v2/individual/readability-improver/docs/contract.md
+++ b/tools/v2/individual/readability-improver/docs/contract.md
@@ -1,0 +1,123 @@
+# Readability Improver — Execution Contract
+
+Stable backend-facing contract for analyzing message readability independently
+of any presentation layer. All types live in `types/readabilityImprover.ts`
+and are re-exported from the folder root `index.ts`.
+
+## Entry points
+
+| Export | Kind | Use when |
+| --- | --- | --- |
+| `safeImproveReadability(input: unknown, options?: unknown): SafeReadabilityResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
+| `improveReadability(input: ReadabilityInput, options?: ReadabilityOptions): ReadabilityResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+
+Both functions are pure and deterministic: no network calls, no mailbox access,
+no randomness, no clock reads, and no mutation of caller-supplied objects.
+Identical input always produces an identical result.
+
+## Input
+
+```ts
+interface ReadabilityInput {
+  messageId: string;      // required, non-empty; echoed back in the result
+  subject: string;        // may be empty when body is not
+  body: string;           // plain text; may be empty when subject is not
+  senderAddress?: string; // correlation only — never analyzed
+  receivedAt?: string;    // ISO 8601 when present
+  language?: string;      // BCP 47; only "en" / "en-*" supported
+}
+
+interface ReadabilityOptions {
+  includeIssues?: boolean; // default true
+  maxIssues?: number;      // 1–100, default 25
+}
+```
+
+## Output
+
+```ts
+interface ReadabilityResult {
+  messageId: string;
+  score: number;              // Flesch reading ease, clamped to [0, 100]
+  grade: "very-easy" | "easy" | "medium" | "hard" | "very-hard";
+  issues: ReadabilityIssue[]; // order of appearance, truncated to maxIssues
+  metrics: ReadabilityMetrics; // word/sentence/paragraph counts, complexity
+  stats: ReadabilityStats;     // issueCandidates, issueCount, truncated
+}
+
+interface ReadabilityIssue {
+  type: "long-sentence" | "complex-word" | "passive-voice" | "long-paragraph" | "shouting";
+  severity: "info" | "warn";
+  source: "subject" | "body";
+  excerpt: string;    // offending text, capped at 80 chars
+  suggestion: string; // actionable improvement
+}
+```
+
+An empty `issues` array is a valid success outcome, not an error.
+
+The guarded entry point wraps this in a discriminated union:
+
+```ts
+type SafeReadabilityResult =
+  | { status: "ok"; result: ReadabilityResult }
+  | { status: "error"; code: ReadabilityErrorCode; message: string; issues: ReadabilityValidationIssue[] };
+```
+
+## Error codes
+
+| Code | Trigger |
+| --- | --- |
+| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options` | `includeIssues` not a boolean, or `maxIssues` outside 1–100. |
+| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
+| `empty-content` | Subject and body are both empty after sanitization. |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+
+## Analysis rules
+
+Rule-based and folder-local; the subject and each body paragraph are scanned
+sentence by sentence, in order of appearance:
+
+| Type | Trigger | Severity |
+| --- | --- | --- |
+| `long-sentence` | > 25 words (> 40 words escalates) | info / warn |
+| `complex-word` | Wordy term with a plain replacement (`PLAIN_LANGUAGE_REPLACEMENTS`, e.g. "utilize" → "use") | info |
+| `passive-voice` | Auxiliary + past participle ("was completed") | info |
+| `long-paragraph` | Body paragraph > 100 words | info |
+| `shouting` | Two or more ALL-CAPS words (4+ letters) in a sentence | warn |
+
+- **Score**: Flesch reading ease
+  (`206.835 − 1.015 × words/sentences − 84.6 × syllables/words`), clamped to
+  [0, 100] and rounded to 1 decimal; 0 for empty text. Syllables use a
+  deterministic vowel-group heuristic with a silent-e correction.
+- **Grade**: ≥ 90 `very-easy`, ≥ 70 `easy`, ≥ 50 `medium`, ≥ 30 `hard`,
+  else `very-hard`.
+- **Truncation**: issues stop at `maxIssues`; `stats.truncated` reports it.
+
+## Sanitization
+
+`safeImproveReadability` normalizes text to NFC and strips ASCII control
+characters and zero-width characters (U+200B–U+200D, U+2060, U+FEFF) before
+analysis, so hidden characters cannot mask wordy terms.
+
+## Fixtures
+
+`services/fixtures.ts` exports:
+
+- `successFixtures` — clean text (no issues), a wordy formal memo, and a
+  passive/shouting sample with their expected issue types.
+- `failureFixtures` — one payload per error path with its expected error code.
+
+Tests in `tests/` replay both sets through the public entry points.
+
+## Boundaries
+
+This tool is a self-contained workspace. It has no imports from the main app,
+routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system, and exports no UI (`components/` and `hooks/` are untouched).
+Run its tests from the repository root with:
+
+```sh
+npx vitest run --config tools/v2/individual/readability-improver/vitest.config.ts
+```

--- a/tools/v2/individual/readability-improver/docs/contract.md
+++ b/tools/v2/individual/readability-improver/docs/contract.md
@@ -6,10 +6,10 @@ and are re-exported from the folder root `index.ts`.
 
 ## Entry points
 
-| Export | Kind | Use when |
-| --- | --- | --- |
-| `safeImproveReadability(input: unknown, options?: unknown): SafeReadabilityResult` | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws. |
-| `improveReadability(input: ReadabilityInput, options?: ReadabilityOptions): ReadabilityResult` | Pure engine | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
+| Export                                                                                         | Kind                        | Use when                                                                                |
+| ---------------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------- |
+| `safeImproveReadability(input: unknown, options?: unknown): SafeReadabilityResult`             | Guarded service entry point | Caller input is untrusted (API handlers, queue consumers). Never throws.                |
+| `improveReadability(input: ReadabilityInput, options?: ReadabilityOptions): ReadabilityResult` | Pure engine                 | Input is already validated and sanitized (e.g. replaying fixtures, internal pipelines). |
 
 Both functions are pure and deterministic: no network calls, no mailbox access,
 no randomness, no clock reads, and no mutation of caller-supplied objects.
@@ -19,17 +19,17 @@ Identical input always produces an identical result.
 
 ```ts
 interface ReadabilityInput {
-  messageId: string;      // required, non-empty; echoed back in the result
-  subject: string;        // may be empty when body is not
-  body: string;           // plain text; may be empty when subject is not
+  messageId: string; // required, non-empty; echoed back in the result
+  subject: string; // may be empty when body is not
+  body: string; // plain text; may be empty when subject is not
   senderAddress?: string; // correlation only — never analyzed
-  receivedAt?: string;    // ISO 8601 when present
-  language?: string;      // BCP 47; only "en" / "en-*" supported
+  receivedAt?: string; // ISO 8601 when present
+  language?: string; // BCP 47; only "en" / "en-*" supported
 }
 
 interface ReadabilityOptions {
   includeIssues?: boolean; // default true
-  maxIssues?: number;      // 1–100, default 25
+  maxIssues?: number; // 1–100, default 25
 }
 ```
 
@@ -38,18 +38,18 @@ interface ReadabilityOptions {
 ```ts
 interface ReadabilityResult {
   messageId: string;
-  score: number;              // Flesch reading ease, clamped to [0, 100]
+  score: number; // Flesch reading ease, clamped to [0, 100]
   grade: "very-easy" | "easy" | "medium" | "hard" | "very-hard";
   issues: ReadabilityIssue[]; // order of appearance, truncated to maxIssues
   metrics: ReadabilityMetrics; // word/sentence/paragraph counts, complexity
-  stats: ReadabilityStats;     // issueCandidates, issueCount, truncated
+  stats: ReadabilityStats; // issueCandidates, issueCount, truncated
 }
 
 interface ReadabilityIssue {
   type: "long-sentence" | "complex-word" | "passive-voice" | "long-paragraph" | "shouting";
   severity: "info" | "warn";
   source: "subject" | "body";
-  excerpt: string;    // offending text, capped at 80 chars
+  excerpt: string; // offending text, capped at 80 chars
   suggestion: string; // actionable improvement
 }
 ```
@@ -61,31 +61,36 @@ The guarded entry point wraps this in a discriminated union:
 ```ts
 type SafeReadabilityResult =
   | { status: "ok"; result: ReadabilityResult }
-  | { status: "error"; code: ReadabilityErrorCode; message: string; issues: ReadabilityValidationIssue[] };
+  | {
+      status: "error";
+      code: ReadabilityErrorCode;
+      message: string;
+      issues: ReadabilityValidationIssue[];
+    };
 ```
 
 ## Error codes
 
-| Code | Trigger |
-| --- | --- |
-| `invalid-input` | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
-| `invalid-options` | `includeIssues` not a boolean, or `maxIssues` outside 1–100. |
-| `input-too-large` | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`). |
-| `empty-content` | Subject and body are both empty after sanitization. |
-| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag. |
+| Code                   | Trigger                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid-input`        | Payload is not an object, `messageId` missing or blank, `subject`/`body` not strings, `receivedAt` unparseable, or optional fields have wrong types. |
+| `invalid-options`      | `includeIssues` not a boolean, or `maxIssues` outside 1–100.                                                                                         |
+| `input-too-large`      | `messageId` > 256 chars, `subject` > 500 chars, `body` > 50,000 chars or > 10,000 words (limits in `GUARD_LIMITS`).                                  |
+| `empty-content`        | Subject and body are both empty after sanitization.                                                                                                  |
+| `unsupported-language` | `language` is set and is not `en` or an `en-*` regional tag.                                                                                         |
 
 ## Analysis rules
 
 Rule-based and folder-local; the subject and each body paragraph are scanned
 sentence by sentence, in order of appearance:
 
-| Type | Trigger | Severity |
-| --- | --- | --- |
-| `long-sentence` | > 25 words (> 40 words escalates) | info / warn |
-| `complex-word` | Wordy term with a plain replacement (`PLAIN_LANGUAGE_REPLACEMENTS`, e.g. "utilize" → "use") | info |
-| `passive-voice` | Auxiliary + past participle ("was completed") | info |
-| `long-paragraph` | Body paragraph > 100 words | info |
-| `shouting` | Two or more ALL-CAPS words (4+ letters) in a sentence | warn |
+| Type             | Trigger                                                                                     | Severity    |
+| ---------------- | ------------------------------------------------------------------------------------------- | ----------- |
+| `long-sentence`  | > 25 words (> 40 words escalates)                                                           | info / warn |
+| `complex-word`   | Wordy term with a plain replacement (`PLAIN_LANGUAGE_REPLACEMENTS`, e.g. "utilize" → "use") | info        |
+| `passive-voice`  | Auxiliary + past participle ("was completed")                                               | info        |
+| `long-paragraph` | Body paragraph > 100 words                                                                  | info        |
+| `shouting`       | Two or more ALL-CAPS words (4+ letters) in a sentence                                       | warn        |
 
 - **Score**: Flesch reading ease
   (`206.835 − 1.015 × words/sentences − 84.6 × syllables/words`), clamped to

--- a/tools/v2/individual/readability-improver/index.ts
+++ b/tools/v2/individual/readability-improver/index.ts
@@ -1,0 +1,44 @@
+// Readability Improver — non-UI execution entry point.
+//
+// Everything a backend caller needs: the pure engine, the guarded service
+// entry point, the typed contract, and fixtures. No UI code is exported.
+
+export {
+  improveReadability,
+  countSyllables,
+  resolveMaxIssues,
+  DEFAULT_MAX_ISSUES,
+  MAX_ISSUES_LIMIT,
+  LONG_SENTENCE_WORDS,
+  VERY_LONG_SENTENCE_WORDS,
+  LONG_PARAGRAPH_WORDS,
+  COMPLEX_WORD_SYLLABLES,
+  MAX_EXCERPT_CHARS,
+  PLAIN_LANGUAGE_REPLACEMENTS,
+} from "./services/readabilityImprover";
+export {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeImproveReadability,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "./services/guards";
+export { successFixtures, failureFixtures } from "./services/fixtures";
+export type { SuccessFixture, FailureFixture } from "./services/fixtures";
+export type {
+  IssueSeverity,
+  IssueSource,
+  ReadabilityErrorCode,
+  ReadabilityGrade,
+  ReadabilityInput,
+  ReadabilityIssue,
+  ReadabilityIssueType,
+  ReadabilityMetrics,
+  ReadabilityOptions,
+  ReadabilityResult,
+  ReadabilityStats,
+  ReadabilityValidationIssue,
+  SafeReadabilityResult,
+} from "./types/readabilityImprover";

--- a/tools/v2/individual/readability-improver/services/fixtures.ts
+++ b/tools/v2/individual/readability-improver/services/fixtures.ts
@@ -1,0 +1,108 @@
+// Readability Improver — typed fixtures for the execution contract.
+//
+// Deterministic sample payloads used by tests and by consumers who want a
+// known-good reference for wiring the service. Success fixtures pass the
+// guarded entry point; failure fixtures each trigger a specific error code.
+
+import { GUARD_LIMITS } from "./guards";
+import type {
+  ReadabilityErrorCode,
+  ReadabilityInput,
+  ReadabilityIssueType,
+} from "../types/readabilityImprover";
+
+export interface SuccessFixture {
+  name: string;
+  input: ReadabilityInput;
+  /** Issue types the engine is expected to report, in order. */
+  expectedIssueTypes: ReadabilityIssueType[];
+}
+
+export interface FailureFixture {
+  name: string;
+  /** Intentionally loosely typed — failure fixtures model bad payloads. */
+  input: unknown;
+  expectedCode: ReadabilityErrorCode;
+}
+
+export const successFixtures: SuccessFixture[] = [
+  {
+    name: "clean-plain-text",
+    input: {
+      messageId: "msg-clean-001",
+      subject: "Lunch on Friday",
+      body: "Want to grab lunch on Friday? The new place is close by. My treat.",
+      senderAddress: "amina@example.com",
+      receivedAt: "2026-07-01T09:15:00.000Z",
+      language: "en",
+    },
+    expectedIssueTypes: [],
+  },
+  {
+    name: "wordy-formal-memo",
+    input: {
+      messageId: "msg-wordy-001",
+      subject: "Process update",
+      body: "We will utilize the new workflow to facilitate onboarding and we expect that every team, including the ones that joined after the reorganization earlier this year, will subsequently adopt it before the next quarterly planning cycle begins.",
+      receivedAt: "2026-07-02T14:30:00.000Z",
+    },
+    expectedIssueTypes: ["long-sentence", "complex-word", "complex-word", "complex-word"],
+  },
+  {
+    name: "passive-and-shouting",
+    input: {
+      messageId: "msg-loud-001",
+      subject: "URGENT PLEASE READ",
+      body: "The report was completed by the intern. Send feedback this week.",
+    },
+    expectedIssueTypes: ["shouting", "passive-voice"],
+  },
+];
+
+export const failureFixtures: FailureFixture[] = [
+  {
+    name: "missing-body",
+    input: {
+      messageId: "msg-invalid-001",
+      subject: "No body field on this payload",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "blank-message-id",
+    input: {
+      messageId: "   ",
+      subject: "Hello",
+      body: "Some text",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "oversized-body",
+    input: {
+      messageId: "msg-oversized-001",
+      subject: "Huge payload",
+      body: "x".repeat(GUARD_LIMITS.maxBodyChars + 1),
+    },
+    expectedCode: "input-too-large",
+  },
+  {
+    name: "empty-content",
+    input: {
+      messageId: "msg-empty-001",
+      subject: "   ",
+      body: "\u200b\u200b",
+    },
+    expectedCode: "empty-content",
+  },
+  {
+    name: "unsupported-language",
+    input: {
+      messageId: "msg-lang-001",
+      subject: "Bonjour",
+      body: "Merci de simplifier ce texte.",
+      language: "fr",
+    },
+    expectedCode: "unsupported-language",
+  },
+];

--- a/tools/v2/individual/readability-improver/services/guards.ts
+++ b/tools/v2/individual/readability-improver/services/guards.ts
@@ -1,0 +1,198 @@
+// Readability Improver — validation, sanitization, and the safe entry point.
+//
+// Folder-local hardening layer that runs before the core engine to reject
+// hostile or oversized input and to strip characters that could hide content
+// or break downstream processing. Pure and deterministic: no network calls,
+// no eval, and no mutation of caller-supplied objects.
+
+import { improveReadability, MAX_ISSUES_LIMIT } from "./readabilityImprover";
+import type {
+  ReadabilityInput,
+  ReadabilityOptions,
+  ReadabilityValidationIssue,
+  SafeReadabilityResult,
+} from "../types/readabilityImprover";
+
+export const GUARD_LIMITS = {
+  maxMessageIdChars: 256,
+  maxSubjectChars: 500,
+  maxBodyChars: 50000,
+  maxBodyWords: 10000,
+} as const;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+
+/** Normalize to NFC and strip control and zero-width characters. */
+export function sanitizeText(text: string): string {
+  return text.normalize("NFC").replace(CONTROL_CHARACTERS, "").replace(INVISIBLE_CHARACTERS, "");
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return 0;
+  }
+  return trimmed.split(/\s+/).length;
+}
+
+/** Structural type check — true when value is a usable ReadabilityInput. */
+export function validateInput(value: unknown): value is ReadabilityInput {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.messageId !== "string" || v.messageId.trim().length === 0) {
+    return false;
+  }
+  if (typeof v.subject !== "string" || typeof v.body !== "string") {
+    return false;
+  }
+  if (v.senderAddress !== undefined && typeof v.senderAddress !== "string") {
+    return false;
+  }
+  if (v.receivedAt !== undefined) {
+    if (typeof v.receivedAt !== "string" || Number.isNaN(new Date(v.receivedAt).getTime())) {
+      return false;
+    }
+  }
+  if (v.language !== undefined && typeof v.language !== "string") {
+    return false;
+  }
+  return true;
+}
+
+/** Structural type check for options. */
+export function validateOptions(value: unknown): value is ReadabilityOptions {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (v.includeIssues !== undefined && typeof v.includeIssues !== "boolean") {
+    return false;
+  }
+  if (v.maxIssues !== undefined) {
+    if (
+      typeof v.maxIssues !== "number" ||
+      !Number.isFinite(v.maxIssues) ||
+      v.maxIssues < 1 ||
+      v.maxIssues > MAX_ISSUES_LIMIT
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Size checks against GUARD_LIMITS. Empty array means within limits. */
+export function checkInputLimits(input: ReadabilityInput): ReadabilityValidationIssue[] {
+  const issues: ReadabilityValidationIssue[] = [];
+  if (input.messageId.length > GUARD_LIMITS.maxMessageIdChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "messageId",
+      message: `messageId exceeds ${GUARD_LIMITS.maxMessageIdChars} characters`,
+    });
+  }
+  if (input.subject.length > GUARD_LIMITS.maxSubjectChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "subject",
+      message: `subject exceeds ${GUARD_LIMITS.maxSubjectChars} characters`,
+    });
+  }
+  if (input.body.length > GUARD_LIMITS.maxBodyChars) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyChars} characters`,
+    });
+  } else if (countWords(input.body) > GUARD_LIMITS.maxBodyWords) {
+    issues.push({
+      code: "input-too-large",
+      field: "body",
+      message: `body exceeds ${GUARD_LIMITS.maxBodyWords} words`,
+    });
+  }
+  return issues;
+}
+
+function isSupportedLanguage(language: string | undefined): boolean {
+  if (language === undefined) {
+    return true;
+  }
+  const normalized = language.toLowerCase();
+  return normalized === "en" || normalized.startsWith("en-");
+}
+
+/** Return a sanitized copy of the input without mutating the original. */
+export function sanitizeInput(input: ReadabilityInput): ReadabilityInput {
+  return {
+    ...input,
+    messageId: input.messageId.trim(),
+    subject: sanitizeText(input.subject),
+    body: sanitizeText(input.body),
+  };
+}
+
+/**
+ * Guarded, non-throwing entry point for untrusted callers.
+ *
+ * Validates, sanitizes, and enforces limits before delegating to
+ * improveReadability. Always returns a discriminated SafeReadabilityResult.
+ */
+export function safeImproveReadability(input: unknown, options?: unknown): SafeReadabilityResult {
+  if (!validateInput(input)) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: "Input must include a non-empty messageId and string subject and body.",
+      issues: [{ code: "invalid-input", message: "Input failed structural validation." }],
+    };
+  }
+  if (!validateOptions(options)) {
+    return {
+      status: "error",
+      code: "invalid-options",
+      message: `Options must use a boolean includeIssues and a maxIssues between 1 and ${MAX_ISSUES_LIMIT}.`,
+      issues: [{ code: "invalid-options", message: "Options failed structural validation." }],
+    };
+  }
+  if (!isSupportedLanguage(input.language)) {
+    return {
+      status: "error",
+      code: "unsupported-language",
+      message: `Language "${input.language}" is not supported; only English ("en") is available.`,
+      issues: [
+        {
+          code: "unsupported-language",
+          field: "language",
+          message: "Only English content can be analyzed.",
+        },
+      ],
+    };
+  }
+  const limitIssues = checkInputLimits(input);
+  if (limitIssues.length > 0) {
+    return {
+      status: "error",
+      code: "input-too-large",
+      message: limitIssues.map((issue) => issue.message).join("; "),
+      issues: limitIssues,
+    };
+  }
+  const sanitized = sanitizeInput(input);
+  if (sanitized.subject.trim().length === 0 && sanitized.body.trim().length === 0) {
+    return {
+      status: "error",
+      code: "empty-content",
+      message: "Subject and body are both empty after sanitization; nothing to analyze.",
+      issues: [{ code: "empty-content", message: "No analyzable content present." }],
+    };
+  }
+  return { status: "ok", result: improveReadability(sanitized, options) };
+}

--- a/tools/v2/individual/readability-improver/services/readabilityImprover.ts
+++ b/tools/v2/individual/readability-improver/services/readabilityImprover.ts
@@ -1,0 +1,272 @@
+// Readability Improver — core analysis engine.
+//
+// Rule-based readability scoring and improvement suggestions over subject and
+// body text. Pure and deterministic: no network calls, no mailbox access, no
+// randomness, no clock reads, and no mutation of caller-supplied objects.
+
+import type {
+  IssueSource,
+  ReadabilityGrade,
+  ReadabilityInput,
+  ReadabilityIssue,
+  ReadabilityMetrics,
+  ReadabilityOptions,
+  ReadabilityResult,
+} from "../types/readabilityImprover";
+
+export const DEFAULT_MAX_ISSUES = 25;
+export const MAX_ISSUES_LIMIT = 100;
+
+/** Sentences above this word count read as long. */
+export const LONG_SENTENCE_WORDS = 25;
+/** Sentences above this word count are a strong readability drag. */
+export const VERY_LONG_SENTENCE_WORDS = 40;
+/** Paragraphs above this word count should be split. */
+export const LONG_PARAGRAPH_WORDS = 100;
+/** Words with at least this many syllables count as complex. */
+export const COMPLEX_WORD_SYLLABLES = 3;
+/** Excerpts are capped at this many characters. */
+export const MAX_EXCERPT_CHARS = 80;
+
+/** Wordy terms and their plain-language replacements. */
+export const PLAIN_LANGUAGE_REPLACEMENTS: Readonly<Record<string, string>> = {
+  additional: "more",
+  approximately: "about",
+  assistance: "help",
+  commence: "start",
+  demonstrate: "show",
+  endeavor: "try",
+  facilitate: "help",
+  leverage: "use",
+  numerous: "many",
+  objective: "goal",
+  prioritize: "rank",
+  purchase: "buy",
+  regarding: "about",
+  subsequently: "later",
+  sufficient: "enough",
+  terminate: "end",
+  utilize: "use",
+  utilized: "used",
+  utilizes: "uses",
+};
+
+const PASSIVE_VOICE_PATTERN = /\b(?:is|are|was|were|been|being|be)\s+[a-z]+ed\b/i;
+const ALL_CAPS_WORD_PATTERN = /\b[A-Z]{4,}\b/g;
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function words(text: string): string[] {
+  return text.split(/\s+/).filter((word) => /[a-zA-Z0-9]/.test(word));
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 0);
+}
+
+function splitParagraphs(body: string): string[] {
+  return body
+    .split(/\r?\n\s*\r?\n/)
+    .map((paragraph) => collapseWhitespace(paragraph))
+    .filter((paragraph) => paragraph.length > 0);
+}
+
+/** Deterministic syllable estimate: vowel groups with a silent-e correction. */
+export function countSyllables(word: string): number {
+  const cleaned = word.toLowerCase().replace(/[^a-z]/g, "");
+  if (cleaned.length === 0) {
+    return 0;
+  }
+  const groups = cleaned.match(/[aeiouy]+/g);
+  let count = groups ? groups.length : 1;
+  if (cleaned.length > 2 && cleaned.endsWith("e") && !cleaned.endsWith("le")) {
+    count -= 1;
+  }
+  return Math.max(count, 1);
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function excerptOf(text: string): string {
+  const collapsed = collapseWhitespace(text);
+  if (collapsed.length <= MAX_EXCERPT_CHARS) {
+    return collapsed;
+  }
+  const cut = collapsed.slice(0, MAX_EXCERPT_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
+function gradeFor(score: number): ReadabilityGrade {
+  if (score >= 90) {
+    return "very-easy";
+  }
+  if (score >= 70) {
+    return "easy";
+  }
+  if (score >= 50) {
+    return "medium";
+  }
+  if (score >= 30) {
+    return "hard";
+  }
+  return "very-hard";
+}
+
+/** Clamp caller-supplied maxIssues into the supported range. */
+export function resolveMaxIssues(maxIssues: number | undefined): number {
+  if (maxIssues === undefined) {
+    return DEFAULT_MAX_ISSUES;
+  }
+  return Math.min(Math.max(Math.trunc(maxIssues), 1), MAX_ISSUES_LIMIT);
+}
+
+function scanSentence(sentence: string, source: IssueSource, issues: ReadabilityIssue[]): void {
+  const sentenceWords = words(sentence);
+
+  if (sentenceWords.length > LONG_SENTENCE_WORDS) {
+    const severity = sentenceWords.length > VERY_LONG_SENTENCE_WORDS ? "warn" : "info";
+    issues.push({
+      type: "long-sentence",
+      severity,
+      source,
+      excerpt: excerptOf(sentence),
+      suggestion: `Split this ${sentenceWords.length}-word sentence; aim for ${LONG_SENTENCE_WORDS} words or fewer.`,
+    });
+  }
+
+  for (const word of sentenceWords) {
+    const normalized = word.toLowerCase().replace(/[^a-z]/g, "");
+    const replacement = PLAIN_LANGUAGE_REPLACEMENTS[normalized];
+    if (replacement !== undefined) {
+      issues.push({
+        type: "complex-word",
+        severity: "info",
+        source,
+        excerpt: normalized,
+        suggestion: `Replace "${normalized}" with "${replacement}".`,
+      });
+    }
+  }
+
+  if (PASSIVE_VOICE_PATTERN.test(sentence)) {
+    issues.push({
+      type: "passive-voice",
+      severity: "info",
+      source,
+      excerpt: excerptOf(sentence),
+      suggestion: "Rewrite in active voice: say who does the action.",
+    });
+  }
+
+  const capsMatches = sentence.match(ALL_CAPS_WORD_PATTERN) ?? [];
+  if (capsMatches.length >= 2) {
+    issues.push({
+      type: "shouting",
+      severity: "warn",
+      source,
+      excerpt: excerptOf(sentence),
+      suggestion: "Use sentence case; all-caps text reads as shouting.",
+    });
+  }
+}
+
+/**
+ * Analyze the readability of a message and suggest improvements.
+ *
+ * Assumes input has already been validated and sanitized — use
+ * safeImproveReadability from services/guards for untrusted callers.
+ */
+export function improveReadability(
+  input: ReadabilityInput,
+  options: ReadabilityOptions = {},
+): ReadabilityResult {
+  const subject = collapseWhitespace(input.subject);
+  const paragraphs = splitParagraphs(input.body);
+
+  const sources: Array<{ text: string; source: IssueSource }> = [];
+  if (subject.length > 0) {
+    sources.push({ text: subject, source: "subject" });
+  }
+  for (const paragraph of paragraphs) {
+    sources.push({ text: paragraph, source: "body" });
+  }
+
+  const allIssues: ReadabilityIssue[] = [];
+  let wordCount = 0;
+  let sentenceCount = 0;
+  let syllableCount = 0;
+  let longSentenceCount = 0;
+  let complexWordCount = 0;
+
+  for (const { text, source } of sources) {
+    const sentences = splitSentences(text);
+    sentenceCount += sentences.length;
+    for (const sentence of sentences) {
+      const sentenceWords = words(sentence);
+      wordCount += sentenceWords.length;
+      if (sentenceWords.length > LONG_SENTENCE_WORDS) {
+        longSentenceCount += 1;
+      }
+      for (const word of sentenceWords) {
+        const syllables = countSyllables(word);
+        syllableCount += syllables;
+        if (syllables >= COMPLEX_WORD_SYLLABLES) {
+          complexWordCount += 1;
+        }
+      }
+      scanSentence(sentence, source, allIssues);
+    }
+    if (source === "body" && words(text).length > LONG_PARAGRAPH_WORDS) {
+      allIssues.push({
+        type: "long-paragraph",
+        severity: "info",
+        source,
+        excerpt: excerptOf(text),
+        suggestion: `Split this ${words(text).length}-word paragraph; aim for ${LONG_PARAGRAPH_WORDS} words or fewer.`,
+      });
+    }
+  }
+
+  // Flesch reading ease; empty text scores 0 rather than a division error.
+  let score = 0;
+  if (wordCount > 0 && sentenceCount > 0) {
+    const raw = 206.835 - 1.015 * (wordCount / sentenceCount) - 84.6 * (syllableCount / wordCount);
+    score = roundTo(Math.min(Math.max(raw, 0), 100), 1);
+  }
+
+  const metrics: ReadabilityMetrics = {
+    wordCount,
+    sentenceCount,
+    paragraphCount: paragraphs.length,
+    averageWordsPerSentence: sentenceCount === 0 ? 0 : roundTo(wordCount / sentenceCount, 1),
+    longSentenceCount,
+    complexWordCount,
+  };
+
+  const includeIssues = options.includeIssues !== false;
+  const maxIssues = resolveMaxIssues(options.maxIssues);
+  const issues = includeIssues ? allIssues.slice(0, maxIssues) : [];
+  const truncated = includeIssues && allIssues.length > maxIssues;
+
+  return {
+    messageId: input.messageId,
+    score,
+    grade: gradeFor(score),
+    issues,
+    metrics,
+    stats: {
+      issueCandidates: allIssues.length,
+      issueCount: issues.length,
+      truncated,
+    },
+  };
+}

--- a/tools/v2/individual/readability-improver/specs.md
+++ b/tools/v2/individual/readability-improver/specs.md
@@ -1,23 +1,3 @@
-# Readability Improver
-
-Improve readability.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
-- tests/
-- docs/
-
 # Readability Improver Specs
 
 ## Purpose
@@ -28,7 +8,30 @@ Improve readability.
 
 All work for this tool should stay in:
 
-$dir/
+`tools/v2/individual/readability-improver/`
+
+This is a self-contained tooling workspace. Do not wire this tool into the
+main app, routing, inbox architecture, wallet core, Stellar core, or design
+system unless a future integration issue explicitly allows it.
+
+## Internal structure
+
+- `index.ts` — non-UI execution entry point (barrel export)
+- `types/` — typed input/output contract and error codes
+- `services/` — analysis engine, validation guards, fixtures
+- `tests/` — vitest suites
+- `docs/` — architecture and contract documentation
+- `components/`, `hooks/` — reserved for future UI work
+
+## Execution contract
+
+The backend-facing contract is documented in `docs/contract.md`:
+
+- Typed inputs (`ReadabilityInput`, `ReadabilityOptions`) and outputs
+  (`ReadabilityResult`, `SafeReadabilityResult`).
+- Machine-readable error codes (`invalid-input`, `invalid-options`,
+  `input-too-large`, `empty-content`, `unsupported-language`).
+- Fixtures covering success and failure cases in `services/fixtures.ts`.
 
 ## Required issue categories
 

--- a/tools/v2/individual/readability-improver/tests/guards.test.ts
+++ b/tools/v2/individual/readability-improver/tests/guards.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GUARD_LIMITS,
+  checkInputLimits,
+  safeImproveReadability,
+  sanitizeInput,
+  sanitizeText,
+  validateInput,
+  validateOptions,
+} from "../services/guards";
+import { failureFixtures, successFixtures } from "../services/fixtures";
+import type { ReadabilityInput } from "../types/readabilityImprover";
+
+function makeInput(overrides: Partial<ReadabilityInput> = {}): ReadabilityInput {
+  return {
+    messageId: "msg-guard-001",
+    subject: "Hello",
+    body: "A short and simple note.",
+    ...overrides,
+  };
+}
+
+describe("sanitizeText", () => {
+  it("strips control and zero-width characters", () => {
+    expect(sanitizeText("he\u0000llo\u200b world\u2060")).toBe("hello world");
+  });
+
+  it("normalizes composed characters to NFC", () => {
+    expect(sanitizeText("cafe\u0301")).toBe("café");
+  });
+});
+
+describe("validateInput", () => {
+  it("accepts a minimal valid input", () => {
+    expect(validateInput(makeInput())).toBe(true);
+  });
+
+  it("rejects non-objects, null, and arrays", () => {
+    expect(validateInput("text")).toBe(false);
+    expect(validateInput(null)).toBe(false);
+    expect(validateInput([makeInput()])).toBe(false);
+  });
+
+  it("rejects a missing or blank messageId", () => {
+    expect(validateInput({ ...makeInput(), messageId: undefined })).toBe(false);
+    expect(validateInput(makeInput({ messageId: "   " }))).toBe(false);
+  });
+
+  it("rejects non-string subject or body", () => {
+    expect(validateInput({ ...makeInput(), subject: 5 })).toBe(false);
+    expect(validateInput({ ...makeInput(), body: undefined })).toBe(false);
+  });
+
+  it("rejects an unparseable receivedAt", () => {
+    expect(validateInput(makeInput({ receivedAt: "not-a-date" }))).toBe(false);
+    expect(validateInput(makeInput({ receivedAt: "2026-07-01T00:00:00.000Z" }))).toBe(true);
+  });
+});
+
+describe("validateOptions", () => {
+  it("accepts undefined and valid shapes", () => {
+    expect(validateOptions(undefined)).toBe(true);
+    expect(validateOptions({})).toBe(true);
+    expect(validateOptions({ includeIssues: false, maxIssues: 10 })).toBe(true);
+  });
+
+  it("rejects wrong types and out-of-range maxIssues", () => {
+    expect(validateOptions({ includeIssues: "yes" })).toBe(false);
+    expect(validateOptions({ maxIssues: 0 })).toBe(false);
+    expect(validateOptions({ maxIssues: Number.NaN })).toBe(false);
+    expect(validateOptions({ maxIssues: 101 })).toBe(false);
+  });
+});
+
+describe("checkInputLimits", () => {
+  it("returns no issues within limits", () => {
+    expect(checkInputLimits(makeInput())).toEqual([]);
+  });
+
+  it("flags each oversized field with input-too-large", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        messageId: "x".repeat(GUARD_LIMITS.maxMessageIdChars + 1),
+        subject: "y".repeat(GUARD_LIMITS.maxSubjectChars + 1),
+        body: "z".repeat(GUARD_LIMITS.maxBodyChars + 1),
+      }),
+    );
+    expect(issues).toHaveLength(3);
+    expect(issues.every((issue) => issue.code === "input-too-large")).toBe(true);
+    expect(issues.map((issue) => issue.field)).toEqual(["messageId", "subject", "body"]);
+  });
+
+  it("flags a body with too many words even under the char limit", () => {
+    const issues = checkInputLimits(
+      makeInput({
+        body: Array(GUARD_LIMITS.maxBodyWords + 1)
+          .fill("w")
+          .join(" "),
+      }),
+    );
+    expect(issues).toEqual([expect.objectContaining({ code: "input-too-large", field: "body" })]);
+  });
+});
+
+describe("sanitizeInput", () => {
+  it("returns a cleaned copy without mutating the original", () => {
+    const input = makeInput({ messageId: "  msg-1  ", subject: "Hi\u200b", body: "ok" });
+    const cleaned = sanitizeInput(input);
+    expect(cleaned).toMatchObject({ messageId: "msg-1", subject: "Hi", body: "ok" });
+    expect(input.messageId).toBe("  msg-1  ");
+  });
+});
+
+describe("safeImproveReadability", () => {
+  it("returns ok with the expected issue types for every success fixture", () => {
+    for (const fixture of successFixtures) {
+      const outcome = safeImproveReadability(fixture.input);
+      expect(outcome.status, fixture.name).toBe("ok");
+      if (outcome.status === "ok") {
+        expect(
+          outcome.result.issues.map((issue) => issue.type),
+          fixture.name,
+        ).toEqual(fixture.expectedIssueTypes);
+      }
+    }
+  });
+
+  it("returns the expected error code for every failure fixture", () => {
+    for (const fixture of failureFixtures) {
+      const outcome = safeImproveReadability(fixture.input);
+      expect(outcome.status, fixture.name).toBe("error");
+      if (outcome.status === "error") {
+        expect(outcome.code, fixture.name).toBe(fixture.expectedCode);
+        expect(outcome.issues.length, fixture.name).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("rejects invalid options with invalid-options", () => {
+    const outcome = safeImproveReadability(makeInput(), { maxIssues: -5 });
+    expect(outcome).toMatchObject({ status: "error", code: "invalid-options" });
+  });
+
+  it("accepts regional English language tags", () => {
+    const outcome = safeImproveReadability(makeInput({ language: "en-GB" }));
+    expect(outcome.status).toBe("ok");
+  });
+
+  it("analyzes sanitized text so hidden characters cannot mask wordy terms", () => {
+    const outcome = safeImproveReadability(
+      makeInput({ subject: "", body: "We will uti\u200blize the tool." }),
+    );
+    expect(outcome.status).toBe("ok");
+    if (outcome.status === "ok") {
+      expect(outcome.result.issues.map((issue) => issue.type)).toEqual(["complex-word"]);
+    }
+  });
+
+  it("never throws on hostile payloads", () => {
+    const hostile = [null, 42, "text", [], { messageId: 1 }, { __proto__: { subject: "x" } }];
+    for (const payload of hostile) {
+      expect(() => safeImproveReadability(payload)).not.toThrow();
+      expect(safeImproveReadability(payload).status).toBe("error");
+    }
+  });
+});

--- a/tools/v2/individual/readability-improver/tests/readabilityImprover.test.ts
+++ b/tools/v2/individual/readability-improver/tests/readabilityImprover.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  improveReadability,
+  countSyllables,
+  resolveMaxIssues,
+  DEFAULT_MAX_ISSUES,
+  MAX_ISSUES_LIMIT,
+  MAX_EXCERPT_CHARS,
+  LONG_SENTENCE_WORDS,
+  VERY_LONG_SENTENCE_WORDS,
+} from "../services/readabilityImprover";
+import { successFixtures } from "../services/fixtures";
+import type { ReadabilityInput } from "../types/readabilityImprover";
+
+function makeInput(overrides: Partial<ReadabilityInput> = {}): ReadabilityInput {
+  return {
+    messageId: "msg-test-001",
+    subject: "",
+    body: "",
+    ...overrides,
+  };
+}
+
+function sentenceOf(wordCount: number): string {
+  return `${Array(wordCount).fill("word").join(" ")}.`;
+}
+
+describe("improveReadability", () => {
+  it("reports the expected issue types for each success fixture", () => {
+    for (const fixture of successFixtures) {
+      const result = improveReadability(fixture.input);
+      expect(
+        result.issues.map((issue) => issue.type),
+        fixture.name,
+      ).toEqual(fixture.expectedIssueTypes);
+      expect(result.messageId).toBe(fixture.input.messageId);
+    }
+  });
+
+  it("scores simple text as easier than dense formal text", () => {
+    const simple = improveReadability(
+      makeInput({ body: "We met today. The plan is set. See you soon." }),
+    );
+    const dense = improveReadability(
+      makeInput({
+        body: "Organizational stakeholders continuously prioritize comprehensive administrative documentation notwithstanding considerable operational complexity.",
+      }),
+    );
+    expect(simple.score).toBeGreaterThan(dense.score);
+    expect(simple.grade).toBe("very-easy");
+    expect(dense.grade).toBe("very-hard");
+  });
+
+  it("clamps the score to [0, 100]", () => {
+    const short = improveReadability(makeInput({ body: "Go now. Do it. Be quick." }));
+    const brutal = improveReadability(
+      makeInput({
+        body: "Incontrovertibly, institutionalization of interdisciplinary organizational responsibilities necessitates internationalization.",
+      }),
+    );
+    expect(short.score).toBeLessThanOrEqual(100);
+    expect(short.score).toBeGreaterThanOrEqual(0);
+    expect(brutal.score).toBe(0);
+  });
+
+  it("flags long sentences as info and very long sentences as warn", () => {
+    const long = improveReadability(makeInput({ body: sentenceOf(LONG_SENTENCE_WORDS + 1) }));
+    const veryLong = improveReadability(
+      makeInput({ body: sentenceOf(VERY_LONG_SENTENCE_WORDS + 1) }),
+    );
+    expect(long.issues[0]).toMatchObject({ type: "long-sentence", severity: "info" });
+    expect(veryLong.issues[0]).toMatchObject({ type: "long-sentence", severity: "warn" });
+    expect(veryLong.metrics.longSentenceCount).toBe(1);
+  });
+
+  it("suggests plain-language replacements for wordy terms", () => {
+    const result = improveReadability(makeInput({ body: "We will utilize the tool." }));
+    expect(result.issues[0]).toMatchObject({
+      type: "complex-word",
+      excerpt: "utilize",
+      suggestion: 'Replace "utilize" with "use".',
+    });
+  });
+
+  it("flags passive voice with an active-voice suggestion", () => {
+    const result = improveReadability(makeInput({ body: "The budget was approved by the board." }));
+    expect(result.issues[0]).toMatchObject({ type: "passive-voice", severity: "info" });
+  });
+
+  it("flags repeated all-caps words as shouting", () => {
+    const shouting = improveReadability(makeInput({ body: "SEND THIS NOW PLEASE." }));
+    const calm = improveReadability(makeInput({ body: "Send the NASA report." }));
+    expect(shouting.issues[0]).toMatchObject({ type: "shouting", severity: "warn" });
+    expect(calm.issues).toEqual([]);
+  });
+
+  it("flags paragraphs above the word limit", () => {
+    const paragraph = Array(21).fill("one two three four five.").join(" ");
+    const result = improveReadability(makeInput({ body: paragraph }));
+    expect(result.issues.some((issue) => issue.type === "long-paragraph")).toBe(true);
+  });
+
+  it("caps excerpts at the excerpt limit", () => {
+    const result = improveReadability(makeInput({ body: sentenceOf(60) }));
+    for (const issue of result.issues) {
+      expect(issue.excerpt.length).toBeLessThanOrEqual(MAX_EXCERPT_CHARS + 1);
+    }
+  });
+
+  it("computes deterministic metrics", () => {
+    const result = improveReadability(
+      makeInput({
+        subject: "Quick note",
+        body: "First point here.\n\nSecond point is longer than the first one.",
+      }),
+    );
+    expect(result.metrics).toMatchObject({
+      sentenceCount: 3,
+      paragraphCount: 2,
+      wordCount: 13,
+    });
+    expect(result.metrics.averageWordsPerSentence).toBeCloseTo(13 / 3, 1);
+  });
+
+  it("truncates issues to maxIssues and reports it in stats", () => {
+    const body = Array(5).fill("We will utilize and leverage assistance.").join(" ");
+    const result = improveReadability(makeInput({ body }), { maxIssues: 4 });
+    expect(result.issues).toHaveLength(4);
+    expect(result.stats.truncated).toBe(true);
+    expect(result.stats.issueCandidates).toBeGreaterThan(4);
+  });
+
+  it("omits issues when includeIssues is false without changing the score", () => {
+    const body = "We will utilize the tool.";
+    const withIssues = improveReadability(makeInput({ body }));
+    const withoutIssues = improveReadability(makeInput({ body }), { includeIssues: false });
+    expect(withoutIssues.issues).toEqual([]);
+    expect(withoutIssues.score).toBe(withIssues.score);
+    expect(withoutIssues.stats.issueCandidates).toBe(withIssues.stats.issueCandidates);
+  });
+
+  it("is deterministic for identical input", () => {
+    const input = makeInput({
+      subject: "URGENT UPDATE NEEDED",
+      body: "The report was completed. We will utilize the findings to facilitate planning.",
+    });
+    expect(improveReadability(input)).toEqual(improveReadability(input));
+  });
+
+  it("does not mutate the caller's input", () => {
+    const input = makeInput({ subject: "Note", body: "We will utilize the tool." });
+    const snapshot = JSON.parse(JSON.stringify(input));
+    improveReadability(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("countSyllables", () => {
+  it("estimates syllables deterministically", () => {
+    expect(countSyllables("go")).toBe(1);
+    expect(countSyllables("table")).toBe(2);
+    expect(countSyllables("delete")).toBe(2);
+    expect(countSyllables("organization")).toBeGreaterThanOrEqual(4);
+    expect(countSyllables("")).toBe(0);
+  });
+});
+
+describe("resolveMaxIssues", () => {
+  it("defaults when undefined and clamps out-of-range values", () => {
+    expect(resolveMaxIssues(undefined)).toBe(DEFAULT_MAX_ISSUES);
+    expect(resolveMaxIssues(0)).toBe(1);
+    expect(resolveMaxIssues(12.7)).toBe(12);
+    expect(resolveMaxIssues(1000)).toBe(MAX_ISSUES_LIMIT);
+  });
+});

--- a/tools/v2/individual/readability-improver/types/readabilityImprover.ts
+++ b/tools/v2/individual/readability-improver/types/readabilityImprover.ts
@@ -1,0 +1,128 @@
+// Readability Improver — typed execution contract.
+//
+// Backend-facing types for the readability-improver tool. These types define
+// the stable, non-UI contract between callers (services, jobs, tests) and the
+// analysis engine. No presentation concerns belong here.
+
+/** Reading-ease band derived from the Flesch score. */
+export type ReadabilityGrade = "very-easy" | "easy" | "medium" | "hard" | "very-hard";
+
+/** How strongly an issue affects readability. */
+export type IssueSeverity = "info" | "warn";
+
+/** Which rule produced an issue. */
+export type ReadabilityIssueType =
+  | "long-sentence"
+  | "complex-word"
+  | "passive-voice"
+  | "long-paragraph"
+  | "shouting";
+
+/** Where an issue was found. */
+export type IssueSource = "subject" | "body";
+
+/** Input accepted by the analysis engine. */
+export interface ReadabilityInput {
+  /** Stable caller-supplied identifier echoed back in the result. */
+  messageId: string;
+  /** Message subject line. May be empty when the body is not. */
+  subject: string;
+  /** Plain-text message body. May be empty when the subject is not. */
+  body: string;
+  /** Optional sender address, kept for correlation only — never analyzed. */
+  senderAddress?: string;
+  /** Optional ISO 8601 timestamp of when the message was received. */
+  receivedAt?: string;
+  /**
+   * Optional BCP 47 language tag. Only English ("en" or "en-*") is
+   * supported; other values are rejected with "unsupported-language".
+   */
+  language?: string;
+}
+
+/** Tuning options for a single analysis call. */
+export interface ReadabilityOptions {
+  /** Include per-finding issues in the result. Defaults to true. */
+  includeIssues?: boolean;
+  /** Upper bound on returned issues (1–100). Defaults to 25. */
+  maxIssues?: number;
+}
+
+/** One readability finding with a concrete improvement suggestion. */
+export interface ReadabilityIssue {
+  /** Which rule matched. */
+  type: ReadabilityIssueType;
+  /** info = stylistic hint, warn = strong readability drag. */
+  severity: IssueSeverity;
+  /** Where the finding is located. */
+  source: IssueSource;
+  /** Snippet of the offending text, capped at 80 characters. */
+  excerpt: string;
+  /** Actionable, human-readable improvement suggestion. */
+  suggestion: string;
+}
+
+/** Deterministic metrics describing the analyzed text. */
+export interface ReadabilityMetrics {
+  wordCount: number;
+  sentenceCount: number;
+  paragraphCount: number;
+  /** Rounded to 1 decimal; 0 when there are no sentences. */
+  averageWordsPerSentence: number;
+  /** Sentences above the long-sentence threshold. */
+  longSentenceCount: number;
+  /** Words with three or more syllables. */
+  complexWordCount: number;
+}
+
+/** Counters describing how the issue scan ran. */
+export interface ReadabilityStats {
+  /** Findings matched before truncation. */
+  issueCandidates: number;
+  /** Findings returned after truncation. */
+  issueCount: number;
+  /** True when maxIssues cut off further findings. */
+  truncated: boolean;
+}
+
+/** Successful analysis output. An empty issue list is a valid outcome. */
+export interface ReadabilityResult {
+  /** Echo of the input messageId. */
+  messageId: string;
+  /** Flesch reading ease clamped to [0, 100], rounded to 1 decimal. */
+  score: number;
+  /** Reading-ease band derived from the score. */
+  grade: ReadabilityGrade;
+  /** Findings in order of appearance, truncated to maxIssues. */
+  issues: ReadabilityIssue[];
+  /** Deterministic text metrics. */
+  metrics: ReadabilityMetrics;
+  /** Scan counters. */
+  stats: ReadabilityStats;
+}
+
+/** Machine-readable failure codes for the safe entry point. */
+export type ReadabilityErrorCode =
+  | "invalid-input"
+  | "invalid-options"
+  | "input-too-large"
+  | "empty-content"
+  | "unsupported-language";
+
+/** One validation problem, tied to a field when known. */
+export interface ReadabilityValidationIssue {
+  code: ReadabilityErrorCode;
+  /** Input field the issue applies to, when identifiable. */
+  field?: string;
+  message: string;
+}
+
+/** Discriminated result of the guarded entry point — never throws. */
+export type SafeReadabilityResult =
+  | { status: "ok"; result: ReadabilityResult }
+  | {
+      status: "error";
+      code: ReadabilityErrorCode;
+      message: string;
+      issues: ReadabilityValidationIssue[];
+    };

--- a/tools/v2/individual/readability-improver/vitest.config.ts
+++ b/tools/v2/individual/readability-improver/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    root: path.resolve(__dirname),
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements the non-UI execution contract for `tools/v2/individual/readability-improver` (#1381). The tool now exposes a stable, backend-facing API that scores reading ease and suggests improvements independently of any presentation concerns.

- **Typed contract** — `types/readabilityImprover.ts` defines `ReadabilityInput`, `ReadabilityOptions`, `ReadabilityResult`, `ReadabilityIssue`, `SafeReadabilityResult`, and the error-code union; documented in `docs/contract.md`.
- **Non-UI service entry point** — `index.ts` exports `safeImproveReadability` (guarded, never throws, returns a discriminated ok/error result) and `improveReadability` (pure engine for pre-validated input). Both are deterministic: no network, no randomness, no clock reads, no input mutation.
- **Analysis rules** — Flesch reading ease (clamped 0–100) with a deterministic syllable heuristic, a grade band, and typed findings: long sentences (info/warn tiers), wordy terms with plain-language replacements ("utilize" → "use"), passive voice, long paragraphs, and all-caps shouting — each with source, excerpt, and an actionable suggestion. An empty issue list is a valid success outcome.
- **Error codes** — `invalid-input`, `invalid-options`, `input-too-large`, `empty-content`, `unsupported-language`, enforced by a folder-local guard layer (`services/guards.ts`) with size limits and control/zero-width character sanitization.
- **Fixtures** — `services/fixtures.ts` covers success cases (clean text with zero issues, wordy formal memo, passive + shouting) and failure cases (one per error path).
- **Tests** — 35 vitest cases across engine and guards, replaying every fixture through the public entry points.

Fits the module boundaries in the tool's existing `docs/ARCHITECTURE.md`: all logic lives in `services/` as pure functions, while `components/` and `hooks/` remain untouched placeholders for future UI work. No styling or layout files are changed. Follows the same contract structure as the merged sentiment-detector (#1413) and task-extractor (#1416) contracts.

## Test plan

```sh
npx vitest run --config tools/v2/individual/readability-improver/vitest.config.ts
```

- [x] 35/35 tests pass
- [x] `tsc --noEmit --strict` clean on the tool's files
- [x] `eslint` clean on the folder

Closes #1381