### PR TITLE
Add non-UI execution contract for components (Fixes #1351)

### DIFF
--- a/tools/v2/team/components/README.md
+++ b/tools/v2/team/components/README.md
@@ -1,0 +1,48 @@
+# Components
+
+This folder is the isolated workspace for the Components tool — a
+presentation-free component registry that resolves and validates reusable UI
+components by id, independent of any rendering layer.
+
+## Ownership Boundary
+
+All work for this tool must stay inside:
+`tools/v2/team/components/`
+
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, or design system unless a future integration issue
+explicitly allows it.
+
+## Non-UI execution contract
+
+The component logic exposes a presentation-free execution contract so it can run
+as a backend service, independent of any UI.
+
+- `types.ts` — domain types: `ComponentDefinition`, `ComponentDescriptor`,
+  `ResolveComponentInput`.
+- `contract.ts` — the typed `ComponentOperation` / `ComponentContractOutput`, the
+  `ComponentResult<T>` discriminated union, explicit `ComponentErrorCode` values,
+  a pure `ComponentRegistry`, and `createComponentsContract(defs)`.
+- `services/components.service.ts` — `createComponentsService(defs)` is the
+  service entry point; its `execute(...)` returns typed success/error results
+  instead of throwing.
+- `fixtures.ts` — deterministic sample component definitions (button, modal, a
+  disabled legacy-banner).
+- `tests/contract.test.ts` — vitest coverage of resolve-by-id, prop validation,
+  list, and the unknown-id / unknown-prop / missing-id error paths.
+
+Usage:
+
+```ts
+import { createComponentsService } from ".";
+
+const contract = createComponentsService([
+  { id: "button", name: "Button", props: { label: "string" } },
+]);
+const res = contract.execute({ operation: "resolve", input: { id: "button" } });
+if (res.ok && res.value.operation === "resolve") {
+  // res.value.descriptor has id/name/props/enabled
+} else {
+  // res.error is a ComponentErrorCode
+}
+```

--- a/tools/v2/team/components/contract.ts
+++ b/tools/v2/team/components/contract.ts
@@ -1,0 +1,119 @@
+/**
+ * contract.ts — Components (non-UI execution contract)
+ *
+ * Backend-facing execution contract for a reusable component registry. It is
+ * presentation-free: no React, no DOM. Operations return a typed
+ * `ComponentResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ */
+
+import type { ComponentDefinition, ComponentDescriptor, ResolveComponentInput } from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum ComponentErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+  /** The requested component id was not found in the registry. */
+  ComponentNotFound = "COMPONENT_NOT_FOUND",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type ComponentResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ComponentErrorCode; message: string };
+
+/** Operations supported by the components contract. */
+export type ComponentOperation =
+  | { operation: "resolve"; input: ResolveComponentInput }
+  | { operation: "list" };
+
+/** Output produced by the contract, keyed by operation. */
+export type ComponentContractOutput =
+  | { operation: "resolve"; descriptor: ComponentDescriptor }
+  | { operation: "list"; descriptors: ComponentDescriptor[] };
+
+/** Backend-facing entry point for the components contract. */
+export interface ComponentsContract {
+  execute(input: ComponentOperation): ComponentResult<ComponentContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): ComponentResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: ComponentErrorCode, message: string): ComponentResult<T> {
+  return { ok: false, error, message };
+}
+
+/** A pure registry of components held in memory. */
+export class ComponentRegistry {
+  private readonly defs: Map<string, ComponentDefinition>;
+
+  constructor(defs: ComponentDefinition[] = []) {
+    this.defs = new Map(defs.map((d) => [d.id, d]));
+  }
+
+  resolve(input: ResolveComponentInput): ComponentResult<ComponentDescriptor> {
+    if (!input || typeof input.id !== "string" || input.id.trim() === "") {
+      return fail(ComponentErrorCode.InvalidInput, "id is required");
+    }
+    const def = this.defs.get(input.id);
+    if (!def) {
+      return fail(ComponentErrorCode.ComponentNotFound, `Component not found: ${input.id}`);
+    }
+    if (input.props) {
+      for (const key of Object.keys(input.props)) {
+        if (!(key in def.props)) {
+          return fail(
+            ComponentErrorCode.InvalidInput,
+            `Unknown prop "${key}" for component ${def.id}`,
+          );
+        }
+      }
+    }
+    const descriptor: ComponentDescriptor = {
+      id: def.id,
+      name: def.name,
+      props: def.props,
+      enabled: def.enabled ?? true,
+    };
+    return ok(descriptor);
+  }
+
+  list(): ComponentResult<ComponentDescriptor[]> {
+    const descriptors: ComponentDescriptor[] = Array.from(this.defs.values()).map((d) => ({
+      id: d.id,
+      name: d.name,
+      props: d.props,
+      enabled: d.enabled ?? true,
+    }));
+    return ok(descriptors);
+  }
+}
+
+/** Build the components execution contract from a registry of definitions. */
+export function createComponentsContract(defs: ComponentDefinition[] = []): ComponentsContract {
+  const registry = new ComponentRegistry(defs);
+  return {
+    execute(input: ComponentOperation): ComponentResult<ComponentContractOutput> {
+      try {
+        if (input.operation === "resolve") {
+          const res = registry.resolve(input.input);
+          if (!res.ok) return res;
+          return ok({ operation: "resolve", descriptor: res.value });
+        }
+        if (input.operation === "list") {
+          const res = registry.list();
+          if (!res.ok) return res;
+          return ok({ operation: "list", descriptors: res.value });
+        }
+        return fail(ComponentErrorCode.InvalidInput, `Unknown operation: ${JSON.stringify(input)}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(ComponentErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/components/fixtures.ts
+++ b/tools/v2/team/components/fixtures.ts
@@ -1,0 +1,30 @@
+/**
+ * fixtures.ts — Components (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { ComponentDefinition } from "./types";
+
+/** A small deterministic component registry. */
+export const COMPONENT_DEFINITIONS: ComponentDefinition[] = [
+  {
+    id: "button",
+    name: "Button",
+    props: { label: "string", variant: "string", disabled: "boolean" },
+    enabled: true,
+  },
+  {
+    id: "modal",
+    name: "Modal",
+    props: { title: "string", open: "boolean" },
+    enabled: true,
+  },
+  {
+    id: "legacy-banner",
+    name: "Legacy Banner",
+    props: { message: "string" },
+    enabled: false,
+  },
+];

--- a/tools/v2/team/components/index.ts
+++ b/tools/v2/team/components/index.ts
@@ -1,0 +1,28 @@
+/**
+ * index.ts — Components
+ *
+ * Folder-local API surface. Exports the non-UI execution contract, its types,
+ * and the service factory. Nothing here imports from the main app.
+ */
+
+// Types
+export type { ComponentDescriptor, ComponentDefinition, ResolveComponentInput } from "./types";
+
+// Contract + service
+export { createComponentsService } from "./services/components.service";
+export {
+  createComponentsContract,
+  ComponentRegistry,
+  ComponentErrorCode,
+  ok,
+  fail,
+} from "./contract";
+export type {
+  ComponentsContract,
+  ComponentOperation,
+  ComponentContractOutput,
+  ComponentResult,
+} from "./contract";
+
+// Fixtures
+export { COMPONENT_DEFINITIONS } from "./fixtures";

--- a/tools/v2/team/components/services/components.service.ts
+++ b/tools/v2/team/components/services/components.service.ts
@@ -1,0 +1,15 @@
+/**
+ * components.service.ts — Components (non-UI service)
+ *
+ * Presentation-free service boundary for the components contract. Wraps the
+ * pure `ComponentRegistry` / `createComponentsContract` reducer into a single
+ * factory entry point.
+ */
+
+import { createComponentsContract, type ComponentsContract } from "../contract";
+import type { ComponentDefinition } from "../types";
+
+/** Build the components execution contract (service entry point). */
+export function createComponentsService(defs: ComponentDefinition[] = []): ComponentsContract {
+  return createComponentsContract(defs);
+}

--- a/tools/v2/team/components/tests/contract.test.ts
+++ b/tools/v2/team/components/tests/contract.test.ts
@@ -1,0 +1,101 @@
+/**
+ * contract.test.ts — Components (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, resolve by id,
+ * prop validation, list, and the edge/error paths (unknown id, unknown prop).
+ * No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createComponentsContract } from "../contract";
+import {
+  ComponentErrorCode,
+  ok,
+  fail,
+  type ComponentResult,
+  type ComponentContractOutput,
+} from "../contract";
+import { COMPONENT_DEFINITIONS } from "../fixtures";
+
+function makeContract() {
+  return createComponentsContract(COMPONENT_DEFINITIONS);
+}
+
+describe("components contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    const r = ok("v");
+    expect(r).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(ComponentErrorCode.ComponentNotFound, "missing");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(ComponentErrorCode.ComponentNotFound);
+      expect(r.message).toBe("missing");
+    }
+  });
+});
+
+describe("components contract — resolve", () => {
+  it("resolves a known component into a descriptor", () => {
+    const contract = makeContract();
+    const res = contract.execute({ operation: "resolve", input: { id: "button" } });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "resolve") {
+      expect(res.value.descriptor.id).toBe("button");
+      expect(res.value.descriptor.name).toBe("Button");
+      expect(res.value.descriptor.props.label).toBe("string");
+    }
+  });
+
+  it("reports disabled components (enabled:false)", () => {
+    const contract = makeContract();
+    const res = contract.execute({ operation: "resolve", input: { id: "legacy-banner" } });
+    if (res.ok && res.value.operation === "resolve") {
+      expect(res.value.descriptor.enabled).toBe(false);
+    }
+  });
+
+  it("rejects an unknown component id (no throw)", () => {
+    const contract = makeContract();
+    const res: ComponentResult<ComponentContractOutput> = contract.execute({
+      operation: "resolve",
+      input: { id: "does-not-exist" },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ComponentErrorCode.ComponentNotFound);
+  });
+
+  it("rejects an unknown prop on a known component (no throw)", () => {
+    const contract = makeContract();
+    const res: ComponentResult<ComponentContractOutput> = contract.execute({
+      operation: "resolve",
+      input: { id: "button", props: { notAProp: 1 } },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ComponentErrorCode.InvalidInput);
+  });
+
+  it("rejects a missing id (no throw)", () => {
+    const contract = makeContract();
+    const res: ComponentResult<ComponentContractOutput> = contract.execute({
+      operation: "resolve",
+      input: { id: "  " },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ComponentErrorCode.InvalidInput);
+  });
+});
+
+describe("components contract — list", () => {
+  it("lists all registered components", () => {
+    const contract = makeContract();
+    const res = contract.execute({ operation: "list" });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "list") {
+      const ids = res.value.descriptors.map((d) => d.id).sort();
+      expect(ids).toEqual(["button", "legacy-banner", "modal"]);
+    }
+  });
+});

--- a/tools/v2/team/components/types.ts
+++ b/tools/v2/team/components/types.ts
@@ -1,0 +1,34 @@
+/**
+ * types.ts — Components (non-UI execution contract)
+ *
+ * Domain types for a reusable component registry. No imports from the main app;
+ * presentation-free.
+ */
+
+/** A normalized component descriptor returned by the contract. */
+export interface ComponentDescriptor {
+  /** Stable component id. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Declared props (name -> type). */
+  props: Record<string, string>;
+  /** Whether the component is enabled/available. */
+  enabled: boolean;
+}
+
+/** Input for resolving a component by id. */
+export interface ResolveComponentInput {
+  /** Component id to resolve. */
+  id: string;
+  /** Optional prop overrides to validate/merge (name -> value). */
+  props?: Record<string, unknown>;
+}
+
+/** A registered component definition (the registry entry). */
+export interface ComponentDefinition {
+  id: string;
+  name: string;
+  props: Record<string, string>;
+  enabled?: boolean;
+}


### PR DESCRIPTION
## Summary

Implements #1351 by adding the components tool's presentation-free execution contract: a reusable component registry that resolves and validates components by id, independent of any rendering layer. Built from scratch (folder was empty).

### Deliverables
- **`types.ts`** — domain types (ComponentDefinition, ComponentDescriptor, ResolveComponentInput).
- **`contract.ts`** — typed ComponentOperation / ComponentContractOutput, explicit ComponentErrorCode values, a ComponentResult<T> discriminated union, a pure ComponentRegistry (resolve + list with prop validation), and createComponentsContract(defs).
- **`services/components.service.ts`** — createComponentsService(defs) service entry point whose execute() returns typed success/error results instead of throwing.
- **`fixtures.ts`** — deterministic sample components (button, modal, disabled legacy-banner).
- **`tests/contract.test.ts`** — vitest coverage of resolve-by-id, prop validation, list, and unknown-id / unknown-prop / missing-id error paths.
- **`README.md`** — documents the contract and usage.

Non-UI only. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (8 tests).

Fixes #1351