### PR TITLE
feat(api): add weighted rate-limit costs for expensive operations

### DIFF
--- a/src/server/api/handler.ts
+++ b/src/server/api/handler.ts
@@ -1,15 +1,13 @@
 import { z } from "zod";
 import { requireActor } from "./actor";
 import { getApiContext } from "./context";
-import { checkAccountLimit, checkIpLimit } from "./abuse-service";
 import { ApiError } from "./errors";
 import { apiFailure, apiSuccess } from "./response";
 import * as metrics from "./metrics";
 import { parseJsonBody } from "./request";
+import { consumeRouteQuota, type RateLimitConfig } from "./rate-limit";
 
-export type RateLimitConfig = {
-  type: "account" | "ip";
-};
+export type { RateLimitConfig } from "./rate-limit";
 
 export type RouteConfig<
   BodySchema extends z.ZodTypeAny,
@@ -53,27 +51,34 @@ export function createRouteHandler<
       // 2. Rate Limiting
       if (config.rateLimit) {
         const { repository: repo } = await getApiContext();
+        let subject: string;
         if (config.rateLimit.type === "account") {
           if (!actorId) {
             throw new ApiError(401, "unauthorized", "Account rate limit requires authentication");
           }
-          const accountLimit = await checkAccountLimit(repo, actorId);
-          if (!accountLimit.allowed) {
-            throw new ApiError(429, "too_many_requests", "Account limit exceeded", {
-              retryAfterSeconds: accountLimit.retryAfterSeconds,
-            });
-          }
-        } else if (config.rateLimit.type === "ip") {
-          const ip =
+          subject = actorId;
+        } else {
+          subject =
             request.headers.get("cf-connecting-ip") ??
             request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
             "unknown";
-          const ipLimit = await checkIpLimit(repo, ip);
-          if (!ipLimit.allowed) {
-            throw new ApiError(429, "too_many_requests", "IP limit exceeded", {
-              retryAfterSeconds: ipLimit.retryAfterSeconds,
-            });
-          }
+        }
+
+        const limit = await consumeRouteQuota(
+          repo,
+          config.rateLimit.type,
+          subject,
+          config.rateLimit.operation,
+        );
+        if (!limit.allowed) {
+          throw new ApiError(
+            429,
+            "too_many_requests",
+            `${config.rateLimit.type === "account" ? "Account" : "IP"} limit exceeded`,
+            {
+              retryAfterSeconds: limit.retryAfterSeconds,
+            },
+          );
         }
       }
 

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -109,8 +109,8 @@ export class HybridApiRepository implements ApiRepository {
     return this.getStub().getCounter(key);
   }
 
-  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
-    return this.getStub().incrementCounter(key, windowSeconds);
+  async incrementCounter(key: string, windowSeconds: number, amount = 1): Promise<number> {
+    return this.getStub().incrementCounter(key, windowSeconds, amount);
   }
 
   // Relay stats stubs matching MemoryApiRepository exactly

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -102,11 +102,14 @@ export class MemoryApiRepository implements ApiRepository {
     return this.counters.get(key)?.length ?? 0;
   }
 
-  async incrementCounter(key: string, windowSeconds: number) {
+  async incrementCounter(key: string, windowSeconds: number, amount = 1) {
+    if (!Number.isSafeInteger(amount) || amount < 1) {
+      throw new RangeError("Counter increment amount must be a positive safe integer");
+    }
     const now = Date.now();
     const windowMilliseconds = windowSeconds * 1000;
     const timestamps = this.counters.get(key) ?? [];
-    const filtered = [...timestamps, now].filter(
+    const filtered = [...timestamps, ...Array<number>(amount).fill(now)].filter(
       (timestamp) => now - timestamp <= windowMilliseconds,
     );
     this.counters.set(key, filtered);

--- a/src/server/api/rate-limit.ts
+++ b/src/server/api/rate-limit.ts
@@ -1,0 +1,43 @@
+import type { ApiRepository } from "./repository";
+
+export const RATE_LIMIT_OPERATION_COSTS = Object.freeze({
+  read: 1,
+  signatureVerification: 3,
+  policyEvaluation: 5,
+  paymentTransition: 10,
+} as const);
+
+export type RateLimitOperation = keyof typeof RATE_LIMIT_OPERATION_COSTS;
+export type RateLimitType = "account" | "ip";
+
+export type RateLimitConfig = {
+  type: RateLimitType;
+  operation: RateLimitOperation;
+};
+
+const RATE_LIMITS: Record<RateLimitType, { max: number; windowSeconds: number }> = {
+  account: { max: 50, windowSeconds: 3600 },
+  ip: { max: 100, windowSeconds: 3600 },
+};
+
+export async function consumeRouteQuota(
+  repository: ApiRepository,
+  type: RateLimitType,
+  subject: string,
+  operation: RateLimitOperation,
+): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  // Preserve the IP limiter's existing fail-open behavior when the edge did
+  // not provide an address; callers can separately flag this condition.
+  if (type === "ip" && (subject === "" || subject === "unknown")) {
+    return { allowed: true };
+  }
+
+  const { max, windowSeconds } = RATE_LIMITS[type];
+  const cost = RATE_LIMIT_OPERATION_COSTS[operation];
+  const count = await repository.incrementCounter(`abuse:${type}:${subject}`, windowSeconds, cost);
+
+  if (count > max) {
+    return { allowed: false, retryAfterSeconds: windowSeconds };
+  }
+  return { allowed: true };
+}

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -60,7 +60,7 @@ export interface ApiRepository {
   getRelayLastFailedDelivery(relayId: string): Promise<string | null>;
   getRelayDeadLetterCount(relayId: string): Promise<number>;
   getCounter(key: string): Promise<number>;
-  incrementCounter(key: string, windowSeconds: number): Promise<number>;
+  incrementCounter(key: string, windowSeconds: number, amount?: number): Promise<number>;
 }
 
 export const defaultMailboxPolicy: MailboxPolicy = {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -92,18 +92,23 @@ export class StealthCoordinator extends DurableObjectBase {
     return timestamps.length;
   }
 
-  async incrementCounter(key: string, windowSeconds: number): Promise<number> {
-    const now = Date.now();
-    const windowMilliseconds = windowSeconds * 1000;
-    const timestamps =
-      ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
+  async incrementCounter(key: string, windowSeconds: number, amount = 1): Promise<number> {
+    if (!Number.isSafeInteger(amount) || amount < 1) {
+      throw new RangeError("Counter increment amount must be a positive safe integer");
+    }
 
-    // Filter timestamps falling within the sliding window
-    const filtered = [...timestamps, now].filter(
-      (timestamp) => now - timestamp <= windowMilliseconds,
-    );
+    return this.runExclusive(`counter:${key}`, async () => {
+      const now = Date.now();
+      const windowMilliseconds = windowSeconds * 1000;
+      const timestamps =
+        ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];
 
-    await this.ctx.storage.put(`counter:${key}`, filtered);
-    return filtered.length;
+      const filtered = [...timestamps, ...Array<number>(amount).fill(now)].filter(
+        (timestamp) => now - timestamp <= windowMilliseconds,
+      );
+
+      await this.ctx.storage.put(`counter:${key}`, filtered);
+      return filtered.length;
+    });
   }
 }

--- a/tests/unit/api/handler.test.ts
+++ b/tests/unit/api/handler.test.ts
@@ -118,6 +118,41 @@ describe("createRouteHandler", () => {
     expect(response.status).toBe(401);
   });
 
+  it("exhausts account quota according to the centrally configured operation cost", async () => {
+    const route = createRouteHandler({
+      requireAuth: true,
+      rateLimit: { type: "account", operation: "paymentTransition" },
+      handler: () => new Response("OK"),
+    });
+    const makeRequest = () =>
+      new Request("http://localhost/api/test", {
+        method: "POST",
+        headers: { [ACTOR_HEADER]: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB" },
+      });
+
+    for (let requestNumber = 0; requestNumber < 5; requestNumber += 1) {
+      await expect(route(makeRequest())).resolves.toMatchObject({ status: 200 });
+    }
+
+    await expect(route(makeRequest())).resolves.toMatchObject({ status: 429 });
+  });
+
+  it("charges simple reads one quota unit", async () => {
+    const route = createRouteHandler({
+      rateLimit: { type: "ip", operation: "read" },
+      handler: () => new Response("OK"),
+    });
+
+    await route(
+      new Request("http://localhost/api/test", {
+        headers: { "cf-connecting-ip": "192.0.2.1" },
+      }),
+    );
+
+    const repository = (globalThis as any).__stealthApiRepository as MemoryApiRepository;
+    await expect(repository.getCounter("abuse:ip:192.0.2.1")).resolves.toBe(1);
+  });
+
   it("adds Cache-Control headers if configured", async () => {
     const handler = createRouteHandler({
       cacheSeconds: 60,

--- a/tests/unit/api/rate-limit.test.ts
+++ b/tests/unit/api/rate-limit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { consumeRouteQuota, RATE_LIMIT_OPERATION_COSTS } from "../../../src/server/api/rate-limit";
+
+describe("weighted route rate limits", () => {
+  it("atomically consumes the configured weight", async () => {
+    const repository = new MemoryApiRepository();
+
+    await consumeRouteQuota(repository, "account", "actor", "signatureVerification");
+
+    await expect(repository.getCounter("abuse:account:actor")).resolves.toBe(
+      RATE_LIMIT_OPERATION_COSTS.signatureVerification,
+    );
+  });
+
+  it("rejects an expensive operation once its weighted quota is exhausted", async () => {
+    const repository = new MemoryApiRepository();
+
+    for (let requestNumber = 0; requestNumber < 5; requestNumber += 1) {
+      await expect(
+        consumeRouteQuota(repository, "account", "actor", "paymentTransition"),
+      ).resolves.toEqual({ allowed: true });
+    }
+
+    await expect(
+      consumeRouteQuota(repository, "account", "actor", "paymentTransition"),
+    ).resolves.toEqual({ allowed: false, retryAfterSeconds: 3600 });
+  });
+
+  it("keeps operation costs in immutable server configuration", () => {
+    expect(Object.isFrozen(RATE_LIMIT_OPERATION_COSTS)).toBe(true);
+    expect(Object.values(RATE_LIMIT_OPERATION_COSTS)).toEqual([1, 3, 5, 10]);
+  });
+});


### PR DESCRIPTION
Closes #1514

What was done
Added weighted rate-limit costs so expensive operations (signature verification, policy evaluation, payment transitions) consume more quota than simple reads, closing the gap where a flat request count let attackers target expensive operations while staying under the limit.

Changes

Added centralized, immutable operation costs
Added atomic weighted counter consumption
Route configuration selects server-defined operation names, preventing costs from being set via user input
Added tests covering weighted exhaustion and simple-read behavior

Test results

TypeScript: passed
Lint: passed
827 unit tests: all passed