### PR TITLE
feat: add typed execution contract and fixtures to fixtures module

### DIFF
--- a/tools/v2/individual/pdf-summary-tool/fixtures/README.md
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/README.md
@@ -1,25 +1,89 @@
 # Fixtures
 
-Test fixtures and sample data for the PDF Summary Tool.
+Test fixtures, typed execution contract, and sample data for the PDF Summary Tool.
+
+## Execution Contract
+
+The fixtures module exposes a **non-UI service entry point** that can run independently of any presentation layer.
+
+### Entry Point
+
+```typescript
+import { FixtureExecutionService, FixtureAction } from "../fixtures";
+
+const service = new FixtureExecutionService();
+const result = await service.execute({
+  action: FixtureAction.GENERATE_SUMMARY,
+  payload: {
+    text: "Extracted PDF text…",
+    settings: { length: "short", style: "bullet-points", includeKeywords: false, language: "en" },
+  },
+});
+
+if (result.success) {
+  console.log(result.data); // Summary object
+} else {
+  console.error(result.error); // { code, message }
+}
+```
+
+### Actions
+
+| Action              | Payload                                        | Success Data        |
+| ------------------- | ---------------------------------------------- | ------------------- |
+| `GENERATE_SUMMARY`  | `{ text: string, settings: SummarySettings }`  | `Summary`           |
+| `VALIDATE_PDF`      | `{ fileName, fileSizeBytes, mimeType }`        | `{ valid: boolean }`|
+| `GET_SETTINGS`      | _(none)_                                       | `SummarySettings`   |
+
+### Error Codes
+
+| Code                   | When                                          |
+| ---------------------- | --------------------------------------------- |
+| `INVALID_INPUT`        | Missing or malformed action / payload         |
+| `FILE_TOO_LARGE`       | File exceeds 50 MB limit                      |
+| `UNSUPPORTED_FORMAT`   | MIME type is not `application/pdf`            |
+| `EXTRACTION_FAILED`    | Text content is empty                         |
+| `SUMMARIZATION_FAILED` | Summary generation fails                      |
+| `ACTION_NOT_SUPPORTED` | Unknown action string                         |
+| `INTERNAL_ERROR`       | Unexpected runtime error                      |
 
 ## Contents
 
-- `sample-pdfs/` - Sample PDF files for testing
-- `expected-summaries.json` - Expected summary outputs for different PDF types
-- `mock-data.ts` - Mock objects and factories for tests
+| File                      | Purpose                                     |
+| ------------------------- | ------------------------------------------- |
+| `execution.types.ts`      | Typed input/output contract & error codes   |
+| `execution.service.ts`    | Stateless service entry point               |
+| `execution.fixtures.ts`   | Success & failure fixture pairs for tests   |
+| `index.ts`                | Barrel export                               |
 
-## Using Fixtures
-
-### In Tests
+## Using Fixtures in Tests
 
 ```typescript
-import { SAMPLE_PDF_PATH } from "../fixtures";
-import { loadMockSummary } from "../fixtures/mock-data";
+import { describe, it, expect } from "vitest";
+import { FixtureExecutionService, SUCCESS_FIXTURES, FAILURE_FIXTURES } from "../fixtures";
 
-test("should summarize PDF", async () => {
-  const file = new File([], "sample.pdf");
-  const summary = await summarizePDF(file);
-  expect(summary).toEqual(loadMockSummary("sample"));
+const service = new FixtureExecutionService();
+
+describe("success cases", () => {
+  SUCCESS_FIXTURES.forEach(({ label, input, expectedOutput }) => {
+    it(label, async () => {
+      const result = await service.execute(input);
+      expect(result.success).toBe(expectedOutput.success);
+      if (expectedOutput.hasData) {
+        expect(result.data).toBeDefined();
+      }
+    });
+  });
+});
+
+describe("failure cases", () => {
+  FAILURE_FIXTURES.forEach(({ label, input, expectedOutput }) => {
+    it(label, async () => {
+      const result = await service.execute(input);
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe(expectedOutput.error?.code);
+    });
+  });
 });
 ```
 
@@ -30,6 +94,7 @@ test("should summarize PDF", async () => {
 - ✅ Document fixture purpose
 - ✅ Version control fixtures
 - ✅ Use factories for complex data
+- ✅ Type all fixture data against the execution contract
 
 - ❌ Don't use actual user data
 - ❌ Don't store large files
@@ -37,20 +102,9 @@ test("should summarize PDF", async () => {
 
 ## Adding New Fixtures
 
-1. Create new file in `fixtures/`
-2. Document what it's for
-3. Use in tests
-4. Commit to version control
-
-Example: `fixtures/mock-data.ts`
-
-```typescript
-export const mockSummaries = {
-  short: { id: '1', content: 'Brief summary...', ... },
-  long: { id: '2', content: 'Detailed summary...', ... }
-};
-
-export function createMockSummary(overrides = {}) {
-  return { id: '1', content: 'Summary', ...overrides };
-}
-```
+1. Add the new action to `FixtureAction` in `execution.types.ts`
+2. Define the payload type
+3. Implement the handler in `execution.service.ts`
+4. Add success and failure entries in `execution.fixtures.ts`
+5. Export via `index.ts`
+6. Tests will pick up the new fixture automatically

--- a/tools/v2/individual/pdf-summary-tool/fixtures/execution.fixtures.ts
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/execution.fixtures.ts
@@ -1,0 +1,170 @@
+/**
+ * PDF Summary Tool — Execution Fixtures
+ *
+ * Typed input/expectedOutput pairs for success and failure scenarios.
+ * Used by tests and as living documentation of the execution contract.
+ *
+ * Pattern follows customer-support-macro-tool/fixtures/macros.fixture.ts
+ * (typed TS objects, not raw JSON).
+ */
+
+import type {
+  FixtureExecutionInput,
+  FixtureExecutionOutput,
+} from "./execution.types";
+import { FixtureAction, FixtureErrorCode } from "./execution.types";
+import type { SummarySettings } from "../types";
+
+// ---------------------------------------------------------------------------
+// Shared constants used across fixtures
+// ---------------------------------------------------------------------------
+
+const SHORT_BULLET_SETTINGS: SummarySettings = {
+  length: "short",
+  style: "bullet-points",
+  includeKeywords: true,
+  language: "en",
+};
+
+const DEFAULT_SETTINGS: SummarySettings = {
+  length: "medium",
+  style: "paragraph",
+  includeKeywords: false,
+  language: "en",
+};
+
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Fixture shape
+// ---------------------------------------------------------------------------
+
+export interface ExecutionFixture {
+  /** Human-readable label for test runners. */
+  label: string;
+  input: FixtureExecutionInput;
+  expectedOutput: Pick<FixtureExecutionOutput, "success"> & {
+    /** Partial match — tests can use `expect.objectContaining`. */
+    error?: { code: FixtureErrorCode };
+    /** When present, tests assert that data is defined. */
+    hasData?: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+export const SUCCESS_FIXTURES: ExecutionFixture[] = [
+  {
+    label: "GENERATE_SUMMARY with valid text and short/bullet-points settings",
+    input: {
+      action: FixtureAction.GENERATE_SUMMARY,
+      payload: {
+        text: "Artificial intelligence has transformed how we process documents in the modern workplace.",
+        settings: SHORT_BULLET_SETTINGS,
+      },
+    },
+    expectedOutput: { success: true, hasData: true },
+  },
+  {
+    label: "VALIDATE_PDF with a small valid PDF",
+    input: {
+      action: FixtureAction.VALIDATE_PDF,
+      payload: {
+        fileName: "report.pdf",
+        fileSizeBytes: 1_024_000, // ~1 MB
+        mimeType: "application/pdf",
+      },
+    },
+    expectedOutput: { success: true, hasData: true },
+  },
+  {
+    label: "GET_SETTINGS returns defaults",
+    input: {
+      action: FixtureAction.GET_SETTINGS,
+    },
+    expectedOutput: { success: true, hasData: true },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Failure cases
+// ---------------------------------------------------------------------------
+
+export const FAILURE_FIXTURES: ExecutionFixture[] = [
+  {
+    label: "GENERATE_SUMMARY with missing payload",
+    input: {
+      action: FixtureAction.GENERATE_SUMMARY,
+      payload: undefined as unknown as { text: string; settings: SummarySettings },
+    },
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.INVALID_INPUT },
+    },
+  },
+  {
+    label: "GENERATE_SUMMARY with empty text",
+    input: {
+      action: FixtureAction.GENERATE_SUMMARY,
+      payload: {
+        text: "   ",
+        settings: DEFAULT_SETTINGS,
+      },
+    },
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.EXTRACTION_FAILED },
+    },
+  },
+  {
+    label: "VALIDATE_PDF with oversized file (exceeds 50 MB)",
+    input: {
+      action: FixtureAction.VALIDATE_PDF,
+      payload: {
+        fileName: "huge-scan.pdf",
+        fileSizeBytes: MAX_FILE_SIZE_BYTES + 1,
+        mimeType: "application/pdf",
+      },
+    },
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.FILE_TOO_LARGE },
+    },
+  },
+  {
+    label: "VALIDATE_PDF with wrong MIME type",
+    input: {
+      action: FixtureAction.VALIDATE_PDF,
+      payload: {
+        fileName: "document.docx",
+        fileSizeBytes: 50_000,
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+    },
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.UNSUPPORTED_FORMAT },
+    },
+  },
+  {
+    label: "Unknown action returns ACTION_NOT_SUPPORTED",
+    input: {
+      action: "TELEPORT_PDF" as FixtureAction,
+      payload: {},
+    },
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.ACTION_NOT_SUPPORTED },
+    },
+  },
+  {
+    label: "Null input returns INVALID_INPUT",
+    input: null as unknown as FixtureExecutionInput,
+    expectedOutput: {
+      success: false,
+      error: { code: FixtureErrorCode.INVALID_INPUT },
+    },
+  },
+];

--- a/tools/v2/individual/pdf-summary-tool/fixtures/execution.service.ts
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/execution.service.ts
@@ -1,0 +1,186 @@
+/**
+ * PDF Summary Tool — Fixture Execution Service
+ *
+ * Non-UI service entry point for the fixtures module.
+ * Provides a stable, backend-facing execution contract that can run
+ * independently of any presentation layer.
+ *
+ * Mirrors the pattern in config/services/ExecutionService.ts.
+ */
+
+import type {
+  FixtureExecutionInput,
+  FixtureExecutionOutput,
+  GenerateSummaryPayload,
+  ValidatePdfPayload,
+} from "./execution.types";
+import {
+  FixtureAction,
+  FixtureErrorCode,
+} from "./execution.types";
+import type { Summary, SummarySettings } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+const SUPPORTED_MIME_TYPES: ReadonlySet<string> = new Set(["application/pdf"]);
+
+const DEFAULT_SETTINGS: SummarySettings = {
+  length: "medium",
+  style: "paragraph",
+  includeKeywords: false,
+  language: "en",
+};
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateless execution service for the pdf-summary-tool fixtures module.
+ *
+ * Every public method returns a structured {@link FixtureExecutionOutput} and
+ * **never throws** — all error paths are captured in the response envelope.
+ */
+export class FixtureExecutionService {
+  /**
+   * Single entry point for all fixture actions.
+   *
+   * @param input - Typed action + payload.
+   * @returns A promise resolving to a structured output envelope.
+   */
+  public async execute(
+    input: FixtureExecutionInput,
+  ): Promise<FixtureExecutionOutput> {
+    try {
+      if (!input || !input.action) {
+        return {
+          success: false,
+          error: {
+            code: FixtureErrorCode.INVALID_INPUT,
+            message: "Missing execution action",
+          },
+        };
+      }
+
+      switch (input.action) {
+        case FixtureAction.GENERATE_SUMMARY:
+          return this.handleGenerateSummary(
+            input.payload as GenerateSummaryPayload | undefined,
+          );
+        case FixtureAction.VALIDATE_PDF:
+          return this.handleValidatePdf(
+            input.payload as ValidatePdfPayload | undefined,
+          );
+        case FixtureAction.GET_SETTINGS:
+          return this.handleGetSettings();
+        default:
+          return {
+            success: false,
+            error: {
+              code: FixtureErrorCode.ACTION_NOT_SUPPORTED,
+              message: `Action "${input.action}" is not supported`,
+            },
+          };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.INTERNAL_ERROR,
+          message:
+            error instanceof Error ? error.message : "Unknown internal error",
+        },
+      };
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Action handlers
+  // -----------------------------------------------------------------------
+
+  private async handleGenerateSummary(
+    payload: GenerateSummaryPayload | undefined,
+  ): Promise<FixtureExecutionOutput<Summary>> {
+    if (!payload || typeof payload.text !== "string" || !payload.settings) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.INVALID_INPUT,
+          message:
+            "payload.text (string) and payload.settings (SummarySettings) are required for GENERATE_SUMMARY",
+        },
+      };
+    }
+
+    if (payload.text.trim().length === 0) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.EXTRACTION_FAILED,
+          message: "Cannot generate summary from empty text",
+        },
+      };
+    }
+
+    const summary: Summary = {
+      id: `summary_${Date.now()}`,
+      pdfId: "fixture-pdf",
+      content: `Summary of: ${payload.text.slice(0, 80)}…`,
+      settings: payload.settings,
+      generatedAt: new Date(),
+    };
+
+    return { success: true, data: summary };
+  }
+
+  private async handleValidatePdf(
+    payload: ValidatePdfPayload | undefined,
+  ): Promise<FixtureExecutionOutput<{ valid: boolean }>> {
+    if (
+      !payload ||
+      typeof payload.fileName !== "string" ||
+      typeof payload.fileSizeBytes !== "number" ||
+      typeof payload.mimeType !== "string"
+    ) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.INVALID_INPUT,
+          message:
+            "payload.fileName, payload.fileSizeBytes, and payload.mimeType are required for VALIDATE_PDF",
+        },
+      };
+    }
+
+    if (payload.fileSizeBytes > MAX_FILE_SIZE_BYTES) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.FILE_TOO_LARGE,
+          message: `File size ${payload.fileSizeBytes} exceeds maximum of ${MAX_FILE_SIZE_BYTES} bytes`,
+        },
+      };
+    }
+
+    if (!SUPPORTED_MIME_TYPES.has(payload.mimeType)) {
+      return {
+        success: false,
+        error: {
+          code: FixtureErrorCode.UNSUPPORTED_FORMAT,
+          message: `MIME type "${payload.mimeType}" is not supported. Expected one of: ${[...SUPPORTED_MIME_TYPES].join(", ")}`,
+        },
+      };
+    }
+
+    return { success: true, data: { valid: true } };
+  }
+
+  private async handleGetSettings(): Promise<
+    FixtureExecutionOutput<SummarySettings>
+  > {
+    return { success: true, data: { ...DEFAULT_SETTINGS } };
+  }
+}

--- a/tools/v2/individual/pdf-summary-tool/fixtures/execution.types.ts
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/execution.types.ts
@@ -1,0 +1,103 @@
+/**
+ * PDF Summary Tool — Fixtures Execution Contract
+ *
+ * Typed inputs, outputs, and error codes for the non-UI service entry point.
+ * Mirrors the contract pattern in config/types/execution.ts but covers the
+ * tool-level PDF processing domain (summarisation, validation, settings).
+ *
+ * This file contains ONLY type definitions and enums — no runtime logic.
+ */
+
+import type { Summary, SummarySettings } from "../types";
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/** Actions the fixture execution service can handle. */
+export enum FixtureAction {
+  /** Generate a summary from extracted PDF text. */
+  GENERATE_SUMMARY = "GENERATE_SUMMARY",
+  /** Validate that a file meets PDF processing constraints. */
+  VALIDATE_PDF = "VALIDATE_PDF",
+  /** Retrieve the current default summary settings. */
+  GET_SETTINGS = "GET_SETTINGS",
+}
+
+// ---------------------------------------------------------------------------
+// Payloads (per-action)
+// ---------------------------------------------------------------------------
+
+/** Payload for {@link FixtureAction.GENERATE_SUMMARY}. */
+export interface GenerateSummaryPayload {
+  /** Pre-extracted text content from the PDF. */
+  text: string;
+  /** Settings that control summary length, style, etc. */
+  settings: SummarySettings;
+}
+
+/** Payload for {@link FixtureAction.VALIDATE_PDF}. */
+export interface ValidatePdfPayload {
+  /** Original file name (used for format checks). */
+  fileName: string;
+  /** File size in bytes. */
+  fileSizeBytes: number;
+  /** MIME type reported by the browser File API. */
+  mimeType: string;
+}
+
+// ---------------------------------------------------------------------------
+// Input
+// ---------------------------------------------------------------------------
+
+/** Discriminated union of all valid execution inputs. */
+export type FixtureExecutionInput =
+  | { action: FixtureAction.GENERATE_SUMMARY; payload: GenerateSummaryPayload }
+  | { action: FixtureAction.VALIDATE_PDF; payload: ValidatePdfPayload }
+  | { action: FixtureAction.GET_SETTINGS; payload?: undefined }
+  | { action: string; payload?: Record<string, unknown> };
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+/** Structured error returned on failure. */
+export interface FixtureExecutionError {
+  code: FixtureErrorCode;
+  message: string;
+}
+
+/** Result envelope returned by every execution call. */
+export interface FixtureExecutionOutput<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: FixtureExecutionError;
+}
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+/** Exhaustive set of error codes the service may return. */
+export enum FixtureErrorCode {
+  /** The input object or required fields are missing / malformed. */
+  INVALID_INPUT = "INVALID_INPUT",
+  /** The file exceeds the maximum allowed size. */
+  FILE_TOO_LARGE = "FILE_TOO_LARGE",
+  /** The file MIME type is not in the supported list. */
+  UNSUPPORTED_FORMAT = "UNSUPPORTED_FORMAT",
+  /** Text extraction from the PDF failed. */
+  EXTRACTION_FAILED = "EXTRACTION_FAILED",
+  /** Summary generation failed. */
+  SUMMARIZATION_FAILED = "SUMMARIZATION_FAILED",
+  /** The requested action is not recognised. */
+  ACTION_NOT_SUPPORTED = "ACTION_NOT_SUPPORTED",
+  /** Catch-all for unexpected runtime errors. */
+  INTERNAL_ERROR = "INTERNAL_ERROR",
+}
+
+// ---------------------------------------------------------------------------
+// Re-export domain types for consumer convenience
+// ---------------------------------------------------------------------------
+
+export type { Summary, SummarySettings };

--- a/tools/v2/individual/pdf-summary-tool/fixtures/index.ts
+++ b/tools/v2/individual/pdf-summary-tool/fixtures/index.ts
@@ -1,0 +1,28 @@
+/**
+ * PDF Summary Tool — Fixtures Barrel Export
+ *
+ * Re-exports types, service, and fixture data from this module.
+ */
+
+// Types & enums
+export {
+  FixtureAction,
+  FixtureErrorCode,
+} from "./execution.types";
+export type {
+  FixtureExecutionInput,
+  FixtureExecutionOutput,
+  FixtureExecutionError,
+  GenerateSummaryPayload,
+  ValidatePdfPayload,
+} from "./execution.types";
+
+// Service
+export { FixtureExecutionService } from "./execution.service";
+
+// Fixture data
+export {
+  SUCCESS_FIXTURES,
+  FAILURE_FIXTURES,
+} from "./execution.fixtures";
+export type { ExecutionFixture } from "./execution.fixtures";

--- a/tools/v2/individual/pdf-summary-tool/tests/execution.service.test.ts
+++ b/tools/v2/individual/pdf-summary-tool/tests/execution.service.test.ts
@@ -1,0 +1,100 @@
+/**
+ * PDF Summary Tool — Fixture Execution Service Tests
+ *
+ * Verifies every success and failure fixture against the
+ * FixtureExecutionService, ensuring the execution contract is stable.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { FixtureExecutionService } from "../fixtures/execution.service";
+import {
+  SUCCESS_FIXTURES,
+  FAILURE_FIXTURES,
+} from "../fixtures/execution.fixtures";
+
+describe("FixtureExecutionService", () => {
+  let service: FixtureExecutionService;
+
+  beforeEach(() => {
+    service = new FixtureExecutionService();
+  });
+
+  // -----------------------------------------------------------------------
+  // Success fixtures
+  // -----------------------------------------------------------------------
+
+  describe("success cases", () => {
+    SUCCESS_FIXTURES.forEach(({ label, input, expectedOutput }) => {
+      it(label, async () => {
+        const result = await service.execute(input);
+
+        expect(result.success).toBe(true);
+        expect(result.error).toBeUndefined();
+
+        if (expectedOutput.hasData) {
+          expect(result.data).toBeDefined();
+        }
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Failure fixtures
+  // -----------------------------------------------------------------------
+
+  describe("failure cases", () => {
+    FAILURE_FIXTURES.forEach(({ label, input, expectedOutput }) => {
+      it(label, async () => {
+        const result = await service.execute(input);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error?.code).toBe(expectedOutput.error?.code);
+        expect(result.data).toBeUndefined();
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Contract invariants
+  // -----------------------------------------------------------------------
+
+  describe("contract invariants", () => {
+    it("never throws — always returns a structured output", async () => {
+      const edgeCases = [
+        null,
+        undefined,
+        {},
+        { action: "" },
+        { action: 42 },
+        "not-an-object",
+      ];
+
+      for (const badInput of edgeCases) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await service.execute(
+          badInput as unknown as Parameters<typeof service.execute>[0],
+        );
+        expect(result).toHaveProperty("success");
+        expect(typeof result.success).toBe("boolean");
+      }
+    });
+
+    it("returns data XOR error — never both", async () => {
+      const allFixtures = [...SUCCESS_FIXTURES, ...FAILURE_FIXTURES];
+
+      for (const { input } of allFixtures) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await service.execute(input);
+
+        if (result.success) {
+          expect(result.data).toBeDefined();
+          expect(result.error).toBeUndefined();
+        } else {
+          expect(result.error).toBeDefined();
+          expect(result.data).toBeUndefined();
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds a stable, non-UI execution contract to tools/v2/individual/pdf-summary-tool/fixtures/ so the module can run and be tested independently of any presentation layer.

Closed #1374