### PR TITLE
feat(team-inbox-rules-builder): add non-UI execution contract

### DIFF
--- a/tools/v2/team/team-inbox-rules-builder/CONTRACT.md
+++ b/tools/v2/team/team-inbox-rules-builder/CONTRACT.md
@@ -1,0 +1,51 @@
+# Team Inbox Rules Builder Execution Contract
+
+This module exposes a backend-facing rules execution boundary with no React,
+DOM, styling, or layout dependency.
+
+## Entry points
+
+- `teamInboxRulesExecutor.execute(input)` is the ready-to-use service entry
+  point backed by `RuleEngineService`.
+- `createTeamInboxRulesExecutor({ evaluator })` creates an executor with an
+  injected evaluator for backend adapters, tests, and automation.
+- Both are exported from the tool's root `index.ts`.
+
+## Input
+
+`TeamInboxRulesExecutionInput` contains:
+
+- `mail`: a complete `MailContext` to evaluate.
+- `rules`: an array of `InboxRule` values. Disabled rules are ignored. An empty
+  array is valid and produces a successful result with zero evaluations.
+
+Runtime validation protects JavaScript, JSON, and other untyped callers.
+Executable rules must have a non-empty ID and name, an enabled flag, at least
+one condition group, and at least one action.
+
+## Output
+
+`TeamInboxRulesExecutionResult` is a discriminated union:
+
+- `{ ok: true, data }` returns evaluation counts, each rule result, and a
+  flattened list of triggered actions paired with their rule IDs.
+- `{ ok: false, error }` returns a stable code, human-readable message, and an
+  optional field path. Expected failures are returned and are not thrown.
+
+Consumers must branch on `error.code`, never on `error.message`.
+
+## Error codes
+
+| Code               | Meaning                                                |
+| ------------------ | ------------------------------------------------------ |
+| `INVALID_INPUT`    | The execution envelope or rules collection is invalid. |
+| `INVALID_MAIL`     | A required mail field is missing or malformed.         |
+| `INVALID_RULE`     | A rule cannot be safely evaluated.                     |
+| `EXECUTION_FAILED` | The injected evaluator failed unexpectedly.            |
+
+## Service boundary
+
+The executor depends only on `TeamInboxRulesEvaluator`, whose single method is
+`evaluateAll(rules, mail)`. This keeps orchestration independent from storage
+and presentation, while allowing the existing rules engine or a backend
+implementation to be supplied.

--- a/tools/v2/team/team-inbox-rules-builder/fixtures/execution.fixtures.ts
+++ b/tools/v2/team/team-inbox-rules-builder/fixtures/execution.fixtures.ts
@@ -1,0 +1,27 @@
+import type { TeamInboxRulesExecutionInput, TeamInboxRulesEvaluator } from "../index";
+import { mockMailContexts, mockRules } from "./rules.fixtures";
+
+/** Success: the executive/high-priority rule matches this mail. */
+export const successfulExecutionInput: TeamInboxRulesExecutionInput = {
+  mail: mockMailContexts[0],
+  rules: mockRules,
+};
+
+/** Failure: mail.from is required by the execution contract. */
+export const invalidMailExecutionInput: TeamInboxRulesExecutionInput = {
+  mail: { ...mockMailContexts[0], from: "" },
+  rules: mockRules,
+};
+
+/** Failure: executable rules require at least one action. */
+export const invalidRuleExecutionInput: TeamInboxRulesExecutionInput = {
+  mail: mockMailContexts[0],
+  rules: [{ ...mockRules[0], actions: [] }],
+};
+
+/** Failure: injected evaluator simulates an unavailable backend dependency. */
+export const failingEvaluator: TeamInboxRulesEvaluator = {
+  evaluateAll() {
+    throw new Error("Rules engine unavailable");
+  },
+};

--- a/tools/v2/team/team-inbox-rules-builder/index.ts
+++ b/tools/v2/team/team-inbox-rules-builder/index.ts
@@ -1,4 +1,14 @@
-export { RuleStorageService, RuleEngineService } from "./services";
+export {
+  RuleStorageService,
+  RuleEngineService,
+  createTeamInboxRulesExecutor,
+  teamInboxRulesExecutor,
+} from "./services";
+export type {
+  TeamInboxRulesEvaluator,
+  TeamInboxRulesExecutorDependencies,
+  TeamInboxRulesExecutor,
+} from "./services";
 export { useRules, useRuleEvaluation } from "./hooks";
 export { EmptyState, LoadingState, ErrorState, SuccessState } from "./components";
 export type {
@@ -14,4 +24,11 @@ export type {
   ConditionOperator,
   MailContext,
   RuleEvaluationResult,
+  TeamInboxRulesExecutionInput,
+  TeamInboxRulesExecutionErrorCode,
+  TeamInboxRulesTriggeredAction,
+  TeamInboxRulesExecutionSuccess,
+  TeamInboxRulesExecutionError,
+  TeamInboxRulesExecutionResult,
+  ExecuteTeamInboxRules,
 } from "./types";

--- a/tools/v2/team/team-inbox-rules-builder/services/execution.service.ts
+++ b/tools/v2/team/team-inbox-rules-builder/services/execution.service.ts
@@ -1,0 +1,150 @@
+import type {
+  InboxRule,
+  MailContext,
+  RuleEvaluationResult,
+  TeamInboxRulesExecutionErrorCode,
+  TeamInboxRulesExecutionInput,
+  TeamInboxRulesExecutionResult,
+} from "../types";
+import { RuleEngineService } from "./rule-engine.service";
+
+/** Minimal service boundary required by the non-UI executor. */
+export interface TeamInboxRulesEvaluator {
+  evaluateAll(rules: InboxRule[], mail: MailContext): RuleEvaluationResult[];
+}
+
+export interface TeamInboxRulesExecutorDependencies {
+  evaluator: TeamInboxRulesEvaluator;
+}
+
+function failure(
+  code: TeamInboxRulesExecutionErrorCode,
+  message: string,
+  path?: string,
+): TeamInboxRulesExecutionResult {
+  return { ok: false, error: { code, message, ...(path ? { path } : {}) } };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateMail(mail: MailContext | undefined): TeamInboxRulesExecutionResult | null {
+  if (!mail || typeof mail !== "object") {
+    return failure("INVALID_MAIL", "mail must be an object", "mail");
+  }
+  if (!isNonEmptyString(mail.from)) {
+    return failure("INVALID_MAIL", "mail.from is required", "mail.from");
+  }
+  if (!Array.isArray(mail.to)) {
+    return failure("INVALID_MAIL", "mail.to must be an array", "mail.to");
+  }
+  if (typeof mail.subject !== "string") {
+    return failure("INVALID_MAIL", "mail.subject must be a string", "mail.subject");
+  }
+  if (typeof mail.body !== "string") {
+    return failure("INVALID_MAIL", "mail.body must be a string", "mail.body");
+  }
+  if (!["low", "normal", "high"].includes(mail.priority)) {
+    return failure("INVALID_MAIL", "mail.priority is invalid", "mail.priority");
+  }
+  if (typeof mail.hasAttachments !== "boolean") {
+    return failure("INVALID_MAIL", "mail.hasAttachments must be a boolean", "mail.hasAttachments");
+  }
+  if (!isNonEmptyString(mail.receivedAt) || Number.isNaN(Date.parse(mail.receivedAt))) {
+    return failure("INVALID_MAIL", "mail.receivedAt must be an ISO date", "mail.receivedAt");
+  }
+  if (!Array.isArray(mail.labels)) {
+    return failure("INVALID_MAIL", "mail.labels must be an array", "mail.labels");
+  }
+  if (!mail.headers || typeof mail.headers !== "object" || Array.isArray(mail.headers)) {
+    return failure("INVALID_MAIL", "mail.headers must be an object", "mail.headers");
+  }
+  return null;
+}
+
+function validateRules(rules: InboxRule[] | undefined): TeamInboxRulesExecutionResult | null {
+  if (!Array.isArray(rules)) {
+    return failure("INVALID_INPUT", "rules must be an array", "rules");
+  }
+
+  for (let index = 0; index < rules.length; index += 1) {
+    const rule = rules[index];
+    const root = `rules[${index}]`;
+    if (!rule || typeof rule !== "object") {
+      return failure("INVALID_RULE", "rule must be an object", root);
+    }
+    if (!isNonEmptyString(rule.id)) {
+      return failure("INVALID_RULE", "rule.id is required", `${root}.id`);
+    }
+    if (!isNonEmptyString(rule.name)) {
+      return failure("INVALID_RULE", "rule.name is required", `${root}.name`);
+    }
+    if (typeof rule.enabled !== "boolean") {
+      return failure("INVALID_RULE", "rule.enabled must be a boolean", `${root}.enabled`);
+    }
+    if (!Array.isArray(rule.conditionGroups) || rule.conditionGroups.length === 0) {
+      return failure(
+        "INVALID_RULE",
+        "rule.conditionGroups must contain at least one group",
+        `${root}.conditionGroups`,
+      );
+    }
+    if (!Array.isArray(rule.actions) || rule.actions.length === 0) {
+      return failure(
+        "INVALID_RULE",
+        "rule.actions must contain at least one action",
+        `${root}.actions`,
+      );
+    }
+  }
+  return null;
+}
+
+/**
+ * Creates a presentation-independent executor. Dependency injection keeps the
+ * orchestration boundary usable with a real engine, fake, or backend adapter.
+ */
+export function createTeamInboxRulesExecutor({ evaluator }: TeamInboxRulesExecutorDependencies) {
+  return {
+    execute(input: TeamInboxRulesExecutionInput): TeamInboxRulesExecutionResult {
+      if (!input || typeof input !== "object") {
+        return failure("INVALID_INPUT", "input must be an object");
+      }
+
+      const mailFailure = validateMail(input.mail);
+      if (mailFailure) return mailFailure;
+
+      const rulesFailure = validateRules(input.rules);
+      if (rulesFailure) return rulesFailure;
+
+      try {
+        const results = evaluator.evaluateAll(input.rules, input.mail);
+        const matches = results.filter((result) => result.matched);
+        return {
+          ok: true,
+          data: {
+            evaluatedRuleCount: results.length,
+            matchedRuleCount: matches.length,
+            results,
+            triggeredActions: matches.flatMap((result) =>
+              result.triggeredActions.map((action) => ({ ruleId: result.ruleId, action })),
+            ),
+          },
+        };
+      } catch (error) {
+        return failure(
+          "EXECUTION_FAILED",
+          error instanceof Error ? error.message : "Rule evaluation failed",
+        );
+      }
+    },
+  };
+}
+
+export type TeamInboxRulesExecutor = ReturnType<typeof createTeamInboxRulesExecutor>;
+
+/** Default backend-facing entry point using the tool's rule engine. */
+export const teamInboxRulesExecutor = createTeamInboxRulesExecutor({
+  evaluator: new RuleEngineService(),
+});

--- a/tools/v2/team/team-inbox-rules-builder/services/index.ts
+++ b/tools/v2/team/team-inbox-rules-builder/services/index.ts
@@ -1,2 +1,9 @@
 export { RuleStorageService } from "./rule-storage.service";
 export { RuleEngineService } from "./rule-engine.service";
+export {
+  createTeamInboxRulesExecutor,
+  teamInboxRulesExecutor,
+  type TeamInboxRulesEvaluator,
+  type TeamInboxRulesExecutorDependencies,
+  type TeamInboxRulesExecutor,
+} from "./execution.service";

--- a/tools/v2/team/team-inbox-rules-builder/tests/execution.service.test.ts
+++ b/tools/v2/team/team-inbox-rules-builder/tests/execution.service.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  createTeamInboxRulesExecutor,
+  teamInboxRulesExecutor,
+} from "../services/execution.service";
+import {
+  failingEvaluator,
+  invalidMailExecutionInput,
+  invalidRuleExecutionInput,
+  successfulExecutionInput,
+} from "../fixtures/execution.fixtures";
+
+describe("teamInboxRulesExecutor", () => {
+  it("executes rules without UI dependencies and returns triggered actions", () => {
+    const result = teamInboxRulesExecutor.execute(successfulExecutionInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.evaluatedRuleCount).toBe(3);
+    expect(result.data.matchedRuleCount).toBe(1);
+    expect(result.data.triggeredActions).toEqual([
+      { ruleId: "rule-1", action: successfulExecutionInput.rules[0].actions[0] },
+      { ruleId: "rule-1", action: successfulExecutionInput.rules[0].actions[1] },
+    ]);
+  });
+
+  it("returns INVALID_MAIL for invalid mail input", () => {
+    const result = teamInboxRulesExecutor.execute(invalidMailExecutionInput);
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "INVALID_MAIL", message: "mail.from is required", path: "mail.from" },
+    });
+  });
+
+  it("returns INVALID_RULE for an invalid rule", () => {
+    const result = teamInboxRulesExecutor.execute(invalidRuleExecutionInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_RULE");
+    expect(result.error.path).toBe("rules[0].actions");
+  });
+
+  it("maps evaluator failures to the stable EXECUTION_FAILED code", () => {
+    const executor = createTeamInboxRulesExecutor({ evaluator: failingEvaluator });
+    const result = executor.execute(successfulExecutionInput);
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "EXECUTION_FAILED", message: "Rules engine unavailable" },
+    });
+  });
+});

--- a/tools/v2/team/team-inbox-rules-builder/types/execution.ts
+++ b/tools/v2/team/team-inbox-rules-builder/types/execution.ts
@@ -1,0 +1,46 @@
+import type { InboxRule, MailContext, RuleAction, RuleEvaluationResult } from "./rules";
+
+/**
+ * Presentation-independent input accepted by the team inbox rules executor.
+ */
+export interface TeamInboxRulesExecutionInput {
+  /** The message to evaluate. */
+  mail: MailContext;
+  /** Rules to evaluate. Disabled rules are ignored by the engine. */
+  rules: InboxRule[];
+}
+
+/** Stable error codes. Consumers should branch on these codes, not messages. */
+export type TeamInboxRulesExecutionErrorCode =
+  | "INVALID_INPUT"
+  | "INVALID_MAIL"
+  | "INVALID_RULE"
+  | "EXECUTION_FAILED";
+
+export interface TeamInboxRulesTriggeredAction {
+  ruleId: string;
+  action: RuleAction;
+}
+
+export interface TeamInboxRulesExecutionSuccess {
+  evaluatedRuleCount: number;
+  matchedRuleCount: number;
+  results: RuleEvaluationResult[];
+  triggeredActions: TeamInboxRulesTriggeredAction[];
+}
+
+export interface TeamInboxRulesExecutionError {
+  code: TeamInboxRulesExecutionErrorCode;
+  message: string;
+  /** Dot/bracket path to the invalid field when validation failed. */
+  path?: string;
+}
+
+/** Discriminated output contract; expected failures are returned, not thrown. */
+export type TeamInboxRulesExecutionResult =
+  | { ok: true; data: TeamInboxRulesExecutionSuccess }
+  | { ok: false; error: TeamInboxRulesExecutionError };
+
+export type ExecuteTeamInboxRules = (
+  input: TeamInboxRulesExecutionInput,
+) => TeamInboxRulesExecutionResult;

--- a/tools/v2/team/team-inbox-rules-builder/types/index.ts
+++ b/tools/v2/team/team-inbox-rules-builder/types/index.ts
@@ -18,3 +18,12 @@ export type {
   RuleEvaluationResult,
   ServiceConfig,
 } from "./rules";
+export type {
+  TeamInboxRulesExecutionInput,
+  TeamInboxRulesExecutionErrorCode,
+  TeamInboxRulesTriggeredAction,
+  TeamInboxRulesExecutionSuccess,
+  TeamInboxRulesExecutionError,
+  TeamInboxRulesExecutionResult,
+  ExecuteTeamInboxRules,
+} from "./execution";


### PR DESCRIPTION
Closes #1366 
What was done
Added a stable, backend-facing execution contract for the team-inbox-rules-builder tool so it can run independently of presentation concerns, with no changes to any UI/layout code.
Changes

Added typed input/output contracts and stable error codes
Exported injectable and default non-UI service entry points
Added fixtures/tests covering success, validation, invalid-rule, and service-failure cases
Documented the contract in CONTRACT.md
No styling, layout, or component files touched

Test results

13 tests, all passing
TypeScript checks: passed
ESLint checks: passed
Diff checks: passed