### PR TITLE
feat(metrics): emit availability and latency metrics for kv and coordinator

### DIFF
--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,3 +1,4 @@
+import { recordDependencyCall } from "./metrics";
 import type { ApiRepository } from "./repository";
 import type { MailboxPolicy, SenderRule, Postage, Receipt, IdempotencyRecord } from "./domain";
 
@@ -12,47 +13,61 @@ export class HybridApiRepository implements ApiRepository {
   }
 
   async getPolicy(owner: string): Promise<MailboxPolicy | null> {
-    const policy = await this.kv.get(this.key("policy", owner), "json");
+    const policy = await recordDependencyCall("kv", () =>
+      this.kv.get(this.key("policy", owner), "json"),
+    );
     return (policy as MailboxPolicy) ?? null;
   }
 
   async setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
-    await this.kv.put(this.key("policy", owner), JSON.stringify(policy));
+    await recordDependencyCall("kv", () =>
+      this.kv.put(this.key("policy", owner), JSON.stringify(policy)),
+    );
     return policy;
   }
 
   async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
-    const rule = await this.kv.get(this.key("sender-rule", owner, sender), "text");
+    const rule = await recordDependencyCall("kv", () =>
+      this.kv.get(this.key("sender-rule", owner, sender), "text"),
+    );
     return (rule as SenderRule) ?? "default";
   }
 
   async setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
     const ruleKey = this.key("sender-rule", owner, sender);
     if (rule === "default") {
-      await this.kv.delete(ruleKey);
+      await recordDependencyCall("kv", () => this.kv.delete(ruleKey));
     } else {
-      await this.kv.put(ruleKey, rule);
+      await recordDependencyCall("kv", () => this.kv.put(ruleKey, rule));
     }
     return rule;
   }
 
   async getPostage(messageId: string): Promise<Postage | null> {
-    const postage = await this.kv.get(this.key("postage", messageId), "json");
+    const postage = await recordDependencyCall("kv", () =>
+      this.kv.get(this.key("postage", messageId), "json"),
+    );
     return (postage as Postage) ?? null;
   }
 
   async setPostage(postage: Postage): Promise<Postage> {
-    await this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage));
+    await recordDependencyCall("kv", () =>
+      this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage)),
+    );
     return postage;
   }
 
   async getReceipt(messageId: string): Promise<Receipt | null> {
-    const receipt = await this.kv.get(this.key("receipt", messageId), "json");
+    const receipt = await recordDependencyCall("kv", () =>
+      this.kv.get(this.key("receipt", messageId), "json"),
+    );
     return (receipt as Receipt) ?? null;
   }
 
   async setReceipt(receipt: Receipt): Promise<Receipt> {
-    await this.kv.put(this.key("receipt", receipt.messageId), JSON.stringify(receipt));
+    await recordDependencyCall("kv", () =>
+      this.kv.put(this.key("receipt", receipt.messageId), JSON.stringify(receipt)),
+    );
     return receipt;
   }
 
@@ -63,19 +78,21 @@ export class HybridApiRepository implements ApiRepository {
   }
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
-    return this.getStub().getIdempotencyRecord(key);
+    return recordDependencyCall("coordinator", () => this.getStub().getIdempotencyRecord(key));
   }
 
   async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
-    await this.getStub().setIdempotencyRecord(key, record);
+    await recordDependencyCall("coordinator", () => this.getStub().setIdempotencyRecord(key, record));
   }
 
   async getCounter(key: string): Promise<number> {
-    return this.getStub().getCounter(key);
+    return recordDependencyCall("coordinator", () => this.getStub().getCounter(key));
   }
 
   async incrementCounter(key: string, windowSeconds: number): Promise<number> {
-    return this.getStub().incrementCounter(key, windowSeconds);
+    return recordDependencyCall("coordinator", () =>
+      this.getStub().incrementCounter(key, windowSeconds),
+    );
   }
 
   // Relay stats stubs matching MemoryApiRepository exactly

--- a/src/server/api/metrics.ts
+++ b/src/server/api/metrics.ts
@@ -1,1 +1,146 @@
-export function incrementCounter(_metric: string, _labels: Record<string, string>): void {}
+﻿/**
+ * Bounded dependency metrics for required infrastructure dependencies.
+ *
+ * Labels are finite and contain no URLs or account identifiers.
+ * Dependency identifiers are fixed constants: "kv" | "coordinator".
+ *
+ * Outcome classifications:
+ *   - "success"  - call completed without error
+ *   - "timeout"  - call exceeded the latency threshold (AbortError / timeout)
+ *   - "failure"  - any other error
+ */
+
+export type Dependency = "kv" | "coordinator";
+export type Outcome = "success" | "timeout" | "failure";
+
+export interface DependencyMetrics {
+  /** Total calls recorded */
+  calls: number;
+  /** Calls that succeeded */
+  successes: number;
+  /** Calls classified as timeout */
+  timeouts: number;
+  /** Calls classified as failure (non-timeout error) */
+  failures: number;
+  /** Sum of latency samples in milliseconds */
+  totalLatencyMs: number;
+  /** Number of latency samples */
+  latencySamples: number;
+}
+
+function emptyMetrics(): DependencyMetrics {
+  return {
+    calls: 0,
+    successes: 0,
+    timeouts: 0,
+    failures: 0,
+    totalLatencyMs: 0,
+    latencySamples: 0,
+  };
+}
+
+// In-process store - suitable for Cloudflare Workers isolate lifetime.
+const store = new Map<string, DependencyMetrics>([
+  ["kv", emptyMetrics()],
+  ["coordinator", emptyMetrics()],
+]);
+
+function get(dep: Dependency): DependencyMetrics {
+  return store.get(dep) as DependencyMetrics;
+}
+
+/**
+ * Record a single availability observation for a dependency.
+ * This is the low-level primitive; prefer recordDependencyCall for
+ * combined availability + latency tracking.
+ */
+export function incrementCounter(metric: string, labels: Record<string, string>): void {
+  const dep = labels["dependency"] as Dependency | undefined;
+  if (!dep || !store.has(dep)) return;
+
+  const m = get(dep);
+  m.calls++;
+
+  if (metric === "dependency_call_success") {
+    m.successes++;
+  } else if (metric === "dependency_call_timeout") {
+    m.timeouts++;
+  } else if (metric === "dependency_call_failure") {
+    m.failures++;
+  }
+}
+
+/**
+ * Record a latency sample for a dependency in milliseconds.
+ */
+export function recordLatency(dep: Dependency, latencyMs: number): void {
+  const m = get(dep);
+  m.totalLatencyMs += latencyMs;
+  m.latencySamples++;
+}
+
+/**
+ * Convenience wrapper: runs fn, classifies the outcome, and emits
+ * both an availability counter and a latency sample.
+ *
+ * Timeout detection: AbortError or errors whose message contains
+ * "timeout" (case-insensitive) are classified as "timeout".
+ */
+export async function recordDependencyCall<T>(dep: Dependency, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    const result = await fn();
+    const latencyMs = Date.now() - start;
+    recordLatency(dep, latencyMs);
+    incrementCounter("dependency_call_success", { dependency: dep });
+    return result;
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    recordLatency(dep, latencyMs);
+    const outcome = classifyError(err);
+    incrementCounter(`dependency_call_${outcome}`, { dependency: dep });
+    throw err;
+  }
+}
+
+function classifyError(err: unknown): "timeout" | "failure" {
+  if (err instanceof Error) {
+    if (err.name === "AbortError" || /timeout/i.test(err.message)) {
+      return "timeout";
+    }
+  }
+  return "failure";
+}
+
+/**
+ * Returns a snapshot of the current metrics for a dependency.
+ * Useful for health-check endpoints and tests.
+ */
+export function getMetrics(dep: Dependency): Readonly<DependencyMetrics> {
+  return { ...get(dep) };
+}
+
+/**
+ * Returns availability ratio [0, 1] for a dependency.
+ * Returns 1 when no calls have been recorded yet.
+ */
+export function getAvailability(dep: Dependency): number {
+  const m = get(dep);
+  if (m.calls === 0) return 1;
+  return m.successes / m.calls;
+}
+
+/**
+ * Returns mean latency in milliseconds, or 0 when no samples exist.
+ */
+export function getMeanLatencyMs(dep: Dependency): number {
+  const m = get(dep);
+  if (m.latencySamples === 0) return 0;
+  return m.totalLatencyMs / m.latencySamples;
+}
+
+/** Reset all metrics (intended for use in tests only). */
+export function _resetMetrics(): void {
+  store.set("kv", emptyMetrics());
+  store.set("coordinator", emptyMetrics());
+}

--- a/tests/unit/api/metrics.test.ts
+++ b/tests/unit/api/metrics.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetMetrics,
+  getAvailability,
+  getMeanLatencyMs,
+  getMetrics,
+  incrementCounter,
+  recordDependencyCall,
+  recordLatency,
+} from "../../../src/server/api/metrics";
+
+beforeEach(() => {
+  _resetMetrics();
+});
+
+describe("incrementCounter", () => {
+  it("counts a success for kv", () => {
+    incrementCounter("dependency_call_success", { dependency: "kv" });
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(1);
+    expect(m.successes).toBe(1);
+    expect(m.timeouts).toBe(0);
+    expect(m.failures).toBe(0);
+  });
+
+  it("counts a timeout for coordinator", () => {
+    incrementCounter("dependency_call_timeout", { dependency: "coordinator" });
+    const m = getMetrics("coordinator");
+    expect(m.calls).toBe(1);
+    expect(m.timeouts).toBe(1);
+    expect(m.successes).toBe(0);
+  });
+
+  it("counts a failure for kv", () => {
+    incrementCounter("dependency_call_failure", { dependency: "kv" });
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(1);
+    expect(m.failures).toBe(1);
+  });
+
+  it("ignores unknown dependency labels", () => {
+    incrementCounter("dependency_call_success", { dependency: "unknown" });
+    expect(getMetrics("kv").calls).toBe(0);
+    expect(getMetrics("coordinator").calls).toBe(0);
+  });
+
+  it("ignores missing dependency label", () => {
+    incrementCounter("dependency_call_success", {});
+    expect(getMetrics("kv").calls).toBe(0);
+  });
+
+  it("does not increment counters for unrecognised metric names", () => {
+    incrementCounter("postage_limit_rejected", { dependency: "kv" });
+    // calls increments but success/timeout/failure stay zero
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(1);
+    expect(m.successes).toBe(0);
+    expect(m.failures).toBe(0);
+  });
+});
+
+describe("recordLatency", () => {
+  it("accumulates latency samples for kv", () => {
+    recordLatency("kv", 10);
+    recordLatency("kv", 30);
+    const m = getMetrics("kv");
+    expect(m.latencySamples).toBe(2);
+    expect(m.totalLatencyMs).toBe(40);
+  });
+
+  it("accumulates latency samples for coordinator", () => {
+    recordLatency("coordinator", 5);
+    expect(getMetrics("coordinator").totalLatencyMs).toBe(5);
+  });
+});
+
+describe("recordDependencyCall", () => {
+  it("emits success and latency on a resolved call", async () => {
+    await recordDependencyCall("kv", async () => "ok");
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(1);
+    expect(m.successes).toBe(1);
+    expect(m.latencySamples).toBe(1);
+    expect(m.totalLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("emits failure and latency on a generic error", async () => {
+    await expect(
+      recordDependencyCall("kv", async () => {
+        throw new Error("connection refused");
+      }),
+    ).rejects.toThrow("connection refused");
+
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(1);
+    expect(m.failures).toBe(1);
+    expect(m.successes).toBe(0);
+    expect(m.latencySamples).toBe(1);
+  });
+
+  it("classifies AbortError as timeout", async () => {
+    const abortErr = new DOMException("signal aborted", "AbortError");
+    await expect(
+      recordDependencyCall("coordinator", async () => {
+        throw abortErr;
+      }),
+    ).rejects.toThrow();
+
+    const m = getMetrics("coordinator");
+    expect(m.timeouts).toBe(1);
+    expect(m.failures).toBe(0);
+  });
+
+  it("classifies errors with 'timeout' in message as timeout", async () => {
+    await expect(
+      recordDependencyCall("coordinator", async () => {
+        throw new Error("Request timeout after 5000ms");
+      }),
+    ).rejects.toThrow();
+
+    expect(getMetrics("coordinator").timeouts).toBe(1);
+  });
+
+  it("re-throws the original error after recording", async () => {
+    const err = new Error("boom");
+    await expect(recordDependencyCall("kv", async () => Promise.reject(err))).rejects.toBe(err);
+  });
+
+  it("tracks kv and coordinator independently", async () => {
+    await recordDependencyCall("kv", async () => "a");
+    await recordDependencyCall("kv", async () => "b");
+    await recordDependencyCall("coordinator", async () => "c");
+
+    expect(getMetrics("kv").calls).toBe(2);
+    expect(getMetrics("coordinator").calls).toBe(1);
+  });
+});
+
+describe("getAvailability", () => {
+  it("returns 1 when no calls recorded", () => {
+    expect(getAvailability("kv")).toBe(1);
+  });
+
+  it("returns 1 when all calls succeeded", async () => {
+    await recordDependencyCall("kv", async () => "ok");
+    await recordDependencyCall("kv", async () => "ok");
+    expect(getAvailability("kv")).toBe(1);
+  });
+
+  it("returns 0.5 when half the calls failed", async () => {
+    await recordDependencyCall("kv", async () => "ok");
+    await expect(
+      recordDependencyCall("kv", async () => {
+        throw new Error("fail");
+      }),
+    ).rejects.toThrow();
+    expect(getAvailability("kv")).toBe(0.5);
+  });
+});
+
+describe("getMeanLatencyMs", () => {
+  it("returns 0 when no samples", () => {
+    expect(getMeanLatencyMs("coordinator")).toBe(0);
+  });
+
+  it("returns the mean of recorded samples", () => {
+    recordLatency("coordinator", 20);
+    recordLatency("coordinator", 40);
+    expect(getMeanLatencyMs("coordinator")).toBe(30);
+  });
+});
+
+describe("_resetMetrics", () => {
+  it("resets all counters to zero", async () => {
+    await recordDependencyCall("kv", async () => "x");
+    _resetMetrics();
+    const m = getMetrics("kv");
+    expect(m.calls).toBe(0);
+    expect(m.latencySamples).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements bounded dependency metrics for the two required infrastructure dependencies (kv, coordinator). Replaces the no-op incrementCounter stub with a real in-process store that tracks success/timeout/failure counts and latency samples per dependency.

- Add recordDependencyCall<T> wrapper that classifies AbortError and timeout-message errors as 'timeout', all others as 'failure'
- Add recordLatency, getMetrics, getAvailability, getMeanLatencyMs
- Instrument all KV and Durable Object calls in HybridApiRepository
- Labels are finite constants with no URLs or account identifiers
- Add 20 unit tests covering all outcome classifications and helpers

Closes #1517