### PR TITLE
docs(policies): add event schema documentation for Soroban policies contract

### DIFF
--- a/contracts/soroban/policies/README.md
+++ b/contracts/soroban/policies/README.md
@@ -25,6 +25,14 @@ deterministic: block, allow, tier, then mailbox default.
 - `evaluate(...)` returns the complete decision, reason, required postage, sender rule, and policy version.
 - `can_mail(...)` returns the boolean result of `evaluate`.
 
+## Events
+
+Policy, delegate, sender-rule, and sender-tier mutations emit ledger events for
+off-chain consumers. The complete public schema—including topic order, payload
+encoding, version semantics, and failure-path guarantees—is documented in
+[`docs/events.md`](docs/events.md) and pinned by the `event_schema` tests in
+`src/lib.rs`.
+
 ## Precedence
 
 1. Block always denies, regardless of price or mailbox defaults.

--- a/contracts/soroban/policies/docs/events.md
+++ b/contracts/soroban/policies/docs/events.md
@@ -11,12 +11,12 @@ contract structs and enums use their normal `#[contracttype]` encoding.
 
 ## Events
 
-| Event | Topics, in order | Data | Emitted by |
-| --- | --- | --- | --- |
-| `policy` | `"policy"`, `owner` | `VersionedMailboxPolicy { policy, version }` | `set_policy`, `set_policy_as` |
-| `delegate` | `"delegate"`, `owner`, `delegate` | `DelegateScope` | `set_delegate` |
-| `sender` | `"sender"`, `owner`, `sender` | `(SenderRule, u32 version)` | `set_sender_rule`, `set_sender_rule_as` |
-| `tier` | `"tier"`, `owner`, `sender` | `(i128 minimum_postage, u32 version)` | `set_sender_tier`, `set_sender_tier_as` |
+| Event      | Topics, in order                  | Data                                         | Emitted by                              |
+| ---------- | --------------------------------- | -------------------------------------------- | --------------------------------------- |
+| `policy`   | `"policy"`, `owner`               | `VersionedMailboxPolicy { policy, version }` | `set_policy`, `set_policy_as`           |
+| `delegate` | `"delegate"`, `owner`, `delegate` | `DelegateScope`                              | `set_delegate`                          |
+| `sender`   | `"sender"`, `owner`, `sender`     | `(SenderRule, u32 version)`                  | `set_sender_rule`, `set_sender_rule_as` |
+| `tier`     | `"tier"`, `owner`, `sender`       | `(i128 minimum_postage, u32 version)`        | `set_sender_tier`, `set_sender_tier_as` |
 
 The public wrapper and its corresponding `*_as` function produce the same
 event. The authorized actor is deliberately not included in the schema; the
@@ -28,10 +28,10 @@ ledger transaction authorization tree is the source for actor attribution.
 
 `VersionedMailboxPolicy` contains:
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `policy` | `MailboxPolicy` | The complete policy persisted by the mutation |
-| `version` | `u32` | The owner's policy version after the mutation |
+| Field     | Type            | Meaning                                       |
+| --------- | --------------- | --------------------------------------------- |
+| `policy`  | `MailboxPolicy` | The complete policy persisted by the mutation |
+| `version` | `u32`           | The owner's policy version after the mutation |
 
 `MailboxPolicy` contains `allow_unknown: bool`, `require_verified: bool`,
 `require_receipt: bool`, and `minimum_postage: i128`.

--- a/contracts/soroban/policies/docs/events.md
+++ b/contracts/soroban/policies/docs/events.md
@@ -1,0 +1,72 @@
+# Policies Contract — Event Schema
+
+The policies contract emits four mutation events. Their topic order and data
+encoding are part of the public contract for ledger indexers, relays, and
+clients. The `event_schema` tests in `src/lib.rs` pin the layouts documented
+below.
+
+All event names are short Soroban symbols. Addresses are native Soroban
+`Address` values. Tuple payloads use Soroban tuple/vector encoding, while
+contract structs and enums use their normal `#[contracttype]` encoding.
+
+## Events
+
+| Event | Topics, in order | Data | Emitted by |
+| --- | --- | --- | --- |
+| `policy` | `"policy"`, `owner` | `VersionedMailboxPolicy { policy, version }` | `set_policy`, `set_policy_as` |
+| `delegate` | `"delegate"`, `owner`, `delegate` | `DelegateScope` | `set_delegate` |
+| `sender` | `"sender"`, `owner`, `sender` | `(SenderRule, u32 version)` | `set_sender_rule`, `set_sender_rule_as` |
+| `tier` | `"tier"`, `owner`, `sender` | `(i128 minimum_postage, u32 version)` | `set_sender_tier`, `set_sender_tier_as` |
+
+The public wrapper and its corresponding `*_as` function produce the same
+event. The authorized actor is deliberately not included in the schema; the
+ledger transaction authorization tree is the source for actor attribution.
+
+## Payload definitions
+
+### `policy`
+
+`VersionedMailboxPolicy` contains:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `policy` | `MailboxPolicy` | The complete policy persisted by the mutation |
+| `version` | `u32` | The owner's policy version after the mutation |
+
+`MailboxPolicy` contains `allow_unknown: bool`, `require_verified: bool`,
+`require_receipt: bool`, and `minimum_postage: i128`.
+
+### `delegate`
+
+The data is the requested `DelegateScope`, containing `can_set_policy: bool`
+and `can_set_senders: bool`. When both values are false, the stored delegation
+is removed and the event records that revocation. Delegate mutations do not
+increment the owner's policy version.
+
+### `sender`
+
+The first data tuple item is `SenderRule`: `Default`, `Allow`, or `Block`.
+`Default` records that the explicit rule was cleared. The second item is the
+owner's policy version after the mutation. Setting a rule also removes any
+sender tier.
+
+### `tier`
+
+The first data tuple item is the non-negative sender-specific minimum postage.
+The second item is the owner's policy version after the mutation. Setting a
+tier makes `Default` the effective stored sender rule.
+
+## Consumer guarantees
+
+- Subscribe by contract address and topic 0, then use the indexed owner and
+  sender/delegate address topics for routing without decoding event data.
+- `policy`, `sender`, and `tier` carry the post-mutation version. Versions are
+  monotonically incremented per owner across those three event types.
+  `delegate` is intentionally unversioned and does not change this counter.
+- An emitted event corresponds to state written by that invocation. Validation
+  or authorization failures emit no event and do not increment the version.
+- Events describe mutations, including idempotent requests; they are not
+  deduplicated state-change notifications.
+- Topic reordering, renaming an event, changing a payload type, or changing
+  tuple/struct field layout is a schema break. Such a change requires a
+  deliberate versioned migration for off-chain consumers.

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -522,7 +522,7 @@ mod event_schema {
                 .unwrap(),
             Error::InvalidPostage
         );
-        assert!(env.events().all().is_empty());
+        assert!(env.events().all().events().is_empty());
         assert_eq!(client.policy_version(&owner), 0);
     }
 }

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -90,6 +90,11 @@ pub enum Error {
 
 #[contractimpl]
 impl PoliciesContract {
+    /// Sets the mailbox policy and emits a `policy` event.
+    ///
+    /// Event topics are `("policy", owner)` and data is
+    /// `VersionedMailboxPolicy { policy, version }`. The version is the
+    /// post-mutation policy version.
     pub fn set_policy(env: Env, owner: Address, policy: MailboxPolicy) -> Result<(), Error> {
         Self::set_policy_as(env, owner.clone(), owner, policy)
     }
@@ -136,6 +141,11 @@ impl PoliciesContract {
             .unwrap_or(0)
     }
 
+    /// Sets or revokes a delegate scope and emits a `delegate` event.
+    ///
+    /// Event topics are `("delegate", owner, delegate)` and data is the
+    /// requested `DelegateScope`. Both scope flags being false represents
+    /// revocation. Delegate changes do not increment the policy version.
     pub fn set_delegate(
         env: Env,
         owner: Address,
@@ -164,6 +174,11 @@ impl PoliciesContract {
             })
     }
 
+    /// Sets or clears a sender rule and emits a `sender` event.
+    ///
+    /// Event topics are `("sender", owner, sender)` and data is
+    /// `(rule, version)`. `SenderRule::Default` represents clearing an
+    /// explicit rule. The version is the post-mutation policy version.
     pub fn set_sender_rule(
         env: Env,
         owner: Address,
@@ -196,6 +211,11 @@ impl PoliciesContract {
         Ok(())
     }
 
+    /// Sets sender-specific minimum postage and emits a `tier` event.
+    ///
+    /// Event topics are `("tier", owner, sender)` and data is
+    /// `(minimum_postage, version)`. The version is the post-mutation policy
+    /// version.
     pub fn set_sender_tier(
         env: Env,
         owner: Address,
@@ -389,6 +409,121 @@ impl PoliciesContract {
             .persistent()
             .set(&DataKey::PolicyVersion(owner.clone()), &version);
         version
+    }
+}
+
+#[cfg(test)]
+mod event_schema {
+    // Ledger indexers decode these raw events, so topic order and payload
+    // values are public API. These tests intentionally exercise the existing
+    // `publish` calls rather than introducing new event types or semantics.
+    extern crate std;
+
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events},
+        IntoVal, Val, Vec,
+    };
+
+    fn assert_last_event(env: &Env, contract_id: &Address, topics: Vec<Val>, data: Val) {
+        assert_eq!(
+            env.events().all(),
+            Vec::from_array(env, [(contract_id.clone(), topics, data)])
+        );
+    }
+
+    #[test]
+    fn policy_event_schema_is_stable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let policy = MailboxPolicy {
+            allow_unknown: true,
+            require_verified: false,
+            require_receipt: true,
+            minimum_postage: 25,
+        };
+
+        client.set_policy(&owner, &policy);
+
+        assert_last_event(
+            &env,
+            &contract_id,
+            (symbol_short!("policy"), owner.clone()).into_val(&env),
+            VersionedMailboxPolicy { policy, version: 1 }.into_val(&env),
+        );
+    }
+
+    #[test]
+    fn delegate_event_schema_is_stable_and_unversioned() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let delegate = Address::generate(&env);
+        let scope = DelegateScope {
+            can_set_policy: true,
+            can_set_senders: false,
+        };
+
+        client.set_delegate(&owner, &delegate, &scope);
+
+        assert_last_event(
+            &env,
+            &contract_id,
+            (symbol_short!("delegate"), owner.clone(), delegate.clone()).into_val(&env),
+            scope.into_val(&env),
+        );
+        assert_eq!(client.policy_version(&owner), 0);
+    }
+
+    #[test]
+    fn sender_and_tier_events_pin_topic_order_and_post_mutation_version() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        client.set_sender_rule(&owner, &sender, &SenderRule::Allow);
+        assert_last_event(
+            &env,
+            &contract_id,
+            (symbol_short!("sender"), owner.clone(), sender.clone()).into_val(&env),
+            (SenderRule::Allow, 1_u32).into_val(&env),
+        );
+
+        client.set_sender_tier(&owner, &sender, &40);
+        assert_last_event(
+            &env,
+            &contract_id,
+            (symbol_short!("tier"), owner.clone(), sender.clone()).into_val(&env),
+            (40_i128, 2_u32).into_val(&env),
+        );
+    }
+
+    #[test]
+    fn rejected_mutations_emit_no_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PoliciesContract, ());
+        let client = PoliciesContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        assert_eq!(
+            client
+                .try_set_sender_tier(&owner, &sender, &-1)
+                .unwrap_err()
+                .unwrap(),
+            Error::InvalidPostage
+        );
+        assert!(env.events().all().is_empty());
+        assert_eq!(client.policy_version(&owner), 0);
     }
 }
 


### PR DESCRIPTION
Closes #1386
What was done
Added stronger event schema documentation for the policies Soroban contract to reduce ledger integration risk, keeping public contract semantics backward compatible.
Changes

Added event schema documentation for policy, delegate, sender, and tier
Added focused schema stability and failure-path tests
Added contract-facing Rust documentation and a README reference
Preserved existing contract semantics — no behavioral changes

Test results

Soroban contract compilation for wasm32v1-none: passed
Formatting and diff checks: passed
Native unit tests could not run locally — missing Windows linker tooling (dlltool.exe/link.exe). Relying on CI for final verification.