### PR TITLE
Add manager review queue tests and docs

### DIFF
--- a/tools/v2/team/manager-review-queue/README.md
+++ b/tools/v2/team/manager-review-queue/README.md
@@ -1,15 +1,51 @@
 # Manager Review Queue
 
-This folder is the isolated workspace for the Manager Review Queue tool.
+Manager Review Queue is an isolated V2 team tool for reviewing high-risk or
+policy-sensitive requests before they are approved, rejected, or escalated.
+The current implementation uses deterministic local fixtures and an in-memory
+service so reviewers can validate the workflow without live mail, wallet,
+database, or Stellar integrations.
 
 ## Ownership Boundary
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\team\manager-review-queue\
-`
+```text
+tools/v2/team/manager-review-queue/
+```
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Folder Map
+
+- `components/` - isolated React components for the queue surface.
+- `services/reviewEngine.ts` - local queue fetch/update behavior backed by fixtures.
+- `fixtures/` - deterministic review queue and guard payload examples.
+- `guards/` - validation, sanitization, and size guards for review inputs.
+- `tests/` - Node-based folder-local tests.
+- `docs/` - API, security, performance, and reviewer guidance.
+
+## Local Verification
+
+Run the folder-local tests from the repository root:
+
+```bash
+node --test tools/v2/team/manager-review-queue/tests/review-guards.test.mjs
+node --test tools/v2/team/manager-review-queue/tests/review-engine.test.mjs
+```
+
+The tests intentionally use Node's built-in runner and local fixtures only.
+They do not require a browser, network access, app authentication, or a
+database.
+
+## Known Limitations
+
+- The service uses an in-memory store and resets only within the current process.
+- `MOCK_NETWORK_DELAY_MS` simulates latency; no real network request is made.
+- Reviewer notes are part of the input type but are not persisted by the current
+  fixture-backed service.
+- Main app integration, routing, authentication, and production data loading are
+  out of scope for this isolated tool.
+
+See `specs.md` and `docs/review-notes.md` for contributor expectations and a
+review checklist.

--- a/tools/v2/team/manager-review-queue/docs/review-notes.md
+++ b/tools/v2/team/manager-review-queue/docs/review-notes.md
@@ -1,0 +1,42 @@
+# Reviewer Notes - Manager Review Queue
+
+Use this checklist to review the isolated Manager Review Queue work without
+connecting it to the main app.
+
+## Quick Checks
+
+- All changed files stay inside `tools/v2/team/manager-review-queue/`.
+- Guard tests pass:
+
+```bash
+node --test tools/v2/team/manager-review-queue/tests/review-guards.test.mjs
+```
+
+- Service behavior tests pass:
+
+```bash
+node --test tools/v2/team/manager-review-queue/tests/review-engine.test.mjs
+```
+
+- The tool still uses deterministic local fixtures only.
+- No route, auth, wallet, database, mail rendering, or Stellar integration files
+  are modified.
+
+## What To Inspect
+
+| Area | File | Expected behavior |
+| --- | --- | --- |
+| Queue service | `services/reviewEngine.ts` | Fetches local queue items, filters by status/risk, paginates, updates status, and can reset local state. |
+| Fixtures | `fixtures/reviewFixtures.ts` | Provides four deterministic review items across pending, approved, and escalated states. |
+| Guard fixtures | `fixtures/sample-review-requests.json` | Covers valid requests, hostile payloads, and sanitization edge cases. |
+| Guard tests | `tests/review-guards.test.mjs` | Validates field allowlists, hostile input rejection, sanitization, and size guards. |
+| Service tests | `tests/review-engine.test.mjs` | Validates fetch filtering, pagination, status updates, not-found errors, and reset behavior. |
+
+## Known Limitations
+
+- The service is intentionally in-memory and fixture-backed.
+- `reviewerNotes` is accepted by the type but not persisted yet.
+- The simulated latency value documents future loading states but the Node tests
+  mirror the pure logic without waiting on timers.
+- Production integration should be handled by a future issue with explicit app
+  wiring approval.

--- a/tools/v2/team/manager-review-queue/specs.md
+++ b/tools/v2/team/manager-review-queue/specs.md
@@ -1,38 +1,50 @@
 # Manager Review Queue
 
-Manager approvals.
+Manager Review Queue gives team leads a local queue for approving, rejecting,
+or escalating review requests. This folder is a self-contained mini-product
+workspace for the V2 later-release tool.
 
 ## Scope
 
-- Release tier: $(System.Collections.Hashtable.Tier.ToUpperInvariant())
-- Audience: $(System.Collections.Hashtable.Audience)
-- Folder ownership: $dir/
+- Release tier: V2
+- Audience: Team
+- Folder ownership: `tools/v2/team/manager-review-queue/`
 
-This is a self-contained tooling workspace. Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, or design system unless a future integration issue explicitly allows it.
+This is a self-contained tooling workspace. Do not wire this tool into the main
+app, routing, inbox architecture, wallet core, Stellar core, database schema, or
+design system unless a future integration issue explicitly allows it.
 
-Recommended internal structure:
+## Internal Structure
 
 - components/
 - services/
 - hooks/
--     ests/
+- tests/
 - docs/
-  "@ | Set-Content -Path "tools/v2/team/manager-review-queue/README.md"
-  @"
+- fixtures/
+- guards/
 
-# Manager Review Queue Specs
+## Core Behavior
 
-## Purpose
+- Show review items from local deterministic fixtures.
+- Support folder-local filtering by review status and minimum risk score.
+- Support simple offset/limit pagination for review lists.
+- Allow isolated status updates against the in-memory store.
+- Provide a reset helper for deterministic local tests.
+- Validate hostile review payloads through the guard layer before future
+  integration work consumes external input.
 
-Manager approvals.
+## Review Requirements
 
-## Contributor boundary
+- Tests or test plans must live inside this folder.
+- Documentation must explain setup, fixtures, usage, review notes, and known
+  limitations.
+- Changes must remain isolated from app-wide tests unless a future integration
+  issue allows it.
+- No production mail, wallet, routing, authentication, or database code should
+  be touched for this tool.
 
-All work for this tool should stay in:
-
-$dir/
-
-## Required issue categories
+## Issue Categories
 
 - Architecture
 - Feature

--- a/tools/v2/team/manager-review-queue/tests/review-engine.test.mjs
+++ b/tools/v2/team/manager-review-queue/tests/review-engine.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * review-engine.test.mjs - Manager Review Queue
+ *
+ * Tests for the local service behavior. The production service is TypeScript,
+ * so these tests mirror the pure queue logic in plain JS and run with Node's
+ * built-in test runner without a TS loader.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const __dirname = join(fileURLToPath(import.meta.url), "..");
+const sourceFixtureText = readFileSync(
+  join(__dirname, "..", "fixtures", "reviewFixtures.ts"),
+  "utf-8",
+);
+
+const FIXTURES = [
+  {
+    id: "rev_001",
+    submitterId: "usr_892",
+    contentSnippet: "Please approve this bulk wire transfer to offshore account.",
+    submittedAt: "2026-06-18T10:00:00Z",
+    status: "pending",
+    riskScore: 85,
+  },
+  {
+    id: "rev_002",
+    submitterId: "usr_105",
+    contentSnippet: "Update to marketing newsletter template",
+    submittedAt: "2026-06-18T11:30:00Z",
+    status: "pending",
+    riskScore: 12,
+  },
+  {
+    id: "rev_003",
+    submitterId: "usr_422",
+    contentSnippet: "Password reset request override",
+    submittedAt: "2026-06-17T15:45:00Z",
+    status: "escalated",
+    riskScore: 92,
+  },
+  {
+    id: "rev_004",
+    submitterId: "usr_892",
+    contentSnippet: "New vendor onboarding documents",
+    submittedAt: "2026-06-16T09:15:00Z",
+    status: "approved",
+    riskScore: 35,
+  },
+];
+
+function createReviewEngine(initialItems = FIXTURES) {
+  let localStore = initialItems.map((item) => ({ ...item }));
+
+  async function fetchReviewQueue(input = {}) {
+    let filteredItems = localStore;
+
+    if (input.filters) {
+      if (input.filters.status) {
+        filteredItems = filteredItems.filter((item) => item.status === input.filters.status);
+      }
+      if (input.filters.minRiskScore !== undefined) {
+        filteredItems = filteredItems.filter(
+          (item) => item.riskScore >= input.filters.minRiskScore,
+        );
+      }
+    }
+
+    const offset = input.offset || 0;
+    const limit = input.limit || 50;
+    const paginatedItems = filteredItems.slice(offset, offset + limit);
+
+    return {
+      items: paginatedItems,
+      totalCount: filteredItems.length,
+    };
+  }
+
+  async function updateReviewItemStatus(input) {
+    const itemIndex = localStore.findIndex((item) => item.id === input.itemId);
+
+    if (itemIndex === -1) {
+      throw new Error(`ReviewItem with ID ${input.itemId} not found.`);
+    }
+
+    const updatedItem = {
+      ...localStore[itemIndex],
+      status: input.newStatus,
+    };
+
+    localStore[itemIndex] = updatedItem;
+
+    return updatedItem;
+  }
+
+  function resetLocalStore() {
+    localStore = initialItems.map((item) => ({ ...item }));
+  }
+
+  return { fetchReviewQueue, updateReviewItemStatus, resetLocalStore };
+}
+
+describe("Manager Review Queue - service fixtures", () => {
+  it("mirrors the review fixture IDs from the TypeScript fixture source", () => {
+    const sourceIds = [...sourceFixtureText.matchAll(/id:\s+"([^"]+)"/g)].map((match) => match[1]);
+
+    assert.deepEqual(
+      FIXTURES.map((item) => item.id),
+      sourceIds,
+    );
+  });
+
+  it("contains deterministic review items with valid statuses and risk scores", () => {
+    assert.equal(FIXTURES.length, 4);
+
+    for (const item of FIXTURES) {
+      assert.match(item.id, /^rev_\d{3}$/);
+      assert.ok(["pending", "approved", "rejected", "escalated"].includes(item.status));
+      assert.equal(typeof item.riskScore, "number");
+      assert.ok(item.riskScore >= 0 && item.riskScore <= 100);
+      assert.ok(Date.parse(item.submittedAt));
+    }
+  });
+});
+
+describe("Manager Review Queue - fetchReviewQueue", () => {
+  let engine;
+
+  beforeEach(() => {
+    engine = createReviewEngine();
+  });
+
+  it("returns all local items when called without filters", async () => {
+    const result = await engine.fetchReviewQueue({});
+
+    assert.equal(result.totalCount, 4);
+    assert.deepEqual(
+      result.items.map((item) => item.id),
+      ["rev_001", "rev_002", "rev_003", "rev_004"],
+    );
+  });
+
+  it("filters by review status", async () => {
+    const result = await engine.fetchReviewQueue({ filters: { status: "pending" } });
+
+    assert.equal(result.totalCount, 2);
+    assert.deepEqual(
+      result.items.map((item) => item.id),
+      ["rev_001", "rev_002"],
+    );
+  });
+
+  it("filters by minimum risk score", async () => {
+    const result = await engine.fetchReviewQueue({ filters: { minRiskScore: 80 } });
+
+    assert.equal(result.totalCount, 2);
+    assert.deepEqual(
+      result.items.map((item) => item.id),
+      ["rev_001", "rev_003"],
+    );
+  });
+
+  it("combines status and risk filters before pagination", async () => {
+    const result = await engine.fetchReviewQueue({
+      filters: { status: "pending", minRiskScore: 50 },
+      limit: 1,
+      offset: 0,
+    });
+
+    assert.equal(result.totalCount, 1);
+    assert.equal(result.items.length, 1);
+    assert.equal(result.items[0].id, "rev_001");
+  });
+
+  it("applies offset and limit to the filtered results", async () => {
+    const result = await engine.fetchReviewQueue({
+      filters: { status: "pending" },
+      limit: 1,
+      offset: 1,
+    });
+
+    assert.equal(result.totalCount, 2);
+    assert.deepEqual(
+      result.items.map((item) => item.id),
+      ["rev_002"],
+    );
+  });
+});
+
+describe("Manager Review Queue - updateReviewItemStatus", () => {
+  let engine;
+
+  beforeEach(() => {
+    engine = createReviewEngine();
+  });
+
+  it("updates an existing item and persists the status in later fetches", async () => {
+    const updated = await engine.updateReviewItemStatus({
+      itemId: "rev_001",
+      newStatus: "approved",
+    });
+
+    assert.equal(updated.status, "approved");
+
+    const pending = await engine.fetchReviewQueue({ filters: { status: "pending" } });
+    assert.deepEqual(
+      pending.items.map((item) => item.id),
+      ["rev_002"],
+    );
+
+    const approved = await engine.fetchReviewQueue({ filters: { status: "approved" } });
+    assert.deepEqual(
+      approved.items.map((item) => item.id),
+      ["rev_001", "rev_004"],
+    );
+  });
+
+  it("throws a useful error when the target item does not exist", async () => {
+    await assert.rejects(
+      () => engine.updateReviewItemStatus({ itemId: "rev_missing", newStatus: "rejected" }),
+      /ReviewItem with ID rev_missing not found/,
+    );
+  });
+
+  it("resets the local store to the deterministic fixture state", async () => {
+    await engine.updateReviewItemStatus({ itemId: "rev_001", newStatus: "rejected" });
+    engine.resetLocalStore();
+
+    const pending = await engine.fetchReviewQueue({ filters: { status: "pending" } });
+    assert.deepEqual(
+      pending.items.map((item) => item.id),
+      ["rev_001", "rev_002"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- clean up the Manager Review Queue README/spec placeholders and document the isolated folder boundary
- add reviewer notes for local inspection, fixtures, guard tests, and known limitations
- add folder-local Node tests for review queue filtering, pagination, status updates, not-found errors, and reset behavior

Closes #628

## Verification
- node --test tools/v2/team/manager-review-queue/tests/review-guards.test.mjs tools/v2/team/manager-review-queue/tests/review-engine.test.mjs
- git diff --check
