### PR TITLE
Add idempotent postage settlement with atomic terminal-state handling

### DIFF
--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,5 +1,12 @@
-import type { ApiRepository } from "./repository";
-import type { MailboxPolicy, SenderRule, Postage, Receipt, IdempotencyRecord } from "./domain";
+import type { ApiRepository, PostageTransitionResult } from "./repository";
+import type {
+  MailboxPolicy,
+  SenderRule,
+  Postage,
+  PostageStatus,
+  Receipt,
+  IdempotencyRecord,
+} from "./domain";
 
 export class HybridApiRepository implements ApiRepository {
   constructor(
@@ -43,7 +50,28 @@ export class HybridApiRepository implements ApiRepository {
 
   async setPostage(postage: Postage): Promise<Postage> {
     await this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage));
+    // Mirror into the coordinator, whose transactional storage is the
+    // source of truth for settlement transitions (see transitionPostage).
+    // KV alone cannot provide the compare-and-swap guarantee settlement
+    // needs, since Workers KV writes are not atomic or strongly consistent.
+    await this.getStub().setPostage(postage);
     return postage;
+  }
+
+  // Settling/refunding postage must be atomic: two concurrent requests
+  // racing on the same messageId must not both succeed. KV get-then-put
+  // cannot guarantee that, so the compare-and-swap is delegated to the
+  // Durable Object coordinator, then mirrored back into KV for fast reads.
+  async transitionPostage(
+    messageId: string,
+    expectedStatus: PostageStatus,
+    nextStatus: PostageStatus,
+  ): Promise<PostageTransitionResult> {
+    const result = await this.getStub().transitionPostage(messageId, expectedStatus, nextStatus);
+    if (result.outcome === "applied") {
+      await this.kv.put(this.key("postage", messageId), JSON.stringify(result.postage));
+    }
+    return result;
   }
 
   async getReceipt(messageId: string): Promise<Receipt | null> {

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -1,5 +1,12 @@
-import type { IdempotencyRecord, MailboxPolicy, Postage, Receipt, SenderRule } from "./domain";
-import type { ApiRepository } from "./repository";
+import type {
+  IdempotencyRecord,
+  MailboxPolicy,
+  Postage,
+  PostageStatus,
+  Receipt,
+  SenderRule,
+} from "./domain";
+import type { ApiRepository, PostageTransitionResult } from "./repository";
 
 function key(owner: string, sender: string) {
   return `${owner}:${sender}`;
@@ -40,6 +47,27 @@ export class MemoryApiRepository implements ApiRepository {
   async setPostage(postage: Postage) {
     this.postage.set(postage.messageId, structuredClone(postage));
     return structuredClone(postage);
+  }
+
+  async transitionPostage(
+    messageId: string,
+    expectedStatus: PostageStatus,
+    nextStatus: PostageStatus,
+  ): Promise<PostageTransitionResult> {
+    // No `await` occurs between the read and the write below, so this
+    // check-then-act sequence runs to completion within a single
+    // microtask and cannot interleave with a concurrent call for the
+    // same messageId, giving us the atomicity the interface requires.
+    const current = this.postage.get(messageId);
+    if (!current) {
+      return { outcome: "not-found" };
+    }
+    if (current.status !== expectedStatus) {
+      return { outcome: "conflict", postage: structuredClone(current) };
+    }
+    const updated: Postage = { ...current, status: nextStatus };
+    this.postage.set(messageId, updated);
+    return { outcome: "applied", postage: structuredClone(updated) };
   }
 
   async getReceipt(messageId: string) {

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -170,9 +170,19 @@ export async function resolvePostage(
   messageId: string,
   status: "refunded" | "settled",
 ) {
-  const postage = await getPostage(repository, messageId);
+  // Use an atomic compare-and-swap instead of get-then-set: two concurrent
+  // settle/refund requests for the same message must not both succeed, and
+  // every loser must observe the same deterministic terminal state rather
+  // than racing to overwrite each other.
+  const result = await repository.transitionPostage(messageId, "pending", status);
 
-  if (postage.status !== "pending") {
+  if (result.outcome === "not-found") {
+    throw new ApiError(404, "not_found", "Postage was not found");
+  }
+
+  if (result.outcome === "conflict") {
+    const { postage } = result;
+
     // Provide detailed explanations for terminal states to aid debugging and retry logic
     const explanations: Record<string, string> = {
       settled:
@@ -191,5 +201,5 @@ export async function resolvePostage(
     });
   }
 
-  return repository.setPostage({ ...postage, status });
+  return result.postage;
 }

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -1,4 +1,26 @@
-import type { IdempotencyRecord, MailboxPolicy, Postage, Receipt, SenderRule } from "./domain";
+import type {
+  IdempotencyRecord,
+  MailboxPolicy,
+  Postage,
+  PostageStatus,
+  Receipt,
+  SenderRule,
+} from "./domain";
+
+/**
+ * Outcome of an atomic compare-and-swap postage state transition.
+ *
+ * - "not-found": no postage record exists for the given messageId.
+ * - "conflict": the postage exists but its current status did not match the
+ *   expected status, so no transition was applied. `postage` reflects the
+ *   actual current record so callers can build a deterministic error.
+ * - "applied": the transition was applied atomically. `postage` reflects the
+ *   updated record.
+ */
+export type PostageTransitionResult =
+  | { outcome: "not-found" }
+  | { outcome: "conflict"; postage: Postage }
+  | { outcome: "applied"; postage: Postage };
 
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
@@ -7,6 +29,20 @@ export interface ApiRepository {
   setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule>;
   getPostage(messageId: string): Promise<Postage | null>;
   setPostage(postage: Postage): Promise<Postage>;
+  /**
+   * Atomically transitions a postage record from `expectedStatus` to
+   * `nextStatus`. Implementations MUST guarantee that concurrent callers
+   * racing on the same messageId observe a single winner: exactly one call
+   * receives `{ outcome: "applied" }` and every other concurrent/subsequent
+   * call receives `{ outcome: "conflict" }` reflecting the terminal state.
+   * This must not be implemented as a plain get-then-set, since that is
+   * vulnerable to double-settlement under concurrent requests.
+   */
+  transitionPostage(
+    messageId: string,
+    expectedStatus: PostageStatus,
+    nextStatus: PostageStatus,
+  ): Promise<PostageTransitionResult>;
   getReceipt(messageId: string): Promise<Receipt | null>;
   setReceipt(receipt: Receipt): Promise<Receipt>;
   getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null>;

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1,4 +1,5 @@
-import type { IdempotencyRecord } from "./domain";
+import type { IdempotencyRecord, Postage, PostageStatus } from "./domain";
+import type { PostageTransitionResult } from "./repository";
 
 const DurableObjectBase: any = import.meta.env.PROD
   ? (await import("cloudflare:workers")).DurableObject
@@ -12,8 +13,31 @@ const DurableObjectBase: any = import.meta.env.PROD
     };
 
 export class StealthCoordinator extends DurableObjectBase {
+  // Per-key serialization for critical sections that must not interleave.
+  // A Durable Object instance is a single JS object, but `await`ing a
+  // storage call still yields to the microtask queue, so two concurrent
+  // RPCs for the same key can otherwise both read state before either
+  // writes it back (the exact double-settlement bug this coordinates
+  // against). Chaining onto a per-key promise guarantees strict
+  // sequential execution of the critical section regardless of Workers
+  // runtime gating behavior, so correctness doesn't depend on unverified
+  // assumptions about how `ctx.storage` schedules concurrent callers.
+  private readonly locks = new Map<string, Promise<unknown>>();
+
   constructor(ctx: DurableObjectState, env: any) {
     super(ctx, env);
+  }
+
+  private runExclusive<T>(lockKey: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(lockKey) ?? Promise.resolve();
+    const result = previous.then(fn, fn);
+    // Keep the chain alive for the next caller, but never let a rejection
+    // here propagate into an unrelated future caller's chain.
+    this.locks.set(
+      lockKey,
+      result.catch(() => undefined),
+    );
+    return result;
   }
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
@@ -25,6 +49,41 @@ export class StealthCoordinator extends DurableObjectBase {
 
   async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
     await this.ctx.storage.put(`idempotency:${key}`, record);
+  }
+
+  // Postage settlement is money-moving and must never double-fire, so its
+  // authoritative state lives in this Durable Object's transactional
+  // storage rather than in eventually-consistent KV.
+  async getPostage(messageId: string): Promise<Postage | null> {
+    const postage = (await this.ctx.storage.get(`postage:${messageId}`)) as Postage | undefined;
+    return postage ?? null;
+  }
+
+  async setPostage(postage: Postage): Promise<Postage> {
+    await this.ctx.storage.put(`postage:${postage.messageId}`, postage);
+    return postage;
+  }
+
+  async transitionPostage(
+    messageId: string,
+    expectedStatus: PostageStatus,
+    nextStatus: PostageStatus,
+  ): Promise<PostageTransitionResult> {
+    // The read-check-write below is serialized per messageId via
+    // runExclusive, so concurrent settle/refund calls for the same
+    // message cannot interleave and double-apply the transition.
+    return this.runExclusive(`postage:${messageId}`, async () => {
+      const current = (await this.ctx.storage.get(`postage:${messageId}`)) as Postage | undefined;
+      if (!current) {
+        return { outcome: "not-found" as const };
+      }
+      if (current.status !== expectedStatus) {
+        return { outcome: "conflict" as const, postage: current };
+      }
+      const updated: Postage = { ...current, status: nextStatus };
+      await this.ctx.storage.put(`postage:${messageId}`, updated);
+      return { outcome: "applied" as const, postage: updated };
+    });
   }
 
   async getCounter(key: string): Promise<number> {

--- a/tests/unit/api/kv-repository.test.ts
+++ b/tests/unit/api/kv-repository.test.ts
@@ -21,12 +21,38 @@ class MockKVNamespace {
   }
 }
 
+class MockCoordinatorStub {
+  private postage = new Map<string, Postage>();
+
+  async getPostage(messageId: string) {
+    return this.postage.get(messageId) ?? null;
+  }
+
+  async setPostage(postage: Postage) {
+    this.postage.set(postage.messageId, postage);
+    return postage;
+  }
+
+  async transitionPostage(messageId: string, expectedStatus: string, nextStatus: string) {
+    const current = this.postage.get(messageId);
+    if (!current) return { outcome: "not-found" as const };
+    if (current.status !== expectedStatus) {
+      return { outcome: "conflict" as const, postage: current };
+    }
+    const updated = { ...current, status: nextStatus } as Postage;
+    this.postage.set(messageId, updated);
+    return { outcome: "applied" as const, postage: updated };
+  }
+}
+
 class MockDurableObjectNamespace {
+  public stub = new MockCoordinatorStub();
+
   idFromName(name: string) {
     return { toString: () => name };
   }
   get(id: any) {
-    return {};
+    return this.stub;
   }
 }
 
@@ -36,12 +62,13 @@ const messageId = "a".repeat(64);
 
 describe("HybridApiRepository - KV Operations", () => {
   let kv: MockKVNamespace;
+  let coordinator: MockDurableObjectNamespace;
   let repo: HybridApiRepository;
 
   beforeEach(() => {
     kv = new MockKVNamespace();
-    const coordinator = new MockDurableObjectNamespace() as any;
-    repo = new HybridApiRepository(kv as any, coordinator);
+    coordinator = new MockDurableObjectNamespace();
+    repo = new HybridApiRepository(kv as any, coordinator as any);
   });
 
   it("persists and retrieves mailbox policy", async () => {
@@ -105,5 +132,55 @@ describe("HybridApiRepository - KV Operations", () => {
     expect(await repo.getRelayLastSuccessfulDelivery("relay-1")).toBeNull();
     expect(await repo.getRelayLastFailedDelivery("relay-1")).toBeNull();
     expect(await repo.getRelayDeadLetterCount("relay-1")).toBe(0);
+  });
+
+  describe("transitionPostage - atomic settlement", () => {
+    it("delegates to the coordinator and mirrors the applied result back into KV", async () => {
+      const postage: Postage = {
+        amount: "200",
+        createdAt: new Date().toISOString(),
+        messageId,
+        paymentHash: "b".repeat(64),
+        recipient: owner,
+        sender,
+        status: "pending",
+      };
+      await repo.setPostage(postage);
+
+      const result = await repo.transitionPostage(messageId, "pending", "settled");
+
+      expect(result).toMatchObject({ outcome: "applied", postage: { status: "settled" } });
+      // KV read path reflects the coordinator's authoritative outcome.
+      await expect(repo.getPostage(messageId)).resolves.toMatchObject({ status: "settled" });
+    });
+
+    it("returns not-found when there is no coordinator record", async () => {
+      const result = await repo.transitionPostage(messageId, "pending", "settled");
+      expect(result).toEqual({ outcome: "not-found" });
+    });
+
+    it("only allows one of two concurrent settlement attempts to succeed", async () => {
+      const postage: Postage = {
+        amount: "300",
+        createdAt: new Date().toISOString(),
+        messageId,
+        paymentHash: "c".repeat(64),
+        recipient: owner,
+        sender,
+        status: "pending",
+      };
+      await repo.setPostage(postage);
+
+      const [first, second] = await Promise.all([
+        repo.transitionPostage(messageId, "pending", "settled"),
+        repo.transitionPostage(messageId, "pending", "settled"),
+      ]);
+
+      const outcomes = [first.outcome, second.outcome].sort();
+      expect(outcomes).toEqual(["applied", "conflict"]);
+
+      // Only one settlement side effect occurred; state is deterministic.
+      await expect(repo.getPostage(messageId)).resolves.toMatchObject({ status: "settled" });
+    });
   });
 });

--- a/tests/unit/api/postage-settlement-idempotency.test.ts
+++ b/tests/unit/api/postage-settlement-idempotency.test.ts
@@ -112,6 +112,76 @@ describe("Postage Settlement Idempotency", () => {
     });
   });
 
+  describe("resolvePostage - concurrent settlement (issue #1545)", () => {
+    it("only settles once when multiple concurrent requests race with no idempotency key", async () => {
+      const repository = new MemoryApiRepository();
+      const messageId = "y".repeat(64);
+
+      await repository.setPostage({
+        amount: "1000",
+        createdAt: "2026-06-14T21:00:00.000Z",
+        messageId,
+        paymentHash: "u".repeat(64),
+        recipient,
+        sender,
+        status: "pending",
+      });
+
+      const outcomes = await Promise.allSettled(
+        Array.from({ length: 10 }, () => resolvePostage(repository, messageId, "settled")),
+      );
+
+      const fulfilled = outcomes.filter((outcome) => outcome.status === "fulfilled");
+      const rejected = outcomes.filter((outcome) => outcome.status === "rejected");
+
+      // Exactly one settlement side effect occurs.
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(9);
+
+      for (const outcome of rejected) {
+        if (outcome.status !== "rejected") continue;
+        expect(outcome.reason).toMatchObject({
+          status: 409,
+          code: "conflict",
+          details: { currentStatus: "settled" },
+        });
+      }
+
+      const finalState = await getPostage(repository, messageId);
+      expect(finalState.status).toBe("settled");
+    });
+
+    it("only allows one winner between a concurrent settle and refund race", async () => {
+      const repository = new MemoryApiRepository();
+      const messageId = "v".repeat(64);
+
+      await repository.setPostage({
+        amount: "1200",
+        createdAt: "2026-06-14T22:00:00.000Z",
+        messageId,
+        paymentHash: "w".repeat(64),
+        recipient,
+        sender,
+        status: "pending",
+      });
+
+      const outcomes = await Promise.allSettled([
+        resolvePostage(repository, messageId, "settled"),
+        resolvePostage(repository, messageId, "refunded"),
+      ]);
+
+      const fulfilled = outcomes.filter((outcome) => outcome.status === "fulfilled");
+      expect(fulfilled).toHaveLength(1);
+
+      const finalState = await getPostage(repository, messageId);
+      // Whichever one won, the final state is a single deterministic terminal status.
+      expect(["settled", "refunded"]).toContain(finalState.status);
+      if (fulfilled[0].status === "fulfilled") {
+        expect(finalState.status).toBe(fulfilled[0].value.status);
+      }
+    });
+  });
+
   describe("idempotency service integration", () => {
     it("records and replays successful settlement", async () => {
       const repository = new MemoryApiRepository();

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -117,6 +117,68 @@ export function runRepositoryContractTests(
       });
     });
 
+    describe("atomic postage transitions", () => {
+      it("reports not-found for a message with no postage", async () => {
+        await expect(repo.transitionPostage(messageId, "pending", "settled")).resolves.toEqual({
+          outcome: "not-found",
+        });
+      });
+
+      it("applies a pending -> settled transition and reflects it in getPostage", async () => {
+        await repo.setPostage({
+          amount: "100",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          messageId,
+          paymentHash,
+          recipient: owner,
+          sender,
+          status: "pending",
+        });
+
+        const result = await repo.transitionPostage(messageId, "pending", "settled");
+        expect(result).toMatchObject({ outcome: "applied", postage: { status: "settled" } });
+        await expect(repo.getPostage(messageId)).resolves.toMatchObject({ status: "settled" });
+      });
+
+      it("reports a conflict with the current status when already terminal", async () => {
+        await repo.setPostage({
+          amount: "100",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          messageId,
+          paymentHash,
+          recipient: owner,
+          sender,
+          status: "settled",
+        });
+
+        await expect(
+          repo.transitionPostage(messageId, "pending", "settled"),
+        ).resolves.toMatchObject({ outcome: "conflict", postage: { status: "settled" } });
+      });
+
+      it("allows exactly one winner out of concurrent settlement attempts", async () => {
+        await repo.setPostage({
+          amount: "100",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          messageId,
+          paymentHash,
+          recipient: owner,
+          sender,
+          status: "pending",
+        });
+
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () => repo.transitionPostage(messageId, "pending", "settled")),
+        );
+
+        const applied = results.filter((result) => result.outcome === "applied");
+        const conflicts = results.filter((result) => result.outcome === "conflict");
+        expect(applied).toHaveLength(1);
+        expect(conflicts).toHaveLength(4);
+        await expect(repo.getPostage(messageId)).resolves.toMatchObject({ status: "settled" });
+      });
+    });
+
     describe("idempotency records", () => {
       it("returns null for a missing idempotency key", async () => {
         await expect(repo.getIdempotencyRecord("missing")).resolves.toBeNull();

--- a/tests/unit/api/stealth-coordinator.test.ts
+++ b/tests/unit/api/stealth-coordinator.test.ts
@@ -14,7 +14,7 @@ vi.mock("cloudflare:workers", () => {
 });
 
 import { StealthCoordinator } from "../../../src/server/api/stealth-coordinator";
-import type { IdempotencyRecord } from "../../../src/server/api/domain";
+import type { IdempotencyRecord, Postage } from "../../../src/server/api/domain";
 
 class MockDurableObjectState {
   public id = { toString: () => "mock-do-id" };
@@ -78,5 +78,58 @@ describe("StealthCoordinator - Durable Object Operations", () => {
     expect(await coordinator.getCounter("limiter-1")).toBe(2);
 
     dateSpy.mockRestore();
+  });
+
+  describe("postage settlement transitions", () => {
+    const recipient = `G${"A".repeat(55)}`;
+    const sender = `G${"B".repeat(55)}`;
+    const messageId = "a".repeat(64);
+
+    const pendingPostage: Postage = {
+      amount: "100",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      messageId,
+      paymentHash: "c".repeat(64),
+      recipient,
+      sender,
+      status: "pending",
+    };
+
+    it("round-trips postage via get/set", async () => {
+      expect(await coordinator.getPostage(messageId)).toBeNull();
+      await coordinator.setPostage(pendingPostage);
+      expect(await coordinator.getPostage(messageId)).toEqual(pendingPostage);
+    });
+
+    it("returns not-found when transitioning a record that was never set", async () => {
+      expect(await coordinator.transitionPostage(messageId, "pending", "settled")).toEqual({
+        outcome: "not-found",
+      });
+    });
+
+    it("applies a valid pending -> settled transition exactly once", async () => {
+      await coordinator.setPostage(pendingPostage);
+
+      const applied = await coordinator.transitionPostage(messageId, "pending", "settled");
+      expect(applied).toMatchObject({ outcome: "applied", postage: { status: "settled" } });
+
+      // A second attempt with the same expected status is now a conflict,
+      // not a second settlement.
+      const conflict = await coordinator.transitionPostage(messageId, "pending", "settled");
+      expect(conflict).toMatchObject({ outcome: "conflict", postage: { status: "settled" } });
+    });
+
+    it("only lets one of two concurrent settlement calls win", async () => {
+      await coordinator.setPostage(pendingPostage);
+
+      const [first, second] = await Promise.all([
+        coordinator.transitionPostage(messageId, "pending", "settled"),
+        coordinator.transitionPostage(messageId, "pending", "settled"),
+      ]);
+
+      const outcomes = [first.outcome, second.outcome].sort();
+      expect(outcomes).toEqual(["applied", "conflict"]);
+      expect(await coordinator.getPostage(messageId)).toMatchObject({ status: "settled" });
+    });
   });
 });


### PR DESCRIPTION
Fixes a check-then-act race in resolvePostage where concurrent settle/refund requests could both observe status: "pending" before either write landed, allowing double-settlement. Replaces the get-then-set with an atomic transitionPostage compare-and-swap, backed by explicit per-messageId locking in the Durable Object coordinator (KV alone can't provide CAS). Added concurrency tests (Promise.all/allSettled) proving exactly one winner under a race.
close #1545