### PR TITLE
feat(cold-email-writer): add non-UI execution contract

### DIFF
--- a/tools/v2/individual/cold-email-writer/README.md
+++ b/tools/v2/individual/cold-email-writer/README.md
@@ -1,15 +1,28 @@
 # Cold Email Writer
 
-This folder is the isolated workspace for the Cold Email Writer tool.
+Cold Email Writer exposes a deterministic, non-UI service for producing a
+plain-text outbound email draft from structured campaign data.
 
-## Ownership Boundary
+## Backend entry point
 
-All work for this tool must stay inside:
+Import `safeWriteColdEmail` from `index.ts` when handling untrusted payloads.
+It validates and sanitizes input, enforces size limits, and returns a
+discriminated result without throwing. Call `writeColdEmail` only when the
+payload has already been validated.
 
-`text
-.\tools\v2\individual\cold-email-writer\
-`
+The complete typed contract and service boundaries are documented in
+`docs/contract.md`. Typed success and failure examples are exported from
+`services/fixtures.ts`.
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+## Local verification
 
-See specs.md for the issue categories and contributor expectations.
+```sh
+npx vitest run tools/v2/individual/cold-email-writer/tests
+npx tsc --noEmit
+```
+
+## Ownership boundary
+
+All code, tests, fixtures, and documentation for this tool stay inside this
+folder. The module has no UI, routing, mailbox, database, or design-system
+dependencies.

--- a/tools/v2/individual/cold-email-writer/docs/contract.md
+++ b/tools/v2/individual/cold-email-writer/docs/contract.md
@@ -1,0 +1,55 @@
+# Non-UI execution contract
+
+## Service boundaries
+
+| Entry point                                             | Intended caller                                 | Behavior                                                |
+| ------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| `safeWriteColdEmail(input: unknown, options?: unknown)` | API handlers, jobs, and other untrusted callers | Validates, sanitizes, enforces limits, and never throws |
+| `writeColdEmail(input, options?)`                       | Trusted internal code                           | Pure deterministic writer; assumes valid input          |
+
+The module is synchronous and has no network, storage, mailbox, clock,
+randomness, UI, or framework dependencies. Generated output is a draft only;
+delivery is explicitly outside this service boundary.
+
+## Input and output
+
+`ColdEmailWriterInput` requires a caller-owned `requestId`, sender and recipient
+identities, an `offer`, a `valueProposition`, and a `callToAction`. Proof points
+and the `professional`, `friendly`, or `direct` tone are optional.
+
+`ColdEmailWriterOptions` controls subject inclusion and caps the generated body
+at 1–300 words.
+
+Successful execution returns `ColdEmailWriterOutput`: the echoed request ID,
+nullable subject, plain-text body, resolved tone, and deterministic word/proof
+metadata. The guarded entry point wraps this as:
+
+```ts
+{ status: "ok", result: ColdEmailWriterOutput }
+```
+
+Failures use:
+
+```ts
+{
+  status: "error";
+  code: ColdEmailWriterErrorCode;
+  message: string;
+  issues: ColdEmailWriterValidationIssue[];
+}
+```
+
+## Stable error codes
+
+| Code              | Meaning                                                |
+| ----------------- | ------------------------------------------------------ |
+| `invalid-input`   | Payload shape or field type is invalid                 |
+| `invalid-options` | Options are malformed or outside supported bounds      |
+| `input-too-large` | A field or collection exceeds a documented guard limit |
+| `empty-content`   | A required string is empty after sanitization          |
+
+## Fixtures
+
+`services/fixtures.ts` exports typed `successFixtures` and `failureFixtures`.
+Every failure fixture declares its expected stable error code, making the
+contract reusable by backend adapters and tests.

--- a/tools/v2/individual/cold-email-writer/index.ts
+++ b/tools/v2/individual/cold-email-writer/index.ts
@@ -1,0 +1,26 @@
+export {
+  DEFAULT_MAX_BODY_WORDS,
+  MAX_BODY_WORDS_LIMIT,
+  writeColdEmail,
+} from "./services/coldEmailWriter";
+export {
+  COLD_EMAIL_INPUT_LIMITS,
+  checkColdEmailInputLimits,
+  safeWriteColdEmail,
+  sanitizeColdEmailInput,
+  sanitizeColdEmailText,
+  validateColdEmailInput,
+  validateColdEmailOptions,
+} from "./services/guards";
+export { failureFixtures, successFixtures } from "./services/fixtures";
+export type { ColdEmailFailureFixture, ColdEmailSuccessFixture } from "./services/fixtures";
+export type {
+  ColdEmailParty,
+  ColdEmailTone,
+  ColdEmailWriterErrorCode,
+  ColdEmailWriterInput,
+  ColdEmailWriterOptions,
+  ColdEmailWriterOutput,
+  ColdEmailWriterValidationIssue,
+  SafeColdEmailWriterResult,
+} from "./types/coldEmailWriter";

--- a/tools/v2/individual/cold-email-writer/services/coldEmailWriter.ts
+++ b/tools/v2/individual/cold-email-writer/services/coldEmailWriter.ts
@@ -1,0 +1,66 @@
+import type {
+  ColdEmailTone,
+  ColdEmailWriterInput,
+  ColdEmailWriterOptions,
+  ColdEmailWriterOutput,
+} from "../types/coldEmailWriter";
+
+export const DEFAULT_MAX_BODY_WORDS = 120;
+export const MAX_BODY_WORDS_LIMIT = 300;
+
+function words(value: string): string[] {
+  return value.trim().split(/\s+/).filter(Boolean);
+}
+
+function truncateWords(value: string, limit: number): string {
+  const tokens = words(value);
+  return tokens.length <= limit ? value : `${tokens.slice(0, limit).join(" ")}…`;
+}
+
+function resolveTone(tone: ColdEmailTone | undefined): ColdEmailTone {
+  return tone ?? "professional";
+}
+
+function openingFor(input: ColdEmailWriterInput, tone: ColdEmailTone): string {
+  const context = input.recipient.company
+    ? ` at ${input.recipient.company}`
+    : input.recipient.role
+      ? ` in your role as ${input.recipient.role}`
+      : "";
+  if (tone === "friendly") {
+    return `Hi ${input.recipient.name}, I thought this might be useful for you${context}.`;
+  }
+  if (tone === "direct") {
+    return `Hi ${input.recipient.name}, I am reaching out about ${input.offer}${context}.`;
+  }
+  return `Hello ${input.recipient.name}, I am reaching out because ${input.offer} may be relevant to you${context}.`;
+}
+
+/** Pure execution engine for payloads that have already been validated. */
+export function writeColdEmail(
+  input: ColdEmailWriterInput,
+  options: ColdEmailWriterOptions = {},
+): ColdEmailWriterOutput {
+  const tone = resolveTone(input.tone);
+  const proof = (input.proofPoints ?? []).map((point) => point.trim()).filter(Boolean);
+  const paragraphs = [
+    openingFor(input, tone),
+    input.valueProposition,
+    proof.length > 0 ? `Relevant results: ${proof.join("; ")}.` : "",
+    input.callToAction,
+    `Best,\n${input.sender.name}`,
+  ].filter(Boolean);
+  const maxWords = Math.trunc(options.maxBodyWords ?? DEFAULT_MAX_BODY_WORDS);
+  const body = truncateWords(paragraphs.join("\n\n"), maxWords);
+
+  return {
+    requestId: input.requestId,
+    subject: options.includeSubject === false ? null : `${input.offer} for ${input.recipient.name}`,
+    body,
+    tone,
+    metadata: {
+      wordCount: words(body).length,
+      proofPointsUsed: proof.length,
+    },
+  };
+}

--- a/tools/v2/individual/cold-email-writer/services/fixtures.ts
+++ b/tools/v2/individual/cold-email-writer/services/fixtures.ts
@@ -1,0 +1,101 @@
+import { COLD_EMAIL_INPUT_LIMITS } from "./guards";
+import type {
+  ColdEmailWriterErrorCode,
+  ColdEmailWriterInput,
+  ColdEmailWriterOptions,
+} from "../types/coldEmailWriter";
+
+export interface ColdEmailSuccessFixture {
+  name: string;
+  input: ColdEmailWriterInput;
+  options?: ColdEmailWriterOptions;
+  expectedTone: "professional" | "friendly" | "direct";
+}
+
+export interface ColdEmailFailureFixture {
+  name: string;
+  input: unknown;
+  options?: unknown;
+  expectedCode: ColdEmailWriterErrorCode;
+}
+
+export const successFixtures: ColdEmailSuccessFixture[] = [
+  {
+    name: "professional-with-proof",
+    input: {
+      requestId: "cold-001",
+      sender: { name: "Amina", company: "Northstar" },
+      recipient: { name: "Jordan", company: "Acme", role: "Sales Director" },
+      offer: "a faster lead-research workflow",
+      valueProposition: "Northstar helps sales teams prepare relevant outreach in minutes.",
+      callToAction: "Would a 15-minute walkthrough next Tuesday be useful?",
+      proofPoints: ["reduced research time by 40% for a 20-person sales team"],
+    },
+    expectedTone: "professional",
+  },
+  {
+    name: "friendly-without-subject",
+    input: {
+      requestId: "cold-002",
+      sender: { name: "Kai" },
+      recipient: { name: "Sam", role: "Founder" },
+      offer: "automated customer follow-ups",
+      valueProposition: "It keeps promising conversations from going quiet.",
+      callToAction: "Open to comparing notes this week?",
+      tone: "friendly",
+    },
+    options: { includeSubject: false, maxBodyWords: 80 },
+    expectedTone: "friendly",
+  },
+];
+
+export const failureFixtures: ColdEmailFailureFixture[] = [
+  {
+    name: "missing-recipient",
+    input: {
+      requestId: "cold-invalid",
+      sender: { name: "Amina" },
+      offer: "an offer",
+      valueProposition: "some value",
+      callToAction: "Talk?",
+    },
+    expectedCode: "invalid-input",
+  },
+  {
+    name: "empty-recipient-name",
+    input: {
+      requestId: "cold-empty",
+      sender: { name: "Amina" },
+      recipient: { name: "\u200b" },
+      offer: "an offer",
+      valueProposition: "some value",
+      callToAction: "Talk?",
+    },
+    expectedCode: "empty-content",
+  },
+  {
+    name: "oversized-offer",
+    input: {
+      requestId: "cold-large",
+      sender: { name: "Amina" },
+      recipient: { name: "Jordan" },
+      offer: "x".repeat(COLD_EMAIL_INPUT_LIMITS.contentFieldChars + 1),
+      valueProposition: "some value",
+      callToAction: "Talk?",
+    },
+    expectedCode: "input-too-large",
+  },
+  {
+    name: "invalid-options",
+    input: {
+      requestId: "cold-options",
+      sender: { name: "Amina" },
+      recipient: { name: "Jordan" },
+      offer: "an offer",
+      valueProposition: "some value",
+      callToAction: "Talk?",
+    },
+    options: { maxBodyWords: 0 },
+    expectedCode: "invalid-options",
+  },
+];

--- a/tools/v2/individual/cold-email-writer/services/guards.ts
+++ b/tools/v2/individual/cold-email-writer/services/guards.ts
@@ -1,0 +1,169 @@
+import { MAX_BODY_WORDS_LIMIT, writeColdEmail } from "./coldEmailWriter";
+import type {
+  ColdEmailParty,
+  ColdEmailWriterInput,
+  ColdEmailWriterOptions,
+  ColdEmailWriterValidationIssue,
+  SafeColdEmailWriterResult,
+} from "../types/coldEmailWriter";
+
+export const COLD_EMAIL_INPUT_LIMITS = {
+  requestIdChars: 256,
+  partyFieldChars: 200,
+  contentFieldChars: 2_000,
+  proofPoints: 10,
+} as const;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const INVISIBLE_CHARACTERS = /[\u200b-\u200d\u2060\ufeff]/g;
+
+export function sanitizeColdEmailText(value: string): string {
+  return value
+    .normalize("NFC")
+    .replace(CONTROL_CHARACTERS, "")
+    .replace(INVISIBLE_CHARACTERS, "")
+    .trim();
+}
+
+function isParty(value: unknown): value is ColdEmailParty {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const party = value as Record<string, unknown>;
+  return (
+    typeof party.name === "string" &&
+    (party.company === undefined || typeof party.company === "string") &&
+    (party.role === undefined || typeof party.role === "string")
+  );
+}
+
+export function validateColdEmailInput(value: unknown): value is ColdEmailWriterInput {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const input = value as Record<string, unknown>;
+  return (
+    typeof input.requestId === "string" &&
+    isParty(input.sender) &&
+    isParty(input.recipient) &&
+    typeof input.offer === "string" &&
+    typeof input.valueProposition === "string" &&
+    typeof input.callToAction === "string" &&
+    (input.proofPoints === undefined ||
+      (Array.isArray(input.proofPoints) &&
+        input.proofPoints.every((point) => typeof point === "string"))) &&
+    (input.tone === undefined ||
+      input.tone === "professional" ||
+      input.tone === "friendly" ||
+      input.tone === "direct")
+  );
+}
+
+export function validateColdEmailOptions(value: unknown): value is ColdEmailWriterOptions {
+  if (value === undefined) return true;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const options = value as Record<string, unknown>;
+  return (
+    (options.includeSubject === undefined || typeof options.includeSubject === "boolean") &&
+    (options.maxBodyWords === undefined ||
+      (typeof options.maxBodyWords === "number" &&
+        Number.isInteger(options.maxBodyWords) &&
+        options.maxBodyWords >= 1 &&
+        options.maxBodyWords <= MAX_BODY_WORDS_LIMIT))
+  );
+}
+
+export function sanitizeColdEmailInput(input: ColdEmailWriterInput): ColdEmailWriterInput {
+  const cleanParty = (party: ColdEmailParty): ColdEmailParty => ({
+    name: sanitizeColdEmailText(party.name),
+    ...(party.company === undefined ? {} : { company: sanitizeColdEmailText(party.company) }),
+    ...(party.role === undefined ? {} : { role: sanitizeColdEmailText(party.role) }),
+  });
+  return {
+    ...input,
+    requestId: sanitizeColdEmailText(input.requestId),
+    sender: cleanParty(input.sender),
+    recipient: cleanParty(input.recipient),
+    offer: sanitizeColdEmailText(input.offer),
+    valueProposition: sanitizeColdEmailText(input.valueProposition),
+    callToAction: sanitizeColdEmailText(input.callToAction),
+    ...(input.proofPoints === undefined
+      ? {}
+      : { proofPoints: input.proofPoints.map(sanitizeColdEmailText) }),
+  };
+}
+
+export function checkColdEmailInputLimits(
+  input: ColdEmailWriterInput,
+): ColdEmailWriterValidationIssue[] {
+  const issues: ColdEmailWriterValidationIssue[] = [];
+  const fields: Array<[string, string, number]> = [
+    ["requestId", input.requestId, COLD_EMAIL_INPUT_LIMITS.requestIdChars],
+    ["sender.name", input.sender.name, COLD_EMAIL_INPUT_LIMITS.partyFieldChars],
+    ["recipient.name", input.recipient.name, COLD_EMAIL_INPUT_LIMITS.partyFieldChars],
+    ["offer", input.offer, COLD_EMAIL_INPUT_LIMITS.contentFieldChars],
+    ["valueProposition", input.valueProposition, COLD_EMAIL_INPUT_LIMITS.contentFieldChars],
+    ["callToAction", input.callToAction, COLD_EMAIL_INPUT_LIMITS.contentFieldChars],
+  ];
+  for (const [field, value, limit] of fields) {
+    if (value.length > limit) {
+      issues.push({
+        code: "input-too-large",
+        field,
+        message: `${field} exceeds ${limit} characters`,
+      });
+    }
+  }
+  if ((input.proofPoints?.length ?? 0) > COLD_EMAIL_INPUT_LIMITS.proofPoints) {
+    issues.push({
+      code: "input-too-large",
+      field: "proofPoints",
+      message: `proofPoints exceeds ${COLD_EMAIL_INPUT_LIMITS.proofPoints} items`,
+    });
+  }
+  return issues;
+}
+
+/** Guarded backend entry point. It always returns a result and never throws. */
+export function safeWriteColdEmail(input: unknown, options?: unknown): SafeColdEmailWriterResult {
+  if (!validateColdEmailInput(input)) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: "Input does not match the ColdEmailWriterInput contract.",
+      issues: [{ code: "invalid-input", message: "Input failed structural validation." }],
+    };
+  }
+  if (!validateColdEmailOptions(options)) {
+    return {
+      status: "error",
+      code: "invalid-options",
+      message: `maxBodyWords must be an integer from 1 to ${MAX_BODY_WORDS_LIMIT}.`,
+      issues: [{ code: "invalid-options", message: "Options failed structural validation." }],
+    };
+  }
+  const limitIssues = checkColdEmailInputLimits(input);
+  if (limitIssues.length > 0) {
+    return {
+      status: "error",
+      code: "input-too-large",
+      message: limitIssues.map((issue) => issue.message).join("; "),
+      issues: limitIssues,
+    };
+  }
+  const sanitized = sanitizeColdEmailInput(input);
+  const required = [
+    sanitized.requestId,
+    sanitized.sender.name,
+    sanitized.recipient.name,
+    sanitized.offer,
+    sanitized.valueProposition,
+    sanitized.callToAction,
+  ];
+  if (required.some((value) => value.length === 0)) {
+    return {
+      status: "error",
+      code: "empty-content",
+      message: "Required text fields must not be empty after sanitization.",
+      issues: [{ code: "empty-content", message: "One or more required fields are empty." }],
+    };
+  }
+  return { status: "ok", result: writeColdEmail(sanitized, options) };
+}

--- a/tools/v2/individual/cold-email-writer/specs.md
+++ b/tools/v2/individual/cold-email-writer/specs.md
@@ -1,41 +1,14 @@
-# Cold Email Writer
-
-Generate outbound cold emails.
-
-## Scope
-
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
-
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
-
-Recommended internal structure:
-
-- components/
-- services/
-- hooks/
--     ests/
-- docs/
-  "@ | Set-Content -Path "tools/v2/individual/cold-email-writer/README.md"
-  @"
-
 # Cold Email Writer Specs
 
 ## Purpose
 
-Generate outbound cold emails.
+Generate a concise outbound cold email from typed prospect, sender, offer, and
+call-to-action data.
 
-## Contributor boundary
+## Execution requirements
 
-All work for this tool should stay in:
-
-$dir/
-
-## Required issue categories
-
-- Architecture
-- Feature
-- UI and accessibility
-- Security and performance
-- Testing and documentation
+- Export a guarded, non-throwing backend service entry point.
+- Keep the core writer pure, synchronous, and deterministic.
+- Return machine-readable error codes for invalid or unsafe payloads.
+- Keep fixtures, tests, types, services, and documentation folder-local.
+- Do not import or modify presentation, styling, routing, or application code.

--- a/tools/v2/individual/cold-email-writer/tests/coldEmailWriter.test.ts
+++ b/tools/v2/individual/cold-email-writer/tests/coldEmailWriter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { failureFixtures, safeWriteColdEmail, successFixtures, writeColdEmail } from "../index";
+
+describe("safeWriteColdEmail", () => {
+  it("executes every success fixture", () => {
+    for (const fixture of successFixtures) {
+      const outcome = safeWriteColdEmail(fixture.input, fixture.options);
+      expect(outcome.status, fixture.name).toBe("ok");
+      if (outcome.status === "ok") {
+        expect(outcome.result.requestId).toBe(fixture.input.requestId);
+        expect(outcome.result.tone).toBe(fixture.expectedTone);
+        expect(outcome.result.metadata.wordCount).toBeGreaterThan(0);
+        expect(outcome.result.subject === null).toBe(fixture.options?.includeSubject === false);
+      }
+    }
+  });
+
+  it("returns the expected code for every failure fixture", () => {
+    for (const fixture of failureFixtures) {
+      const outcome = safeWriteColdEmail(fixture.input, fixture.options);
+      expect(outcome.status, fixture.name).toBe("error");
+      if (outcome.status === "error") {
+        expect(outcome.code, fixture.name).toBe(fixture.expectedCode);
+        expect(outcome.issues.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("never throws for hostile payloads", () => {
+    for (const payload of [null, 42, "email", [], { __proto__: { recipient: {} } }]) {
+      expect(() => safeWriteColdEmail(payload)).not.toThrow();
+      expect(safeWriteColdEmail(payload).status).toBe("error");
+    }
+  });
+
+  it("sanitizes zero-width characters before writing", () => {
+    const input = {
+      ...successFixtures[0].input,
+      requestId: "  cold-hidden  ",
+      recipient: { name: "Jo\u200brdan" },
+    };
+    const outcome = safeWriteColdEmail(input);
+    expect(outcome.status).toBe("ok");
+    if (outcome.status === "ok") {
+      expect(outcome.result.requestId).toBe("cold-hidden");
+      expect(outcome.result.body).toContain("Jordan");
+    }
+  });
+});
+
+describe("writeColdEmail", () => {
+  it("is deterministic and does not mutate input", () => {
+    const input = structuredClone(successFixtures[0].input);
+    const snapshot = structuredClone(input);
+    expect(writeColdEmail(input)).toEqual(writeColdEmail(input));
+    expect(input).toEqual(snapshot);
+  });
+
+  it("honors the body word cap", () => {
+    const result = writeColdEmail(successFixtures[0].input, { maxBodyWords: 12 });
+    expect(result.metadata.wordCount).toBeLessThanOrEqual(12);
+  });
+});

--- a/tools/v2/individual/cold-email-writer/types/coldEmailWriter.ts
+++ b/tools/v2/individual/cold-email-writer/types/coldEmailWriter.ts
@@ -1,0 +1,55 @@
+export type ColdEmailTone = "professional" | "friendly" | "direct";
+
+export interface ColdEmailParty {
+  name: string;
+  company?: string;
+  role?: string;
+}
+
+export interface ColdEmailWriterInput {
+  requestId: string;
+  sender: ColdEmailParty;
+  recipient: ColdEmailParty;
+  offer: string;
+  valueProposition: string;
+  callToAction: string;
+  proofPoints?: string[];
+  tone?: ColdEmailTone;
+}
+
+export interface ColdEmailWriterOptions {
+  includeSubject?: boolean;
+  maxBodyWords?: number;
+}
+
+export interface ColdEmailWriterOutput {
+  requestId: string;
+  subject: string | null;
+  body: string;
+  tone: ColdEmailTone;
+  metadata: {
+    wordCount: number;
+    proofPointsUsed: number;
+  };
+}
+
+export type ColdEmailWriterErrorCode =
+  | "invalid-input"
+  | "invalid-options"
+  | "input-too-large"
+  | "empty-content";
+
+export interface ColdEmailWriterValidationIssue {
+  code: ColdEmailWriterErrorCode;
+  field?: string;
+  message: string;
+}
+
+export type SafeColdEmailWriterResult =
+  | { status: "ok"; result: ColdEmailWriterOutput }
+  | {
+      status: "error";
+      code: ColdEmailWriterErrorCode;
+      message: string;
+      issues: ColdEmailWriterValidationIssue[];
+    };


### PR DESCRIPTION
Closes #1382
What was done
Added a stable, backend-facing execution contract for the cold-email-writer tool so it can run independently of presentation concerns, with no changes to any UI/layout code.
Changes

Added typed input, output, options, validation issues, and stable error codes
Exported safeWriteColdEmail as the non-UI service entry point
Added a pure, deterministic writeColdEmail service
Added typed success and failure fixtures
Documented the contract in tools/v2/individual/cold-email-writer/docs/contract.md

Test results

6 tests added covering success, failures, sanitization, determinism, and limits — all passing
Vitest: passed
TypeScript: passed
ESLint: passed
Prettier: passed
Git whitespace checks: passed