### PR TITLE
feat(email-template-library): add non-UI execution contract

### DIFF
--- a/tools/v2/individual/email-template-library/README.md
+++ b/tools/v2/individual/email-template-library/README.md
@@ -13,3 +13,13 @@ All work for this tool must stay inside:
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
 See specs.md for the issue categories and contributor expectations.
+
+## Non-UI execution
+
+The folder root exports a versioned backend-facing service contract with no UI dependencies. See `docs/execution-contract.md` for request, response, error-code, and fixture details.
+
+Run its focused tests with:
+
+```sh
+node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/service.test.ts
+```

--- a/tools/v2/individual/email-template-library/docs/execution-contract.md
+++ b/tools/v2/individual/email-template-library/docs/execution-contract.md
@@ -1,0 +1,26 @@
+# Non-UI execution contract
+
+The folder root exports a presentation-independent TypeScript API. It performs no network, persistence, React, or DOM work.
+
+## Entry points
+
+- `executeEmailTemplateLibrary(request, templates)` executes one request against a caller-owned, read-only catalog.
+- `createEmailTemplateLibraryService(templates)` snapshots a validated catalog and returns an object with `execute(request)`.
+
+Requests always include `tool: "email-template-library"`, `version: 1`, and an operation:
+
+- `list` optionally filters by `categoryId`.
+- `get` returns one template by `templateId`.
+- `render` substitutes declared `{{variable}}` placeholders using a string `values` map.
+
+Responses are discriminated by `status`. Success responses contain a typed `result`; failures contain a stable `error.code`, human-readable `message`, and optional machine-readable `details`.
+
+## Error codes
+
+- `INVALID_REQUEST`: envelope, operation, identifier, filter, or values are malformed.
+- `UNSUPPORTED_VERSION`: the caller requests a contract version other than `1`.
+- `INVALID_TEMPLATE`: a catalog entry violates the documented template shape.
+- `TEMPLATE_NOT_FOUND`: no catalog entry matches `templateId`.
+- `MISSING_VARIABLES`: rendering omitted one or more declared variables.
+
+The complete input, output, service, entity, and error types are exported from `types/index.ts`. JSON fixtures under `fixtures/` cover a successful render, missing render variables, and an unknown template.

--- a/tools/v2/individual/email-template-library/fixtures/failure-missing-variables.json
+++ b/tools/v2/individual/email-template-library/fixtures/failure-missing-variables.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "tool": "email-template-library",
+    "version": 1,
+    "operation": "render",
+    "templateId": "template-follow-up",
+    "values": { "firstName": "Avery" }
+  },
+  "expectedError": {
+    "code": "MISSING_VARIABLES",
+    "missingVariables": ["topic"]
+  }
+}

--- a/tools/v2/individual/email-template-library/fixtures/failure-template-not-found.json
+++ b/tools/v2/individual/email-template-library/fixtures/failure-template-not-found.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "tool": "email-template-library",
+    "version": 1,
+    "operation": "get",
+    "templateId": "template-unknown"
+  },
+  "expectedError": {
+    "code": "TEMPLATE_NOT_FOUND",
+    "templateId": "template-unknown"
+  }
+}

--- a/tools/v2/individual/email-template-library/fixtures/success.json
+++ b/tools/v2/individual/email-template-library/fixtures/success.json
@@ -1,0 +1,28 @@
+{
+  "templates": [
+    {
+      "id": "template-follow-up",
+      "name": "Friendly follow-up",
+      "categoryId": "follow-up",
+      "subject": "Following up, {{firstName}}",
+      "body": "Hello {{firstName}},\n\nI wanted to follow up about {{topic}}.",
+      "variables": [
+        { "key": "firstName", "label": "First name" },
+        { "key": "topic", "label": "Topic" }
+      ]
+    }
+  ],
+  "request": {
+    "tool": "email-template-library",
+    "version": 1,
+    "operation": "render",
+    "templateId": "template-follow-up",
+    "values": { "firstName": "Avery", "topic": "the project timeline" }
+  },
+  "expected": {
+    "operation": "render",
+    "templateId": "template-follow-up",
+    "subject": "Following up, Avery",
+    "body": "Hello Avery,\n\nI wanted to follow up about the project timeline."
+  }
+}

--- a/tools/v2/individual/email-template-library/index.ts
+++ b/tools/v2/individual/email-template-library/index.ts
@@ -1,0 +1,5 @@
+export {
+  createEmailTemplateLibraryService,
+  executeEmailTemplateLibrary,
+} from "./services/index.ts";
+export * from "./types/index.ts";

--- a/tools/v2/individual/email-template-library/services/email-template-library.service.ts
+++ b/tools/v2/individual/email-template-library/services/email-template-library.service.ts
@@ -1,0 +1,188 @@
+import {
+  EMAIL_TEMPLATE_LIBRARY_ERROR_CODES,
+  EMAIL_TEMPLATE_LIBRARY_TOOL,
+  EMAIL_TEMPLATE_LIBRARY_VERSION,
+} from "../types/index.ts";
+import type {
+  EmailTemplate,
+  EmailTemplateLibraryFailure,
+  EmailTemplateLibraryRequest,
+  EmailTemplateLibraryResponse,
+  EmailTemplateLibraryService,
+} from "../types/index.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function failure(
+  code: EmailTemplateLibraryFailure["error"]["code"],
+  message: string,
+  details?: EmailTemplateLibraryFailure["error"]["details"],
+): EmailTemplateLibraryFailure {
+  return {
+    status: "error",
+    tool: EMAIL_TEMPLATE_LIBRARY_TOOL,
+    version: EMAIL_TEMPLATE_LIBRARY_VERSION,
+    error: { code, message, ...(details ? { details } : {}) },
+  };
+}
+
+function cloneTemplate(template: EmailTemplate): EmailTemplate {
+  return { ...template, variables: template.variables.map((variable) => ({ ...variable })) };
+}
+
+function validateTemplate(value: unknown): string[] {
+  if (!isRecord(value)) return ["id", "name", "categoryId", "subject", "body", "variables"];
+  const fields: string[] = [];
+  if (typeof value.id !== "string" || value.id.trim() === "") fields.push("id");
+  if (typeof value.name !== "string" || value.name.trim() === "") fields.push("name");
+  if (!(typeof value.categoryId === "string" || value.categoryId === null))
+    fields.push("categoryId");
+  if (typeof value.subject !== "string") fields.push("subject");
+  if (typeof value.body !== "string") fields.push("body");
+  if (
+    !Array.isArray(value.variables) ||
+    value.variables.some(
+      (variable) =>
+        !isRecord(variable) ||
+        typeof variable.key !== "string" ||
+        variable.key.trim() === "" ||
+        typeof variable.label !== "string" ||
+        variable.label.trim() === "",
+    )
+  )
+    fields.push("variables");
+  return fields;
+}
+
+export function createEmailTemplateLibraryService(
+  sourceTemplates: readonly EmailTemplate[],
+): EmailTemplateLibraryService {
+  const templates = sourceTemplates.map((template) => cloneTemplate(template));
+  const invalidTemplate = templates.find((template) => validateTemplate(template).length > 0);
+  if (invalidTemplate) {
+    throw new Error(`Invalid email template catalog entry: ${invalidTemplate.id || "unknown"}`);
+  }
+
+  return { execute: (request) => executeEmailTemplateLibrary(request, templates) };
+}
+
+export function executeEmailTemplateLibrary(
+  request: EmailTemplateLibraryRequest,
+  sourceTemplates: readonly EmailTemplate[],
+): EmailTemplateLibraryResponse {
+  if (!isRecord(request) || request.tool !== EMAIL_TEMPLATE_LIBRARY_TOOL) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.INVALID_REQUEST,
+      "The request must be an email-template-library request object.",
+    );
+  }
+  if (request.version !== EMAIL_TEMPLATE_LIBRARY_VERSION) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.UNSUPPORTED_VERSION,
+      `Unsupported email-template-library version ${String(request.version)}.`,
+    );
+  }
+
+  for (const template of sourceTemplates) {
+    const fields = validateTemplate(template);
+    if (fields.length > 0) {
+      return failure(
+        EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.INVALID_TEMPLATE,
+        "The template catalog contains an invalid template.",
+        {
+          templateId:
+            isRecord(template) && typeof template.id === "string" ? template.id : undefined,
+          fields,
+        },
+      );
+    }
+  }
+
+  if (request.operation === "list") {
+    if (
+      !(
+        request.categoryId === undefined ||
+        request.categoryId === null ||
+        typeof request.categoryId === "string"
+      )
+    ) {
+      return failure(
+        EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.INVALID_REQUEST,
+        "categoryId must be a string or null.",
+      );
+    }
+    const matches =
+      request.categoryId === undefined
+        ? sourceTemplates
+        : sourceTemplates.filter((template) => template.categoryId === request.categoryId);
+    return {
+      status: "ok",
+      tool: EMAIL_TEMPLATE_LIBRARY_TOOL,
+      version: EMAIL_TEMPLATE_LIBRARY_VERSION,
+      result: { operation: "list", templates: matches.map(cloneTemplate) },
+    };
+  }
+
+  if (
+    (request.operation !== "get" && request.operation !== "render") ||
+    typeof request.templateId !== "string" ||
+    request.templateId.trim() === ""
+  ) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.INVALID_REQUEST,
+      "A supported operation and non-empty templateId are required.",
+    );
+  }
+  const template = sourceTemplates.find((candidate) => candidate.id === request.templateId);
+  if (!template) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.TEMPLATE_NOT_FOUND,
+      `Template ${request.templateId} was not found.`,
+      { templateId: request.templateId },
+    );
+  }
+  if (request.operation === "get") {
+    return {
+      status: "ok",
+      tool: EMAIL_TEMPLATE_LIBRARY_TOOL,
+      version: EMAIL_TEMPLATE_LIBRARY_VERSION,
+      result: { operation: "get", template: cloneTemplate(template) },
+    };
+  }
+  if (
+    !isRecord(request.values) ||
+    Object.values(request.values).some((value) => typeof value !== "string")
+  ) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.INVALID_REQUEST,
+      "Render values must be a string map.",
+    );
+  }
+  const missingVariables = template.variables
+    .map(({ key }) => key)
+    .filter((key) => !(key in request.values));
+  if (missingVariables.length > 0) {
+    return failure(
+      EMAIL_TEMPLATE_LIBRARY_ERROR_CODES.MISSING_VARIABLES,
+      "Values are required for every declared template variable.",
+      { templateId: template.id, missingVariables },
+    );
+  }
+  const substitute = (text: string) =>
+    text.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (match, key: string) =>
+      Object.prototype.hasOwnProperty.call(request.values, key) ? request.values[key] : match,
+    );
+  return {
+    status: "ok",
+    tool: EMAIL_TEMPLATE_LIBRARY_TOOL,
+    version: EMAIL_TEMPLATE_LIBRARY_VERSION,
+    result: {
+      operation: "render",
+      templateId: template.id,
+      subject: substitute(template.subject),
+      body: substitute(template.body),
+    },
+  };
+}

--- a/tools/v2/individual/email-template-library/services/index.ts
+++ b/tools/v2/individual/email-template-library/services/index.ts
@@ -1,0 +1,4 @@
+export {
+  createEmailTemplateLibraryService,
+  executeEmailTemplateLibrary,
+} from "./email-template-library.service.ts";

--- a/tools/v2/individual/email-template-library/tests/service.test.ts
+++ b/tools/v2/individual/email-template-library/tests/service.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { executeEmailTemplateLibrary } from "../index.ts";
+import type { EmailTemplate, EmailTemplateLibraryRequest } from "../types/index.ts";
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures");
+const load = async <T>(name: string): Promise<T> =>
+  JSON.parse(await readFile(join(fixtures, name), "utf8")) as T;
+
+test("renders a template from the success fixture", async () => {
+  const fixture = await load<{
+    templates: EmailTemplate[];
+    request: EmailTemplateLibraryRequest;
+    expected: unknown;
+  }>("success.json");
+  const response = executeEmailTemplateLibrary(fixture.request, fixture.templates);
+  assert.equal(response.status, "ok");
+  if (response.status === "ok") assert.deepEqual(response.result, fixture.expected);
+});
+
+test("returns stable failure codes from failure fixtures", async () => {
+  const success = await load<{ templates: EmailTemplate[] }>("success.json");
+  for (const name of ["failure-missing-variables.json", "failure-template-not-found.json"]) {
+    const fixture = await load<{
+      request: EmailTemplateLibraryRequest;
+      expectedError: { code: string; missingVariables?: string[]; templateId?: string };
+    }>(name);
+    const response = executeEmailTemplateLibrary(fixture.request, success.templates);
+    assert.equal(response.status, "error");
+    if (response.status === "error") {
+      assert.equal(response.error.code, fixture.expectedError.code);
+      if (fixture.expectedError.missingVariables)
+        assert.deepEqual(
+          response.error.details?.missingVariables,
+          fixture.expectedError.missingVariables,
+        );
+      if (fixture.expectedError.templateId)
+        assert.equal(response.error.details?.templateId, fixture.expectedError.templateId);
+    }
+  }
+});
+
+test("list results are cloned and cannot mutate service source data", async () => {
+  const fixture = await load<{ templates: EmailTemplate[] }>("success.json");
+  const request = { tool: "email-template-library", version: 1, operation: "list" } as const;
+  const first = executeEmailTemplateLibrary(request, fixture.templates);
+  assert.equal(first.status, "ok");
+  if (first.status !== "ok" || first.result.operation !== "list") return;
+  first.result.templates[0].name = "mutated";
+  const second = executeEmailTemplateLibrary(request, fixture.templates);
+  assert.equal(second.status, "ok");
+  if (second.status === "ok" && second.result.operation === "list")
+    assert.equal(second.result.templates[0].name, "Friendly follow-up");
+});

--- a/tools/v2/individual/email-template-library/types/index.ts
+++ b/tools/v2/individual/email-template-library/types/index.ts
@@ -1,0 +1,96 @@
+export const EMAIL_TEMPLATE_LIBRARY_TOOL = "email-template-library" as const;
+export const EMAIL_TEMPLATE_LIBRARY_VERSION = 1 as const;
+
+export const EMAIL_TEMPLATE_LIBRARY_ERROR_CODES = {
+  INVALID_REQUEST: "INVALID_REQUEST",
+  UNSUPPORTED_VERSION: "UNSUPPORTED_VERSION",
+  INVALID_TEMPLATE: "INVALID_TEMPLATE",
+  TEMPLATE_NOT_FOUND: "TEMPLATE_NOT_FOUND",
+  MISSING_VARIABLES: "MISSING_VARIABLES",
+} as const;
+
+export type EmailTemplateLibraryErrorCode =
+  (typeof EMAIL_TEMPLATE_LIBRARY_ERROR_CODES)[keyof typeof EMAIL_TEMPLATE_LIBRARY_ERROR_CODES];
+
+export interface TemplateVariable {
+  key: string;
+  label: string;
+}
+
+export interface EmailTemplate {
+  id: string;
+  name: string;
+  categoryId: string | null;
+  subject: string;
+  body: string;
+  variables: TemplateVariable[];
+}
+
+interface BaseRequest {
+  tool: typeof EMAIL_TEMPLATE_LIBRARY_TOOL;
+  version: typeof EMAIL_TEMPLATE_LIBRARY_VERSION;
+}
+
+export interface ListTemplatesRequest extends BaseRequest {
+  operation: "list";
+  categoryId?: string | null;
+}
+
+export interface GetTemplateRequest extends BaseRequest {
+  operation: "get";
+  templateId: string;
+}
+
+export interface RenderTemplateRequest extends BaseRequest {
+  operation: "render";
+  templateId: string;
+  values: Record<string, string>;
+}
+
+export type EmailTemplateLibraryRequest =
+  | ListTemplatesRequest
+  | GetTemplateRequest
+  | RenderTemplateRequest;
+
+export interface ListTemplatesResult {
+  operation: "list";
+  templates: EmailTemplate[];
+}
+
+export interface GetTemplateResult {
+  operation: "get";
+  template: EmailTemplate;
+}
+
+export interface RenderTemplateResult {
+  operation: "render";
+  templateId: string;
+  subject: string;
+  body: string;
+}
+
+export interface EmailTemplateLibrarySuccess {
+  status: "ok";
+  tool: typeof EMAIL_TEMPLATE_LIBRARY_TOOL;
+  version: typeof EMAIL_TEMPLATE_LIBRARY_VERSION;
+  result: ListTemplatesResult | GetTemplateResult | RenderTemplateResult;
+}
+
+export interface EmailTemplateLibraryFailure {
+  status: "error";
+  tool: typeof EMAIL_TEMPLATE_LIBRARY_TOOL;
+  version: typeof EMAIL_TEMPLATE_LIBRARY_VERSION;
+  error: {
+    code: EmailTemplateLibraryErrorCode;
+    message: string;
+    details?: { templateId?: string; fields?: string[]; missingVariables?: string[] };
+  };
+}
+
+export type EmailTemplateLibraryResponse =
+  | EmailTemplateLibrarySuccess
+  | EmailTemplateLibraryFailure;
+
+export interface EmailTemplateLibraryService {
+  execute(request: EmailTemplateLibraryRequest): EmailTemplateLibraryResponse;
+}


### PR DESCRIPTION
Closes #1378
What was done
Added a stable, backend-facing execution contract for the email-template-library tool so it can run independently of presentation concerns, with no changes to any UI/layout code.
Changes

Added typed, versioned request/response and error contracts
Exported non-UI list, get, and render service entry points
Added success and failure fixtures with focused tests
Documented the execution contract

Test results

3/3 focused Node tests passed
Repository-wide TypeScript check: passed
Focused ESLint check: passed
Git whitespace validation: passed