### PR TITLE
Canonicalize request bodies before computing idempotency digests

### DIFF
--- a/src/server/api/idempotency-service.ts
+++ b/src/server/api/idempotency-service.ts
@@ -1,9 +1,17 @@
 import { createHash } from "node:crypto";
 import type { ApiRepository } from "./repository";
 import type { IdempotencyRecord } from "./domain";
+import { canonicalize } from "./envelope";
 
-export function hashIdempotencyKey(actor: string, rawKey: string): string {
-  return createHash("sha256").update(`${actor}:${rawKey}`).digest("hex");
+/**
+ * Issue #1501: canonicalize request bodies before computing idempotency
+ * digests so semantically identical JSON (different key order) hashes the same,
+ * while genuinely different values still conflict. Array order, numeric/string
+ * distinctions, and the actor scope all remain significant.
+ */
+export function hashIdempotencyKey(actor: string, rawKey: unknown): string {
+  const canonical = canonicalize(rawKey);
+  return createHash("sha256").update(`${actor}:${canonical}`).digest("hex");
 }
 
 export async function checkIdempotency(

--- a/tests/unit/api/idempotency-canonicalization.test.ts
+++ b/tests/unit/api/idempotency-canonicalization.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { hashIdempotencyKey } from "../../../src/server/api/idempotency-service";
+
+// Issue #1501: canonicalize request bodies before computing idempotency digests.
+const actor = "owner-A";
+
+describe("idempotency key canonicalization", () => {
+  it("produces the same digest for object-key reordering", () => {
+    const a = { b: 1, a: 2, c: 3 };
+    const b = { c: 3, a: 2, b: 1 };
+    expect(hashIdempotencyKey(actor, a)).toBe(hashIdempotencyKey(actor, b));
+  });
+
+  it("keeps array order significant", () => {
+    const a = [1, 2, 3];
+    const b = [3, 2, 1];
+    expect(hashIdempotencyKey(actor, a)).not.toBe(hashIdempotencyKey(actor, b));
+  });
+
+  it("keeps numeric vs string distinctions significant", () => {
+    expect(hashIdempotencyKey(actor, 1)).not.toBe(hashIdempotencyKey(actor, "1"));
+  });
+
+  it("keeps nested structure significant", () => {
+    const a = { x: { y: 1 } };
+    const b = { x: { y: 2 } };
+    expect(hashIdempotencyKey(actor, a)).not.toBe(hashIdempotencyKey(actor, b));
+  });
+
+  it("binds the digest to the actor", () => {
+    const payload = { b: 1, a: 2 };
+    expect(hashIdempotencyKey("owner-A", payload)).not.toBe(hashIdempotencyKey("owner-B", payload));
+  });
+
+  it("is deterministic across calls", () => {
+    const payload = { z: [1, 2], a: "x", m: { n: true } };
+    expect(hashIdempotencyKey(actor, payload)).toBe(hashIdempotencyKey(actor, payload));
+  });
+});


### PR DESCRIPTION
## Goal
Enforce canonical JSON serialization for idempotency digests (issue #1501) so semantically identical requests hash the same while genuinely different values still conflict.

## Changes
- `src/server/api/idempotency-service.ts`: `hashIdempotencyKey` now canonicalizes the raw key via the existing JCS `canonicalize()` helper before hashing, so object-key ordering no longer changes the digest.
- `tests/unit/api/idempotency-canonicalization.test.ts`: key-order invariance, array-order significance, numeric-vs-string distinction, nested-structure sensitivity, actor binding, and determinism.

## Verification
- `npx vitest run tests/unit/api/idempotency-canonicalization.test.ts` → 6 passed.
- `npx prettier@3.8.5 --check` clean on changed files.

Fixes #1501