### PR TITLE
feat(auth): introduce signed-request authentication with replay protection

### DIFF
--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -1,0 +1,249 @@
+/**
+ * Signed-request authentication for the Stealth API.
+ *
+ * A caller proves control of a Stellar account by signing a canonical
+ * request payload with the corresponding Ed25519 private key. The server
+ * verifies the signature against the claimed public key (G-address) without
+ * any prior challenge round-trip.
+ *
+ * ## Canonical payload
+ *
+ *   stealth-auth:v1:<METHOD>:<PATH>:<TIMESTAMP>:<NONCE>
+ *
+ * Field descriptions
+ *   - "stealth-auth:v1"  – fixed domain prefix; prevents cross-protocol reuse
+ *   - METHOD             – uppercase HTTP method (GET, POST, …)
+ *   - PATH               – URL pathname only, no query string or origin
+ *   - TIMESTAMP          – ISO 8601 UTC timestamp (caller's clock)
+ *   - NONCE              – caller-chosen opaque string, ≥ 8 chars, ≤ 128 chars
+ *
+ * ## Request headers
+ *
+ *   x-stealth-address    – Stellar G-address (claimed public key)
+ *   x-stealth-timestamp  – ISO 8601 timestamp matching the payload
+ *   x-stealth-nonce      – nonce matching the payload
+ *   x-stealth-signature  – lowercase hex Ed25519 signature over the
+ *                          UTF-8 bytes of the canonical payload
+ *
+ * ## Security properties
+ *
+ *   Expiration    – timestamps outside a ±CLOCK_SKEW_MS window are rejected.
+ *   Replay        – each (address, nonce) pair is recorded for the signature
+ *                   lifetime; reuse within that window is rejected.
+ *   Domain sep    – the "stealth-auth:v1" prefix prevents reuse of signatures
+ *                   produced for other purposes (e.g. message envelopes).
+ *   No raw data   – the nonce key stored for replay protection is a SHA-256
+ *                   digest of "address:nonce" so neither raw value is persisted.
+ */
+
+import { createHash } from "node:crypto";
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+import { stellarAddressSchema } from "./domain";
+import { ApiError } from "./errors";
+import type { ApiRepository } from "./repository";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const AUTH_DOMAIN_PREFIX = "stealth-auth:v1";
+
+/** Headers the caller must supply. */
+export const AUTH_HEADERS = {
+  address: "x-stealth-address",
+  timestamp: "x-stealth-timestamp",
+  nonce: "x-stealth-nonce",
+  signature: "x-stealth-signature",
+} as const;
+
+/** Maximum clock drift tolerated in milliseconds (5 minutes). */
+export const CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+/** Window used to persist nonce records for replay protection (seconds). */
+export const NONCE_WINDOW_SECONDS = Math.ceil((CLOCK_SKEW_MS * 2) / 1000);
+
+/** Minimum / maximum allowed nonce length (characters). */
+const NONCE_MIN_LEN = 8;
+const NONCE_MAX_LEN = 128;
+
+// ---------------------------------------------------------------------------
+// Canonical payload
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the canonical payload that the caller must sign.
+ * Consumers (client-side code and tests) should call this to reproduce
+ * the exact string that the server will verify.
+ */
+export function buildCanonicalPayload(
+  method: string,
+  path: string,
+  timestamp: string,
+  nonce: string,
+): string {
+  return `${AUTH_DOMAIN_PREFIX}:${method.toUpperCase()}:${path}:${timestamp}:${nonce}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function deriveNonceKey(address: string, nonce: string): string {
+  return createHash("sha256")
+    .update(`${address}:${nonce}`)
+    .digest("hex");
+}
+
+function header(request: Request, name: string): string | null {
+  return request.headers.get(name);
+}
+
+function requireHeader(request: Request, name: string): string {
+  const value = header(request, name);
+  if (!value) {
+    throw new ApiError(401, "unauthorized", `Missing required header: ${name}`);
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Core verification
+// ---------------------------------------------------------------------------
+
+export interface VerifiedActor {
+  /** The verified Stellar G-address. Safe to use as a principal. */
+  address: string;
+}
+
+/**
+ * Verifies a signed request and returns the authenticated principal.
+ *
+ * Performs, in order:
+ *   1. Header presence and format validation
+ *   2. Timestamp expiration check
+ *   3. Ed25519 signature verification
+ *   4. Replay-nonce check (requires repository)
+ *
+ * Throws ApiError(401) for any verification failure.
+ */
+export async function verifySignedRequest(
+  request: Request,
+  repository: ApiRepository,
+  now = new Date(),
+): Promise<VerifiedActor> {
+  // 1. Read and validate headers
+  const rawAddress = requireHeader(request, AUTH_HEADERS.address);
+  const rawTimestamp = requireHeader(request, AUTH_HEADERS.timestamp);
+  const nonce = requireHeader(request, AUTH_HEADERS.nonce);
+  const rawSignature = requireHeader(request, AUTH_HEADERS.signature);
+
+  const addressResult = stellarAddressSchema.safeParse(rawAddress);
+  if (!addressResult.success) {
+    throw new ApiError(401, "unauthorized", `${AUTH_HEADERS.address} must be a valid Stellar G-address`);
+  }
+  const address = addressResult.data;
+
+  if (nonce.length < NONCE_MIN_LEN || nonce.length > NONCE_MAX_LEN) {
+    throw new ApiError(
+      401,
+      "unauthorized",
+      `${AUTH_HEADERS.nonce} must be between ${NONCE_MIN_LEN} and ${NONCE_MAX_LEN} characters`,
+    );
+  }
+
+  if (!/^[a-f0-9]{128}$/.test(rawSignature)) {
+    throw new ApiError(
+      401,
+      "unauthorized",
+      `${AUTH_HEADERS.signature} must be a 128-character lowercase hex string`,
+    );
+  }
+
+  // 2. Expiration check
+  const timestamp = new Date(rawTimestamp);
+  if (isNaN(timestamp.getTime())) {
+    throw new ApiError(401, "unauthorized", `${AUTH_HEADERS.timestamp} is not a valid ISO 8601 timestamp`);
+  }
+
+  const drift = Math.abs(now.getTime() - timestamp.getTime());
+  if (drift > CLOCK_SKEW_MS) {
+    throw new ApiError(401, "unauthorized", "Request timestamp is outside the acceptable window");
+  }
+
+  // 3. Signature verification
+  const url = new URL(request.url);
+  const canonical = buildCanonicalPayload(request.method, url.pathname, rawTimestamp, nonce);
+  const payload = Buffer.from(canonical, "utf8");
+  const signature = Buffer.from(rawSignature, "hex");
+
+  let keypair: Keypair;
+  try {
+    keypair = Keypair.fromPublicKey(address);
+  } catch {
+    throw new ApiError(401, "unauthorized", "Could not load public key from address");
+  }
+
+  let valid: boolean;
+  try {
+    valid = keypair.verify(payload, signature);
+  } catch {
+    valid = false;
+  }
+
+  if (!valid) {
+    throw new ApiError(401, "unauthorized", "Signature verification failed");
+  }
+
+  // 4. Replay protection — store nonce digest; reject if already seen
+  const nonceKey = `auth:nonce:${deriveNonceKey(address, nonce)}`;
+  const existing = await repository.getIdempotencyRecord(nonceKey);
+  if (existing) {
+    throw new ApiError(401, "unauthorized", "Nonce has already been used");
+  }
+
+  await repository.setIdempotencyRecord(nonceKey, {
+    status: 200,
+    body: null,
+    createdAt: now.toISOString(),
+  });
+
+  return { address };
+}
+
+// ---------------------------------------------------------------------------
+// Route-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Require a fully verified actor. Throws ApiError(401) if any
+ * verification step fails.
+ *
+ * Pass `repository` so replay protection can be enforced.
+ */
+export async function requireVerifiedActor(
+  request: Request,
+  repository: ApiRepository,
+  now?: Date,
+): Promise<string> {
+  const actor = await verifySignedRequest(request, repository, now);
+  return actor.address;
+}
+
+/**
+ * Require that the verified actor matches a specific expected address.
+ * Throws ApiError(403) if the actor does not match.
+ */
+export async function requireVerifiedActorMatches(
+  request: Request,
+  repository: ApiRepository,
+  expectedAddress: string,
+  now?: Date,
+): Promise<string> {
+  const address = await requireVerifiedActor(request, repository, now);
+  if (address !== expectedAddress) {
+    throw new ApiError(403, "forbidden", "The authenticated actor cannot modify this resource");
+  }
+  return address;
+}

--- a/tests/unit/api/auth.test.ts
+++ b/tests/unit/api/auth.test.ts
@@ -1,0 +1,398 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  AUTH_HEADERS,
+  CLOCK_SKEW_MS,
+  NONCE_WINDOW_SECONDS,
+  buildCanonicalPayload,
+  requireVerifiedActor,
+  requireVerifiedActorMatches,
+  verifySignedRequest,
+} from "../../../src/server/api/auth";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTimestamp(offsetMs = 0, base = new Date()): string {
+  return new Date(base.getTime() + offsetMs).toISOString();
+}
+
+function makeNonce(): string {
+  return Math.random().toString(36).slice(2).padEnd(8, "x");
+}
+
+function signRequest(
+  keypair: Keypair,
+  opts: {
+    method?: string;
+    path?: string;
+    timestamp?: string;
+    nonce?: string;
+  } = {},
+): { timestamp: string; nonce: string; signature: string } {
+  const timestamp = opts.timestamp ?? makeTimestamp();
+  const nonce = opts.nonce ?? makeNonce();
+  const method = opts.method ?? "GET";
+  const path = opts.path ?? "/api/v1/test";
+  const canonical = buildCanonicalPayload(method, path, timestamp, nonce);
+  const sig = keypair.sign(Buffer.from(canonical, "utf8"));
+  const signature = Buffer.from(sig).toString("hex");
+  return { timestamp, nonce, signature };
+}
+
+function makeRequest(
+  keypair: Keypair,
+  opts: {
+    method?: string;
+    path?: string;
+    timestamp?: string;
+    nonce?: string;
+    overrideHeaders?: Record<string, string>;
+  } = {},
+): Request {
+  const method = opts.method ?? "GET";
+  const path = opts.path ?? "/api/v1/test";
+  const { timestamp, nonce, signature } = signRequest(keypair, {
+    method,
+    path,
+    timestamp: opts.timestamp,
+    nonce: opts.nonce,
+  });
+
+  const headers: Record<string, string> = {
+    [AUTH_HEADERS.address]: keypair.publicKey(),
+    [AUTH_HEADERS.timestamp]: timestamp,
+    [AUTH_HEADERS.nonce]: nonce,
+    [AUTH_HEADERS.signature]: signature,
+    ...opts.overrideHeaders,
+  };
+
+  return new Request(`https://stealth.test${path}`, { method, headers });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifySignedRequest", () => {
+  let repo: MemoryApiRepository;
+  let keypair: Keypair;
+  let now: Date;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+    keypair = Keypair.random();
+    now = new Date("2026-07-20T12:00:00.000Z");
+  });
+
+  // -- Happy path --
+
+  it("accepts a well-formed signed request", async () => {
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    const actor = await verifySignedRequest(req, repo, now);
+    expect(actor.address).toBe(keypair.publicKey());
+  });
+
+  it("returns the verified G-address uppercased", async () => {
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    const actor = await verifySignedRequest(req, repo, now);
+    expect(actor.address).toMatch(/^G[A-Z2-7]{55}$/);
+  });
+
+  // -- Missing headers --
+
+  it("rejects when x-stealth-address is absent", async () => {
+    const req = makeRequest(keypair, {
+      timestamp: now.toISOString(),
+      overrideHeaders: { [AUTH_HEADERS.address]: "" },
+    });
+    // rebuilding without address header
+    const headers = new Headers(req.headers);
+    headers.delete(AUTH_HEADERS.address);
+    const bare = new Request(req.url, { method: req.method, headers });
+    await expect(verifySignedRequest(bare, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects when x-stealth-signature is absent", async () => {
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    const headers = new Headers(req.headers);
+    headers.delete(AUTH_HEADERS.signature);
+    const bare = new Request(req.url, { method: req.method, headers });
+    await expect(verifySignedRequest(bare, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  // -- Bad address format --
+
+  it("rejects a non-G-address in x-stealth-address", async () => {
+    const req = makeRequest(keypair, {
+      timestamp: now.toISOString(),
+      overrideHeaders: { [AUTH_HEADERS.address]: "not-a-stellar-address" },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  // -- Timestamp expiration --
+
+  it("rejects a timestamp too far in the past", async () => {
+    const stale = makeTimestamp(-(CLOCK_SKEW_MS + 1000), now);
+    const req = makeRequest(keypair, { timestamp: stale });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+
+  it("rejects a timestamp too far in the future", async () => {
+    const future = makeTimestamp(CLOCK_SKEW_MS + 1000, now);
+    const req = makeRequest(keypair, { timestamp: future });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+
+  it("accepts a timestamp at exactly the clock-skew boundary", async () => {
+    const edge = makeTimestamp(-CLOCK_SKEW_MS, now);
+    const req = makeRequest(keypair, { timestamp: edge });
+    const actor = await verifySignedRequest(req, repo, now);
+    expect(actor.address).toBe(keypair.publicKey());
+  });
+
+  it("rejects a non-ISO timestamp", async () => {
+    const req = makeRequest(keypair, {
+      timestamp: now.toISOString(),
+      overrideHeaders: { [AUTH_HEADERS.timestamp]: "not-a-date" },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  // -- Nonce validation --
+
+  it("rejects a nonce shorter than 8 characters", async () => {
+    const { timestamp, signature } = signRequest(keypair, {
+      timestamp: now.toISOString(),
+      nonce: "short",
+    });
+    const req = new Request("https://stealth.test/api/v1/test", {
+      headers: {
+        [AUTH_HEADERS.address]: keypair.publicKey(),
+        [AUTH_HEADERS.timestamp]: timestamp,
+        [AUTH_HEADERS.nonce]: "short",
+        [AUTH_HEADERS.signature]: signature,
+      },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a nonce longer than 128 characters", async () => {
+    const longNonce = "x".repeat(129);
+    const { timestamp, signature } = signRequest(keypair, {
+      timestamp: now.toISOString(),
+      nonce: longNonce,
+    });
+    const req = new Request("https://stealth.test/api/v1/test", {
+      headers: {
+        [AUTH_HEADERS.address]: keypair.publicKey(),
+        [AUTH_HEADERS.timestamp]: timestamp,
+        [AUTH_HEADERS.nonce]: longNonce,
+        [AUTH_HEADERS.signature]: signature,
+      },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  // -- Signature verification --
+
+  it("rejects a signature produced by a different keypair", async () => {
+    const other = Keypair.random();
+    const { timestamp, nonce } = signRequest(keypair, { timestamp: now.toISOString() });
+    // sign with other key but claim keypair's address
+    const canonical = buildCanonicalPayload("GET", "/api/v1/test", timestamp, nonce);
+    const badSig = Buffer.from(other.sign(Buffer.from(canonical, "utf8"))).toString("hex");
+
+    const req = new Request("https://stealth.test/api/v1/test", {
+      headers: {
+        [AUTH_HEADERS.address]: keypair.publicKey(),
+        [AUTH_HEADERS.timestamp]: timestamp,
+        [AUTH_HEADERS.nonce]: nonce,
+        [AUTH_HEADERS.signature]: badSig,
+      },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a tampered canonical payload (wrong path)", async () => {
+    // sign for /api/v1/test but send request to /api/v1/other
+    const { timestamp, nonce } = signRequest(keypair, {
+      path: "/api/v1/test",
+      timestamp: now.toISOString(),
+    });
+    const canonical = buildCanonicalPayload("GET", "/api/v1/test", timestamp, nonce);
+    const sig = Buffer.from(keypair.sign(Buffer.from(canonical, "utf8"))).toString("hex");
+
+    const req = new Request("https://stealth.test/api/v1/other", {
+      headers: {
+        [AUTH_HEADERS.address]: keypair.publicKey(),
+        [AUTH_HEADERS.timestamp]: timestamp,
+        [AUTH_HEADERS.nonce]: nonce,
+        [AUTH_HEADERS.signature]: sig,
+      },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a signature that is not valid hex", async () => {
+    const req = makeRequest(keypair, {
+      timestamp: now.toISOString(),
+      overrideHeaders: { [AUTH_HEADERS.signature]: "zz".repeat(64) },
+    });
+    await expect(verifySignedRequest(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+
+  // -- Replay protection --
+
+  it("rejects a replayed nonce from the same address", async () => {
+    const nonce = makeNonce();
+    const req1 = makeRequest(keypair, { timestamp: now.toISOString(), nonce });
+    await verifySignedRequest(req1, repo, now);
+
+    // second request with same nonce — must be a fresh signed request
+    const { signature, timestamp } = signRequest(keypair, {
+      timestamp: now.toISOString(),
+      nonce,
+    });
+    const req2 = new Request("https://stealth.test/api/v1/test", {
+      headers: {
+        [AUTH_HEADERS.address]: keypair.publicKey(),
+        [AUTH_HEADERS.timestamp]: timestamp,
+        [AUTH_HEADERS.nonce]: nonce,
+        [AUTH_HEADERS.signature]: signature,
+      },
+    });
+    await expect(verifySignedRequest(req2, repo, now)).rejects.toMatchObject({
+      status: 401,
+      code: "unauthorized",
+    });
+  });
+
+  it("allows same nonce from a different address", async () => {
+    const nonce = makeNonce();
+    const other = Keypair.random();
+
+    const req1 = makeRequest(keypair, { timestamp: now.toISOString(), nonce });
+    await verifySignedRequest(req1, repo, now);
+
+    const req2 = makeRequest(other, { timestamp: now.toISOString(), nonce });
+    const actor = await verifySignedRequest(req2, repo, now);
+    expect(actor.address).toBe(other.publicKey());
+  });
+
+  it("stores only a digest of address:nonce, not the raw values", async () => {
+    const nonce = makeNonce();
+    const req = makeRequest(keypair, { timestamp: now.toISOString(), nonce });
+    await verifySignedRequest(req, repo, now);
+
+    // the raw nonce and address should not appear as idempotency keys
+    const rawNonceKey = await repo.getIdempotencyRecord(`auth:nonce:${nonce}`);
+    expect(rawNonceKey).toBeNull();
+    const rawAddressKey = await repo.getIdempotencyRecord(`auth:nonce:${keypair.publicKey()}`);
+    expect(rawAddressKey).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireVerifiedActor
+// ---------------------------------------------------------------------------
+
+describe("requireVerifiedActor", () => {
+  let repo: MemoryApiRepository;
+  let keypair: Keypair;
+  let now: Date;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+    keypair = Keypair.random();
+    now = new Date("2026-07-20T12:00:00.000Z");
+  });
+
+  it("returns the verified address on success", async () => {
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    const address = await requireVerifiedActor(req, repo, now);
+    expect(address).toBe(keypair.publicKey());
+  });
+
+  it("throws 401 on invalid signature", async () => {
+    const req = makeRequest(keypair, {
+      timestamp: now.toISOString(),
+      overrideHeaders: { [AUTH_HEADERS.signature]: "aa".repeat(64) },
+    });
+    await expect(requireVerifiedActor(req, repo, now)).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireVerifiedActorMatches
+// ---------------------------------------------------------------------------
+
+describe("requireVerifiedActorMatches", () => {
+  let repo: MemoryApiRepository;
+  let keypair: Keypair;
+  let now: Date;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+    keypair = Keypair.random();
+    now = new Date("2026-07-20T12:00:00.000Z");
+  });
+
+  it("returns the address when it matches", async () => {
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    const address = await requireVerifiedActorMatches(req, repo, keypair.publicKey(), now);
+    expect(address).toBe(keypair.publicKey());
+  });
+
+  it("throws 403 when the verified address does not match", async () => {
+    const other = Keypair.random();
+    const req = makeRequest(keypair, { timestamp: now.toISOString() });
+    await expect(
+      requireVerifiedActorMatches(req, repo, other.publicKey(), now),
+    ).rejects.toMatchObject({ status: 403, code: "forbidden" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCanonicalPayload
+// ---------------------------------------------------------------------------
+
+describe("buildCanonicalPayload", () => {
+  it("produces a deterministic string", () => {
+    const p1 = buildCanonicalPayload("POST", "/api/v1/receipts", "2026-07-20T12:00:00.000Z", "abc12345");
+    const p2 = buildCanonicalPayload("POST", "/api/v1/receipts", "2026-07-20T12:00:00.000Z", "abc12345");
+    expect(p1).toBe(p2);
+  });
+
+  it("includes the domain prefix", () => {
+    const p = buildCanonicalPayload("GET", "/api", "2026-07-20T12:00:00.000Z", "nonce123");
+    expect(p).toMatch(/^stealth-auth:v1:/);
+  });
+
+  it("uppercases the method", () => {
+    const p = buildCanonicalPayload("post", "/api", "2026-07-20T12:00:00.000Z", "nonce123");
+    expect(p).toContain(":POST:");
+  });
+
+  it("changes with every field", () => {
+    const base = buildCanonicalPayload("GET", "/api", "2026-07-20T12:00:00.000Z", "nonce123");
+    expect(buildCanonicalPayload("POST", "/api", "2026-07-20T12:00:00.000Z", "nonce123")).not.toBe(base);
+    expect(buildCanonicalPayload("GET", "/other", "2026-07-20T12:00:00.000Z", "nonce123")).not.toBe(base);
+    expect(buildCanonicalPayload("GET", "/api", "2026-07-20T12:00:01.000Z", "nonce123")).not.toBe(base);
+    expect(buildCanonicalPayload("GET", "/api", "2026-07-20T12:00:00.000Z", "nonce124")).not.toBe(base);
+  });
+
+  it("does not include NONCE_WINDOW_SECONDS in the export to confirm it is exported", () => {
+    // just assert the constant is a positive integer
+    expect(NONCE_WINDOW_SECONDS).toBeGreaterThan(0);
+    expect(Number.isInteger(NONCE_WINDOW_SECONDS)).toBe(true);
+  });
+});


### PR DESCRIPTION


Replaces header-only identification in actor.ts with cryptographic proof
of Stellar key ownership via Ed25519 signed requests.

Canonical payload (domain-separated, no challenge round-trip):
  stealth-auth:v1:<METHOD>:<PATH>:<TIMESTAMP>:<NONCE>

New headers:
  x-stealth-address    verified Stellar G-address (claimed public key)
  x-stealth-timestamp  ISO 8601 UTC timestamp
  x-stealth-nonce      caller-chosen opaque string (8-128 chars)
  x-stealth-signature  128-char lowercase hex Ed25519 signature

Security properties:
  - Expiration: timestamps outside +/-5 min window are rejected
  - Replay protection: (address, nonce) digest stored for the window;
    reused nonces rejected; only SHA-256 digest persisted, never raw values
  - Domain separation: stealth-auth:v1 prefix prevents cross-protocol reuse
  - Signature verification: Keypair.verify() from @stellar/stellar-sdk

Exports:
  verifySignedRequest          - core verifier, returns VerifiedActor
  requireVerifiedActor         - route helper, returns address string
  requireVerifiedActorMatches  - route helper with ownership assertion
  buildCanonicalPayload        - shared by client and server

26 unit tests covering happy path, expiration, invalid signatures,
tampered payloads, nonce bounds, replay rejection, and digest privacy.

Closes #1459
