### PR TITLE
fix(policies): return stable reason codes in evaluation

### DIFF
--- a/src/routes/api/v1/policies/evaluate.ts
+++ b/src/routes/api/v1/policies/evaluate.ts
@@ -21,7 +21,23 @@ export const Route = createFileRoute("/api/v1/policies/evaluate")({
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, evaluationSchema);
           const result = await evaluateMailboxPolicy((await getApiContext()).repository, input);
-          return apiSuccess(request, result);
+
+          const reasonMessages: Record<string, string> = {
+            sender_allowed: "Sender is explicitly allowed by the recipient.",
+            sender_blocked: "Sender is explicitly blocked by the recipient.",
+            unknown_senders_disabled: "Recipient does not accept mail from unknown senders.",
+            verification_required: "Recipient requires sender verification.",
+            insufficient_postage: "Provided postage is insufficient for this recipient.",
+            policy_satisfied: "Sender satisfies all recipient mailbox policies.",
+          };
+
+          const decision = {
+            allowed: result.allowed,
+            reasonCode: result.reason,
+            message: reasonMessages[result.reason] ?? "Unknown policy evaluation result.",
+          };
+
+          return apiSuccess(request, decision);
         }),
     },
   },

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -86,6 +86,33 @@ export const openApiDocument = {
           },
         },
       },
+      PolicyEvaluationDecision: {
+        type: "object",
+        required: ["allowed", "reasonCode", "message"],
+        additionalProperties: false,
+        properties: {
+          allowed: {
+            type: "boolean",
+            description: "True if the sender is allowed to mail the recipient.",
+          },
+          reasonCode: {
+            type: "string",
+            description: "Stable reason code for the policy outcome.",
+            enum: [
+              "sender_allowed",
+              "sender_blocked",
+              "unknown_senders_disabled",
+              "verification_required",
+              "insufficient_postage",
+              "policy_satisfied",
+            ],
+          },
+          message: {
+            type: "string",
+            description: "Human-readable but non-authoritative explanation of the decision.",
+          },
+        },
+      },
     },
   },
   paths: {
@@ -143,6 +170,16 @@ export const openApiDocument = {
         operationId: "evaluateMailboxPolicy",
         summary: "Evaluate whether a sender can mail a recipient",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Policy evaluation decision",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/PolicyEvaluationDecision" },
+              },
+            },
+          },
+        },
       },
     },
     "/postage": {


### PR DESCRIPTION
Closes #1542

# PR Description

I implemented policy evaluation reason codes as part of the public API contract for the mailbox policy evaluation endpoint. Previously, the `/api/v1/policies/evaluate` endpoint returned the raw result of the evaluation function directly, which leaked internal structures such as the `policy` configuration parameters and the matching `rule` overrides. This was unsafe and lacked stability. Furthermore, clients had to parse the raw text results to determine why a message was blocked or allowed.

With this change, the POST request to `/api/v1/policies/evaluate` now returns a standardized, minimal, and documented decision object containing the fields `allowed`, `reasonCode`, and a human-readable `message`. I introduced a mapping in the route handler that links the internal evaluation reasons to stable reason codes and customer-friendly messages. This avoids exposing any internal implementation details while providing a stable contract for downstream client integrations.

# Changes Made
* Modified `src/routes/api/v1/policies/evaluate.ts` to map internal evaluation outcomes to a public decision object consisting of `allowed`, `reasonCode`, and a human-readable `message`.
* Updated `src/server/api/openapi.ts` to declare the `PolicyEvaluationDecision` schema and documented it as the 200 JSON response for `/policies/evaluate`.

# Testing
* Checked type safety and compilation using `npx tsc --noEmit` which completed successfully with zero errors.
* The test runner startup issue (due to a node version compatibility error on the runner environment with Cloudflare Vite plugin) is left as-is, following the instruction to not go out of scope.