### PR TITLE
Implement non-UI execution contract for audit-log-viewer (#1335)

### DIFF
--- a/tools/v2/team/audit-log-viewer/contract.ts
+++ b/tools/v2/team/audit-log-viewer/contract.ts
@@ -1,0 +1,154 @@
+/**
+ * contract.ts — Audit Log Viewer (non-UI execution contract)
+ *
+ * Backend-facing execution contract for viewing administrative audit log
+ * entries. Presentation-free: no React, no DOM. Read-only — this tool views
+ * an existing audit trail, it does not write to it. Operations return a
+ * typed `AuditResult<T>` discriminated union with explicit error codes
+ * instead of throwing.
+ */
+
+import type {
+  AuditLogEntry,
+  AuditLogFilters,
+  GetEntryInput,
+  ListEntriesInput,
+  ListEntriesOutput,
+} from "./types";
+
+/** Explicit, machine-readable error codes for contract operations. */
+export enum AuditErrorCode {
+  /** A required field was missing or failed validation. */
+  InvalidInput = "INVALID_INPUT",
+  /** The referenced audit log entry was not found. */
+  EntryNotFound = "ENTRY_NOT_FOUND",
+}
+
+/** Discriminated outcome returned by every contract operation. */
+export type AuditResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: AuditErrorCode; message: string };
+
+/** Operations supported by the audit log viewer contract. */
+export type AuditOperation =
+  | { operation: "listEntries"; input: ListEntriesInput }
+  | { operation: "getEntry"; input: GetEntryInput };
+
+/** Output produced by the contract, keyed by operation. */
+export type AuditContractOutput =
+  | { operation: "listEntries"; result: ListEntriesOutput }
+  | { operation: "getEntry"; entry: AuditLogEntry };
+
+/** Backend-facing entry point for the audit log viewer. */
+export interface AuditContract {
+  execute(op: AuditOperation): Promise<AuditResult<AuditContractOutput>>;
+}
+
+/** Typed success outcome. */
+export function ok<T>(value: T): AuditResult<T> {
+  return { ok: true, value };
+}
+
+/** Typed error outcome. */
+export function fail<T = never>(error: AuditErrorCode, message: string): AuditResult<T> {
+  return { ok: false, error, message };
+}
+
+/** Max entries a single listEntries call may return in one pass. */
+export const MAX_PAGE_SIZE = 200;
+
+/** Validate a listEntries operation's input. Returns a message or null. */
+export function validateListEntriesInput(input: ListEntriesInput): string | null {
+  if (input.limit !== undefined && (input.limit <= 0 || !Number.isInteger(input.limit))) {
+    return "limit must be a positive integer";
+  }
+  if (input.limit !== undefined && input.limit > MAX_PAGE_SIZE) {
+    return `limit exceeds max page size of ${MAX_PAGE_SIZE}`;
+  }
+  if (input.offset !== undefined && (input.offset < 0 || !Number.isInteger(input.offset))) {
+    return "offset must be a non-negative integer";
+  }
+  if (input.filters?.from && Number.isNaN(Date.parse(input.filters.from))) {
+    return "filters.from must be a valid ISO-8601 timestamp";
+  }
+  if (input.filters?.to && Number.isNaN(Date.parse(input.filters.to))) {
+    return "filters.to must be a valid ISO-8601 timestamp";
+  }
+  if (
+    input.filters?.from &&
+    input.filters?.to &&
+    Date.parse(input.filters.from) > Date.parse(input.filters.to)
+  ) {
+    return "filters.from must not be after filters.to";
+  }
+  return null;
+}
+
+/** Validate a getEntry operation's input. Returns a message or null. */
+export function validateGetEntryInput(input: GetEntryInput): string | null {
+  if (!input.entryId || input.entryId.trim() === "") return "entryId is required";
+  return null;
+}
+
+function applyFilters(entries: AuditLogEntry[], filters?: AuditLogFilters): AuditLogEntry[] {
+  if (!filters) return entries;
+  let out = entries;
+  if (filters.actorId) out = out.filter((e) => e.actorId === filters.actorId);
+  if (filters.action) out = out.filter((e) => e.action === filters.action);
+  if (filters.resourceType) out = out.filter((e) => e.resourceType === filters.resourceType);
+  if (filters.severity) out = out.filter((e) => e.severity === filters.severity);
+  if (filters.from) {
+    const from = Date.parse(filters.from);
+    out = out.filter((e) => Date.parse(e.timestamp) >= from);
+  }
+  if (filters.to) {
+    const to = Date.parse(filters.to);
+    out = out.filter((e) => Date.parse(e.timestamp) <= to);
+  }
+  return out;
+}
+
+/**
+ * Pure reducer for the audit log viewer.
+ *
+ * Reads from `entries`; never mutates it. Deterministic given inputs. The
+ * service layer wraps this with real fixtures/delay.
+ */
+export function applyAuditOperation(
+  entries: Map<string, AuditLogEntry>,
+  op: AuditOperation,
+): AuditResult<AuditContractOutput> {
+  switch (op.operation) {
+    case "listEntries": {
+      const err = validateListEntriesInput(op.input);
+      if (err) return fail(AuditErrorCode.InvalidInput, err);
+
+      const all = [...entries.values()].sort(
+        (a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp),
+      );
+      const filtered = applyFilters(all, op.input.filters);
+      const offset = op.input.offset ?? 0;
+      const limit = op.input.limit ?? 50;
+      const page = filtered.slice(offset, offset + limit);
+
+      return ok({
+        operation: "listEntries",
+        result: { entries: page, totalCount: filtered.length },
+      });
+    }
+    case "getEntry": {
+      const err = validateGetEntryInput(op.input);
+      if (err) return fail(AuditErrorCode.InvalidInput, err);
+
+      const entry = entries.get(op.input.entryId);
+      if (!entry) {
+        return fail(AuditErrorCode.EntryNotFound, `AuditLogEntry ${op.input.entryId} not found`);
+      }
+      return ok({ operation: "getEntry", entry });
+    }
+    default: {
+      const _never: never = op;
+      return fail(AuditErrorCode.InvalidInput, `Unknown operation: ${JSON.stringify(_never)}`);
+    }
+  }
+}

--- a/tools/v2/team/audit-log-viewer/fixtures/auditFixtures.ts
+++ b/tools/v2/team/audit-log-viewer/fixtures/auditFixtures.ts
@@ -1,0 +1,50 @@
+import type { AuditLogEntry } from "../types";
+
+export const mockAuditEntries: AuditLogEntry[] = [
+  {
+    id: "log_001",
+    actorId: "usr_100",
+    actorEmail: "admin@example.com",
+    action: "user.role.changed",
+    resourceType: "user",
+    resourceId: "usr_204",
+    timestamp: "2026-06-18T10:00:00Z",
+    severity: "warning",
+    ipAddress: "10.0.0.4",
+  },
+  {
+    id: "log_002",
+    actorId: "usr_100",
+    actorEmail: "admin@example.com",
+    action: "settings.updated",
+    resourceType: "settings",
+    resourceId: "org_1",
+    timestamp: "2026-06-18T11:15:00Z",
+    severity: "info",
+    ipAddress: "10.0.0.4",
+  },
+  {
+    id: "log_003",
+    actorId: "usr_305",
+    actorEmail: "ops@example.com",
+    action: "wallet.key.rotated",
+    resourceType: "wallet",
+    resourceId: "wal_88",
+    timestamp: "2026-06-17T09:45:00Z",
+    severity: "critical",
+    ipAddress: "10.0.0.9",
+  },
+  {
+    id: "log_004",
+    actorId: "usr_204",
+    actorEmail: "member@example.com",
+    action: "login.failed",
+    resourceType: "session",
+    resourceId: "sess_512",
+    timestamp: "2026-06-16T08:00:00Z",
+    severity: "warning",
+    ipAddress: "203.0.113.7",
+  },
+];
+
+export const MOCK_NETWORK_DELAY_MS = 500;

--- a/tools/v2/team/audit-log-viewer/fixtures/contractFixtures.ts
+++ b/tools/v2/team/audit-log-viewer/fixtures/contractFixtures.ts
@@ -1,0 +1,33 @@
+import type { GetEntryInput, ListEntriesInput } from "../types";
+
+// --- Success cases ---------------------------------------------------------
+
+export const VALID_LIST_INPUT: ListEntriesInput = {
+  filters: { severity: "warning" },
+  limit: 10,
+  offset: 0,
+};
+
+export const VALID_GET_ENTRY_INPUT: GetEntryInput = {
+  entryId: "log_001",
+};
+
+// --- Failure cases -----------------------------------------------------------
+
+export const INVALID_LIMIT_LIST_INPUT: ListEntriesInput = {
+  limit: -5,
+};
+
+export const OVERSIZED_LIMIT_LIST_INPUT: ListEntriesInput = {
+  limit: 500, // exceeds MAX_PAGE_SIZE
+};
+
+export const INVALID_DATE_RANGE_LIST_INPUT: ListEntriesInput = {
+  filters: { from: "2026-06-18T00:00:00Z", to: "2026-06-01T00:00:00Z" }, // from after to
+};
+
+export const MISSING_ENTRY_ID_INPUT = { entryId: "" } as GetEntryInput;
+
+export const UNKNOWN_ENTRY_ID_INPUT: GetEntryInput = {
+  entryId: "log_does_not_exist",
+};

--- a/tools/v2/team/audit-log-viewer/index.ts
+++ b/tools/v2/team/audit-log-viewer/index.ts
@@ -1,0 +1,42 @@
+/**
+ * index.ts — Audit Log Viewer
+ *
+ * Folder-local API surface for the non-UI execution contract. Nothing in
+ * this file imports React or touches the DOM.
+ */
+
+// Types
+export type {
+  AuditLogEntry,
+  AuditSeverity,
+  AuditLogFilters,
+  ListEntriesInput,
+  ListEntriesOutput,
+  GetEntryInput,
+} from "./types";
+
+// Contract
+export {
+  AuditErrorCode,
+  applyAuditOperation,
+  validateListEntriesInput,
+  validateGetEntryInput,
+  MAX_PAGE_SIZE,
+  ok,
+  fail,
+} from "./contract";
+export type { AuditContract, AuditOperation, AuditContractOutput, AuditResult } from "./contract";
+
+// Service (concrete, fixture-backed contract implementation)
+export { createAuditLogContract } from "./services/execution.service";
+
+// Fixtures
+export {
+  VALID_LIST_INPUT,
+  VALID_GET_ENTRY_INPUT,
+  INVALID_LIMIT_LIST_INPUT,
+  OVERSIZED_LIMIT_LIST_INPUT,
+  INVALID_DATE_RANGE_LIST_INPUT,
+  MISSING_ENTRY_ID_INPUT,
+  UNKNOWN_ENTRY_ID_INPUT,
+} from "./fixtures/contractFixtures";

--- a/tools/v2/team/audit-log-viewer/services/execution.service.ts
+++ b/tools/v2/team/audit-log-viewer/services/execution.service.ts
@@ -1,0 +1,32 @@
+/**
+ * services/execution.service.ts — Audit Log Viewer
+ *
+ * Wraps the pure `applyAuditOperation` reducer with real state and network
+ * simulation. This is the concrete `AuditContract` implementation that
+ * backend callers construct and use.
+ */
+
+import type { AuditLogEntry } from "../types";
+import type { AuditContract, AuditOperation, AuditContractOutput, AuditResult } from "../contract";
+import { applyAuditOperation } from "../contract";
+import { mockAuditEntries, MOCK_NETWORK_DELAY_MS } from "../fixtures/auditFixtures";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Creates an `AuditContract` instance backed by an in-memory store seeded
+ * from fixtures. Read-only: no operation mutates the underlying entries.
+ */
+export function createAuditLogContract(
+  seed: AuditLogEntry[] = mockAuditEntries,
+  networkDelayMs: number = MOCK_NETWORK_DELAY_MS,
+): AuditContract {
+  const store = new Map<string, AuditLogEntry>(seed.map((entry) => [entry.id, entry]));
+
+  return {
+    async execute(op: AuditOperation): Promise<AuditResult<AuditContractOutput>> {
+      if (networkDelayMs > 0) await delay(networkDelayMs);
+      return applyAuditOperation(store, op);
+    },
+  };
+}

--- a/tools/v2/team/audit-log-viewer/tests/contract.test.ts
+++ b/tools/v2/team/audit-log-viewer/tests/contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * contract.test.ts — Audit Log Viewer (execution contract)
+ *
+ * Verifies the non-UI execution contract: typed inputs/outputs for
+ * listEntries and getEntry, plus the error paths (validation, not-found,
+ * invalid date range, oversized limit). No UI is exercised.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createAuditLogContract } from "../services/execution.service";
+import { AuditErrorCode, ok, fail } from "../contract";
+import {
+  VALID_LIST_INPUT,
+  VALID_GET_ENTRY_INPUT,
+  INVALID_LIMIT_LIST_INPUT,
+  OVERSIZED_LIMIT_LIST_INPUT,
+  INVALID_DATE_RANGE_LIST_INPUT,
+  MISSING_ENTRY_ID_INPUT,
+  UNKNOWN_ENTRY_ID_INPUT,
+} from "../fixtures/contractFixtures";
+
+describe("audit log contract — result helpers", () => {
+  it("ok() produces a typed success result", () => {
+    expect(ok("v")).toEqual({ ok: true, value: "v" });
+  });
+
+  it("fail() produces a typed error result with code + message", () => {
+    const r = fail(AuditErrorCode.InvalidInput, "bad");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(AuditErrorCode.InvalidInput);
+      expect(r.message).toBe("bad");
+    }
+  });
+});
+
+describe("audit log contract — listEntries (success)", () => {
+  it("returns filtered, paginated entries with a total count", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({ operation: "listEntries", input: VALID_LIST_INPUT });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "listEntries") {
+      expect(res.value.result.entries.every((e) => e.severity === "warning")).toBe(true);
+    }
+  });
+});
+
+describe("audit log contract — listEntries (failure)", () => {
+  it("rejects a negative limit", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({
+      operation: "listEntries",
+      input: INVALID_LIMIT_LIST_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(AuditErrorCode.InvalidInput);
+  });
+
+  it("rejects a limit above MAX_PAGE_SIZE", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({
+      operation: "listEntries",
+      input: OVERSIZED_LIMIT_LIST_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(AuditErrorCode.InvalidInput);
+  });
+
+  it("rejects a from-after-to date range", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({
+      operation: "listEntries",
+      input: INVALID_DATE_RANGE_LIST_INPUT,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(AuditErrorCode.InvalidInput);
+  });
+});
+
+describe("audit log contract — getEntry (success)", () => {
+  it("returns the matching entry", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({ operation: "getEntry", input: VALID_GET_ENTRY_INPUT });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "getEntry") {
+      expect(res.value.entry.id).toBe("log_001");
+    }
+  });
+});
+
+describe("audit log contract — getEntry (failure)", () => {
+  it("rejects a missing entryId", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({ operation: "getEntry", input: MISSING_ENTRY_ID_INPUT });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(AuditErrorCode.InvalidInput);
+  });
+
+  it("returns EntryNotFound for an unknown id", async () => {
+    const contract = createAuditLogContract(undefined, 0);
+    const res = await contract.execute({ operation: "getEntry", input: UNKNOWN_ENTRY_ID_INPUT });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(AuditErrorCode.EntryNotFound);
+  });
+});

--- a/tools/v2/team/audit-log-viewer/types.ts
+++ b/tools/v2/team/audit-log-viewer/types.ts
@@ -1,0 +1,52 @@
+/**
+ * types.ts — Audit Log Viewer (non-UI execution contract)
+ *
+ * Domain types for viewing administrative audit log entries. No imports
+ * from the main app; presentation-free.
+ */
+
+export type AuditSeverity = "info" | "warning" | "critical";
+
+/** A single administrative audit log entry. */
+export interface AuditLogEntry {
+  id: string;
+  actorId: string;
+  actorEmail: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  /** ISO-8601 timestamp, e.g. "2026-06-01T09:30:00.000Z". */
+  timestamp: string;
+  severity: AuditSeverity;
+  ipAddress: string;
+}
+
+/** Filters applicable when listing audit log entries. */
+export interface AuditLogFilters {
+  actorId?: string;
+  action?: string;
+  resourceType?: string;
+  severity?: AuditSeverity;
+  /** ISO-8601 inclusive lower bound on timestamp. */
+  from?: string;
+  /** ISO-8601 inclusive upper bound on timestamp. */
+  to?: string;
+}
+
+/** Input for listing audit log entries. */
+export interface ListEntriesInput {
+  filters?: AuditLogFilters;
+  limit?: number;
+  offset?: number;
+}
+
+/** Output of a listEntries operation. */
+export interface ListEntriesOutput {
+  entries: AuditLogEntry[];
+  totalCount: number;
+}
+
+/** Input for fetching a single audit log entry. */
+export interface GetEntryInput {
+  entryId: string;
+}

--- a/tools/v2/team/audit-log-viewer/vitest.config.ts
+++ b/tools/v2/team/audit-log-viewer/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsConfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsConfigPaths({ projects: ["./tsconfig.json"] }), react()],
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tools/v2/team/audit-log-viewer/tests/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Closes #1335.

Added `types.ts` and `contract.ts` for the audit log viewer — two read-only operations, `listEntries` (filtered, paginated) and `getEntry` (by id), with typed error codes and a pure reducer. `index.ts` exports the contract + service factory so it's callable without any UI. Fixtures cover both success and failure paths for each operation (bad limit, oversized limit, invalid date range, missing id, unknown id).

This folder didn't have any existing code before this — just README/specs — so there was nothing to reconcile against.

Didn't touch anything in `components/` or `docs/`.