### PR TITLE
Reject empty JSON bodies with a dedicated API error

### DIFF
--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -24,6 +24,9 @@ export async function parseJsonBody<T>(
   }
 
   const body = await request.text();
+  if (!body.trim()) {
+    throw new ApiError(400, "bad_request", "Request body must not be empty");
+  }
   if (new TextEncoder().encode(body).byteLength > maxBytes) {
     throw new ApiError(413, "bad_request", `Request body exceeds ${maxBytes} bytes`);
   }

--- a/tests/unit/api/request.empty-body.test.ts
+++ b/tests/unit/api/request.empty-body.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { parseJsonBody } from "../../../src/server/api/request";
+import { z } from "zod";
+
+describe("parseJsonBody empty/whitespace handling", () => {
+  it("rejects an empty required body", async () => {
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "",
+    });
+
+    await expect(parseJsonBody(request, z.object({ amount: z.number() }))).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+
+  it("rejects whitespace-only bodies", async () => {
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "   \t\n  ",
+    });
+
+    await expect(parseJsonBody(request, z.object({ amount: z.number() }))).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+
+  it("keeps malformed JSON distinguishable from empty body", async () => {
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    await expect(parseJsonBody(request, z.object({ amount: z.number() }))).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+});


### PR DESCRIPTION
Reject empty and whitespace-only request bodies in `parseJsonBody` before parsing, so clients get a stable 400 instead of a generic JSON parse failure.

Fixes #1483