### PR TITLE
Document storage key migration rules for the receipts contract

### DIFF
--- a/contracts/soroban/receipts/README.md
+++ b/contracts/soroban/receipts/README.md
@@ -25,6 +25,14 @@ topic layout, data encoding, ordering, and stability guarantees for off-chain
 consumers — is documented in `docs/events.md` and pinned by the
 `event_schema` tests in `src/lib.rs`.
 
+## Storage
+
+`DataKey::Guard` (instance storage) and `DataKey::Receipt(message_id)` (persistent
+storage) are the contract's only storage keys. Their encoding, backward-compatible
+evolution rules, and migration plan for a future key-structure change are
+documented in `docs/storage.md` and pinned by the `storage_keys` tests in
+`src/lib.rs`.
+
 ## Authorization boundaries
 
 - `delivered` requires the sender's authorization, and the signature is bound

--- a/contracts/soroban/receipts/docs/storage.md
+++ b/contracts/soroban/receipts/docs/storage.md
@@ -3,10 +3,10 @@
 The receipts contract uses two Soroban storage spaces, keyed by the `DataKey` enum
 defined in `src/lib.rs`.
 
-| Variant                | Storage space | Written by                    | Read by                              |
-| ----------------------- | -------------- | ------------------------------ | -------------------------------------- |
-| `DataKey::Guard`        | Instance       | `configure_guard` (once)       | `guard`, `delivered`, `read`           |
-| `DataKey::Receipt(id)`  | Persistent     | `delivered` (first write only) | `delivered`, `read`, `get`             |
+| Variant                | Storage space | Written by                     | Read by                      |
+| ---------------------- | ------------- | ------------------------------ | ---------------------------- |
+| `DataKey::Guard`       | Instance      | `configure_guard` (once)       | `guard`, `delivered`, `read` |
+| `DataKey::Receipt(id)` | Persistent    | `delivered` (first write only) | `delivered`, `read`, `get`   |
 
 `Guard` is a single, contract-wide configuration value set at most once
 (`GuardAlreadyConfigured` on a second call). `Receipt(id)` is keyed by the 32-byte
@@ -17,9 +17,9 @@ storage space.
 ## How `DataKey` is encoded
 
 Soroban's `#[contracttype]` derive encodes each enum variant as a host vector whose
-first element is a `Symbol` built from the variant's Rust *name* (`"Guard"`,
+first element is a `Symbol` built from the variant's Rust _name_ (`"Guard"`,
 `"Receipt"`), followed by any tuple fields. Decoding looks up a previously-written
-key by that name among the enum's *current* variants — the numeric declaration
+key by that name among the enum's _current_ variants — the numeric declaration
 order plays no part in the encoding. Concretely, this means:
 
 - **Renaming or removing a variant that has ever written storage is unsafe.** The

--- a/contracts/soroban/receipts/docs/storage.md
+++ b/contracts/soroban/receipts/docs/storage.md
@@ -1,0 +1,59 @@
+# Receipts Contract — Storage Layout & Migration Notes
+
+The receipts contract uses two Soroban storage spaces, keyed by the `DataKey` enum
+defined in `src/lib.rs`.
+
+| Variant                | Storage space | Written by                    | Read by                              |
+| ----------------------- | -------------- | ------------------------------ | -------------------------------------- |
+| `DataKey::Guard`        | Instance       | `configure_guard` (once)       | `guard`, `delivered`, `read`           |
+| `DataKey::Receipt(id)`  | Persistent     | `delivered` (first write only) | `delivered`, `read`, `get`             |
+
+`Guard` is a single, contract-wide configuration value set at most once
+(`GuardAlreadyConfigured` on a second call). `Receipt(id)` is keyed by the 32-byte
+message id and holds the full `Receipt` record; `delivered` creates it and `read`
+updates its `read_at` field in place — the key itself never changes shape or moves
+storage space.
+
+## How `DataKey` is encoded
+
+Soroban's `#[contracttype]` derive encodes each enum variant as a host vector whose
+first element is a `Symbol` built from the variant's Rust *name* (`"Guard"`,
+`"Receipt"`), followed by any tuple fields. Decoding looks up a previously-written
+key by that name among the enum's *current* variants — the numeric declaration
+order plays no part in the encoding. Concretely, this means:
+
+- **Renaming or removing a variant that has ever written storage is unsafe.** The
+  encoded `Symbol` changes (or disappears), so any key written under the old name
+  becomes permanently undecodable and its ledger entry is orphaned.
+- **Changing a variant's tuple field types is unsafe** for the same reason: the
+  encoded shape no longer matches what was previously persisted.
+- **Reordering variants is safe** on its own, since decoding is name-based, not
+  positional. New variants should still be appended at the end, both to keep
+  declaration order matching historical introduction order, and to stay consistent
+  with the convention used by the other Soroban contracts in this workspace (see
+  `contracts/soroban/policies/src/lib.rs`).
+
+## Migrating a key's structure
+
+If a key's structure ever needs to change (e.g. a new `Receipt` field that must be
+part of the key rather than the stored record, or splitting `Receipt` into a
+tiered key), do not repurpose the existing variant. Instead:
+
+1. Leave the existing variant (`Receipt(BytesN<32>)`) in place so already-written
+   entries stay readable under it.
+2. Add a new variant (e.g. `ReceiptV2(BytesN<32>, u32)`) for the new shape.
+3. Give read paths an explicit fallback: try the new key, and if absent, fall back
+   to the old key (and optionally backfill the new key on read or via a dedicated
+   migration entry point).
+4. Document the coexistence period and removal plan for the old variant here.
+
+No such migration is in progress today; this document exists so the first one
+starts from an explicit, reviewed plan rather than an ad hoc rename.
+
+## Test coverage
+
+The `storage_keys` test module in `src/lib.rs` pins the encoded discriminant name
+for each `DataKey` variant (`guard_key_discriminant_is_pinned`,
+`receipt_key_discriminant_is_pinned`) so an accidental rename fails CI before it
+can reach production, and verifies that distinct message ids never collide in
+persistent storage (`distinct_message_ids_produce_distinct_receipt_keys`).

--- a/contracts/soroban/receipts/src/lib.rs
+++ b/contracts/soroban/receipts/src/lib.rs
@@ -128,6 +128,34 @@ pub struct Read {
     pub receipt: Receipt,
 }
 
+/// Storage Key Migration Notes:
+///
+/// `DataKey::Guard` lives in instance storage; `DataKey::Receipt(message_id)` entries
+/// live in persistent storage (see `configure_guard`/`guard` vs. `delivered`/`read`/`get`).
+/// Soroban's `#[contracttype]` derive encodes each variant as a `Vec` whose first element
+/// is a `Symbol` built from the variant's *name* (e.g. `"Guard"`, `"Receipt"`), and decodes
+/// a previously-written key by looking that name up among the enum's current variants —
+/// the numeric declaration order is not part of the encoding. That has concrete
+/// consequences for evolving this enum without corrupting already-written ledger state:
+/// - **Never rename or remove a variant** that has ever been used to write instance or
+///   persistent storage. Renaming changes the encoded `Symbol`, so every key written
+///   under the old name becomes permanently undecodable and its ledger entry is orphaned.
+/// - **Never change a variant's tuple field types** (e.g. widening `Receipt(BytesN<32>)`
+///   to carry an extra argument). This changes the encoded shape and breaks decoding of
+///   every entry written before the change, the same way a rename does.
+/// - Reordering variants is safe on its own — decoding matches by name, not position —
+///   but new variants should still be **appended at the end** to keep the declaration
+///   order matching historical introduction order for readers and auditors, and to stay
+///   consistent with the convention used by the other Soroban contracts in this workspace
+///   (see `contracts/soroban/policies/src/lib.rs`).
+/// - If a key's structure must change, leave the old variant in place (so existing ledger
+///   entries stay readable under it) and add a new variant instead (e.g. `ReceiptV2(..)`),
+///   with an explicit read/write migration path for callers that need to move data from
+///   the old key to the new one.
+///
+/// The `storage_keys` test module below pins the encoded discriminant name for each
+/// variant, so an accidental rename fails CI instead of silently orphaning ledger data.
+/// See `docs/storage.md` for the full storage layout.
 #[contracttype]
 enum DataKey {
     Guard,
@@ -711,6 +739,58 @@ mod test {
                 .unwrap(),
             Error::GuardNotConfigured
         );
+    }
+}
+
+#[cfg(test)]
+mod storage_keys {
+    // Storage key discriminant pinning tests.
+    //
+    // `DataKey` variants are encoded by name (see the migration notes above `DataKey`),
+    // so a rename is the actual backward-compatibility hazard for this enum — not
+    // reordering. These tests pin the exact discriminant `Symbol` written for each
+    // variant; a rename fails here before it can orphan already-written ledger state.
+    extern crate std;
+
+    use super::*;
+    use soroban_sdk::{TryFromVal, Val, Vec as SorobanVec};
+    use std::string::ToString;
+
+    fn discriminant_name(env: &Env, key: &DataKey) -> std::string::String {
+        let val = Val::try_from_val(env, key).unwrap();
+        let vec: SorobanVec<Val> = SorobanVec::try_from_val(env, &val).unwrap();
+        let discriminant: soroban_sdk::Symbol =
+            soroban_sdk::Symbol::try_from_val(env, &vec.get(0).unwrap()).unwrap();
+        discriminant.to_string()
+    }
+
+    #[test]
+    fn guard_key_discriminant_is_pinned() {
+        let env = Env::default();
+        assert_eq!(discriminant_name(&env, &DataKey::Guard), "Guard");
+    }
+
+    #[test]
+    fn receipt_key_discriminant_is_pinned() {
+        let env = Env::default();
+        let key = DataKey::Receipt(BytesN::from_array(&env, &[1u8; 32]));
+        assert_eq!(discriminant_name(&env, &key), "Receipt");
+    }
+
+    #[test]
+    fn distinct_message_ids_produce_distinct_receipt_keys() {
+        let env = Env::default();
+        let contract_id = env.register(ReceiptsContract, ());
+        env.as_contract(&contract_id, || {
+            let key_a = DataKey::Receipt(BytesN::from_array(&env, &[1u8; 32]));
+            let key_b = DataKey::Receipt(BytesN::from_array(&env, &[2u8; 32]));
+
+            env.storage().persistent().set(&key_a, &1u32);
+            env.storage().persistent().set(&key_b, &2u32);
+
+            assert_eq!(env.storage().persistent().get::<_, u32>(&key_a), Some(1));
+            assert_eq!(env.storage().persistent().get::<_, u32>(&key_b), Some(2));
+        });
     }
 }
 


### PR DESCRIPTION
## Problem

The receipts Soroban contract's `DataKey` enum had no storage key migration
notes, unlike the sibling policies contract, which already documents this for
its own `DataKey` enum. That left future contributors without a documented
rule for evolving the receipts contract's storage keys without corrupting
already-written ledger state.

## Changes

- Add a "Storage Key Migration Notes" doc comment above `DataKey` in
  `contracts/soroban/receipts/src/lib.rs` explaining precisely how Soroban's
  `#[contracttype]` derive encodes enum variants: by the variant's *name* (as
  a `Symbol`), not by its declaration position. This means:
  - Renaming or removing a variant that has ever written storage is unsafe
    (the previously-written key becomes undecodable).
  - Changing a variant's tuple field types is unsafe for the same reason.
  - Reordering variants is actually safe, though new variants should still be
    appended at the end for readability and consistency with the policies
    contract's convention.
- Add a `storage_keys` test module in `src/lib.rs` that pins the encoded
  discriminant name for both `DataKey` variants (`Guard`, `Receipt`) and
  verifies distinct message ids never collide in persistent storage. A future
  accidental rename now fails CI instead of silently orphaning ledger data.
- Add `contracts/soroban/receipts/docs/storage.md` documenting the full
  storage layout (which variant lives in which storage space, written/read
  by which entry points) and an explicit migration path for any future
  key-structure change.
- Link the new doc from `contracts/soroban/receipts/README.md`.

No public contract semantics changed: `DataKey` variants, their storage
spaces, and every entry point's behavior are unchanged.

## Test plan

- [x] `cargo test -p stealth-receipts` — all 25 tests pass (22 pre-existing +
      3 new `storage_keys` tests).
- [x] Verified no other Soroban contract in this workspace commits
      proptest-generated `test_snapshots` artifacts, so none were added here.

closes #1401