### PR TITLE
Add testing + documentation plan for Legal and Compliance Review Flag

### DIFF
--- a/src/tools/v2/team/legal-and-compliance-review-flag/README.md
+++ b/src/tools/v2/team/legal-and-compliance-review-flag/README.md
@@ -1,0 +1,33 @@
+# Legal and Compliance Review Flag — Review Notes
+
+Isolated V2 "team" tool. All review material for this tool lives in this folder.
+
+## Current state
+
+The non-UI execution contract for this tool is **not yet merged to `main`**, so
+there is no `engine.ts`/`types.ts` to exercise yet. To satisfy the issue
+("documented test plan if code is not ready"), this folder ships:
+
+- `TEST_PLAN.md` — the expected reducer contract + the list of tests to add.
+- `fixtures.ts` — typed fixtures (`ReviewFlag`, `RaiseInput`, `ResolveInput`,
+  sample flags/inputs/list).
+
+## What to review
+
+1. **Test plan** — `TEST_PLAN.md` defines the `raise` / `resolve` / `list`
+   lifecycle and the edge cases (duplicate raise, resolve-missing, empty list,
+   immutability).
+2. **Fixtures** — `fixtures.ts` mirrors the shape the future `engine.ts` must
+   satisfy, so tests can be dropped in without rework.
+3. **Once code lands** — add `__tests__/reviewFlag.test.ts` following the plan
+   and run:
+
+```sh
+npm install
+npx vitest run src/tools/v2/team/legal-and-compliance-review-flag
+```
+
+## Known limitations
+
+- No live logic yet; this is a review-ready scaffold, not a passing test suite.
+- Severity/resolution vocabulary is provisional until the contract merges.

--- a/src/tools/v2/team/legal-and-compliance-review-flag/TEST_PLAN.md
+++ b/src/tools/v2/team/legal-and-compliance-review-flag/TEST_PLAN.md
@@ -1,0 +1,57 @@
+# Legal and Compliance Review Flag — Test Plan
+
+> **Status:** code not yet present on `main` (the non-UI execution contract for
+> this tool has not landed). Per the issue ("documented test plan if code is not
+> ready"), this folder carries a concrete test plan + fixtures so the behavior
+> can be validated independently as soon as the contract lands.
+
+## Scope
+
+Isolated V2 "team" tool. Everything stays inside this folder; no app/routing/
+wallet/Stellar core changes.
+
+## Expected behavior (contract under test)
+
+A "review flag" lifecycle over a document/thread, with a non-UI service
+entry point. Based on the tool name and the sibling tools' contracts:
+
+| Operation       | Input                                      | Expected result                                                              |
+| --------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
+| `raise`         | `{ targetId, raisedBy, reason, severity }` | A flag is created with status `OPEN`, a monotonic `flagId`, `raisedAt` set.  |
+| `resolve`       | `{ flagId, resolvedBy, resolution }`       | Status transitions `OPEN` → `RESOLVED`; records `resolvedAt` + `resolvedBy`. |
+| `list`          | `{ targetId? }`                            | Returns flags, optionally filtered by target; newest first.                  |
+| duplicate raise | same `targetId` already `OPEN`             | rejected (`error: "already flagged"`) — no second open flag.                 |
+| resolve absent  | `flagId` does not exist                    | rejected (`error: "flag not found"`).                                        |
+| list filter     | `targetId` with no flags                   | returns empty list (no error).                                               |
+| immutability    | any op                                     | input objects are not mutated; operations return new state.                  |
+
+## Fixtures (`fixtures.ts`)
+
+- `mockOpenFlag` — a sample `OPEN` flag.
+- `mockResolvedFlag` — a sample `RESOLVED` flag.
+- `mockRaiseInput` / `mockResolveInput` — representative service inputs.
+- `mockFlagList` — a small list spanning `OPEN` and `RESOLVED`.
+
+## Planned tests (to add once `engine.ts` lands)
+
+File: `__tests__/reviewFlag.test.ts`
+
+- `raise` creates an `OPEN` flag with monotonic id + timestamp.
+- `resolve` moves `OPEN` → `RESOLVED` and records resolver + resolution.
+- duplicate `raise` on an already-`OPEN` target is rejected.
+- `resolve` of a missing `flagId` is rejected.
+- `list` filters by `targetId` and returns empty when none exist.
+- operations are immutable (no mutation of inputs).
+
+## How to run (once code exists)
+
+```sh
+npm install
+npx vitest run src/tools/v2/team/legal-and-compliance-review-flag
+```
+
+## Known limitations
+
+- No persistence/auth layer yet; this is the isolated logic contract.
+- Severity levels and resolution vocabulary are placeholders until the
+  execution contract is merged.

--- a/src/tools/v2/team/legal-and-compliance-review-flag/fixtures.ts
+++ b/src/tools/v2/team/legal-and-compliance-review-flag/fixtures.ts
@@ -1,0 +1,66 @@
+export type FlagStatus = "OPEN" | "RESOLVED";
+export type FlagSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export interface ReviewFlag {
+  flagId: string;
+  targetId: string;
+  raisedBy: string;
+  reason: string;
+  severity: FlagSeverity;
+  status: FlagStatus;
+  raisedAt: string;
+  resolvedBy?: string;
+  resolution?: string;
+  resolvedAt?: string;
+}
+
+export interface RaiseInput {
+  targetId: string;
+  raisedBy: string;
+  reason: string;
+  severity: FlagSeverity;
+}
+
+export interface ResolveInput {
+  flagId: string;
+  resolvedBy: string;
+  resolution: string;
+}
+
+export const mockOpenFlag: ReviewFlag = {
+  flagId: "flag_001",
+  targetId: "doc_abc",
+  raisedBy: "usr_compliance12",
+  reason: "Unverified data source cited in reply.",
+  severity: "HIGH",
+  status: "OPEN",
+  raisedAt: "2023-10-01T10:00:00Z",
+};
+
+export const mockResolvedFlag: ReviewFlag = {
+  flagId: "flag_002",
+  targetId: "doc_def",
+  raisedBy: "usr_compliance12",
+  reason: "Conflicting compliance claim.",
+  severity: "MEDIUM",
+  status: "RESOLVED",
+  raisedAt: "2023-09-20T09:00:00Z",
+  resolvedBy: "usr_compliance99",
+  resolution: "Verified against policy 4.2; cleared.",
+  resolvedAt: "2023-09-21T15:30:00Z",
+};
+
+export const mockRaiseInput: RaiseInput = {
+  targetId: "doc_xyz",
+  raisedBy: "usr_compliance12",
+  reason: "Potential PII leakage in draft.",
+  severity: "CRITICAL",
+};
+
+export const mockResolveInput: ResolveInput = {
+  flagId: "flag_001",
+  resolvedBy: "usr_compliance99",
+  resolution: "Redacted PII; cleared.",
+};
+
+export const mockFlagList: ReviewFlag[] = [mockOpenFlag, mockResolvedFlag];


### PR DESCRIPTION
## Goal
Add contributor-friendly tests and documentation for the isolated Legal and Compliance Review Flag tool (issue #618).

## Note on code availability
The non-UI execution contract for this tool is **not yet merged to `main`** (no `src/tools/v2/team/legal-and-compliance-review-flag/` code exists on `main`). Per the issue ("documented test plan if code is not ready"), this PR ships a concrete, review-ready plan + fixtures instead of a passing executable suite.

## Changes (all inside `tools/v2/team/legal-and-compliance-review-flag/`)
- `TEST_PLAN.md` — the expected `raise` / `resolve` / `list` lifecycle, edge cases
  (duplicate raise, resolve-missing, empty list, immutability), and the list of tests to add once `engine.ts` lands.
- `fixtures.ts` — typed fixtures (`ReviewFlag`, `RaiseInput`, `ResolveInput`, sample flags/inputs/list)
  that mirror the shape the future engine must satisfy, so tests drop in without rework.
- `README.md` — review notes and how to run once code exists.

## Verification
- Marked as a documented test plan (no executable tests yet, by design).
- ESLint/prettier clean on the added files.

Fixes #618