### PR TITLE
feat: add repository record validation and API latency histograms

### DIFF
--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -1,5 +1,20 @@
 import { MemoryApiRepository } from "./memory-repository";
+import { ValidatedApiRepository, registerRecordSchema } from "./repository";
 import type { ApiRepository } from "./repository";
+import {
+  mailboxPolicySchema,
+  senderRuleSchema,
+  postageSchema,
+  receiptSchema,
+  idempotencyRecordSchema,
+} from "./domain";
+
+// Register schemas once at module init for Issue #1508 record validation
+registerRecordSchema("mailboxPolicy", mailboxPolicySchema);
+registerRecordSchema("senderRule", senderRuleSchema);
+registerRecordSchema("postage", postageSchema);
+registerRecordSchema("receipt", receiptSchema);
+registerRecordSchema("idempotencyRecord", idempotencyRecordSchema);
 
 interface ApiContext {
   repository: ApiRepository;
@@ -50,7 +65,7 @@ export function validateApiConfig(config: ApiConfig): void {
 
 export async function getApiContext(): Promise<ApiContext> {
   if (!import.meta.env.PROD) {
-    globalApi.__stealthApiRepository ??= new MemoryApiRepository();
+    globalApi.__stealthApiRepository ??= new ValidatedApiRepository(new MemoryApiRepository());
     return { repository: globalApi.__stealthApiRepository };
   }
 
@@ -80,7 +95,9 @@ export async function getApiContext(): Promise<ApiContext> {
   }
 
   const { HybridApiRepository } = await import("./kv-repository");
-  const repo = new HybridApiRepository(env.STEALTH_KV, env.STEALTH_COORDINATOR);
+  const repo = new ValidatedApiRepository(
+    new HybridApiRepository(env.STEALTH_KV, env.STEALTH_COORDINATOR),
+  );
   globalApi.__stealthApiRepository = repo;
   return { repository: repo };
 }

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -9,7 +9,8 @@ export type ApiErrorCode =
   | "not_found"
   | "unauthorized"
   | "validation_error"
-  | "too_many_requests";
+  | "too_many_requests"
+  | "data_integrity_error";
 
 export type ValidationRuleCode =
   | "invalid_type"
@@ -43,6 +44,28 @@ export class ApiError extends Error {
     this.status = status;
     this.code = code;
     this.details = details;
+  }
+}
+
+/**
+ * Issue #1508: classified data-integrity error that never leaks the
+ * contents of a corrupt record to clients.
+ *
+ * `recordType` identifies the kind of record that failed validation
+ * (e.g. "postage", "receipt"). `correlationId` ties the error back to
+ * server-side diagnostics without exposing the corrupt payload.
+ */
+export class DataIntegrityError extends Error {
+  readonly recordType: string;
+  readonly correlationId: string;
+  readonly code: ApiErrorCode = "data_integrity_error";
+  readonly status = 500;
+
+  constructor(recordType: string, correlationId: string, message?: string) {
+    super(message ?? `Stored ${recordType} record failed validation`);
+    this.name = "DataIntegrityError";
+    this.recordType = recordType;
+    this.correlationId = correlationId;
   }
 }
 

--- a/src/server/api/metrics.ts
+++ b/src/server/api/metrics.ts
@@ -1,6 +1,94 @@
-export function incrementCounter(_metric: string, _labels?: Record<string, string>): void {}
+// Issue #1510: API request latency histograms and counters.
+//
+// Default histogram bucket boundaries (in milliseconds) suitable for API
+// request durations. These cover sub-5 ms fast-path responses through
+// multi-second slow dependencies.
+export const DEFAULT_LATENCY_BUCKETS = [
+  5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000,
+] as const;
+
+interface CounterEntry {
+  value: number;
+}
+
+interface HistogramEntry {
+  buckets: Record<string, number>;
+  sum: number;
+  count: number;
+}
+
+const counters = new Map<string, CounterEntry>();
+const histograms = new Map<string, HistogramEntry>();
+
+function labelKey(name: string, labels: Record<string, string>): string {
+  const parts = Object.entries(labels)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}:"${v}"`);
+  return parts.length ? `${name}{${parts.join(",")}}` : name;
+}
+
+function bucketFor(value: number, buckets: readonly number[]): string {
+  for (const boundary of buckets) {
+    if (value <= boundary) return `~${boundary}`;
+  }
+  return `~+Inf`;
+}
+
+export function incrementCounter(metric: string, labels?: Record<string, string>): void {
+  const key = labelKey(metric, labels ?? {});
+  const entry = counters.get(key) ?? { value: 0 };
+  entry.value += 1;
+  counters.set(key, entry);
+}
+
 export function recordHistogram(
-  _metric: string,
-  _value: number,
-  _labels?: Record<string, string>,
-): void {}
+  metric: string,
+  value: number,
+  labels?: Record<string, string>,
+  buckets: readonly number[] = DEFAULT_LATENCY_BUCKETS,
+): void {
+  const key = labelKey(metric, labels ?? {});
+  const entry = histograms.get(key) ?? { buckets: {}, sum: 0, count: 0 };
+  const bucket = bucketFor(value, buckets);
+  entry.buckets[bucket] = (entry.buckets[bucket] ?? 0) + 1;
+  entry.sum += value;
+  entry.count += 1;
+  histograms.set(key, entry);
+}
+
+/**
+ * Returns a snapshot of all accumulated metrics data.
+ * Useful for test assertions and for building a /metrics endpoint.
+ */
+export function snapshot(): {
+  counters: Record<string, number>;
+  histograms: Record<string, { buckets: Record<string, number>; sum: number; count: number }>;
+} {
+  const counterSnapshot: Record<string, number> = {};
+  for (const [key, entry] of counters) {
+    counterSnapshot[key] = entry.value;
+  }
+
+  const histogramSnapshot: Record<
+    string,
+    { buckets: Record<string, number>; sum: number; count: number }
+  > = {};
+  for (const [key, entry] of histograms) {
+    histogramSnapshot[key] = {
+      buckets: { ...entry.buckets },
+      sum: entry.sum,
+      count: entry.count,
+    };
+  }
+
+  return { counters: counterSnapshot, histograms: histogramSnapshot };
+}
+
+/**
+ * Resets all collected metrics. Useful between tests or before fresh
+ * measurement windows.
+ */
+export function reset(): void {
+  counters.clear();
+  histograms.clear();
+}

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -1,3 +1,4 @@
+import type { ZodSchema } from "zod";
 import type {
   IdempotencyRecord,
   MailboxPolicy,
@@ -6,6 +7,7 @@ import type {
   Receipt,
   SenderRule,
 } from "./domain";
+import { DataIntegrityError } from "./errors";
 
 /**
  * Outcome of an atomic compare-and-swap postage state transition.
@@ -61,6 +63,7 @@ export interface ApiRepository {
   getRelayDeadLetterCount(relayId: string): Promise<number>;
   getCounter(key: string): Promise<number>;
   incrementCounter(key: string, windowSeconds: number, amount?: number): Promise<number>;
+  reset?(): void;
 }
 
 export const defaultMailboxPolicy: MailboxPolicy = {
@@ -68,3 +71,136 @@ export const defaultMailboxPolicy: MailboxPolicy = {
   minimumPostage: "0",
   requireVerified: true,
 };
+
+// ---------------------------------------------------------------------------
+// Issue #1508: Record validation at adapter boundaries
+// ---------------------------------------------------------------------------
+
+let correlationCounter = 0;
+
+export function generateCorrelationId(): string {
+  correlationCounter += 1;
+  return `di-${Date.now()}-${correlationCounter}`;
+}
+
+const recordSchemas = new Map<string, ZodSchema>();
+
+export function registerRecordSchema(type: string, schema: ZodSchema): void {
+  recordSchemas.set(type, schema);
+}
+
+export function validateRecord<T>(recordType: string, data: unknown): T {
+  const schema = recordSchemas.get(recordType);
+  if (!schema) return data as T;
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new DataIntegrityError(
+      recordType,
+      generateCorrelationId(),
+      `Stored ${recordType} record failed validation`,
+    );
+  }
+  return result.data as T;
+}
+
+/**
+ * Wraps any ApiRepository to validate records at adapter boundaries.
+ * Corrupt records throw a DataIntegrityError that never leaks the
+ * corrupt payload to clients — only the record type and correlation ID
+ * are exposed.
+ */
+export class ValidatedApiRepository implements ApiRepository {
+  constructor(private readonly inner: ApiRepository) {}
+
+  async getPolicy(owner: string): Promise<MailboxPolicy | null> {
+    const raw = await this.inner.getPolicy(owner);
+    return raw ? validateRecord<MailboxPolicy>("mailboxPolicy", raw) : null;
+  }
+
+  setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
+    return this.inner.setPolicy(owner, policy);
+  }
+
+  async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
+    const raw = await this.inner.getSenderRule(owner, sender);
+    return validateRecord<SenderRule>("senderRule", raw);
+  }
+
+  setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
+    return this.inner.setSenderRule(owner, sender, rule);
+  }
+
+  async getPostage(messageId: string): Promise<Postage | null> {
+    const raw = await this.inner.getPostage(messageId);
+    return raw ? validateRecord<Postage>("postage", raw) : null;
+  }
+
+  setPostage(postage: Postage): Promise<Postage> {
+    return this.inner.setPostage(postage);
+  }
+
+  transitionPostage(
+    messageId: string,
+    expectedStatus: PostageStatus,
+    nextStatus: PostageStatus,
+  ): Promise<PostageTransitionResult> {
+    return this.inner.transitionPostage(messageId, expectedStatus, nextStatus);
+  }
+
+  async getReceipt(messageId: string): Promise<Receipt | null> {
+    const raw = await this.inner.getReceipt(messageId);
+    return raw ? validateRecord<Receipt>("receipt", raw) : null;
+  }
+
+  setReceipt(receipt: Receipt): Promise<Receipt> {
+    return this.inner.setReceipt(receipt);
+  }
+
+  acquireIdempotencyRecord(
+    key: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult> {
+    return this.inner.acquireIdempotencyRecord(key, leaseMs);
+  }
+
+  async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
+    const raw = await this.inner.getIdempotencyRecord(key);
+    return raw ? validateRecord<IdempotencyRecord>("idempotencyRecord", raw) : null;
+  }
+
+  setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {
+    return this.inner.setIdempotencyRecord(key, record);
+  }
+
+  getRelayQueueDepth(relayId: string): Promise<number> {
+    return this.inner.getRelayQueueDepth(relayId);
+  }
+
+  getRelayRetryCount(relayId: string): Promise<number> {
+    return this.inner.getRelayRetryCount(relayId);
+  }
+
+  getRelayLastSuccessfulDelivery(relayId: string): Promise<string | null> {
+    return this.inner.getRelayLastSuccessfulDelivery(relayId);
+  }
+
+  getRelayLastFailedDelivery(relayId: string): Promise<string | null> {
+    return this.inner.getRelayLastFailedDelivery(relayId);
+  }
+
+  getRelayDeadLetterCount(relayId: string): Promise<number> {
+    return this.inner.getRelayDeadLetterCount(relayId);
+  }
+
+  getCounter(key: string): Promise<number> {
+    return this.inner.getCounter(key);
+  }
+
+  incrementCounter(key: string, windowSeconds: number, amount?: number): Promise<number> {
+    return this.inner.incrementCounter(key, windowSeconds, amount);
+  }
+
+  reset(): void {
+    this.inner.reset?.();
+  }
+}

--- a/tests/unit/api/metrics.test.ts
+++ b/tests/unit/api/metrics.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  incrementCounter,
+  recordHistogram,
+  snapshot,
+  reset,
+  DEFAULT_LATENCY_BUCKETS,
+} from "../../../src/server/api/metrics";
+
+describe("metrics", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  describe("incrementCounter", () => {
+    it("increments a named counter", () => {
+      incrementCounter("api_requests_total", { method: "GET", path: "/api/test", status: "200" });
+      const snap = snapshot();
+      expect(snap.counters['api_requests_total{method:"GET",path:"/api/test",status:"200"}']).toBe(
+        1,
+      );
+    });
+
+    it("increments multiple times", () => {
+      incrementCounter("api_requests_total", { method: "POST", path: "/api/data", status: "201" });
+      incrementCounter("api_requests_total", { method: "POST", path: "/api/data", status: "201" });
+      const snap = snapshot();
+      expect(
+        snap.counters['api_requests_total{method:"POST",path:"/api/data",status:"201"}'],
+      ).toBe(2);
+    });
+
+    it("separates counters by labels", () => {
+      incrementCounter("api_requests_total", { method: "GET", path: "/api/a", status: "200" });
+      incrementCounter("api_requests_total", { method: "POST", path: "/api/b", status: "400" });
+      const snap = snapshot();
+      expect(Object.keys(snap.counters)).toHaveLength(2);
+    });
+
+    it("works without labels", () => {
+      incrementCounter("some_metric");
+      const snap = snapshot();
+      expect(snap.counters["some_metric"]).toBe(1);
+    });
+  });
+
+  describe("recordHistogram", () => {
+    it("records a value into the correct bucket", () => {
+      recordHistogram("api_latency", 30, { method: "GET", path: "/api/test", status: "200" });
+      const snap = snapshot();
+      const hist = snap.histograms['api_latency{method:"GET",path:"/api/test",status:"200"}'];
+      expect(hist).toBeDefined();
+      expect(hist.count).toBe(1);
+      expect(hist.sum).toBeCloseTo(30);
+      // 30ms falls in the ~50 bucket
+      expect(hist.buckets["~50"]).toBe(1);
+    });
+
+    it("places values in the correct buckets", () => {
+      const labels = { method: "GET", path: "/api/test", status: "200" };
+      recordHistogram("api_latency", 3, labels);  // ~5
+      recordHistogram("api_latency", 12, labels); // ~25
+      recordHistogram("api_latency", 80, labels); // ~100
+      recordHistogram("api_latency", 3000, labels); // ~5000
+      recordHistogram("api_latency", 6000, labels); // ~+Inf
+
+      const snap = snapshot();
+      const hist = snap.histograms['api_latency{method:"GET",path:"/api/test",status:"200"}'];
+      expect(hist.count).toBe(5);
+      expect(hist.buckets["~5"]).toBe(1);
+      expect(hist.buckets["~25"]).toBe(1);
+      expect(hist.buckets["~100"]).toBe(1);
+      expect(hist.buckets["~5000"]).toBe(1);
+      expect(hist.buckets["~+Inf"]).toBe(1);
+    });
+
+    it("tracks total sum of recorded values", () => {
+      const labels = { method: "GET", path: "/api/test", status: "200" };
+      recordHistogram("api_latency", 10, labels);
+      recordHistogram("api_latency", 20, labels);
+      recordHistogram("api_latency", 30, labels);
+
+      const snap = snapshot();
+      const hist = snap.histograms['api_latency{method:"GET",path:"/api/test",status:"200"}'];
+      expect(hist.sum).toBeCloseTo(60);
+    });
+
+    it("uses default latency buckets when none provided", () => {
+      expect(DEFAULT_LATENCY_BUCKETS).toEqual([5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]);
+    });
+
+    it("separates histograms by labels", () => {
+      recordHistogram("api_latency", 10, { method: "GET", path: "/api/a", status: "200" });
+      recordHistogram("api_latency", 200, { method: "POST", path: "/api/b", status: "500" });
+
+      const snap = snapshot();
+      expect(Object.keys(snap.histograms)).toHaveLength(2);
+    });
+  });
+
+  describe("snapshot / reset", () => {
+    it("snapshot returns current state without mutation", () => {
+      incrementCounter("test", { label: "a" });
+      const snap1 = snapshot();
+      expect(snap1.counters['test{label:"a"}']).toBe(1);
+
+      // Mutating the snapshot should not affect internal state
+      snap1.counters['test{label:"a"}'] = 999;
+      const snap2 = snapshot();
+      expect(snap2.counters['test{label:"a"}']).toBe(1);
+    });
+
+    it("reset clears all counters and histograms", () => {
+      incrementCounter("test");
+      recordHistogram("latency", 50);
+      reset();
+      const snap = snapshot();
+      expect(snap.counters).toEqual({});
+      expect(snap.histograms).toEqual({});
+    });
+  });
+});

--- a/tests/unit/api/validated-repository.test.ts
+++ b/tests/unit/api/validated-repository.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ValidatedApiRepository, registerRecordSchema } from "../../../src/server/api/repository";
+import { ValidatedApiRepository as ValidatedRepo } from "../../../src/server/api/repository";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { DataIntegrityError } from "../../../src/server/api/errors";
+import {
+  mailboxPolicySchema,
+  senderRuleSchema,
+  postageSchema,
+  receiptSchema,
+  idempotencyRecordSchema,
+} from "../../../src/server/api/domain";
+
+// Register schemas for validation (same as context.ts)
+registerRecordSchema("mailboxPolicy", mailboxPolicySchema);
+registerRecordSchema("senderRule", senderRuleSchema);
+registerRecordSchema("postage", postageSchema);
+registerRecordSchema("receipt", receiptSchema);
+registerRecordSchema("idempotencyRecord", idempotencyRecordSchema);
+
+const owner = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+const messageId = "a".repeat(64);
+
+describe("ValidatedApiRepository - record integrity", () => {
+  let inner: MemoryApiRepository;
+  let repo: ValidatedApiRepository;
+
+  beforeEach(() => {
+    inner = new MemoryApiRepository();
+    repo = new ValidatedApiRepository(inner);
+  });
+
+  it("passes through valid records", async () => {
+    await inner.setPolicy(owner, {
+      allowUnknown: true,
+      minimumPostage: "100",
+      requireVerified: false,
+    });
+
+    await expect(repo.getPolicy(owner)).resolves.toMatchObject({
+      allowUnknown: true,
+      minimumPostage: "100",
+    });
+  });
+
+  it("throws DataIntegrityError when stored policy record is corrupt", async () => {
+    const innerMap = (inner as any)["policies"] as Map<string, unknown>;
+    innerMap.set(owner, { allowUnknown: "not-a-boolean", minimumPostage: "100" });
+
+    let error: unknown;
+    try {
+      await repo.getPolicy(owner);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.recordType).toBe("mailboxPolicy");
+      expect(error.correlationId).toMatch(/^di-/);
+    }
+  });
+
+  it("throws DataIntegrityError when stored postage record is corrupt", async () => {
+    const innerMap = (inner as any)["postage"] as Map<string, unknown>;
+    innerMap.set(messageId, {
+      amount: "not-a-number",
+      createdAt: "invalid-date",
+      messageId,
+    });
+
+    let error: unknown;
+    try {
+      await repo.getPostage(messageId);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.recordType).toBe("postage");
+    }
+  });
+
+  it("throws DataIntegrityError when stored receipt record is corrupt", async () => {
+    const innerMap = (inner as any)["receipts"] as Map<string, unknown>;
+    innerMap.set(messageId, {
+      deliveredAt: null,
+      messageId: 12345,
+      readAt: null,
+      recipient: "not-a-valid-address",
+    });
+
+    let error: unknown;
+    try {
+      await repo.getReceipt(messageId);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.recordType).toBe("receipt");
+    }
+  });
+
+  it("throws DataIntegrityError when stored sender rule is corrupt", async () => {
+    const innerMap = (inner as any)["senderRules"] as Map<string, unknown>;
+    innerMap.set(`${owner}:${sender}`, "invalid-rule-value");
+
+    let error: unknown;
+    try {
+      await repo.getSenderRule(owner, sender);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.recordType).toBe("senderRule");
+    }
+  });
+
+  it("returns null for missing records (not corrupt)", async () => {
+    await expect(repo.getPolicy("nonexistent")).resolves.toBeNull();
+    await expect(repo.getPostage("nonexistent")).resolves.toBeNull();
+    await expect(repo.getReceipt("nonexistent")).resolves.toBeNull();
+  });
+
+  it("does not corrupt the error message reveal the record payload", async () => {
+    const innerMap = (inner as any)["policies"] as Map<string, unknown>;
+    innerMap.set(owner, { allowUnknown: "bad-value" });
+
+    let error: unknown;
+    try {
+      await repo.getPolicy(owner);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.message).not.toContain("bad-value");
+      expect(error.message).toContain("mailboxPolicy");
+    }
+  });
+
+  it("generates unique correlation IDs for each integrity error", async () => {
+    const innerMap = (inner as any)["policies"] as Map<string, unknown>;
+    innerMap.set(owner, { allowUnknown: "bad" });
+
+    try {
+      await repo.getPolicy(owner);
+    } catch (e1) {
+      try {
+        innerMap.set(owner, { allowUnknown: "also-bad" });
+        await repo.getPolicy(owner);
+      } catch (e2) {
+        expect(e1).toBeInstanceOf(DataIntegrityError);
+        expect(e2).toBeInstanceOf(DataIntegrityError);
+        if (e1 instanceof DataIntegrityError && e2 instanceof DataIntegrityError) {
+          expect(e1.correlationId).not.toBe(e2.correlationId);
+        }
+        return;
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #1508 — Add repository corruption and invalid-record handling

- Add DataIntegrityError class with safe diagnostic info (record type, correlation ID)
- Register Zod schemas for all persisted record types (mailboxPolicy, senderRule, postage, receipt, idempotencyRecord)
- Implement ValidatedApiRepository wrapper that validates records at adapter boundaries
- Corrupt records throw DataIntegrityError with record type and correlation ID — never leak payload contents to clients
- Integrate wrapper into context.ts for both dev (MemoryApiRepository) and prod (HybridApiRepository) paths
- Add full test coverage: valid records pass through, corrupt records throw classified errors, unique correlation IDs, null returns for missing records

Closes #1510 — Add API request latency histograms

- Replace no-op stub with real histogram implementation in metrics.ts
- Use appropriate latency buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000] ms
- Track bucket distribution, sum, and count per label combination
- Support snapshot() for metrics inspection and reset() for test isolation
- Route labels use stable templates (already handled in handler.ts: method, path, status)
- Add comprehensive test coverage: labeling, bucket placement, sum tracking, snapshot isolation, reset
