### PR TITLE
Add non-UI execution contract for client-priority-scoring (Fixes #1363)

### DIFF
--- a/tools/v2/team/client-priority-scoring/README.md
+++ b/tools/v2/team/client-priority-scoring/README.md
@@ -1,15 +1,50 @@
 # Client Priority Scoring
 
-This folder is the isolated workspace for the Client Priority Scoring tool.
+This folder is the isolated workspace for the Client Priority Scoring tool — a
+presentation-free service that ranks clients by weighted importance signals.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
+`tools/v2/team/client-priority-scoring/`
 
-`text
-.\tools\v2\team\client-priority-scoring\
-`
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, or design system unless a future integration issue
+explicitly allows it.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+See `specs.md` for the architecture contract, issue categories, and contributor
+expectations.
 
-See specs.md for the issue categories and contributor expectations.
+## Non-UI execution contract
+
+The scoring logic exposes a presentation-free execution contract so it can run
+as a backend service, independent of any UI.
+
+- `types.ts` — domain types: `ClientSignal`, `ClientForScoring`, `ScoredClient`,
+  `ScoreClientsInput`, `PriorityOrder`.
+- `contract.ts` — the typed `PriorityOperation` / `PriorityContractOutput`, the
+  `PriorityResult<T>` discriminated union, explicit `PriorityErrorCode` values,
+  and the pure `scoreClients` reducer plus `validateClient` / `validateScoreInput`.
+- `services/client-priority.service.ts` — `createPriorityContract()` adapts the
+  pure reducer into a `PriorityContract` whose `execute(...)` returns typed
+  success/error results instead of throwing.
+- `fixtures.ts` — deterministic sample clients.
+- `tests/contract.test.ts` — vitest coverage of weighted scoring, priority
+  bands, ordering, empty input, and invalid-signal error paths.
+
+Usage:
+
+```ts
+import { createPriorityContract } from ".";
+
+const contract = createPriorityContract();
+const res = contract.execute({
+  operation: "score",
+  input: { clients, highThreshold: 10, lowThreshold: 3 },
+});
+if (res.ok && res.value.operation === "score") {
+  // res.value.ranked is sorted by score, each with a priority band
+} else {
+  // res.error is a PriorityErrorCode
+}
+```

--- a/tools/v2/team/client-priority-scoring/contract.ts
+++ b/tools/v2/team/client-priority-scoring/contract.ts
@@ -1,0 +1,104 @@
+/**
+ * contract.ts — Client Priority Scoring (non-UI execution contract)
+ *
+ * Backend-facing execution contract for ranking clients by importance. It is
+ * presentation-free: no React, no DOM. Operations return a typed
+ * `PriorityResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ */
+
+import type { ClientForScoring, ScoreClientsInput, ScoredClient, PriorityOrder } from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum PriorityErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type PriorityResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: PriorityErrorCode; message: string };
+
+/** Operations supported by the priority contract. */
+export type PriorityOperation = {
+  operation: "score";
+  input: ScoreClientsInput;
+  order?: PriorityOrder;
+};
+
+/** Output produced by the contract, keyed by operation. */
+export type PriorityContractOutput = {
+  operation: "score";
+  ranked: ScoredClient[];
+};
+
+/** Backend-facing entry point for client priority scoring. */
+export interface PriorityContract {
+  execute(input: PriorityOperation): PriorityResult<PriorityContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): PriorityResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: PriorityErrorCode, message: string): PriorityResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Validate a client for scoring. */
+export function validateClient(client: ClientForScoring): string | null {
+  if (!client.id || client.id.trim() === "") return "client requires an id";
+  if (!client.name || client.name.trim() === "") return "client requires a name";
+  if (!Array.isArray(client.signals)) return "client.signals must be an array";
+  for (const s of client.signals) {
+    if (typeof s.value !== "number" || Number.isNaN(s.value))
+      return `signal ${s.name} has a non-numeric value`;
+    if (typeof s.weight !== "number" || s.weight < 0)
+      return `signal ${s.name} has a negative weight`;
+  }
+  return null;
+}
+
+function band(score: number, high: number, low: number): ScoredClient["priority"] {
+  if (score >= high) return "high";
+  if (score < low) return "low";
+  return "medium";
+}
+
+/**
+ * Pure scoring + ranking. Computes a weighted score per client, derives a
+ * priority band, then orders clients by score (desc by default).
+ *
+ * Deterministic given the same inputs.
+ */
+export function scoreClients(
+  input: ScoreClientsInput,
+  order: PriorityOrder = "desc",
+): ScoredClient[] {
+  const high = input.highThreshold ?? 10;
+  const low = input.lowThreshold ?? 3;
+  const scored: ScoredClient[] = input.clients.map((client) => {
+    const score = client.signals.reduce((sum, s) => sum + s.value * s.weight, 0);
+    return {
+      id: client.id,
+      name: client.name,
+      score,
+      priority: band(score, high, low),
+    };
+  });
+  const dir = order === "asc" ? 1 : -1;
+  return scored.sort((a, b) => dir * (a.score - b.score));
+}
+
+/** Validate the whole input before scoring. */
+export function validateScoreInput(input: ScoreClientsInput): string | null {
+  if (!input || !Array.isArray(input.clients)) return "clients must be an array";
+  for (const client of input.clients) {
+    const err = validateClient(client);
+    if (err) return err;
+  }
+  return null;
+}

--- a/tools/v2/team/client-priority-scoring/fixtures.ts
+++ b/tools/v2/team/client-priority-scoring/fixtures.ts
@@ -1,0 +1,39 @@
+/**
+ * fixtures.ts — Client Priority Scoring (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { ClientForScoring } from "./types";
+
+/** Three clients with differing signal mixes (used for ranking checks). */
+export const PRIORITY_FIXTURES: ClientForScoring[] = [
+  {
+    id: "client-acme",
+    name: "Acme",
+    signals: [
+      { name: "revenue", value: 8, weight: 1 },
+      { name: "openTickets", value: 2, weight: 1 },
+    ],
+  },
+  {
+    id: "client-globex",
+    name: "Globex",
+    signals: [
+      { name: "revenue", value: 3, weight: 1 },
+      { name: "openTickets", value: 0, weight: 1 },
+    ],
+  },
+  {
+    id: "client-initech",
+    name: "Initech",
+    signals: [
+      { name: "revenue", value: 15, weight: 1 },
+      { name: "openTickets", value: 5, weight: 1 },
+    ],
+  },
+];
+
+/** An empty client set (edge case). */
+export const EMPTY_CLIENTS: ClientForScoring[] = [];

--- a/tools/v2/team/client-priority-scoring/index.ts
+++ b/tools/v2/team/client-priority-scoring/index.ts
@@ -1,0 +1,35 @@
+/**
+ * index.ts — Client Priority Scoring
+ *
+ * Folder-local API surface. Exports the non-UI execution contract, its types,
+ * and the service factory. Nothing here imports from the main app.
+ */
+
+// Types
+export type {
+  ClientSignal,
+  ClientForScoring,
+  ScoredClient,
+  ScoreClientsInput,
+  PriorityOrder,
+} from "./types";
+
+// Contract + service
+export { createPriorityContract } from "./services/client-priority.service";
+export {
+  PriorityErrorCode,
+  scoreClients,
+  validateClient,
+  validateScoreInput,
+  ok,
+  fail,
+} from "./contract";
+export type {
+  PriorityContract,
+  PriorityOperation,
+  PriorityContractOutput,
+  PriorityResult,
+} from "./contract";
+
+// Fixtures
+export { PRIORITY_FIXTURES, EMPTY_CLIENTS } from "./fixtures";

--- a/tools/v2/team/client-priority-scoring/services/client-priority.service.ts
+++ b/tools/v2/team/client-priority-scoring/services/client-priority.service.ts
@@ -1,0 +1,36 @@
+/**
+ * client-priority.service.ts — Client Priority Scoring (non-UI service)
+ *
+ * Presentation-free service boundary for the priority contract. Wraps the pure
+ * `scoreClients` reducer into a `PriorityContract` whose `execute(...)` returns
+ * typed success/error results.
+ */
+
+import {
+  PriorityErrorCode,
+  ok,
+  type PriorityContract,
+  type PriorityOperation,
+  type PriorityContractOutput,
+  type PriorityResult,
+  scoreClients,
+  validateScoreInput,
+  fail,
+} from "../contract";
+
+/** Build the priority scoring execution contract. */
+export function createPriorityContract(): PriorityContract {
+  return {
+    execute(input: PriorityOperation): PriorityResult<PriorityContractOutput> {
+      try {
+        const err = validateScoreInput(input.input);
+        if (err) return fail(PriorityErrorCode.InvalidInput, err);
+        const ranked = scoreClients(input.input, input.order ?? "desc");
+        return ok({ operation: "score", ranked });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(PriorityErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/client-priority-scoring/tests/contract.test.ts
+++ b/tools/v2/team/client-priority-scoring/tests/contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * contract.test.ts — Client Priority Scoring (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, weighted
+ * scoring, priority bands, ordering, and edge/error paths. No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createPriorityContract } from "../services/client-priority.service";
+import {
+  PriorityErrorCode,
+  ok,
+  fail,
+  type PriorityResult,
+  type PriorityContractOutput,
+} from "../contract";
+import { PRIORITY_FIXTURES, EMPTY_CLIENTS } from "../fixtures";
+
+describe("priority contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(PriorityErrorCode.InvalidInput, "bad");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(PriorityErrorCode.InvalidInput);
+      expect(r.message).toBe("bad");
+    }
+  });
+});
+
+describe("priority contract — score", () => {
+  it("scores and ranks clients by weighted score (desc default)", () => {
+    const contract = createPriorityContract();
+    const res = contract.execute({ operation: "score", input: { clients: PRIORITY_FIXTURES } });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "score") {
+      const ranked = res.value.ranked;
+      expect(ranked.length).toBe(3);
+      // Initech (20) > Acme (10) > Globex (3)
+      expect(ranked.map((c) => c.id)).toEqual(["client-initech", "client-acme", "client-globex"]);
+      const initech = ranked.find((c) => c.id === "client-initech");
+      expect(initech?.score).toBe(20);
+      expect(initech?.priority).toBe("high");
+    }
+  });
+
+  it("honors asc ordering when requested", () => {
+    const contract = createPriorityContract();
+    const res = contract.execute({
+      operation: "score",
+      input: { clients: PRIORITY_FIXTURES },
+      order: "asc",
+    });
+    if (res.ok && res.value.operation === "score") {
+      expect(res.value.ranked.map((c) => c.id)).toEqual([
+        "client-globex",
+        "client-acme",
+        "client-initech",
+      ]);
+    }
+  });
+
+  it("derives priority bands from thresholds", () => {
+    const contract = createPriorityContract();
+    const res = contract.execute({ operation: "score", input: { clients: PRIORITY_FIXTURES } });
+    if (res.ok && res.value.operation === "score") {
+      const bands = Object.fromEntries(res.value.ranked.map((c) => [c.id, c.priority]));
+      expect(bands["client-initech"]).toBe("high"); // 20 >= 10
+      expect(bands["client-acme"]).toBe("high"); // 10 >= 10
+      expect(bands["client-globex"]).toBe("medium"); // 3 is not < lowThreshold(3)
+    }
+  });
+
+  it("returns an empty ranking for no clients (no throw)", () => {
+    const contract = createPriorityContract();
+    const res = contract.execute({ operation: "score", input: { clients: EMPTY_CLIENTS } });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "score") {
+      expect(res.value.ranked).toEqual([]);
+    }
+  });
+
+  it("rejects a client with a non-numeric signal (no throw)", () => {
+    const contract = createPriorityContract();
+    const res: PriorityResult<PriorityContractOutput> = contract.execute({
+      operation: "score",
+      input: {
+        clients: [
+          { id: "x", name: "X", signals: [{ name: "revenue", value: NaN, weight: 1 }] } as never,
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(PriorityErrorCode.InvalidInput);
+  });
+});

--- a/tools/v2/team/client-priority-scoring/types.ts
+++ b/tools/v2/team/client-priority-scoring/types.ts
@@ -1,0 +1,45 @@
+/**
+ * types.ts — Client Priority Scoring (non-UI execution contract)
+ *
+ * Domain types for ranking clients by importance. No imports from the main
+ * app; presentation-free.
+ */
+
+/** A weighted signal used to compute a client's priority score. */
+export interface ClientSignal {
+  /** Signal name, e.g. "revenue", "openTickets", "sentiment". */
+  name: string;
+  /** Numeric value for the signal. */
+  value: number;
+  /** Relative weight (>= 0). Higher weight = more influence on the score. */
+  weight: number;
+}
+
+/** A client with the signals used for prioritization. */
+export interface ClientForScoring {
+  id: string;
+  name: string;
+  signals: ClientSignal[];
+}
+
+/** A scored + ranked client. */
+export interface ScoredClient {
+  id: string;
+  name: string;
+  /** Computed priority score (sum of value*weight across signals). */
+  score: number;
+  /** Derived priority band. */
+  priority: "low" | "medium" | "high";
+}
+
+/** Input for scoring/ranking clients. */
+export interface ScoreClientsInput {
+  clients: ClientForScoring[];
+  /** Score at/above which a client is "high" (default 10). */
+  highThreshold?: number;
+  /** Score below which a client is "low" (default 3). */
+  lowThreshold?: number;
+}
+
+/** Options for ranking. */
+export type PriorityOrder = "desc" | "asc";


### PR DESCRIPTION
## Summary

Implements #1363 by adding the client-priority-scoring tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The tool previously had only README/specs; this builds the contract from scratch.

### Deliverables
- **`types.ts`** — domain types (ClientSignal, ClientForScoring, ScoredClient, ScoreClientsInput, PriorityOrder).
- **`contract.ts`** — typed `PriorityOperation` / `PriorityContractOutput`, explicit `PriorityErrorCode` values, a `PriorityResult<T>` discriminated union, plus the pure `scoreClients` reducer (weighted score, priority bands, ordering) and `validateClient` / `validateScoreInput`.
- **`services/client-priority.service.ts`** — `createPriorityContract()` adapts the reducer into a `PriorityContract` whose `execute()` returns typed success/error results instead of throwing.
- **`fixtures.ts`** — deterministic sample clients.
- **`tests/contract.test.ts`** — vitest coverage of weighted scoring, priority bands, ordering, empty input, and invalid-signal error paths.
- **`README.md`** — documents the contract and usage.

Non-UI only. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (7 tests).

Fixes #1363