### PR TITLE
Add non-UI execution contract for response-time-tracker

### DIFF
--- a/tools/v2/team/response-time-tracker/README.md
+++ b/tools/v2/team/response-time-tracker/README.md
@@ -70,22 +70,37 @@ The fixture data is intentionally small so OSS contributors can reason about
 the expected behavior without running the main app. The service layer defaults
 to loading fixture data with an 800 ms simulated delay.
 
+## Non-UI Execution Contract
+
+`runResponseTimeQuery` (exported from `index.ts`, defined in
+`services/execution-contract.ts`) is a stable, backend-facing entry point that
+runs a full query (entries, metrics, team members) and resolves with a typed
+`ResponseTimeQueryResult` — it never throws. See
+`docs/execution-contract.md` for the typed input/output contract and error
+codes, and `fixtures/execution-contract-cases.json` for the success/failure
+cases it is tested against.
+
 ## Documentation Map
 
 - `specs.md` — Local product contract, boundaries, and required categories.
 - `docs/test-plan.md` — Manual and automated review steps.
 - `docs/review-notes.md` — What was validated and what remains out of scope.
+- `docs/execution-contract.md` — Typed non-UI input/output contract and error codes.
 
 ## Tests
 
-Run the local test from the repository root:
+Run the local tests from the repository root:
 
 ```bash
 node --test tools/v2/team/response-time-tracker/tests/response-time.test.mjs
+node --test tools/v2/team/response-time-tracker/tests/execution-contract.test.mjs
 ```
 
-The test uses Node's built-in test runner and validates the response-time
-service logic (metrics calculation, date filtering, error handling).
+The tests use Node's built-in test runner. `response-time.test.mjs` validates
+the response-time service logic (metrics calculation, date filtering, error
+handling); `execution-contract.test.mjs` validates the non-UI execution
+contract's success and failure cases against
+`fixtures/execution-contract-cases.json`.
 
 ## Known Limitations
 

--- a/tools/v2/team/response-time-tracker/docs/execution-contract.md
+++ b/tools/v2/team/response-time-tracker/docs/execution-contract.md
@@ -59,10 +59,10 @@ not on the presence of a particular key.
 
 ## Error codes
 
-| Code                 | Meaning                                                                                   | When it is returned                                    |
-| --------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| `INVALID_DATE_RANGE`  | `range.start` is after `range.end`, or either bound fails to parse as a date.               | Before any fetch is attempted — no service call is made. |
-| `FETCH_FAILED`        | The underlying data fetch rejected (e.g. a simulated failure via `failureRate`).            | After the service call, when `Promise.all(...)` rejects.  |
+| Code                 | Meaning                                                                          | When it is returned                                      |
+| -------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `INVALID_DATE_RANGE` | `range.start` is after `range.end`, or either bound fails to parse as a date.    | Before any fetch is attempted — no service call is made. |
+| `FETCH_FAILED`       | The underlying data fetch rejected (e.g. a simulated failure via `failureRate`). | After the service call, when `Promise.all(...)` rejects. |
 
 Both codes are exhaustive for the current contract: any call either resolves
 successfully or resolves with one of these two codes. Adding a new failure

--- a/tools/v2/team/response-time-tracker/docs/execution-contract.md
+++ b/tools/v2/team/response-time-tracker/docs/execution-contract.md
@@ -1,0 +1,94 @@
+# Execution Contract — Response Time Tracker
+
+This document defines the non-UI, backend-facing execution contract for the
+Response Time Tracker tool: a stable entry point that can be called from a
+script, a test, or a future server context without importing React or any
+component from `components/`.
+
+## Entry point
+
+```ts
+import { runResponseTimeQuery } from "tools/v2/team/response-time-tracker";
+
+const result = await runResponseTimeQuery(
+  { range: { start: "2026-06-10", end: "2026-06-12" } }, // ResponseTimeQueryInput, optional
+  { simulateDelay: false }, // ResponseTimeServiceConfig, optional
+);
+```
+
+`runResponseTimeQuery` is defined in `services/execution-contract.ts` and
+re-exported from the tool's `index.ts` barrel. It never throws — every
+outcome, success or failure, is represented in the returned
+`ResponseTimeQueryResult`.
+
+## Typed input
+
+```typescript
+interface ResponseTimeQueryInput {
+  range?: DateRange; // { start: string; end: string } — ISO 8601 dates (YYYY-MM-DD)
+}
+```
+
+Omitting `range` queries the full dataset. The optional second argument,
+`ResponseTimeServiceConfig` (defined in `services/response-time-service.ts`),
+controls simulated latency and failure injection and is intended for tests and
+fixtures, not production callers.
+
+## Typed output
+
+```typescript
+type ResponseTimeQueryResult =
+  | { ok: true; data: ResponseTimeQueryData }
+  | { ok: false; error: ResponseTimeQueryError };
+
+interface ResponseTimeQueryData {
+  entries: ResponseTimeEntry[];
+  metrics: ResponseTimeMetrics;
+  teamMembers: TeamMember[];
+}
+
+interface ResponseTimeQueryError {
+  code: ResponseTimeErrorCode;
+  message: string;
+}
+```
+
+`data` and `error` are mutually exclusive: a result with `ok: true` always has
+`data` and never `error`, and vice versa. Callers should discriminate on `ok`,
+not on the presence of a particular key.
+
+## Error codes
+
+| Code                 | Meaning                                                                                   | When it is returned                                    |
+| --------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `INVALID_DATE_RANGE`  | `range.start` is after `range.end`, or either bound fails to parse as a date.               | Before any fetch is attempted — no service call is made. |
+| `FETCH_FAILED`        | The underlying data fetch rejected (e.g. a simulated failure via `failureRate`).            | After the service call, when `Promise.all(...)` rejects.  |
+
+Both codes are exhaustive for the current contract: any call either resolves
+successfully or resolves with one of these two codes. Adding a new failure
+mode should extend `ResponseTimeErrorCode` rather than reuse an existing code
+for an unrelated condition.
+
+## Fixtures
+
+`fixtures/execution-contract-cases.json` enumerates named success and failure
+cases (input, optional service config, and expected outcome) used by
+`tests/execution-contract.test.mjs`:
+
+- **`successCases`**: no range (full dataset), a narrowing single-day range,
+  and a range that matches nothing (an empty result set is still a success,
+  not an error).
+- **`failureCases`**: an inverted range, an unparseable date bound, and a
+  simulated service failure (`failureRate: 1`) — covering both the
+  input-validation error path and the fetch-failure error path.
+
+## Relationship to the UI layer
+
+`useResponseTimes` (in `hooks/`) is the UI-facing consumer of the service
+layer and predates this contract; it manages `FetchState` for three
+independently-loading slices (entries, metrics, team members) to drive
+loading/empty/error/success rendering per `specs.md`. `runResponseTimeQuery`
+does not replace that hook — it is a separate, coarser-grained entry point for
+callers that want one awaited call with a single typed result and don't need
+per-slice loading states. Neither the hook nor any component was changed by
+this contract; no styling or layout files are part of this change.

--- a/tools/v2/team/response-time-tracker/docs/test-plan.md
+++ b/tools/v2/team/response-time-tracker/docs/test-plan.md
@@ -6,6 +6,7 @@ Run from the repository root:
 
 ```bash
 node --test tools/v2/team/response-time-tracker/tests/response-time.test.mjs
+node --test tools/v2/team/response-time-tracker/tests/execution-contract.test.mjs
 ```
 
 ### What the automated test covers
@@ -15,6 +16,14 @@ node --test tools/v2/team/response-time-tracker/tests/response-time.test.mjs
 3. **Service: empty metrics** — All-zero metrics when no entries exist.
 4. **Service: error handling** — Throws when failure rate is 100%.
 5. **Service: date filtering** — Returns empty array when range matches nothing.
+6. **Execution contract: success cases** — No range, a narrowing range, and a
+   range matching nothing all resolve `{ ok: true, data: ... }`
+   (`fixtures/execution-contract-cases.json`).
+7. **Execution contract: failure cases** — An inverted range, an unparseable
+   date bound, and a simulated service failure all resolve
+   `{ ok: false, error: { code, message } }` with the expected error code.
+8. **Execution contract: result shape** — `runResponseTimeQuery` never throws,
+   and `data`/`error` are mutually exclusive on the returned result.
 
 ## Manual Review Steps
 

--- a/tools/v2/team/response-time-tracker/fixtures/execution-contract-cases.json
+++ b/tools/v2/team/response-time-tracker/fixtures/execution-contract-cases.json
@@ -1,0 +1,37 @@
+{
+  "successCases": [
+    {
+      "name": "no range returns the full fixture dataset",
+      "input": {},
+      "expect": { "totalResponses": 7, "teamMemberCount": 3 }
+    },
+    {
+      "name": "single-day range narrows to matching entries",
+      "input": { "range": { "start": "2026-06-10", "end": "2026-06-10" } },
+      "expect": { "totalResponses": 2, "teamMemberCount": 3 }
+    },
+    {
+      "name": "range outside all entries returns zero entries without erroring",
+      "input": { "range": { "start": "2025-01-01", "end": "2025-01-02" } },
+      "expect": { "totalResponses": 0, "teamMemberCount": 3 }
+    }
+  ],
+  "failureCases": [
+    {
+      "name": "start date after end date is rejected before fetching",
+      "input": { "range": { "start": "2026-06-15", "end": "2026-06-10" } },
+      "expectErrorCode": "INVALID_DATE_RANGE"
+    },
+    {
+      "name": "unparseable date bounds are rejected before fetching",
+      "input": { "range": { "start": "not-a-date", "end": "2026-06-10" } },
+      "expectErrorCode": "INVALID_DATE_RANGE"
+    },
+    {
+      "name": "underlying service failure surfaces as FETCH_FAILED",
+      "input": {},
+      "config": { "simulateDelay": false, "failureRate": 1 },
+      "expectErrorCode": "FETCH_FAILED"
+    }
+  ]
+}

--- a/tools/v2/team/response-time-tracker/index.ts
+++ b/tools/v2/team/response-time-tracker/index.ts
@@ -6,5 +6,13 @@ export { StatsCard } from "./components/stats-card";
 export { DateRangePicker } from "./components/date-range-picker";
 export { useResponseTimes } from "./hooks/use-response-times";
 export { createResponseTimeService } from "./services/response-time-service";
+export { runResponseTimeQuery } from "./services/execution-contract";
 
 export type { DateRange, FetchState, ResponseTimeEntry, TeamMember } from "./types";
+export type {
+  ResponseTimeErrorCode,
+  ResponseTimeQueryData,
+  ResponseTimeQueryError,
+  ResponseTimeQueryInput,
+  ResponseTimeQueryResult,
+} from "./services/execution-contract";

--- a/tools/v2/team/response-time-tracker/services/execution-contract.ts
+++ b/tools/v2/team/response-time-tracker/services/execution-contract.ts
@@ -1,8 +1,5 @@
 import type { DateRange, ResponseTimeEntry, ResponseTimeMetrics, TeamMember } from "../types";
-import {
-  createResponseTimeService,
-  type ResponseTimeServiceConfig,
-} from "./response-time-service";
+import { createResponseTimeService, type ResponseTimeServiceConfig } from "./response-time-service";
 
 /**
  * Non-UI execution contract for the Response Time Tracker.

--- a/tools/v2/team/response-time-tracker/services/execution-contract.ts
+++ b/tools/v2/team/response-time-tracker/services/execution-contract.ts
@@ -1,0 +1,91 @@
+import type { DateRange, ResponseTimeEntry, ResponseTimeMetrics, TeamMember } from "../types";
+import {
+  createResponseTimeService,
+  type ResponseTimeServiceConfig,
+} from "./response-time-service";
+
+/**
+ * Non-UI execution contract for the Response Time Tracker.
+ *
+ * `runResponseTimeQuery` is the stable backend-facing entry point for this tool:
+ * it can be called from a script, a test, or a future server context without
+ * importing React or any component. It never throws — every outcome, success or
+ * failure, is represented in the returned `ResponseTimeQueryResult`. See
+ * `docs/execution-contract.md` for the full contract and error code reference.
+ */
+
+/**
+ * - `INVALID_DATE_RANGE`: the supplied `range` has a `start` after its `end`
+ *   (or either bound fails to parse as a date). Returned before any fetch is
+ *   attempted.
+ * - `FETCH_FAILED`: the underlying data fetch rejected (e.g. a simulated
+ *   failure via `ResponseTimeServiceConfig.failureRate`).
+ */
+export type ResponseTimeErrorCode = "INVALID_DATE_RANGE" | "FETCH_FAILED";
+
+export interface ResponseTimeQueryInput {
+  /** Optional date range filter. Omit to query the full fixture dataset. */
+  range?: DateRange;
+}
+
+export interface ResponseTimeQueryData {
+  entries: ResponseTimeEntry[];
+  metrics: ResponseTimeMetrics;
+  teamMembers: TeamMember[];
+}
+
+export interface ResponseTimeQueryError {
+  code: ResponseTimeErrorCode;
+  message: string;
+}
+
+export type ResponseTimeQueryResult =
+  | { ok: true; data: ResponseTimeQueryData }
+  | { ok: false; error: ResponseTimeQueryError };
+
+function isValidRange(range: DateRange): boolean {
+  const start = new Date(range.start).getTime();
+  const end = new Date(range.end).getTime();
+  return Number.isFinite(start) && Number.isFinite(end) && start <= end;
+}
+
+/**
+ * Runs a single response-time query end to end (entries, team members, and
+ * aggregate metrics) and returns a typed result. Non-UI callers should use this
+ * instead of calling `createResponseTimeService` directly, so error handling
+ * and input validation stay centralized in one place.
+ */
+export async function runResponseTimeQuery(
+  input: ResponseTimeQueryInput = {},
+  config: ResponseTimeServiceConfig = {},
+): Promise<ResponseTimeQueryResult> {
+  if (input.range && !isValidRange(input.range)) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_DATE_RANGE",
+        message: `Invalid date range: start (${input.range.start}) must not be after end (${input.range.end}).`,
+      },
+    };
+  }
+
+  const service = createResponseTimeService(config);
+
+  try {
+    const [entries, metrics, teamMembers] = await Promise.all([
+      service.getEntries(input.range),
+      service.getMetrics(input.range),
+      service.getTeamMembers(),
+    ]);
+
+    return { ok: true, data: { entries, metrics, teamMembers } };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "FETCH_FAILED",
+        message: err instanceof Error ? err.message : "Failed to load response time data.",
+      },
+    };
+  }
+}

--- a/tools/v2/team/response-time-tracker/tests/execution-contract.test.mjs
+++ b/tools/v2/team/response-time-tracker/tests/execution-contract.test.mjs
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+
+// This mirrors the reimplementation approach used in response-time.test.mjs:
+// the real contract lives in ../services/execution-contract.ts (TypeScript),
+// and this file re-implements its logic in plain JS against the same JSON
+// fixtures so the isolated tool folder can be tested with Node's built-in
+// test runner, with no TS loader/build step required.
+
+const sampleEntries = JSON.parse(
+  fs.readFileSync(new URL("../fixtures/sample-response-times.json", import.meta.url), "utf-8"),
+);
+const sampleMembers = JSON.parse(
+  fs.readFileSync(new URL("../fixtures/team-members.json", import.meta.url), "utf-8"),
+);
+const contractCases = JSON.parse(
+  fs.readFileSync(new URL("../fixtures/execution-contract-cases.json", import.meta.url), "utf-8"),
+);
+
+const SLA_MS = 14400000;
+
+function calculateMetrics(entries) {
+  if (entries.length === 0) {
+    return {
+      averageResponseTimeMs: 0,
+      medianResponseTimeMs: 0,
+      fastestResponseTimeMs: 0,
+      slowestResponseTimeMs: 0,
+      totalResponses: 0,
+      metCount: 0,
+      missedCount: 0,
+      breachedCount: 0,
+      slaMs: SLA_MS,
+      withinSLAPercentage: 0,
+    };
+  }
+
+  const sorted = [...entries].sort((a, b) => a.responseTimeMs - b.responseTimeMs);
+  const total = sorted.length;
+  const mid = Math.floor(total / 2);
+
+  return {
+    averageResponseTimeMs: Math.round(entries.reduce((s, e) => s + e.responseTimeMs, 0) / total),
+    medianResponseTimeMs:
+      total % 2 === 0
+        ? Math.round((sorted[mid - 1].responseTimeMs + sorted[mid].responseTimeMs) / 2)
+        : sorted[mid].responseTimeMs,
+    fastestResponseTimeMs: sorted[0].responseTimeMs,
+    slowestResponseTimeMs: sorted[total - 1].responseTimeMs,
+    totalResponses: total,
+    metCount: entries.filter((e) => e.status === "met").length,
+    missedCount: entries.filter((e) => e.status === "missed").length,
+    breachedCount: entries.filter((e) => e.status === "breached").length,
+    slaMs: SLA_MS,
+    withinSLAPercentage: Math.round(
+      (entries.filter((e) => e.status === "met").length / total) * 100,
+    ),
+  };
+}
+
+function filterByDateRange(entries, range) {
+  const start = new Date(range.start).getTime();
+  const endExclusive = new Date(range.end).getTime() + 86400000;
+  return entries.filter((e) => {
+    const sent = new Date(e.sentAt).getTime();
+    return sent >= start && sent < endExclusive;
+  });
+}
+
+function isValidRange(range) {
+  const start = new Date(range.start).getTime();
+  const end = new Date(range.end).getTime();
+  return Number.isFinite(start) && Number.isFinite(end) && start <= end;
+}
+
+// Plain-JS mirror of createResponseTimeService from response-time-service.ts.
+function createResponseTimeService(config = {}) {
+  const { simulateDelay = true, delayMs = 800, failureRate = 0 } = config;
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  async function getEntries(range) {
+    if (simulateDelay) await delay(delayMs);
+    if (Math.random() < failureRate) {
+      throw new Error("Failed to load response time entries.");
+    }
+    let entries = sampleEntries;
+    if (range) entries = filterByDateRange(entries, range);
+    return entries;
+  }
+
+  async function getTeamMembers() {
+    if (simulateDelay) await delay(delayMs / 2);
+    return sampleMembers;
+  }
+
+  async function getMetrics(range) {
+    const entries = await getEntries(range);
+    return calculateMetrics(entries);
+  }
+
+  return { getEntries, getTeamMembers, getMetrics };
+}
+
+// Plain-JS mirror of runResponseTimeQuery from execution-contract.ts.
+async function runResponseTimeQuery(input = {}, config = {}) {
+  if (input.range && !isValidRange(input.range)) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_DATE_RANGE",
+        message: `Invalid date range: start (${input.range.start}) must not be after end (${input.range.end}).`,
+      },
+    };
+  }
+
+  const service = createResponseTimeService(config);
+
+  try {
+    const [entries, metrics, teamMembers] = await Promise.all([
+      service.getEntries(input.range),
+      service.getMetrics(input.range),
+      service.getTeamMembers(),
+    ]);
+    return { ok: true, data: { entries, metrics, teamMembers } };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "FETCH_FAILED",
+        message: err instanceof Error ? err.message : "Failed to load response time data.",
+      },
+    };
+  }
+}
+
+describe("Response Time Tracker — Execution Contract", () => {
+  describe("success cases", () => {
+    for (const testCase of contractCases.successCases) {
+      it(testCase.name, async () => {
+        const result = await runResponseTimeQuery(testCase.input, { simulateDelay: false });
+        assert.strictEqual(result.ok, true);
+        assert.strictEqual(result.data.metrics.totalResponses, testCase.expect.totalResponses);
+        assert.strictEqual(result.data.entries.length, testCase.expect.totalResponses);
+        assert.strictEqual(result.data.teamMembers.length, testCase.expect.teamMemberCount);
+      });
+    }
+  });
+
+  describe("failure cases", () => {
+    for (const testCase of contractCases.failureCases) {
+      it(testCase.name, async () => {
+        const result = await runResponseTimeQuery(testCase.input, testCase.config ?? {});
+        assert.strictEqual(result.ok, false);
+        assert.strictEqual(result.error.code, testCase.expectErrorCode);
+        assert.ok(typeof result.error.message === "string" && result.error.message.length > 0);
+      });
+    }
+  });
+
+  describe("result shape", () => {
+    it("never throws, even on service failure", async () => {
+      await assert.doesNotReject(async () => {
+        await runResponseTimeQuery({}, { simulateDelay: false, failureRate: 1 });
+      });
+    });
+
+    it("success and failure results are mutually exclusive", async () => {
+      const success = await runResponseTimeQuery({}, { simulateDelay: false });
+      assert.strictEqual("data" in success, true);
+      assert.strictEqual("error" in success, false);
+
+      const failure = await runResponseTimeQuery(
+        { range: { start: "2026-06-15", end: "2026-06-10" } },
+        { simulateDelay: false },
+      );
+      assert.strictEqual("error" in failure, true);
+      assert.strictEqual("data" in failure, false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The response-time-tracker tool (`tools/v2/team/response-time-tracker`) only
exposed `createResponseTimeService`, whose methods throw plain `Error`
objects and must be called individually (`getEntries`, `getMetrics`,
`getTeamMembers`). There was no single, documented, non-UI entry point a
backend-facing caller (a script, a test, a future server context) could rely
on independent of the React hook/component layer.

## Changes

- Add `runResponseTimeQuery` in
  `tools/v2/team/response-time-tracker/services/execution-contract.ts`: a
  typed, non-UI entry point that runs a full query (entries, metrics, team
  members) in a single call and resolves with a `ResponseTimeQueryResult`
  discriminated union (`{ ok: true; data }` or `{ ok: false; error }`)
  instead of throwing.
  - Date ranges are validated up front (`INVALID_DATE_RANGE`) before any
    fetch is attempted.
  - Underlying service failures are caught and surfaced as a typed
    `FETCH_FAILED` error.
- Export `runResponseTimeQuery` and its associated types from the tool's
  `index.ts` barrel, alongside the existing exports.
- Add `fixtures/execution-contract-cases.json` with named success cases (no
  range, a narrowing range, a range matching nothing) and failure cases (an
  inverted range, an unparseable date bound, a simulated service failure).
- Add `tests/execution-contract.test.mjs`, exercising all of the above with
  Node's built-in test runner, following the same plain-JS-mirror pattern
  already used by `tests/response-time.test.mjs` so no TypeScript loader is
  required to run it.
- Document the full typed input/output contract and error codes in
  `docs/execution-contract.md`, and link it from `README.md` and
  `docs/test-plan.md`.

No component, hook, or styling/layout file was touched — this tool remains
folder-local and isolated per `specs.md` and `docs/ARCHITECTURE.md`.

## Test plan

- [x] `node --test tools/v2/team/response-time-tracker/tests/response-time.test.mjs tools/v2/team/response-time-tracker/tests/execution-contract.test.mjs` — 19/19 tests pass (11 pre-existing + 8 new).
- [x] `tsc --noEmit` — no new type errors.

closes #1334