### PR TITLE
feat(pdf-summary-tool): add non-UI execution contract (#1371)

### DIFF
--- a/tools/v2/individual/pdf-summary-tool/fixtures/execution.json
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/execution.json
@@ -1,0 +1,210 @@
+{
+  "successCases": [
+    {
+      "name": "SUMMARIZE_PDF with full settings",
+      "input": {
+        "action": "SUMMARIZE_PDF",
+        "payload": {
+          "pdfContent": "The quarterly financial report shows significant growth in revenue across all departments. Operating expenses remained stable while profit margins improved by twelve percent compared to the previous quarter. The marketing team achieved record customer acquisition rates. Research and development investments continued to yield positive results with three new product launches.",
+          "fileName": "quarterly-report.pdf",
+          "fileSizeBytes": 1048576,
+          "settings": {
+            "length": "short",
+            "style": "bullet-points",
+            "includeKeywords": true,
+            "language": "en"
+          }
+        }
+      },
+      "expectedOutput": {
+        "success": true,
+        "dataShape": {
+          "hasSummary": true,
+          "hasKeywords": true,
+          "summaryHasBullets": true
+        }
+      }
+    },
+    {
+      "name": "SUMMARIZE_PDF with default settings",
+      "input": {
+        "action": "SUMMARIZE_PDF",
+        "payload": {
+          "pdfContent": "Machine learning models have transformed the way organizations approach data analysis. These models can identify patterns in large datasets that would be impossible for humans to detect manually. From predictive analytics to natural language processing, the applications are vast and growing rapidly across industries.",
+          "fileName": "ml-overview.pdf",
+          "fileSizeBytes": 524288
+        }
+      },
+      "expectedOutput": {
+        "success": true,
+        "dataShape": {
+          "hasSummary": true,
+          "hasKeywords": false,
+          "summaryHasBullets": false
+        }
+      }
+    },
+    {
+      "name": "VALIDATE_PDF with valid file",
+      "input": {
+        "action": "VALIDATE_PDF",
+        "payload": {
+          "fileName": "report.pdf",
+          "fileSizeBytes": 2097152,
+          "mimeType": "application/pdf"
+        }
+      },
+      "expectedOutput": {
+        "success": true,
+        "data": {
+          "isValid": true,
+          "fileName": "report.pdf",
+          "fileSizeBytes": 2097152,
+          "mimeType": "application/pdf"
+        }
+      }
+    },
+    {
+      "name": "LIST_SUMMARIES returns empty initially",
+      "input": {
+        "action": "LIST_SUMMARIES"
+      },
+      "expectedOutput": {
+        "success": true,
+        "data": {
+          "summaries": [],
+          "count": 0
+        }
+      }
+    }
+  ],
+  "failureCases": [
+    {
+      "name": "SUMMARIZE_PDF missing pdfContent",
+      "input": {
+        "action": "SUMMARIZE_PDF",
+        "payload": {
+          "fileName": "report.pdf",
+          "fileSizeBytes": 1024
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "INVALID_INPUT",
+          "message": "pdfContent and fileName are required for SUMMARIZE_PDF"
+        }
+      }
+    },
+    {
+      "name": "SUMMARIZE_PDF content too short",
+      "input": {
+        "action": "SUMMARIZE_PDF",
+        "payload": {
+          "pdfContent": "Too short.",
+          "fileName": "tiny.pdf",
+          "fileSizeBytes": 10
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "CONTENT_TOO_SHORT",
+          "message": "Content must be at least 50 characters to summarize"
+        }
+      }
+    },
+    {
+      "name": "VALIDATE_PDF file too large",
+      "input": {
+        "action": "VALIDATE_PDF",
+        "payload": {
+          "fileName": "huge.pdf",
+          "fileSizeBytes": 104857600,
+          "mimeType": "application/pdf"
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "FILE_TOO_LARGE",
+          "message": "File size 104857600 bytes exceeds maximum of 52428800 bytes"
+        }
+      }
+    },
+    {
+      "name": "VALIDATE_PDF unsupported MIME type",
+      "input": {
+        "action": "VALIDATE_PDF",
+        "payload": {
+          "fileName": "image.png",
+          "fileSizeBytes": 1024,
+          "mimeType": "image/png"
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "UNSUPPORTED_FILE_TYPE",
+          "message": "MIME type \"image/png\" is not supported. Expected one of: application/pdf"
+        }
+      }
+    },
+    {
+      "name": "GET_SUMMARY not found",
+      "input": {
+        "action": "GET_SUMMARY",
+        "payload": {
+          "summaryId": "nonexistent-id"
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "SUMMARY_NOT_FOUND",
+          "message": "Summary with id \"nonexistent-id\" not found"
+        }
+      }
+    },
+    {
+      "name": "DELETE_SUMMARY not found",
+      "input": {
+        "action": "DELETE_SUMMARY",
+        "payload": {
+          "summaryId": "nonexistent-id"
+        }
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "SUMMARY_NOT_FOUND",
+          "message": "Summary with id \"nonexistent-id\" not found"
+        }
+      }
+    },
+    {
+      "name": "Unknown action",
+      "input": {
+        "action": "UNKNOWN_ACTION"
+      },
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "ACTION_NOT_SUPPORTED",
+          "message": "Action UNKNOWN_ACTION is not supported"
+        }
+      }
+    },
+    {
+      "name": "Missing action",
+      "input": {},
+      "expectedOutput": {
+        "success": false,
+        "error": {
+          "code": "INVALID_INPUT",
+          "message": "Missing execution action"
+        }
+      }
+    }
+  ]
+}

--- a/tools/v2/individual/pdf-summary-tool/services/ExecutionService.ts
+++ b/tools/v2/individual/pdf-summary-tool/services/ExecutionService.ts
@@ -1,0 +1,396 @@
+/**
+ * PDF Summary Tool - Execution Service
+ *
+ * Non-UI service entry point for the PDF Summary Tool.
+ * Provides a stable, backend-facing execution contract that can run
+ * independently of React, the browser, or any UI layer.
+ *
+ * All actions are dispatched through the single `execute()` method.
+ */
+
+import type { Summary, SummarySettings } from "../types";
+import {
+  ExecutionAction,
+  ExecutionErrorCode,
+  type ExecutionInput,
+  type ExecutionOutput,
+  type SummarizePdfPayload,
+  type ValidatePdfPayload,
+  type GetSummaryPayload,
+  type DeleteSummaryPayload,
+} from "../types/execution";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum character count for text to be summarizable. */
+const MIN_CONTENT_LENGTH = 50;
+
+/** Maximum file size in bytes (50 MB). */
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+/** MIME types accepted as valid PDFs. */
+const SUPPORTED_MIME_TYPES = ["application/pdf"];
+
+/** Default summary settings applied when the caller omits them. */
+const DEFAULT_SETTINGS: SummarySettings = {
+  length: "medium",
+  style: "paragraph",
+  includeKeywords: false,
+  language: "en",
+};
+
+/** Target word counts per summary length tier. */
+const LENGTH_WORD_TARGETS: Record<SummarySettings["length"], number> = {
+  short: 60,
+  medium: 150,
+  long: 300,
+};
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ExecutionService {
+  /** In-memory summary store. Keeps the service headless-compatible. */
+  private summaries = new Map<string, Summary>();
+
+  /**
+   * Non-UI service entry point for pdf-summary-tool.
+   * Provides a stable backend-facing execution contract.
+   */
+  public async execute(input: ExecutionInput): Promise<ExecutionOutput> {
+    try {
+      if (!input || !input.action) {
+        return {
+          success: false,
+          error: {
+            code: ExecutionErrorCode.INVALID_INPUT,
+            message: "Missing execution action",
+          },
+        };
+      }
+
+      switch (input.action) {
+        case ExecutionAction.SUMMARIZE_PDF:
+          return this.handleSummarizePdf(input);
+        case ExecutionAction.VALIDATE_PDF:
+          return this.handleValidatePdf(input);
+        case ExecutionAction.GET_SUMMARY:
+          return this.handleGetSummary(input);
+        case ExecutionAction.LIST_SUMMARIES:
+          return this.handleListSummaries();
+        case ExecutionAction.DELETE_SUMMARY:
+          return this.handleDeleteSummary(input);
+        default:
+          return {
+            success: false,
+            error: {
+              code: ExecutionErrorCode.ACTION_NOT_SUPPORTED,
+              message: `Action ${input.action} is not supported`,
+            },
+          };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.INTERNAL_ERROR,
+          message:
+            error instanceof Error ? error.message : "Unknown internal error",
+        },
+      };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Action handlers
+  // -------------------------------------------------------------------------
+
+  private async handleSummarizePdf(
+    input: ExecutionInput,
+  ): Promise<ExecutionOutput> {
+    const payload = input.payload as SummarizePdfPayload | undefined;
+
+    if (!payload?.pdfContent || !payload?.fileName) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.INVALID_INPUT,
+          message:
+            "pdfContent and fileName are required for SUMMARIZE_PDF",
+        },
+      };
+    }
+
+    if (payload.pdfContent.trim().length < MIN_CONTENT_LENGTH) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.CONTENT_TOO_SHORT,
+          message: `Content must be at least ${MIN_CONTENT_LENGTH} characters to summarize`,
+        },
+      };
+    }
+
+    const settings: SummarySettings = {
+      ...DEFAULT_SETTINGS,
+      ...(payload.settings ?? {}),
+    };
+
+    const summaryContent = this.generateSummaryText(
+      payload.pdfContent,
+      settings,
+    );
+
+    const keywords = settings.includeKeywords
+      ? this.extractKeywords(payload.pdfContent)
+      : undefined;
+
+    const summary: Summary = {
+      id: this.generateSummaryId(payload.fileName),
+      pdfId: payload.fileName,
+      content: summaryContent,
+      settings,
+      generatedAt: new Date(),
+    };
+
+    // Persist to in-memory store
+    this.summaries.set(summary.id, summary);
+
+    return {
+      success: true,
+      data: {
+        summary,
+        ...(keywords ? { keywords } : {}),
+      },
+    };
+  }
+
+  private async handleValidatePdf(
+    input: ExecutionInput,
+  ): Promise<ExecutionOutput> {
+    const payload = input.payload as ValidatePdfPayload | undefined;
+
+    if (!payload?.fileName || payload?.fileSizeBytes == null || !payload?.mimeType) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.INVALID_INPUT,
+          message:
+            "fileName, fileSizeBytes, and mimeType are required for VALIDATE_PDF",
+        },
+      };
+    }
+
+    if (payload.fileSizeBytes > MAX_FILE_SIZE_BYTES) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.FILE_TOO_LARGE,
+          message: `File size ${payload.fileSizeBytes} bytes exceeds maximum of ${MAX_FILE_SIZE_BYTES} bytes`,
+        },
+      };
+    }
+
+    if (!SUPPORTED_MIME_TYPES.includes(payload.mimeType)) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.UNSUPPORTED_FILE_TYPE,
+          message: `MIME type "${payload.mimeType}" is not supported. Expected one of: ${SUPPORTED_MIME_TYPES.join(", ")}`,
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        isValid: true,
+        fileName: payload.fileName,
+        fileSizeBytes: payload.fileSizeBytes,
+        mimeType: payload.mimeType,
+      },
+    };
+  }
+
+  private async handleGetSummary(
+    input: ExecutionInput,
+  ): Promise<ExecutionOutput> {
+    const payload = input.payload as GetSummaryPayload | undefined;
+
+    if (!payload?.summaryId) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.INVALID_INPUT,
+          message: "summaryId is required for GET_SUMMARY",
+        },
+      };
+    }
+
+    const summary = this.summaries.get(payload.summaryId);
+    if (!summary) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.SUMMARY_NOT_FOUND,
+          message: `Summary with id "${payload.summaryId}" not found`,
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: { summary },
+    };
+  }
+
+  private async handleListSummaries(): Promise<ExecutionOutput> {
+    return {
+      success: true,
+      data: {
+        summaries: Array.from(this.summaries.values()),
+        count: this.summaries.size,
+      },
+    };
+  }
+
+  private async handleDeleteSummary(
+    input: ExecutionInput,
+  ): Promise<ExecutionOutput> {
+    const payload = input.payload as DeleteSummaryPayload | undefined;
+
+    if (!payload?.summaryId) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.INVALID_INPUT,
+          message: "summaryId is required for DELETE_SUMMARY",
+        },
+      };
+    }
+
+    if (!this.summaries.has(payload.summaryId)) {
+      return {
+        success: false,
+        error: {
+          code: ExecutionErrorCode.SUMMARY_NOT_FOUND,
+          message: `Summary with id "${payload.summaryId}" not found`,
+        },
+      };
+    }
+
+    this.summaries.delete(payload.summaryId);
+
+    return {
+      success: true,
+      data: {
+        deletedId: payload.summaryId,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers (deterministic, pure-ish)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Generate a deterministic summary ID from the filename.
+   * Uses a simple hash so the same file always gets the same ID.
+   */
+  private generateSummaryId(fileName: string): string {
+    let hash = 0;
+    for (let i = 0; i < fileName.length; i++) {
+      const char = fileName.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash |= 0; // Convert to 32-bit integer
+    }
+    return `summary-${Math.abs(hash).toString(36)}`;
+  }
+
+  /**
+   * Generate a deterministic summary from text content and settings.
+   *
+   * This is a text-truncation/extraction algorithm (no AI/ML), consistent
+   * with the spec's constraint of "deterministic output for same input."
+   */
+  private generateSummaryText(
+    content: string,
+    settings: SummarySettings,
+  ): string {
+    const sentences = this.splitSentences(content);
+    const targetWords = LENGTH_WORD_TARGETS[settings.length];
+
+    // Select sentences until we reach the target word count
+    const selected: string[] = [];
+    let wordCount = 0;
+
+    for (const sentence of sentences) {
+      const words = sentence.split(/\s+/).filter(Boolean);
+      if (wordCount + words.length > targetWords && selected.length > 0) {
+        break;
+      }
+      selected.push(sentence.trim());
+      wordCount += words.length;
+    }
+
+    if (selected.length === 0 && sentences.length > 0) {
+      selected.push(sentences[0].trim());
+    }
+
+    // Format according to style
+    if (settings.style === "bullet-points") {
+      return selected.map((s) => `• ${s}`).join("\n");
+    }
+
+    return selected.join(" ");
+  }
+
+  /**
+   * Split text into sentence-like segments.
+   * Handles common abbreviations to avoid false splits.
+   */
+  private splitSentences(text: string): string[] {
+    return text
+      .replace(/\n+/g, " ")
+      .split(/(?<=[.!?])\s+/)
+      .filter((s) => s.trim().length > 0);
+  }
+
+  /**
+   * Extract keywords using simple word-frequency analysis.
+   * Returns the top 5 most frequent non-stopword tokens.
+   */
+  private extractKeywords(text: string, limit = 5): string[] {
+    const stopWords = new Set([
+      "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+      "of", "with", "by", "from", "is", "it", "as", "be", "was", "were",
+      "are", "been", "being", "have", "has", "had", "do", "does", "did",
+      "will", "would", "could", "should", "may", "might", "shall", "can",
+      "not", "this", "that", "these", "those", "i", "you", "he", "she",
+      "we", "they", "me", "him", "her", "us", "them", "my", "your", "his",
+      "its", "our", "their", "what", "which", "who", "whom", "how", "when",
+      "where", "why", "all", "each", "every", "both", "few", "more", "most",
+      "other", "some", "such", "no", "nor", "only", "own", "same", "so",
+      "than", "too", "very", "just", "if", "then", "also", "about", "up",
+    ]);
+
+    const words = text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, "")
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !stopWords.has(w));
+
+    const freq = new Map<string, number>();
+    for (const word of words) {
+      freq.set(word, (freq.get(word) ?? 0) + 1);
+    }
+
+    return Array.from(freq.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([word]) => word);
+  }
+}

--- a/tools/v2/individual/pdf-summary-tool/services/ExecutionService.ts
+++ b/tools/v2/individual/pdf-summary-tool/services/ExecutionService.ts
@@ -97,8 +97,7 @@ export class ExecutionService {
         success: false,
         error: {
           code: ExecutionErrorCode.INTERNAL_ERROR,
-          message:
-            error instanceof Error ? error.message : "Unknown internal error",
+          message: error instanceof Error ? error.message : "Unknown internal error",
         },
       };
     }
@@ -108,9 +107,7 @@ export class ExecutionService {
   // Action handlers
   // -------------------------------------------------------------------------
 
-  private async handleSummarizePdf(
-    input: ExecutionInput,
-  ): Promise<ExecutionOutput> {
+  private async handleSummarizePdf(input: ExecutionInput): Promise<ExecutionOutput> {
     const payload = input.payload as SummarizePdfPayload | undefined;
 
     if (!payload?.pdfContent || !payload?.fileName) {
@@ -118,8 +115,7 @@ export class ExecutionService {
         success: false,
         error: {
           code: ExecutionErrorCode.INVALID_INPUT,
-          message:
-            "pdfContent and fileName are required for SUMMARIZE_PDF",
+          message: "pdfContent and fileName are required for SUMMARIZE_PDF",
         },
       };
     }
@@ -139,10 +135,7 @@ export class ExecutionService {
       ...(payload.settings ?? {}),
     };
 
-    const summaryContent = this.generateSummaryText(
-      payload.pdfContent,
-      settings,
-    );
+    const summaryContent = this.generateSummaryText(payload.pdfContent, settings);
 
     const keywords = settings.includeKeywords
       ? this.extractKeywords(payload.pdfContent)
@@ -168,9 +161,7 @@ export class ExecutionService {
     };
   }
 
-  private async handleValidatePdf(
-    input: ExecutionInput,
-  ): Promise<ExecutionOutput> {
+  private async handleValidatePdf(input: ExecutionInput): Promise<ExecutionOutput> {
     const payload = input.payload as ValidatePdfPayload | undefined;
 
     if (!payload?.fileName || payload?.fileSizeBytes == null || !payload?.mimeType) {
@@ -178,8 +169,7 @@ export class ExecutionService {
         success: false,
         error: {
           code: ExecutionErrorCode.INVALID_INPUT,
-          message:
-            "fileName, fileSizeBytes, and mimeType are required for VALIDATE_PDF",
+          message: "fileName, fileSizeBytes, and mimeType are required for VALIDATE_PDF",
         },
       };
     }
@@ -215,9 +205,7 @@ export class ExecutionService {
     };
   }
 
-  private async handleGetSummary(
-    input: ExecutionInput,
-  ): Promise<ExecutionOutput> {
+  private async handleGetSummary(input: ExecutionInput): Promise<ExecutionOutput> {
     const payload = input.payload as GetSummaryPayload | undefined;
 
     if (!payload?.summaryId) {
@@ -257,9 +245,7 @@ export class ExecutionService {
     };
   }
 
-  private async handleDeleteSummary(
-    input: ExecutionInput,
-  ): Promise<ExecutionOutput> {
+  private async handleDeleteSummary(input: ExecutionInput): Promise<ExecutionOutput> {
     const payload = input.payload as DeleteSummaryPayload | undefined;
 
     if (!payload?.summaryId) {
@@ -316,10 +302,7 @@ export class ExecutionService {
    * This is a text-truncation/extraction algorithm (no AI/ML), consistent
    * with the spec's constraint of "deterministic output for same input."
    */
-  private generateSummaryText(
-    content: string,
-    settings: SummarySettings,
-  ): string {
+  private generateSummaryText(content: string, settings: SummarySettings): string {
     const sentences = this.splitSentences(content);
     const targetWords = LENGTH_WORD_TARGETS[settings.length];
 
@@ -365,16 +348,99 @@ export class ExecutionService {
    */
   private extractKeywords(text: string, limit = 5): string[] {
     const stopWords = new Set([
-      "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
-      "of", "with", "by", "from", "is", "it", "as", "be", "was", "were",
-      "are", "been", "being", "have", "has", "had", "do", "does", "did",
-      "will", "would", "could", "should", "may", "might", "shall", "can",
-      "not", "this", "that", "these", "those", "i", "you", "he", "she",
-      "we", "they", "me", "him", "her", "us", "them", "my", "your", "his",
-      "its", "our", "their", "what", "which", "who", "whom", "how", "when",
-      "where", "why", "all", "each", "every", "both", "few", "more", "most",
-      "other", "some", "such", "no", "nor", "only", "own", "same", "so",
-      "than", "too", "very", "just", "if", "then", "also", "about", "up",
+      "the",
+      "a",
+      "an",
+      "and",
+      "or",
+      "but",
+      "in",
+      "on",
+      "at",
+      "to",
+      "for",
+      "of",
+      "with",
+      "by",
+      "from",
+      "is",
+      "it",
+      "as",
+      "be",
+      "was",
+      "were",
+      "are",
+      "been",
+      "being",
+      "have",
+      "has",
+      "had",
+      "do",
+      "does",
+      "did",
+      "will",
+      "would",
+      "could",
+      "should",
+      "may",
+      "might",
+      "shall",
+      "can",
+      "not",
+      "this",
+      "that",
+      "these",
+      "those",
+      "i",
+      "you",
+      "he",
+      "she",
+      "we",
+      "they",
+      "me",
+      "him",
+      "her",
+      "us",
+      "them",
+      "my",
+      "your",
+      "his",
+      "its",
+      "our",
+      "their",
+      "what",
+      "which",
+      "who",
+      "whom",
+      "how",
+      "when",
+      "where",
+      "why",
+      "all",
+      "each",
+      "every",
+      "both",
+      "few",
+      "more",
+      "most",
+      "other",
+      "some",
+      "such",
+      "no",
+      "nor",
+      "only",
+      "own",
+      "same",
+      "so",
+      "than",
+      "too",
+      "very",
+      "just",
+      "if",
+      "then",
+      "also",
+      "about",
+      "up",
     ]);
 
     const words = text

--- a/tools/v2/individual/pdf-summary-tool/services/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/services/index.ts
@@ -8,8 +8,11 @@
  * - pdfProcessing: Extract text, validate PDFs
  * - summarization: Generate summaries
  * - storage: Persist and retrieve summaries
+ * - ExecutionService: Non-UI execution contract entry point
  */
 
 // export * from './pdfProcessing';
 // export * from './summarization';
 // export * from './storage';
+export * from "./ExecutionService";
+

--- a/tools/v2/individual/pdf-summary-tool/services/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/services/index.ts
@@ -15,4 +15,3 @@
 // export * from './summarization';
 // export * from './storage';
 export * from "./ExecutionService";
-

--- a/tools/v2/individual/pdf-summary-tool/tests/execution.test.ts
+++ b/tools/v2/individual/pdf-summary-tool/tests/execution.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ExecutionService } from "../services/ExecutionService";
+import type { ExecutionInput, ExecutionOutput } from "../types/execution";
+import fixtures from "../fixtures/execution.json";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FixtureCase {
+  name?: string;
+  input: ExecutionInput;
+  expectedOutput: {
+    success: boolean;
+    data?: Record<string, any>;
+    dataShape?: Record<string, boolean>;
+    error?: { code: string; message: string };
+  };
+}
+
+// The sample content used by the SUMMARIZE_PDF success fixture (full settings).
+const SAMPLE_CONTENT =
+  "The quarterly financial report shows significant growth in revenue across all departments. " +
+  "Operating expenses remained stable while profit margins improved by twelve percent compared " +
+  "to the previous quarter. The marketing team achieved record customer acquisition rates. " +
+  "Research and development investments continued to yield positive results with three new " +
+  "product launches.";
+
+let service: ExecutionService;
+
+beforeEach(() => {
+  service = new ExecutionService();
+});
+
+// ---------------------------------------------------------------------------
+// Fixture-driven tests
+// ---------------------------------------------------------------------------
+
+describe("ExecutionService — success fixtures", () => {
+  const cases = fixtures.successCases as FixtureCase[];
+
+  for (const fixture of cases) {
+    it(fixture.name ?? `succeeds for ${fixture.input.action}`, async () => {
+      const result: ExecutionOutput = await service.execute(
+        fixture.input as ExecutionInput,
+      );
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+
+      // If the fixture specifies an exact data match, verify it
+      if (fixture.expectedOutput.data) {
+        expect(result.data).toEqual(fixture.expectedOutput.data);
+      }
+
+      // If the fixture specifies a shape check, verify structural properties
+      if (fixture.expectedOutput.dataShape) {
+        const shape = fixture.expectedOutput.dataShape;
+        if (shape.hasSummary) {
+          expect(result.data).toHaveProperty("summary");
+          expect(result.data.summary).toHaveProperty("id");
+          expect(result.data.summary).toHaveProperty("pdfId");
+          expect(result.data.summary).toHaveProperty("content");
+          expect(result.data.summary).toHaveProperty("settings");
+          expect(result.data.summary).toHaveProperty("generatedAt");
+        }
+        if (shape.hasKeywords === true) {
+          expect(result.data).toHaveProperty("keywords");
+          expect(Array.isArray(result.data.keywords)).toBe(true);
+          expect(result.data.keywords.length).toBeGreaterThan(0);
+        }
+        if (shape.hasKeywords === false) {
+          expect(result.data.keywords).toBeUndefined();
+        }
+        if (shape.summaryHasBullets === true) {
+          expect(result.data.summary.content).toContain("•");
+        }
+        if (shape.summaryHasBullets === false) {
+          expect(result.data.summary.content).not.toContain("•");
+        }
+      }
+    });
+  }
+});
+
+describe("ExecutionService — failure fixtures", () => {
+  const cases = fixtures.failureCases as FixtureCase[];
+
+  for (const fixture of cases) {
+    it(fixture.name ?? `fails for ${fixture.input.action}`, async () => {
+      const result: ExecutionOutput = await service.execute(
+        fixture.input as ExecutionInput,
+      );
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe(fixture.expectedOutput.error!.code);
+      expect(result.error!.message).toBe(
+        fixture.expectedOutput.error!.message,
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Targeted behavioural tests
+// ---------------------------------------------------------------------------
+
+describe("ExecutionService — determinism", () => {
+  it("produces identical output for identical SUMMARIZE_PDF input", async () => {
+    const input: ExecutionInput = {
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "determinism-test.pdf",
+        fileSizeBytes: 1024,
+        settings: { length: "short", style: "paragraph", includeKeywords: false, language: "en" },
+      },
+    };
+
+    const a = await service.execute(input);
+    // Use a fresh instance to prove there's no cross-state leakage
+    const freshService = new ExecutionService();
+    const b = await freshService.execute(input);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(a.data.summary.content).toBe(b.data.summary.content);
+    expect(a.data.summary.id).toBe(b.data.summary.id);
+    expect(a.data.summary.pdfId).toBe(b.data.summary.pdfId);
+    expect(a.data.summary.settings).toEqual(b.data.summary.settings);
+  });
+});
+
+describe("ExecutionService — summary lifecycle", () => {
+  it("create → get → list → delete → get (not found)", async () => {
+    // 1. Create
+    const createResult = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "lifecycle-test.pdf",
+        fileSizeBytes: 2048,
+      },
+    });
+    expect(createResult.success).toBe(true);
+    const summaryId = createResult.data.summary.id;
+    expect(typeof summaryId).toBe("string");
+
+    // 2. Get — should find it
+    const getResult = await service.execute({
+      action: "GET_SUMMARY",
+      payload: { summaryId },
+    });
+    expect(getResult.success).toBe(true);
+    expect(getResult.data.summary.id).toBe(summaryId);
+    expect(getResult.data.summary.content).toBe(
+      createResult.data.summary.content,
+    );
+
+    // 3. List — should contain exactly one
+    const listResult = await service.execute({ action: "LIST_SUMMARIES" });
+    expect(listResult.success).toBe(true);
+    expect(listResult.data.count).toBe(1);
+    expect(listResult.data.summaries).toHaveLength(1);
+    expect(listResult.data.summaries[0].id).toBe(summaryId);
+
+    // 4. Delete
+    const deleteResult = await service.execute({
+      action: "DELETE_SUMMARY",
+      payload: { summaryId },
+    });
+    expect(deleteResult.success).toBe(true);
+    expect(deleteResult.data.deletedId).toBe(summaryId);
+
+    // 5. Get again — should not find it
+    const getAgain = await service.execute({
+      action: "GET_SUMMARY",
+      payload: { summaryId },
+    });
+    expect(getAgain.success).toBe(false);
+    expect(getAgain.error!.code).toBe("SUMMARY_NOT_FOUND");
+  });
+});
+
+describe("ExecutionService — keyword extraction", () => {
+  it("returns keywords when includeKeywords is true", async () => {
+    const result = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "keywords-test.pdf",
+        fileSizeBytes: 1024,
+        settings: { includeKeywords: true },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.keywords).toBeDefined();
+    expect(Array.isArray(result.data.keywords)).toBe(true);
+    expect(result.data.keywords.length).toBeGreaterThan(0);
+    // Keywords should be lowercase strings
+    for (const kw of result.data.keywords) {
+      expect(typeof kw).toBe("string");
+      expect(kw).toBe(kw.toLowerCase());
+    }
+  });
+
+  it("omits keywords when includeKeywords is false", async () => {
+    const result = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "no-keywords.pdf",
+        fileSizeBytes: 1024,
+        settings: { includeKeywords: false },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.keywords).toBeUndefined();
+  });
+});
+
+describe("ExecutionService — summary settings", () => {
+  it("applies default settings when none are provided", async () => {
+    const result = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "defaults.pdf",
+        fileSizeBytes: 1024,
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.summary.settings).toEqual({
+      length: "medium",
+      style: "paragraph",
+      includeKeywords: false,
+      language: "en",
+    });
+  });
+
+  it("merges partial settings with defaults", async () => {
+    const result = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "partial.pdf",
+        fileSizeBytes: 1024,
+        settings: { length: "long" },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.summary.settings.length).toBe("long");
+    expect(result.data.summary.settings.style).toBe("paragraph");
+    expect(result.data.summary.settings.includeKeywords).toBe(false);
+    expect(result.data.summary.settings.language).toBe("en");
+  });
+
+  it("formats as bullet points when style is bullet-points", async () => {
+    const result = await service.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "bullets.pdf",
+        fileSizeBytes: 1024,
+        settings: { style: "bullet-points" },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.summary.content).toContain("•");
+  });
+});
+
+describe("ExecutionService — state isolation", () => {
+  it("each instance starts with empty storage", async () => {
+    // First instance: create a summary
+    const s1 = new ExecutionService();
+    await s1.execute({
+      action: "SUMMARIZE_PDF",
+      payload: {
+        pdfContent: SAMPLE_CONTENT,
+        fileName: "isolation.pdf",
+        fileSizeBytes: 1024,
+      },
+    });
+    const list1 = await s1.execute({ action: "LIST_SUMMARIES" });
+    expect(list1.data.count).toBe(1);
+
+    // Second instance: should be empty
+    const s2 = new ExecutionService();
+    const list2 = await s2.execute({ action: "LIST_SUMMARIES" });
+    expect(list2.data.count).toBe(0);
+  });
+});

--- a/tools/v2/individual/pdf-summary-tool/tests/execution.test.ts
+++ b/tools/v2/individual/pdf-summary-tool/tests/execution.test.ts
@@ -41,9 +41,7 @@ describe("ExecutionService — success fixtures", () => {
 
   for (const fixture of cases) {
     it(fixture.name ?? `succeeds for ${fixture.input.action}`, async () => {
-      const result: ExecutionOutput = await service.execute(
-        fixture.input as ExecutionInput,
-      );
+      const result: ExecutionOutput = await service.execute(fixture.input as ExecutionInput);
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
 
@@ -87,16 +85,12 @@ describe("ExecutionService — failure fixtures", () => {
 
   for (const fixture of cases) {
     it(fixture.name ?? `fails for ${fixture.input.action}`, async () => {
-      const result: ExecutionOutput = await service.execute(
-        fixture.input as ExecutionInput,
-      );
+      const result: ExecutionOutput = await service.execute(fixture.input as ExecutionInput);
       expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
       expect(result.error!.code).toBe(fixture.expectedOutput.error!.code);
-      expect(result.error!.message).toBe(
-        fixture.expectedOutput.error!.message,
-      );
+      expect(result.error!.message).toBe(fixture.expectedOutput.error!.message);
     });
   }
 });
@@ -153,9 +147,7 @@ describe("ExecutionService — summary lifecycle", () => {
     });
     expect(getResult.success).toBe(true);
     expect(getResult.data.summary.id).toBe(summaryId);
-    expect(getResult.data.summary.content).toBe(
-      createResult.data.summary.content,
-    );
+    expect(getResult.data.summary.content).toBe(createResult.data.summary.content);
 
     // 3. List — should contain exactly one
     const listResult = await service.execute({ action: "LIST_SUMMARIES" });

--- a/tools/v2/individual/pdf-summary-tool/types/execution.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/execution.ts
@@ -1,0 +1,146 @@
+/**
+ * PDF Summary Tool - Execution Contract Types
+ *
+ * Defines the typed input/output contract for non-UI, backend-facing
+ * execution of the PDF Summary Tool. This contract is serializable
+ * and independent of browser/React APIs.
+ *
+ * See MODULE_BOUNDARIES.md for type design guidelines.
+ */
+
+import type { SummarySettings } from "./index";
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/** All actions supported by the top-level execution contract. */
+export enum ExecutionAction {
+  /** Generate a summary from pre-extracted PDF text content. */
+  SUMMARIZE_PDF = "SUMMARIZE_PDF",
+
+  /** Validate a PDF file's metadata (name, size, MIME type). */
+  VALIDATE_PDF = "VALIDATE_PDF",
+
+  /** Retrieve a previously generated summary by ID. */
+  GET_SUMMARY = "GET_SUMMARY",
+
+  /** List all stored summaries. */
+  LIST_SUMMARIES = "LIST_SUMMARIES",
+
+  /** Delete a stored summary by ID. */
+  DELETE_SUMMARY = "DELETE_SUMMARY",
+}
+
+// ---------------------------------------------------------------------------
+// Per-action payloads
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload for SUMMARIZE_PDF.
+ *
+ * Accepts pre-extracted text — *not* a raw File object — so the contract
+ * stays serializable and decoupled from the browser File API.
+ */
+export interface SummarizePdfPayload {
+  /** Pre-extracted text content from the PDF. */
+  pdfContent: string;
+
+  /** Original filename of the PDF. */
+  fileName: string;
+
+  /** File size in bytes (used for metadata). */
+  fileSizeBytes: number;
+
+  /** Optional overrides; defaults are applied for any missing fields. */
+  settings?: Partial<SummarySettings>;
+}
+
+/** Payload for VALIDATE_PDF. */
+export interface ValidatePdfPayload {
+  /** Original filename of the PDF. */
+  fileName: string;
+
+  /** File size in bytes. */
+  fileSizeBytes: number;
+
+  /** MIME type reported by the file / upload layer. */
+  mimeType: string;
+}
+
+/** Payload for GET_SUMMARY. */
+export interface GetSummaryPayload {
+  /** ID of the summary to retrieve. */
+  summaryId: string;
+}
+
+/** Payload for DELETE_SUMMARY. */
+export interface DeleteSummaryPayload {
+  /** ID of the summary to delete. */
+  summaryId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input / Output envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level execution input.
+ *
+ * `action` is typed as the union of `ExecutionAction` and `string` so the
+ * service can gracefully reject unknown actions at runtime.
+ */
+export interface ExecutionInput {
+  action: ExecutionAction | string;
+  payload?: Record<string, any>;
+}
+
+/**
+ * Top-level execution output.
+ *
+ * Exactly one of `data` or `error` will be present:
+ * - `success: true`  → `data` is set
+ * - `success: false` → `error` is set
+ */
+export interface ExecutionOutput<T = any> {
+  success: boolean;
+  data?: T;
+  error?: ExecutionError;
+}
+
+/** Structured error returned on failure. */
+export interface ExecutionError {
+  code: ExecutionErrorCode;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+/** Exhaustive set of error codes for the execution contract. */
+export enum ExecutionErrorCode {
+  /** A required field is missing or the action itself is absent. */
+  INVALID_INPUT = "INVALID_INPUT",
+
+  /** A field is present but its value is invalid. */
+  VALIDATION_ERROR = "VALIDATION_ERROR",
+
+  /** The requested summary does not exist in storage. */
+  SUMMARY_NOT_FOUND = "SUMMARY_NOT_FOUND",
+
+  /** The supplied pdfContent is too short to summarize. */
+  CONTENT_TOO_SHORT = "CONTENT_TOO_SHORT",
+
+  /** The file exceeds the maximum allowed size. */
+  FILE_TOO_LARGE = "FILE_TOO_LARGE",
+
+  /** The file's MIME type is not in the supported list. */
+  UNSUPPORTED_FILE_TYPE = "UNSUPPORTED_FILE_TYPE",
+
+  /** The requested action string is not a known ExecutionAction. */
+  ACTION_NOT_SUPPORTED = "ACTION_NOT_SUPPORTED",
+
+  /** An unexpected internal error occurred. */
+  INTERNAL_ERROR = "INTERNAL_ERROR",
+}

--- a/tools/v2/individual/pdf-summary-tool/types/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/types/index.ts
@@ -125,3 +125,5 @@ export interface UseSummarySettingsReturn {
 }
 
 // Add more types as needed following this pattern
+
+export * from "./execution";

--- a/tools/v2/individual/pdf-summary-tool/vitest.config.ts
+++ b/tools/v2/individual/pdf-summary-tool/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    root: path.resolve(__dirname),
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Introduces a stable, backend-facing execution contract for the PDF Summary Tool, decoupling core tool logic from presentation/UI concerns.

Typed contract (types/execution.ts): ExecutionAction enum with 5 actions (SUMMARIZE_PDF, VALIDATE_PDF, GET_SUMMARY, LIST_SUMMARIES, DELETE_SUMMARY), per-action payload interfaces, generic ExecutionInput/ExecutionOutput envelope, and ExecutionErrorCode enum.

Service entry point (services/ExecutionService.ts): Stateless class with a single execute() method that dispatches to action handlers. Uses in-memory storage and deterministic text-extraction summarization — zero browser, React, or localStorage dependencies.

Fixtures (fixtures/execution.json): 12 cases (4 success, 8 failure) covering all actions and error codes.

Tests (tests/execution.test.ts): 20 Vitest tests across 7 groups — fixture-driven validation, determinism, full CRUD lifecycle, keyword extraction, settings merging, and instance isolation.

Closes #1371