### PR TITLE
Add non-UI execution contract for shared-contact-notes (Fixes #1357)

### DIFF
--- a/tools/v2/team/shared-contact-notes/README.md
+++ b/tools/v2/team/shared-contact-notes/README.md
@@ -54,3 +54,35 @@ immediately but still return Promises, allowing UI layers to always await.
 - No integration with the main application's contact models.
 - The UI layer is self-contained and not wired into the main app shell or routing.
 - No real-time or multi-user collaboration support.
+
+## Non-UI execution contract
+
+The note engine also exposes a presentation-free execution contract so it can
+run as a backend service, independent of any UI.
+
+- `contract.ts` — the typed `NotesOperation` / `NotesContractOutput`, the
+  `NotesResult<T>` discriminated union, explicit `NoteErrorCode` values, and the
+  `createNotesContract(service)` factory. The contract adapts the existing
+  `NoteService` (which throws `ValidationError` / `NoteNotFoundError`) into typed
+  results, so callers never catch exceptions.
+- `contract.fixtures.ts` — representative create inputs (valid, empty content).
+- `tests/contract.test.ts` — vitest coverage of the full lifecycle plus the
+  validation / not-found error paths.
+
+Usage:
+
+```ts
+import { NoteService, createNotesContract } from ".";
+
+const service = new NoteService([], { delayMs: 0 });
+const contract = createNotesContract(service);
+const res = await contract.execute({
+  operation: "create",
+  input: { contactId: "contact-acme", content: "Prefers async updates.", authorId: "user-ada" },
+});
+if (res.ok && res.value.operation === "create") {
+  // res.value.note has the persisted note
+} else {
+  // res.error is a NoteErrorCode
+}
+```

--- a/tools/v2/team/shared-contact-notes/contract.fixtures.ts
+++ b/tools/v2/team/shared-contact-notes/contract.fixtures.ts
@@ -1,0 +1,22 @@
+/**
+ * contract.fixtures.ts — Shared Contact Notes (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { CreateNoteInput } from "./types";
+
+/** A valid note creation input. */
+export const VALID_CREATE_INPUT: CreateNoteInput = {
+  contactId: "contact-acme",
+  content: "Champion wants weekly digest, prefers async updates.",
+  authorId: "user-ada",
+};
+
+/** A creation input missing content (should fail validation). */
+export const INVALID_CREATE_INPUT: CreateNoteInput = {
+  contactId: "contact-acme",
+  content: "   ",
+  authorId: "user-ada",
+};

--- a/tools/v2/team/shared-contact-notes/contract.ts
+++ b/tools/v2/team/shared-contact-notes/contract.ts
@@ -1,0 +1,121 @@
+/**
+ * contract.ts — Shared Contact Notes (non-UI execution contract)
+ *
+ * Backend-facing execution contract for shared notes on a contact. It is
+ * presentation-free: no React, no DOM. Operations return a typed
+ * `NotesResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ *
+ * The underlying stateful logic already exists in `./service` (`NoteService`,
+ * which throws `ValidationError` / `NoteNotFoundError`); this contract wraps it
+ * so callers receive typed results rather than catching exceptions.
+ */
+
+import { NoteService } from "./service";
+import { NoteNotFoundError, ValidationError } from "./errors";
+import type { ContactId, CreateNoteInput, Note, NoteId, UpdateNoteInput } from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum NoteErrorCode {
+  /** Input failed validation (missing/empty fields). */
+  InvalidInput = "INVALID_INPUT",
+  /** The referenced note was not found. */
+  NoteNotFound = "NOTE_NOT_FOUND",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type NotesResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: NoteErrorCode; message: string };
+
+/** Operations supported by the notes contract. */
+export type NotesOperation =
+  | { operation: "create"; input: CreateNoteInput }
+  | { operation: "getByContact"; contactId: ContactId }
+  | { operation: "getById"; id: NoteId }
+  | { operation: "update"; id: NoteId; input: UpdateNoteInput }
+  | { operation: "delete"; id: NoteId }
+  | { operation: "archive"; id: NoteId };
+
+/** Output produced by the contract, keyed by operation. */
+export type NotesContractOutput =
+  | { operation: "create"; note: Note }
+  | { operation: "getByContact"; notes: Note[] }
+  | { operation: "getById"; note: Note }
+  | { operation: "update"; note: Note }
+  | { operation: "delete"; deletedId: NoteId }
+  | { operation: "archive"; note: Note };
+
+/** Backend-facing entry point for shared contact notes. */
+export interface NotesContract {
+  execute(input: NotesOperation): Promise<NotesResult<NotesContractOutput>>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): NotesResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: NoteErrorCode, message: string): NotesResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Map a thrown service error to a typed contract result. */
+function toResult<T>(err: unknown): NotesResult<T> {
+  if (err instanceof ValidationError) {
+    return fail(NoteErrorCode.InvalidInput, err.message);
+  }
+  if (err instanceof NoteNotFoundError) {
+    return fail(NoteErrorCode.NoteNotFound, err.message);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return fail(NoteErrorCode.InvalidInput, message);
+}
+
+/**
+ * Build the notes execution contract from a `NoteService` instance.
+ *
+ * The contract adapts the service's throwing methods into typed results, so
+ * callers never catch exceptions. The service owns all state.
+ */
+export function createNotesContract(service: NoteService): NotesContract {
+  return {
+    async execute(input: NotesOperation): Promise<NotesResult<NotesContractOutput>> {
+      try {
+        switch (input.operation) {
+          case "create": {
+            const note = await service.create(input.input);
+            return ok({ operation: "create", note });
+          }
+          case "getByContact": {
+            const notes = await service.getByContact(input.contactId);
+            return ok({ operation: "getByContact", notes });
+          }
+          case "getById": {
+            const note = await service.getById(input.id);
+            return ok({ operation: "getById", note });
+          }
+          case "update": {
+            const note = await service.update(input.id, input.input);
+            return ok({ operation: "update", note });
+          }
+          case "delete": {
+            await service.delete(input.id);
+            return ok({ operation: "delete", deletedId: input.id });
+          }
+          case "archive": {
+            const note = await service.archive(input.id);
+            return ok({ operation: "archive", note });
+          }
+          default: {
+            const _never: never = input;
+            return fail(NoteErrorCode.InvalidInput, `Unknown operation: ${JSON.stringify(_never)}`);
+          }
+        }
+      } catch (err) {
+        return toResult(err);
+      }
+    },
+  };
+}

--- a/tools/v2/team/shared-contact-notes/index.ts
+++ b/tools/v2/team/shared-contact-notes/index.ts
@@ -12,6 +12,11 @@ export type {
 } from "./types";
 export { validateCreateNote, validateUpdateNote } from "./validation";
 
+// Non-UI execution contract
+export { createNotesContract } from "./contract";
+export { NoteErrorCode, ok, fail } from "./contract";
+export type { NotesContract, NotesOperation, NotesContractOutput, NotesResult } from "./contract";
+
 // Hook
 export { useContactNotes } from "./hooks/useContactNotes";
 

--- a/tools/v2/team/shared-contact-notes/tests/contract.test.ts
+++ b/tools/v2/team/shared-contact-notes/tests/contract.test.ts
@@ -1,0 +1,127 @@
+/**
+ * contract.test.ts — Shared Contact Notes (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, the full
+ * create -> get -> update -> archive -> delete lifecycle, and the edge/error
+ * paths (validation, unknown note). No UI is exercised. The underlying
+ * NoteService is synchronous (delayMs: 0) and in-memory.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { NoteService } from "../service";
+import { createNotesContract } from "../contract";
+import { NoteErrorCode, ok, fail, type NotesResult, type NotesContractOutput } from "../contract";
+import { VALID_CREATE_INPUT, INVALID_CREATE_INPUT } from "../contract.fixtures";
+
+function makeContract() {
+  const service = new NoteService([], { delayMs: 0 });
+  return createNotesContract(service);
+}
+
+describe("notes contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(NoteErrorCode.NoteNotFound, "missing");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(NoteErrorCode.NoteNotFound);
+      expect(r.message).toBe("missing");
+    }
+  });
+});
+
+describe("notes contract — lifecycle", () => {
+  let contract: ReturnType<typeof makeContract>;
+  beforeEach(() => {
+    contract = makeContract();
+  });
+
+  it("create returns a new note with a generated id", async () => {
+    const res = await contract.execute({ operation: "create", input: VALID_CREATE_INPUT });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "create") {
+      expect(res.value.note.id).toBeTruthy();
+      expect(res.value.note.contactId).toBe("contact-acme");
+      expect(res.value.note.archivedAt).toBeNull();
+    }
+  });
+
+  it("getByContact returns notes for a contact", async () => {
+    const created = await contract.execute({ operation: "create", input: VALID_CREATE_INPUT });
+    const id = created.ok && created.value.operation === "create" ? created.value.note.id : "";
+    const res = await contract.execute({ operation: "getById", id });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "getById") {
+      expect(res.value.note.id).toBe(id);
+    }
+    const byContact = await contract.execute({
+      operation: "getByContact",
+      contactId: "contact-acme",
+    });
+    if (byContact.ok && byContact.value.operation === "getByContact") {
+      expect(byContact.value.notes.length).toBe(1);
+    }
+  });
+
+  it("update changes content and bumps updatedAt", async () => {
+    const created = await contract.execute({ operation: "create", input: VALID_CREATE_INPUT });
+    const id = created.ok && created.value.operation === "create" ? created.value.note.id : "";
+    const res = await contract.execute({
+      operation: "update",
+      id,
+      input: { content: "Updated: prefers Slack over email." },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "update") {
+      expect(res.value.note.content).toBe("Updated: prefers Slack over email.");
+    }
+  });
+
+  it("archive sets archivedAt", async () => {
+    const created = await contract.execute({ operation: "create", input: VALID_CREATE_INPUT });
+    const id = created.ok && created.value.operation === "create" ? created.value.note.id : "";
+    const res = await contract.execute({ operation: "archive", id });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "archive") {
+      expect(res.value.note.archivedAt).not.toBeNull();
+    }
+  });
+
+  it("delete removes a note (reports deletedId)", async () => {
+    const created = await contract.execute({ operation: "create", input: VALID_CREATE_INPUT });
+    const id = created.ok && created.value.operation === "create" ? created.value.note.id : "";
+    const res = await contract.execute({ operation: "delete", id });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "delete") {
+      expect(res.value.deletedId).toBe(id);
+    }
+    const after = await contract.execute({ operation: "getById", id });
+    expect(after.ok).toBe(false);
+  });
+});
+
+describe("notes contract — error handling", () => {
+  it("create rejects empty content (no throw)", async () => {
+    const contract = makeContract();
+    const res: NotesResult<NotesContractOutput> = await contract.execute({
+      operation: "create",
+      input: INVALID_CREATE_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(NoteErrorCode.InvalidInput);
+  });
+
+  it("getById of an unknown note maps to NoteNotFound (no throw)", async () => {
+    const contract = makeContract();
+    const res: NotesResult<NotesContractOutput> = await contract.execute({
+      operation: "getById",
+      id: "note-does-not-exist",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(NoteErrorCode.NoteNotFound);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1357 by adding the shared-contact-notes tool's presentation-free execution contract, so it can run as a backend service independent of any UI. The tool already had a `NoteService` (throwing); this adds the typed contract boundary the issue asks for.

### Deliverables
- **`contract.ts`** — typed `NotesOperation` / `NotesContractOutput`, explicit `NoteErrorCode` values, a `NotesResult<T>` discriminated union, and the `createNotesContract(service)` factory. Adapts `NoteService`'s thrown `ValidationError` / `NoteNotFoundError` into typed results (no exceptions leak to callers).
- **`contract.fixtures.ts`** — representative create inputs (valid, empty content).
- **`tests/contract.test.ts`** — vitest coverage of the full create → get → update → archive → delete lifecycle plus validation / not-found error paths.
- **`index.ts` + `README.md`** — expose and document the contract.

Non-UI only; existing service/UI untouched. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (9 tests).

Fixes #1357