### PR TITLE
Add testing + documentation for Invoice Approval Workflow

### DIFF
--- a/src/tools/v2/team/invoice-approval-workflow/README.md
+++ b/src/tools/v2/team/invoice-approval-workflow/README.md
@@ -1,23 +1,33 @@
-# Invoice Approval Workflow (V2 Tool)
+# Invoice Approval Workflow — Review Notes
 
-Welcome to the **Invoice Approval Workflow** module. This is a V2 later-release tool designed for the team audience. It is being built as a completely isolated mini-product to prevent regressions in the core application during development.
+Isolated V2 "team" tool. All review material for this tool lives in this folder.
+The production logic is in `engine.ts` / `types.ts`; the UI shell is
+`InvoiceApprovalWorkflow.tsx`.
 
-## 📖 Architecture & Guidelines
+## What to review
 
-Before contributing to this folder, **you must read the [Architecture Contract](./architecture.md)**.
+1. **Pure logic** — `engine.ts`:
+   - `canProcessInvoice(invoice)` — only `PENDING` invoices are actionable.
+   - `processInvoiceAction(invoice, action)` — immutable approve/reject reducer
+     returning a `WorkflowResult<Invoice>` (never throws).
+   - `calculatePendingTotal(invoices, currency)` — outstanding exposure per currency.
+2. **Types** — `types.ts` (`Invoice`, `ApprovalAction`, `InvoiceStatus`, `WorkflowResult`).
+3. **Fixtures** — `__fixtures__/mockInvoices.ts` (pending / approved / rejected / list).
+4. **Tests** — `__tests__/engine.test.ts` (vitest).
 
-## 🚀 Quick Start for Contributors
+## How to run the tests
 
-1. **Stay Local:** All components, services, and hooks must be created inside `src/tools/v2/team/invoice-approval-workflow/`.
-2. **Use Fixtures:** Do not connect to the real database or the main app's authentication state. Create local mock files for testing.
-3. **No Global Mutations:** Do not modify the existing routing tree, dashboard layout, main mail rendering engine, or the shared design system.
+```sh
+# from repo root
+npm install
+npx vitest run src/tools/v2/team/invoice-approval-workflow
+```
 
-## 🛠 Features (In Progress)
+Expected: all `engine.test.ts` cases green (canProcess, process approve/reject,
+immutability, mismatch/non-pending/no-reason errors, pending-total math).
 
-This tool will handle:
+## Known limitations
 
-- Submission of internal or external vendor invoices.
-- Establishing an approval queue for designated team members.
-- Tracking approval states (PENDING, APPROVED, REJECTED) in an isolated context.
-
-_Note: For questions regarding future integration with the global Stellar-Mail application shell, refer to the follow-up integration issues in the main repository tracker._
+- `InvoiceApprovalWorkflow.tsx` is a presentational shell only; no state wiring.
+- No persistence / auth layer — this is the isolated logic contract.
+- Date fields are ISO strings; no timezone normalization is performed here.

--- a/src/tools/v2/team/invoice-approval-workflow/__tests__/engine.test.ts
+++ b/src/tools/v2/team/invoice-approval-workflow/__tests__/engine.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { canProcessInvoice, processInvoiceAction, calculatePendingTotal } from "../engine";
+import {
+  mockPendingInvoice,
+  mockApprovedInvoice,
+  mockRejectedInvoice,
+  mockInvoiceList,
+} from "../__fixtures__/mockInvoices";
+import type { ApprovalAction, Invoice } from "../types";
+
+describe("canProcessInvoice", () => {
+  it("returns true for a PENDING invoice", () => {
+    expect(canProcessInvoice(mockPendingInvoice)).toBe(true);
+  });
+
+  it("returns false for an already-decided (APPROVED) invoice", () => {
+    expect(canProcessInvoice(mockApprovedInvoice)).toBe(false);
+  });
+
+  it("returns false for an already-decided (REJECTED) invoice", () => {
+    expect(canProcessInvoice(mockRejectedInvoice)).toBe(false);
+  });
+});
+
+describe("processInvoiceAction", () => {
+  const approver = "usr_admin999";
+
+  it("approves a PENDING invoice and stamps the approver", () => {
+    const action: ApprovalAction = {
+      invoiceId: mockPendingInvoice.id,
+      action: "APPROVE",
+      approverId: approver,
+    };
+    const result = processInvoiceAction(mockPendingInvoice, action);
+    expect(result.success).toBe(true);
+    expect(result.data?.status).toBe("APPROVED");
+    expect(result.data?.approverId).toBe(approver);
+  });
+
+  it("rejects a PENDING invoice with a reason and records it in notes", () => {
+    const action: ApprovalAction = {
+      invoiceId: mockPendingInvoice.id,
+      action: "REJECT",
+      approverId: approver,
+      reason: "Over budget",
+    };
+    const result = processInvoiceAction(mockPendingInvoice, action);
+    expect(result.success).toBe(true);
+    expect(result.data?.status).toBe("REJECTED");
+    expect(result.data?.notes).toContain("[REJECT]: Over budget");
+  });
+
+  it("does not mutate the input invoice (immutable update)", () => {
+    const before: Invoice = { ...mockPendingInvoice };
+    const action: ApprovalAction = {
+      invoiceId: mockPendingInvoice.id,
+      action: "APPROVE",
+      approverId: approver,
+    };
+    processInvoiceAction(mockPendingInvoice, action);
+    expect(mockPendingInvoice.status).toBe("PENDING");
+    expect(mockPendingInvoice).toEqual(before);
+  });
+
+  it("fails when the invoice is not PENDING", () => {
+    const action: ApprovalAction = {
+      invoiceId: mockApprovedInvoice.id,
+      action: "APPROVE",
+      approverId: approver,
+    };
+    const result = processInvoiceAction(mockApprovedInvoice, action);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(mockApprovedInvoice.status);
+  });
+
+  it("fails when the action invoiceId does not match the invoice", () => {
+    const action: ApprovalAction = {
+      invoiceId: "inv_other",
+      action: "APPROVE",
+      approverId: approver,
+    };
+    const result = processInvoiceAction(mockPendingInvoice, action);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("does not match");
+  });
+
+  it("fails when rejecting without a reason", () => {
+    const action: ApprovalAction = {
+      invoiceId: mockPendingInvoice.id,
+      action: "REJECT",
+      approverId: approver,
+    };
+    const result = processInvoiceAction(mockPendingInvoice, action);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("reason");
+  });
+});
+
+describe("calculatePendingTotal", () => {
+  it("sums only PENDING invoices in the requested currency", () => {
+    // mockInvoiceList: inv_001 (USD 1500 PENDING), inv_004 (USD 300 PENDING)
+    expect(calculatePendingTotal(mockInvoiceList, "USD")).toBe(1800);
+  });
+
+  it("ignores non-USD currencies", () => {
+    expect(calculatePendingTotal(mockInvoiceList, "EUR")).toBe(0);
+  });
+
+  it("ignores already-decided invoices", () => {
+    // Approved EUR invoice (450.5) must not count
+    expect(calculatePendingTotal(mockInvoiceList, "EUR")).toBe(0);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(calculatePendingTotal([], "USD")).toBe(0);
+  });
+});

--- a/src/tools/v2/team/invoice-approval-workflow/fixtures.ts
+++ b/src/tools/v2/team/invoice-approval-workflow/fixtures.ts
@@ -1,0 +1,1 @@
+export * from "./__fixtures__/mockInvoices";


### PR DESCRIPTION
## Goal
Add contributor-friendly tests and documentation for the isolated Invoice Approval Workflow tool (issue #608).

## Changes (all inside `tools/v2/team/invoice-approval-workflow/`)
- `__tests__/engine.test.ts` — vitest unit tests for `engine.ts`:
  - `canProcessInvoice` (only `PENDING` is actionable)
  - `processInvoiceAction` approve/reject, immutable update, mismatch / non-pending / reject-without-reason errors
  - `calculatePendingTotal` per-currency math
- `fixtures.ts` — barrel re-export of the existing mock invoices.
- `README.md` — review notes: what to review, how to run, known limitations.

## Verification
- `npx vitest run src/tools/v2/team/invoice-approval-workflow` → 13 passed.
- ESLint/prettier clean on the added files; no repo-wide config change.

Fixes #608