### PR TITLE
Add non-UI execution contract for invoice-approval-workflow (Fixes #1356)

### DIFF
--- a/tools/v2/team/invoice-approval-workflow/README.md
+++ b/tools/v2/team/invoice-approval-workflow/README.md
@@ -1,15 +1,54 @@
 # Invoice Approval Workflow
 
-This folder is the isolated workspace for the Invoice Approval Workflow tool.
+This folder is the isolated workspace for the Invoice Approval Workflow tool — a
+presentation-free service that runs an invoice review process: submit →
+approve/reject → list by status.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
+`tools/v2/team/invoice-approval-workflow/`
 
-`text
-.\tools\v2\team\invoice-approval-workflow\
-`
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, database schema, or existing design system unless a future
+integration issue explicitly allows it.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+See `specs.md` for the architecture contract, issue categories, and contributor
+expectations.
 
-See specs.md for the issue categories and contributor expectations.
+## Non-UI execution contract
+
+The workflow exposes a presentation-free execution contract so it can run as a
+backend service, independent of any UI.
+
+- `types.ts` — domain types: `Invoice`, `InvoiceInput`, `InvoiceStatus`,
+  `ApprovalDecision`.
+- `contract.ts` — the typed contract: `InvoiceOperation`, `InvoiceContractOutput`,
+  the `InvoiceResult<T>` discriminated union, and explicit `InvoiceErrorCode`
+  values. Also holds the pure reducer `applyInvoiceOperation` plus
+  `validateInvoiceInput`.
+- `services/invoice-approval.service.ts` — `createInvoiceApprovalContract()`
+  keeps state in an in-memory map and adapts the pure reducer into an
+  `InvoiceContract` whose `execute(...)` returns typed success/error results
+  instead of throwing.
+- `fixtures.ts` — representative submit inputs (valid, non-positive amount,
+  missing vendor).
+- `tests/contract.test.ts` — vitest coverage of the submit → approve/reject →
+  list lifecycle plus the validation / not-found / invalid-state error paths.
+
+Usage:
+
+```ts
+import { createInvoiceApprovalContract } from ".";
+
+const contract = createInvoiceApprovalContract();
+const submitted = contract.execute({
+  operation: "submit",
+  input: { vendor: "Acme Hosting LLC", amount: 1250, submittedBy: "finops@acme.example.com" },
+});
+if (submitted.ok && submitted.value.operation === "submit") {
+  const id = submitted.value.invoice.id;
+  const decided = contract.execute({ operation: "approve", id, approver: "lead@acme.example.com" });
+  // decided.ok === true, or decided.error is an InvoiceErrorCode
+}
+```

--- a/tools/v2/team/invoice-approval-workflow/contract.ts
+++ b/tools/v2/team/invoice-approval-workflow/contract.ts
@@ -1,0 +1,139 @@
+/**
+ * contract.ts — Invoice Approval Workflow (non-UI execution contract)
+ *
+ * Backend-facing execution contract for an invoice approval workflow. It is
+ * presentation-free: no React, no DOM. Operations return a typed
+ * `InvoiceResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ */
+
+import type { Invoice, InvoiceInput, InvoiceStatus, ApprovalDecision } from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum InvoiceErrorCode {
+  /** A required field was missing or failed validation (e.g. amount <= 0). */
+  InvalidInput = "INVALID_INPUT",
+  /** The referenced invoice was not found. */
+  InvoiceNotFound = "INVOICE_NOT_FOUND",
+  /** The invoice is not in a state that allows the requested decision. */
+  InvalidState = "INVALID_STATE",
+  /** The approver is not authorized to decide this invoice. */
+  Unauthorized = "UNAUTHORIZED",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type InvoiceResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: InvoiceErrorCode; message: string };
+
+/** Operations supported by the invoice approval contract. */
+export type InvoiceOperation =
+  | { operation: "submit"; input: InvoiceInput }
+  | { operation: "approve"; id: string; approver: string }
+  | { operation: "reject"; id: string; approver: string; reason: string }
+  | { operation: "list"; status?: InvoiceStatus };
+
+/** Output produced by the contract, keyed by operation. */
+export type InvoiceContractOutput =
+  | { operation: "submit"; invoice: Invoice }
+  | { operation: "approve"; invoice: Invoice }
+  | { operation: "reject"; invoice: Invoice }
+  | { operation: "list"; invoices: Invoice[] };
+
+/** Backend-facing entry point for the invoice approval workflow. */
+export interface InvoiceContract {
+  execute(input: InvoiceOperation): InvoiceResult<InvoiceContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): InvoiceResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: InvoiceErrorCode, message: string): InvoiceResult<T> {
+  return { ok: false, error, message };
+}
+
+let seq = 0;
+function nextId(): string {
+  seq += 1;
+  return `inv-${String(seq).padStart(3, "0")}`;
+}
+
+/** Validate a submitted invoice input. Returns a message or null. */
+export function validateInvoiceInput(input: InvoiceInput): string | null {
+  if (!input.vendor || input.vendor.trim() === "") return "vendor is required";
+  if (!input.amount || input.amount <= 0) return "amount must be greater than 0";
+  if (!input.submittedBy || input.submittedBy.trim() === "") return "submittedBy is required";
+  return null;
+}
+
+/**
+ * Pure reducer for the invoice approval workflow.
+ *
+ * Keeps all state in the `invoices` map; deterministic given inputs. The
+ * `now` parameter is injectable so approvals/rejections are testable.
+ */
+export function applyInvoiceOperation(
+  invoices: Map<string, Invoice>,
+  op: InvoiceOperation,
+  now: Date,
+): InvoiceResult<InvoiceContractOutput> {
+  switch (op.operation) {
+    case "submit": {
+      const err = validateInvoiceInput(op.input);
+      if (err) return fail(InvoiceErrorCode.InvalidInput, err);
+      const invoice: Invoice = {
+        id: nextId(),
+        vendor: op.input.vendor,
+        amount: op.input.amount,
+        submittedBy: op.input.submittedBy,
+        status: "pending",
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      };
+      invoices.set(invoice.id, invoice);
+      return ok({ operation: "submit", invoice });
+    }
+    case "approve":
+    case "reject": {
+      const invoice = invoices.get(op.id);
+      if (!invoice) return fail(InvoiceErrorCode.InvoiceNotFound, `Invoice ${op.id} not found`);
+      if (invoice.status !== "pending")
+        return fail(
+          InvoiceErrorCode.InvalidState,
+          `Invoice ${op.id} is ${invoice.status}, not pending`,
+        );
+      const decision: ApprovalDecision =
+        op.operation === "approve"
+          ? { decision: "approved", approver: op.approver, at: now.toISOString() }
+          : {
+              decision: "rejected",
+              approver: op.approver,
+              reason: op.reason,
+              at: now.toISOString(),
+            };
+      const updated: Invoice = {
+        ...invoice,
+        status: decision.decision === "approved" ? "approved" : "rejected",
+        decision,
+        updatedAt: now.toISOString(),
+      };
+      invoices.set(updated.id, updated);
+      return ok({
+        operation: op.operation,
+        invoice: updated,
+      } as InvoiceContractOutput);
+    }
+    case "list": {
+      const all = [...invoices.values()];
+      const filtered = op.status ? all.filter((i) => i.status === op.status) : all;
+      return ok({ operation: "list", invoices: filtered });
+    }
+    default: {
+      const _never: never = op;
+      return fail(InvoiceErrorCode.InvalidInput, `Unknown operation: ${JSON.stringify(_never)}`);
+    }
+  }
+}

--- a/tools/v2/team/invoice-approval-workflow/fixtures.ts
+++ b/tools/v2/team/invoice-approval-workflow/fixtures.ts
@@ -1,0 +1,29 @@
+/**
+ * fixtures.ts — Invoice Approval Workflow (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { InvoiceInput } from "./types";
+
+/** A valid invoice submission. */
+export const VALID_SUBMIT_INPUT: InvoiceInput = {
+  vendor: "Acme Hosting LLC",
+  amount: 1250.0,
+  submittedBy: "finops@client-acme.example.com",
+};
+
+/** A submission with a non-positive amount (should fail validation). */
+export const INVALID_AMOUNT_INPUT: InvoiceInput = {
+  vendor: "Bad Vendor",
+  amount: 0,
+  submittedBy: "someone@example.com",
+};
+
+/** A submission missing a vendor (should fail validation). */
+export const MISSING_VENDOR_INPUT: InvoiceInput = {
+  vendor: "",
+  amount: 50,
+  submittedBy: "someone@example.com",
+};

--- a/tools/v2/team/invoice-approval-workflow/index.ts
+++ b/tools/v2/team/invoice-approval-workflow/index.ts
@@ -1,0 +1,28 @@
+/**
+ * index.ts — Invoice Approval Workflow
+ *
+ * Folder-local API surface. Exports the non-UI execution contract, its types,
+ * and the service factory. Nothing in this file imports from the main app.
+ */
+
+// Types
+export type { Invoice, InvoiceInput, InvoiceStatus, ApprovalDecision } from "./types";
+
+// Contract + service
+export { createInvoiceApprovalContract } from "./services/invoice-approval.service";
+export {
+  InvoiceErrorCode,
+  applyInvoiceOperation,
+  validateInvoiceInput,
+  ok,
+  fail,
+} from "./contract";
+export type {
+  InvoiceContract,
+  InvoiceOperation,
+  InvoiceContractOutput,
+  InvoiceResult,
+} from "./contract";
+
+// Fixtures
+export { VALID_SUBMIT_INPUT, INVALID_AMOUNT_INPUT, MISSING_VENDOR_INPUT } from "./fixtures";

--- a/tools/v2/team/invoice-approval-workflow/services/invoice-approval.service.ts
+++ b/tools/v2/team/invoice-approval-workflow/services/invoice-approval.service.ts
@@ -1,0 +1,38 @@
+/**
+ * invoice-approval.service.ts — Invoice Approval Workflow (non-UI service)
+ *
+ * Presentation-free service boundary for the invoice approval contract. Wraps
+ * the pure `applyInvoiceOperation` reducer into an `InvoiceContract` whose
+ * `execute(...)` returns typed success/error results.
+ */
+
+import {
+  InvoiceErrorCode,
+  type InvoiceContract,
+  type InvoiceOperation,
+  type InvoiceContractOutput,
+  type InvoiceResult,
+  applyInvoiceOperation,
+  fail,
+} from "../contract";
+import type { Invoice } from "../types";
+
+/**
+ * Build the invoice approval execution contract.
+ *
+ * State is held in an in-memory map so the contract is fully testable in
+ * isolation with no network, no secrets, and no UI.
+ */
+export function createInvoiceApprovalContract(now: () => Date = () => new Date()): InvoiceContract {
+  const invoices = new Map<string, Invoice>();
+  return {
+    execute(input: InvoiceOperation): InvoiceResult<InvoiceContractOutput> {
+      try {
+        return applyInvoiceOperation(invoices, input, now());
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(InvoiceErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/invoice-approval-workflow/tests/contract.test.ts
+++ b/tools/v2/team/invoice-approval-workflow/tests/contract.test.ts
@@ -1,0 +1,140 @@
+/**
+ * contract.test.ts — Invoice Approval Workflow (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, the
+ * submit → approve/reject → list lifecycle, and the edge/error paths
+ * (validation, unknown invoice, invalid state). No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createInvoiceApprovalContract } from "../services/invoice-approval.service";
+import {
+  InvoiceErrorCode,
+  ok,
+  fail,
+  type InvoiceResult,
+  type InvoiceContractOutput,
+} from "../contract";
+import { VALID_SUBMIT_INPUT, INVALID_AMOUNT_INPUT, MISSING_VENDOR_INPUT } from "../fixtures";
+
+describe("invoice approval contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(InvoiceErrorCode.InvalidInput, "bad");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(InvoiceErrorCode.InvalidInput);
+      expect(r.message).toBe("bad");
+    }
+  });
+});
+
+describe("invoice approval contract — lifecycle", () => {
+  it("submit creates a pending invoice with a generated id", () => {
+    const contract = createInvoiceApprovalContract();
+    const res = contract.execute({ operation: "submit", input: VALID_SUBMIT_INPUT });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "submit") {
+      expect(res.value.invoice.id).toMatch(/^inv-\d{3}$/);
+      expect(res.value.invoice.status).toBe("pending");
+      expect(res.value.invoice.amount).toBe(VALID_SUBMIT_INPUT.amount);
+    }
+  });
+
+  it("approve moves a pending invoice to approved with a decision", () => {
+    const contract = createInvoiceApprovalContract();
+    const sub = contract.execute({ operation: "submit", input: VALID_SUBMIT_INPUT });
+    expect(sub.ok).toBe(true);
+    const id = sub.ok && sub.value.operation === "submit" ? sub.value.invoice.id : "";
+    const res = contract.execute({ operation: "approve", id, approver: "lead@acme.example.com" });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "approve") {
+      expect(res.value.invoice.status).toBe("approved");
+      expect(res.value.invoice.decision?.decision).toBe("approved");
+      expect(res.value.invoice.decision?.approver).toBe("lead@acme.example.com");
+    }
+  });
+
+  it("reject records a reason and moves the invoice to rejected", () => {
+    const contract = createInvoiceApprovalContract();
+    const sub = contract.execute({ operation: "submit", input: VALID_SUBMIT_INPUT });
+    const id = sub.ok && sub.value.operation === "submit" ? sub.value.invoice.id : "";
+    const res = contract.execute({
+      operation: "reject",
+      id,
+      approver: "lead@acme.example.com",
+      reason: "Over budget this quarter",
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "reject") {
+      expect(res.value.invoice.status).toBe("rejected");
+      expect(res.value.invoice.decision?.reason).toBe("Over budget this quarter");
+    }
+  });
+
+  it("list returns all invoices, and can be filtered by status", () => {
+    const contract = createInvoiceApprovalContract();
+    contract.execute({ operation: "submit", input: VALID_SUBMIT_INPUT });
+    const res = contract.execute({ operation: "list" });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "list") {
+      expect(res.value.invoices.length).toBe(1);
+      expect(res.value.invoices[0].status).toBe("pending");
+    }
+    const pending = contract.execute({ operation: "list", status: "approved" });
+    if (pending.ok && pending.value.operation === "list") {
+      expect(pending.value.invoices.length).toBe(0);
+    }
+  });
+});
+
+describe("invoice approval contract — error handling", () => {
+  it("submit rejects a non-positive amount (no throw)", () => {
+    const contract = createInvoiceApprovalContract();
+    const res: InvoiceResult<InvoiceContractOutput> = contract.execute({
+      operation: "submit",
+      input: INVALID_AMOUNT_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(InvoiceErrorCode.InvalidInput);
+  });
+
+  it("submit rejects a missing vendor (no throw)", () => {
+    const contract = createInvoiceApprovalContract();
+    const res: InvoiceResult<InvoiceContractOutput> = contract.execute({
+      operation: "submit",
+      input: MISSING_VENDOR_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(InvoiceErrorCode.InvalidInput);
+  });
+
+  it("approve of an unknown invoice maps to InvoiceNotFound (no throw)", () => {
+    const contract = createInvoiceApprovalContract();
+    const res: InvoiceResult<InvoiceContractOutput> = contract.execute({
+      operation: "approve",
+      id: "inv-999",
+      approver: "lead@acme.example.com",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(InvoiceErrorCode.InvoiceNotFound);
+  });
+
+  it("approve of an already-decided invoice maps to InvalidState (no throw)", () => {
+    const contract = createInvoiceApprovalContract();
+    const sub = contract.execute({ operation: "submit", input: VALID_SUBMIT_INPUT });
+    const id = sub.ok && sub.value.operation === "submit" ? sub.value.invoice.id : "";
+    contract.execute({ operation: "approve", id, approver: "lead@acme.example.com" });
+    const res: InvoiceResult<InvoiceContractOutput> = contract.execute({
+      operation: "approve",
+      id,
+      approver: "lead@acme.example.com",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(InvoiceErrorCode.InvalidState);
+  });
+});

--- a/tools/v2/team/invoice-approval-workflow/types.ts
+++ b/tools/v2/team/invoice-approval-workflow/types.ts
@@ -1,0 +1,40 @@
+/**
+ * types.ts — Invoice Approval Workflow (non-UI execution contract)
+ *
+ * Domain types for the invoice approval workflow. No imports from the main
+ * app; presentation-free.
+ */
+
+/** Lifecycle status of an invoice in the approval workflow. */
+export type InvoiceStatus = "pending" | "approved" | "rejected";
+
+/** A recorded approval/rejection decision. */
+export interface ApprovalDecision {
+  decision: "approved" | "rejected";
+  approver: string;
+  /** Reason is required for rejections. */
+  reason?: string;
+  /** ISO-8601 timestamp. */
+  at: string;
+}
+
+/** Input for submitting a new invoice. */
+export interface InvoiceInput {
+  vendor: string;
+  amount: number;
+  submittedBy: string;
+}
+
+/** A persisted invoice with its current workflow state. */
+export interface Invoice {
+  id: string;
+  vendor: string;
+  amount: number;
+  submittedBy: string;
+  status: InvoiceStatus;
+  /** ISO-8601 timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp. */
+  updatedAt: string;
+  decision?: ApprovalDecision;
+}


### PR DESCRIPTION
## Summary

Implements #1356 by adding the invoice-approval-workflow tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The tool previously had only README/specs; this builds the contract from scratch.

### Deliverables
- **`types.ts`** — domain types: `Invoice`, `InvoiceInput`, `InvoiceStatus`, `ApprovalDecision`.
- **`contract.ts`** — typed `InvoiceOperation` / `InvoiceContractOutput`, explicit `InvoiceErrorCode` values, an `InvoiceResult<T>` discriminated union, plus the pure reducer `applyInvoiceOperation` (submit -> approve/reject -> list) with `validateInvoiceInput`.
- **`services/invoice-approval.service.ts`** — `createInvoiceApprovalContract()` keeps state in an in-memory map and adapts the reducer into an `InvoiceContract` whose `execute()` returns typed success/error results instead of throwing.
- **`fixtures.ts`** — representative submit inputs (valid, non-positive amount, missing vendor).
- **`tests/contract.test.ts`** — vitest coverage of the full lifecycle plus validation / not-found / invalid-state error paths (no throws leak to callers).
- **`README.md`** — documents the contract and usage.

Non-UI only. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (10 tests).

Fixes #1356