### PR TITLE
Add non-UI execution contract for team-workload-balancer (Fixes #1360)

### DIFF
--- a/tools/v2/team/team-workload-balancer/README.md
+++ b/tools/v2/team/team-workload-balancer/README.md
@@ -13,3 +13,39 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Non-UI execution contract
+
+The workload balancer exposes a presentation-free execution contract so it can
+run as a backend service, independent of any UI.
+
+- `contract.ts` — the typed `WorkloadOperation` / `WorkloadContractOutput`, the
+  `WorkloadResult<T>` discriminated union, explicit `WorkloadErrorCode` values,
+  and `validateBalanceInput`. Wraps the existing synchronous `balanceWorkload`
+  in `services/workload-service`.
+- `index.ts` — `createWorkloadContract()` returns a `WorkloadContract` whose
+  `execute(...)` returns typed success/error results instead of throwing.
+- `contract.fixtures.ts` — deterministic sample members/items.
+- `tests/contract.test.ts` — vitest coverage of delegation to `balanceWorkload`,
+  deterministic strategies (round-robin / least-loaded), and invalid-input error
+  paths.
+
+Usage:
+
+```ts
+import { createWorkloadContract } from ".";
+
+const contract = createWorkloadContract();
+const res = contract.execute({
+  operation: "balance",
+  unassignedItems,
+  members,
+  allItems,
+  config: { strategy: "least-loaded" },
+});
+if (res.ok && res.value.operation === "balance") {
+  // res.value.result.assignments / res.value.result.metrics
+} else {
+  // res.error is a WorkloadErrorCode
+}
+```

--- a/tools/v2/team/team-workload-balancer/contract.fixtures.ts
+++ b/tools/v2/team/team-workload-balancer/contract.fixtures.ts
@@ -1,0 +1,67 @@
+/**
+ * contract.fixtures.ts — Team Workload Balancer (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape. Mirrors the JSON fixtures shipped with the tool.
+ */
+
+import type { TeamMember, WorkloadItem } from "./types";
+
+/** A small deterministic team (no randomness in assignments). */
+export const SAMPLE_MEMBERS: TeamMember[] = [
+  {
+    id: "mem-001",
+    name: "Alex Chen",
+    capacity: 10,
+    currentLoad: 4,
+    roles: ["developer"],
+    skills: ["react", "node"],
+  },
+  {
+    id: "mem-002",
+    name: "Jordan Taylor",
+    capacity: 8,
+    currentLoad: 5,
+    roles: ["developer"],
+    skills: ["react", "python"],
+  },
+  {
+    id: "mem-003",
+    name: "Morgan Singh",
+    capacity: 6,
+    currentLoad: 2,
+    roles: ["designer"],
+    skills: ["css", "figma"],
+  },
+];
+
+/** Two unassigned items to balance. */
+export const SAMPLE_UNASSIGNED: WorkloadItem[] = [
+  {
+    id: "item-001",
+    title: "Fix login bug",
+    description: "",
+    priority: "high",
+    status: "pending",
+    estimatedEffort: 3,
+    assignedTo: null,
+    createdAt: "2026-06-01T09:00:00.000Z",
+    dueAt: null,
+    tags: ["react"],
+  },
+  {
+    id: "item-002",
+    title: "Design settings page",
+    description: "",
+    priority: "medium",
+    status: "pending",
+    estimatedEffort: 2,
+    assignedTo: null,
+    createdAt: "2026-06-01T10:00:00.000Z",
+    dueAt: null,
+    tags: ["css"],
+  },
+];
+
+/** The full item set (includes the unassigned ones). */
+export const SAMPLE_ALL_ITEMS: WorkloadItem[] = [...SAMPLE_UNASSIGNED];

--- a/tools/v2/team/team-workload-balancer/contract.ts
+++ b/tools/v2/team/team-workload-balancer/contract.ts
@@ -1,0 +1,95 @@
+/**
+ * contract.ts — Team Workload Balancer (non-UI execution contract)
+ *
+ * Backend-facing execution contract for distributing work items across team
+ * members. It is presentation-free: no React, no DOM. Operations return a typed
+ * `WorkloadResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ *
+ * The underlying balancing logic already exists in `./services/workload-service`
+ * (`balanceWorkload`); this contract wraps it with a typed boundary.
+ */
+
+import { balanceWorkload } from "./services/workload-service";
+import type { BalancerConfig, BalanceResult, TeamMember, WorkloadItem } from "./types";
+/** Explicit, machine-readable error codes for contract operations. */
+export enum WorkloadErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type WorkloadResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: WorkloadErrorCode; message: string };
+
+/** Operations supported by the workload contract. */
+export type WorkloadOperation = {
+  operation: "balance";
+  unassignedItems: WorkloadItem[];
+  members: TeamMember[];
+  allItems: WorkloadItem[];
+  config: BalancerConfig;
+};
+
+/** Output produced by the contract, keyed by operation. */
+export type WorkloadContractOutput = {
+  operation: "balance";
+  result: BalanceResult;
+};
+
+/** Backend-facing entry point for the team workload balancer. */
+export interface WorkloadContract {
+  execute(input: WorkloadOperation): WorkloadResult<WorkloadContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): WorkloadResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: WorkloadErrorCode, message: string): WorkloadResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Validate balance inputs. */
+export function validateBalanceInput(input: WorkloadOperation): string | null {
+  if (!Array.isArray(input.members)) return "members must be an array";
+  if (!Array.isArray(input.allItems)) return "allItems must be an array";
+  if (!Array.isArray(input.unassignedItems)) return "unassignedItems must be an array";
+  if (!input.config || typeof input.config !== "object") return "config is required";
+  if (!input.config.strategy) return "config.strategy is required";
+  return null;
+}
+
+/**
+ * Build the workload balancing execution contract.
+ *
+ * Pure: delegates to `balanceWorkload`, returning a typed result. The
+ * underlying service is synchronous and free of UI concerns, so the contract is
+ * fully testable in isolation with no network, no secrets, and no UI.
+ */
+export function createWorkloadContract(): WorkloadContract {
+  return {
+    execute(input: WorkloadOperation): WorkloadResult<WorkloadContractOutput> {
+      try {
+        if (input.operation !== "balance") {
+          return fail(WorkloadErrorCode.InvalidInput, `Unknown operation: ${input.operation}`);
+        }
+        const err = validateBalanceInput(input);
+        if (err) return fail(WorkloadErrorCode.InvalidInput, err);
+        const result = balanceWorkload(
+          input.unassignedItems,
+          input.members,
+          input.allItems,
+          input.config,
+        );
+        return ok({ operation: "balance", result });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(WorkloadErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/team-workload-balancer/index.ts
+++ b/tools/v2/team/team-workload-balancer/index.ts
@@ -6,6 +6,16 @@ export {
   suggestAssignment,
 } from "./services/workload-service";
 
+// Non-UI execution contract
+export { createWorkloadContract } from "./contract";
+export { WorkloadErrorCode, validateBalanceInput, ok, fail } from "./contract";
+export type {
+  WorkloadContract,
+  WorkloadOperation,
+  WorkloadContractOutput,
+  WorkloadResult,
+} from "./contract";
+
 export type {
   AssignmentSuggestion,
   BalanceResult,

--- a/tools/v2/team/team-workload-balancer/tests/contract.test.ts
+++ b/tools/v2/team/team-workload-balancer/tests/contract.test.ts
@@ -1,0 +1,95 @@
+/**
+ * contract.test.ts — Team Workload Balancer (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, delegation to
+ * the existing balanceWorkload, and the edge/error paths. No UI is exercised.
+ * Uses deterministic strategies (round-robin / least-loaded) to avoid the
+ * capacity-weighted random path.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createWorkloadContract } from "../contract";
+import {
+  WorkloadErrorCode,
+  ok,
+  fail,
+  type WorkloadResult,
+  type WorkloadContractOutput,
+} from "../contract";
+import { SAMPLE_MEMBERS, SAMPLE_UNASSIGNED, SAMPLE_ALL_ITEMS } from "../contract.fixtures";
+
+describe("workload contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(WorkloadErrorCode.InvalidInput, "bad");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(WorkloadErrorCode.InvalidInput);
+      expect(r.message).toBe("bad");
+    }
+  });
+});
+
+describe("workload contract — balance", () => {
+  it("delegates to balanceWorkload and returns assignments + metrics", () => {
+    const contract = createWorkloadContract();
+    const res = contract.execute({
+      operation: "balance",
+      unassignedItems: SAMPLE_UNASSIGNED,
+      members: SAMPLE_MEMBERS,
+      allItems: SAMPLE_ALL_ITEMS,
+      config: { strategy: "least-loaded", prioritizeBy: null, considerSkills: false },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "balance") {
+      expect(res.value.result.assignments.length).toBe(2);
+      expect(res.value.result.metrics.members.length).toBe(3);
+      expect(res.value.result.assignments.every((a) => a.suggestedMemberId)).toBe(true);
+    }
+  });
+
+  it("uses round-robin deterministically", () => {
+    const contract = createWorkloadContract();
+    const res = contract.execute({
+      operation: "balance",
+      unassignedItems: SAMPLE_UNASSIGNED,
+      members: SAMPLE_MEMBERS,
+      allItems: SAMPLE_ALL_ITEMS,
+      config: { strategy: "round-robin", prioritizeBy: null, considerSkills: false },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "balance") {
+      expect(res.value.result.assignments.length).toBe(2);
+    }
+  });
+
+  it("rejects missing members (no throw)", () => {
+    const contract = createWorkloadContract();
+    const res: WorkloadResult<WorkloadContractOutput> = contract.execute({
+      operation: "balance",
+      unassignedItems: SAMPLE_UNASSIGNED,
+      members: undefined as never,
+      allItems: SAMPLE_ALL_ITEMS,
+      config: { strategy: "least-loaded", prioritizeBy: null, considerSkills: false },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(WorkloadErrorCode.InvalidInput);
+  });
+
+  it("rejects a missing config (no throw)", () => {
+    const contract = createWorkloadContract();
+    const res: WorkloadResult<WorkloadContractOutput> = contract.execute({
+      operation: "balance",
+      unassignedItems: SAMPLE_UNASSIGNED,
+      members: SAMPLE_MEMBERS,
+      allItems: SAMPLE_ALL_ITEMS,
+      config: undefined as never,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(WorkloadErrorCode.InvalidInput);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1360 by adding the team-workload-balancer tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The tool already had balancing logic in `services/workload-service`; this adds the typed contract boundary the issue asks for.

### Deliverables
- **`contract.ts`** — typed `WorkloadOperation` / `WorkloadContractOutput`, explicit `WorkloadErrorCode` values, a `WorkloadResult<T>` discriminated union, and `validateBalanceInput`. Wraps the existing synchronous `balanceWorkload`.
- **`index.ts`** — `createWorkloadContract()` returns a `WorkloadContract` whose `execute()` returns typed success/error results instead of throwing.
- **`contract.fixtures.ts`** — deterministic sample members/items.
- **`tests/contract.test.ts`** — vitest coverage of delegation to `balanceWorkload`, deterministic strategies (round-robin / least-loaded), and invalid-input error paths.
- **`README.md`** — documents the contract and usage.

Non-UI only; existing balancing/UI untouched. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (6 tests).

Fixes #1360