### PR TITLE
Add non-UI execution contract for team-digest-generator (Fixes #1348)

### DIFF
--- a/tools/v2/team/team-digest-generator/README.md
+++ b/tools/v2/team/team-digest-generator/README.md
@@ -50,3 +50,31 @@ team-digest-generator/
 ## Future Integration
 
 This tool is designed as an isolated mini-product. If a future issue requires integration with the main app (dashboard, inbox, settings), that work should be in a separate issue with explicit approval to modify protected areas.
+
+## Non-UI execution contract
+
+The digest generator exposes a presentation-free execution contract so it can run
+as a backend service, independent of any UI.
+
+- `contract.ts` — the typed `DigestOperation` / `DigestContractOutput`, the
+  `DigestResult<T>` discriminated union, explicit `DigestErrorCode` values, and
+  `validateDigestInput`. Wraps the existing `generateTeamDigest` in `src/`.
+- `index.ts` — `createDigestContract()` returns a `DigestContract` whose
+  `execute(...)` returns typed success/error results instead of throwing.
+- `contract.fixtures.ts` — deterministic sample items.
+- `tests/contract.test.ts` — vitest coverage of aggregation, the `topSubjectLimit`
+  option, empty input, and invalid-item error paths.
+
+Usage:
+
+```ts
+import { createDigestContract } from ".";
+
+const contract = createDigestContract();
+const res = contract.execute({ operation: "generate", items });
+if (res.ok && res.value.operation === "generate") {
+  // res.value.summary has authors/projects/tags/actionItems/topSubjects
+} else {
+  // res.error is a DigestErrorCode
+}
+```

--- a/tools/v2/team/team-digest-generator/contract.fixtures.ts
+++ b/tools/v2/team/team-digest-generator/contract.fixtures.ts
@@ -1,0 +1,51 @@
+/**
+ * contract.fixtures.ts — Team Digest Generator (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { TeamDigestItem } from "./src/digestGenerator";
+
+/** A small deterministic set of digest items across authors/projects/tags. */
+export const DIGEST_FIXTURES: TeamDigestItem[] = [
+  {
+    id: "item-1",
+    author: "Ada",
+    subject: "Shipped onboarding flow",
+    project: "onboarding",
+    tags: ["release"],
+    createdAt: "2026-06-01T09:00:00.000Z",
+    isActionItem: false,
+  },
+  {
+    id: "item-2",
+    author: "Ada",
+    subject: "Fix billing bug",
+    project: "billing",
+    tags: ["bug"],
+    createdAt: "2026-06-01T10:30:00.000Z",
+    isActionItem: true,
+  },
+  {
+    id: "item-3",
+    author: "Grace",
+    subject: "Draft Q3 roadmap",
+    project: "planning",
+    tags: ["planning", "docs"],
+    createdAt: "2026-06-02T11:00:00.000Z",
+    isActionItem: false,
+  },
+  {
+    id: "item-4",
+    author: "Grace",
+    subject: "Review security PR",
+    project: "security",
+    tags: ["review"],
+    createdAt: "2026-06-02T14:00:00.000Z",
+    isActionItem: true,
+  },
+];
+
+/** An empty item set (edge case). */
+export const EMPTY_ITEMS: TeamDigestItem[] = [];

--- a/tools/v2/team/team-digest-generator/contract.ts
+++ b/tools/v2/team/team-digest-generator/contract.ts
@@ -1,0 +1,93 @@
+/**
+ * contract.ts — Team Digest Generator (non-UI execution contract)
+ *
+ * Backend-facing execution contract for generating a team digest. It is
+ * presentation-free: no React, no DOM. Operations return a typed
+ * `DigestResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ *
+ * The underlying aggregation logic already exists in `./src/digestGenerator`
+ * (`generateTeamDigest`); this contract wraps it with a typed boundary.
+ */
+
+import {
+  generateTeamDigest,
+  type TeamDigestItem,
+  type TeamDigestSummary,
+} from "./src/digestGenerator";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum DigestErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type DigestResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: DigestErrorCode; message: string };
+
+/** Operations supported by the digest contract. */
+export type DigestOperation = {
+  operation: "generate";
+  items: TeamDigestItem[];
+  options?: { topSubjectLimit?: number };
+};
+
+/** Output produced by the contract, keyed by operation. */
+export type DigestContractOutput = {
+  operation: "generate";
+  summary: TeamDigestSummary;
+};
+
+/** Backend-facing entry point for the team digest generator. */
+export interface DigestContract {
+  execute(input: DigestOperation): DigestResult<DigestContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): DigestResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: DigestErrorCode, message: string): DigestResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Validate digest input items. */
+export function validateDigestInput(items: TeamDigestItem[] | undefined): string | null {
+  if (!items) return "items are required";
+  if (!Array.isArray(items)) return "items must be an array";
+  for (const item of items) {
+    if (!item.id || item.id.trim() === "") return "each item requires an id";
+    if (!item.author || item.author.trim() === "") return "each item requires an author";
+  }
+  return null;
+}
+
+/**
+ * Build the team digest execution contract.
+ *
+ * Pure: delegates aggregation to `generateTeamDigest`, returning a typed
+ * result. State never escapes the function, so it is fully testable in
+ * isolation with no network, no secrets, and no UI.
+ */
+export function createDigestContract(): DigestContract {
+  return {
+    execute(input: DigestOperation): DigestResult<DigestContractOutput> {
+      try {
+        if (input.operation !== "generate") {
+          return fail(DigestErrorCode.InvalidInput, `Unknown operation: ${input.operation}`);
+        }
+        const err = validateDigestInput(input.items);
+        if (err) return fail(DigestErrorCode.InvalidInput, err);
+        const summary = generateTeamDigest(input.items, input.options);
+        return ok({ operation: "generate", summary });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(DigestErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/team-digest-generator/index.ts
+++ b/tools/v2/team/team-digest-generator/index.ts
@@ -1,0 +1,24 @@
+/**
+ * index.ts — Team Digest Generator
+ *
+ * Folder-local API surface for the execution contract. Exports the non-UI
+ * digest contract, its types, and the service factory. Nothing here imports
+ * from the main app.
+ */
+
+// Aggregation logic (existing)
+export { generateTeamDigest } from "./src/digestGenerator";
+export type { TeamDigestItem, TeamDigestSummary } from "./src/digestGenerator";
+
+// Contract + service
+export { createDigestContract } from "./contract";
+export { DigestErrorCode, validateDigestInput, ok, fail } from "./contract";
+export type {
+  DigestContract,
+  DigestOperation,
+  DigestContractOutput,
+  DigestResult,
+} from "./contract";
+
+// Contract fixtures
+export { DIGEST_FIXTURES, EMPTY_ITEMS } from "./contract.fixtures";

--- a/tools/v2/team/team-digest-generator/tests/contract.test.ts
+++ b/tools/v2/team/team-digest-generator/tests/contract.test.ts
@@ -1,0 +1,82 @@
+/**
+ * contract.test.ts — Team Digest Generator (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, aggregation
+ * correctness, and the edge/error paths (empty input, invalid items). No UI is
+ * exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createDigestContract } from "../contract";
+import {
+  DigestErrorCode,
+  ok,
+  fail,
+  type DigestResult,
+  type DigestContractOutput,
+} from "../contract";
+import { DIGEST_FIXTURES, EMPTY_ITEMS } from "../contract.fixtures";
+
+describe("digest contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(DigestErrorCode.InvalidInput, "bad");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(DigestErrorCode.InvalidInput);
+      expect(r.message).toBe("bad");
+    }
+  });
+});
+
+describe("digest contract — generate", () => {
+  it("aggregates counts and action items from input", () => {
+    const contract = createDigestContract();
+    const res = contract.execute({ operation: "generate", items: DIGEST_FIXTURES });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "generate") {
+      const s = res.value.summary;
+      expect(s.totalItems).toBe(4);
+      expect(s.authors).toEqual({ Ada: 2, Grace: 2 });
+      expect(s.actionItems.length).toBe(2);
+      expect(s.topSubjects.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("honors topSubjectLimit option", () => {
+    const contract = createDigestContract();
+    const res = contract.execute({
+      operation: "generate",
+      items: DIGEST_FIXTURES,
+      options: { topSubjectLimit: 2 },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "generate") {
+      expect(res.value.summary.topSubjects.length).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("returns an empty summary for empty input (no throw)", () => {
+    const contract = createDigestContract();
+    const res = contract.execute({ operation: "generate", items: EMPTY_ITEMS });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "generate") {
+      expect(res.value.summary.totalItems).toBe(0);
+      expect(res.value.summary.authors).toEqual({});
+    }
+  });
+
+  it("rejects items missing an author (no throw)", () => {
+    const contract = createDigestContract();
+    const res: DigestResult<DigestContractOutput> = contract.execute({
+      operation: "generate",
+      items: [{ id: "x", author: "", subject: "s" } as never],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(DigestErrorCode.InvalidInput);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1348 by adding the team-digest-generator tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The tool already had aggregation logic in `src/digestGenerator`; this adds the typed contract boundary the issue asks for.

### Deliverables
- **`contract.ts`** — typed `DigestOperation` / `DigestContractOutput`, explicit `DigestErrorCode` values, a `DigestResult<T>` discriminated union, and `validateDigestInput`. Wraps the existing `generateTeamDigest`.
- **`index.ts`** — `createDigestContract()` returns a `DigestContract` whose `execute()` returns typed success/error results instead of throwing.
- **`contract.fixtures.ts`** — deterministic sample items.
- **`tests/contract.test.ts`** — vitest coverage of aggregation, the `topSubjectLimit` option, empty input, and invalid-item error paths (no throws leak).
- **`README.md`** — documents the contract and usage.

Non-UI only; existing aggregation/UI untouched. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (6 tests).

Fixes #1348