### PR TITLE
docs(mail-to-ticket): define isolated architecture contract

### DIFF
--- a/tools/v2/team/mail-to-ticket-converter/ARCHITECTURE.md
+++ b/tools/v2/team/mail-to-ticket-converter/ARCHITECTURE.md
@@ -1,0 +1,75 @@
+# Mail-to-Ticket Converter Architecture
+
+## Folder Contract
+
+The tool is a self-contained mini-product rooted at
+`tools/v2/team/mail-to-ticket-converter/`. Its planned internal structure is:
+
+```text
+mail-to-ticket-converter/
+|-- components/  # Presentational draft-review UI
+|-- services/    # Pure conversion and validation logic
+|-- hooks/       # Local orchestration between UI and services
+|-- fixtures/    # Sanitized deterministic examples
+|-- tests/       # Folder-local tests and test plans
+|-- docs/        # Ownership and integration constraints
+|-- types/       # Input, output, rule, and error contracts
+|-- index.ts     # Future public entry point for this mini-product
+|-- README.md
+|-- specs.md
+`-- ARCHITECTURE.md
+```
+
+Directories listed here are planned boundaries; this architecture issue does not
+add runtime modules merely to populate them.
+
+## Module Responsibilities
+
+### Types
+
+Owns serializable mail input, conversion rule, ticket draft, warning, and error
+contracts. Types must not depend on React or provider SDKs.
+
+### Services
+
+Owns deterministic normalization, validation, and draft construction. Services
+accept values through typed parameters and must not read application state or make
+network calls.
+
+### Hooks
+
+Owns tool-local UI state and invokes services. Hooks may depend on React, local
+types, and local services. They must not access global contexts or core stores.
+
+### Components
+
+Owns rendering and review interactions. Components consume props or local hooks;
+they do not parse mail, persist data, or call external ticket APIs.
+
+### Fixtures and Tests
+
+Fixtures own sanitized, deterministic samples. Tests verify service contracts,
+invalid inputs, mapping behavior, and component states without live dependencies.
+
+### Docs
+
+Owns architectural decisions, data ownership, integration constraints, and future
+contributor guidance.
+
+## Dependency Direction
+
+```text
+components -> hooks -> services -> types
+tests ---------------------------> local modules
+fixtures ------------------------> tests and demos
+```
+
+Dependencies must flow inward. Services cannot import hooks or components, and no
+module may import from the main application.
+
+## Future Integration Boundary
+
+A future main-app adapter may translate inbox data into the tool's input contract
+and translate an approved draft into a provider request. That adapter must be
+designed in a separate issue and remain outside this folder; it must not cause the
+tool to own inbox, authentication, database, or provider state.

--- a/tools/v2/team/mail-to-ticket-converter/README.md
+++ b/tools/v2/team/mail-to-ticket-converter/README.md
@@ -1,85 +1,26 @@
 # Mail-to-Ticket Converter
 
-Convert incoming emails into trackable support tickets for team triage and resolution.
+Folder-local architecture contract for the V2 Mail-to-Ticket Converter team tool.
+The tool will turn normalized mail data into reviewable ticket drafts, but this
+issue does not implement or integrate that behavior.
 
-## Ownership Boundary
+## Status
 
-All work for this tool must stay inside:
+- Release tier: V2 later-release tool
+- Audience: Team
+- Integration status: Isolated and not mounted in the main application
+- Owned path: `tools/v2/team/mail-to-ticket-converter/`
 
-```
-tools/v2/team/mail-to-ticket-converter/
-```
+## Documents
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+- [Architecture](ARCHITECTURE.md) defines module responsibilities and dependency
+  direction.
+- [Specification](specs.md) defines the future tool contract and non-goals.
+- [Data ownership](docs/data-ownership.md) defines input, derived, and persisted
+  data boundaries.
+- [Integration constraints](docs/integration-constraints.md) defines allowed and
+  forbidden dependencies.
+- [Test plan](tests/test-plan.md) defines future contract-level coverage.
 
-## Tool Workflow
-
-1. View unconverted emails in the **Inbox** tab
-2. Click **Convert** on an email to open the ticket creation form
-3. Adjust subject, description, priority, category, and assignee
-4. Submit to create a ticket — the email is removed from the inbox
-5. View and manage tickets in the **Tickets** tab
-6. Advance ticket status (open → in-progress → resolved → closed)
-7. Assign tickets to team members
-8. View aggregate metrics in the **Metrics** tab
-
-## States
-
-| State   | Appearance                                                                |
-| ------- | ------------------------------------------------------------------------- |
-| Loading | Centered skeleton text with `aria-busy="true"`                            |
-| Empty   | Dashed border container with message (no unconverted emails / no tickets) |
-| Error   | Red-tinted banner with error message and Retry button (`role="alert"`)    |
-| Success | Fully rendered data with interactive controls                             |
-
-## Accessibility
-
-- `role="tablist"`, `role="tab"`, `role="tabpanel"` for tab navigation
-- `role="list"` / `role="listitem"` for lists
-- `role="alert"` for error banners
-- `aria-selected` on active tab
-- `aria-busy` on loading states and submit buttons
-- `aria-label` on all interactive controls
-- `sr-only` labels on select elements
-
-## Visual Style
-
-Components use Tailwind CSS v4 dark-theme tokens from the global design system:
-
-- `--accent`, `--surface-primary`, `--surface-secondary`, `--border-subtle`
-- `--text-primary`, `--text-secondary`, `--text-tertiary`, `--text-muted`
-- Status badges: yellow (open), blue (in-progress), green (resolved), gray (closed)
-- Priority indicators: green (low), yellow (medium), orange (high), red (critical)
-
-## Fixtures
-
-| File                           | Contents                                    |
-| ------------------------------ | ------------------------------------------- |
-| `fixtures/sample-emails.json`  | 5 synthetic emails from external senders    |
-| `fixtures/sample-tickets.json` | 4 pre-converted tickets in various statuses |
-| `fixtures/team-members.json`   | 5 team support members                      |
-
-## Documentation Map
-
-- `specs.md` — Data contracts, in/out-of-scope behavior, required issue categories
-- `docs/test-plan.md` — Automated test coverage and manual review checklist
-- `docs/review-notes.md` — Validated behavior, known limitations, future integration notes
-
-## Tests
-
-Run from repo root:
-
-```bash
-node --test "tools/v2/team/mail-to-ticket-converter/tests/*.test.mjs"
-```
-
-Tests validate fixture integrity and `computeMetrics` business logic using Node's built-in test runner.
-
-## Known Limitations
-
-- No real email fetching — uses local JSON fixtures
-- No database persistence — data is in-memory only
-- No authentication or authorization
-- No search, filter, or pagination
-- No attachment handling beyond the boolean flag
-- Not wired into the main application
+All future work for this tool must remain inside this directory until a separate
+integration issue explicitly authorizes changes elsewhere.

--- a/tools/v2/team/mail-to-ticket-converter/docs/data-ownership.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/data-ownership.md
@@ -1,0 +1,33 @@
+# Data Ownership
+
+## Main Application Owned
+
+- Mailbox and message records
+- Authentication and team membership
+- Attachment content and access authorization
+- Database persistence
+- Ticket-provider credentials and submission status
+
+The tool receives snapshots of required values and never mutates these sources.
+
+## Tool Owned
+
+- Normalized input values created from the provided snapshot
+- Conversion rules supplied to a service invocation
+- In-memory ticket drafts, validation warnings, and review state
+- Sanitized local fixtures used by tests
+
+Tool-owned runtime data is ephemeral until a future integration defines an
+explicit persistence adapter.
+
+## Data Flow
+
+```text
+external adapter -> typed mail snapshot -> conversion service -> ticket draft
+                                                         |
+                                                         `-> warnings/errors
+```
+
+No raw credentials, authentication tokens, or unnecessary message content may be
+stored in fixtures, logs, errors, or analytics. Attachment bytes remain owned by
+the source system; only authorized metadata references may cross the boundary.

--- a/tools/v2/team/mail-to-ticket-converter/docs/integration-constraints.md
+++ b/tools/v2/team/mail-to-ticket-converter/docs/integration-constraints.md
@@ -1,0 +1,27 @@
+# Integration Constraints
+
+## Allowed
+
+- Standard TypeScript and browser APIs
+- React inside future folder-local hooks and components
+- Existing test tooling without changing root configuration
+- Imports between modules inside this tool directory
+- Dependency injection through typed folder-local interfaces
+
+## Forbidden in This Issue
+
+- Main application shell, dashboard, navigation, or routing changes
+- Authentication, wallet, Stellar, inbox, mail-rendering, or database changes
+- Imports from main-app stores, contexts, services, routes, or design-system files
+- Direct network calls to ticket providers
+- Root dependency or build-configuration changes
+- Files changed outside `tools/v2/team/mail-to-ticket-converter/`
+
+## Future Integration
+
+Integration requires a separate issue that defines an adapter owned by the
+consumer. The adapter may map application data to this tool's public contracts,
+but must not expose internal application objects or credentials to local services.
+
+Any proposed cross-boundary import, persistence mechanism, provider SDK, route, or
+global UI registration requires maintainer approval before implementation.

--- a/tools/v2/team/mail-to-ticket-converter/specs.md
+++ b/tools/v2/team/mail-to-ticket-converter/specs.md
@@ -1,112 +1,48 @@
-# Mail-to-Ticket Converter Specs
+# Mail-to-Ticket Converter Specification
 
 ## Purpose
 
-Convert incoming emails into trackable support tickets so team members can triage, assign, prioritize, and resolve issues without leaving the mail tooling ecosystem.
+Convert a normalized email into a ticket draft that a team member can review
+before a future integration submits it to an external ticket system.
 
-## Scope
+## Future Inputs
 
-- Release tier: V2
-- Audience: Team
-- Folder ownership: `tools/v2/team/mail-to-ticket-converter/`
-- Integration status: Isolated — not wired into main app
+- Message identifier and thread identifier
+- Subject and plain-text body
+- Sender and recipient metadata
+- Received timestamp
+- Optional attachments represented as metadata only
+- Team-provided conversion rules and destination project identifier
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+The tool must receive these values through a folder-local typed contract. It must
+not read the main inbox store, authentication context, or database directly.
 
-## In-Scope Behavior
+## Future Outputs
 
-- View a list of unconverted emails from fixtures
-- Create a ticket from an email with adjustable subject, description, priority, category, and optional assignee
-- View a list of tickets with status, priority, assignment, and resolution info
-- Advance ticket status: open → in-progress → resolved → closed (reopenable)
-- Assign tickets to team members via a dropdown
-- View aggregate metrics: total, by status, by priority, by category, average resolution time
-- In-memory state management with loading/empty/error/success states
+- Ticket title and description
+- Source message reference
+- Suggested priority, labels, and assignee identifiers
+- Attachment references without attachment content mutation
+- Validation warnings that require team review
 
-## Out-of-Scope Behavior
+Conversion produces a draft. Creating a ticket in an external system is an
+integration concern and is outside this issue.
 
-- No real email fetching (SMTP/IMAP) — fixture-only
-- No database persistence — ephemeral in-memory data
-- No authentication, authorization, or user identity
-- No notification system for assignments or status changes
-- No search, filter, or pagination
-- No undo for ticket creation
-- No attachment upload or preview
-- No real-time updates or WebSocket
-- No integration with the main mail app inbox, routing, or design system
+## Functional Boundaries
 
-## Data Contract
+The future mini-product may normalize email input, apply deterministic mapping
+rules, produce ticket drafts, expose local review components, and provide local
+fixtures and tests.
 
-```typescript
-type Priority = "low" | "medium" | "high" | "critical";
+It may not send mail, mutate inbox data, create routes, access wallets or Stellar,
+write to the application database, or call a ticket provider directly without a
+separate approved integration issue.
 
-type TicketStatus = "open" | "in-progress" | "resolved" | "closed";
+## Contributor Rules
 
-type TicketCategory = "bug" | "feature-request" | "support" | "billing" | "other";
+Future contributors may add or refine folder-local types, pure conversion logic,
+adapters defined behind local interfaces, local UI components, fixtures, and tests.
 
-interface EmailSender {
-  name: string;
-  email: string;
-}
-
-interface Email {
-  id: string;
-  threadId: string;
-  from: EmailSender;
-  to: EmailSender;
-  subject: string;
-  body: string;
-  receivedAt: string; // ISO 8601
-  hasAttachments: boolean;
-}
-
-interface CreateTicketInput {
-  subject: string;
-  description: string;
-  priority: Priority;
-  category: TicketCategory;
-  assignedTo?: string; // TeamMember.id
-  createdBy: string; // TeamMember.id
-}
-
-interface Ticket {
-  id: string;
-  emailId: string;
-  subject: string;
-  description: string;
-  priority: Priority;
-  status: TicketStatus;
-  category: TicketCategory;
-  assignedTo: string | null;
-  createdBy: string;
-  createdAt: string;
-  updatedAt: string;
-  resolution: string | null;
-}
-
-interface TeamMember {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-}
-
-interface TicketMetrics {
-  totalTickets: number;
-  openTickets: number;
-  inProgressTickets: number;
-  resolvedTickets: number;
-  closedTickets: number;
-  byPriority: Record<Priority, number>;
-  byCategory: Record<TicketCategory, number>;
-  averageResolutionTimeHours: number | null;
-}
-```
-
-## Required Issue Categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+Future contributors may not import main-app features, modify global configuration,
+change routing or navigation, alter the design system, or move ownership of source
+mail data into this tool.

--- a/tools/v2/team/mail-to-ticket-converter/tests/test-plan.md
+++ b/tools/v2/team/mail-to-ticket-converter/tests/test-plan.md
@@ -1,0 +1,16 @@
+# Test Plan
+
+Future implementation issues should add folder-local tests for:
+
+- Valid mail snapshots producing deterministic ticket drafts
+- Missing or malformed required fields returning typed errors
+- Mapping rules for priority, labels, assignees, and destination projects
+- HTML or unsafe content being normalized before draft construction
+- Attachment metadata remaining references rather than copied content
+- Services operating without network, database, inbox, wallet, or Stellar access
+- Hooks exposing loading, success, warning, and error states
+- Components rendering empty, review, and failure states from local contracts
+- Fixtures containing no secrets or real personal mail data
+
+Tests must use local fixtures and mocks. Live mailboxes, ticket systems, wallets,
+Stellar networks, and application databases are outside this tool's test boundary.


### PR DESCRIPTION
## Summary

Defines the folder-local architecture contract for the V2 Mail-to-Ticket Converter team tool.

Closes #619.

## Changes

- Defines boundaries for components, services, hooks, types, fixtures, tests, and docs
- Documents data ownership and lifecycle
- Defines allowed dependencies and integration constraints
- Documents what future contributors may and may not change
- Adds a folder-local test plan
- Replaces corrupted placeholder documentation

## Scope

All changes are limited to:

`tools/v2/team/mail-to-ticket-converter/`

No application shell, routing, inbox, wallet, Stellar, database, authentication, or design-system files were modified.

## Validation

- `git diff --check`
- `bun x prettier --check tools/v2/team/mail-to-ticket-converter`