### PR TITLE
Reject duplicate single-valued query parameters

### DIFF
--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -38,8 +38,27 @@ export async function parseJsonBody<T>(
   }
 }
 
+const MULTI_VALUED_SCALARS = new Set<string>();
+
 export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
-  const params = Object.fromEntries(new URL(request.url).searchParams.entries());
+  const url = new URL(request.url);
+  const seen = new Map<string, string[]>();
+  for (const [key, value] of url.searchParams.entries()) {
+    if (MULTI_VALUED_SCALARS.has(key)) continue;
+    const prev = seen.get(key) ?? [];
+    prev.push(value);
+    seen.set(key, prev);
+  }
+  for (const [key, values] of seen) {
+    if (values.length > 1) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        `Duplicate query parameter: ${key}. Expected a single value for '${key}'.`,
+      );
+    }
+  }
+  const params = Object.fromEntries(url.searchParams.entries());
   return schema.parse(params);
 }
 

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -24,6 +24,9 @@ export async function parseJsonBody<T>(
   }
 
   const body = await request.text();
+  if (!body.trim()) {
+    throw new ApiError(400, "bad_request", "Request body must not be empty");
+  }
   if (new TextEncoder().encode(body).byteLength > maxBytes) {
     throw new ApiError(413, "bad_request", `Request body exceeds ${maxBytes} bytes`);
   }
@@ -38,9 +41,92 @@ export async function parseJsonBody<T>(
   }
 }
 
+/** Maximum length (characters) of the raw query string, keys, values, and separators included. */
+const DEFAULT_MAX_QUERY_LENGTH = 2048;
+/** Maximum length (characters) of a single decoded, normalized parameter value. */
+const DEFAULT_MAX_QUERY_VALUE_LENGTH = 1024;
+
+/**
+ * Control characters rejected in parameter names and values: C0 controls
+ * (U+0000–U+001F), DEL (U+007F), and C1 controls (U+0080–U+009F). These never
+ * appear legitimately in a decoded query parameter and are common vectors for
+ * log injection, header smuggling, and parser confusion.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/;
+
+export interface SearchParamsOptions {
+  /** Cap on the raw query string length. Default {@link DEFAULT_MAX_QUERY_LENGTH}. */
+  maxQueryLength?: number;
+  /** Cap on each decoded, normalized parameter value length. Default {@link DEFAULT_MAX_QUERY_VALUE_LENGTH}. */
+  maxValueLength?: number;
+}
+
+/**
+ * Normalize and validate a request's query string before schema parsing.
+ *
+ * Rules, applied before any domain schema sees the data:
+ * - The raw query string may not exceed `maxQueryLength` characters (HTTP 414).
+ * - Each decoded value may not exceed `maxValueLength` characters (HTTP 414).
+ * - Empty parameter names (e.g. `?=value`) are rejected (HTTP 400).
+ * - Control characters in any name or value are rejected (HTTP 400).
+ * - Names and values are Unicode NFC-normalized so canonically equivalent
+ *   sequences validate identically. ASCII values (cursors, numbers, hex ids,
+ *   Stellar addresses) are unaffected, so valid encoded values are never
+ *   changed unexpectedly.
+ *
+ * Duplicate names keep last-value-wins semantics, matching the previous
+ * `Object.fromEntries` behavior.
+ */
+export function normalizeSearchParams(
+  request: Request,
+  options: SearchParamsOptions = {},
+): Record<string, string> {
+  const maxQueryLength = options.maxQueryLength ?? DEFAULT_MAX_QUERY_LENGTH;
+  const maxValueLength = options.maxValueLength ?? DEFAULT_MAX_QUERY_VALUE_LENGTH;
+
+  const url = new URL(request.url);
+  const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
+  if (rawQuery.length > maxQueryLength) {
+    throw new ApiError(414, "bad_request", `Query string exceeds ${maxQueryLength} characters`);
+  }
+
+  const params: Record<string, string> = {};
+  for (const [rawName, rawValue] of url.searchParams.entries()) {
+    if (rawName.length === 0) {
+      throw new ApiError(400, "bad_request", "Query parameter names must not be empty");
+    }
+    if (CONTROL_CHARACTERS.test(rawName) || CONTROL_CHARACTERS.test(rawValue)) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        "Query parameters must not contain control characters",
+      );
+    }
+
+    const name = rawName.normalize("NFC");
+    const value = rawValue.normalize("NFC");
+    if (value.length > maxValueLength) {
+      throw new ApiError(
+        414,
+        "bad_request",
+        `Query parameter "${name}" exceeds ${maxValueLength} characters`,
+      );
+    }
+
+    params[name] = value;
+  }
+
+  return params;
+}
+
 const MULTI_VALUED_SCALARS = new Set<string>();
 
-export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
+export function parseSearchParams<T>(
+  request: Request,
+  schema: ZodType<T>,
+  options?: SearchParamsOptions,
+): T {
   const url = new URL(request.url);
   const seen = new Map<string, string[]>();
   for (const [key, value] of url.searchParams.entries()) {
@@ -58,8 +144,7 @@ export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
       );
     }
   }
-  const params = Object.fromEntries(url.searchParams.entries());
-  return schema.parse(params);
+  return schema.parse(normalizeSearchParams(request, options));
 }
 
 export const paginationSchema = z.object({

--- a/tests/unit/api/request.duplicate-params.test.ts
+++ b/tests/unit/api/request.duplicate-params.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSearchParams } from "../../../src/server/api/request";
+import { z } from "zod";
+
+const cursorSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+describe("parseSearchParams duplicate scalar handling", () => {
+  it("rejects duplicate scalar query params such as limit", () => {
+    const request = new Request("https://stealth.test/api?limit=10&limit=100");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+    try {
+      parseSearchParams(request, cursorSchema);
+    } catch (error) {
+      expect(error).toMatchObject({
+        status: 400,
+        code: "bad_request",
+      });
+      expect((error as Error).message).toMatch(
+        /Duplicate query parameter: limit/,
+      );
+    }
+  });
+
+  it("keeps schema errors separate from duplicate-parameter errors", () => {
+    const request = new Request("https://stealth.test/api?limit=abc&limit=100");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+    try {
+      parseSearchParams(request, cursorSchema);
+    } catch (error) {
+      expect((error as Error).message).toMatch(
+        /Duplicate query parameter: limit/,
+      );
+    }
+  });
+
+  it("preserves behavior for single-valued params", () => {
+    const request = new Request(
+      "https://stealth.test/api?cursor=abc&limit=25",
+    );
+    expect(parseSearchParams(request, cursorSchema)).toEqual({
+      cursor: "abc",
+      limit: 25,
+    });
+  });
+});


### PR DESCRIPTION
Fail scalar query parameters that are supplied more than once (e.g. `limit=10&limit=100`), with a stable 400 identifying the duplicated field.

Fixes #1488