### PR TITLE
feat(approval-chain-builder): add non-UI execution contract

### DIFF
--- a/tools/v2/team/approval-chain-builder/CONTRACT.md
+++ b/tools/v2/team/approval-chain-builder/CONTRACT.md
@@ -1,0 +1,91 @@
+# Approval Chain Builder Execution Contract
+
+This is the stable, backend-facing contract for constructing an approval chain.
+It has no React, DOM, styling, routing, transport, or database dependency.
+
+## Entry point
+
+```ts
+import {
+  approvalChainBuilderService,
+  createApprovalChainBuilderService,
+} from "./tools/v2/team/approval-chain-builder";
+
+const result = await approvalChainBuilderService.execute(input);
+```
+
+The default service creates a normalized draft chain in memory. Applications
+that need persistence construct a service with an `ApprovalChainRepository`:
+
+```ts
+const service = createApprovalChainBuilderService({ repository });
+const result = await service.execute(input);
+```
+
+The optional `generateId` and `now` dependencies make IDs and timestamps
+replaceable for backend integrations and deterministic tests.
+
+## Input: `ApprovalChainBuilderInput`
+
+| Field           | Type                   | Required | Contract                                     |
+| --------------- | ---------------------- | -------- | -------------------------------------------- |
+| `subjectId`     | `string`               | yes      | Non-empty id of the object being approved.   |
+| `subjectType`   | `string`               | yes      | Non-empty category such as `invoice`.        |
+| `name`          | `string`               | yes      | Non-empty chain name.                        |
+| `createdBy`     | `string`               | yes      | Non-empty creator identity.                  |
+| `stages`        | `ApprovalStageInput[]` | yes      | One or more stages, executed in array order. |
+| `correlationId` | `string`               | no       | Opaque value propagated to the output.       |
+
+Each stage accepts an optional `id`, a non-empty `name`, one or more unique
+`approverIds`, and an optional integer `requiredApprovals`. When the threshold
+is omitted it defaults to the number of approvers. It must be between one and
+the number of approvers. Caller-supplied stage IDs must be unique in the chain.
+
+## Output: `ApprovalChainBuilderResult`
+
+The result is a discriminated union:
+
+```ts
+type ApprovalChainBuilderResult =
+  | { ok: true; data: ApprovalChain }
+  | { ok: false; error: ApprovalChainError };
+```
+
+A successful `ApprovalChain` contains a generated chain ID, normalized input
+fields, an ISO-8601 `createdAt`, `status: "draft"`, and ordered stages. Each
+stage has an ID, a zero-based `order`, unique approver IDs, and a resolved
+approval threshold.
+
+Use `ok` to narrow the result. Error messages are diagnostic and may change;
+consumers must use the stable `error.code` for control flow.
+
+## Error codes
+
+| Code                         | Meaning                                                            |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `INVALID_INPUT`              | A required scalar, stage, or approver value is missing or invalid. |
+| `DUPLICATE_STAGE_ID`         | Two stages use the same caller-supplied ID.                        |
+| `DUPLICATE_APPROVER`         | An approver occurs more than once in one stage.                    |
+| `INVALID_APPROVAL_THRESHOLD` | The threshold is not an integer in the allowed range.              |
+| `PERSISTENCE_FAILED`         | The injected repository rejected or threw while saving.            |
+| `INTERNAL_ERROR`             | An unexpected clock, ID generation, or execution failure occurred. |
+
+Input-specific errors include a dot-path `field`, such as
+`stages.0.requiredApprovals`.
+
+## Service boundary
+
+The executor owns contract validation, normalization, stage ordering, ID and
+timestamp assignment, and mapping expected failures to typed results.
+
+The caller owns authentication and authorization, network transport, database
+transactions, retries, presentation, and workflow execution after the draft is
+created. Persistence is available only through the minimal
+`ApprovalChainRepository.save(chain)` boundary. Expected failures are returned,
+not thrown.
+
+## Fixtures
+
+`fixtures/execution.fixtures.ts` exports a successful two-stage input plus
+failure fixtures for empty stages, duplicate approvers, duplicate stage IDs,
+an invalid threshold, and a failing repository.

--- a/tools/v2/team/approval-chain-builder/README.md
+++ b/tools/v2/team/approval-chain-builder/README.md
@@ -13,3 +13,12 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Non-UI execution
+
+The public backend-facing API is exported from `index.ts`. Use
+`approvalChainBuilderService.execute(input)` for in-memory construction, or
+`createApprovalChainBuilderService({ repository })` to inject persistence.
+
+Typed inputs, outputs, errors, service boundaries, and fixtures are documented
+in [CONTRACT.md](./CONTRACT.md).

--- a/tools/v2/team/approval-chain-builder/fixtures/execution.fixtures.ts
+++ b/tools/v2/team/approval-chain-builder/fixtures/execution.fixtures.ts
@@ -1,0 +1,62 @@
+import type { ApprovalChainBuilderInput } from "../types/contract";
+
+export const successfulChainInput: ApprovalChainBuilderInput = {
+  subjectId: "invoice-1042",
+  subjectType: "invoice",
+  name: "High-value invoice approval",
+  createdBy: "operations@example.com",
+  correlationId: "request-88",
+  stages: [
+    {
+      id: "manager-review",
+      name: "Manager review",
+      approverIds: ["manager-1", "manager-2"],
+      requiredApprovals: 1,
+    },
+    {
+      id: "finance-review",
+      name: "Finance review",
+      approverIds: ["finance-1"],
+    },
+  ],
+};
+
+export const missingStagesInput: ApprovalChainBuilderInput = {
+  ...successfulChainInput,
+  stages: [],
+};
+
+export const duplicateApproverInput: ApprovalChainBuilderInput = {
+  ...successfulChainInput,
+  stages: [
+    {
+      name: "Manager review",
+      approverIds: ["manager-1", "manager-1"],
+    },
+  ],
+};
+
+export const invalidThresholdInput: ApprovalChainBuilderInput = {
+  ...successfulChainInput,
+  stages: [
+    {
+      name: "Finance review",
+      approverIds: ["finance-1"],
+      requiredApprovals: 2,
+    },
+  ],
+};
+
+export const duplicateStageIdInput: ApprovalChainBuilderInput = {
+  ...successfulChainInput,
+  stages: [
+    { id: "review", name: "First review", approverIds: ["manager-1"] },
+    { id: "review", name: "Second review", approverIds: ["finance-1"] },
+  ],
+};
+
+export const failingRepository = {
+  async save(): Promise<void> {
+    throw new Error("Fixture persistence outage");
+  },
+};

--- a/tools/v2/team/approval-chain-builder/index.ts
+++ b/tools/v2/team/approval-chain-builder/index.ts
@@ -1,0 +1,24 @@
+export { approvalChainBuilderService, createApprovalChainBuilderService } from "./services";
+export type {
+  ApprovalChainBuilderDependencies,
+  ApprovalChainBuilderService,
+  ApprovalChainRepository,
+} from "./services";
+export type {
+  ApprovalChain,
+  ApprovalChainBuilderInput,
+  ApprovalChainBuilderResult,
+  ApprovalChainError,
+  ApprovalChainErrorCode,
+  ApprovalStage,
+  ApprovalStageInput,
+  ExecuteApprovalChainBuilder,
+} from "./types";
+export {
+  duplicateApproverInput,
+  duplicateStageIdInput,
+  failingRepository,
+  invalidThresholdInput,
+  missingStagesInput,
+  successfulChainInput,
+} from "./fixtures/execution.fixtures";

--- a/tools/v2/team/approval-chain-builder/services/execution.service.ts
+++ b/tools/v2/team/approval-chain-builder/services/execution.service.ts
@@ -1,0 +1,160 @@
+import type {
+  ApprovalChain,
+  ApprovalChainBuilderInput,
+  ApprovalChainBuilderResult,
+  ApprovalChainErrorCode,
+  ApprovalStage,
+} from "../types/contract";
+
+/** Optional persistence boundary. Transport and storage details stay outside this tool. */
+export interface ApprovalChainRepository {
+  save(chain: ApprovalChain): Promise<void>;
+}
+
+export interface ApprovalChainBuilderDependencies {
+  repository?: ApprovalChainRepository;
+  generateId?: () => string;
+  now?: () => Date;
+}
+
+function failure(
+  code: ApprovalChainErrorCode,
+  message: string,
+  field?: string,
+): ApprovalChainBuilderResult {
+  return { ok: false, error: { code, message, ...(field ? { field } : {}) } };
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateInput(input: ApprovalChainBuilderInput): ApprovalChainBuilderResult | undefined {
+  const requiredStrings: Array<[keyof ApprovalChainBuilderInput, unknown]> = [
+    ["subjectId", input?.subjectId],
+    ["subjectType", input?.subjectType],
+    ["name", input?.name],
+    ["createdBy", input?.createdBy],
+  ];
+
+  for (const [field, value] of requiredStrings) {
+    if (!nonEmptyString(value)) {
+      return failure("INVALID_INPUT", `${field} must be a non-empty string`, field);
+    }
+  }
+
+  if (!Array.isArray(input.stages) || input.stages.length === 0) {
+    return failure("INVALID_INPUT", "stages must contain at least one stage", "stages");
+  }
+
+  const stageIds = new Set<string>();
+  for (const [index, stage] of input.stages.entries()) {
+    const path = `stages.${index}`;
+    if (!stage || !nonEmptyString(stage.name)) {
+      return failure("INVALID_INPUT", "stage name must be a non-empty string", `${path}.name`);
+    }
+    if (stage.id !== undefined && !nonEmptyString(stage.id)) {
+      return failure("INVALID_INPUT", "stage id must be a non-empty string", `${path}.id`);
+    }
+    if (stage.id && stageIds.has(stage.id)) {
+      return failure("DUPLICATE_STAGE_ID", `stage id "${stage.id}" is duplicated`, `${path}.id`);
+    }
+    if (stage.id) stageIds.add(stage.id);
+
+    if (!Array.isArray(stage.approverIds) || stage.approverIds.length === 0) {
+      return failure(
+        "INVALID_INPUT",
+        "approverIds must contain at least one approver",
+        `${path}.approverIds`,
+      );
+    }
+
+    const approvers = new Set<string>();
+    for (const [approverIndex, approverId] of stage.approverIds.entries()) {
+      if (!nonEmptyString(approverId)) {
+        return failure(
+          "INVALID_INPUT",
+          "approver id must be a non-empty string",
+          `${path}.approverIds.${approverIndex}`,
+        );
+      }
+      if (approvers.has(approverId)) {
+        return failure(
+          "DUPLICATE_APPROVER",
+          `approver "${approverId}" is duplicated within stage ${index}`,
+          `${path}.approverIds.${approverIndex}`,
+        );
+      }
+      approvers.add(approverId);
+    }
+
+    const threshold = stage.requiredApprovals ?? stage.approverIds.length;
+    if (!Number.isInteger(threshold) || threshold < 1 || threshold > stage.approverIds.length) {
+      return failure(
+        "INVALID_APPROVAL_THRESHOLD",
+        "requiredApprovals must be an integer between 1 and the number of approvers",
+        `${path}.requiredApprovals`,
+      );
+    }
+  }
+}
+
+function defaultGenerateId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `chain-${Date.now()}-${Math.random()}`;
+}
+
+/**
+ * Creates a non-UI executor with replaceable clock, id generation, and storage.
+ */
+export function createApprovalChainBuilderService(
+  dependencies: ApprovalChainBuilderDependencies = {},
+) {
+  const generateId = dependencies.generateId ?? defaultGenerateId;
+  const now = dependencies.now ?? (() => new Date());
+
+  async function execute(input: ApprovalChainBuilderInput): Promise<ApprovalChainBuilderResult> {
+    try {
+      const validationFailure = validateInput(input);
+      if (validationFailure) return validationFailure;
+
+      const stages: ApprovalStage[] = input.stages.map((stage, order) => ({
+        id: stage.id ?? generateId(),
+        name: stage.name.trim(),
+        approverIds: stage.approverIds.map((id) => id.trim()),
+        requiredApprovals: stage.requiredApprovals ?? stage.approverIds.length,
+        order,
+      }));
+
+      const chain: ApprovalChain = {
+        id: generateId(),
+        subjectId: input.subjectId.trim(),
+        subjectType: input.subjectType.trim(),
+        name: input.name.trim(),
+        createdBy: input.createdBy.trim(),
+        createdAt: now().toISOString(),
+        status: "draft",
+        stages,
+        ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+      };
+
+      if (dependencies.repository) {
+        try {
+          await dependencies.repository.save(chain);
+        } catch {
+          return failure("PERSISTENCE_FAILED", "The approval chain could not be persisted");
+        }
+      }
+
+      return { ok: true, data: chain };
+    } catch {
+      return failure("INTERNAL_ERROR", "Approval chain execution failed unexpectedly");
+    }
+  }
+
+  return { execute };
+}
+
+/** Default backend-facing entry point. It builds without assuming a persistence backend. */
+export const approvalChainBuilderService = createApprovalChainBuilderService();
+
+export type ApprovalChainBuilderService = ReturnType<typeof createApprovalChainBuilderService>;

--- a/tools/v2/team/approval-chain-builder/services/index.ts
+++ b/tools/v2/team/approval-chain-builder/services/index.ts
@@ -1,0 +1,9 @@
+export {
+  approvalChainBuilderService,
+  createApprovalChainBuilderService,
+} from "./execution.service";
+export type {
+  ApprovalChainBuilderDependencies,
+  ApprovalChainBuilderService,
+  ApprovalChainRepository,
+} from "./execution.service";

--- a/tools/v2/team/approval-chain-builder/tests/execution.service.test.ts
+++ b/tools/v2/team/approval-chain-builder/tests/execution.service.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  approvalChainBuilderService,
+  createApprovalChainBuilderService,
+} from "../services/execution.service";
+import {
+  duplicateApproverInput,
+  duplicateStageIdInput,
+  failingRepository,
+  invalidThresholdInput,
+  missingStagesInput,
+  successfulChainInput,
+} from "../fixtures/execution.fixtures";
+import type { ApprovalChain } from "../types/contract";
+
+function deterministicService(repository?: { save: (chain: ApprovalChain) => Promise<void> }) {
+  let sequence = 0;
+  return createApprovalChainBuilderService({
+    generateId: () => `generated-${++sequence}`,
+    now: () => new Date("2026-07-18T10:00:00.000Z"),
+    repository,
+  });
+}
+
+describe("approval chain builder execution contract", () => {
+  it("builds an ordered, normalized chain", async () => {
+    const result = await deterministicService().execute(successfulChainInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toMatchObject({
+      id: "generated-1",
+      subjectId: "invoice-1042",
+      status: "draft",
+      createdAt: "2026-07-18T10:00:00.000Z",
+      correlationId: "request-88",
+    });
+    expect(result.data.stages).toEqual([
+      {
+        id: "manager-review",
+        name: "Manager review",
+        approverIds: ["manager-1", "manager-2"],
+        requiredApprovals: 1,
+        order: 0,
+      },
+      {
+        id: "finance-review",
+        name: "Finance review",
+        approverIds: ["finance-1"],
+        requiredApprovals: 1,
+        order: 1,
+      },
+    ]);
+  });
+
+  it("generates ids for stages that omit them", async () => {
+    const result = await deterministicService().execute({
+      ...successfulChainInput,
+      stages: [{ name: "Legal review", approverIds: ["legal-1"] }],
+    });
+
+    expect(result.ok && result.data.stages[0].id).toBe("generated-1");
+    expect(result.ok && result.data.id).toBe("generated-2");
+  });
+
+  it.each([
+    [missingStagesInput, "INVALID_INPUT", "stages"],
+    [duplicateApproverInput, "DUPLICATE_APPROVER", "stages.0.approverIds.1"],
+    [invalidThresholdInput, "INVALID_APPROVAL_THRESHOLD", "stages.0.requiredApprovals"],
+    [duplicateStageIdInput, "DUPLICATE_STAGE_ID", "stages.1.id"],
+  ] as const)("returns a typed failure for invalid fixtures", async (input, code, field) => {
+    const result = await deterministicService().execute(input);
+
+    expect(result).toMatchObject({ ok: false, error: { code, field } });
+  });
+
+  it("persists through the injected repository after building", async () => {
+    const save = vi.fn(async (_chain: ApprovalChain) => undefined);
+    const result = await deterministicService({ save }).execute(successfulChainInput);
+
+    expect(result.ok).toBe(true);
+    expect(save).toHaveBeenCalledOnce();
+    expect(save.mock.calls[0][0]).toMatchObject({ subjectId: "invoice-1042" });
+  });
+
+  it("maps repository errors to PERSISTENCE_FAILED", async () => {
+    const result = await createApprovalChainBuilderService({
+      repository: failingRepository,
+    }).execute(successfulChainInput);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "PERSISTENCE_FAILED" },
+    });
+  });
+
+  it("exports a directly callable default non-UI service", async () => {
+    const result = await approvalChainBuilderService.execute(successfulChainInput);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tools/v2/team/approval-chain-builder/types/contract.ts
+++ b/tools/v2/team/approval-chain-builder/types/contract.ts
@@ -1,0 +1,75 @@
+/**
+ * Presentation-independent execution contract for Approval Chain Builder.
+ *
+ * Consumers should branch on `ok` and `error.code`, never on error messages.
+ */
+
+export type ApprovalChainErrorCode =
+  | "INVALID_INPUT"
+  | "DUPLICATE_STAGE_ID"
+  | "DUPLICATE_APPROVER"
+  | "INVALID_APPROVAL_THRESHOLD"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
+
+export interface ApprovalStageInput {
+  /** Optional caller-owned id. A generated id is used when omitted. */
+  id?: string;
+  /** Human-readable stage name, such as "Finance review". */
+  name: string;
+  /** Identities eligible to approve this stage. */
+  approverIds: string[];
+  /** Approvals required to complete the stage. Defaults to all approvers. */
+  requiredApprovals?: number;
+}
+
+export interface ApprovalChainBuilderInput {
+  /** Id of the business object that will use the chain. */
+  subjectId: string;
+  /** Stable subject category, for example "invoice" or "purchase-order". */
+  subjectType: string;
+  /** Name used to identify the chain outside presentation code. */
+  name: string;
+  /** Identity responsible for creating the chain. */
+  createdBy: string;
+  /** Ordered stages. A chain must contain at least one stage. */
+  stages: ApprovalStageInput[];
+  /** Optional opaque correlation id propagated to the result. */
+  correlationId?: string;
+}
+
+export interface ApprovalStage {
+  id: string;
+  name: string;
+  approverIds: string[];
+  requiredApprovals: number;
+  /** Zero-based position in sequential execution order. */
+  order: number;
+}
+
+export interface ApprovalChain {
+  id: string;
+  subjectId: string;
+  subjectType: string;
+  name: string;
+  createdBy: string;
+  createdAt: string;
+  status: "draft";
+  stages: ApprovalStage[];
+  correlationId?: string;
+}
+
+export interface ApprovalChainError {
+  code: ApprovalChainErrorCode;
+  message: string;
+  /** Dot-path to the invalid field when the error is input-specific. */
+  field?: string;
+}
+
+export type ApprovalChainBuilderResult =
+  | { ok: true; data: ApprovalChain }
+  | { ok: false; error: ApprovalChainError };
+
+export type ExecuteApprovalChainBuilder = (
+  input: ApprovalChainBuilderInput,
+) => Promise<ApprovalChainBuilderResult>;

--- a/tools/v2/team/approval-chain-builder/types/index.ts
+++ b/tools/v2/team/approval-chain-builder/types/index.ts
@@ -1,0 +1,10 @@
+export type {
+  ApprovalChain,
+  ApprovalChainBuilderInput,
+  ApprovalChainBuilderResult,
+  ApprovalChainError,
+  ApprovalChainErrorCode,
+  ApprovalStage,
+  ApprovalStageInput,
+  ExecuteApprovalChainBuilder,
+} from "./contract";

--- a/tools/v2/team/approval-chain-builder/vitest.config.ts
+++ b/tools/v2/team/approval-chain-builder/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Closes #1361 
What was done
Added a stable, backend-facing execution contract for the approval-chain-builder tool so it can run independently of presentation concerns, with no changes to any UI/layout code.
Changes

Added typed inputs, outputs, and stable error codes
Added a dependency-injected non-UI service as the execution entry point
Added fixtures covering success and failure cases
Documented the backend contract
No styling or layout files touched

Test results

9 contract tests added, all passing
TypeScript checks: passed
Scoped ESLint checks: passed