### PR TITLE
Add non-UI execution contract for client-thread-timeline (Fixes #1367)

### DIFF
--- a/tools/v2/team/client-thread-timeline/README.md
+++ b/tools/v2/team/client-thread-timeline/README.md
@@ -1,15 +1,53 @@
 # Client Thread Timeline
 
-This folder is the isolated workspace for the Client Thread Timeline tool.
+This folder is the isolated workspace for the Client Thread Timeline tool — a
+presentation-free service that groups raw mail messages into a per-client,
+per-thread chronological timeline.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
+`tools/v2/team/client-thread-timeline/`
 
-`text
-.\tools\v2\team\client-thread-timeline\
-`
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+See `specs.md` for the architecture contract, issue categories, and contributor
+expectations.
 
-See specs.md for the issue categories and contributor expectations.
+## Non-UI execution contract
+
+The timeline exposes a presentation-free execution contract so it can run as a
+backend service, independent of any UI.
+
+- `types.ts` — domain types: `TimelineMessage`, `TimelineThread`,
+  `ClientTimeline`, and the `BuildTimelineInput` / `GetThreadInput` inputs.
+- `contract.ts` — the typed contract: `TimelineOperation`,
+  `TimelineContractOutput`, the `TimelineResult<T>` discriminated union, and
+  explicit `TimelineErrorCode` values. Also holds the pure helpers
+  `buildClientTimeline` / `getClientThread`.
+- `services/timeline.service.ts` — `createTimelineContract()` adapts the pure
+  helpers into a `TimelineContract` whose `execute(...)` returns a typed
+  success/error result instead of throwing.
+- `fixtures.ts` — deterministic sample messages (two clients, two threads,
+  intentionally unsorted).
+- `tests/contract.test.ts` — vitest coverage of the contract and its
+  happy/edge/error paths.
+
+Usage:
+
+```ts
+import { createTimelineContract } from ".";
+
+const contract = createTimelineContract();
+const res = contract.execute({
+  operation: "buildTimeline",
+  input: { clientId: "client-acme", messages },
+});
+if (res.ok && res.value.operation === "buildTimeline") {
+  // res.value.timeline.threads is ordered by time, grouped by thread
+} else {
+  // res.error is a TimelineErrorCode (e.g. NotFound)
+}
+```

--- a/tools/v2/team/client-thread-timeline/contract.ts
+++ b/tools/v2/team/client-thread-timeline/contract.ts
@@ -52,10 +52,7 @@ export function ok<T>(value: T): TimelineResult<T> {
 }
 
 /** Typed error outcome. */
-export function fail<T = never>(
-  error: TimelineErrorCode,
-  message: string,
-): TimelineResult<T> {
+export function fail<T = never>(error: TimelineErrorCode, message: string): TimelineResult<T> {
   return { ok: false, error, message };
 }
 
@@ -81,15 +78,11 @@ export function buildClientTimeline(
   }
 
   const dir = order === "desc" ? -1 : 1;
-  const threads: TimelineThread[] = [...byThread.entries()].map(
-    ([threadId, msgs]) => ({
-      threadId,
-      clientId,
-      messages: [...msgs].sort(
-        (a, b) => dir * (Date.parse(a.timestamp) - Date.parse(b.timestamp)),
-      ),
-    }),
-  );
+  const threads: TimelineThread[] = [...byThread.entries()].map(([threadId, msgs]) => ({
+    threadId,
+    clientId,
+    messages: [...msgs].sort((a, b) => dir * (Date.parse(a.timestamp) - Date.parse(b.timestamp))),
+  }));
 
   // Order threads by their earliest message timestamp.
   threads.sort((a, b) => {
@@ -109,12 +102,8 @@ export function buildClientTimeline(
  */
 export function getClientThread(input: GetThreadInput): TimelineThread | null {
   const { clientId, threadId, messages } = input;
-  const owned = messages.filter(
-    (m) => m.clientId === clientId && m.threadId === threadId,
-  );
+  const owned = messages.filter((m) => m.clientId === clientId && m.threadId === threadId);
   if (owned.length === 0) return null;
-  const sorted = [...owned].sort(
-    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp),
-  );
+  const sorted = [...owned].sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
   return { threadId, clientId, messages: sorted };
 }

--- a/tools/v2/team/client-thread-timeline/contract.ts
+++ b/tools/v2/team/client-thread-timeline/contract.ts
@@ -1,0 +1,120 @@
+/**
+ * contract.ts — Client Thread Timeline (non-UI execution contract)
+ *
+ * Backend-facing execution contract for building a per-client, per-thread
+ * chronological timeline from raw messages. Presentation-free: no React, no
+ * DOM. Operations return a typed WatchlistResult-style outcome with explicit
+ * error codes instead of throwing.
+ */
+
+import type {
+  BuildTimelineInput,
+  ClientTimeline,
+  GetThreadInput,
+  TimelineMessage,
+  TimelineOrder,
+  TimelineThread,
+} from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum TimelineErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+  /** The referenced client/thread was not found among the inputs. */
+  NotFound = "NOT_FOUND",
+  /** A message referenced an unknown client/thread. */
+  OrphanMessage = "ORPHAN_MESSAGE",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type TimelineResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: TimelineErrorCode; message: string };
+
+/** Operations supported by the timeline contract. */
+export type TimelineOperation =
+  | { operation: "buildTimeline"; input: BuildTimelineInput; order?: TimelineOrder }
+  | { operation: "getThread"; input: GetThreadInput };
+
+/** Outputs produced by the timeline contract, keyed by operation. */
+export type TimelineContractOutput =
+  | { operation: "buildTimeline"; timeline: ClientTimeline }
+  | { operation: "getThread"; thread: TimelineThread };
+
+/** Backend-facing entry point for the client thread timeline. */
+export interface TimelineContract {
+  execute(input: TimelineOperation): TimelineResult<TimelineContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): TimelineResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(
+  error: TimelineErrorCode,
+  message: string,
+): TimelineResult<T> {
+  return { ok: false, error, message };
+}
+
+/**
+ * Build a ClientTimeline from raw messages.
+ *
+ * Groups messages by threadId, orders each thread's messages by timestamp
+ * (asc by default, desc if requested), and orders threads by their earliest
+ * message. Empty and unsorted inputs are handled without error.
+ */
+export function buildClientTimeline(
+  input: BuildTimelineInput,
+  order: TimelineOrder = "asc",
+): ClientTimeline {
+  const { clientId, messages } = input;
+  const owned = messages.filter((m) => m.clientId === clientId);
+
+  const byThread = new Map<string, TimelineMessage[]>();
+  for (const m of owned) {
+    const list = byThread.get(m.threadId) ?? [];
+    list.push(m);
+    byThread.set(m.threadId, list);
+  }
+
+  const dir = order === "desc" ? -1 : 1;
+  const threads: TimelineThread[] = [...byThread.entries()].map(
+    ([threadId, msgs]) => ({
+      threadId,
+      clientId,
+      messages: [...msgs].sort(
+        (a, b) => dir * (Date.parse(a.timestamp) - Date.parse(b.timestamp)),
+      ),
+    }),
+  );
+
+  // Order threads by their earliest message timestamp.
+  threads.sort((a, b) => {
+    const aEarliest = Date.parse(a.messages[0]?.timestamp ?? "0");
+    const bEarliest = Date.parse(b.messages[0]?.timestamp ?? "0");
+    return dir * (aEarliest - bEarliest);
+  });
+
+  const totalMessages = threads.reduce((sum, t) => sum + t.messages.length, 0);
+  return { clientId, threads, totalMessages };
+}
+
+/**
+ * Extract a single thread for a client.
+ *
+ * Returns NotFound if the client/thread has no messages in the input.
+ */
+export function getClientThread(input: GetThreadInput): TimelineThread | null {
+  const { clientId, threadId, messages } = input;
+  const owned = messages.filter(
+    (m) => m.clientId === clientId && m.threadId === threadId,
+  );
+  if (owned.length === 0) return null;
+  const sorted = [...owned].sort(
+    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp),
+  );
+  return { threadId, clientId, messages: sorted };
+}

--- a/tools/v2/team/client-thread-timeline/fixtures.ts
+++ b/tools/v2/team/client-thread-timeline/fixtures.ts
@@ -1,0 +1,56 @@
+/**
+ * fixtures.ts — Client Thread Timeline (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape. Two clients, two threads, unsorted on purpose.
+ */
+
+import type { TimelineMessage } from "./types";
+
+/** A mixed set of messages across two clients and two threads (unsorted). */
+export const TIMELINE_FIXTURES: TimelineMessage[] = [
+  {
+    id: "m-3",
+    clientId: "client-acme",
+    threadId: "thread-onboarding",
+    timestamp: "2026-06-01T14:00:00.000Z",
+    author: "Acme CS",
+    subject: "Welcome to Acme",
+    direction: "outbound",
+  },
+  {
+    id: "m-1",
+    clientId: "client-acme",
+    threadId: "thread-onboarding",
+    timestamp: "2026-06-01T09:00:00.000Z",
+    author: "Acme User",
+    subject: "Getting started question",
+    direction: "inbound",
+  },
+  {
+    id: "m-2",
+    clientId: "client-acme",
+    threadId: "thread-billing",
+    timestamp: "2026-06-03T11:30:00.000Z",
+    author: "Acme User",
+    subject: "Invoice discrepancy",
+    direction: "inbound",
+  },
+  {
+    id: "m-4",
+    clientId: "client-globex",
+    threadId: "thread-support",
+    timestamp: "2026-06-02T10:00:00.000Z",
+    author: "Globex User",
+    subject: "API outage",
+    direction: "inbound",
+  },
+];
+
+/** Messages for client-acme only (subset of TIMELINE_FIXTURES). */
+export const ACME_MESSAGES: TimelineMessage[] = TIMELINE_FIXTURES.filter(
+  (m) => m.clientId === "client-acme",
+);
+
+/** A client with no messages at all (edge case). */
+export const EMPTY_MESSAGES: TimelineMessage[] = [];

--- a/tools/v2/team/client-thread-timeline/index.ts
+++ b/tools/v2/team/client-thread-timeline/index.ts
@@ -16,16 +16,8 @@ export type {
 } from "./types";
 
 // Contract + service
-export {
-  createTimelineContract,
-} from "./services/timeline.service";
-export {
-  TimelineErrorCode,
-  buildClientTimeline,
-  getClientThread,
-  ok,
-  fail,
-} from "./contract";
+export { createTimelineContract } from "./services/timeline.service";
+export { TimelineErrorCode, buildClientTimeline, getClientThread, ok, fail } from "./contract";
 export type {
   TimelineContract,
   TimelineOperation,
@@ -34,8 +26,4 @@ export type {
 } from "./contract";
 
 // Fixtures
-export {
-  TIMELINE_FIXTURES,
-  ACME_MESSAGES,
-  EMPTY_MESSAGES,
-} from "./fixtures";
+export { TIMELINE_FIXTURES, ACME_MESSAGES, EMPTY_MESSAGES } from "./fixtures";

--- a/tools/v2/team/client-thread-timeline/index.ts
+++ b/tools/v2/team/client-thread-timeline/index.ts
@@ -1,0 +1,41 @@
+/**
+ * index.ts — Client Thread Timeline
+ *
+ * Folder-local API surface. Exports the non-UI execution contract, its types,
+ * and the underlying helpers. Nothing in this file imports from the main app.
+ */
+
+// Types
+export type {
+  TimelineMessage,
+  TimelineThread,
+  ClientTimeline,
+  BuildTimelineInput,
+  GetThreadInput,
+  TimelineOrder,
+} from "./types";
+
+// Contract + service
+export {
+  createTimelineContract,
+} from "./services/timeline.service";
+export {
+  TimelineErrorCode,
+  buildClientTimeline,
+  getClientThread,
+  ok,
+  fail,
+} from "./contract";
+export type {
+  TimelineContract,
+  TimelineOperation,
+  TimelineContractOutput,
+  TimelineResult,
+} from "./contract";
+
+// Fixtures
+export {
+  TIMELINE_FIXTURES,
+  ACME_MESSAGES,
+  EMPTY_MESSAGES,
+} from "./fixtures";

--- a/tools/v2/team/client-thread-timeline/services/timeline.service.ts
+++ b/tools/v2/team/client-thread-timeline/services/timeline.service.ts
@@ -1,0 +1,59 @@
+/**
+ * timeline.service.ts — Client Thread Timeline (non-UI service entry point)
+ *
+ * Presentation-free service boundary for the timeline contract. Wraps the pure
+ * `buildClientTimeline` / `getClientThread` helpers into a `TimelineContract`
+ * whose `execute(...)` returns typed success/error results.
+ */
+
+import {
+  TimelineErrorCode,
+  type TimelineContract,
+  type TimelineOperation,
+  type TimelineContractOutput,
+  type TimelineResult,
+  buildClientTimeline,
+  getClientThread,
+  fail,
+} from "../contract";
+
+/**
+ * Build the timeline execution contract.
+ *
+ * The service is pure: all state lives in the input messages, so it is fully
+ * testable in isolation with no network, no secrets, and no UI.
+ */
+export function createTimelineContract(): TimelineContract {
+  return {
+    execute(input: TimelineOperation): TimelineResult<TimelineContractOutput> {
+      try {
+        switch (input.operation) {
+          case "buildTimeline": {
+            const timeline = buildClientTimeline(input.input, input.order ?? "asc");
+            return { ok: true, value: { operation: "buildTimeline", timeline } };
+          }
+          case "getThread": {
+            const thread = getClientThread(input.input);
+            if (!thread) {
+              return fail(
+                TimelineErrorCode.NotFound,
+                `No thread ${input.input.threadId} for client ${input.input.clientId}`,
+              );
+            }
+            return { ok: true, value: { operation: "getThread", thread } };
+          }
+          default: {
+            const _never: never = input;
+            return fail(
+              TimelineErrorCode.InvalidInput,
+              `Unknown operation: ${JSON.stringify(_never)}`,
+            );
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(TimelineErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/client-thread-timeline/tests/contract.test.ts
+++ b/tools/v2/team/client-thread-timeline/tests/contract.test.ts
@@ -16,11 +16,7 @@ import {
   fail,
   type TimelineResult,
 } from "../contract";
-import {
-  TIMELINE_FIXTURES,
-  ACME_MESSAGES,
-  EMPTY_MESSAGES,
-} from "../fixtures";
+import { TIMELINE_FIXTURES, ACME_MESSAGES, EMPTY_MESSAGES } from "../fixtures";
 
 describe("timeline contract — result helpers", () => {
   it("ok() produces a typed success result", () => {
@@ -65,9 +61,7 @@ describe("timeline contract — buildTimeline", () => {
     });
     expect(res.ok).toBe(true);
     if (res.ok && res.value.operation === "buildTimeline") {
-      const onboarding = res.value.timeline.threads.find(
-        (t) => t.threadId === "thread-onboarding",
-      );
+      const onboarding = res.value.timeline.threads.find((t) => t.threadId === "thread-onboarding");
       expect(onboarding?.messages.map((m) => m.id)).toEqual(["m-1", "m-3"]);
     }
   });

--- a/tools/v2/team/client-thread-timeline/tests/contract.test.ts
+++ b/tools/v2/team/client-thread-timeline/tests/contract.test.ts
@@ -1,0 +1,139 @@
+/**
+ * contract.test.ts — Client Thread Timeline (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, grouping,
+ * chronological ordering, and edge cases (empty input, unknown thread,
+ * multiple clients). No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTimelineContract } from "../services/timeline.service";
+import {
+  TimelineErrorCode,
+  buildClientTimeline,
+  getClientThread,
+  ok,
+  fail,
+  type TimelineResult,
+} from "../contract";
+import {
+  TIMELINE_FIXTURES,
+  ACME_MESSAGES,
+  EMPTY_MESSAGES,
+} from "../fixtures";
+
+describe("timeline contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(TimelineErrorCode.NotFound, "missing");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(TimelineErrorCode.NotFound);
+      expect(r.message).toBe("missing");
+    }
+  });
+});
+
+describe("timeline contract — buildTimeline", () => {
+  it("groups messages by thread for the requested client", () => {
+    const contract = createTimelineContract();
+    const res = contract.execute({
+      operation: "buildTimeline",
+      input: { clientId: "client-acme", messages: TIMELINE_FIXTURES },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "buildTimeline") {
+      const { timeline } = res.value;
+      expect(timeline.clientId).toBe("client-acme");
+      // client-globex messages are excluded
+      expect(timeline.threads.length).toBe(2);
+      expect(timeline.totalMessages).toBe(ACME_MESSAGES.length);
+      const threadIds = timeline.threads.map((t) => t.threadId).sort();
+      expect(threadIds).toEqual(["thread-billing", "thread-onboarding"]);
+    }
+  });
+
+  it("orders messages within a thread chronologically (asc default)", () => {
+    const contract = createTimelineContract();
+    const res = contract.execute({
+      operation: "buildTimeline",
+      input: { clientId: "client-acme", messages: TIMELINE_FIXTURES },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "buildTimeline") {
+      const onboarding = res.value.timeline.threads.find(
+        (t) => t.threadId === "thread-onboarding",
+      );
+      expect(onboarding?.messages.map((m) => m.id)).toEqual(["m-1", "m-3"]);
+    }
+  });
+
+  it("honors desc ordering when requested", () => {
+    const timeline = buildClientTimeline(
+      { clientId: "client-acme", messages: TIMELINE_FIXTURES },
+      "desc",
+    );
+    const onboarding = timeline.threads.find((t) => t.threadId === "thread-onboarding");
+    expect(onboarding?.messages.map((m) => m.id)).toEqual(["m-3", "m-1"]);
+  });
+
+  it("returns an empty timeline for a client with no messages", () => {
+    const contract = createTimelineContract();
+    const res = contract.execute({
+      operation: "buildTimeline",
+      input: { clientId: "client-unknown", messages: EMPTY_MESSAGES },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "buildTimeline") {
+      expect(res.value.timeline.threads).toEqual([]);
+      expect(res.value.timeline.totalMessages).toBe(0);
+    }
+  });
+});
+
+describe("timeline contract — getThread", () => {
+  it("returns the requested thread ordered by time", () => {
+    const contract = createTimelineContract();
+    const res = contract.execute({
+      operation: "getThread",
+      input: {
+        clientId: "client-acme",
+        threadId: "thread-onboarding",
+        messages: TIMELINE_FIXTURES,
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "getThread") {
+      expect(res.value.thread.messages.map((m) => m.id)).toEqual(["m-1", "m-3"]);
+    }
+  });
+
+  it("returns NotFound for an unknown thread (no throw)", () => {
+    const contract = createTimelineContract();
+    const res: TimelineResult<never> = contract.execute({
+      operation: "getThread",
+      input: {
+        clientId: "client-acme",
+        threadId: "thread-does-not-exist",
+        messages: TIMELINE_FIXTURES,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toBe(TimelineErrorCode.NotFound);
+    }
+  });
+
+  it("getClientThread returns null for unknown thread (pure helper)", () => {
+    const thread = getClientThread({
+      clientId: "client-acme",
+      threadId: "nope",
+      messages: TIMELINE_FIXTURES,
+    });
+    expect(thread).toBeNull();
+  });
+});

--- a/tools/v2/team/client-thread-timeline/tests/contract.test.ts
+++ b/tools/v2/team/client-thread-timeline/tests/contract.test.ts
@@ -14,6 +14,7 @@ import {
   getClientThread,
   ok,
   fail,
+  type TimelineContractOutput,
   type TimelineResult,
 } from "../contract";
 import { TIMELINE_FIXTURES, ACME_MESSAGES, EMPTY_MESSAGES } from "../fixtures";
@@ -108,7 +109,7 @@ describe("timeline contract — getThread", () => {
 
   it("returns NotFound for an unknown thread (no throw)", () => {
     const contract = createTimelineContract();
-    const res: TimelineResult<never> = contract.execute({
+    const res: TimelineResult<TimelineContractOutput> = contract.execute({
       operation: "getThread",
       input: {
         clientId: "client-acme",

--- a/tools/v2/team/client-thread-timeline/types.ts
+++ b/tools/v2/team/client-thread-timeline/types.ts
@@ -1,0 +1,54 @@
+/**
+ * types.ts — Client Thread Timeline (non-UI execution contract)
+ *
+ * Domain types for grouping mail messages into a per-client, per-thread
+ * chronological timeline. No imports from the main app; presentation-free.
+ */
+
+/** A single mail message in a thread. */
+export interface TimelineMessage {
+  id: string;
+  /** Client this message belongs to. */
+  clientId: string;
+  /** Thread this message belongs to (groups related messages). */
+  threadId: string;
+  /** ISO-8601 timestamp, e.g. "2026-06-01T09:30:00.000Z". */
+  timestamp: string;
+  /** Author/participant display label. */
+  author: string;
+  /** Short subject or summary. */
+  subject: string;
+  /** Direction of the message relative to the team. */
+  direction: "inbound" | "outbound";
+}
+
+/** A thread is a group of messages sharing a threadId, ordered by time. */
+export interface TimelineThread {
+  threadId: string;
+  clientId: string;
+  messages: TimelineMessage[];
+}
+
+/** A client timeline is the set of threads for one client, ordered by time. */
+export interface ClientTimeline {
+  clientId: string;
+  threads: TimelineThread[];
+  /** Total message count across all threads. */
+  totalMessages: number;
+}
+
+/** Input for building a client timeline. */
+export interface BuildTimelineInput {
+  clientId: string;
+  messages: TimelineMessage[];
+}
+
+/** Input for querying a single thread. */
+export interface GetThreadInput {
+  clientId: string;
+  threadId: string;
+  messages: TimelineMessage[];
+}
+
+/** Supported sort orders for a timeline. */
+export type TimelineOrder = "asc" | "desc";


### PR DESCRIPTION
## Summary

Implements #1367 by adding the client-thread-timeline tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The folder previously had only a README and specs; this builds the contract from scratch.

### Deliverables
- **`types.ts`** — domain types: `TimelineMessage`, `TimelineThread`, `ClientTimeline`, `BuildTimelineInput`, `GetThreadInput`, `TimelineOrder`.
- **`contract.ts`** — typed `TimelineOperation` / `TimelineContractOutput`, explicit `TimelineErrorCode` values, a `TimelineResult<T>` discriminated union, plus the pure helpers `buildClientTimeline` / `getClientThread` (group by thread, order chronologically asc/desc, order threads by earliest message).
- **`services/timeline.service.ts`** — `createTimelineContract()` adapts the pure helpers into a `TimelineContract` whose `execute()` returns typed success/error results instead of throwing.
- **`fixtures.ts`** — deterministic sample messages (two clients, two threads, intentionally unsorted).
- **`tests/contract.test.ts`** — vitest coverage of grouping, chronological ordering (asc/desc), empty-input handling, unknown-thread `NotFound`, and multi-client isolation.
- **`README.md`** — documents the contract and usage.

Non-UI only. Scoped `tsc --noEmit` and `vitest` both pass (9 tests).

Fixes #1367