### PR TITLE
Add testing + documentation for Knowledge Base Suggestion

### DIFF
--- a/src/tools/v2/team/knowledge-base-suggestion/README.md
+++ b/src/tools/v2/team/knowledge-base-suggestion/README.md
@@ -1,0 +1,33 @@
+# Knowledge Base Suggestion — Review Notes
+
+Isolated V2 "team" tool. All review material for this tool lives in this folder.
+The component is `KnowledgeBaseSuggestion.tsx` (presentational; state is held
+locally with `useState`).
+
+## What to review
+
+1. **Component** — `KnowledgeBaseSuggestion.tsx` renders five visual states:
+   `idle`, `loading`, `empty`, `error`, `success`. State is toggled by the demo
+   buttons in the header.
+2. **Accessibility** — the output region is `aria-live="polite"`, the loading
+   region is `aria-busy`, and the error uses `role="alert"`.
+3. **Tests** — `__tests__/KnowledgeBaseSuggestion.test.tsx` (vitest +
+   `@testing-library/react` + `jsdom`).
+
+## How to run the tests
+
+```sh
+# from repo root
+npm install
+npx vitest run src/tools/v2/team/knowledge-base-suggestion
+```
+
+Expected: all state transitions render the correct region/alert/list, and the
+accessible region is exposed.
+
+## Known limitations
+
+- This is a UI demo shell: it does not call a real knowledge-base indexer and
+  the "success" articles are hard-coded. A non-UI execution contract / scoring
+  layer is tracked separately and should be wired in once available.
+- No persistence or routing; fully isolated per the issue boundary.

--- a/src/tools/v2/team/knowledge-base-suggestion/__tests__/KnowledgeBaseSuggestion.test.tsx
+++ b/src/tools/v2/team/knowledge-base-suggestion/__tests__/KnowledgeBaseSuggestion.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { KnowledgeBaseSuggestion } from "../KnowledgeBaseSuggestion";
+
+const first = <T,>(els: T[]): T => els[0];
+
+describe("KnowledgeBaseSuggestion", () => {
+  it("renders the idle prompt by default", () => {
+    render(<KnowledgeBaseSuggestion />);
+    expect(screen.getAllByText(/Click "Analyze Thread" to fetch/i)[0]).toBeInTheDocument();
+  });
+
+  it("shows the loading spinner after clicking Analyze Thread", async () => {
+    const user = userEvent.setup();
+    render(<KnowledgeBaseSuggestion />);
+    await user.click(first(screen.getAllByRole("button", { name: /Analyze Thread/i })));
+    expect(screen.getAllByLabelText(/Analyzing email content/i)[0]).toBeInTheDocument();
+  });
+
+  it("shows the empty state after clicking No Matches Found", async () => {
+    const user = userEvent.setup();
+    render(<KnowledgeBaseSuggestion />);
+    await user.click(first(screen.getAllByRole("button", { name: /No Matches Found/i })));
+    expect(screen.getAllByText(/No suggestions found/i)[0]).toBeInTheDocument();
+  });
+
+  it("shows the error alert after clicking Simulate Error", async () => {
+    const user = userEvent.setup();
+    render(<KnowledgeBaseSuggestion />);
+    await user.click(first(screen.getAllByRole("button", { name: /Simulate Error/i })));
+    expect(screen.getAllByRole("alert")[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Search service unavailable/i)[0]).toBeInTheDocument();
+  });
+
+  it("shows suggested articles after clicking View Suggestions", async () => {
+    const user = userEvent.setup();
+    render(<KnowledgeBaseSuggestion />);
+    await user.click(first(screen.getAllByRole("button", { name: /View Suggestions/i })));
+    expect(
+      screen.getAllByRole("list", { name: /Suggested Articles List/i })[0],
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Configuring Wallet Authentication/i)[0]).toBeInTheDocument();
+  });
+
+  it("exposes an accessible region labelled for screen readers", () => {
+    render(<KnowledgeBaseSuggestion />);
+    expect(
+      screen.getAllByRole("region", { name: /Knowledge Base Suggestions/i })[0],
+    ).toBeInTheDocument();
+  });
+});

--- a/src/tools/v2/team/knowledge-base-suggestion/fixtures.ts
+++ b/src/tools/v2/team/knowledge-base-suggestion/fixtures.ts
@@ -1,0 +1,30 @@
+export type SuggestionState = "idle" | "loading" | "success" | "error" | "empty";
+
+export interface KnowledgeSuggestion {
+  title: string;
+  summary: string;
+  match: number;
+}
+
+export const mockSuggestionStates: SuggestionState[] = [
+  "idle",
+  "loading",
+  "empty",
+  "error",
+  "success",
+];
+
+export const mockSuggestions: KnowledgeSuggestion[] = [
+  {
+    title: "Configuring Wallet Authentication",
+    summary:
+      "Learn how to securely configure web3 wallet signatures, challenge issuance, and JWT validation flows for new users.",
+    match: 98,
+  },
+  {
+    title: "Troubleshooting Stellar Node Sync Issues",
+    summary:
+      "Common resolution paths for when the EventIndexer falls behind the active ledger or drops webhook payloads during network congestion.",
+    match: 85,
+  },
+];


### PR DESCRIPTION
## Goal
Add contributor-friendly tests and documentation for the isolated Knowledge Base Suggestion tool (issue #613).

## Changes (all inside `tools/v2/team/knowledge-base-suggestion/`)
- `__tests__/KnowledgeBaseSuggestion.test.tsx` — vitest + jsdom component tests covering the
  idle / loading / empty / error / success state transitions and the accessible `region`.
  jsdom + jest-dom are scoped per-file (`// @vitest-environment jsdom` + `import "@testing-library/jest-dom/vitest"`),
  so no repo-wide test config change is required.
- `fixtures.ts` — typed fixtures for the suggestion states/articles.
- `README.md` — review notes: what to review, how to run, known limitations.

## Verification
- `npx vitest run src/tools/v2/team/knowledge-base-suggestion` → 6 passed.
- ESLint/prettier clean on the added files.

Fixes #613