### PR TITLE
feat(monitoring): add alert configurations and runbooks for authentication and rate limits

### DIFF
--- a/docs/deployment/ALERTS.md
+++ b/docs/deployment/ALERTS.md
@@ -8,43 +8,48 @@ This guide defines the runbooks and operational procedures for responding to aut
 
 The Stealth API handler exposes the following Prometheus-style metrics:
 
-*   `api_requests_total{method, path, status}`: Cumulative count of all processed requests.
-*   `api_errors_total{method, path, status}`: Cumulative count of all requests resulting in an error response.
-*   `api_latency`: Request latency histogram.
+- `api_requests_total{method, path, status}`: Cumulative count of all processed requests.
+- `api_errors_total{method, path, status}`: Cumulative count of all requests resulting in an error response.
+- `api_latency`: Request latency histogram.
 
 ---
 
 ## Investigation Principles & Privacy Safeguards
 
-When triaging anomalies, operators must strictly avoid accessing or logging sensitive user information. 
+When triaging anomalies, operators must strictly avoid accessing or logging sensitive user information.
 
 ### Prohibited Diagnostic Fields (DO NOT LOG or EXPOSE)
-*   **Raw IP Addresses**: Must not be logged in plaintext (use truncated subnets or hashed IP representations).
-*   **Stellar Private Keys**: Never expose or output signing or recovery keys.
-*   **Plaintext Message Content**: Do not extract email/message bodies during debug sessions.
-*   **Raw Cryptographic Signatures**: The signature strings themselves must not be included in logs or alerting tickets.
-*   **Account/Stellar G-Addresses**: Avoid using raw addresses as high-cardinality metric labels to prevent database bloat and trackability vectors.
+
+- **Raw IP Addresses**: Must not be logged in plaintext (use truncated subnets or hashed IP representations).
+- **Stellar Private Keys**: Never expose or output signing or recovery keys.
+- **Plaintext Message Content**: Do not extract email/message bodies during debug sessions.
+- **Raw Cryptographic Signatures**: The signature strings themselves must not be included in logs or alerting tickets.
+- **Account/Stellar G-Addresses**: Avoid using raw addresses as high-cardinality metric labels to prevent database bloat and trackability vectors.
 
 ### Safe Diagnostic Fields (RECOMMENDED FOR INVESTIGATION)
-*   **Request Correlation ID (`x-request-id`)**: The primary server-generated identifier to trace the lifecycle of a request.
-*   **HTTP Route & Method**: The target endpoint and request verb (e.g., `POST /api/v1/postage`).
-*   **Response Status Code**: The standard HTTP status returned (e.g., `401`, `409`, `429`).
-*   **Normalized Metrics Rates**: Aggregate error-to-success ratios.
-*   **Redacted logs**: Error metadata indicating only validation rules violated without mirroring the invalid values.
+
+- **Request Correlation ID (`x-request-id`)**: The primary server-generated identifier to trace the lifecycle of a request.
+- **HTTP Route & Method**: The target endpoint and request verb (e.g., `POST /api/v1/postage`).
+- **Response Status Code**: The standard HTTP status returned (e.g., `401`, `409`, `429`).
+- **Normalized Metrics Rates**: Aggregate error-to-success ratios.
+- **Redacted logs**: Error metadata indicating only validation rules violated without mirroring the invalid values.
 
 ---
 
 ## Runbook: StealthAuthInvalidSignaturesSpike
 
 ### Alert Definition
+
 Triggers when the rate of `401` unauthorized responses exceeds 5% of total requests over a 5-minute sliding window.
 
 ### Potential Causes
+
 1.  **Client Signature Generation Drift**: A recent client release contains bugs in how payload digests or signatures are generated.
 2.  **Clock Desynchronization**: The system time of clients or validators has drifted, causing valid signatures to fail validation due to expiration windows.
 3.  **Active Credential/Signature Spraying**: A malicious actor is sending forged signatures trying to authenticate.
 
 ### Investigation Steps
+
 1.  **Check Scope**: Determine if the spike is isolated to a specific path/method (e.g., `/api/v1/postage/index`) by querying:
     ```promql
     sum by (path, method) (rate(api_errors_total{status="401"}[5m]))
@@ -56,23 +61,27 @@ Triggers when the rate of `401` unauthorized responses exceeds 5% of total reque
 3.  **Check Clock Health**: Verify NTP synchronization status on the API servers and database nodes.
 
 ### Remediation
-*   If a clock sync issue is confirmed, remediate the NTP daemon on affected servers.
-*   If it is a client bug, roll back the recently promoted client version.
-*   If it is spraying, deploy a Cloudflare Web Application Firewall (WAF) rule to block or rate-limit the attacking subnets.
+
+- If a clock sync issue is confirmed, remediate the NTP daemon on affected servers.
+- If it is a client bug, roll back the recently promoted client version.
+- If it is spraying, deploy a Cloudflare Web Application Firewall (WAF) rule to block or rate-limit the attacking subnets.
 
 ---
 
 ## Runbook: StealthAuthReplayAttemptsDetected
 
 ### Alert Definition
+
 Triggers when the rate of `409` conflict responses exceeds 3% of total requests over a 5-minute sliding window.
 
 ### Potential Causes
+
 1.  **Idempotency Key Duplication**: A client is incorrectly reuseing the same `X-Idempotency-Key` for different request bodies.
 2.  **Network-Level Replay Attack**: An attacker has intercepted a valid signed request and is attempting to replay it to cause duplicate transactions or exhaust resources.
 3.  **Aggressive Client Retries**: Network lag is causing clients to retry requests before receiving responses, triggering the idempotency lock.
 
 ### Investigation Steps
+
 1.  **Check Idempotency Replays**: Query log outputs to determine if the `409` conflict is due to completed operations or in-progress operations:
     ```promql
     sum by (path) (rate(api_errors_total{status="409"}[5m]))
@@ -81,22 +90,26 @@ Triggers when the rate of `409` conflict responses exceeds 3% of total requests 
 3.  **Validate Idempotency Storage Health**: Check the status of the strongly consistent layer (Durable Objects / SQLite) to ensure idempotency leases are being freed correctly.
 
 ### Remediation
-*   If caused by client-side idempotency generation bugs, update client routing logic or clear local storage cache if appropriate.
-*   If an active replay attack is suspected, rotate active verification keys or blacklist the compromised payload footprint.
+
+- If caused by client-side idempotency generation bugs, update client routing logic or clear local storage cache if appropriate.
+- If an active replay attack is suspected, rotate active verification keys or blacklist the compromised payload footprint.
 
 ---
 
 ## Runbook: StealthSustainedThrottling
 
 ### Alert Definition
+
 Triggers when the rate of `429` too many requests responses exceeds 10% of total requests over a 10-minute sliding window.
 
 ### Potential Causes
+
 1.  **IP or Account Abuse**: An actor is flooding endpoints with unauthenticated or authenticated traffic.
 2.  **Misconfigured Client Pollers**: A client-side infinite loop or high-frequency polling script is flooding the API.
 3.  **Under-provisioned Rate Limits**: The configured rate limit thresholds are too low for current organic user growth.
 
 ### Investigation Steps
+
 1.  **Determine Scope**: Check if the rate-limiting is occurring primarily on IP limits or Account limits by querying:
     ```promql
     sum by (path) (rate(api_errors_total{status="429"}[5m]))
@@ -104,8 +117,9 @@ Triggers when the rate of `429` too many requests responses exceeds 10% of total
 2.  **Correlate with Edge Metrics**: Check Cloudflare Web Analytics to see if request volume spikes match specific ASNs or countries.
 
 ### Remediation
-*   If a specific actor or botnet is responsible, block the traffic at the Cloudflare edge layer.
-*   If limits are too restrictive for normal usage, update rate limit rules in the database or config.
+
+- If a specific actor or botnet is responsible, block the traffic at the Cloudflare edge layer.
+- If limits are too restrictive for normal usage, update rate limit rules in the database or config.
 
 ---
 
@@ -114,7 +128,9 @@ Triggers when the rate of `429` too many requests responses exceeds 10% of total
 Operators can test the alert pipeline without introducing security risks by simulating anomalies using synthetic metrics.
 
 ### Method 1: Target Path Mocking
+
 Send synthetic requests with test headers to trigger the validation errors:
+
 ```bash
 # Trigger 401 alert (Invalid G-Address)
 for i in {1..50}; do
@@ -132,7 +148,9 @@ done
 ```
 
 ### Method 2: Prometheus Pushgateway Injection
+
 For automated CI/CD validation, push synthetic metrics directly to the Prometheus Pushgateway:
+
 ```bash
 # Push synthetic 401 spike
 cat <<EOF | curl --data-binary @- http://pushgateway.monitoring.svc:9091/metrics/job/stealth_synthetic_test

--- a/docs/deployment/ALERTS.md
+++ b/docs/deployment/ALERTS.md
@@ -1,0 +1,150 @@
+# Operational Alerts and Runbooks
+
+This guide defines the runbooks and operational procedures for responding to authentication, rate-limiting, and anomaly detection alerts on the Stealth API.
+
+---
+
+## Metric Reference
+
+The Stealth API handler exposes the following Prometheus-style metrics:
+
+*   `api_requests_total{method, path, status}`: Cumulative count of all processed requests.
+*   `api_errors_total{method, path, status}`: Cumulative count of all requests resulting in an error response.
+*   `api_latency`: Request latency histogram.
+
+---
+
+## Investigation Principles & Privacy Safeguards
+
+When triaging anomalies, operators must strictly avoid accessing or logging sensitive user information. 
+
+### Prohibited Diagnostic Fields (DO NOT LOG or EXPOSE)
+*   **Raw IP Addresses**: Must not be logged in plaintext (use truncated subnets or hashed IP representations).
+*   **Stellar Private Keys**: Never expose or output signing or recovery keys.
+*   **Plaintext Message Content**: Do not extract email/message bodies during debug sessions.
+*   **Raw Cryptographic Signatures**: The signature strings themselves must not be included in logs or alerting tickets.
+*   **Account/Stellar G-Addresses**: Avoid using raw addresses as high-cardinality metric labels to prevent database bloat and trackability vectors.
+
+### Safe Diagnostic Fields (RECOMMENDED FOR INVESTIGATION)
+*   **Request Correlation ID (`x-request-id`)**: The primary server-generated identifier to trace the lifecycle of a request.
+*   **HTTP Route & Method**: The target endpoint and request verb (e.g., `POST /api/v1/postage`).
+*   **Response Status Code**: The standard HTTP status returned (e.g., `401`, `409`, `429`).
+*   **Normalized Metrics Rates**: Aggregate error-to-success ratios.
+*   **Redacted logs**: Error metadata indicating only validation rules violated without mirroring the invalid values.
+
+---
+
+## Runbook: StealthAuthInvalidSignaturesSpike
+
+### Alert Definition
+Triggers when the rate of `401` unauthorized responses exceeds 5% of total requests over a 5-minute sliding window.
+
+### Potential Causes
+1.  **Client Signature Generation Drift**: A recent client release contains bugs in how payload digests or signatures are generated.
+2.  **Clock Desynchronization**: The system time of clients or validators has drifted, causing valid signatures to fail validation due to expiration windows.
+3.  **Active Credential/Signature Spraying**: A malicious actor is sending forged signatures trying to authenticate.
+
+### Investigation Steps
+1.  **Check Scope**: Determine if the spike is isolated to a specific path/method (e.g., `/api/v1/postage/index`) by querying:
+    ```promql
+    sum by (path, method) (rate(api_errors_total{status="401"}[5m]))
+    ```
+2.  **Analyze Logs**: Search application logs using correlation IDs for `401` status codes. Verify if the error message indicates a formatting issue (e.g., "Missing x-stealth-address header") or schema validation failure:
+    ```
+    [API ERROR] POST /api/v1/postage - 401 (1.20ms) ApiError: x-stealth-address must be a valid Stellar G-address
+    ```
+3.  **Check Clock Health**: Verify NTP synchronization status on the API servers and database nodes.
+
+### Remediation
+*   If a clock sync issue is confirmed, remediate the NTP daemon on affected servers.
+*   If it is a client bug, roll back the recently promoted client version.
+*   If it is spraying, deploy a Cloudflare Web Application Firewall (WAF) rule to block or rate-limit the attacking subnets.
+
+---
+
+## Runbook: StealthAuthReplayAttemptsDetected
+
+### Alert Definition
+Triggers when the rate of `409` conflict responses exceeds 3% of total requests over a 5-minute sliding window.
+
+### Potential Causes
+1.  **Idempotency Key Duplication**: A client is incorrectly reuseing the same `X-Idempotency-Key` for different request bodies.
+2.  **Network-Level Replay Attack**: An attacker has intercepted a valid signed request and is attempting to replay it to cause duplicate transactions or exhaust resources.
+3.  **Aggressive Client Retries**: Network lag is causing clients to retry requests before receiving responses, triggering the idempotency lock.
+
+### Investigation Steps
+1.  **Check Idempotency Replays**: Query log outputs to determine if the `409` conflict is due to completed operations or in-progress operations:
+    ```promql
+    sum by (path) (rate(api_errors_total{status="409"}[5m]))
+    ```
+2.  **Analyze Request IDs**: Group the events by path to identify if multiple distinct client request attempts are sharing headers.
+3.  **Validate Idempotency Storage Health**: Check the status of the strongly consistent layer (Durable Objects / SQLite) to ensure idempotency leases are being freed correctly.
+
+### Remediation
+*   If caused by client-side idempotency generation bugs, update client routing logic or clear local storage cache if appropriate.
+*   If an active replay attack is suspected, rotate active verification keys or blacklist the compromised payload footprint.
+
+---
+
+## Runbook: StealthSustainedThrottling
+
+### Alert Definition
+Triggers when the rate of `429` too many requests responses exceeds 10% of total requests over a 10-minute sliding window.
+
+### Potential Causes
+1.  **IP or Account Abuse**: An actor is flooding endpoints with unauthenticated or authenticated traffic.
+2.  **Misconfigured Client Pollers**: A client-side infinite loop or high-frequency polling script is flooding the API.
+3.  **Under-provisioned Rate Limits**: The configured rate limit thresholds are too low for current organic user growth.
+
+### Investigation Steps
+1.  **Determine Scope**: Check if the rate-limiting is occurring primarily on IP limits or Account limits by querying:
+    ```promql
+    sum by (path) (rate(api_errors_total{status="429"}[5m]))
+    ```
+2.  **Correlate with Edge Metrics**: Check Cloudflare Web Analytics to see if request volume spikes match specific ASNs or countries.
+
+### Remediation
+*   If a specific actor or botnet is responsible, block the traffic at the Cloudflare edge layer.
+*   If limits are too restrictive for normal usage, update rate limit rules in the database or config.
+
+---
+
+## Testing with Synthetic Metrics
+
+Operators can test the alert pipeline without introducing security risks by simulating anomalies using synthetic metrics.
+
+### Method 1: Target Path Mocking
+Send synthetic requests with test headers to trigger the validation errors:
+```bash
+# Trigger 401 alert (Invalid G-Address)
+for i in {1..50}; do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "x-stealth-address: invalid-stellar-address" \
+    https://api.stealth.test/api/v1/postage
+done
+
+# Trigger 429 alert (IP Rate Limit)
+# Run request bursts to trigger the IP rate-limiting threshold
+for i in {1..100}; do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    https://api.stealth.test/api/v1/postage/quote
+done
+```
+
+### Method 2: Prometheus Pushgateway Injection
+For automated CI/CD validation, push synthetic metrics directly to the Prometheus Pushgateway:
+```bash
+# Push synthetic 401 spike
+cat <<EOF | curl --data-binary @- http://pushgateway.monitoring.svc:9091/metrics/job/stealth_synthetic_test
+api_errors_total{method="POST",path="/api/v1/postage",status="401"} 120
+api_requests_total{method="POST",path="/api/v1/postage",status="401"} 120
+api_requests_total{method="POST",path="/api/v1/postage",status="200"} 500
+EOF
+
+# Push synthetic 429 spike
+cat <<EOF | curl --data-binary @- http://pushgateway.monitoring.svc:9091/metrics/job/stealth_synthetic_test
+api_errors_total{method="GET",path="/api/v1/postage/quote",status="429"} 150
+api_requests_total{method="GET",path="/api/v1/postage/quote",status="429"} 150
+api_requests_total{method="GET",path="/api/v1/postage/quote",status="200"} 200
+EOF
+```

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -2,6 +2,5 @@
 
 Deployment runbooks, environment setup, Cloudflare notes, network configuration, and release checklists.
 
-*   [Operational Alerts and Runbooks](ALERTS.md) - System alerts, investigation guides, and runbooks.
-*   [Prometheus Alert Rules](alerts.yaml) - Prometheus alerting rules configuration for anomalies.
-
+- [Operational Alerts and Runbooks](ALERTS.md) - System alerts, investigation guides, and runbooks.
+- [Prometheus Alert Rules](alerts.yaml) - Prometheus alerting rules configuration for anomalies.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,3 +1,7 @@
 # Deployment
 
 Deployment runbooks, environment setup, Cloudflare notes, network configuration, and release checklists.
+
+*   [Operational Alerts and Runbooks](ALERTS.md) - System alerts, investigation guides, and runbooks.
+*   [Prometheus Alert Rules](alerts.yaml) - Prometheus alerting rules configuration for anomalies.
+

--- a/docs/deployment/alerts.yaml
+++ b/docs/deployment/alerts.yaml
@@ -1,0 +1,35 @@
+groups:
+  - name: stealth-api-anomalies
+    rules:
+      - alert: StealthAuthInvalidSignaturesSpike
+        expr: (sum(rate(api_errors_total{status="401"}[5m])) / sum(rate(api_requests_total[5m]))) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+          tier: api
+        annotations:
+          summary: "Spike in invalid authentication signatures detected"
+          description: "Over the last 5 minutes, 401 unauthorized errors represent {{ $value | humanizePercentage }} of all requests on the API, indicating a potential signature generation issue or credential spraying."
+          runbook_url: "https://github.com/Dopezapha/stealth/blob/main/docs/deployment/ALERTS.md#runbook-stealthauthinvalidsignaturesspike"
+
+      - alert: StealthAuthReplayAttemptsDetected
+        expr: (sum(rate(api_errors_total{status="409"}[5m])) / sum(rate(api_requests_total[5m]))) > 0.03
+        for: 5m
+        labels:
+          severity: warning
+          tier: api
+        annotations:
+          summary: "Spike in potential replay attempts or duplicate mutations"
+          description: "Over the last 5 minutes, 409 conflict errors represent {{ $value | humanizePercentage }} of all requests, indicating potential message replays or idempotency failures."
+          runbook_url: "https://github.com/Dopezapha/stealth/blob/main/docs/deployment/ALERTS.md#runbook-stealthauthreplayattemptsdetected"
+
+      - alert: StealthSustainedThrottling
+        expr: (sum(rate(api_errors_total{status="429"}[10m])) / sum(rate(api_requests_total[10m]))) > 0.10
+        for: 10m
+        labels:
+          severity: warning
+          tier: api
+        annotations:
+          summary: "Sustained high rate of client throttling (HTTP 429)"
+          description: "Over the last 10 minutes, 10% or more of requests have been throttled (HTTP 429), indicating either an active denial-of-service attempt or a misconfigured high-volume client."
+          runbook_url: "https://github.com/Dopezapha/stealth/blob/main/docs/deployment/ALERTS.md#runbook-stealthsustainedthrottling"


### PR DESCRIPTION
Closes #1521

# PR Description

I implemented operational alerting configurations and runbooks to address issue #1521. This work focuses on monitoring authentication and rate-limiting anomalies to detect potential system abuse or client code defects.

Currently, the API tracks request counts and errors but lacks formal alerting rules. I created Prometheus-style alert rules to track anomalous error rates. 

I defined three alert rules to target specific failure states:
1. Invalid signatures (HTTP 401): This alert triggers if the rate of 401 unauthorized errors exceeds 5% of all incoming requests over a 5-minute sliding window. 
2. Replay attempts (HTTP 409): This alert triggers if the rate of 409 conflict errors exceeds 3% of all requests over a 5-minute sliding window, indicating potential message replays or idempotency failures.
3. Sustained throttling (HTTP 429): This alert triggers if the rate of 429 too many requests errors exceeds 10% of all requests over a 10-minute window, highlighting potential abuse or misconfigured client pollers.

All three alerts utilize relative rates instead of raw request thresholds to prevent alert fatigue when the application scales up or down.

In addition to the alerting rules, I wrote a guide containing runbooks for these alerts. The guide defines the investigation steps and specifies what diagnostic fields are safe to read, such as request correlation IDs, HTTP methods, paths, and status codes. It explicitly lists prohibited fields, including raw IP addresses, private keys, message contents, and raw cryptographic signatures, to preserve user privacy.

These alerts are valuable because they give operators immediate visibility into authentication failures and abuse attempts without compromising user confidentiality.

# Changes Made
* Created docs/deployment/alerts.yaml to define Prometheus alerting rules for authentication spikes, replay attempts, and throttling anomalies
* Created docs/deployment/ALERTS.md to establish investigation guides, define safe diagnostic boundaries, and outline synthetic testing steps
* Updated docs/deployment/README.md to link to the new alerts guide and rules configuration files

# Testing
I tested the documentation and config logic. The Prometheus alert rules can be verified using the following methods:

1. Generating synthetic error bursts to simulate invalid signatures:
```bash
for i in {1..50}; do
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "x-stealth-address: invalid-stellar-address" \
    https://api.stealth.test/api/v1/postage
done
```

2. Generating synthetic error bursts to simulate rate limit throttling:
```bash
for i in {1..100}; do
  curl -s -o /dev/null -w "%{http_code}\n" \
    https://api.stealth.test/api/v1/postage/quote
done
```

3. Injecting synthetic metrics directly into a Prometheus Pushgateway for CI/CD pipeline tests:
```bash
cat <<EOF | curl --data-binary @- http://pushgateway.monitoring.svc:9091/metrics/job/stealth_synthetic_test
api_errors_total{method="POST",path="/api/v1/postage",status="401"} 120
api_requests_total{method="POST",path="/api/v1/postage",status="401"} 120
api_requests_total{method="POST",path="/api/v1/postage",status="200"} 500
EOF
```