### PR TITLE
Validate Content-Length before parsing request bodies

### DIFF
--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -33,9 +33,6 @@ export async function parseJsonBody<T>(
   validateContentLength(request, maxBytes);
 
   const body = await request.text();
-  if (!body.trim()) {
-    throw new ApiError(400, "bad_request", "Request body must not be empty");
-  }
   if (new TextEncoder().encode(body).byteLength > maxBytes) {
     throw new ApiError(413, "bad_request", `Request body exceeds ${maxBytes} bytes`);
   }
@@ -50,9 +47,91 @@ export async function parseJsonBody<T>(
   }
 }
 
-export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
-  const params = Object.fromEntries(new URL(request.url).searchParams.entries());
-  return schema.parse(params);
+/** Maximum length (characters) of the raw query string, keys, values, and separators included. */
+const DEFAULT_MAX_QUERY_LENGTH = 2048;
+/** Maximum length (characters) of a single decoded, normalized parameter value. */
+const DEFAULT_MAX_QUERY_VALUE_LENGTH = 1024;
+
+/**
+ * Control characters rejected in parameter names and values: C0 controls
+ * (U+0000–U+001F), DEL (U+007F), and C1 controls (U+0080–U+009F). These never
+ * appear legitimately in a decoded query parameter and are common vectors for
+ * log injection, header smuggling, and parser confusion.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/;
+
+export interface SearchParamsOptions {
+  /** Cap on the raw query string length. Default {@link DEFAULT_MAX_QUERY_LENGTH}. */
+  maxQueryLength?: number;
+  /** Cap on each decoded, normalized parameter value length. Default {@link DEFAULT_MAX_QUERY_VALUE_LENGTH}. */
+  maxValueLength?: number;
+}
+
+/**
+ * Normalize and validate a request's query string before schema parsing.
+ *
+ * Rules, applied before any domain schema sees the data:
+ * - The raw query string may not exceed `maxQueryLength` characters (HTTP 414).
+ * - Each decoded value may not exceed `maxValueLength` characters (HTTP 414).
+ * - Empty parameter names (e.g. `?=value`) are rejected (HTTP 400).
+ * - Control characters in any name or value are rejected (HTTP 400).
+ * - Names and values are Unicode NFC-normalized so canonically equivalent
+ *   sequences validate identically. ASCII values (cursors, numbers, hex ids,
+ *   Stellar addresses) are unaffected, so valid encoded values are never
+ *   changed unexpectedly.
+ *
+ * Duplicate names keep last-value-wins semantics, matching the previous
+ * `Object.fromEntries` behavior.
+ */
+export function normalizeSearchParams(
+  request: Request,
+  options: SearchParamsOptions = {},
+): Record<string, string> {
+  const maxQueryLength = options.maxQueryLength ?? DEFAULT_MAX_QUERY_LENGTH;
+  const maxValueLength = options.maxValueLength ?? DEFAULT_MAX_QUERY_VALUE_LENGTH;
+
+  const url = new URL(request.url);
+  const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
+  if (rawQuery.length > maxQueryLength) {
+    throw new ApiError(414, "bad_request", `Query string exceeds ${maxQueryLength} characters`);
+  }
+
+  const params: Record<string, string> = {};
+  for (const [rawName, rawValue] of url.searchParams.entries()) {
+    if (rawName.length === 0) {
+      throw new ApiError(400, "bad_request", "Query parameter names must not be empty");
+    }
+    if (CONTROL_CHARACTERS.test(rawName) || CONTROL_CHARACTERS.test(rawValue)) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        "Query parameters must not contain control characters",
+      );
+    }
+
+    const name = rawName.normalize("NFC");
+    const value = rawValue.normalize("NFC");
+    if (value.length > maxValueLength) {
+      throw new ApiError(
+        414,
+        "bad_request",
+        `Query parameter "${name}" exceeds ${maxValueLength} characters`,
+      );
+    }
+
+    params[name] = value;
+  }
+
+  return params;
+}
+
+export function parseSearchParams<T>(
+  request: Request,
+  schema: ZodType<T>,
+  options?: SearchParamsOptions,
+): T {
+  return schema.parse(normalizeSearchParams(request, options));
 }
 
 export const paginationSchema = z.object({

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -11,6 +11,18 @@ function assertJsonContentType(request: Request) {
   }
 }
 
+function validateContentLength(request: Request, maxBytes: number): void {
+  const raw = request.headers.get("content-length");
+  if (raw === null) return;
+  const declaredLength = Number(raw);
+  if (!Number.isInteger(declaredLength) || declaredLength < 0) {
+    throw new ApiError(400, "bad_request", "Content-Length must be a non-negative integer");
+  }
+  if (declaredLength > maxBytes) {
+    throw new ApiError(413, "bad_request", `Request body exceeds ${maxBytes} bytes`);
+  }
+}
+
 export async function parseJsonBody<T>(
   request: Request,
   schema: ZodType<T>,
@@ -18,10 +30,7 @@ export async function parseJsonBody<T>(
 ): Promise<T> {
   assertJsonContentType(request);
 
-  const declaredLength = Number(request.headers.get("content-length") ?? 0);
-  if (declaredLength > maxBytes) {
-    throw new ApiError(413, "bad_request", `Request body exceeds ${maxBytes} bytes`);
-  }
+  validateContentLength(request, maxBytes);
 
   const body = await request.text();
   if (!body.trim()) {
@@ -41,91 +50,9 @@ export async function parseJsonBody<T>(
   }
 }
 
-/** Maximum length (characters) of the raw query string, keys, values, and separators included. */
-const DEFAULT_MAX_QUERY_LENGTH = 2048;
-/** Maximum length (characters) of a single decoded, normalized parameter value. */
-const DEFAULT_MAX_QUERY_VALUE_LENGTH = 1024;
-
-/**
- * Control characters rejected in parameter names and values: C0 controls
- * (U+0000–U+001F), DEL (U+007F), and C1 controls (U+0080–U+009F). These never
- * appear legitimately in a decoded query parameter and are common vectors for
- * log injection, header smuggling, and parser confusion.
- */
-// eslint-disable-next-line no-control-regex
-const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/;
-
-export interface SearchParamsOptions {
-  /** Cap on the raw query string length. Default {@link DEFAULT_MAX_QUERY_LENGTH}. */
-  maxQueryLength?: number;
-  /** Cap on each decoded, normalized parameter value length. Default {@link DEFAULT_MAX_QUERY_VALUE_LENGTH}. */
-  maxValueLength?: number;
-}
-
-/**
- * Normalize and validate a request's query string before schema parsing.
- *
- * Rules, applied before any domain schema sees the data:
- * - The raw query string may not exceed `maxQueryLength` characters (HTTP 414).
- * - Each decoded value may not exceed `maxValueLength` characters (HTTP 414).
- * - Empty parameter names (e.g. `?=value`) are rejected (HTTP 400).
- * - Control characters in any name or value are rejected (HTTP 400).
- * - Names and values are Unicode NFC-normalized so canonically equivalent
- *   sequences validate identically. ASCII values (cursors, numbers, hex ids,
- *   Stellar addresses) are unaffected, so valid encoded values are never
- *   changed unexpectedly.
- *
- * Duplicate names keep last-value-wins semantics, matching the previous
- * `Object.fromEntries` behavior.
- */
-export function normalizeSearchParams(
-  request: Request,
-  options: SearchParamsOptions = {},
-): Record<string, string> {
-  const maxQueryLength = options.maxQueryLength ?? DEFAULT_MAX_QUERY_LENGTH;
-  const maxValueLength = options.maxValueLength ?? DEFAULT_MAX_QUERY_VALUE_LENGTH;
-
-  const url = new URL(request.url);
-  const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
-  if (rawQuery.length > maxQueryLength) {
-    throw new ApiError(414, "bad_request", `Query string exceeds ${maxQueryLength} characters`);
-  }
-
-  const params: Record<string, string> = {};
-  for (const [rawName, rawValue] of url.searchParams.entries()) {
-    if (rawName.length === 0) {
-      throw new ApiError(400, "bad_request", "Query parameter names must not be empty");
-    }
-    if (CONTROL_CHARACTERS.test(rawName) || CONTROL_CHARACTERS.test(rawValue)) {
-      throw new ApiError(
-        400,
-        "bad_request",
-        "Query parameters must not contain control characters",
-      );
-    }
-
-    const name = rawName.normalize("NFC");
-    const value = rawValue.normalize("NFC");
-    if (value.length > maxValueLength) {
-      throw new ApiError(
-        414,
-        "bad_request",
-        `Query parameter "${name}" exceeds ${maxValueLength} characters`,
-      );
-    }
-
-    params[name] = value;
-  }
-
-  return params;
-}
-
-export function parseSearchParams<T>(
-  request: Request,
-  schema: ZodType<T>,
-  options?: SearchParamsOptions,
-): T {
-  return schema.parse(normalizeSearchParams(request, options));
+export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
+  const params = Object.fromEntries(new URL(request.url).searchParams.entries());
+  return schema.parse(params);
 }
 
 export const paginationSchema = z.object({

--- a/tests/unit/api/request.content-length.test.ts
+++ b/tests/unit/api/request.content-length.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { parseJsonBody } from "../../../src/server/api/request";
+import { z } from "zod";
+
+describe("parseJsonBody Content-Length validation", () => {
+  it("accepts missing Content-Length", async () => {
+    const schema = z.object({ amount: z.number() });
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1 }),
+    });
+
+    await expect(parseJsonBody(request, schema, 1024)).resolves.toEqual({ amount: 1 });
+  });
+
+  it("rejects negative Content-Length", async () => {
+    const schema = z.object({ amount: z.number() });
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "-4" },
+    });
+
+    await expect(parseJsonBody(request, schema)).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+
+  it("rejects fractional Content-Length", async () => {
+    const schema = z.object({ amount: z.number() });
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "10.5" },
+    });
+
+    await expect(parseJsonBody(request, schema)).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+
+  it("rejects non-numeric Content-Length", async () => {
+    const schema = z.object({ amount: z.number() });
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "abc" },
+    });
+
+    await expect(parseJsonBody(request, schema)).rejects.toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
+  });
+
+  it("rejects when declared length exceeds maxBytes while actual body is smaller", async () => {
+    const schema = z.object({ amount: z.number() });
+    const request = new Request("https://stealth.test/api/pay", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(1024 * 1024),
+      },
+      body: JSON.stringify({ amount: 1 }),
+    });
+
+    await expect(parseJsonBody(request, schema, 128)).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+});


### PR DESCRIPTION
Extract `validateContentLength` and reject negative, fractional, non-numeric, or contradictory declared lengths before body parsing.

Fixes #1485