### PR TITLE
docs(knowledge-base): define isolated architecture contract

### DIFF
--- a/tools/v2/team/knowledge-base-suggestion/ARCHITECTURE.md
+++ b/tools/v2/team/knowledge-base-suggestion/ARCHITECTURE.md
@@ -1,0 +1,77 @@
+# Knowledge Base Suggestion Architecture
+
+## Folder Contract
+
+The tool is a self-contained mini-product rooted at
+`tools/v2/team/knowledge-base-suggestion/`. Its planned internal structure is:
+
+```text
+knowledge-base-suggestion/
+|-- components/  # Presentational suggestion UI
+|-- services/    # Pure filtering and ranking logic
+|-- hooks/       # Local orchestration between UI and services
+|-- fixtures/    # Sanitized deterministic examples
+|-- tests/       # Folder-local tests and test plans
+|-- docs/        # Ownership and integration constraints
+|-- types/       # Context, article, result, and error contracts
+|-- index.ts     # Future public entry point for this mini-product
+|-- README.md
+|-- specs.md
+`-- ARCHITECTURE.md
+```
+
+Directories listed here are planned boundaries; this architecture issue does not
+add runtime modules merely to populate them.
+
+## Module Responsibilities
+
+### Types
+
+Owns serializable mail context, article snapshot, ranking configuration, suggestion,
+and error contracts. Types must not depend on React or provider SDKs.
+
+### Services
+
+Owns deterministic validation, eligibility filtering, scoring, ordering, and match
+explanations. Services accept snapshots through typed parameters and must not read
+application state or make network calls.
+
+### Hooks
+
+Owns tool-local loading and selection state and invokes services. Hooks may depend
+on React, local types, and local services. They must not access global contexts or
+core stores.
+
+### Components
+
+Owns rendering of suggestions, reasons, empty states, and errors. Components
+consume props or local hooks; they do not query article providers or mutate mail.
+
+### Fixtures and Tests
+
+Fixtures own sanitized, deterministic mail contexts and article snapshots. Tests
+verify contracts, filtering, ordering, tie-breaking, and component states without
+live dependencies.
+
+### Docs
+
+Owns architectural decisions, data ownership, integration constraints, and future
+contributor guidance.
+
+## Dependency Direction
+
+```text
+components -> hooks -> services -> types
+tests ---------------------------> local modules
+fixtures ------------------------> tests and demos
+```
+
+Dependencies must flow inward. Services cannot import hooks or components, and no
+module may import from the main application.
+
+## Future Integration Boundary
+
+A future consumer-owned adapter may provide authorized article snapshots and a
+normalized mail context, then display selected suggestions in the main app. That
+adapter requires a separate issue and remains responsible for authentication,
+permissions, provider access, inbox state, and content insertion.

--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,15 +1,26 @@
 # Knowledge Base Suggestion
 
-This folder is the isolated workspace for the Knowledge Base Suggestion tool.
+Folder-local architecture contract for the V2 Knowledge Base Suggestion team tool.
+The tool will rank relevant internal documentation for a normalized mail context,
+but this issue does not implement or integrate that behavior.
 
-## Ownership Boundary
+## Status
 
-All work for this tool must stay inside:
+- Release tier: V2 later-release tool
+- Audience: Team
+- Integration status: Isolated and not mounted in the main application
+- Owned path: `tools/v2/team/knowledge-base-suggestion/`
 
-`text
-.\tools\v2\team\knowledge-base-suggestion\
-`
+## Documents
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+- [Architecture](ARCHITECTURE.md) defines module responsibilities and dependency
+  direction.
+- [Specification](specs.md) defines the future tool contract and non-goals.
+- [Data ownership](docs/data-ownership.md) defines mail, article, and suggestion
+  data boundaries.
+- [Integration constraints](docs/integration-constraints.md) defines allowed and
+  forbidden dependencies.
+- [Test plan](tests/test-plan.md) defines future contract-level coverage.
 
-See specs.md for the issue categories and contributor expectations.
+All future work for this tool must remain inside this directory until a separate
+integration issue explicitly authorizes changes elsewhere.

--- a/tools/v2/team/knowledge-base-suggestion/docs/data-ownership.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/data-ownership.md
@@ -1,0 +1,37 @@
+# Data Ownership
+
+## Main Application or Provider Owned
+
+- Mailbox, message, and thread records
+- Authentication, team membership, and authorization decisions
+- Knowledge-base articles, revisions, visibility rules, and full content
+- Search indexes and database persistence
+- Analytics and user-selection persistence
+
+The tool receives authorized snapshots and never mutates their sources.
+
+## Tool Owned
+
+- Normalized context derived from the provided mail snapshot
+- In-memory candidate eligibility and ranking calculations
+- Suggestion results, match reasons, warnings, and local selection state
+- Sanitized local fixtures used by tests
+
+Tool-owned runtime data is ephemeral until a future integration defines explicit
+consumer-owned persistence.
+
+## Data Flow
+
+```text
+consumer adapter -> mail context + authorized article snapshots
+                                      |
+                                      v
+                           filter and ranking service
+                                      |
+                                      v
+                        suggestions + reasons/warnings
+```
+
+The tool must treat access metadata as a filter, never as proof of authorization.
+It must not retain raw credentials, authentication tokens, full private articles,
+or unnecessary message content in fixtures, logs, errors, or analytics.

--- a/tools/v2/team/knowledge-base-suggestion/docs/integration-constraints.md
+++ b/tools/v2/team/knowledge-base-suggestion/docs/integration-constraints.md
@@ -1,0 +1,28 @@
+# Integration Constraints
+
+## Allowed
+
+- Standard TypeScript and browser APIs
+- React inside future folder-local hooks and components
+- Existing test tooling without changing root configuration
+- Imports between modules inside this tool directory
+- Dependency injection through typed folder-local interfaces
+
+## Forbidden in This Issue
+
+- Main application shell, dashboard, navigation, or routing changes
+- Authentication, wallet, Stellar, inbox, mail-rendering, or database changes
+- Imports from main-app stores, contexts, services, routes, or design-system files
+- Direct network calls to knowledge-base or search providers
+- Root dependency or build-configuration changes
+- Files changed outside `tools/v2/team/knowledge-base-suggestion/`
+
+## Future Integration
+
+Integration requires a separate issue that defines an adapter owned by the
+consumer. The adapter must authorize and sanitize candidate article snapshots
+before passing them to this tool and must re-check authorization before opening or
+inserting article content.
+
+Any proposed cross-boundary import, persistence mechanism, provider SDK, route, or
+global UI registration requires maintainer approval before implementation.

--- a/tools/v2/team/knowledge-base-suggestion/specs.md
+++ b/tools/v2/team/knowledge-base-suggestion/specs.md
@@ -1,41 +1,48 @@
-# Knowledge Base Suggestion
-
-Suggest internal documentation.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/team/knowledge-base-suggestion/README.md"
-  @"
-
-# Knowledge Base Suggestion Specs
+# Knowledge Base Suggestion Specification
 
 ## Purpose
 
-Suggest internal documentation.
+Rank internal knowledge-base articles against a normalized email context so a team
+member can review relevant guidance while handling a conversation.
 
-## Contributor boundary
+## Future Inputs
 
-All work for this tool should stay in:
+- Message and thread identifiers
+- Subject and normalized plain-text excerpt
+- Optional team, product, locale, and category context
+- Candidate article snapshots containing identifiers, titles, summaries, tags,
+  locale, revision, and access metadata
+- Team-provided ranking configuration
 
-$dir/
+The tool must receive these values through a folder-local typed contract. It must
+not read the inbox store, authentication context, database, or knowledge-base
+provider directly.
 
-## Required issue categories
+## Future Outputs
 
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+- Ranked article suggestions with stable article identifiers
+- Relevance score and explainable match reasons
+- Article revision and access metadata copied from the input snapshot
+- Validation warnings or a typed no-suggestion result
+
+Outputs are recommendations only. Fetching full article content, enforcing access,
+and inserting content into mail are integration concerns outside this issue.
+
+## Functional Boundaries
+
+The future mini-product may normalize supplied context, filter inaccessible or
+incompatible candidates, rank article snapshots deterministically, expose local
+review components, and provide local fixtures and tests.
+
+It may not mutate mail, index the main database, bypass article permissions, send
+messages, create routes, access wallets or Stellar, or call a knowledge-base
+provider directly without a separate approved integration issue.
+
+## Contributor Rules
+
+Future contributors may add or refine folder-local types, pure ranking logic,
+adapter interfaces, local components, fixtures, and tests.
+
+Future contributors may not import main-app features, modify global configuration,
+change routing or navigation, alter the design system, or move ownership of mail or
+knowledge-base records into this tool.

--- a/tools/v2/team/knowledge-base-suggestion/tests/test-plan.md
+++ b/tools/v2/team/knowledge-base-suggestion/tests/test-plan.md
@@ -1,0 +1,18 @@
+# Test Plan
+
+Future implementation issues should add folder-local tests for:
+
+- Relevant article snapshots producing deterministic ranked suggestions
+- Missing or malformed inputs returning typed errors
+- Visibility, locale, product, and team metadata filtering
+- Stable tie-breaking when candidates receive equal scores
+- Match reasons corresponding to the factors used by ranking
+- Empty candidate sets producing a typed no-suggestion result
+- Services operating without network, database, inbox, wallet, or Stellar access
+- Hooks exposing loading, success, empty, and error states
+- Components rendering suggestions without inserting or mutating mail content
+- Fixtures containing no secrets, private articles, or real personal mail data
+
+Tests must use local fixtures and mocks. Live mailboxes, knowledge-base providers,
+search indexes, wallets, Stellar networks, and application databases are outside
+this tool's test boundary.


### PR DESCRIPTION
## Summary

Defines the folder-local architecture contract for the V2 Knowledge Base Suggestion team tool.

Closes #609.

## Changes

- Defines boundaries for components, services, hooks, types, fixtures, tests, and docs
- Documents ownership of mail context, article snapshots, and suggestions
- Defines deterministic ranking and filtering responsibilities
- Documents integration and dependency constraints
- Defines permitted and forbidden future contributor changes
- Adds a folder-local test plan
- Replaces corrupted placeholder documentation

## Scope

All changes are limited to:

`tools/v2/team/knowledge-base-suggestion/`

No application shell, routing, inbox, wallet, Stellar, database, authentication, or design-system files were modified.

## Validation

- `git diff --check`
- `bun x prettier --check tools/v2/team/knowledge-base-suggestion`