### PR TITLE
Add non-UI execution contract for knowledge-base-suggestion (Fixes #1341)

### DIFF
--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,15 +1,48 @@
 # Knowledge Base Suggestion
 
-This folder is the isolated workspace for the Knowledge Base Suggestion tool.
+This folder is the isolated workspace for the Knowledge Base Suggestion tool — a
+presentation-free service that matches a query to internal documentation
+articles and ranks them by relevance.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
+`tools/v2/team/knowledge-base-suggestion/`
 
-`text
-.\tools\v2\team\knowledge-base-suggestion\
-`
+Do not wire this tool into the main app, routing, inbox architecture, wallet
+core, Stellar core, or design system unless a future integration issue
+explicitly allows it.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+## Non-UI execution contract
 
-See specs.md for the issue categories and contributor expectations.
+The suggestion logic exposes a presentation-free execution contract so it can
+run as a backend service, independent of any UI.
+
+- `types.ts` — domain types: `KbArticle`, `KbSuggestion`, `SuggestInput`.
+- `contract.ts` — the typed `KbOperation` / `KbContractOutput`, the `KbResult<T>`
+  discriminated union, explicit `KbErrorCode` values, the pure `suggestKb`
+  reducer (tag-overlap + title-keyword scoring, deterministic ranking), and
+  `validateSuggest`.
+- `services/kb-suggestion.service.ts` — `createKbSuggestionService()` returns a
+  `KbContract` whose `execute(query, corpus)` returns typed success/error
+  results (including the `NO_MATCH` case) instead of throwing.
+- `fixtures.ts` — deterministic sample articles.
+- `tests/contract.test.ts` — vitest coverage of ranking, limit, and the
+  empty-query / no-match / invalid-corpus error paths.
+
+Usage:
+
+```ts
+import { createKbSuggestionService } from ".";
+
+const contract = createKbSuggestionService();
+const res = contract.execute(
+  { operation: "suggest", input: { query: "invoice billing" } },
+  corpus,
+);
+if (res.ok && res.value.operation === "suggest") {
+  // res.value.suggestions is ranked by relevance
+} else {
+  // res.error is a KbErrorCode
+}
+```

--- a/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/tools/v2/team/knowledge-base-suggestion/README.md
@@ -36,10 +36,7 @@ Usage:
 import { createKbSuggestionService } from ".";
 
 const contract = createKbSuggestionService();
-const res = contract.execute(
-  { operation: "suggest", input: { query: "invoice billing" } },
-  corpus,
-);
+const res = contract.execute({ operation: "suggest", input: { query: "invoice billing" } }, corpus);
 if (res.ok && res.value.operation === "suggest") {
   // res.value.suggestions is ranked by relevance
 } else {

--- a/tools/v2/team/knowledge-base-suggestion/contract.ts
+++ b/tools/v2/team/knowledge-base-suggestion/contract.ts
@@ -1,0 +1,93 @@
+/**
+ * contract.ts — Knowledge Base Suggestion (non-UI execution contract)
+ *
+ * Backend-facing execution contract for suggesting internal documentation.
+ * It is presentation-free: no React, no DOM. Operations return a typed
+ * `KbResult<T>` discriminated union with explicit error codes instead of
+ * throwing.
+ */
+
+import type { KbArticle, KbSuggestion, SuggestInput } from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum KbErrorCode {
+  /** The query was missing/empty or the corpus was invalid. */
+  InvalidInput = "INVALID_INPUT",
+  /** No articles matched the query. */
+  NoMatch = "NO_MATCH",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type KbResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: KbErrorCode; message: string };
+
+/** Operations supported by the KB suggestion contract. */
+export type KbOperation = { operation: "suggest"; input: SuggestInput };
+
+/** Output produced by the contract, keyed by operation. */
+export type KbContractOutput = {
+  operation: "suggest";
+  suggestions: KbSuggestion[];
+};
+
+/** Backend-facing entry point for KB suggestions. */
+export interface KbContract {
+  execute(input: KbOperation, corpus: KbArticle[]): KbResult<KbContractOutput>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): KbResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: KbErrorCode, message: string): KbResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Tokenize a query into lowercase alphanumeric terms. */
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Pure relevance scoring. Scores each article by:
+ *  - tag overlap with the query tokens (+2 per matched tag)
+ *  - title keyword hits (+1 per query token found in the title)
+ * Returns suggestions sorted by score desc, capped at `limit`.
+ * Deterministic given the same inputs.
+ */
+export function suggestKb(query: string, corpus: KbArticle[], limit = 5): KbSuggestion[] {
+  const terms = tokenize(query);
+  const scored: KbSuggestion[] = [];
+  for (const article of corpus) {
+    let score = 0;
+    const titleLower = article.title.toLowerCase();
+    for (const term of terms) {
+      if (article.tags.some((t) => t.toLowerCase() === term)) score += 2;
+      if (titleLower.includes(term)) score += 1;
+    }
+    if (score > 0) {
+      scored.push({
+        articleId: article.id,
+        title: article.title,
+        summary: article.summary,
+        score,
+      });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+  return scored.slice(0, limit);
+}
+
+/** Validate inputs before scoring. */
+export function validateSuggest(input: SuggestInput, corpus: KbArticle[]): string | null {
+  if (!Array.isArray(corpus)) return "corpus must be an array";
+  if (!input || typeof input.query !== "string" || input.query.trim().length === 0)
+    return "query is required";
+  return null;
+}

--- a/tools/v2/team/knowledge-base-suggestion/fixtures.ts
+++ b/tools/v2/team/knowledge-base-suggestion/fixtures.ts
@@ -1,0 +1,30 @@
+/**
+ * fixtures.ts — Knowledge Base Suggestion (execution contract fixtures)
+ *
+ * Deterministic local fixtures used by the contract tests and as documentation
+ * of the contract shape.
+ */
+
+import type { KbArticle } from "./types";
+
+/** A small deterministic KB corpus. */
+export const KB_ARTICLES: KbArticle[] = [
+  {
+    id: "kb-onboarding",
+    title: "Team Onboarding Checklist",
+    tags: ["onboarding", "getting-started", "team"],
+    summary: "Steps for ramping new team members.",
+  },
+  {
+    id: "kb-billing",
+    title: "Billing and Invoices FAQ",
+    tags: ["billing", "invoices", "finance"],
+    summary: "How to read invoices and handle disputes.",
+  },
+  {
+    id: "kb-security",
+    title: "Security Incident Response",
+    tags: ["security", "incident", "runbook"],
+    summary: "What to do during a security incident.",
+  },
+];

--- a/tools/v2/team/knowledge-base-suggestion/index.ts
+++ b/tools/v2/team/knowledge-base-suggestion/index.ts
@@ -1,0 +1,17 @@
+/**
+ * index.ts — Knowledge Base Suggestion
+ *
+ * Folder-local API surface. Exports the non-UI execution contract, its types,
+ * and the service factory. Nothing here imports from the main app.
+ */
+
+// Types
+export type { KbArticle, KbSuggestion, SuggestInput } from "./types";
+
+// Contract + service
+export { createKbSuggestionService } from "./services/kb-suggestion.service";
+export { KbErrorCode, suggestKb, tokenize, validateSuggest, ok, fail } from "./contract";
+export type { KbContract, KbOperation, KbContractOutput, KbResult } from "./contract";
+
+// Fixtures
+export { KB_ARTICLES } from "./fixtures";

--- a/tools/v2/team/knowledge-base-suggestion/services/kb-suggestion.service.ts
+++ b/tools/v2/team/knowledge-base-suggestion/services/kb-suggestion.service.ts
@@ -1,0 +1,43 @@
+/**
+ * kb-suggestion.service.ts — Knowledge Base Suggestion (non-UI service)
+ *
+ * Presentation-free service boundary for the KB suggestion contract. Wraps the
+ * pure `suggestKb` reducer into a `KbContract` whose `execute(...)` returns
+ * typed success/error results (including the NO_MATCH case) instead of throwing.
+ */
+
+import {
+  KbErrorCode,
+  ok,
+  type KbContract,
+  type KbOperation,
+  type KbContractOutput,
+  type KbResult,
+  suggestKb,
+  validateSuggest,
+  fail,
+} from "../contract";
+import type { KbArticle } from "../types";
+
+/** Build the KB suggestion execution contract. */
+export function createKbSuggestionService(): KbContract {
+  return {
+    execute(input: KbOperation, corpus: KbArticle[]): KbResult<KbContractOutput> {
+      try {
+        if (input.operation !== "suggest") {
+          return fail(KbErrorCode.InvalidInput, `Unknown operation: ${input.operation}`);
+        }
+        const err = validateSuggest(input.input, corpus);
+        if (err) return fail(KbErrorCode.InvalidInput, err);
+        const suggestions = suggestKb(input.input.query, corpus, input.input.limit ?? 5);
+        if (suggestions.length === 0) {
+          return fail(KbErrorCode.NoMatch, "No matching articles found");
+        }
+        return ok({ operation: "suggest", suggestions });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return fail(KbErrorCode.InvalidInput, message);
+      }
+    },
+  };
+}

--- a/tools/v2/team/knowledge-base-suggestion/tests/contract.test.ts
+++ b/tools/v2/team/knowledge-base-suggestion/tests/contract.test.ts
@@ -1,0 +1,77 @@
+/**
+ * contract.test.ts — Knowledge Base Suggestion (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs, relevance
+ * scoring/ranking, limit, and the edge/error paths (empty query, no match,
+ * invalid corpus). No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createKbSuggestionService } from "../services/kb-suggestion.service";
+import { KbErrorCode, ok, fail, type KbResult, type KbContractOutput } from "../contract";
+import { KB_ARTICLES } from "../fixtures";
+
+function makeContract() {
+  return createKbSuggestionService();
+}
+
+describe("kb contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    expect(ok("v")).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(KbErrorCode.NoMatch, "none");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(KbErrorCode.NoMatch);
+      expect(r.message).toBe("none");
+    }
+  });
+});
+
+describe("kb contract — suggest", () => {
+  it("ranks billing query to the billing article", () => {
+    const contract = makeContract();
+    const res = contract.execute(
+      { operation: "suggest", input: { query: "invoice billing" } },
+      KB_ARTICLES,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "suggest") {
+      expect(res.value.suggestions[0].articleId).toBe("kb-billing");
+      expect(res.value.suggestions[0].score).toBeGreaterThan(0);
+    }
+  });
+
+  it("respects the limit", () => {
+    const contract = makeContract();
+    const res = contract.execute(
+      { operation: "suggest", input: { query: "team security billing onboarding", limit: 1 } },
+      KB_ARTICLES,
+    );
+    if (res.ok && res.value.operation === "suggest") {
+      expect(res.value.suggestions.length).toBe(1);
+    }
+  });
+
+  it("returns NoMatch for an unrelated query (no throw)", () => {
+    const contract = makeContract();
+    const res: KbResult<KbContractOutput> = contract.execute(
+      { operation: "suggest", input: { query: "quantum banana spaceship" } },
+      KB_ARTICLES,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(KbErrorCode.NoMatch);
+  });
+
+  it("rejects an empty query (no throw)", () => {
+    const contract = makeContract();
+    const res: KbResult<KbContractOutput> = contract.execute(
+      { operation: "suggest", input: { query: "   " } },
+      KB_ARTICLES,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(KbErrorCode.InvalidInput);
+  });
+});

--- a/tools/v2/team/knowledge-base-suggestion/types.ts
+++ b/tools/v2/team/knowledge-base-suggestion/types.ts
@@ -1,0 +1,33 @@
+/**
+ * types.ts — Knowledge Base Suggestion (non-UI execution contract)
+ *
+ * Domain types for suggesting internal documentation articles. No imports from
+ * the main app; presentation-free.
+ */
+
+/** A knowledge base article. */
+export interface KbArticle {
+  id: string;
+  title: string;
+  /** Tags used for relevance matching. */
+  tags: string[];
+  /** Short summary shown to the user. */
+  summary?: string;
+}
+
+/** A ranked suggestion. */
+export interface KbSuggestion {
+  articleId: string;
+  title: string;
+  summary?: string;
+  /** Relevance score (higher = better). */
+  score: number;
+}
+
+/** Input for suggesting KB articles. */
+export interface SuggestInput {
+  /** Free-text query to match against the corpus. */
+  query: string;
+  /** Maximum number of suggestions to return. */
+  limit?: number;
+}


### PR DESCRIPTION
## Summary

Implements #1341 by adding the knowledge-base-suggestion tool's presentation-free execution contract: matches a query to internal docs and ranks by relevance. Built from scratch (folder had only README/specs).

### Deliverables
- **`types.ts`** — domain types (KbArticle, KbSuggestion, SuggestInput).
- **`contract.ts`** — typed KbOperation / KbContractOutput, explicit KbErrorCode values, a KbResult<T> discriminated union, the pure suggestKb reducer (tag-overlap + title-keyword scoring, deterministic ranking), and validateSuggest.
- **`services/kb-suggestion.service.ts`** — createKbSuggestionService() returns a KbContract whose execute(query, corpus) returns typed success/error results (including the NO_MATCH case) instead of throwing.
- **`fixtures.ts`** — deterministic sample articles.
- **`tests/contract.test.ts`** — vitest coverage of ranking, limit, and empty-query / no-match / invalid-corpus error paths.
- **`README.md`** — documents the contract and usage.

Non-UI only. Scoped prettier, eslint, `tsc --noEmit` and vitest all pass (6 tests).

Fixes #1341