### PR TITLE
 feat(team-security-flagging): add non-UI execution contract

### DIFF
--- a/tools/v2/team/team-security-flagging/README.md
+++ b/tools/v2/team/team-security-flagging/README.md
@@ -142,6 +142,38 @@ validateStatusTransition("resolved", "new"); // throws SecurityFlagError
 
 ---
 
+## Non-UI Execution Contract
+
+`executeSecurityFlagging(input, dependencies)` is the stable backend-facing
+entry point. Its typed input, success record, error envelope, and injected
+service boundaries are declared in `contract/execution-contract.d.ts` and
+exported through `index.ts`. It has no React, DOM, styling, or layout concerns.
+
+```js
+import { executeSecurityFlagging } from "./services/security-flagging-execution.service.mjs";
+
+const outcome = await executeSecurityFlagging(input, {
+  authorizeReporter: (email) => authorizationService.canReport(email),
+  findActiveFlag: ({ emailId, threadId }) => repository.findActive(emailId, threadId),
+  persistFlag: (record) => repository.insert(record),
+  generateId: () => crypto.randomUUID(),
+  now: () => new Date(),
+});
+```
+
+Expected failures return a discriminated `{ ok: false, error }` result with one
+of these stable codes: `INVALID_INPUT`, `UNAUTHORIZED_REPORTER`,
+`DUPLICATE_FLAG`, `PERSISTENCE_FAILED`, or `INTERNAL_ERROR`. Callers should
+branch on `error.code`, not the human-readable message.
+
+Authorization, duplicate lookup, persistence, ID generation, and time are
+caller-supplied service boundaries. This makes execution deterministic in tests
+and independent of databases, transports, and presentation code.
+
+The companion `fixtures/execution-contract-cases.json` covers deterministic
+success plus validation, authorization, duplicate, persistence, and unexpected
+dependency failures.
+
 ## Fixtures
 
 `fixtures/security-flag-cases.json` contains:

--- a/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
+++ b/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
@@ -1,0 +1,66 @@
+/** Typed backend contract for the presentation-independent security flagging service. */
+export type SecurityFlagSeverity = "critical" | "high" | "medium" | "low";
+export type SecurityFlagCategory =
+  | "phishing"
+  | "credential-theft"
+  | "malware"
+  | "data-breach"
+  | "suspicious-sender"
+  | "unauthorized-access"
+  | "social-engineering"
+  | "other";
+
+export interface SecurityFlaggingInput {
+  emailId: string;
+  threadId: string;
+  reportedBy: string;
+  severity: SecurityFlagSeverity;
+  category: SecurityFlagCategory;
+  subject: string;
+  senderEmail: string;
+  description: string;
+  evidence?: readonly string[];
+}
+
+export interface SecurityFlaggingRecord extends SecurityFlaggingInput {
+  id: string;
+  status: "new";
+  evidence: readonly string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Stable codes callers may branch on. Error messages are not stable. */
+export type SecurityFlaggingErrorCode =
+  | "INVALID_INPUT"
+  | "UNAUTHORIZED_REPORTER"
+  | "DUPLICATE_FLAG"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
+
+export interface SecurityFlaggingError {
+  code: SecurityFlaggingErrorCode;
+  message: string;
+  field?: string;
+  existingFlagId?: string;
+}
+
+export type SecurityFlaggingOutput =
+  | { ok: true; data: SecurityFlaggingRecord }
+  | { ok: false; error: SecurityFlaggingError };
+
+/** I/O and environmental behavior supplied by the backend caller. */
+export interface SecurityFlaggingDependencies {
+  authorizeReporter(reporterEmail: string): boolean | Promise<boolean>;
+  findActiveFlag(input: {
+    emailId: string;
+    threadId: string;
+  }): string | null | Promise<string | null>;
+  persistFlag(record: SecurityFlaggingRecord): void | Promise<void>;
+  generateId(): string;
+  now(): Date;
+}
+
+export interface SecurityFlaggingExecutor {
+  execute(input: SecurityFlaggingInput): Promise<SecurityFlaggingOutput>;
+}

--- a/tools/v2/team/team-security-flagging/fixtures/execution-contract-cases.json
+++ b/tools/v2/team/team-security-flagging/fixtures/execution-contract-cases.json
@@ -1,0 +1,63 @@
+{
+  "success": {
+    "input": {
+      "emailId": "email-contract-001",
+      "threadId": "thread-contract-001",
+      "reportedBy": "analyst@company.example",
+      "severity": "high",
+      "category": "phishing",
+      "subject": "  Suspicious account verification request  ",
+      "senderEmail": "alerts@untrusted.example",
+      "description": "  Sender requested credentials through an unfamiliar link.  ",
+      "evidence": ["  Domain is not allow-listed  ", "Urgent credential request"]
+    },
+    "expected": {
+      "id": "flag-contract-001",
+      "emailId": "email-contract-001",
+      "threadId": "thread-contract-001",
+      "reportedBy": "analyst@company.example",
+      "severity": "high",
+      "category": "phishing",
+      "subject": "Suspicious account verification request",
+      "senderEmail": "alerts@untrusted.example",
+      "description": "Sender requested credentials through an unfamiliar link.",
+      "evidence": ["Domain is not allow-listed", "Urgent credential request"],
+      "status": "new",
+      "createdAt": "2026-07-18T12:00:00.000Z",
+      "updatedAt": "2026-07-18T12:00:00.000Z"
+    }
+  },
+  "failures": [
+    {
+      "name": "missing subject",
+      "override": { "subject": " " },
+      "mode": "normal",
+      "expectedCode": "INVALID_INPUT",
+      "expectedField": "subject"
+    },
+    {
+      "name": "unauthorized reporter",
+      "override": {},
+      "mode": "unauthorized",
+      "expectedCode": "UNAUTHORIZED_REPORTER"
+    },
+    {
+      "name": "duplicate active flag",
+      "override": {},
+      "mode": "duplicate",
+      "expectedCode": "DUPLICATE_FLAG"
+    },
+    {
+      "name": "storage failure",
+      "override": {},
+      "mode": "persistence-failure",
+      "expectedCode": "PERSISTENCE_FAILED"
+    },
+    {
+      "name": "authorization dependency failure",
+      "override": {},
+      "mode": "internal-failure",
+      "expectedCode": "INTERNAL_ERROR"
+    }
+  ]
+}

--- a/tools/v2/team/team-security-flagging/index.ts
+++ b/tools/v2/team/team-security-flagging/index.ts
@@ -1,0 +1,15 @@
+/** Public, presentation-independent API for team-security-flagging. */
+export {
+  createSecurityFlaggingExecutor,
+  executeSecurityFlagging,
+  SecurityFlaggingErrorCode,
+} from "./services/security-flagging-execution.service.mjs";
+export type {
+  SecurityFlaggingDependencies,
+  SecurityFlaggingError,
+  SecurityFlaggingErrorCode as SecurityFlaggingErrorCodeType,
+  SecurityFlaggingExecutor,
+  SecurityFlaggingInput,
+  SecurityFlaggingOutput,
+  SecurityFlaggingRecord,
+} from "./contract/execution-contract";

--- a/tools/v2/team/team-security-flagging/services/security-flagging-execution.service.mjs
+++ b/tools/v2/team/team-security-flagging/services/security-flagging-execution.service.mjs
@@ -1,0 +1,116 @@
+/** Backend-facing execution service. No UI, DOM, or infrastructure imports. */
+import {
+  SecurityFlagError,
+  sanitizeText,
+  validateCategory,
+  validateCreateFlagInput,
+  validateDescription,
+  validateEmail,
+  validateEmailId,
+  validateEvidence,
+  validateSeverity,
+  validateThreadId,
+} from "./security-flagging.service.mjs";
+
+export const SecurityFlaggingErrorCode = Object.freeze({
+  INVALID_INPUT: "INVALID_INPUT",
+  UNAUTHORIZED_REPORTER: "UNAUTHORIZED_REPORTER",
+  DUPLICATE_FLAG: "DUPLICATE_FLAG",
+  PERSISTENCE_FAILED: "PERSISTENCE_FAILED",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+});
+
+function failure(code, message, details = {}) {
+  return { ok: false, error: { code, message, ...details } };
+}
+
+function validateAndNormalize(input) {
+  validateCreateFlagInput(input);
+  const subject = sanitizeText(input.subject);
+  if (!subject) throw new SecurityFlagError("subject is required", "subject");
+
+  return {
+    emailId: validateEmailId(input.emailId),
+    threadId: validateThreadId(input.threadId),
+    reportedBy: validateEmail(input.reportedBy),
+    severity: validateSeverity(input.severity),
+    category: validateCategory(input.category),
+    subject,
+    senderEmail: validateEmail(input.senderEmail),
+    description: validateDescription(input.description),
+    evidence: validateEvidence(input.evidence ?? []),
+  };
+}
+
+/** Bind the executor to explicit authorization, storage, id, and clock boundaries. */
+export function createSecurityFlaggingExecutor(dependencies) {
+  if (!dependencies || typeof dependencies !== "object") {
+    throw new TypeError("Security flagging dependencies are required");
+  }
+
+  async function execute(input) {
+    let normalized;
+    try {
+      normalized = validateAndNormalize(input);
+    } catch (error) {
+      if (error instanceof SecurityFlagError) {
+        return failure(SecurityFlaggingErrorCode.INVALID_INPUT, error.message, {
+          ...(error.field ? { field: error.field } : {}),
+        });
+      }
+      return failure(SecurityFlaggingErrorCode.INVALID_INPUT, "Input must match the contract");
+    }
+
+    try {
+      if (!(await dependencies.authorizeReporter(normalized.reportedBy))) {
+        return failure(
+          SecurityFlaggingErrorCode.UNAUTHORIZED_REPORTER,
+          "Reporter is not authorized to create security flags",
+        );
+      }
+
+      const existingFlagId = await dependencies.findActiveFlag({
+        emailId: normalized.emailId,
+        threadId: normalized.threadId,
+      });
+      if (existingFlagId) {
+        return failure(
+          SecurityFlaggingErrorCode.DUPLICATE_FLAG,
+          "An active security flag already exists for this email",
+          { existingFlagId },
+        );
+      }
+
+      const timestamp = dependencies.now().toISOString();
+      const record = {
+        id: dependencies.generateId(),
+        ...normalized,
+        status: "new",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+
+      try {
+        await dependencies.persistFlag(record);
+      } catch {
+        return failure(
+          SecurityFlaggingErrorCode.PERSISTENCE_FAILED,
+          "The security flag could not be persisted",
+        );
+      }
+      return { ok: true, data: record };
+    } catch {
+      return failure(
+        SecurityFlaggingErrorCode.INTERNAL_ERROR,
+        "Unexpected security flagging execution failure",
+      );
+    }
+  }
+
+  return Object.freeze({ execute });
+}
+
+/** One-shot non-UI service entry point. */
+export function executeSecurityFlagging(input, dependencies) {
+  return createSecurityFlaggingExecutor(dependencies).execute(input);
+}

--- a/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
+++ b/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  createSecurityFlaggingExecutor,
+  executeSecurityFlagging,
+  SecurityFlaggingErrorCode,
+} from "../services/security-flagging-execution.service.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cases = JSON.parse(
+  await readFile(join(here, "..", "fixtures", "execution-contract-cases.json"), "utf8"),
+);
+
+function dependencies(mode = "normal") {
+  const persisted = [];
+  return {
+    persisted,
+    authorizeReporter: async () => {
+      if (mode === "internal-failure") throw new Error("auth unavailable");
+      return mode !== "unauthorized";
+    },
+    findActiveFlag: async () => (mode === "duplicate" ? "flag-existing-001" : null),
+    persistFlag: async (record) => {
+      if (mode === "persistence-failure") throw new Error("storage unavailable");
+      persisted.push(record);
+    },
+    generateId: () => "flag-contract-001",
+    now: () => new Date("2026-07-18T12:00:00.000Z"),
+  };
+}
+
+test("error codes are stable and unique", () => {
+  const codes = Object.values(SecurityFlaggingErrorCode);
+  assert.equal(new Set(codes).size, codes.length);
+  for (const [key, value] of Object.entries(SecurityFlaggingErrorCode)) assert.equal(key, value);
+});
+
+test("entry point normalizes, persists, and returns the success fixture", async () => {
+  const deps = dependencies();
+  const result = await executeSecurityFlagging(cases.success.input, deps);
+  assert.deepEqual(result, { ok: true, data: cases.success.expected });
+  assert.deepEqual(deps.persisted, [cases.success.expected]);
+});
+
+test("fixtures cover validation and service-boundary failures", async () => {
+  for (const fixture of cases.failures) {
+    const deps = dependencies(fixture.mode);
+    const result = await createSecurityFlaggingExecutor(deps).execute({
+      ...cases.success.input,
+      ...fixture.override,
+    });
+    assert.equal(result.ok, false, fixture.name);
+    assert.equal(result.error.code, fixture.expectedCode, fixture.name);
+    if (fixture.expectedField) assert.equal(result.error.field, fixture.expectedField);
+    assert.equal(deps.persisted.length, 0, fixture.name);
+  }
+});
+
+test("duplicate failures expose the existing flag id", async () => {
+  const result = await executeSecurityFlagging(cases.success.input, dependencies("duplicate"));
+  assert.equal(result.ok, false);
+  assert.equal(result.error.existingFlagId, "flag-existing-001");
+});
+
+test("missing dependencies are rejected during construction", () => {
+  assert.throws(() => createSecurityFlaggingExecutor(), TypeError);
+});


### PR DESCRIPTION
Closes #1358 
What was done
Added a stable, backend-facing execution contract for the team-security-flagging tool so it can run independently of presentation concerns, with no changes to any UI/layout code.
Changes

Added typed inputs, outputs, dependency boundaries, and stable error codes
Exported executeSecurityFlagging and an executor factory as the non-UI service entry point
Added fixtures and tests covering both success and failure cases
Documented the backend contract
No styling, layout, or component files touched

Test results

55 tests passed
TypeScript checks: passed
Formatting checks: passed