### PR TITLE
Expose API build and protocol versions safely

### DIFF
--- a/src/routes/api/v1/health.ts
+++ b/src/routes/api/v1/health.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { getVersionInfo } from "@/server/api/version";
 
 export const Route = createFileRoute("/api/v1/health")({
   server: {
@@ -12,6 +13,7 @@ export const Route = createFileRoute("/api/v1/health")({
             service: "stealth-mail-api",
             status: "ok",
             version: "v1",
+            versions: getVersionInfo(),
           }),
         ),
     },

--- a/src/server/api/version.ts
+++ b/src/server/api/version.ts
@@ -1,0 +1,27 @@
+import { protocolManifest } from "./protocol";
+
+// Issue #1522: expose a safe, read-only build + protocol version descriptor.
+// Values are sourced from immutable build configuration and the protocol
+// manifest only — never from request input — and must never include secrets
+// or source paths.
+export interface VersionInfo {
+  build: string;
+  apiVersion: string;
+  supportedVersions: readonly string[];
+}
+
+// A non-secret build identifier injected at build time. Falls back to a stable
+// development placeholder so the field is always present and never leaks paths.
+function readBuildId(): string {
+  const injected =
+    typeof import.meta.env?.VITE_BUILD_ID === "string" ? import.meta.env.VITE_BUILD_ID.trim() : "";
+  return injected || "development";
+}
+
+export function getVersionInfo(): VersionInfo {
+  return {
+    build: readBuildId(),
+    apiVersion: protocolManifest.apiVersion,
+    supportedVersions: protocolManifest.supportedVersions,
+  };
+}

--- a/tests/unit/api/version.test.ts
+++ b/tests/unit/api/version.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { protocolManifest } from "../../../src/server/api/protocol";
+import { getVersionInfo } from "../../../src/server/api/version";
+
+// Issue #1522: build + protocol versions must be exposed safely.
+describe("version info", () => {
+  it("exposes an explicit, non-empty build identifier", () => {
+    const info = getVersionInfo();
+    expect(typeof info.build).toBe("string");
+    expect(info.build.length).toBeGreaterThan(0);
+  });
+
+  it("reports the api version and supported versions from the protocol manifest", () => {
+    const info = getVersionInfo();
+    expect(info.apiVersion).toBe(protocolManifest.apiVersion);
+    expect(info.supportedVersions).toEqual(protocolManifest.supportedVersions);
+  });
+
+  it("is deterministic and not influenced by any argument", () => {
+    const first = JSON.stringify(getVersionInfo());
+    const second = JSON.stringify(getVersionInfo());
+    expect(first).toBe(second);
+  });
+
+  it("never leaks secrets or filesystem paths", () => {
+    const serialized = JSON.stringify(getVersionInfo());
+    expect(serialized).not.toMatch(/secret|password|token|key/i);
+    expect(serialized).not.toMatch(/[A-Za-z]:\\|\/(home|Users|var|etc)\//);
+  });
+});


### PR DESCRIPTION
Closes #1522

# Goal
Expose a safe, read-only build + protocol version response.

## Changes
- `src/server/api/version.ts`: `getVersionInfo()` returns a non-secret build identifier plus explicit api/supported versions, sourced from immutable build config + the protocol manifest only (never request input).
- `src/routes/api/v1/health.ts`: surfaces it as `versions`.
- `tests/unit/api/version.test.ts`: asserts explicit build id, versions match the manifest, determinism (no argument influence), and no secret/path leakage.

## Verification
- `npx vitest run tests/unit/api/version.test.ts` → 4 passed.
- Full `tests/unit/api` → 78 passed; prettier@3.8.5 / eslint / tsc clean.

Closes #1522