### PR TITLE
feat: add non-UI execution contract for mail-to-ticket-converter - Cl…

### DIFF
--- a/tools/v2/team/mail-to-ticket-converter/execution.fixtures.ts
+++ b/tools/v2/team/mail-to-ticket-converter/execution.fixtures.ts
@@ -1,57 +1,57 @@
-import type { MailToTicketInput } from './execution';
+import type { MailToTicketInput } from "./execution";
 
 export const successfulInput: MailToTicketInput = {
-  emailId: 'email-001',
-  subject: 'Login page not loading',
-  description: 'Users report that the login page shows a white screen after entering credentials.',
-  priority: 'high',
-  category: 'bug',
-  assignedTo: 'member-1',
-  createdBy: 'support@example.com',
+  emailId: "email-001",
+  subject: "Login page not loading",
+  description: "Users report that the login page shows a white screen after entering credentials.",
+  priority: "high",
+  category: "bug",
+  assignedTo: "member-1",
+  createdBy: "support@example.com",
 };
 
 export const missingEmailIdInput: MailToTicketInput = {
-  emailId: '',
-  subject: 'Test ticket',
-  description: 'Description',
-  priority: 'medium',
-  category: 'support',
-  createdBy: 'user@example.com',
+  emailId: "",
+  subject: "Test ticket",
+  description: "Description",
+  priority: "medium",
+  category: "support",
+  createdBy: "user@example.com",
 };
 
 export const invalidPriorityInput: MailToTicketInput = {
-  emailId: 'email-002',
-  subject: 'Feature request',
-  description: 'Add dark mode support',
-  priority: 'urgent' as any,
-  category: 'feature-request',
-  createdBy: 'user@example.com',
+  emailId: "email-002",
+  subject: "Feature request",
+  description: "Add dark mode support",
+  priority: "urgent" as any,
+  category: "feature-request",
+  createdBy: "user@example.com",
 };
 
 export const missingCreatedByInput: MailToTicketInput = {
-  emailId: 'email-003',
-  subject: 'Billing question',
-  description: 'Need invoice clarification',
-  priority: 'low',
-  category: 'billing',
-  createdBy: '',
+  emailId: "email-003",
+  subject: "Billing question",
+  description: "Need invoice clarification",
+  priority: "low",
+  category: "billing",
+  createdBy: "",
 };
 
 export const unassignedInput: MailToTicketInput = {
-  emailId: 'email-004',
-  subject: 'General inquiry',
-  description: 'How do I reset my password?',
-  priority: 'low',
-  category: 'support',
-  createdBy: 'user@example.com',
+  emailId: "email-004",
+  subject: "General inquiry",
+  description: "How do I reset my password?",
+  priority: "low",
+  category: "support",
+  createdBy: "user@example.com",
 };
 
 export const criticalBugInput: MailToTicketInput = {
-  emailId: 'email-005',
-  subject: 'Payment gateway down',
-  description: 'All payments are failing with 500 errors since 10:00 AM UTC.',
-  priority: 'critical',
-  category: 'bug',
-  assignedTo: 'member-2',
-  createdBy: 'ops@example.com',
+  emailId: "email-005",
+  subject: "Payment gateway down",
+  description: "All payments are failing with 500 errors since 10:00 AM UTC.",
+  priority: "critical",
+  category: "bug",
+  assignedTo: "member-2",
+  createdBy: "ops@example.com",
 };

--- a/tools/v2/team/mail-to-ticket-converter/execution.fixtures.ts
+++ b/tools/v2/team/mail-to-ticket-converter/execution.fixtures.ts
@@ -1,0 +1,57 @@
+import type { MailToTicketInput } from './execution';
+
+export const successfulInput: MailToTicketInput = {
+  emailId: 'email-001',
+  subject: 'Login page not loading',
+  description: 'Users report that the login page shows a white screen after entering credentials.',
+  priority: 'high',
+  category: 'bug',
+  assignedTo: 'member-1',
+  createdBy: 'support@example.com',
+};
+
+export const missingEmailIdInput: MailToTicketInput = {
+  emailId: '',
+  subject: 'Test ticket',
+  description: 'Description',
+  priority: 'medium',
+  category: 'support',
+  createdBy: 'user@example.com',
+};
+
+export const invalidPriorityInput: MailToTicketInput = {
+  emailId: 'email-002',
+  subject: 'Feature request',
+  description: 'Add dark mode support',
+  priority: 'urgent' as any,
+  category: 'feature-request',
+  createdBy: 'user@example.com',
+};
+
+export const missingCreatedByInput: MailToTicketInput = {
+  emailId: 'email-003',
+  subject: 'Billing question',
+  description: 'Need invoice clarification',
+  priority: 'low',
+  category: 'billing',
+  createdBy: '',
+};
+
+export const unassignedInput: MailToTicketInput = {
+  emailId: 'email-004',
+  subject: 'General inquiry',
+  description: 'How do I reset my password?',
+  priority: 'low',
+  category: 'support',
+  createdBy: 'user@example.com',
+};
+
+export const criticalBugInput: MailToTicketInput = {
+  emailId: 'email-005',
+  subject: 'Payment gateway down',
+  description: 'All payments are failing with 500 errors since 10:00 AM UTC.',
+  priority: 'critical',
+  category: 'bug',
+  assignedTo: 'member-2',
+  createdBy: 'ops@example.com',
+};

--- a/tools/v2/team/mail-to-ticket-converter/execution.ts
+++ b/tools/v2/team/mail-to-ticket-converter/execution.ts
@@ -1,0 +1,78 @@
+/**
+ * Execution contract for Mail-to-Ticket Converter.
+ * Non-UI, backend-facing types for mail-to-ticket execution.
+ */
+
+/** Error codes for mail-to-ticket execution failures */
+export type MailToTicketErrorCode =
+  | 'INVALID_INPUT'
+  | 'EMAIL_NOT_FOUND'
+  | 'DUPLICATE_TICKET'
+  | 'ASSIGNMENT_FAILED'
+  | 'STATUS_TRANSITION_INVALID'
+  | 'PERSISTENCE_FAILED'
+  | 'INTERNAL_ERROR';
+
+/** Input for converting an email to a ticket */
+export interface MailToTicketInput {
+  /** ID of the source email */
+  emailId: string;
+  /** Ticket subject */
+  subject: string;
+  /** Ticket description */
+  description: string;
+  /** Priority level */
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  /** Ticket category */
+  category: 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
+  /** Optional team member to assign */
+  assignedTo?: string;
+  /** Identity creating the ticket */
+  createdBy: string;
+}
+
+/** Output from successful ticket creation */
+export interface MailToTicketOutput {
+  /** Unique ticket identifier */
+  id: string;
+  /** Reference to source email */
+  emailId: string;
+  /** Ticket subject */
+  subject: string;
+  /** Ticket description */
+  description: string;
+  /** Priority level */
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  /** Current status */
+  status: 'open' | 'in-progress' | 'resolved' | 'closed';
+  /** Ticket category */
+  category: 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
+  /** Assigned team member id */
+  assignedTo: string | null;
+  /** Creator identity */
+  createdBy: string;
+  /** Creation timestamp */
+  createdAt: string;
+  /** Last update timestamp */
+  updatedAt: string;
+  /** Resolution notes */
+  resolution: string | null;
+}
+
+/** Error result structure */
+export interface MailToTicketError {
+  code: MailToTicketErrorCode;
+  message: string;
+  /** Dot-path to invalid field when applicable */
+  field?: string;
+}
+
+/** Discriminated union result type */
+export type MailToTicketResult =
+  | { ok: true; data: MailToTicketOutput }
+  | { ok: false; error: MailToTicketError };
+
+/** Execution function type signature */
+export type ExecuteMailToTicket = (
+  input: MailToTicketInput,
+) => Promise<MailToTicketResult>;

--- a/tools/v2/team/mail-to-ticket-converter/execution.ts
+++ b/tools/v2/team/mail-to-ticket-converter/execution.ts
@@ -5,13 +5,13 @@
 
 /** Error codes for mail-to-ticket execution failures */
 export type MailToTicketErrorCode =
-  | 'INVALID_INPUT'
-  | 'EMAIL_NOT_FOUND'
-  | 'DUPLICATE_TICKET'
-  | 'ASSIGNMENT_FAILED'
-  | 'STATUS_TRANSITION_INVALID'
-  | 'PERSISTENCE_FAILED'
-  | 'INTERNAL_ERROR';
+  | "INVALID_INPUT"
+  | "EMAIL_NOT_FOUND"
+  | "DUPLICATE_TICKET"
+  | "ASSIGNMENT_FAILED"
+  | "STATUS_TRANSITION_INVALID"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
 
 /** Input for converting an email to a ticket */
 export interface MailToTicketInput {
@@ -22,9 +22,9 @@ export interface MailToTicketInput {
   /** Ticket description */
   description: string;
   /** Priority level */
-  priority: 'low' | 'medium' | 'high' | 'critical';
+  priority: "low" | "medium" | "high" | "critical";
   /** Ticket category */
-  category: 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
+  category: "bug" | "feature-request" | "support" | "billing" | "other";
   /** Optional team member to assign */
   assignedTo?: string;
   /** Identity creating the ticket */
@@ -42,11 +42,11 @@ export interface MailToTicketOutput {
   /** Ticket description */
   description: string;
   /** Priority level */
-  priority: 'low' | 'medium' | 'high' | 'critical';
+  priority: "low" | "medium" | "high" | "critical";
   /** Current status */
-  status: 'open' | 'in-progress' | 'resolved' | 'closed';
+  status: "open" | "in-progress" | "resolved" | "closed";
   /** Ticket category */
-  category: 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
+  category: "bug" | "feature-request" | "support" | "billing" | "other";
   /** Assigned team member id */
   assignedTo: string | null;
   /** Creator identity */
@@ -69,10 +69,7 @@ export interface MailToTicketError {
 
 /** Discriminated union result type */
 export type MailToTicketResult =
-  | { ok: true; data: MailToTicketOutput }
-  | { ok: false; error: MailToTicketError };
+  { ok: true; data: MailToTicketOutput } | { ok: false; error: MailToTicketError };
 
 /** Execution function type signature */
-export type ExecuteMailToTicket = (
-  input: MailToTicketInput,
-) => Promise<MailToTicketResult>;
+export type ExecuteMailToTicket = (input: MailToTicketInput) => Promise<MailToTicketResult>;

--- a/tools/v2/team/mail-to-ticket-converter/types.ts
+++ b/tools/v2/team/mail-to-ticket-converter/types.ts
@@ -1,8 +1,8 @@
-export type Priority = "low" | "medium" | "high" | "critical";
+export type Priority = 'low' | 'medium' | 'high' | 'critical';
 
-export type TicketStatus = "open" | "in-progress" | "resolved" | "closed";
+export type TicketStatus = 'open' | 'in-progress' | 'resolved' | 'closed';
 
-export type TicketCategory = "bug" | "feature-request" | "support" | "billing" | "other";
+export type TicketCategory = 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
 
 export interface EmailSender {
   name: string;
@@ -69,10 +69,10 @@ export interface MailToTicketServiceConfig {
 }
 
 export type FetchState<T> =
-  | { status: "loading" }
-  | { status: "empty" }
-  | { status: "error"; message: string }
-  | { status: "success"; data: T };
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; data: T };
 
 export interface IMailToTicketService {
   getEmails(): Promise<Email[]>;
@@ -83,3 +83,13 @@ export interface IMailToTicketService {
   assignTicket(ticketId: string, memberId: string): Promise<Ticket>;
   getMetrics(): Promise<TicketMetrics>;
 }
+
+// Execution contract exports
+export type {
+  MailToTicketErrorCode,
+  MailToTicketInput,
+  MailToTicketOutput,
+  MailToTicketError,
+  MailToTicketResult,
+  ExecuteMailToTicket,
+} from './execution';

--- a/tools/v2/team/mail-to-ticket-converter/types.ts
+++ b/tools/v2/team/mail-to-ticket-converter/types.ts
@@ -1,8 +1,8 @@
-export type Priority = 'low' | 'medium' | 'high' | 'critical';
+export type Priority = "low" | "medium" | "high" | "critical";
 
-export type TicketStatus = 'open' | 'in-progress' | 'resolved' | 'closed';
+export type TicketStatus = "open" | "in-progress" | "resolved" | "closed";
 
-export type TicketCategory = 'bug' | 'feature-request' | 'support' | 'billing' | 'other';
+export type TicketCategory = "bug" | "feature-request" | "support" | "billing" | "other";
 
 export interface EmailSender {
   name: string;
@@ -69,10 +69,10 @@ export interface MailToTicketServiceConfig {
 }
 
 export type FetchState<T> =
-  | { status: 'loading' }
-  | { status: 'empty' }
-  | { status: 'error'; message: string }
-  | { status: 'success'; data: T };
+  | { status: "loading" }
+  | { status: "empty" }
+  | { status: "error"; message: string }
+  | { status: "success"; data: T };
 
 export interface IMailToTicketService {
   getEmails(): Promise<Email[]>;
@@ -92,4 +92,4 @@ export type {
   MailToTicketError,
   MailToTicketResult,
   ExecuteMailToTicket,
-} from './execution';
+} from "./execution";


### PR DESCRIPTION
- Added execution.ts with typed input/output contracts, error codes, and discriminated union result type
- Added execution.fixtures.ts covering success and failure cases
- Updated types.ts to export new execution contract types
- No styling or layout changes

Closes #1345