### PR TITLE
Add startup configuration validation gate

### DIFF
--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -59,13 +59,25 @@ export async function getApiContext(): Promise<ApiContext> {
   }
 
   const { env } = await import("cloudflare:workers");
+
+  // The Cloudflare env type only declares the KV and coordinator bindings;
+  // the cursor secret is read defensively so an undeclared secret fails the
+  // validation gate rather than a type error.
+  const cursorSecret = (env as Record<string, string | undefined>).STEALTH_CURSOR_SECRET;
+
   validateApiConfig({
     isProd: true,
     kvBinding: env.STEALTH_KV,
     coordinatorBinding: env.STEALTH_COORDINATOR,
-    cursorSecret: env.STEALTH_CURSOR_SECRET,
+    cursorSecret,
     supportedVersions: ["v1"],
   });
+
+  if (!env.STEALTH_KV || !env.STEALTH_COORDINATOR) {
+    throw new Error(
+      "Configuration error: STEALTH_KV or STEALTH_COORDINATOR binding is not declared in wrangler.jsonc.",
+    );
+  }
 
   const { HybridApiRepository } = await import("./kv-repository");
   globalApi.__stealthApiRepository = new HybridApiRepository(

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -9,6 +9,45 @@ const globalApi = globalThis as typeof globalThis & {
   __stealthApiRepository?: ApiRepository;
 };
 
+/**
+ * Issue #1516: startup configuration validation gate.
+ *
+ * Validates required environment bindings, secrets, supported versions, and
+ * storage adapters at startup / first initialization. Misconfigured deployments
+ * fail clearly before serving partial or unsafe API behavior. Dev vs prod
+ * requirements are distinguished, and secret values are never logged.
+ */
+export interface ApiConfig {
+  isProd: boolean;
+  kvBinding?: unknown;
+  coordinatorBinding?: unknown;
+  cursorSecret?: string;
+  supportedVersions: readonly string[];
+}
+
+export function validateApiConfig(config: ApiConfig): void {
+  if (config.isProd) {
+    if (!config.kvBinding) {
+      throw new Error("Configuration error: STEALTH_KV binding is not declared in wrangler.jsonc.");
+    }
+    if (!config.coordinatorBinding) {
+      throw new Error(
+        "Configuration error: STEALTH_COORDINATOR binding is not declared in wrangler.jsonc.",
+      );
+    }
+    if (!config.cursorSecret) {
+      // Never echo the secret value — only that it is missing.
+      throw new Error("Configuration error: STEALTH_CURSOR_SECRET is required in production.");
+    }
+  }
+
+  if (config.supportedVersions.length === 0) {
+    throw new Error(
+      "Configuration error: at least one supported protocol version must be configured.",
+    );
+  }
+}
+
 export async function getApiContext(): Promise<ApiContext> {
   if (!import.meta.env.PROD) {
     globalApi.__stealthApiRepository ??= new MemoryApiRepository();
@@ -20,12 +59,13 @@ export async function getApiContext(): Promise<ApiContext> {
   }
 
   const { env } = await import("cloudflare:workers");
-  if (!env.STEALTH_KV || !env.STEALTH_COORDINATOR) {
-    throw new Error(
-      "Configuration error: STEALTH_KV or STEALTH_COORDINATOR binding is not declared in wrangler.jsonc. " +
-        "Make sure to create the KV namespace and declare both KV and Durable Object bindings in wrangler.jsonc.",
-    );
-  }
+  validateApiConfig({
+    isProd: true,
+    kvBinding: env.STEALTH_KV,
+    coordinatorBinding: env.STEALTH_COORDINATOR,
+    cursorSecret: env.STEALTH_CURSOR_SECRET,
+    supportedVersions: ["v1"],
+  });
 
   const { HybridApiRepository } = await import("./kv-repository");
   globalApi.__stealthApiRepository = new HybridApiRepository(

--- a/tests/unit/api/config-validation.test.ts
+++ b/tests/unit/api/config-validation.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { validateApiConfig } from "../../../src/server/api/context";
+
+// Issue #1516: startup configuration validation gate.
+describe("validateApiConfig", () => {
+  const base = {
+    isProd: false,
+    supportedVersions: ["v1"] as const,
+  };
+
+  it("accepts a minimal development configuration", () => {
+    expect(() => validateApiConfig({ ...base, isProd: false })).not.toThrow();
+  });
+
+  it("accepts a complete production configuration", () => {
+    expect(() =>
+      validateApiConfig({
+        isProd: true,
+        kvBinding: {},
+        coordinatorBinding: {},
+        cursorSecret: "secret-value",
+        supportedVersions: ["v1"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails when production is missing the KV binding", () => {
+    expect(() => validateApiConfig({ isProd: true, supportedVersions: ["v1"] })).toThrow(
+      /STEALTH_KV/,
+    );
+  });
+
+  it("fails when production is missing the coordinator binding", () => {
+    expect(() =>
+      validateApiConfig({
+        isProd: true,
+        kvBinding: {},
+        supportedVersions: ["v1"],
+      }),
+    ).toThrow(/STEALTH_COORDINATOR/);
+  });
+
+  it("fails when production is missing the cursor secret", () => {
+    expect(() =>
+      validateApiConfig({
+        isProd: true,
+        kvBinding: {},
+        coordinatorBinding: {},
+        supportedVersions: ["v1"],
+      }),
+    ).toThrow(/STEALTH_CURSOR_SECRET/);
+  });
+
+  it("never leaks the secret value in the error message", () => {
+    let message = "";
+    try {
+      validateApiConfig({
+        isProd: true,
+        kvBinding: {},
+        coordinatorBinding: {},
+        cursorSecret: "super-secret-do-not-leak",
+        supportedVersions: ["v1"],
+      });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).not.toContain("super-secret-do-not-leak");
+  });
+
+  it("fails when no supported versions are configured", () => {
+    expect(() => validateApiConfig({ ...base, isProd: false, supportedVersions: [] })).toThrow(
+      /supported protocol version/,
+    );
+  });
+
+  it("does not require prod bindings in development", () => {
+    expect(() => validateApiConfig({ ...base, isProd: false })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Goal
Validate required environment bindings, secrets, supported versions, and storage adapters at startup / first initialization so misconfigured deployments fail clearly before serving partial or unsafe API behavior (issue #1516).

## Changes
- `src/server/api/context.ts`: extract `validateApiConfig()` — enforces KV + coordinator bindings, the cursor secret, and at least one supported version in production; distinguishes dev vs prod; never logs secret values. `getApiContext()` calls it before constructing the production repository.
- `tests/unit/api/config-validation.test.ts`: valid dev, valid prod, missing KV/coordinator/secret in prod, no secret leakage in error messages, empty supported-versions, and dev bypass.

## Verification
- `npx vitest run tests/unit/api/config-validation.test.ts` → 8 passed.
- `npx prettier@3.8.5 --check` clean on changed files.

Fixes #1516