### PR TITLE
feat(api): add canonical Stellar address normalization

### DIFF
--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const stellarAddressSchema = z
   .string()
   .trim()
+  .toUpperCase()
   .regex(/^G[A-Z2-7]{55}$/, "Expected a Stellar G-address");
 
 export const hash32Schema = z

--- a/tests/unit/api/domain.test.ts
+++ b/tests/unit/api/domain.test.ts
@@ -26,6 +26,10 @@ describe("API domain schemas", () => {
 
   it("enforces Stellar addresses and 32-byte hashes", () => {
     expect(stellarAddressSchema.parse(address)).toBe(address);
+    // Add normalization tests for canonical address handling
+    expect(stellarAddressSchema.parse(address.toLowerCase())).toBe(address);
+    expect(stellarAddressSchema.parse(`  ${address.toLowerCase()}  `)).toBe(address);
+    
     expect(hash32Schema.parse("a".repeat(64))).toBe("a".repeat(64));
     expect(() => stellarAddressSchema.parse("eve*stealth.xyz")).toThrow();
     expect(() => hash32Schema.parse("abc")).toThrow();

--- a/tests/unit/api/domain.test.ts
+++ b/tests/unit/api/domain.test.ts
@@ -29,7 +29,7 @@ describe("API domain schemas", () => {
     // Add normalization tests for canonical address handling
     expect(stellarAddressSchema.parse(address.toLowerCase())).toBe(address);
     expect(stellarAddressSchema.parse(`  ${address.toLowerCase()}  `)).toBe(address);
-    
+
     expect(hash32Schema.parse("a".repeat(64))).toBe("a".repeat(64));
     expect(() => stellarAddressSchema.parse("eve*stealth.xyz")).toThrow();
     expect(() => hash32Schema.parse("abc")).toThrow();


### PR DESCRIPTION
### What was done
- Appended a strict `.toUpperCase()` mutator to the foundational `stellarAddressSchema` defined inside `src/server/api/domain.ts`.
- Augmented `tests/unit/api/domain.test.ts` to assert that intentionally lowercased and whitespace-padded variants output pristine, identical canonical G-address buffers.

### Why it was done
- Malformed strings (`g` vs `G`) flowing natively downstream without normalization could inadvertently trigger duplicate logical actors inside database queries or cause cryptographic mismatch issues across validation parameters. 
- Applying this transform centrally at the `domain.ts` Zod schema intercepts all ingress data uniformly. Any payload mapped via `stellarAddressSchema` normalizes universally across headers, paths, query parameters, bodies, storage keys, and signatures.

### How it was verified
- Added comprehensive regex invariant checks in unit tests specifically mocking lowercased addresses and trailing whitespaces.

closes #1535 
