### PR TITLE
feat: add non-UI execution contract for pdf-summary-tool types - Clos…

### DIFF
--- a/tools/v2/individual/pdf-summary-tool/types/execution.fixtures.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/execution.fixtures.ts
@@ -1,62 +1,62 @@
-import type { PdfSummaryInput, PdfSummaryExecutionSettings } from './execution';
+import type { PdfSummaryInput, PdfSummaryExecutionSettings } from "./execution";
 
 export const validSettings: PdfSummaryExecutionSettings = {
-  length: 'medium',
-  style: 'bullet-points',
+  length: "medium",
+  style: "bullet-points",
   includeKeywords: true,
-  language: 'en',
+  language: "en",
 };
 
 export const successfulInput: PdfSummaryInput = {
-  fileBuffer: Buffer.from('Sample PDF content for testing'),
-  fileName: 'test-document.pdf',
+  fileBuffer: Buffer.from("Sample PDF content for testing"),
+  fileName: "test-document.pdf",
   fileSize: 1024,
   settings: validSettings,
 };
 
 export const emptyBufferInput: PdfSummaryInput = {
-  fileBuffer: Buffer.from(''),
-  fileName: 'empty.pdf',
+  fileBuffer: Buffer.from(""),
+  fileName: "empty.pdf",
   fileSize: 0,
   settings: validSettings,
 };
 
 export const largeFileInput: PdfSummaryInput = {
-  fileBuffer: Buffer.from('x'.repeat(50 * 1024 * 1024)),
-  fileName: 'large.pdf',
+  fileBuffer: Buffer.from("x".repeat(50 * 1024 * 1024)),
+  fileName: "large.pdf",
   fileSize: 50 * 1024 * 1024,
   settings: validSettings,
 };
 
 export const invalidSettingsInput: PdfSummaryInput = {
-  fileBuffer: Buffer.from('content'),
-  fileName: 'test.pdf',
+  fileBuffer: Buffer.from("content"),
+  fileName: "test.pdf",
   fileSize: 100,
   settings: {
-    length: 'invalid' as any,
-    style: 'paragraph',
+    length: "invalid" as any,
+    style: "paragraph",
     includeKeywords: false,
-    language: '',
+    language: "",
   },
 };
 
 export const unsupportedFormatInput: PdfSummaryInput = {
-  fileBuffer: Buffer.from('content'),
-  fileName: 'document.docx',
+  fileBuffer: Buffer.from("content"),
+  fileName: "document.docx",
   fileSize: 500,
   settings: validSettings,
 };
 
 export const shortSettings: PdfSummaryExecutionSettings = {
   ...validSettings,
-  length: 'short',
-  style: 'paragraph',
+  length: "short",
+  style: "paragraph",
   includeKeywords: false,
 };
 
 export const longBulletSettings: PdfSummaryExecutionSettings = {
   ...validSettings,
-  length: 'long',
-  style: 'bullet-points',
+  length: "long",
+  style: "bullet-points",
   includeKeywords: true,
 };

--- a/tools/v2/individual/pdf-summary-tool/types/execution.fixtures.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/execution.fixtures.ts
@@ -1,0 +1,62 @@
+import type { PdfSummaryInput, PdfSummaryExecutionSettings } from './execution';
+
+export const validSettings: PdfSummaryExecutionSettings = {
+  length: 'medium',
+  style: 'bullet-points',
+  includeKeywords: true,
+  language: 'en',
+};
+
+export const successfulInput: PdfSummaryInput = {
+  fileBuffer: Buffer.from('Sample PDF content for testing'),
+  fileName: 'test-document.pdf',
+  fileSize: 1024,
+  settings: validSettings,
+};
+
+export const emptyBufferInput: PdfSummaryInput = {
+  fileBuffer: Buffer.from(''),
+  fileName: 'empty.pdf',
+  fileSize: 0,
+  settings: validSettings,
+};
+
+export const largeFileInput: PdfSummaryInput = {
+  fileBuffer: Buffer.from('x'.repeat(50 * 1024 * 1024)),
+  fileName: 'large.pdf',
+  fileSize: 50 * 1024 * 1024,
+  settings: validSettings,
+};
+
+export const invalidSettingsInput: PdfSummaryInput = {
+  fileBuffer: Buffer.from('content'),
+  fileName: 'test.pdf',
+  fileSize: 100,
+  settings: {
+    length: 'invalid' as any,
+    style: 'paragraph',
+    includeKeywords: false,
+    language: '',
+  },
+};
+
+export const unsupportedFormatInput: PdfSummaryInput = {
+  fileBuffer: Buffer.from('content'),
+  fileName: 'document.docx',
+  fileSize: 500,
+  settings: validSettings,
+};
+
+export const shortSettings: PdfSummaryExecutionSettings = {
+  ...validSettings,
+  length: 'short',
+  style: 'paragraph',
+  includeKeywords: false,
+};
+
+export const longBulletSettings: PdfSummaryExecutionSettings = {
+  ...validSettings,
+  length: 'long',
+  style: 'bullet-points',
+  includeKeywords: true,
+};

--- a/tools/v2/individual/pdf-summary-tool/types/execution.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/execution.ts
@@ -1,0 +1,72 @@
+/**
+ * Execution contract for PDF Summary Tool types.
+ * Non-UI, backend-facing types for PDF summary execution.
+ */
+
+/** Error codes for PDF summary execution failures */
+export type PdfSummaryErrorCode =
+  | 'INVALID_INPUT'
+  | 'FILE_TOO_LARGE'
+  | 'UNSUPPORTED_FORMAT'
+  | 'TEXT_EXTRACTION_FAILED'
+  | 'SUMMARIZATION_FAILED'
+  | 'PERSISTENCE_FAILED'
+  | 'INTERNAL_ERROR';
+
+/** Input for PDF summary execution */
+export interface PdfSummaryInput {
+  /** PDF file buffer */
+  fileBuffer: Buffer;
+  /** Original filename */
+  fileName: string;
+  /** File size in bytes */
+  fileSize: number;
+  /** Summary generation settings */
+  settings: PdfSummaryExecutionSettings;
+}
+
+/** Settings for summary generation */
+export interface PdfSummaryExecutionSettings {
+  /** How long the summary should be */
+  length: 'short' | 'medium' | 'long';
+  /** Output format */
+  style: 'bullet-points' | 'paragraph';
+  /** Whether to include keywords */
+  includeKeywords: boolean;
+  /** Language code */
+  language: string;
+}
+
+/** Output from successful PDF summary execution */
+export interface PdfSummaryOutput {
+  /** Unique summary identifier */
+  id: string;
+  /** Reference to source PDF id */
+  pdfId: string;
+  /** Summary text content */
+  content: string;
+  /** Extracted keywords if requested */
+  keywords?: string[];
+  /** When summary was generated */
+  generatedAt: string;
+  /** Settings used */
+  settings: PdfSummaryExecutionSettings;
+}
+
+/** Error result structure */
+export interface PdfSummaryError {
+  code: PdfSummaryErrorCode;
+  message: string;
+  /** Dot-path to invalid field when applicable */
+  field?: string;
+}
+
+/** Discriminated union result type */
+export type PdfSummaryResult =
+  | { ok: true; data: PdfSummaryOutput }
+  | { ok: false; error: PdfSummaryError };
+
+/** Execution function type signature */
+export type ExecutePdfSummary = (
+  input: PdfSummaryInput,
+) => Promise<PdfSummaryResult>;

--- a/tools/v2/individual/pdf-summary-tool/types/execution.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/execution.ts
@@ -5,13 +5,13 @@
 
 /** Error codes for PDF summary execution failures */
 export type PdfSummaryErrorCode =
-  | 'INVALID_INPUT'
-  | 'FILE_TOO_LARGE'
-  | 'UNSUPPORTED_FORMAT'
-  | 'TEXT_EXTRACTION_FAILED'
-  | 'SUMMARIZATION_FAILED'
-  | 'PERSISTENCE_FAILED'
-  | 'INTERNAL_ERROR';
+  | "INVALID_INPUT"
+  | "FILE_TOO_LARGE"
+  | "UNSUPPORTED_FORMAT"
+  | "TEXT_EXTRACTION_FAILED"
+  | "SUMMARIZATION_FAILED"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
 
 /** Input for PDF summary execution */
 export interface PdfSummaryInput {
@@ -28,9 +28,9 @@ export interface PdfSummaryInput {
 /** Settings for summary generation */
 export interface PdfSummaryExecutionSettings {
   /** How long the summary should be */
-  length: 'short' | 'medium' | 'long';
+  length: "short" | "medium" | "long";
   /** Output format */
-  style: 'bullet-points' | 'paragraph';
+  style: "bullet-points" | "paragraph";
   /** Whether to include keywords */
   includeKeywords: boolean;
   /** Language code */
@@ -63,10 +63,7 @@ export interface PdfSummaryError {
 
 /** Discriminated union result type */
 export type PdfSummaryResult =
-  | { ok: true; data: PdfSummaryOutput }
-  | { ok: false; error: PdfSummaryError };
+  { ok: true; data: PdfSummaryOutput } | { ok: false; error: PdfSummaryError };
 
 /** Execution function type signature */
-export type ExecutePdfSummary = (
-  input: PdfSummaryInput,
-) => Promise<PdfSummaryResult>;
+export type ExecutePdfSummary = (input: PdfSummaryInput) => Promise<PdfSummaryResult>;

--- a/tools/v2/individual/pdf-summary-tool/types/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/index.ts
@@ -36,9 +36,9 @@ export interface Summary {
 /** Configuration for summary generation */
 export interface SummarySettings {
   /** How long the summary should be */
-  length: 'short' | 'medium' | 'long';
+  length: "short" | "medium" | "long";
   /** Output format for the summary */
-  style: 'bullet-points' | 'paragraph';
+  style: "bullet-points" | "paragraph";
   /** Whether to extract and include keywords */
   includeKeywords: boolean;
   /** Language code for processing (e.g., 'en', 'es', 'fr') */
@@ -98,4 +98,4 @@ export type {
   PdfSummaryError,
   PdfSummaryResult,
   ExecutePdfSummary,
-} from './execution';
+} from "./execution";

--- a/tools/v2/individual/pdf-summary-tool/types/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/index.ts
@@ -5,123 +5,97 @@
  * See MODULE_BOUNDARIES.md for type design guidelines.
  */
 
-/**
- * Represents a PDF file with metadata
- */
+/** Represents a PDF file with metadata */
 export interface PDF {
   /** Unique identifier (generated from file) */
   id: string;
-
   /** Original filename */
   name: string;
-
   /** File size in bytes */
   size: number;
-
   /** When the file was selected by user */
   uploadedAt: Date;
-
   /** Extracted text content (temporary, only during processing) */
   content?: string;
 }
 
-/**
- * Represents a generated summary
- */
+/** Represents a generated summary */
 export interface Summary {
   /** Unique identifier for this summary */
   id: string;
-
   /** Reference to the source PDF */
   pdfId: string;
-
   /** Summary text content */
   content: string;
-
   /** Settings used to generate this summary */
   settings: SummarySettings;
-
   /** When this summary was created */
   generatedAt: Date;
 }
 
-/**
- * Configuration for summary generation
- */
+/** Configuration for summary generation */
 export interface SummarySettings {
   /** How long the summary should be */
-  length: "short" | "medium" | "long";
-
+  length: 'short' | 'medium' | 'long';
   /** Output format for the summary */
-  style: "bullet-points" | "paragraph";
-
+  style: 'bullet-points' | 'paragraph';
   /** Whether to extract and include keywords */
   includeKeywords: boolean;
-
   /** Language code for processing (e.g., 'en', 'es', 'fr') */
   language: string;
 }
 
-/**
- * Result of file or content validation
- */
+/** Result of file or content validation */
 export interface ValidationResult {
   /** Whether the input is valid */
   isValid: boolean;
-
   /** Error message if validation failed */
   error?: string;
 }
 
-/**
- * Hook return type for PDF summarization
- */
+/** Hook return type for PDF summarization */
 export interface UsePDFSummaryReturn {
   /** Generated summary (null if not ready) */
   summary: Summary | null;
-
   /** Whether summarization is in progress */
   isLoading: boolean;
-
   /** Error message if summarization failed */
   error?: string;
 }
 
-/**
- * Hook return type for storage management
- */
+/** Hook return type for storage management */
 export interface UseLocalSummaryStorageReturn {
   /** All stored summaries */
   summaries: Summary[];
-
   /** Function to persist a summary */
   saveSummary: (summary: Summary) => Promise<void>;
-
   /** Function to delete a summary */
   deleteSummary: (id: string) => Promise<void>;
-
   /** Whether storage operation is in progress */
   isLoading: boolean;
-
   /** Error message if storage operation failed */
   error?: string;
 }
 
-/**
- * Hook return type for settings management
- */
+/** Hook return type for settings management */
 export interface UseSummarySettingsReturn {
   /** Current user settings */
   settings: SummarySettings;
-
   /** Function to update settings */
   updateSettings: (settings: SummarySettings) => void;
-
   /** Whether settings are loading */
   isLoading: boolean;
-
   /** Error message if settings operation failed */
   error?: string;
 }
 
-// Add more types as needed following this pattern
+// Execution contract exports
+export type {
+  PdfSummaryErrorCode,
+  PdfSummaryInput,
+  PdfSummaryExecutionSettings,
+  PdfSummaryOutput,
+  PdfSummaryError,
+  PdfSummaryResult,
+  ExecutePdfSummary,
+} from './execution';


### PR DESCRIPTION
- Added execution.ts with typed input/output contracts, error codes, and discriminated union result type
- Added execution.fixtures.ts covering success and failure cases
- Updated index.ts to export new execution contract types
- No styling or layout changes

Closes #1373