### PR TITLE
Replace process-local API repository with Cloudflare-backed persistence (#1493)

### DIFF
--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,0 +1,317 @@
+# Implementation Plan — Issue #1493
+
+## Replace the process-local API repository with environment-backed persistence (KV + Durable Object Split)
+
+Branch: `fix/env-backed-repository-1493`
+
+---
+
+## 1. Context & Rationale for Hybrid Architecture (KV + Durable Object)
+
+To avoid consistency and race condition bugs in production:
+
+- **Eventually Consistent Layer (Cloudflare KV):** Used for read-heavy, write-rarely point-lookups (Policies, Sender Rules, Postage, and Receipts).
+- **Strongly Consistent Layer (Durable Objects):** Used for operations requiring absolute atomic correctness and serial execution (Idempotency Records and sliding-window Rate-Limiter Counters).
+
+Using KV alone for idempotency or counters in a multi-region deployment leads to race conditions (e.g., dual execution on concurrent requests). A single-instance Durable Object resolves this by serializing state accesses for these specific domains.
+
+---
+
+## 2. Infrastructure Setup & Bindings
+
+### 2a. `wrangler.jsonc` Updates
+
+We will modify `wrangler.jsonc` to point to a custom server entrypoint `src/server.ts` (instead of the library default) and configure bindings:
+
+```jsonc
+{
+  "main": "src/server.ts",
+  "kv_namespaces": [
+    {
+      "binding": "STEALTH_KV",
+      "id": "<production-kv-id>",
+      "preview_id": "<preview-kv-id>",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "STEALTH_COORDINATOR",
+        "class_name": "StealthCoordinator",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["StealthCoordinator"],
+    },
+  ],
+}
+```
+
+---
+
+## 3. Implementation Details
+
+### 3a. `src/server.ts` — Custom Server Entrypoint
+
+To expose the Durable Object to Wrangler/workerd, we must export it from the server main entry:
+
+```typescript
+import handler from "@tanstack/react-start/server-entry";
+export { StealthCoordinator } from "./server/api/stealth-coordinator";
+
+export default handler;
+```
+
+---
+
+### 3b. `src/types/cloudflare.d.ts` — Types
+
+Declare the virtual module and environment bindings:
+
+```typescript
+declare module "cloudflare:workers" {
+  export const env: {
+    STEALTH_KV?: KVNamespace;
+    STEALTH_COORDINATOR?: DurableObjectNamespace;
+  };
+}
+```
+
+---
+
+### 3c. `src/server/api/stealth-coordinator.ts` — Durable Object (Consistent Layer)
+
+Implements the Durable Object class using DO's built-in key-value storage (`this.ctx.storage`) for atomic operations.
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+import type { IdempotencyRecord } from "./domain";
+
+export class StealthCoordinator extends DurableObject {
+  constructor(ctx: DurableObjectState, env: any) {
+    super(ctx, env);
+  }
+
+  async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
+    const record = await this.ctx.storage.get<IdempotencyRecord>(`idempotency:${key}`);
+    return record ?? null;
+  }
+
+  async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
+    await this.ctx.storage.put(`idempotency:${key}`, record);
+  }
+
+  async getCounter(key: string): Promise<number> {
+    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+    return timestamps.length;
+  }
+
+  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
+    const now = Date.now();
+    const windowMilliseconds = windowSeconds * 1000;
+    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+
+    // Filter timestamps falling within the sliding window
+    const filtered = [...timestamps, now].filter(
+      (timestamp) => now - timestamp <= windowMilliseconds,
+    );
+
+    await this.ctx.storage.put(`counter:${key}`, filtered);
+    return filtered.length;
+  }
+}
+```
+
+---
+
+### 3d. `src/server/api/kv-repository.ts` — KV Adapter (Eventual Layer)
+
+Implements standard read/write for non-transactional domains:
+
+- `getPolicy` / `setPolicy`
+- `getSenderRule` / `setSenderRule` (rules fallback to `"default"` and delete key when rules are set back to default)
+- `getPostage` / `setPostage`
+- `getReceipt` / `setReceipt`
+
+---
+
+### 3e. `src/server/api/context.ts` — Environment Selector
+
+Modify `getApiContext()` to be `async` and conditionally instantiate a `HybridApiRepository` in production:
+
+```typescript
+import { MemoryApiRepository } from "./memory-repository";
+import type { ApiRepository } from "./repository";
+import type { MailboxPolicy, SenderRule, Postage, Receipt, IdempotencyRecord } from "./domain";
+
+export class HybridApiRepository implements ApiRepository {
+  constructor(
+    private kv: KVNamespace,
+    private coordinator: DurableObjectNamespace,
+  ) {}
+
+  // Prefixing helper to avoid namespace collision
+  private key(prefix: string, ...parts: string[]) {
+    return `${prefix}:${parts.join(":")}`;
+  }
+
+  async getPolicy(owner: string): Promise<MailboxPolicy | null> {
+    const policy = await this.kv.get<MailboxPolicy>(this.key("policy", owner), "json");
+    return policy ?? null;
+  }
+
+  async setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
+    await this.kv.put(this.key("policy", owner), JSON.stringify(policy));
+    return policy;
+  }
+
+  async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
+    const rule = await this.kv.get(this.key("sender-rule", owner, sender), "text");
+    return (rule as SenderRule) ?? "default";
+  }
+
+  async setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
+    const ruleKey = this.key("sender-rule", owner, sender);
+    if (rule === "default") {
+      await this.kv.delete(ruleKey);
+    } else {
+      await this.kv.put(ruleKey, rule);
+    }
+    return rule;
+  }
+
+  async getPostage(messageId: string): Promise<Postage | null> {
+    const postage = await this.kv.get<Postage>(this.key("postage", messageId), "json");
+    return postage ?? null;
+  }
+
+  async setPostage(postage: Postage): Promise<Postage> {
+    await this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage));
+    return postage;
+  }
+
+  async getReceipt(messageId: string): Promise<Receipt | null> {
+    const receipt = await this.kv.get<Receipt>(this.key("receipt", messageId), "json");
+    return receipt ?? null;
+  }
+
+  async setReceipt(receipt: Receipt): Promise<Receipt> {
+    await this.kv.put(this.key("receipt", receipt.messageId), JSON.stringify(receipt));
+    return receipt;
+  }
+
+  // Consistent operations routed to Durable Object
+  private getStub() {
+    const id = this.coordinator.idFromName("global-stealth-coordinator");
+    return this.coordinator.get(id);
+  }
+
+  async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
+    // Durable Object RPC call
+    return this.getStub().getIdempotencyRecord(key);
+  }
+
+  async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
+    // Durable Object RPC call
+    await this.getStub().setIdempotencyRecord(key, record);
+  }
+
+  async getCounter(key: string): Promise<number> {
+    // Durable Object RPC call
+    return this.getStub().getCounter(key);
+  }
+
+  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
+    // Durable Object RPC call
+    return this.getStub().incrementCounter(key, windowSeconds);
+  }
+
+  // Relay stub methods matching MemoryApiRepository exactly
+  async getRelayQueueDepth(relayId: string): Promise<number> {
+    return 0;
+  }
+
+  async getRelayRetryCount(relayId: string): Promise<number> {
+    return 0;
+  }
+
+  async getRelayLastSuccessfulDelivery(relayId: string): Promise<string | null> {
+    return null;
+  }
+
+  async getRelayLastFailedDelivery(relayId: string): Promise<string | null> {
+    return null;
+  }
+
+  async getRelayDeadLetterCount(relayId: string): Promise<number> {
+    return 0;
+  }
+}
+
+export async function getApiContext(): Promise<ApiContext> {
+  if (!import.meta.env.PROD) {
+    globalApi.__stealthApiRepository ??= new MemoryApiRepository();
+    return { repository: globalApi.__stealthApiRepository };
+  }
+
+  const { env } = await import("cloudflare:workers");
+  if (!env.STEALTH_KV || !env.STEALTH_COORDINATOR) {
+    throw new Error("Missing required cloudflare bindings: STEALTH_KV or STEALTH_COORDINATOR");
+  }
+  return { repository: new HybridApiRepository(env.STEALTH_KV, env.STEALTH_COORDINATOR) };
+}
+```
+
+---
+
+### 3f. Call sites — `src/routes/api/v1/**`
+
+Change from sync `getApiContext()` to async `await getApiContext()` at the 14 call sites across the following 11 files:
+
+1. `src/routes/api/v1/policies/$owner.ts`
+2. `src/routes/api/v1/policies/evaluate.ts`
+3. `src/routes/api/v1/policies/$owner/senders/$sender.ts`
+4. `src/routes/api/v1/postage/index.ts`
+5. `src/routes/api/v1/postage/$messageId.ts`
+6. `src/routes/api/v1/postage/$messageId/refund.ts`
+7. `src/routes/api/v1/postage/$messageId/settle.ts`
+8. `src/routes/api/v1/postage/quote.ts`
+9. `src/routes/api/v1/receipts/index.ts`
+10. `src/routes/api/v1/receipts/$messageId.ts`
+11. `src/routes/api/v1/receipts/$messageId/read.ts`
+
+---
+
+## 4. Test Strategy
+
+1. **`tests/unit/api/kv-repository.test.ts`**: Tests the KV adapter using a `Map` stub of `KVNamespace`.
+2. **`tests/unit/api/stealth-coordinator.test.ts`**: Tests the `StealthCoordinator` class methods using a mock Durable Object context.
+3. Verify that existing unit tests continue to pass (using the unchanged `MemoryApiRepository`).
+
+---
+
+## 5. Scope Boundaries
+
+- ❌ `src/server/api/repository.ts` — **not touched**
+- ❌ `src/server/api/memory-repository.ts` — **not touched**
+- ❌ `tools/v2/**` — **not touched**
+- ✅ Route files touched only to add `await` to `getApiContext()`.
+
+---
+
+## 6. File Inventory
+
+| File                                         | Action                                                                                          |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `wrangler.jsonc`                             | Modify — Update `main` entry, add `kv_namespaces`, `durable_objects`, and `migrations`          |
+| `src/server.ts`                              | **New** — Custom server entrypoint                                                              |
+| `src/types/cloudflare.d.ts`                  | **New** — Type definitions for Cloudflare bindings                                              |
+| `src/server/api/stealth-coordinator.ts`      | **New** — Durable Object implementation                                                         |
+| `src/server/api/kv-repository.ts`            | **New** — Cloudflare KV adapter implementation                                                  |
+| `src/server/api/context.ts`                  | Modify — Update `getApiContext` to be async and instantiate `HybridApiRepository` in production |
+| `src/routes/api/v1/**` (11 files)            | Modify — Change `getApiContext()` to `await getApiContext()`                                    |
+| `tests/unit/api/kv-repository.test.ts`       | **New** — Unit tests for KV adapter                                                             |
+| `tests/unit/api/stealth-coordinator.test.ts` | **New** — Unit tests for Durable Object                                                         |

--- a/src/routes/api/v1/policies/$owner.ts
+++ b/src/routes/api/v1/policies/$owner.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/api/v1/policies/$owner")({
       GET: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const owner = stellarAddressSchema.parse(params.owner);
-          const result = await getMailboxPolicy(getApiContext().repository, owner);
+          const result = await getMailboxPolicy((await getApiContext()).repository, owner);
           return apiSuccess(request, result);
         }),
       PUT: ({ request, params }) =>
@@ -21,7 +21,7 @@ export const Route = createFileRoute("/api/v1/policies/$owner")({
           const owner = stellarAddressSchema.parse(params.owner);
           requireActorMatches(request, owner);
           const policy = await parseJsonBody(request, mailboxPolicySchema);
-          const result = await setMailboxPolicy(getApiContext().repository, owner, policy);
+          const result = await setMailboxPolicy((await getApiContext()).repository, owner, policy);
           return apiSuccess(request, result);
         }),
     },

--- a/src/routes/api/v1/policies/$owner/senders/$sender.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender.ts
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
           const sender = stellarAddressSchema.parse(params.sender);
           return apiSuccess(
             request,
-            await getSenderRule(getApiContext().repository, owner, sender),
+            await getSenderRule((await getApiContext()).repository, owner, sender),
           );
         }),
       PUT: ({ request, params }) =>
@@ -30,7 +30,7 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
           const { rule } = await parseJsonBody(request, ruleBodySchema);
           return apiSuccess(
             request,
-            await setSenderRule(getApiContext().repository, owner, sender, rule),
+            await setSenderRule((await getApiContext()).repository, owner, sender, rule),
           );
         }),
       DELETE: ({ request, params }) =>
@@ -40,7 +40,7 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
           requireActorMatches(request, owner);
           return apiSuccess(
             request,
-            await setSenderRule(getApiContext().repository, owner, sender, "default"),
+            await setSenderRule((await getApiContext()).repository, owner, sender, "default"),
           );
         }),
     },

--- a/src/routes/api/v1/policies/evaluate.ts
+++ b/src/routes/api/v1/policies/evaluate.ts
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/api/v1/policies/evaluate")({
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, evaluationSchema);
-          const result = await evaluateMailboxPolicy(getApiContext().repository, input);
+          const result = await evaluateMailboxPolicy((await getApiContext()).repository, input);
           return apiSuccess(request, result);
         }),
     },

--- a/src/routes/api/v1/postage/$messageId.ts
+++ b/src/routes/api/v1/postage/$messageId.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/api/v1/postage/$messageId")({
         handleApiRequest(request, async () => {
           const messageId = hash32Schema.parse(params.messageId);
           const actor = requireActor(request);
-          const postage = await getPostage(getApiContext().repository, messageId);
+          const postage = await getPostage((await getApiContext()).repository, messageId);
           assertPostageParticipant(postage, actor);
           return apiSuccess(request, postage);
         }),

--- a/src/routes/api/v1/postage/$messageId/refund.ts
+++ b/src/routes/api/v1/postage/$messageId/refund.ts
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/refund")({
     handlers: {
       POST: ({ request, params }) =>
         handleApiRequest(request, async () => {
-          const repository = getApiContext().repository;
+          const repository = (await getApiContext()).repository;
           // Authenticate before loading so unauthenticated callers cannot
           // probe whether a message id exists.
           requireActor(request);

--- a/src/routes/api/v1/postage/$messageId/settle.ts
+++ b/src/routes/api/v1/postage/$messageId/settle.ts
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/settle")({
     handlers: {
       POST: ({ request, params }) =>
         handleApiRequest(request, async () => {
-          const repository = getApiContext().repository;
+          const repository = (await getApiContext()).repository;
           // Authenticate before loading so unauthenticated callers cannot
           // probe whether a message id exists.
           requireActor(request);

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/api/v1/postage/")({
           const input = await parseJsonBody(request, submissionSchema);
           requireActorMatches(request, input.sender);
 
-          const repo = getApiContext().repository;
+          const repo = (await getApiContext()).repository;
           const rawIdempotencyKey = request.headers.get("x-idempotency-key");
           if (rawIdempotencyKey) {
             const existing = await checkIdempotency(repo, input.sender, rawIdempotencyKey);

--- a/src/routes/api/v1/postage/quote.ts
+++ b/src/routes/api/v1/postage/quote.ts
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/api/v1/postage/quote")({
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, quoteSchema);
-          const quote = await quotePostage(getApiContext().repository, input);
+          const quote = await quotePostage((await getApiContext()).repository, input);
           return apiSuccess(request, quote);
         }),
     },

--- a/src/routes/api/v1/receipts/$messageId.ts
+++ b/src/routes/api/v1/receipts/$messageId.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/api/v1/receipts/$messageId")({
         handleApiRequest(request, async () => {
           const messageId = hash32Schema.parse(params.messageId);
           const actor = requireActor(request);
-          const receipt = await getReceipt(getApiContext().repository, messageId);
+          const receipt = await getReceipt((await getApiContext()).repository, messageId);
           assertReceiptParticipant(receipt, actor);
           return apiSuccess(request, receipt);
         }),

--- a/src/routes/api/v1/receipts/$messageId/read.ts
+++ b/src/routes/api/v1/receipts/$messageId/read.ts
@@ -13,7 +13,7 @@ export const Route = createFileRoute("/api/v1/receipts/$messageId/read")({
     handlers: {
       POST: ({ request, params }) =>
         handleApiRequest(request, async () => {
-          const repository = getApiContext().repository;
+          const repository = (await getApiContext()).repository;
           const messageId = hash32Schema.parse(params.messageId);
           const current = await getReceipt(repository, messageId);
           const principal = requireActor(request);

--- a/src/routes/api/v1/receipts/index.ts
+++ b/src/routes/api/v1/receipts/index.ts
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/api/v1/receipts/")({
           const input = await parseJsonBody(request, deliverySchema);
           const principal = requireActor(request);
           assertCanPublishDeliveryReceipt(principal, input);
-          const receipt = await createDeliveryReceipt(getApiContext().repository, input);
+          const receipt = await createDeliveryReceipt((await getApiContext()).repository, input);
           return apiSuccess(request, receipt, { status: 201 });
         }),
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,5 @@
+import handler from "@tanstack/react-start/server-entry";
+
+export { StealthCoordinator } from "./server/api/stealth-coordinator";
+
+export default handler;

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -6,10 +6,31 @@ interface ApiContext {
 }
 
 const globalApi = globalThis as typeof globalThis & {
-  __stealthApiRepository?: MemoryApiRepository;
+  __stealthApiRepository?: ApiRepository;
 };
 
-export function getApiContext(): ApiContext {
-  globalApi.__stealthApiRepository ??= new MemoryApiRepository();
+export async function getApiContext(): Promise<ApiContext> {
+  if (!import.meta.env.PROD) {
+    globalApi.__stealthApiRepository ??= new MemoryApiRepository();
+    return { repository: globalApi.__stealthApiRepository };
+  }
+
+  if (globalApi.__stealthApiRepository) {
+    return { repository: globalApi.__stealthApiRepository };
+  }
+
+  const { env } = await import("cloudflare:workers");
+  if (!env.STEALTH_KV || !env.STEALTH_COORDINATOR) {
+    throw new Error(
+      "Configuration error: STEALTH_KV or STEALTH_COORDINATOR binding is not declared in wrangler.jsonc. " +
+        "Make sure to create the KV namespace and declare both KV and Durable Object bindings in wrangler.jsonc.",
+    );
+  }
+
+  const { HybridApiRepository } = await import("./kv-repository");
+  globalApi.__stealthApiRepository = new HybridApiRepository(
+    env.STEALTH_KV,
+    env.STEALTH_COORDINATOR,
+  );
   return { repository: globalApi.__stealthApiRepository };
 }

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,0 +1,101 @@
+import type { ApiRepository } from "./repository";
+import type { MailboxPolicy, SenderRule, Postage, Receipt, IdempotencyRecord } from "./domain";
+
+export class HybridApiRepository implements ApiRepository {
+  constructor(
+    private readonly kv: KVNamespace,
+    private readonly coordinator: DurableObjectNamespace,
+  ) {}
+
+  private key(prefix: string, ...parts: string[]): string {
+    return `${prefix}:${parts.join(":")}`;
+  }
+
+  async getPolicy(owner: string): Promise<MailboxPolicy | null> {
+    const policy = await this.kv.get(this.key("policy", owner), "json");
+    return (policy as MailboxPolicy) ?? null;
+  }
+
+  async setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
+    await this.kv.put(this.key("policy", owner), JSON.stringify(policy));
+    return policy;
+  }
+
+  async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
+    const rule = await this.kv.get(this.key("sender-rule", owner, sender), "text");
+    return (rule as SenderRule) ?? "default";
+  }
+
+  async setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
+    const ruleKey = this.key("sender-rule", owner, sender);
+    if (rule === "default") {
+      await this.kv.delete(ruleKey);
+    } else {
+      await this.kv.put(ruleKey, rule);
+    }
+    return rule;
+  }
+
+  async getPostage(messageId: string): Promise<Postage | null> {
+    const postage = await this.kv.get(this.key("postage", messageId), "json");
+    return (postage as Postage) ?? null;
+  }
+
+  async setPostage(postage: Postage): Promise<Postage> {
+    await this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage));
+    return postage;
+  }
+
+  async getReceipt(messageId: string): Promise<Receipt | null> {
+    const receipt = await this.kv.get(this.key("receipt", messageId), "json");
+    return (receipt as Receipt) ?? null;
+  }
+
+  async setReceipt(receipt: Receipt): Promise<Receipt> {
+    await this.kv.put(this.key("receipt", receipt.messageId), JSON.stringify(receipt));
+    return receipt;
+  }
+
+  // Consistent layer delegated to Durable Object via RPC
+  private getStub() {
+    const id = this.coordinator.idFromName("global-stealth-coordinator");
+    return this.coordinator.get(id);
+  }
+
+  async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
+    return this.getStub().getIdempotencyRecord(key);
+  }
+
+  async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
+    await this.getStub().setIdempotencyRecord(key, record);
+  }
+
+  async getCounter(key: string): Promise<number> {
+    return this.getStub().getCounter(key);
+  }
+
+  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
+    return this.getStub().incrementCounter(key, windowSeconds);
+  }
+
+  // Relay stats stubs matching MemoryApiRepository exactly
+  async getRelayQueueDepth(_relayId: string): Promise<number> {
+    return 0;
+  }
+
+  async getRelayRetryCount(_relayId: string): Promise<number> {
+    return 0;
+  }
+
+  async getRelayLastSuccessfulDelivery(_relayId: string): Promise<string | null> {
+    return null;
+  }
+
+  async getRelayLastFailedDelivery(_relayId: string): Promise<string | null> {
+    return null;
+  }
+
+  async getRelayDeadLetterCount(_relayId: string): Promise<number> {
+    return 0;
+  }
+}

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -17,7 +17,9 @@ export class StealthCoordinator extends DurableObjectBase {
   }
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
-    const record = (await this.ctx.storage.get(`idempotency:${key}`)) as IdempotencyRecord | undefined;
+    const record = (await this.ctx.storage.get(`idempotency:${key}`)) as
+      | IdempotencyRecord
+      | undefined;
     return record ?? null;
   }
 
@@ -26,14 +28,16 @@ export class StealthCoordinator extends DurableObjectBase {
   }
 
   async getCounter(key: string): Promise<number> {
-    const timestamps = ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
+    const timestamps =
+      ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
     return timestamps.length;
   }
 
   async incrementCounter(key: string, windowSeconds: number): Promise<number> {
     const now = Date.now();
     const windowMilliseconds = windowSeconds * 1000;
-    const timestamps = ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
+    const timestamps =
+      ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
 
     // Filter timestamps falling within the sliding window
     const filtered = [...timestamps, now].filter(

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1,0 +1,36 @@
+import { DurableObject } from "cloudflare:workers";
+import type { IdempotencyRecord } from "./domain";
+
+export class StealthCoordinator extends DurableObject {
+  constructor(ctx: DurableObjectState, env: any) {
+    super(ctx, env);
+  }
+
+  async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
+    const record = await this.ctx.storage.get<IdempotencyRecord>(`idempotency:${key}`);
+    return record ?? null;
+  }
+
+  async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
+    await this.ctx.storage.put(`idempotency:${key}`, record);
+  }
+
+  async getCounter(key: string): Promise<number> {
+    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+    return timestamps.length;
+  }
+
+  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
+    const now = Date.now();
+    const windowMilliseconds = windowSeconds * 1000;
+    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+
+    // Filter timestamps falling within the sliding window
+    const filtered = [...timestamps, now].filter(
+      (timestamp) => now - timestamp <= windowMilliseconds,
+    );
+
+    await this.ctx.storage.put(`counter:${key}`, filtered);
+    return filtered.length;
+  }
+}

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -17,7 +17,7 @@ export class StealthCoordinator extends DurableObjectBase {
   }
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
-    const record = await this.ctx.storage.get<IdempotencyRecord>(`idempotency:${key}`);
+    const record = (await this.ctx.storage.get(`idempotency:${key}`)) as IdempotencyRecord | undefined;
     return record ?? null;
   }
 
@@ -26,14 +26,14 @@ export class StealthCoordinator extends DurableObjectBase {
   }
 
   async getCounter(key: string): Promise<number> {
-    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+    const timestamps = ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
     return timestamps.length;
   }
 
   async incrementCounter(key: string, windowSeconds: number): Promise<number> {
     const now = Date.now();
     const windowMilliseconds = windowSeconds * 1000;
-    const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
+    const timestamps = ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
 
     // Filter timestamps falling within the sliding window
     const filtered = [...timestamps, now].filter(

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -34,12 +34,12 @@ export class StealthCoordinator extends DurableObjectBase {
     const now = Date.now();
     const windowMilliseconds = windowSeconds * 1000;
     const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
-    
+
     // Filter timestamps falling within the sliding window
     const filtered = [...timestamps, now].filter(
       (timestamp) => now - timestamp <= windowMilliseconds,
     );
-    
+
     await this.ctx.storage.put(`counter:${key}`, filtered);
     return filtered.length;
   }

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1,7 +1,17 @@
-import { DurableObject } from "cloudflare:workers";
 import type { IdempotencyRecord } from "./domain";
 
-export class StealthCoordinator extends DurableObject {
+const DurableObjectBase: any = import.meta.env.PROD
+  ? (await import("cloudflare:workers")).DurableObject
+  : class {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+    };
+
+export class StealthCoordinator extends DurableObjectBase {
   constructor(ctx: DurableObjectState, env: any) {
     super(ctx, env);
   }
@@ -24,12 +34,12 @@ export class StealthCoordinator extends DurableObject {
     const now = Date.now();
     const windowMilliseconds = windowSeconds * 1000;
     const timestamps = (await this.ctx.storage.get<number[]>(`counter:${key}`)) ?? [];
-
+    
     // Filter timestamps falling within the sliding window
     const filtered = [...timestamps, now].filter(
       (timestamp) => now - timestamp <= windowMilliseconds,
     );
-
+    
     await this.ctx.storage.put(`counter:${key}`, filtered);
     return filtered.length;
   }

--- a/src/types/cloudflare.d.ts
+++ b/src/types/cloudflare.d.ts
@@ -1,0 +1,36 @@
+interface KVNamespace {
+  get(key: string, type: "text"): Promise<string | null>;
+  get<T>(key: string, type: "json"): Promise<T | null>;
+  put(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+interface DurableObjectId {
+  toString(): string;
+}
+
+interface DurableObjectNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): any;
+}
+
+interface DurableObjectState {
+  id: DurableObjectId;
+  storage: {
+    get<T>(key: string): Promise<T | undefined>;
+    put(key: string, value: any): Promise<void>;
+    delete(key: string): Promise<boolean>;
+  };
+}
+
+declare module "cloudflare:workers" {
+  export const env: {
+    STEALTH_KV?: KVNamespace;
+    STEALTH_COORDINATOR?: DurableObjectNamespace;
+  };
+  export class DurableObject {
+    ctx: DurableObjectState;
+    env: any;
+    constructor(ctx: DurableObjectState, env: any);
+  }
+}

--- a/tests/unit/api/kv-repository.test.ts
+++ b/tests/unit/api/kv-repository.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { HybridApiRepository } from "../../../src/server/api/kv-repository";
+import type { MailboxPolicy, Postage, Receipt } from "../../../src/server/api/domain";
+
+class MockKVNamespace {
+  public store = new Map<string, string>();
+
+  async get(key: string, type: "text" | "json") {
+    const val = this.store.get(key);
+    if (val === undefined) return null;
+    if (type === "json") return JSON.parse(val);
+    return val;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+class MockDurableObjectNamespace {
+  idFromName(name: string) {
+    return { toString: () => name };
+  }
+  get(id: any) {
+    return {};
+  }
+}
+
+const owner = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+const messageId = "a".repeat(64);
+
+describe("HybridApiRepository - KV Operations", () => {
+  let kv: MockKVNamespace;
+  let repo: HybridApiRepository;
+
+  beforeEach(() => {
+    kv = new MockKVNamespace();
+    const coordinator = new MockDurableObjectNamespace() as any;
+    repo = new HybridApiRepository(kv as any, coordinator);
+  });
+
+  it("persists and retrieves mailbox policy", async () => {
+    const policy: MailboxPolicy = {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    };
+    await repo.setPolicy(owner, policy);
+    const retrieved = await repo.getPolicy(owner);
+    expect(retrieved).toEqual(policy);
+  });
+
+  it("returns null for non-existent policy", async () => {
+    const retrieved = await repo.getPolicy(owner);
+    expect(retrieved).toBeNull();
+  });
+
+  it("persists, retrieves, and deletes sender rules", async () => {
+    expect(await repo.getSenderRule(owner, sender)).toBe("default");
+
+    await repo.setSenderRule(owner, sender, "allow");
+    expect(await repo.getSenderRule(owner, sender)).toBe("allow");
+
+    await repo.setSenderRule(owner, sender, "default");
+    expect(await repo.getSenderRule(owner, sender)).toBe("default");
+    expect(kv.store.has(`sender-rule:${owner}:${sender}`)).toBe(false);
+  });
+
+  it("persists and retrieves postage", async () => {
+    const postage: Postage = {
+      amount: "200",
+      createdAt: new Date().toISOString(),
+      messageId,
+      paymentHash: "b".repeat(64),
+      recipient: owner,
+      sender,
+      status: "pending",
+    };
+    await repo.setPostage(postage);
+    const retrieved = await repo.getPostage(messageId);
+    expect(retrieved).toEqual(postage);
+  });
+
+  it("persists and retrieves receipt", async () => {
+    const receipt: Receipt = {
+      deliveredAt: new Date().toISOString(),
+      messageId,
+      readAt: null,
+      recipient: owner,
+      sender,
+    };
+    await repo.setReceipt(receipt);
+    const retrieved = await repo.getReceipt(messageId);
+    expect(retrieved).toEqual(receipt);
+  });
+
+  it("returns defaults/0 for relay stubs", async () => {
+    expect(await repo.getRelayQueueDepth("relay-1")).toBe(0);
+    expect(await repo.getRelayRetryCount("relay-1")).toBe(0);
+    expect(await repo.getRelayLastSuccessfulDelivery("relay-1")).toBeNull();
+    expect(await repo.getRelayLastFailedDelivery("relay-1")).toBeNull();
+    expect(await repo.getRelayDeadLetterCount("relay-1")).toBe(0);
+  });
+});

--- a/tests/unit/api/receipt-routes.security.test.ts
+++ b/tests/unit/api/receipt-routes.security.test.ts
@@ -15,10 +15,6 @@ const messageId = "d".repeat(64);
 const deliveryHandler = (DeliveryRoute.options as any).server?.handlers?.POST;
 const readHandler = (ReadRoute.options as any).server?.handlers?.POST;
 
-function repository() {
-  return getApiContext().repository as MemoryApiRepository;
-}
-
 function deliveryRequest(actor: string) {
   return new Request("https://stealth.test/api/v1/receipts", {
     method: "POST",
@@ -38,13 +34,18 @@ function readRequest(actor: string) {
 }
 
 describe("receipt route publication roles", () => {
-  beforeEach(() => repository().reset());
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
 
   it("allows only the sender to publish a delivery receipt", async () => {
     const response = await deliveryHandler({ request: deliveryRequest(sender) });
 
     expect(response.status).toBe(201);
-    await expect(repository().getReceipt(messageId)).resolves.toMatchObject({
+    await expect(repo.getReceipt(messageId)).resolves.toMatchObject({
       messageId,
       readAt: null,
       recipient,
@@ -60,11 +61,11 @@ describe("receipt route publication roles", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: { code: "forbidden" } });
-    await expect(repository().getReceipt(messageId)).resolves.toBeNull();
+    await expect(repo.getReceipt(messageId)).resolves.toBeNull();
   });
 
   it("allows only the recipient to publish a read receipt", async () => {
-    await createDeliveryReceipt(repository(), { messageId, recipient, sender });
+    await createDeliveryReceipt(repo, { messageId, recipient, sender });
 
     const response = await readHandler({
       request: readRequest(recipient),
@@ -72,7 +73,7 @@ describe("receipt route publication roles", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(repository().getReceipt(messageId)).resolves.toMatchObject({
+    await expect(repo.getReceipt(messageId)).resolves.toMatchObject({
       readAt: expect.any(String),
     });
   });
@@ -81,7 +82,7 @@ describe("receipt route publication roles", () => {
     ["sender", sender],
     ["unrelated actor", unrelatedActor],
   ])("rejects the %s as a read publisher without mutating state", async (_role, actor) => {
-    await createDeliveryReceipt(repository(), { messageId, recipient, sender });
+    await createDeliveryReceipt(repo, { messageId, recipient, sender });
 
     const response = await readHandler({
       request: readRequest(actor),
@@ -90,6 +91,6 @@ describe("receipt route publication roles", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: { code: "forbidden" } });
-    await expect(repository().getReceipt(messageId)).resolves.toMatchObject({ readAt: null });
+    await expect(repo.getReceipt(messageId)).resolves.toMatchObject({ readAt: null });
   });
 });

--- a/tests/unit/api/stealth-coordinator.test.ts
+++ b/tests/unit/api/stealth-coordinator.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => {
+  return {
+    DurableObject: class DurableObject {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+    },
+  };
+});
+
+import { StealthCoordinator } from "../../../src/server/api/stealth-coordinator";
+import type { IdempotencyRecord } from "../../../src/server/api/domain";
+
+class MockDurableObjectState {
+  public id = { toString: () => "mock-do-id" };
+  public storage = {
+    store: new Map<string, any>(),
+    async get(key: string) {
+      return this.store.get(key);
+    },
+    async put(key: string, value: any) {
+      this.store.set(key, value);
+    },
+    async delete(key: string) {
+      return this.store.delete(key);
+    },
+  };
+}
+
+describe("StealthCoordinator - Durable Object Operations", () => {
+  let state: MockDurableObjectState;
+  let coordinator: StealthCoordinator;
+
+  beforeEach(() => {
+    state = new MockDurableObjectState();
+    coordinator = new StealthCoordinator(state as any, {});
+  });
+
+  it("handles idempotency records", async () => {
+    const record: IdempotencyRecord = {
+      body: { ok: true },
+      createdAt: new Date().toISOString(),
+      status: 201,
+    };
+
+    expect(await coordinator.getIdempotencyRecord("key-1")).toBeNull();
+    await coordinator.setIdempotencyRecord("key-1", record);
+    expect(await coordinator.getIdempotencyRecord("key-1")).toEqual(record);
+  });
+
+  it("handles counter sliding window rate-limiting", async () => {
+    expect(await coordinator.getCounter("limiter-1")).toBe(0);
+
+    const now = Date.now();
+    const dateSpy = vi.spyOn(Date, "now");
+
+    // First increment at T = 0
+    dateSpy.mockReturnValue(now);
+    expect(await coordinator.incrementCounter("limiter-1", 60)).toBe(1);
+
+    // Second increment at T = 10s
+    dateSpy.mockReturnValue(now + 10000);
+    expect(await coordinator.incrementCounter("limiter-1", 60)).toBe(2);
+
+    // Get counter should reflect current size (2)
+    expect(await coordinator.getCounter("limiter-1")).toBe(2);
+
+    // Third increment at T = 70s (this should drop the first timestamp at T = 0 since 70 - 0 = 70 > 60)
+    dateSpy.mockReturnValue(now + 70000);
+    expect(await coordinator.incrementCounter("limiter-1", 60)).toBe(2); // T=10s and T=70s remain
+
+    // Get counter should reflect current size (2)
+    expect(await coordinator.getCounter("limiter-1")).toBe(2);
+
+    dateSpy.mockRestore();
+  });
+});

--- a/tests/unit/protocol/vectors.test.ts
+++ b/tests/unit/protocol/vectors.test.ts
@@ -293,7 +293,7 @@ describe("relay_submission", () => {
 
   for (const c of (vectors.categories as any).relay_submission.cases) {
     it(c.id, async () => {
-      const context = getApiContext();
+      const context = await getApiContext();
       (context.repository as any).reset();
 
       // For the policy block case, we need to pre-configure a blocked rule.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,9 +30,6 @@ export default defineConfig(({ command }) => ({
   optimizeDeps: {
     exclude: ["cloudflare:workers"],
   },
-  ssr: {
-    external: ["cloudflare:workers"],
-  },
   plugins: [
     tailwindcss(),
     tsConfigPaths({ projects: ["./tsconfig.json"] }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,15 @@ export default defineConfig(({ command }) => ({
       "@tanstack/query-core",
     ],
   },
+  // cloudflare:workers is a virtual module provided by workerd at runtime only.
+  // Exclude it from Vite's dep pre-bundler (dev) and SSR bundler so it is never
+  // resolved as a real package in either vite dev or e2e (playwright + vite dev).
+  optimizeDeps: {
+    exclude: ["cloudflare:workers"],
+  },
+  ssr: {
+    external: ["cloudflare:workers"],
+  },
   plugins: [
     tailwindcss(),
     tsConfigPaths({ projects: ["./tsconfig.json"] }),

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,26 @@
   "name": "stealth-mail",
   "compatibility_date": "2025-09-24",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
+  "main": "src/server.ts",
+  "kv_namespaces": [
+    {
+      "binding": "STEALTH_KV",
+      "id": "placeholder-prod-id",
+      "preview_id": "placeholder-preview-id",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "STEALTH_COORDINATOR",
+        "class_name": "StealthCoordinator",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["StealthCoordinator"],
+    },
+  ],
 }


### PR DESCRIPTION
Closes #1493

## Summary
This replaces the production `globalThis`-backed `MemoryApiRepository` singleton with a Cloudflare-native persistence layer, allowing API state to survive Worker restarts and remain consistent across isolates and instances.

Production now uses a hybrid backend:

- **Cloudflare KV** (`STEALTH_KV`) stores read-heavy, infrequently updated data such as policies, sender rules, postage, and receipts.
- **Durable Object** (`STEALTH_COORDINATOR`) stores idempotency records and sliding-window rate-limit counters, where atomic read-modify-write operations are required.

These live in separate backends rather than one, because KV is only eventually consistent — writes can take up to 60 seconds to propagate globally ([Cloudflare docs](https://developers.cloudflare.com/kv/reference/consistency/)) — which is fine for policies/postage/receipts but would silently break idempotency guarantees and let the rate limiter under-count concurrent requests. Durable Objects give strong consistency for just those two data types via single-instance serialization.

`getApiContext()` is now asynchronous and selects the appropriate repository based on the runtime environment. Development and tests continue using the existing in-memory repository, unchanged.

## Changes
- Added a Cloudflare-backed `HybridApiRepository` using KV and Durable Objects.
- Added the `StealthCoordinator` Durable Object and a custom Worker entrypoint (`src/server.ts`).
- Made `getApiContext()` asynchronous and updated all call sites (11 route files, 14 call sites).
- Added Cloudflare ambient type declarations for projects that do not install `@cloudflare/workers-types`.
- Added unit tests covering the new persistence layer.
- Throws an explicit configuration error if `STEALTH_KV` or `STEALTH_COORDINATOR` bindings are missing at runtime in production, rather than silently falling back to memory.

## Explicitly out of scope
- `src/server/api/repository.ts` (interface) — untouched.
- `src/server/api/memory-repository.ts` — untouched, still used for dev/test.
- `tools/v2/**` — untouched, unrelated.
- Pagination/ordering work (issue #1491) — separate issue, not addressed here.

## Deployment
`wrangler.jsonc` currently contains placeholder KV namespace IDs. These must be replaced with real namespace IDs (via `wrangler kv namespace create stealth-kv` and `--preview`) before deploying.

## Known limitation
The hand-written Cloudflare type definitions do not type-check Durable Object RPC methods. Adding `@cloudflare/workers-types` in a follow-up would provide stronger compile-time safety.

## Testing
- ✅ `npm run test` — all 649 tests pass, including new tests covering the KV and Durable Object implementations.
- ✅ `npm run build` — production build succeeds.
- ✅ Verified locally with `wrangler dev` that the Worker resolves the `cloudflare:workers` runtime bindings correctly.