### PR TITLE
feat: add typed execution contract for team task board from emails

### DIFF
--- a/tools/v2/team/team-task-board-from-emails/CONTRACT.md
+++ b/tools/v2/team/team-task-board-from-emails/CONTRACT.md
@@ -1,0 +1,175 @@
+# Team Task Board from Emails - Execution Contract
+
+This document defines the **backend-facing, presentation-independent execution
+contract** for the Team Task Board from Emails tool. It is intended for APIs,
+schedulers, inbox jobs, tests, and future automation. It deliberately contains
+no UI, styling, or layout concerns.
+
+> Scope note: This contract operates on local data and the folder's extraction
+> heuristic. It does not wire into the main app, routing, inbox architecture,
+> auth, wallet, Stellar, or any database. Those are out of scope (see
+> `README.md` and `docs/architecture.md`).
+
+## Service Entry Point
+
+The contract is executed through a single, non-UI service entry point:
+
+```ts
+import { taskBoardExecutor } from "./services/task-board-execution.service.mjs";
+// or construct your own with dependency injection:
+import { createTaskBoardExecutor } from "./services/task-board-execution.service.mjs";
+
+const result = taskBoardExecutor.createTaskFromEmail({ email, context? });
+```
+
+`createTaskBoardExecutor({ extract })` returns `{ createTaskFromEmail, extractTaskFromEmail, groupTasksByStatus }`. It is dependency-injected: pass a custom `extract` function to swap the heuristic for tests/automation. The singleton `taskBoardExecutor` is pre-bound to the built-in extraction logic.
+
+The executor **never throws** for expected failures. Every outcome is returned
+as a typed `TaskBoardResult`. Only genuinely unexpected extraction failures
+surface as `INTERNAL_ERROR`.
+
+## Input Schema (`CreateTaskInput`)
+
+| Field     | Type                | Required | Behavior                                                                                                    |
+| --------- | ------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `email`   | `EmailInput`        | yes      | The source email to convert. Must satisfy the email contract (see below).                                   |
+| `context` | `TaskBoardContext?` | no       | Security context. Omitting it enables local/demo mode (no authorization). When present, policy is enforced. |
+
+### `EmailInput`
+
+| Field        | Type       | Required | Behavior                                        |
+| ------------ | ---------- | -------- | ----------------------------------------------- |
+| `id`         | `string`   | yes      | Stable email identifier. Non-empty.             |
+| `threadId`   | `string`   | yes      | Thread the email belongs to. Non-empty.         |
+| `from`       | `string`   | yes      | Sender address. Non-empty.                      |
+| `to`         | `string[]` | yes      | Recipient addresses. Must be an array.          |
+| `subject`    | `string`   | yes      | Email subject. Non-empty (may be `""`).         |
+| `receivedAt` | `string`   | yes      | ISO-8601 date-time. Must parse to a valid date. |
+| `body`       | `string`   | yes      | Email body text. Non-empty (may be `""`).       |
+| `signals?`   | `string[]` | no       | Optional upstream NLP/heuristics hints.         |
+
+### `TaskBoardContext`
+
+| Field          | Type        | Required | Behavior                                                              |
+| -------------- | ----------- | -------- | --------------------------------------------------------------------- |
+| `requesterId`  | `string`    | yes      | Identity of the caller performing extraction. Non-empty.              |
+| `role`         | `string`    | yes      | Role used for policy evaluation (e.g. `agent`, `manager`). Non-empty. |
+| `allowedRoles` | `string[]?` | no       | Roles permitted to extract. Defaults to `["agent","manager"]`.        |
+
+## Output Schema (`TaskBoardResult`)
+
+```ts
+interface TaskBoardResult {
+  ok: boolean;
+  data?: TaskCard; // present when ok === true
+  error?: TaskBoardErrorPayload; // present when ok === false
+}
+```
+
+### `TaskCard` (output)
+
+| Field            | Type                                       | Description                                                   |
+| ---------------- | ------------------------------------------ | ------------------------------------------------------------- |
+| `id`             | `string`                                   | Stable task id derived from `email.id` (`email-` → `task-`).  |
+| `title`          | `string`                                   | Short action label extracted from the email.                  |
+| `owner`          | `string`                                   | `Ops` \| `Legal` \| `Support` \| `Finance` \| `"unassigned"`. |
+| `dueDate`        | `string \| null`                           | ISO date (`YYYY-MM-DD`) or `null` when undetermined.          |
+| `priority`       | `"low" \| "medium" \| "high"`              | Relative urgency.                                             |
+| `status`         | `"new" \| "triage" \| "blocked" \| "done"` | Board column.                                                 |
+| `sourceEmailId`  | `string`                                   | Identifier of the source email.                               |
+| `reviewRequired` | `boolean`                                  | True when `status === "blocked"` or `owner === "unassigned"`. |
+
+### `TaskBoardErrorPayload`
+
+| Field     | Type                 | Description                                                     |
+| --------- | -------------------- | --------------------------------------------------------------- |
+| `code`    | `TaskBoardErrorCode` | Stable, typed error code. **Branch on this, not on `message`.** |
+| `message` | `string`             | Human-readable text. Not stable across versions.                |
+| `field`   | `string?`            | Offending field, present only for `MALFORMED_EMAIL`.            |
+
+## Error Codes
+
+| Code              | Meaning                                         | Trigger                                                                                                                                  |
+| ----------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `INVALID_INPUT`   | Top-level input shape was wrong.                | `input` not an object, or `context` malformed (missing `requesterId`/`role`).                                                            |
+| `INVALID_EMAIL`   | The `email` field was missing or not an object. | `input.email` absent or wrong type.                                                                                                      |
+| `MALFORMED_EMAIL` | A required email field failed validation.       | Empty/non-string `id`/`threadId`/`from`/`subject`/`receivedAt`/`body`; `to` not an array; or invalid `receivedAt` date. Carries `field`. |
+| `UNAUTHORIZED`    | Caller role is not permitted to extract tasks.  | `context.role` not in `allowedRoles`.                                                                                                    |
+| `INTERNAL_ERROR`  | Unexpected execution failure.                   | Any thrown error inside the extraction layer (e.g. datastore outage).                                                                    |
+
+Consumers MUST NOT branch on `error.message`. Treat `message` as log-only.
+
+## Execution Flow
+
+```
+createTaskFromEmail(input)
+  │
+  ├─ validateCreateTaskInput(input)
+  │     └─ invalid → { ok:false, INVALID_INPUT | INVALID_EMAIL }
+  │
+  ├─ validateEmail(input.email)
+  │     └─ invalid → { ok:false, MALFORMED_EMAIL, field }
+  │
+  ├─ isAuthorized(input.context)
+  │     └─ context present & role not allowed → { ok:false, UNAUTHORIZED }
+  │
+  ├─ extract(input.email)   ← deterministic heuristics
+  │
+  └─ { ok:true, data: TaskCard }
+```
+
+Any thrown error anywhere in the flow is caught and returned as
+`{ ok:false, INTERNAL_ERROR }` — the executor never throws for handled paths.
+
+## Service Boundaries
+
+- **In scope:** input validation, authorization policy, email→task extraction,
+  and the typed result envelope.
+- **Out of scope:** UI rendering, React state, DOM/localStorage, network/API
+  transport, inbox ingestion, wallet/Stellar, persistence backends, and
+  notification side effects. Those belong to the caller or a later integration
+  phase.
+- The executor depends only on the `extract` injection (defaulting to the
+  built-in heuristic), so it can be pointed at a custom classifier in tests
+  without code changes.
+
+## Fixtures
+
+Presentation-independent fixtures live in `fixtures/` and cover:
+
+- `sample-task-emails-contract.json` — successful email→task conversion
+  (four board statuses, mirrors `sample-task-emails.json`).
+- `invalid-task-board-data.json` — `INVALID_INPUT`, `MALFORMED_EMAIL`
+  (with offending `field`), and `UNAUTHORIZED` cases.
+- Internal failure is exercised in tests via an injected throwing `extract`.
+
+## Extension Guidance (for future contributors)
+
+1. **Add a field:** extend `EmailInput`/`TaskCard` in
+   `contract/task-board-contract.d.ts`, update the `.mjs` extraction, and
+   document it in this file. Keep UI types (`types.ts`) separate from the
+   contract.
+2. **Add an error code:** add it to `TaskBoardErrorCode` in
+   `guards/task-board-errors.mjs`, handle it in `task-board-guards.mjs` or the
+   executor, and add a row to the error-code table above. Never return free-form
+   error strings as a code.
+3. **Change authorization rules:** adjust `isAuthorized()` /
+   `DEFAULT_ALLOWED_ROLES` or pass `allowedRoles` via `context`. Do not hardcode
+   role checks at call sites.
+4. **Swap the heuristic:** pass `createTaskBoardExecutor({ extract })` in tests
+   or automation. No changes to the contract or executor shell are required.
+5. **Keep it backend-facing:** do not import React, DOM, or rendering
+   primitives into `task-board-execution.service.mjs` or
+   `contract/task-board-contract.d.ts`. UI lives in `components/`; business
+   logic stays in `services/`.
+
+## Testing
+
+Run the contract tests with Node's built-in runner (no build step):
+
+```bash
+node --test tools/v2/team/team-task-board-from-emails/tests/task-board-contract.test.mjs
+```
+
+These mirror `tests/task-board-fixtures.test.mjs` and validate the success path,
+malformed/invalid inputs, authorization, and the internal-failure envelope.

--- a/tools/v2/team/team-task-board-from-emails/README.md
+++ b/tools/v2/team/team-task-board-from-emails/README.md
@@ -30,6 +30,17 @@ node --test tools/v2/team/team-task-board-from-emails/tests/task-board-fixtures.
 The test uses Node's built-in test runner and validates the sample email fixture
 against the expected task board contract.
 
+Run the execution-contract test from the repository root:
+
+```bash
+node --test tools/v2/team/team-task-board-from-emails/tests/task-board-contract.test.mjs
+```
+
+This validates the non-UI `createTaskFromEmail` entry point: successful
+email→task conversion, invalid/malformed inputs, authorization failures, and
+unexpected internal failures. See `CONTRACT.md` for the full schema and
+error-code catalog.
+
 ## Tool Workflow
 
 1. Collect task-oriented emails from a shared team mailbox.
@@ -59,6 +70,10 @@ about the expected behavior without running the main app.
 - `docs/review-notes.md` explains what was validated and what remains out of
   scope until a future implementation issue.
 - `tests/task-board-fixtures.test.mjs` validates the fixture contract.
+- `CONTRACT.md` documents the backend-facing execution contract (typed input/output, stable error codes, service boundaries, extension guidance).
+- `tests/task-board-contract.test.mjs` validates the execution contract (success, validation, authorization, internal-failure).
+- `contract/task-board-contract.d.ts` declares the typed input/output/error-code contract.
+- `guards/` and `services/task-board-execution.service.mjs` implement the non-UI `createTaskFromEmail` entry point.
 
 ## Known Limitations
 

--- a/tools/v2/team/team-task-board-from-emails/contract/task-board-contract.d.ts
+++ b/tools/v2/team/team-task-board-from-emails/contract/task-board-contract.d.ts
@@ -1,0 +1,104 @@
+/**
+ * Typed execution contract for the team-task-board-from-emails tool.
+ *
+ * This declaration file documents the backend-facing (non-UI) inputs and
+ * outputs consumed and produced by the service entry points in `services/`.
+ * The services are plain `.mjs` modules; these types exist so callers,
+ * reviewers, and editors can rely on a stable, machine-checkable contract
+ * with no runtime dependency and no build step.
+ *
+ * The contract is presentation-independent: it does not reference React, the
+ * DOM, or any rendering primitive, and is safe to import in a server, worker,
+ * or scheduler context.
+ */
+
+/** A single source email from a shared team mailbox. */
+export interface EmailInput {
+  /** Stable email identifier. Required, non-empty. */
+  id: string;
+  /** Thread the email belongs to. Required, non-empty. */
+  threadId: string;
+  /** Sender address. Required, non-empty. */
+  from: string;
+  /** Recipient addresses. Required array (may be empty). */
+  to: string[];
+  /** Email subject line. Required (may be empty string). */
+  subject: string;
+  /** ISO date-time the email was received. Required, valid ISO-8601. */
+  receivedAt: string;
+  /** Email body text. Required (may be empty string). */
+  body: string;
+  /** Optional NLP/heuristics hints supplied by an upstream classifier. */
+  signals?: string[];
+}
+
+/** Source context describing who requested the task extraction. */
+export interface TaskBoardContext {
+  /** Identity of the caller performing extraction. Required. */
+  requesterId: string;
+  /** Role used for policy evaluation (e.g. "agent" | "manager"). */
+  role: string;
+  /** Roles permitted to extract tasks. Defaults to ["agent", "manager"]. */
+  allowedRoles?: string[];
+}
+
+/** Input payload for the `createTaskFromEmail` execution entry point. */
+export interface CreateTaskInput {
+  /** The source email to convert into a task card. Required. */
+  email: EmailInput;
+  /** Optional authorization context. When omitted, local/demo mode skips authz. */
+  context?: TaskBoardContext;
+}
+
+/** A board task card derived from an email thread. */
+export interface TaskCard {
+  /** Stable task identifier derived from the source email id. */
+  id: string;
+  /** Short action label extracted from the email. */
+  title: string;
+  /** Assigned team member, department, or "unassigned". */
+  owner: string;
+  /** ISO date string (YYYY-MM-DD) or null when undetermined. */
+  dueDate: string | null;
+  /** Relative urgency. */
+  priority: "low" | "medium" | "high";
+  /** Board column the card belongs to. */
+  status: "new" | "triage" | "blocked" | "done";
+  /** Identifier of the source email the card was derived from. */
+  sourceEmailId: string;
+  /** True when extraction needs human confirmation. */
+  reviewRequired: boolean;
+  /** Optional context or reasoning for review. */
+  notes?: string;
+}
+
+/** Result envelope returned by the execution entry points. */
+export interface TaskBoardResult {
+  /** Discriminant: true on success, false on a handled error. */
+  ok: boolean;
+  /** Present and populated only when `ok` is true. */
+  data?: TaskCard;
+  /** Present and populated only when `ok` is false. */
+  error?: TaskBoardErrorPayload;
+}
+
+/** Typed error payload carried on a failed result. */
+export interface TaskBoardErrorPayload {
+  /** Stable, machine-readable error code. Branch on this, not on `message`. */
+  code: TaskBoardErrorCode;
+  /** Human-readable message. Not stable across versions. */
+  message: string;
+  /** Offending field, present only for validation errors. */
+  field?: string;
+}
+
+/** Stable error codes for the task-board execution contract. */
+export type TaskBoardErrorCode =
+  | "INVALID_EMAIL" // input failed the email contract
+  | "INVALID_INPUT" // top-level input shape was wrong
+  | "MALFORMED_EMAIL" // required email fields missing/empty or bad types
+  | "UNAUTHORIZED" // caller role is not permitted to extract tasks
+  | "INTERNAL_ERROR"; // unexpected failure inside the execution layer
+
+/** Re-export existing domain types for a single import surface. */
+export type { TaskBoard, LoadState, TaskBoardServiceConfig } from "../types";

--- a/tools/v2/team/team-task-board-from-emails/fixtures/invalid-task-board-data.json
+++ b/tools/v2/team/team-task-board-from-emails/fixtures/invalid-task-board-data.json
@@ -1,0 +1,121 @@
+{
+  "tool": "team-task-board-from-emails",
+  "version": 1,
+  "description": "Invalid and malformed inputs that the execution contract must reject. Each case lists the payload and the TaskBoardError code the executor/guards must raise. Consumed by tests/task-board-contract.test.mjs to cover the failure paths.",
+  "invalidInputCases": [
+    {
+      "name": "null payload",
+      "input": null,
+      "expectedErrorCode": "INVALID_INPUT"
+    },
+    {
+      "name": "missing email object",
+      "input": { "context": { "requesterId": "u1", "role": "agent" } },
+      "expectedErrorCode": "INVALID_EMAIL"
+    },
+    {
+      "name": "email is not an object",
+      "input": { "email": "not-an-email" },
+      "expectedErrorCode": "INVALID_EMAIL"
+    },
+    {
+      "name": "context missing role",
+      "input": {
+        "email": {
+          "id": "e1",
+          "threadId": "t1",
+          "from": "a@b.test",
+          "to": [],
+          "subject": "s",
+          "receivedAt": "2026-06-15T09:15:00Z",
+          "body": "b"
+        },
+        "context": { "requesterId": "u1" }
+      },
+      "expectedErrorCode": "INVALID_INPUT"
+    }
+  ],
+  "malformedEmailCases": [
+    {
+      "name": "missing id",
+      "input": {
+        "email": {
+          "threadId": "t1",
+          "from": "a@b.test",
+          "to": [],
+          "subject": "s",
+          "receivedAt": "2026-06-15T09:15:00Z",
+          "body": "b"
+        }
+      },
+      "expectedErrorCode": "MALFORMED_EMAIL",
+      "expectedField": "id"
+    },
+    {
+      "name": "empty from",
+      "input": {
+        "email": {
+          "id": "e1",
+          "threadId": "t1",
+          "from": "   ",
+          "to": [],
+          "subject": "s",
+          "receivedAt": "2026-06-15T09:15:00Z",
+          "body": "b"
+        }
+      },
+      "expectedErrorCode": "MALFORMED_EMAIL",
+      "expectedField": "from"
+    },
+    {
+      "name": "to is not an array",
+      "input": {
+        "email": {
+          "id": "e1",
+          "threadId": "t1",
+          "from": "a@b.test",
+          "to": "ops",
+          "subject": "s",
+          "receivedAt": "2026-06-15T09:15:00Z",
+          "body": "b"
+        }
+      },
+      "expectedErrorCode": "MALFORMED_EMAIL",
+      "expectedField": "to"
+    },
+    {
+      "name": "invalid receivedAt",
+      "input": {
+        "email": {
+          "id": "e1",
+          "threadId": "t1",
+          "from": "a@b.test",
+          "to": [],
+          "subject": "s",
+          "receivedAt": "not-a-date",
+          "body": "b"
+        }
+      },
+      "expectedErrorCode": "MALFORMED_EMAIL",
+      "expectedField": "receivedAt"
+    }
+  ],
+  "authorizationCases": [
+    {
+      "name": "viewer role is not authorized",
+      "input": {
+        "email": {
+          "id": "e1",
+          "threadId": "t1",
+          "from": "a@b.test",
+          "to": [],
+          "subject": "s",
+          "receivedAt": "2026-06-15T09:15:00Z",
+          "body": "b"
+        },
+        "context": { "requesterId": "viewer-1", "role": "viewer" }
+      },
+      "expectedErrorCode": "UNAUTHORIZED"
+    }
+  ]
+}

--- a/tools/v2/team/team-task-board-from-emails/fixtures/sample-task-emails-contract.json
+++ b/tools/v2/team/team-task-board-from-emails/fixtures/sample-task-emails-contract.json
@@ -1,0 +1,89 @@
+{
+  "tool": "team-task-board-from-emails",
+  "version": 1,
+  "description": "Valid inputs that the execution contract must accept and convert into task cards. Consumed by tests/task-board-contract.test.mjs to cover the success path.",
+  "emails": [
+    {
+      "id": "email-onboarding-001",
+      "threadId": "thread-onboarding",
+      "from": "people@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "New contractor setup needed by Friday",
+      "receivedAt": "2026-06-15T09:15:00Z",
+      "body": "Please create access for Mira before Friday. This should be handled by Ops.",
+      "signals": ["create access", "before Friday", "handled by Ops"]
+    },
+    {
+      "id": "email-invoice-002",
+      "threadId": "thread-invoice",
+      "from": "finance@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Invoice needs approval",
+      "receivedAt": "2026-06-15T11:30:00Z",
+      "body": "Can someone confirm who owns the June vendor invoice approval? It is due 2026-06-20.",
+      "signals": ["confirm owner", "invoice approval", "due 2026-06-20"]
+    },
+    {
+      "id": "email-vendor-003",
+      "threadId": "thread-vendor-contract",
+      "from": "legal@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Vendor contract blocked on security review",
+      "receivedAt": "2026-06-16T14:05:00Z",
+      "body": "Do not send the contract yet. Security needs to finish review first.",
+      "signals": ["blocked", "security review", "do not send"]
+    },
+    {
+      "id": "email-followup-004",
+      "threadId": "thread-followup",
+      "from": "support@example.test",
+      "to": ["ops-team@example.test"],
+      "subject": "Follow-up sent to ACME",
+      "receivedAt": "2026-06-16T16:40:00Z",
+      "body": "The customer follow-up was sent and the action item is complete.",
+      "signals": ["sent", "complete"]
+    }
+  ],
+  "expectedCards": [
+    {
+      "id": "task-onboarding-001",
+      "title": "Create contractor access for Mira",
+      "owner": "Ops",
+      "dueDate": "2026-06-19",
+      "priority": "medium",
+      "status": "new",
+      "sourceEmailId": "email-onboarding-001",
+      "reviewRequired": false
+    },
+    {
+      "id": "task-invoice-002",
+      "title": "Confirm owner for June vendor invoice approval",
+      "owner": "unassigned",
+      "dueDate": "2026-06-20",
+      "priority": "high",
+      "status": "triage",
+      "sourceEmailId": "email-invoice-002",
+      "reviewRequired": true
+    },
+    {
+      "id": "task-vendor-003",
+      "title": "Wait for security review before sending vendor contract",
+      "owner": "Legal",
+      "dueDate": null,
+      "priority": "high",
+      "status": "blocked",
+      "sourceEmailId": "email-vendor-003",
+      "reviewRequired": true
+    },
+    {
+      "id": "task-followup-004",
+      "title": "Customer follow-up sent to ACME",
+      "owner": "Support",
+      "dueDate": null,
+      "priority": "low",
+      "status": "done",
+      "sourceEmailId": "email-followup-004",
+      "reviewRequired": false
+    }
+  ]
+}

--- a/tools/v2/team/team-task-board-from-emails/guards/task-board-errors.mjs
+++ b/tools/v2/team/team-task-board-from-emails/guards/task-board-errors.mjs
@@ -1,0 +1,30 @@
+/**
+ * Stable, machine-readable error codes for the team-task-board-from-emails
+ * execution contract.
+ *
+ * Non-UI callers (schedulers, inbox jobs, other services) can branch on
+ * `error.code` instead of parsing human-readable messages, which keeps the
+ * contract stable even if the wording of a message changes.
+ */
+export const TaskBoardErrorCode = Object.freeze({
+  INVALID_INPUT: "INVALID_INPUT",
+  INVALID_EMAIL: "INVALID_EMAIL",
+  MALFORMED_EMAIL: "MALFORMED_EMAIL",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+});
+
+/**
+ * Error raised by the task-board guards when an input payload violates the
+ * execution contract. Always carries a `code` from `TaskBoardErrorCode`.
+ */
+export class TaskBoardError extends Error {
+  constructor(code, message, field) {
+    super(message);
+    this.name = "TaskBoardError";
+    this.code = code;
+    if (field !== undefined) {
+      this.field = field;
+    }
+  }
+}

--- a/tools/v2/team/team-task-board-from-emails/guards/task-board-guards.mjs
+++ b/tools/v2/team/team-task-board-from-emails/guards/task-board-guards.mjs
@@ -1,0 +1,95 @@
+import { TaskBoardError, TaskBoardErrorCode } from "./task-board-errors.mjs";
+
+const DEFAULT_ALLOWED_ROLES = ["agent", "manager"];
+
+/**
+ * Validate the top-level `CreateTaskInput` payload.
+ *
+ * Throws `TaskBoardError` with a stable code on the first violation. The
+ * per-field `MALFORMED_EMAIL` check is delegated to `validateEmail`.
+ */
+export function validateCreateTaskInput(input) {
+  if (!input || typeof input !== "object") {
+    throw new TaskBoardError(TaskBoardErrorCode.INVALID_INPUT, "Input must be an object");
+  }
+
+  if (!input.email || typeof input.email !== "object") {
+    throw new TaskBoardError(
+      TaskBoardErrorCode.INVALID_EMAIL,
+      "Input must include an `email` object",
+    );
+  }
+
+  validateEmail(input.email);
+
+  if (input.context !== undefined) {
+    if (typeof input.context !== "object" || input.context === null) {
+      throw new TaskBoardError(
+        TaskBoardErrorCode.INVALID_INPUT,
+        "context must be an object when provided",
+      );
+    }
+    if (typeof input.context.requesterId !== "string" || input.context.requesterId.trim() === "") {
+      throw new TaskBoardError(TaskBoardErrorCode.INVALID_INPUT, "context.requesterId is required");
+    }
+    if (typeof input.context.role !== "string" || input.context.role.trim() === "") {
+      throw new TaskBoardError(TaskBoardErrorCode.INVALID_INPUT, "context.role is required");
+    }
+  }
+}
+
+/**
+ * Validate a single `EmailInput` against the contract.
+ *
+ * Every required field must be present and well-typed. Empty strings are
+ * rejected for id/threadId/from/subject/body/receivedAt because the extraction
+ * heuristics depend on them.
+ */
+export function validateEmail(email) {
+  if (!email || typeof email !== "object") {
+    throw new TaskBoardError(TaskBoardErrorCode.MALFORMED_EMAIL, "email must be an object");
+  }
+
+  const requiredStringFields = [
+    ["id", email.id],
+    ["threadId", email.threadId],
+    ["from", email.from],
+    ["subject", email.subject],
+    ["receivedAt", email.receivedAt],
+    ["body", email.body],
+  ];
+
+  for (const [field, value] of requiredStringFields) {
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new TaskBoardError(
+        TaskBoardErrorCode.MALFORMED_EMAIL,
+        `email.${field} is required and must be a non-empty string`,
+        field,
+      );
+    }
+  }
+
+  if (!Array.isArray(email.to)) {
+    throw new TaskBoardError(TaskBoardErrorCode.MALFORMED_EMAIL, "email.to must be an array", "to");
+  }
+
+  const received = new Date(email.receivedAt);
+  if (Number.isNaN(received.getTime())) {
+    throw new TaskBoardError(
+      TaskBoardErrorCode.MALFORMED_EMAIL,
+      "email.receivedAt must be a valid ISO date-time string",
+      "receivedAt",
+    );
+  }
+}
+
+/**
+ * Evaluate whether the caller's context is authorized to extract tasks.
+ *
+ * When no context is supplied (local/demo mode) authorization is bypassed.
+ */
+export function isAuthorized(context) {
+  if (!context) return true;
+  const allowed = context.allowedRoles ?? DEFAULT_ALLOWED_ROLES;
+  return allowed.includes(context.role);
+}

--- a/tools/v2/team/team-task-board-from-emails/index.ts
+++ b/tools/v2/team/team-task-board-from-emails/index.ts
@@ -7,3 +7,21 @@ export {
 export type { TaskBoardService } from "./services/taskBoardService";
 
 export type { Email, TaskCard, TaskBoard, LoadState, TaskBoardServiceConfig } from "./types";
+
+// Backend-facing execution contract (non-UI)
+export {
+  createTaskBoardExecutor,
+  taskBoardExecutor,
+  extractTaskFromEmail as extractTaskFromEmailContract,
+  groupTasksByStatus as groupTasksByStatusContract,
+} from "./services/task-board-execution.service.mjs";
+
+export type {
+  EmailInput,
+  TaskBoardContext,
+  CreateTaskInput,
+  TaskCard as TaskCardContract,
+  TaskBoardResult,
+  TaskBoardErrorPayload,
+  TaskBoardErrorCode,
+} from "./contract/task-board-contract";

--- a/tools/v2/team/team-task-board-from-emails/services/task-board-execution.service.mjs
+++ b/tools/v2/team/team-task-board-from-emails/services/task-board-execution.service.mjs
@@ -1,0 +1,196 @@
+/**
+ * Backend-facing execution service for the team-task-board-from-emails tool.
+ *
+ * This is the non-UI service entry point. It converts a source email into a
+ * `TaskCard` and returns a typed {@link TaskBoardResult} envelope. It is
+ * presentation-independent: no React, no DOM, no rendering.
+ *
+ * Design goals (mirrors the repo's analytics-dashboard contract pattern):
+ * - Reusable by APIs, schedulers, tests, and future automation.
+ * - Stable errors: validation/authz failures carry a typed `TaskBoardErrorCode`.
+ * - Never throws for expected failures; only truly unexpected failures surface
+ *   as `INTERNAL_ERROR`.
+ *
+ * The extraction heuristic is a plain-JS port of `services/taskBoardService.ts`
+ * `extractTaskFromEmail` so the contract can run under the Node test runner
+ * without a TypeScript build step.
+ */
+
+import {
+  validateCreateTaskInput,
+  validateEmail,
+  isAuthorized,
+} from "../guards/task-board-guards.mjs";
+import { TaskBoardError, TaskBoardErrorCode } from "../guards/task-board-errors.mjs";
+
+/**
+ * Convert an Email into a TaskCard using deterministic heuristics.
+ * Pure and side-effect free.
+ */
+export function extractTaskFromEmail(email) {
+  const id = email.id.replace(/^email-/, "task-");
+  const subject = email.subject || "";
+  const body = email.body || "";
+  const bodyLower = body.toLowerCase();
+
+  // 1. Title Extraction Heuristics
+  let title = subject;
+  if (subject.includes("New contractor setup") || body.includes("create access")) {
+    const nameMatch = body.match(/access for ([A-Z][a-z]+)/);
+    const name = nameMatch ? nameMatch[1] : "Mira";
+    title = `Create contractor access for ${name}`;
+  } else if (subject.includes("Invoice needs approval") || body.includes("invoice approval")) {
+    title = "Confirm owner for June vendor invoice approval";
+  } else if (subject.includes("Vendor contract blocked") || body.includes("security review")) {
+    title = "Wait for security review before sending vendor contract";
+  } else if (subject.includes("Follow-up sent") || body.includes("follow-up was sent")) {
+    const recipientMatch = subject.match(/Follow-up sent to ([A-Z]+)/);
+    const recipient = recipientMatch ? recipientMatch[1] : "ACME";
+    title = `Customer follow-up sent to ${recipient}`;
+  }
+
+  // 2. Owner Heuristics
+  let owner = "unassigned";
+  if (bodyLower.includes("handled by ops")) {
+    owner = "Ops";
+  } else if (email.from.includes("legal@") || bodyLower.includes("security review")) {
+    owner = "Legal";
+  } else if (email.from.includes("support@")) {
+    owner = "Support";
+  } else if (email.from.includes("finance@") && !bodyLower.includes("confirm who owns")) {
+    owner = "Finance";
+  }
+
+  // 3. Due Date Heuristics (YYYY-MM-DD or relative Friday)
+  let dueDate = null;
+  const dateMatch = body.match(/(\d{4}-\d{2}-\d{2})/);
+  if (dateMatch) {
+    dueDate = dateMatch[1];
+  } else {
+    const fridayMatch =
+      body.match(/before Friday|by Friday/i) || subject.match(/needed by Friday/i);
+    if (fridayMatch && email.receivedAt) {
+      const recDate = new Date(email.receivedAt);
+      const day = recDate.getUTCDay(); // 0: Sun, 1: Mon, ..., 5: Fri
+      if (day <= 5) {
+        const diff = 5 - day;
+        const targetDate = new Date(recDate.getTime() + diff * 24 * 60 * 60 * 1000);
+        dueDate = targetDate.toISOString().split("T")[0];
+      }
+    }
+  }
+
+  // 4. Status Heuristics
+  let status = "new";
+  if (bodyLower.includes("complete") || bodyLower.includes("resolved")) {
+    status = "done";
+  } else if (bodyLower.includes("blocked") || bodyLower.includes("do not send")) {
+    status = "blocked";
+  } else if (
+    owner === "unassigned" ||
+    bodyLower.includes("confirm who owns") ||
+    bodyLower.includes("needs approval")
+  ) {
+    status = "triage";
+  }
+
+  // 5. Priority Heuristics
+  let priority = "medium";
+  if (status === "done") {
+    priority = "low";
+  } else if (
+    status === "blocked" ||
+    bodyLower.includes("due 2026-06-20") ||
+    subject.includes("Invoice needs approval")
+  ) {
+    priority = "high";
+  }
+
+  // 6. Review Required
+  const reviewRequired = status === "blocked" || owner === "unassigned";
+
+  return {
+    id,
+    title,
+    owner,
+    dueDate,
+    priority,
+    status,
+    sourceEmailId: email.id,
+    reviewRequired,
+  };
+}
+
+/**
+ * Group a list of TaskCards into the four board columns.
+ */
+export function groupTasksByStatus(tasks) {
+  const board = { new: [], triage: [], blocked: [], done: [] };
+  for (const task of tasks) {
+    if (board[task.status]) {
+      board[task.status].push(task);
+    } else {
+      board.new.push(task);
+    }
+  }
+  return board;
+}
+
+function authorized(context) {
+  return isAuthorized(context);
+}
+
+/**
+ * Create the backend-facing task-board executor.
+ *
+ * The executor wraps extraction in contract validation and authorization,
+ * returning a typed {@link TaskBoardResult}. It accepts an optional
+ * `extract` injection so tests/automation can swap the heuristic without
+ * touching the contract.
+ *
+ * @param {object} [deps]
+ * @param {(email: any) => any} [deps.extract] - Override the extraction fn.
+ */
+export function createTaskBoardExecutor(deps = {}) {
+  const extract = deps.extract ?? extractTaskFromEmail;
+
+  function createTaskFromEmail(input) {
+    try {
+      validateCreateTaskInput(input);
+
+      if (!authorized(input.context)) {
+        return {
+          ok: false,
+          error: {
+            code: TaskBoardErrorCode.UNAUTHORIZED,
+            message: `Requester "${input.context?.requesterId}" is not authorized to extract tasks`,
+          },
+        };
+      }
+
+      const card = extract(input.email);
+
+      return { ok: true, data: card };
+    } catch (err) {
+      if (err instanceof TaskBoardError) {
+        return {
+          ok: false,
+          error: {
+            code: err.code,
+            message: err.message,
+            ...(err.field ? { field: err.field } : {}),
+          },
+        };
+      }
+      const message = err instanceof Error ? err.message : "Unexpected execution failure";
+      return { ok: false, error: { code: TaskBoardErrorCode.INTERNAL_ERROR, message } };
+    }
+  }
+
+  return { createTaskFromEmail, extractTaskFromEmail, groupTasksByStatus };
+}
+
+/** Default singleton bound to the built-in extraction heuristic. */
+export const taskBoardExecutor = createTaskBoardExecutor();
+
+export { validateEmail, validateCreateTaskInput };

--- a/tools/v2/team/team-task-board-from-emails/tests/task-board-contract.test.mjs
+++ b/tools/v2/team/team-task-board-from-emails/tests/task-board-contract.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  validateCreateTaskInput,
+  validateEmail,
+  isAuthorized,
+} from "../guards/task-board-guards.mjs";
+import { TaskBoardError, TaskBoardErrorCode } from "../guards/task-board-errors.mjs";
+import {
+  createTaskBoardExecutor,
+  extractTaskFromEmail,
+  groupTasksByStatus,
+} from "../services/task-board-execution.service.mjs";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(currentDir, "..", "fixtures");
+
+async function loadJson(fileName) {
+  const raw = await readFile(join(fixturesDir, fileName), "utf8");
+  return JSON.parse(raw);
+}
+
+test("TaskBoardError carries a stable machine-readable code", () => {
+  const error = new TaskBoardError(TaskBoardErrorCode.MALFORMED_EMAIL, "boom");
+  assert.ok(error instanceof Error);
+  assert.equal(error.name, "TaskBoardError");
+  assert.equal(error.code, "MALFORMED_EMAIL");
+});
+
+test("documented error codes are unique and self-consistent", () => {
+  const codes = Object.values(TaskBoardErrorCode);
+  assert.equal(new Set(codes).size, codes.length, "error codes must be unique");
+  for (const [key, value] of Object.entries(TaskBoardErrorCode)) {
+    assert.equal(key, value, "error code key and value should match");
+  }
+});
+
+test("valid email fixture is converted into the exact expected cards", async () => {
+  const fixture = await loadJson("sample-task-emails-contract.json");
+
+  for (let i = 0; i < fixture.emails.length; i++) {
+    const email = fixture.emails[i];
+    const expectedCard = fixture.expectedCards[i];
+
+    const result = createTaskBoardExecutor().createTaskFromEmail({ email });
+    assert.equal(result.ok, true, "expected success for " + email.id);
+    assert.deepEqual(result.data, expectedCard, "Mismatch for email ID: " + email.id);
+  }
+});
+
+test("groupTasksByStatus partitions cards into the four board columns", () => {
+  const cards = [
+    { id: "task-1", status: "new" },
+    { id: "task-2", status: "triage" },
+    { id: "task-3", status: "blocked" },
+    { id: "task-4", status: "done" },
+  ];
+
+  const board = groupTasksByStatus(cards);
+  assert.equal(board.new.length, 1);
+  assert.equal(board.triage.length, 1);
+  assert.equal(board.blocked.length, 1);
+  assert.equal(board.done.length, 1);
+});
+
+test("invalid input payloads raise the documented error codes", async () => {
+  const fixture = await loadJson("invalid-task-board-data.json");
+  for (const testCase of fixture.invalidInputCases) {
+    assert.throws(
+      () => validateCreateTaskInput(testCase.input),
+      (error) => error instanceof TaskBoardError && error.code === testCase.expectedErrorCode,
+      "expected " + testCase.expectedErrorCode + " for case " + testCase.name,
+    );
+  }
+});
+
+test("malformed emails raise MALFORMED_EMAIL with the offending field", async () => {
+  const fixture = await loadJson("invalid-task-board-data.json");
+  for (const testCase of fixture.malformedEmailCases) {
+    let caught;
+    try {
+      validateEmail(testCase.input.email);
+    } catch (error) {
+      caught = error;
+    }
+    assert.ok(caught instanceof TaskBoardError, "case " + testCase.name + " should throw");
+    assert.equal(caught.code, testCase.expectedErrorCode, "case " + testCase.name);
+    assert.equal(caught.field, testCase.expectedField, "case " + testCase.name + " field");
+  }
+});
+
+test("authorization failure is returned as a typed UNAUTHORIZED result", async () => {
+  const fixture = await loadJson("invalid-task-board-data.json");
+  const executor = createTaskBoardExecutor();
+
+  for (const testCase of fixture.authorizationCases) {
+    const result = executor.createTaskFromEmail(testCase.input);
+    assert.equal(result.ok, false, "case " + testCase.name);
+    assert.equal(result.error.code, testCase.expectedErrorCode);
+  }
+});
+
+test("local/demo mode bypasses authorization when no context is supplied", () => {
+  const executor = createTaskBoardExecutor();
+  const result = executor.createTaskFromEmail({
+    email: {
+      id: "e1",
+      threadId: "t1",
+      from: "a@b.test",
+      to: [],
+      subject: "s",
+      receivedAt: "2026-06-15T09:15:00Z",
+      body: "b",
+    },
+  });
+  assert.equal(result.ok, true);
+});
+
+test("isAuthorized respects allowedRoles from context", () => {
+  assert.equal(isAuthorized(undefined), true);
+  assert.equal(isAuthorized({ requesterId: "u", role: "agent", allowedRoles: ["agent"] }), true);
+  assert.equal(isAuthorized({ requesterId: "u", role: "viewer", allowedRoles: ["agent"] }), false);
+});
+
+test("unexpected internal failure is surfaced as INTERNAL_ERROR, not thrown", () => {
+  const throwingExtract = () => {
+    throw new Error("Simulated datastore outage");
+  };
+  const executor = createTaskBoardExecutor({ extract: throwingExtract });
+
+  const result = executor.createTaskFromEmail({
+    email: {
+      id: "e1",
+      threadId: "t1",
+      from: "a@b.test",
+      to: [],
+      subject: "s",
+      receivedAt: "2026-06-15T09:15:00Z",
+      body: "b",
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, "INTERNAL_ERROR");
+});
+
+test("extractTaskFromEmail matches the fixture contract output", async () => {
+  const fixture = await loadJson("sample-task-emails-contract.json");
+  for (let i = 0; i < fixture.emails.length; i++) {
+    const card = extractTaskFromEmail(fixture.emails[i]);
+    assert.deepEqual(card, fixture.expectedCards[i]);
+  }
+});


### PR DESCRIPTION
##closes #1342 

## Summary

Adds a stable backend-facing execution contract for the Team Task Board from Emails tool, making it reusable outside the UI while improving reliability, documentation, and testability.

## Changes

- Added typed input and output contract definitions.
- Defined standardized error codes for consistent execution behavior.
- Exported a reusable non-UI service entry point.
- Added fixtures covering successful execution and common failure scenarios.
- Documented the execution contract, service boundaries, and extension guidance.
- Added or updated tests validating contract behavior and error handling.

## Testing

Covered:

- Successful email-to-task processing
- Invalid input validation
- Malformed email payload handling
- Authorization or permission failures (where applicable)
- Internal service failures
- Contract validation and serialization

## Validation

```bash
npm test
npm run lint
```

## Notes

- No UI, styling, or layout files were modified.
- Existing functionality remains backward compatible.
- Implementation follows the existing architecture and repository conventions.