### PR TITLE
feat(tooling): implement Non-UI execution contract for private-note-o…

### DIFF
--- a/tools/v2/individual/private-note-on-email/README.md
+++ b/tools/v2/individual/private-note-on-email/README.md
@@ -6,10 +6,18 @@ This folder is the isolated workspace for the Private Note on Email tool.
 
 All work for this tool must stay inside:
 
-`text
-.\tools\v2\individual\private-note-on-email\
+`
+tools/v2/individual/private-note-on-email/
 `
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 
-See specs.md for the issue categories and contributor expectations.
+## Execution Contract & Entry Points
+
+This tool exports a stable, non-UI execution contract:
+
+- `safeAttachPrivateNote(input: unknown, options?: unknown)`: Safe entry point for untrusted callers that validates inputs, sanitizes note text, enforces limits, and never throws.
+- `attachPrivateNote(input, options?)`: Pure deterministic service for attaching private notes to email messages.
+- `successFixtures` & `failureFixtures`: Comprehensive fixtures for integration testing.
+
+See [docs/contract.md](./docs/contract.md) for full input/output specifications, error codes, and service boundaries.

--- a/tools/v2/individual/private-note-on-email/README.md
+++ b/tools/v2/individual/private-note-on-email/README.md
@@ -6,9 +6,7 @@ This folder is the isolated workspace for the Private Note on Email tool.
 
 All work for this tool must stay inside:
 
-`
-tools/v2/individual/private-note-on-email/
-`
+`tools/v2/individual/private-note-on-email/`
 
 Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
 

--- a/tools/v2/individual/private-note-on-email/docs/contract.md
+++ b/tools/v2/individual/private-note-on-email/docs/contract.md
@@ -1,0 +1,73 @@
+# Non-UI Execution Contract: Private Note on Email
+
+## Service Boundaries
+
+| Entry point | Intended caller | Behavior |
+| --- | --- | --- |
+| `safeAttachPrivateNote(input: unknown, options?: unknown)` | API handlers, webhooks, untrusted callers | Validates, sanitizes, enforces limits, and never throws |
+| `attachPrivateNote(input, options?)` | Trusted internal code | Pure deterministic service; assumes valid input shape |
+
+The module is synchronous and has no UI, CSS, DOM, framework, database, network, wallet, or Stellar core dependencies.
+
+## Input & Output Contract
+
+### `PrivateNoteAttachmentInput`
+- `requestId`: `string` (caller-owned unique identifier)
+- `emailId`: `string` (target email identifier)
+- `emailSubject`?: `string` (optional email subject)
+- `emailSender`?: `string` (optional sender address)
+- `noteText`: `string` (body of the private note)
+- `importance`?: `"low" | "medium" | "high" | "urgent"` (default: `"medium"`)
+- `visibility`?: `"private" | "shared_with_team" | "confidential"` (default: `"private"`)
+- `tags`?: `string[]` (optional array of metadata tags)
+- `reminderAt`?: `string` (optional ISO 8601 reminder timestamp)
+
+### `PrivateNoteAttachmentOptions`
+- `maxNoteLength`?: `number` (max character length, default: 4000, max: 20000)
+- `maxTags`?: `number` (max tags count, default: 10, max: 50)
+- `autoTagKeywords`?: `boolean` (auto-extract key tags from note text, default: `true`)
+- `stripHtml`?: `boolean` (sanitize and strip HTML tags, default: `true`)
+
+### `PrivateNoteAttachmentOutput`
+- `requestId`: `string`
+- `emailId`: `string`
+- `noteId`: `string` (deterministic ID: `note_<emailId>_<hash>`)
+- `cleanNoteText`: `string` (sanitized plain-text note)
+- `importance`: `PrivateNoteImportance`
+- `visibility`: `PrivateNoteVisibility`
+- `tags`: `string[]` (lowercased, deduplicated tags)
+- `characterCount`: `number`
+- `wordCount`: `number`
+- `createdAt`: `string` (ISO 8601 timestamp)
+- `reminderAt`: `string | null`
+- `metadata`: `{ emailSubjectSnippet: string | null; emailSender: string | null; autoTagged: boolean }`
+
+The guarded entry point returns:
+```ts
+{ status: "ok", result: PrivateNoteAttachmentOutput }
+```
+
+Or on error:
+```ts
+{
+  status: "error";
+  code: PrivateNoteErrorCode;
+  message: string;
+  issues: PrivateNoteValidationIssue[];
+}
+```
+
+## Error Codes
+
+| Code | Meaning |
+| --- | --- |
+| `invalid-input` | Payload shape or field type is invalid |
+| `invalid-options` | Options are malformed or outside supported bounds |
+| `note-too-long` | `noteText` exceeds max character length limit |
+| `too-many-tags` | `tags` count exceeds maximum allowed tags limit |
+| `empty-note` | `noteText` is empty or whitespace-only after sanitization |
+
+## Fixtures
+
+`services/fixtures.ts` exports typed `successFixtures` and `failureFixtures`.
+Every failure fixture specifies its expected error code, making the contract reusable across backend adapters and test runners.

--- a/tools/v2/individual/private-note-on-email/docs/contract.md
+++ b/tools/v2/individual/private-note-on-email/docs/contract.md
@@ -2,16 +2,17 @@
 
 ## Service Boundaries
 
-| Entry point | Intended caller | Behavior |
-| --- | --- | --- |
+| Entry point                                                | Intended caller                           | Behavior                                                |
+| ---------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
 | `safeAttachPrivateNote(input: unknown, options?: unknown)` | API handlers, webhooks, untrusted callers | Validates, sanitizes, enforces limits, and never throws |
-| `attachPrivateNote(input, options?)` | Trusted internal code | Pure deterministic service; assumes valid input shape |
+| `attachPrivateNote(input, options?)`                       | Trusted internal code                     | Pure deterministic service; assumes valid input shape   |
 
 The module is synchronous and has no UI, CSS, DOM, framework, database, network, wallet, or Stellar core dependencies.
 
 ## Input & Output Contract
 
 ### `PrivateNoteAttachmentInput`
+
 - `requestId`: `string` (caller-owned unique identifier)
 - `emailId`: `string` (target email identifier)
 - `emailSubject`?: `string` (optional email subject)
@@ -23,12 +24,14 @@ The module is synchronous and has no UI, CSS, DOM, framework, database, network,
 - `reminderAt`?: `string` (optional ISO 8601 reminder timestamp)
 
 ### `PrivateNoteAttachmentOptions`
+
 - `maxNoteLength`?: `number` (max character length, default: 4000, max: 20000)
 - `maxTags`?: `number` (max tags count, default: 10, max: 50)
 - `autoTagKeywords`?: `boolean` (auto-extract key tags from note text, default: `true`)
 - `stripHtml`?: `boolean` (sanitize and strip HTML tags, default: `true`)
 
 ### `PrivateNoteAttachmentOutput`
+
 - `requestId`: `string`
 - `emailId`: `string`
 - `noteId`: `string` (deterministic ID: `note_<emailId>_<hash>`)
@@ -43,11 +46,13 @@ The module is synchronous and has no UI, CSS, DOM, framework, database, network,
 - `metadata`: `{ emailSubjectSnippet: string | null; emailSender: string | null; autoTagged: boolean }`
 
 The guarded entry point returns:
+
 ```ts
 { status: "ok", result: PrivateNoteAttachmentOutput }
 ```
 
 Or on error:
+
 ```ts
 {
   status: "error";
@@ -59,13 +64,13 @@ Or on error:
 
 ## Error Codes
 
-| Code | Meaning |
-| --- | --- |
-| `invalid-input` | Payload shape or field type is invalid |
-| `invalid-options` | Options are malformed or outside supported bounds |
-| `note-too-long` | `noteText` exceeds max character length limit |
-| `too-many-tags` | `tags` count exceeds maximum allowed tags limit |
-| `empty-note` | `noteText` is empty or whitespace-only after sanitization |
+| Code              | Meaning                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `invalid-input`   | Payload shape or field type is invalid                    |
+| `invalid-options` | Options are malformed or outside supported bounds         |
+| `note-too-long`   | `noteText` exceeds max character length limit             |
+| `too-many-tags`   | `tags` count exceeds maximum allowed tags limit           |
+| `empty-note`      | `noteText` is empty or whitespace-only after sanitization |
 
 ## Fixtures
 

--- a/tools/v2/individual/private-note-on-email/index.ts
+++ b/tools/v2/individual/private-note-on-email/index.ts
@@ -1,0 +1,28 @@
+export {
+  attachPrivateNote,
+  safeAttachPrivateNote,
+} from "./services/privateNoteOnEmail";
+
+export {
+  PRIVATE_NOTE_LIMITS,
+  checkPrivateNoteInputLimits,
+  sanitizePrivateNoteInput,
+  sanitizeText,
+  validatePrivateNoteInput,
+  validatePrivateNoteOptions,
+} from "./services/guards";
+
+export { failureFixtures, successFixtures } from "./services/fixtures";
+export type { PrivateNoteFailureFixture, PrivateNoteSuccessFixture } from "./services/fixtures";
+
+export type {
+  PrivateNoteAttachmentInput,
+  PrivateNoteAttachmentOptions,
+  PrivateNoteAttachmentOutput,
+  PrivateNoteErrorCode,
+  PrivateNoteImportance,
+  PrivateNoteMetadata,
+  PrivateNoteValidationIssue,
+  PrivateNoteVisibility,
+  SafePrivateNoteResult,
+} from "./types/privateNoteOnEmail";

--- a/tools/v2/individual/private-note-on-email/index.ts
+++ b/tools/v2/individual/private-note-on-email/index.ts
@@ -1,7 +1,4 @@
-export {
-  attachPrivateNote,
-  safeAttachPrivateNote,
-} from "./services/privateNoteOnEmail";
+export { attachPrivateNote, safeAttachPrivateNote } from "./services/privateNoteOnEmail";
 
 export {
   PRIVATE_NOTE_LIMITS,

--- a/tools/v2/individual/private-note-on-email/services/fixtures.ts
+++ b/tools/v2/individual/private-note-on-email/services/fixtures.ts
@@ -1,0 +1,182 @@
+import type {
+  PrivateNoteAttachmentInput,
+  PrivateNoteAttachmentOptions,
+  PrivateNoteErrorCode,
+} from "../types/privateNoteOnEmail";
+
+export interface PrivateNoteSuccessFixture {
+  name: string;
+  description: string;
+  input: PrivateNoteAttachmentInput;
+  options?: PrivateNoteAttachmentOptions;
+  expected: {
+    cleanNoteText: string;
+    importance: string;
+    visibility: string;
+    tagsContains?: string[];
+    hasReminder: boolean;
+  };
+}
+
+export interface PrivateNoteFailureFixture {
+  name: string;
+  description: string;
+  input: unknown;
+  options?: unknown;
+  expectedErrorCode: PrivateNoteErrorCode;
+}
+
+export const successFixtures: PrivateNoteSuccessFixture[] = [
+  {
+    name: "basic_note",
+    description: "Attaches a simple text note to an email with default settings",
+    input: {
+      requestId: "req_basic_001",
+      emailId: "msg_1001",
+      emailSubject: "Project Update Q3",
+      emailSender: "alice@example.com",
+      noteText: "Discuss budget allocation during tomorrow's sync.",
+    },
+    expected: {
+      cleanNoteText: "Discuss budget allocation during tomorrow's sync.",
+      importance: "medium",
+      visibility: "private",
+      hasReminder: false,
+    },
+  },
+  {
+    name: "urgent_confidential_note_with_reminder",
+    description: "Attaches an urgent confidential note with custom tags and a reminder",
+    input: {
+      requestId: "req_urgent_002",
+      emailId: "msg_1002",
+      emailSubject: "Quarterly Audit Confidential",
+      emailSender: "cfo@example.com",
+      noteText: "Review financial disclosures before board presentation.",
+      importance: "urgent",
+      visibility: "confidential",
+      tags: ["finance", "audit"],
+      reminderAt: "2026-08-01T09:00:00.000Z",
+    },
+    options: {
+      autoTagKeywords: true,
+    },
+    expected: {
+      cleanNoteText: "Review financial disclosures before board presentation.",
+      importance: "urgent",
+      visibility: "confidential",
+      tagsContains: ["finance", "audit", "review"],
+      hasReminder: true,
+    },
+  },
+  {
+    name: "html_sanitization_note",
+    description: "Strips HTML tags and normalizes spacing in note text",
+    input: {
+      requestId: "req_html_003",
+      emailId: "msg_1003",
+      noteText: "<p>Important: <b>Verify invoice details</b> before sending payment!</p>",
+      emailSubject: "Invoice #9920",
+    },
+    options: {
+      stripHtml: true,
+    },
+    expected: {
+      cleanNoteText: "Important: Verify invoice details before sending payment!",
+      importance: "medium",
+      visibility: "private",
+      hasReminder: false,
+    },
+  },
+  {
+    name: "autotag_extraction_note",
+    description: "Automatically extracts keyword tags when enabled",
+    input: {
+      requestId: "req_autotag_004",
+      emailId: "msg_1004",
+      noteText: "Urgent follow-up needed for contract approval meeting.",
+    },
+    options: {
+      autoTagKeywords: true,
+    },
+    expected: {
+      cleanNoteText: "Urgent follow-up needed for contract approval meeting.",
+      importance: "medium",
+      visibility: "private",
+      tagsContains: ["urgent", "followup", "approval", "meeting"],
+      hasReminder: false,
+    },
+  },
+];
+
+export const failureFixtures: PrivateNoteFailureFixture[] = [
+  {
+    name: "invalid_input_missing_required_fields",
+    description: "Fails validation when requestId or emailId is missing",
+    input: {
+      noteText: "Orphan note without email ID",
+    },
+    expectedErrorCode: "invalid-input",
+  },
+  {
+    name: "invalid_input_wrong_field_types",
+    description: "Fails validation when noteText is not a string or importance is invalid",
+    input: {
+      requestId: "req_fail_002",
+      emailId: "msg_2002",
+      noteText: 12345,
+      importance: "super-critical",
+    },
+    expectedErrorCode: "invalid-input",
+  },
+  {
+    name: "invalid_options_out_of_bounds",
+    description: "Fails validation when maxNoteLength option is non-integer or negative",
+    input: {
+      requestId: "req_fail_003",
+      emailId: "msg_2003",
+      noteText: "Valid note text",
+    },
+    options: {
+      maxNoteLength: -10,
+    },
+    expectedErrorCode: "invalid-options",
+  },
+  {
+    name: "empty_note_text",
+    description: "Fails limit check when noteText is whitespace-only",
+    input: {
+      requestId: "req_fail_004",
+      emailId: "msg_2004",
+      noteText: "   \n\t  ",
+    },
+    expectedErrorCode: "empty-note",
+  },
+  {
+    name: "note_too_long",
+    description: "Fails limit check when noteText exceeds specified maxNoteLength limit",
+    input: {
+      requestId: "req_fail_005",
+      emailId: "msg_2005",
+      noteText: "This note text exceeds the small length limit set in options.",
+    },
+    options: {
+      maxNoteLength: 20,
+    },
+    expectedErrorCode: "note-too-long",
+  },
+  {
+    name: "too_many_tags",
+    description: "Fails limit check when tags array count exceeds maxTags option limit",
+    input: {
+      requestId: "req_fail_006",
+      emailId: "msg_2006",
+      noteText: "Note with too many tags",
+      tags: ["tag1", "tag2", "tag3", "tag4", "tag5"],
+    },
+    options: {
+      maxTags: 3,
+    },
+    expectedErrorCode: "too-many-tags",
+  },
+];

--- a/tools/v2/individual/private-note-on-email/services/guards.ts
+++ b/tools/v2/individual/private-note-on-email/services/guards.ts
@@ -1,0 +1,238 @@
+import type {
+  PrivateNoteAttachmentInput,
+  PrivateNoteAttachmentOptions,
+  PrivateNoteErrorCode,
+  PrivateNoteValidationIssue,
+  SafePrivateNoteResult,
+} from "../types/privateNoteOnEmail";
+
+export const PRIVATE_NOTE_LIMITS = {
+  DEFAULT_MAX_NOTE_LENGTH: 4000,
+  MAX_NOTE_LENGTH_LIMIT: 20000,
+  DEFAULT_MAX_TAGS: 10,
+  MAX_TAGS_LIMIT: 50,
+} as const;
+
+export function sanitizeText(text: string, stripHtml: boolean = true): string {
+  let cleaned = text || "";
+  if (stripHtml) {
+    cleaned = cleaned.replace(/<[^>]*>/g, " ");
+  }
+  return cleaned.replace(/\s+/g, " ").trim();
+}
+
+export function validatePrivateNoteInput(input: unknown): {
+  valid: boolean;
+  issues: PrivateNoteValidationIssue[];
+} {
+  const issues: PrivateNoteValidationIssue[] = [];
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      valid: false,
+      issues: [{ field: "input", message: "Input must be a valid non-array object" }],
+    };
+  }
+
+  const record = input as Record<string, unknown>;
+
+  if (typeof record.requestId !== "string" || !record.requestId.trim()) {
+    issues.push({
+      field: "requestId",
+      message: "requestId is required and must be a non-empty string",
+    });
+  }
+
+  if (typeof record.emailId !== "string" || !record.emailId.trim()) {
+    issues.push({
+      field: "emailId",
+      message: "emailId is required and must be a non-empty string",
+    });
+  }
+
+  if (typeof record.noteText !== "string") {
+    issues.push({
+      field: "noteText",
+      message: "noteText is required and must be a string",
+    });
+  }
+
+  if (record.emailSubject !== undefined && typeof record.emailSubject !== "string") {
+    issues.push({
+      field: "emailSubject",
+      message: "emailSubject must be a string if provided",
+    });
+  }
+
+  if (record.emailSender !== undefined && typeof record.emailSender !== "string") {
+    issues.push({
+      field: "emailSender",
+      message: "emailSender must be a string if provided",
+    });
+  }
+
+  if (record.importance !== undefined) {
+    const validImportances = ["low", "medium", "high", "urgent"];
+    if (!validImportances.includes(record.importance as string)) {
+      issues.push({
+        field: "importance",
+        message: `importance must be one of: ${validImportances.join(", ")}`,
+      });
+    }
+  }
+
+  if (record.visibility !== undefined) {
+    const validVisibilities = ["private", "shared_with_team", "confidential"];
+    if (!validVisibilities.includes(record.visibility as string)) {
+      issues.push({
+        field: "visibility",
+        message: `visibility must be one of: ${validVisibilities.join(", ")}`,
+      });
+    }
+  }
+
+  if (record.tags !== undefined) {
+    if (!Array.isArray(record.tags) || !record.tags.every((t) => typeof t === "string")) {
+      issues.push({
+        field: "tags",
+        message: "tags must be an array of strings if provided",
+      });
+    }
+  }
+
+  if (record.reminderAt !== undefined) {
+    if (typeof record.reminderAt !== "string" || isNaN(Date.parse(record.reminderAt))) {
+      issues.push({
+        field: "reminderAt",
+        message: "reminderAt must be a valid ISO date string if provided",
+      });
+    }
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+export function validatePrivateNoteOptions(options: unknown): {
+  valid: boolean;
+  issues: PrivateNoteValidationIssue[];
+} {
+  if (options === undefined || options === null) {
+    return { valid: true, issues: [] };
+  }
+
+  if (typeof options !== "object" || Array.isArray(options)) {
+    return {
+      valid: false,
+      issues: [{ field: "options", message: "Options must be a valid non-array object" }],
+    };
+  }
+
+  const issues: PrivateNoteValidationIssue[] = [];
+  const record = options as Record<string, unknown>;
+
+  if (record.maxNoteLength !== undefined) {
+    if (
+      typeof record.maxNoteLength !== "number" ||
+      !Number.isInteger(record.maxNoteLength) ||
+      record.maxNoteLength < 1 ||
+      record.maxNoteLength > PRIVATE_NOTE_LIMITS.MAX_NOTE_LENGTH_LIMIT
+    ) {
+      issues.push({
+        field: "maxNoteLength",
+        message: `maxNoteLength must be an integer between 1 and ${PRIVATE_NOTE_LIMITS.MAX_NOTE_LENGTH_LIMIT}`,
+      });
+    }
+  }
+
+  if (record.maxTags !== undefined) {
+    if (
+      typeof record.maxTags !== "number" ||
+      !Number.isInteger(record.maxTags) ||
+      record.maxTags < 1 ||
+      record.maxTags > PRIVATE_NOTE_LIMITS.MAX_TAGS_LIMIT
+    ) {
+      issues.push({
+        field: "maxTags",
+        message: `maxTags must be an integer between 1 and ${PRIVATE_NOTE_LIMITS.MAX_TAGS_LIMIT}`,
+      });
+    }
+  }
+
+  if (record.autoTagKeywords !== undefined && typeof record.autoTagKeywords !== "boolean") {
+    issues.push({
+      field: "autoTagKeywords",
+      message: "autoTagKeywords must be a boolean if provided",
+    });
+  }
+
+  if (record.stripHtml !== undefined && typeof record.stripHtml !== "boolean") {
+    issues.push({
+      field: "stripHtml",
+      message: "stripHtml must be a boolean if provided",
+    });
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+export function sanitizePrivateNoteInput(
+  input: PrivateNoteAttachmentInput,
+  stripHtml: boolean = true
+): PrivateNoteAttachmentInput {
+  const cleanNoteText = sanitizeText(input.noteText, stripHtml);
+  const cleanSubject = input.emailSubject ? sanitizeText(input.emailSubject, stripHtml) : undefined;
+  const cleanSender = input.emailSender ? sanitizeText(input.emailSender, stripHtml) : undefined;
+
+  const cleanTags = input.tags
+    ? input.tags
+        .map((tag) => tag.trim().toLowerCase().replace(/[^a-z0-9_-]/g, ""))
+        .filter((tag) => tag.length > 0)
+    : undefined;
+
+  return {
+    ...input,
+    requestId: input.requestId.trim(),
+    emailId: input.emailId.trim(),
+    emailSubject: cleanSubject,
+    emailSender: cleanSender,
+    noteText: cleanNoteText,
+    tags: cleanTags,
+  };
+}
+
+export function checkPrivateNoteInputLimits(
+  input: PrivateNoteAttachmentInput,
+  options?: PrivateNoteAttachmentOptions
+): { ok: boolean; code?: PrivateNoteErrorCode; message?: string; issues?: PrivateNoteValidationIssue[] } {
+  const maxLen = options?.maxNoteLength ?? PRIVATE_NOTE_LIMITS.DEFAULT_MAX_NOTE_LENGTH;
+  const maxTags = options?.maxTags ?? PRIVATE_NOTE_LIMITS.DEFAULT_MAX_TAGS;
+
+  if (!input.noteText || input.noteText.trim().length === 0) {
+    return {
+      ok: false,
+      code: "empty-note",
+      message: "Private note text is empty or contains only whitespace",
+      issues: [{ field: "noteText", message: "noteText cannot be empty" }],
+    };
+  }
+
+  if (input.noteText.length > maxLen) {
+    return {
+      ok: false,
+      code: "note-too-long",
+      message: `Note text length (${input.noteText.length}) exceeds maximum allowed limit (${maxLen})`,
+      issues: [{ field: "noteText", message: `noteText exceeds limit of ${maxLen} characters` }],
+    };
+  }
+
+  if (input.tags && input.tags.length > maxTags) {
+    return {
+      ok: false,
+      code: "too-many-tags",
+      message: `Number of tags (${input.tags.length}) exceeds maximum allowed limit (${maxTags})`,
+      issues: [{ field: "tags", message: `tags count exceeds limit of ${maxTags}` }],
+    };
+  }
+
+  return { ok: true };
+}

--- a/tools/v2/individual/private-note-on-email/services/guards.ts
+++ b/tools/v2/individual/private-note-on-email/services/guards.ts
@@ -177,7 +177,7 @@ export function validatePrivateNoteOptions(options: unknown): {
 
 export function sanitizePrivateNoteInput(
   input: PrivateNoteAttachmentInput,
-  stripHtml: boolean = true
+  stripHtml: boolean = true,
 ): PrivateNoteAttachmentInput {
   const cleanNoteText = sanitizeText(input.noteText, stripHtml);
   const cleanSubject = input.emailSubject ? sanitizeText(input.emailSubject, stripHtml) : undefined;
@@ -185,7 +185,12 @@ export function sanitizePrivateNoteInput(
 
   const cleanTags = input.tags
     ? input.tags
-        .map((tag) => tag.trim().toLowerCase().replace(/[^a-z0-9_-]/g, ""))
+        .map((tag) =>
+          tag
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9_-]/g, ""),
+        )
         .filter((tag) => tag.length > 0)
     : undefined;
 
@@ -202,8 +207,13 @@ export function sanitizePrivateNoteInput(
 
 export function checkPrivateNoteInputLimits(
   input: PrivateNoteAttachmentInput,
-  options?: PrivateNoteAttachmentOptions
-): { ok: boolean; code?: PrivateNoteErrorCode; message?: string; issues?: PrivateNoteValidationIssue[] } {
+  options?: PrivateNoteAttachmentOptions,
+): {
+  ok: boolean;
+  code?: PrivateNoteErrorCode;
+  message?: string;
+  issues?: PrivateNoteValidationIssue[];
+} {
   const maxLen = options?.maxNoteLength ?? PRIVATE_NOTE_LIMITS.DEFAULT_MAX_NOTE_LENGTH;
   const maxTags = options?.maxTags ?? PRIVATE_NOTE_LIMITS.DEFAULT_MAX_TAGS;
 

--- a/tools/v2/individual/private-note-on-email/services/privateNoteOnEmail.ts
+++ b/tools/v2/individual/private-note-on-email/services/privateNoteOnEmail.ts
@@ -1,0 +1,164 @@
+import type {
+  PrivateNoteAttachmentInput,
+  PrivateNoteAttachmentOptions,
+  PrivateNoteAttachmentOutput,
+  PrivateNoteImportance,
+  PrivateNoteVisibility,
+  SafePrivateNoteResult,
+} from "../types/privateNoteOnEmail";
+import {
+  checkPrivateNoteInputLimits,
+  sanitizePrivateNoteInput,
+  validatePrivateNoteInput,
+  validatePrivateNoteOptions,
+} from "./guards";
+
+function generateHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+function extractAutoKeywords(text: string): string[] {
+  const commonKeywords = [
+    "urgent",
+    "followup",
+    "follow-up",
+    "action",
+    "todo",
+    "meeting",
+    "deadline",
+    "review",
+    "approval",
+    "invoice",
+    "payment",
+    "confidential",
+    "vip",
+  ];
+  const lowerText = text.toLowerCase();
+  const matched = commonKeywords.filter((kw) => lowerText.includes(kw));
+  return matched.map((kw) => (kw === "follow-up" ? "followup" : kw));
+}
+
+export function attachPrivateNote(
+  input: PrivateNoteAttachmentInput,
+  options?: PrivateNoteAttachmentOptions
+): PrivateNoteAttachmentOutput {
+  const stripHtml = options?.stripHtml ?? true;
+  const sanitizedInput = sanitizePrivateNoteInput(input, stripHtml);
+
+  const importance: PrivateNoteImportance = sanitizedInput.importance ?? "medium";
+  const visibility: PrivateNoteVisibility = sanitizedInput.visibility ?? "private";
+
+  let finalTags: string[] = sanitizedInput.tags ? [...sanitizedInput.tags] : [];
+
+  let autoTagged = false;
+  if (options?.autoTagKeywords !== false) {
+    const autoKeywords = extractAutoKeywords(sanitizedInput.noteText);
+    if (autoKeywords.length > 0) {
+      const tagSet = new Set([...finalTags, ...autoKeywords]);
+      finalTags = Array.from(tagSet);
+      autoTagged = true;
+    }
+  }
+
+  // Deduplicate and trim tags
+  finalTags = Array.from(new Set(finalTags.map((t) => t.trim().toLowerCase()))).filter(
+    (t) => t.length > 0
+  );
+
+  const words = sanitizedInput.noteText.split(/\s+/).filter((w) => w.length > 0);
+  const wordCount = words.length;
+  const characterCount = sanitizedInput.noteText.length;
+
+  const contentHash = generateHash(`${sanitizedInput.emailId}:${sanitizedInput.noteText}`);
+  const noteId = `note_${sanitizedInput.emailId}_${contentHash}`;
+
+  const nowIso = new Date().toISOString();
+  const reminderAt = sanitizedInput.reminderAt ? new Date(sanitizedInput.reminderAt).toISOString() : null;
+
+  const subjectSnippet = sanitizedInput.emailSubject
+    ? sanitizedInput.emailSubject.length > 60
+      ? `${sanitizedInput.emailSubject.slice(0, 57)}...`
+      : sanitizedInput.emailSubject
+    : null;
+
+  return {
+    requestId: sanitizedInput.requestId,
+    emailId: sanitizedInput.emailId,
+    noteId,
+    cleanNoteText: sanitizedInput.noteText,
+    importance,
+    visibility,
+    tags: finalTags,
+    characterCount,
+    wordCount,
+    createdAt: nowIso,
+    reminderAt,
+    metadata: {
+      emailSubjectSnippet: subjectSnippet,
+      emailSender: sanitizedInput.emailSender ?? null,
+      autoTagged,
+    },
+  };
+}
+
+export function safeAttachPrivateNote(
+  input: unknown,
+  options?: unknown
+): SafePrivateNoteResult {
+  const inputValidation = validatePrivateNoteInput(input);
+  if (!inputValidation.valid) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: "Private note input payload validation failed",
+      issues: inputValidation.issues,
+    };
+  }
+
+  const optionsValidation = validatePrivateNoteOptions(options);
+  if (!optionsValidation.valid) {
+    return {
+      status: "error",
+      code: "invalid-options",
+      message: "Private note options validation failed",
+      issues: optionsValidation.issues,
+    };
+  }
+
+  const typedInput = input as PrivateNoteAttachmentInput;
+  const typedOptions = options as PrivateNoteAttachmentOptions | undefined;
+
+  const stripHtml = typedOptions?.stripHtml ?? true;
+  const sanitizedInput = sanitizePrivateNoteInput(typedInput, stripHtml);
+
+  const limitsCheck = checkPrivateNoteInputLimits(sanitizedInput, typedOptions);
+  if (!limitsCheck.ok) {
+    return {
+      status: "error",
+      code: limitsCheck.code!,
+      message: limitsCheck.message!,
+      issues: limitsCheck.issues ?? [],
+    };
+  }
+
+  try {
+    const result = attachPrivateNote(sanitizedInput, typedOptions);
+    return {
+      status: "ok",
+      result,
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      code: "invalid-input",
+      message: err instanceof Error ? err.message : "Unexpected error processing private note",
+      issues: [{ field: "input", message: "Unexpected failure during execution" }],
+    };
+  }
+}

--- a/tools/v2/individual/private-note-on-email/services/privateNoteOnEmail.ts
+++ b/tools/v2/individual/private-note-on-email/services/privateNoteOnEmail.ts
@@ -46,7 +46,7 @@ function extractAutoKeywords(text: string): string[] {
 
 export function attachPrivateNote(
   input: PrivateNoteAttachmentInput,
-  options?: PrivateNoteAttachmentOptions
+  options?: PrivateNoteAttachmentOptions,
 ): PrivateNoteAttachmentOutput {
   const stripHtml = options?.stripHtml ?? true;
   const sanitizedInput = sanitizePrivateNoteInput(input, stripHtml);
@@ -68,7 +68,7 @@ export function attachPrivateNote(
 
   // Deduplicate and trim tags
   finalTags = Array.from(new Set(finalTags.map((t) => t.trim().toLowerCase()))).filter(
-    (t) => t.length > 0
+    (t) => t.length > 0,
   );
 
   const words = sanitizedInput.noteText.split(/\s+/).filter((w) => w.length > 0);
@@ -79,7 +79,9 @@ export function attachPrivateNote(
   const noteId = `note_${sanitizedInput.emailId}_${contentHash}`;
 
   const nowIso = new Date().toISOString();
-  const reminderAt = sanitizedInput.reminderAt ? new Date(sanitizedInput.reminderAt).toISOString() : null;
+  const reminderAt = sanitizedInput.reminderAt
+    ? new Date(sanitizedInput.reminderAt).toISOString()
+    : null;
 
   const subjectSnippet = sanitizedInput.emailSubject
     ? sanitizedInput.emailSubject.length > 60
@@ -107,10 +109,7 @@ export function attachPrivateNote(
   };
 }
 
-export function safeAttachPrivateNote(
-  input: unknown,
-  options?: unknown
-): SafePrivateNoteResult {
+export function safeAttachPrivateNote(input: unknown, options?: unknown): SafePrivateNoteResult {
   const inputValidation = validatePrivateNoteInput(input);
   if (!inputValidation.valid) {
     return {

--- a/tools/v2/individual/private-note-on-email/tests/privateNoteOnEmail.test.ts
+++ b/tools/v2/individual/private-note-on-email/tests/privateNoteOnEmail.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachPrivateNote,
+  failureFixtures,
+  PRIVATE_NOTE_LIMITS,
+  safeAttachPrivateNote,
+  sanitizeText,
+  successFixtures,
+  validatePrivateNoteInput,
+  validatePrivateNoteOptions,
+} from "../index";
+
+describe("Private Note on Email - Non-UI Execution Contract", () => {
+  describe("Sanitization & Guards", () => {
+    it("strips HTML tags and normalizes whitespace", () => {
+      const dirty = "<div>Hello   <b>world</b>!   \n\n   New line</div>";
+      const clean = sanitizeText(dirty, true);
+      expect(clean).toBe("Hello world ! New line");
+    });
+
+    it("validates input structure and required fields", () => {
+      const result = validatePrivateNoteInput({ noteText: "Valid text" });
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: "requestId" }),
+          expect.objectContaining({ field: "emailId" }),
+        ])
+      );
+    });
+
+    it("validates options bounds", () => {
+      const result = validatePrivateNoteOptions({ maxNoteLength: 999999 });
+      expect(result.valid).toBe(false);
+      expect(result.issues[0].field).toBe("maxNoteLength");
+    });
+  });
+
+  describe("Pure Service: attachPrivateNote", () => {
+    it("attaches a private note deterministically with metadata and word counts", () => {
+      const output = attachPrivateNote({
+        requestId: "req_test_01",
+        emailId: "email_abc123",
+        emailSubject: "Quarterly Review Sync",
+        emailSender: "bob@example.com",
+        noteText: "Action item: Prepare Q3 metrics slides.",
+        importance: "high",
+        visibility: "private",
+        tags: ["ActionItem", "Metrics"],
+      });
+
+      expect(output.requestId).toBe("req_test_01");
+      expect(output.emailId).toBe("email_abc123");
+      expect(output.noteId).toMatch(/^note_email_abc123_/);
+      expect(output.cleanNoteText).toBe("Action item: Prepare Q3 metrics slides.");
+      expect(output.importance).toBe("high");
+      expect(output.visibility).toBe("private");
+      expect(output.tags).toEqual(["actionitem", "metrics", "action"]);
+      expect(output.characterCount).toBe(39);
+      expect(output.wordCount).toBe(6);
+      expect(output.metadata.emailSubjectSnippet).toBe("Quarterly Review Sync");
+      expect(output.metadata.emailSender).toBe("bob@example.com");
+      expect(output.metadata.autoTagged).toBe(true);
+      expect(Date.parse(output.createdAt)).not.toBeNaN();
+    });
+  });
+
+  describe("Guarded Service: safeAttachPrivateNote", () => {
+    it("executes safely and returns status ok for valid inputs", () => {
+      const res = safeAttachPrivateNote({
+        requestId: "req_safe_01",
+        emailId: "email_safe_100",
+        noteText: "Check contract terms before signing.",
+      });
+
+      expect(res.status).toBe("ok");
+      if (res.status === "ok") {
+        expect(res.result.cleanNoteText).toBe("Check contract terms before signing.");
+        expect(res.result.importance).toBe("medium");
+      }
+    });
+
+    it("never throws when receiving arbitrary untrusted inputs", () => {
+      expect(() => safeAttachPrivateNote(null)).not.toThrow();
+      expect(() => safeAttachPrivateNote(undefined)).not.toThrow();
+      expect(() => safeAttachPrivateNote("string_instead_of_object")).not.toThrow();
+      expect(() => safeAttachPrivateNote([], { maxNoteLength: "invalid" })).not.toThrow();
+    });
+  });
+
+  describe("Fixture Driven Verification", () => {
+    it("passes all successFixtures", () => {
+      for (const fixture of successFixtures) {
+        const res = safeAttachPrivateNote(fixture.input, fixture.options);
+        expect(res.status, `Fixture ${fixture.name} should succeed`).toBe("ok");
+        if (res.status === "ok") {
+          expect(res.result.cleanNoteText).toBe(fixture.expected.cleanNoteText);
+          expect(res.result.importance).toBe(fixture.expected.importance);
+          expect(res.result.visibility).toBe(fixture.expected.visibility);
+          if (fixture.expected.tagsContains) {
+            for (const tag of fixture.expected.tagsContains) {
+              expect(res.result.tags).toContain(tag);
+            }
+          }
+          if (fixture.expected.hasReminder) {
+            expect(res.result.reminderAt).not.toBeNull();
+          } else {
+            expect(res.result.reminderAt).toBeNull();
+          }
+        }
+      }
+    });
+
+    it("fails with expected error codes for all failureFixtures", () => {
+      for (const fixture of failureFixtures) {
+        const res = safeAttachPrivateNote(fixture.input, fixture.options);
+        expect(res.status, `Fixture ${fixture.name} should return error`).toBe("error");
+        if (res.status === "error") {
+          expect(res.code, `Fixture ${fixture.name} error code`).toBe(fixture.expectedErrorCode);
+          expect(res.issues.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+});

--- a/tools/v2/individual/private-note-on-email/tests/privateNoteOnEmail.test.ts
+++ b/tools/v2/individual/private-note-on-email/tests/privateNoteOnEmail.test.ts
@@ -25,7 +25,7 @@ describe("Private Note on Email - Non-UI Execution Contract", () => {
         expect.arrayContaining([
           expect.objectContaining({ field: "requestId" }),
           expect.objectContaining({ field: "emailId" }),
-        ])
+        ]),
       );
     });
 

--- a/tools/v2/individual/private-note-on-email/types/privateNoteOnEmail.ts
+++ b/tools/v2/individual/private-note-on-email/types/privateNoteOnEmail.ts
@@ -1,0 +1,67 @@
+export type PrivateNoteImportance = "low" | "medium" | "high" | "urgent";
+
+export type PrivateNoteVisibility = "private" | "shared_with_team" | "confidential";
+
+export interface PrivateNoteAttachmentInput {
+  requestId: string;
+  emailId: string;
+  emailSubject?: string;
+  emailSender?: string;
+  noteText: string;
+  importance?: PrivateNoteImportance;
+  visibility?: PrivateNoteVisibility;
+  tags?: string[];
+  reminderAt?: string;
+}
+
+export interface PrivateNoteAttachmentOptions {
+  maxNoteLength?: number;
+  maxTags?: number;
+  autoTagKeywords?: boolean;
+  stripHtml?: boolean;
+}
+
+export interface PrivateNoteMetadata {
+  emailSubjectSnippet: string | null;
+  emailSender: string | null;
+  autoTagged: boolean;
+}
+
+export interface PrivateNoteAttachmentOutput {
+  requestId: string;
+  emailId: string;
+  noteId: string;
+  cleanNoteText: string;
+  importance: PrivateNoteImportance;
+  visibility: PrivateNoteVisibility;
+  tags: string[];
+  characterCount: number;
+  wordCount: number;
+  createdAt: string;
+  reminderAt: string | null;
+  metadata: PrivateNoteMetadata;
+}
+
+export type PrivateNoteErrorCode =
+  | "invalid-input"
+  | "invalid-options"
+  | "note-too-long"
+  | "too-many-tags"
+  | "empty-note";
+
+export interface PrivateNoteValidationIssue {
+  field: string;
+  message: string;
+}
+
+export type SafePrivateNoteResult =
+  | {
+      status: "ok";
+      result: PrivateNoteAttachmentOutput;
+    }
+  | {
+      status: "error";
+      code: PrivateNoteErrorCode;
+      message: string;
+      issues: PrivateNoteValidationIssue[];
+    };


### PR DESCRIPTION
closes #1380  

 ## 📝 Overview
    
    This PR establishes a stable, non-UI backend execution contract for the `private-note-on-email` tool in private-note-on-email.
    
    It provides typed inputs and outputs, input validation and sanitization guards, deterministic service execution, comprehensive success/failure fixtures, unit tests, and contract documentation, allowing the tool to run independently
  of UI or presentation logic.
    
    ---
    
    ## 🎯 Problem Statement
    
    The `private-note-on-email` tool previously lacked a dedicated backend execution contract and entry points. Establishing a non-UI service boundary allows backend jobs, API endpoints, webhooks, and background workers to attach
  private notes to email messages safely without framework, DOM, or visual presentation dependencies.
    
    ---
    
    ## 🚀 Key Changes

    ### 1. Typed Inputs & Outputs (privateNoteOnEmail.ts)
    * **`PrivateNoteAttachmentInput`**: Requires caller `requestId`, `emailId`, `noteText`. Optional `emailSubject`, `emailSender`, `importance`, `visibility`, `tags`, `reminderAt`.
    * **`PrivateNoteAttachmentOptions`**: Controls `maxNoteLength`, `maxTags`, `autoTagKeywords`, and `stripHtml`.
    * **`PrivateNoteAttachmentOutput`**: Returns echoed `requestId`, `emailId`, generated `noteId`, `cleanNoteText`, resolved `importance` & `visibility`, deduplicated `tags`, `characterCount`, `wordCount`, `createdAt`, `reminderAt`,
  and `metadata`.
    * **`SafePrivateNoteResult`**: Discriminated union returning `{ status: "ok"; result }` or `{ status: "error"; code; message; issues }`.

    ### 2. Guard & Sanitization Layer (guards.ts)
    * **Input & Options Validation**: `validatePrivateNoteInput` and `validatePrivateNoteOptions` validate payload structure and option bounds.
    * **Sanitization**: `sanitizeText` strips HTML tags and normalizes whitespace. `sanitizePrivateNoteInput` lowercases and cleans tags.
    * **Limits Enforcement**: `checkPrivateNoteInputLimits` enforces character length limits (`maxNoteLength`) and tag limits (`maxTags`).

    ### 3. Service Entry Points (privateNoteOnEmail.ts)
    * **`safeAttachPrivateNote(input, options)`**: Safe, non-throwing entry point for untrusted callers.
    * **`attachPrivateNote(input, options)`**: Pure deterministic service for trusted internal usage.

    ### 4. Fixture Suite (fixtures.ts)
    * **`successFixtures`**: Covers standard notes, urgent/confidential notes with reminders, HTML sanitization notes, and keyword auto-tagging.
    * **`failureFixtures`**: Covers `invalid-input`, `invalid-options`, `empty-note`, `note-too-long`, and `too-many-tags` error codes.

    ### 5. Documentation & Index (contract.md & index.ts)
    * Exported all public types, entry points, limits, and fixtures via `index.ts`.
    * Documented service boundaries, error codes, and input/output contracts in `docs/contract.md` and `README.md`.

    ---

    ## ✅ Acceptance Criteria Checklist

    - [x] **Typed input and output contract is documented**: Fully documented in `docs/contract.md` and `README.md`.
    - [x] **Non-UI service entry point is exported**: `safeAttachPrivateNote` and `attachPrivateNote` exported from `index.ts`.
    - [x] **Fixtures cover success and failure cases**: `successFixtures` and `failureFixtures` exported and verified.
    - [x] **No styling or layout files are changed**: All changes isolated within `tools/v2/individual/private-note-on-email/`.

    ---

    ## 🧪 Verification & Unit Test Results

    ```bash
    npx vitest run tools/v2/individual/private-note-on-email/tests/privateNoteOnEmail.test.ts
    # Result: 8 passed (8 test cases, 100% pass rate)
