### PR TITLE
feat(api): implement structured audit logging for policy and sender r…

### DIFF
--- a/src/routes/api/v1/policies/$owner.ts
+++ b/src/routes/api/v1/policies/$owner.ts
@@ -19,9 +19,12 @@ export const Route = createFileRoute("/api/v1/policies/$owner")({
       PUT: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const owner = stellarAddressSchema.parse(params.owner);
-          requireActorMatches(request, owner);
+          const actor = requireActorMatches(request, owner);
           const policy = await parseJsonBody(request, mailboxPolicySchema);
-          const result = await setMailboxPolicy(getApiContext().repository, owner, policy);
+          const result = await setMailboxPolicy(getApiContext().repository, owner, policy, {
+            request,
+            actor,
+          });
           return apiSuccess(request, result);
         }),
     },

--- a/src/routes/api/v1/policies/$owner/senders/$sender.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender.ts
@@ -26,21 +26,27 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
         handleApiRequest(request, async () => {
           const owner = stellarAddressSchema.parse(params.owner);
           const sender = stellarAddressSchema.parse(params.sender);
-          requireActorMatches(request, owner);
+          const actor = requireActorMatches(request, owner);
           const { rule } = await parseJsonBody(request, ruleBodySchema);
           return apiSuccess(
             request,
-            await setSenderRule(getApiContext().repository, owner, sender, rule),
+            await setSenderRule(getApiContext().repository, owner, sender, rule, {
+              request,
+              actor,
+            }),
           );
         }),
       DELETE: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const owner = stellarAddressSchema.parse(params.owner);
           const sender = stellarAddressSchema.parse(params.sender);
-          requireActorMatches(request, owner);
+          const actor = requireActorMatches(request, owner);
           return apiSuccess(
             request,
-            await setSenderRule(getApiContext().repository, owner, sender, "default"),
+            await setSenderRule(getApiContext().repository, owner, sender, "default", {
+              request,
+              actor,
+            }),
           );
         }),
     },

--- a/src/server/api/audit-service.ts
+++ b/src/server/api/audit-service.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+
+export interface AuditEventContext {
+  request: Request;
+  actor: string;
+}
+
+export interface PolicyAuditEvent {
+  requestId: string;
+  timestamp: string;
+  actor: string;
+  owner: string;
+  action: "update_mailbox_policy" | "update_sender_rule" | "delete_sender_rule";
+  target: {
+    type: "mailbox_policy" | "sender_rule";
+    sender?: string;
+  };
+  changes: {
+    before: Record<string, unknown> | string | null;
+    after: Record<string, unknown> | string | null;
+  };
+  status: "success" | "failure";
+  error?: string;
+}
+
+export function logPolicyAuditEvent(params: {
+  ctx: AuditEventContext;
+  owner: string;
+  action: PolicyAuditEvent["action"];
+  targetType: PolicyAuditEvent["target"]["type"];
+  sender?: string;
+  before: PolicyAuditEvent["changes"]["before"];
+  after: PolicyAuditEvent["changes"]["after"];
+  status: PolicyAuditEvent["status"];
+  error?: string;
+}) {
+  const requestId = params.ctx.request.headers.get("x-request-id")?.trim() || crypto.randomUUID();
+  
+  const event: PolicyAuditEvent = {
+    requestId,
+    timestamp: new Date().toISOString(),
+    actor: params.ctx.actor,
+    owner: params.owner,
+    action: params.action,
+    target: {
+      type: params.targetType,
+      ...(params.sender ? { sender: params.sender } : {}),
+    },
+    changes: {
+      before: params.before,
+      after: params.after,
+    },
+    status: params.status,
+    ...(params.error ? { error: params.error } : {}),
+  };
+
+  // Structured logging to console
+  console.log(JSON.stringify(event));
+}

--- a/src/server/api/policy-audit.test.ts
+++ b/src/server/api/policy-audit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryApiRepository } from "./memory-repository";
+import { setMailboxPolicy, setSenderRule } from "./policy-service";
+import type { PolicyAuditEvent } from "./audit-service";
+
+describe("Policy Audit Logging", () => {
+  const owner = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFXYAUIAGRZBG6LNO4A" + "AA".substring(0, 2);
+  const sender = "GCS5A4Z5J6Q6BXLFMNDLFJUNPU2HY3ZMFXYAUIAGRZBG6LNO4AAAA";
+  const actor = owner;
+
+  const mockRequest = new Request("http://localhost/api/v1/policies", {
+    headers: {
+      "x-request-id": "req-test-12345",
+      "x-stealth-address": actor,
+    },
+  });
+
+  const ctx = { request: mockRequest, actor };
+
+  it("emits success audit log for mailbox policy updates", async () => {
+    const repo = new MemoryApiRepository();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const newPolicy = {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    };
+
+    await setMailboxPolicy(repo, owner, newPolicy, ctx);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const loggedJson = consoleSpy.mock.calls[0][0];
+    const event: PolicyAuditEvent = JSON.parse(loggedJson);
+
+    expect(event.requestId).toBe("req-test-12345");
+    expect(event.actor).toBe(actor);
+    expect(event.owner).toBe(owner);
+    expect(event.action).toBe("update_mailbox_policy");
+    expect(event.target.type).toBe("mailbox_policy");
+    expect(event.status).toBe("success");
+    expect(event.changes.after).toEqual(newPolicy);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("emits success audit log for sender rule updates", async () => {
+    const repo = new MemoryApiRepository();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await setSenderRule(repo, owner, sender, "allow", ctx);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const event: PolicyAuditEvent = JSON.parse(consoleSpy.mock.calls[0][0]);
+
+    expect(event.action).toBe("update_sender_rule");
+    expect(event.target.type).toBe("sender_rule");
+    expect(event.target.sender).toBe(sender);
+    expect(event.changes.before).toBe("default");
+    expect(event.changes.after).toBe("allow");
+    expect(event.status).toBe("success");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("emits delete_sender_rule when rule is reset to default", async () => {
+    const repo = new MemoryApiRepository();
+    await repo.setSenderRule(owner, sender, "block");
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await setSenderRule(repo, owner, sender, "default", ctx);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const event: PolicyAuditEvent = JSON.parse(consoleSpy.mock.calls[0][0]);
+
+    expect(event.action).toBe("delete_sender_rule");
+    expect(event.changes.before).toBe("block");
+    expect(event.changes.after).toBe("default");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("emits failure audit log when repository operation fails", async () => {
+    const repo = new MemoryApiRepository();
+    vi.spyOn(repo, "setPolicy").mockRejectedValueOnce(new Error("Database connection lost"));
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const newPolicy = {
+      allowUnknown: false,
+      minimumPostage: "0",
+      requireVerified: true,
+    };
+
+    await expect(setMailboxPolicy(repo, owner, newPolicy, ctx)).rejects.toThrow("Database connection lost");
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const event: PolicyAuditEvent = JSON.parse(consoleSpy.mock.calls[0][0]);
+
+    expect(event.status).toBe("failure");
+    expect(event.error).toBe("Database connection lost");
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -1,6 +1,7 @@
 import type { MailboxPolicy, SenderRule } from "./domain";
 import type { ApiRepository } from "./repository";
 import { defaultMailboxPolicy } from "./repository";
+import { logPolicyAuditEvent, type AuditEventContext } from "./audit-service";
 
 export async function getMailboxPolicy(repository: ApiRepository, owner: string) {
   const stored = await repository.getPolicy(owner);
@@ -15,12 +16,51 @@ export async function setMailboxPolicy(
   repository: ApiRepository,
   owner: string,
   policy: MailboxPolicy,
+  ctx?: AuditEventContext,
 ) {
-  return {
-    owner,
-    policy: await repository.setPolicy(owner, policy),
-    source: "configured" as const,
-  };
+  let beforeState: MailboxPolicy | null = null;
+  try {
+    const existing = await repository.getPolicy(owner);
+    beforeState = existing ?? defaultMailboxPolicy;
+  } catch {
+    // Gracefully fallback if pre-fetch fails
+  }
+
+  try {
+    const updatedPolicy = await repository.setPolicy(owner, policy);
+    
+    if (ctx) {
+      logPolicyAuditEvent({
+        ctx,
+        owner,
+        action: "update_mailbox_policy",
+        targetType: "mailbox_policy",
+        before: beforeState,
+        after: updatedPolicy,
+        status: "success",
+      });
+    }
+
+    return {
+      owner,
+      policy: updatedPolicy,
+      source: "configured" as const,
+    };
+  } catch (error) {
+    if (ctx) {
+      logPolicyAuditEvent({
+        ctx,
+        owner,
+        action: "update_mailbox_policy",
+        targetType: "mailbox_policy",
+        before: beforeState,
+        after: null,
+        status: "failure",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    throw error;
+  }
 }
 
 export async function getSenderRule(repository: ApiRepository, owner: string, sender: string) {
@@ -36,12 +76,55 @@ export async function setSenderRule(
   owner: string,
   sender: string,
   rule: SenderRule,
+  ctx?: AuditEventContext,
 ) {
-  return {
-    owner,
-    rule: await repository.setSenderRule(owner, sender, rule),
-    sender,
-  };
+  let beforeRule: SenderRule = "default";
+  try {
+    beforeRule = await repository.getSenderRule(owner, sender);
+  } catch {
+    // Gracefully fallback if pre-fetch fails
+  }
+
+  const isDelete = rule === "default";
+  const actionName = isDelete ? "delete_sender_rule" : "update_sender_rule";
+
+  try {
+    const updatedRule = await repository.setSenderRule(owner, sender, rule);
+
+    if (ctx) {
+      logPolicyAuditEvent({
+        ctx,
+        owner,
+        action: actionName,
+        targetType: "sender_rule",
+        sender,
+        before: beforeRule,
+        after: updatedRule,
+        status: "success",
+      });
+    }
+
+    return {
+      owner,
+      rule: updatedRule,
+      sender,
+    };
+  } catch (error) {
+    if (ctx) {
+      logPolicyAuditEvent({
+        ctx,
+        owner,
+        action: actionName,
+        targetType: "sender_rule",
+        sender,
+        before: beforeRule,
+        after: null,
+        status: "failure",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    throw error;
+  }
 }
 
 export async function evaluateMailboxPolicy(


### PR DESCRIPTION
Closes #1540
### 🎯 Objective
Implements deterministic, backend-level audit logging for all mutations affecting `mailbox policy` structures and `sender-rule` states within the core application API lifecycle. This ensures compliance, troubleshooting visibility, and external log aggregation capabilities.

### 🛠️ Changes Implemented

* **Audit Logging Engine (`src/server/api/audit-service.ts`)**: Created a dedicated logging service that formats payloads cleanly into JSON stringified lines sent to `stdout`. Every log captures `requestId` (extracted from header or generated via `crypto.randomUUID()`), `timestamp`, authenticated `actor`, resource `owner`, specific `action`, target type metadata, before/after structural state changes, and completion status.
* **Business Logic Enhancements (`src/server/api/policy-service.ts`)**: Upgraded `setMailboxPolicy` and `setSenderRule` to intercept context objects, resolve current states *prior* to changes, execute mutations safely within isolated execution scopes, and emit corresponding success or failure logs (including granular error tracking strings).
* **Routing Lifecycle Wiring (`src/routes/api/v1/...`)**: Wired `AuditEventContext` down from incoming handler scopes in both the main `$owner.ts` configuration route and granular `$owner/senders/$sender.ts` rules (covering `PUT` and `DELETE` requests).
* **Validation Suite (`src/server/api/policy-audit.test.ts`)**: Built rigorous test cases using Vitest validating standard updates, rule deletions, ID propagation, and error fallback scenarios.