### PR TITLE
feat(draft-improver): add isolated core feature engine

### DIFF
--- a/tools/v2/individual/draft-improver/docs/engine.md
+++ b/tools/v2/individual/draft-improver/docs/engine.md
@@ -1,0 +1,83 @@
+# Draft Improver - Core Engine
+
+The core engine analyses an email draft and returns a quality score, a set of
+metrics, and a list of actionable suggestions. It lives entirely inside this
+tool folder and is **not** wired into the main application.
+
+## Design
+
+- **Pure and deterministic** - the same input always produces the same output.
+- **No side effects** - no network calls, no file access, no secrets, and no
+  reading of real user data.
+- **Synchronous** - the `improveDraft` call returns immediately. There is no
+  async "loading" state in the engine itself; a future UI can show a spinner
+  while it awaits the (near-instant) call.
+
+## Public API
+
+Import only from the folder-local entry point, `index.ts`. Example usage:
+
+    import { improveDraft } from "..";
+
+    const result = improveDraft({
+      subject: "Project kickoff",
+      body: "Hi Sam, please review the plan.",
+    });
+
+    if (result.ok) {
+      // result.analysis.score, result.analysis.metrics, result.analysis.suggestions
+    } else {
+      // result.error.code is "EMPTY_DRAFT" or "INVALID_INPUT"
+    }
+
+## Input
+
+The `DraftInput` object:
+
+| Field     | Type      | Notes                                   |
+| :-------- | :-------- | :-------------------------------------- |
+| `subject` | `string?` | Optional subject line.                  |
+| `body`    | `string`  | Required draft body. Must be non-empty. |
+
+## Output
+
+The call returns a discriminated union, `DraftImproverResult`:
+
+- On success: `ok: true` with an `analysis` object containing:
+  - `score` - overall quality from 0 to 100.
+  - `metrics` - a `DraftMetrics` object (word, sentence, and paragraph counts,
+    average and longest sentence length, estimated reading time, filler-word
+    count, hedging-phrase count, adverb count, exclamation count, all-caps
+    count, and greeting / sign-off presence).
+  - `suggestions` - a list of `Suggestion` items, each with a stable `id`,
+    `category`, `severity`, `message`, and optional `detail`.
+- On failure: `ok: false` with an `error` object whose `code` is one of:
+  - `EMPTY_DRAFT` - the body was empty or whitespace only.
+  - `INVALID_INPUT` - the body was missing or not a string.
+
+Callers should branch on `result.ok` before reading `analysis` or `error`.
+
+## Suggestion categories
+
+`clarity`, `tone`, `length`, `structure`, `professionalism`.
+
+## Scoring
+
+The score starts at 100. Each suggestion subtracts a fixed penalty based on its
+severity (`warning` more than `suggestion`; `info` none). The result is clamped
+to the 0-100 range. Scoring is intentionally simple and transparent so it is
+easy to reason about.
+
+## Limitations
+
+- Heuristics are rule-based and English-oriented; they do not use a language
+  model and will not catch every writing issue.
+- Detection relies on simple word and phrase matching, so unusual phrasing may
+  be missed or over-flagged.
+- The engine judges structure and style, not factual accuracy or intent.
+
+## Local review
+
+Deterministic sample drafts are exported as `DRAFT_FIXTURES` from `index.ts`
+(a clean draft, a rambling one, a "shouty" one, and an empty-body error case).
+Feed these into the engine to review the output by hand.

--- a/tools/v2/individual/draft-improver/index.ts
+++ b/tools/v2/individual/draft-improver/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Draft Improver - folder-local public API surface.
+ *
+ * This is the only entry point other code in this tool folder should import
+ * from. The tool is intentionally not wired into the main application; a future
+ * integration can decide how, and whether, to surface it in the UI.
+ */
+
+export { improveDraft } from "./services/draft-improver";
+export { DRAFT_FIXTURES } from "./services/fixtures";
+export type { DraftFixture } from "./services/fixtures";
+export type {
+  DraftAnalysis,
+  DraftImproverError,
+  DraftImproverErrorCode,
+  DraftImproverResult,
+  DraftInput,
+  DraftMetrics,
+  Suggestion,
+  SuggestionCategory,
+  SuggestionSeverity,
+} from "./services/types";

--- a/tools/v2/individual/draft-improver/services/draft-improver.ts
+++ b/tools/v2/individual/draft-improver/services/draft-improver.ts
@@ -1,0 +1,334 @@
+import type {
+  DraftAnalysis,
+  DraftImproverResult,
+  DraftInput,
+  DraftMetrics,
+  Suggestion,
+} from "./types";
+
+/** Words that usually add little meaning and can often be trimmed. */
+const FILLER_WORDS: readonly string[] = [
+  "just",
+  "really",
+  "very",
+  "actually",
+  "basically",
+  "literally",
+  "simply",
+  "quite",
+];
+
+/** Hedging phrases that tend to weaken a message. */
+const WEAK_PHRASES: readonly string[] = [
+  "i think",
+  "i guess",
+  "sort of",
+  "kind of",
+  "sorry to bother",
+  "just checking in",
+];
+
+/** Openings that count as a greeting when the draft starts with them. */
+const GREETINGS: readonly string[] = [
+  "hi",
+  "hello",
+  "hey",
+  "dear",
+  "good morning",
+  "good afternoon",
+  "good evening",
+];
+
+/** Phrases that count as a closing sign-off. */
+const SIGN_OFFS: readonly string[] = [
+  "regards",
+  "best",
+  "thanks",
+  "thank you",
+  "sincerely",
+  "cheers",
+];
+
+const WORDS_PER_MINUTE = 200;
+const RECOMMENDED_SUBJECT_MAX = 60;
+const LONG_SENTENCE_WORDS = 25;
+const VERY_LONG_SENTENCE_WORDS = 40;
+
+const SEVERITY_PENALTY: Record<Suggestion["severity"], number> = {
+  info: 0,
+  suggestion: 5,
+  warning: 12,
+};
+
+function toWords(text: string): string[] {
+  const matches = text.toLowerCase().match(/[a-z0-9']+/g);
+  return matches === null ? [] : matches;
+}
+
+function toSentences(text: string): string[] {
+  return text
+    .split(/[.!?]+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function toParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function countPhrases(loweredText: string, phrases: readonly string[]): number {
+  let total = 0;
+  for (const phrase of phrases) {
+    let index = loweredText.indexOf(phrase);
+    while (index !== -1) {
+      total += 1;
+      index = loweredText.indexOf(phrase, index + phrase.length);
+    }
+  }
+  return total;
+}
+
+function countAdverbs(words: readonly string[]): number {
+  let total = 0;
+  for (const word of words) {
+    if (word.length > 4 && word.endsWith("ly")) {
+      total += 1;
+    }
+  }
+  return total;
+}
+
+function countAllCapsWords(text: string): number {
+  const tokens = text.match(/[A-Za-z]{3,}/g);
+  if (tokens === null) {
+    return 0;
+  }
+  let total = 0;
+  for (const token of tokens) {
+    if (token === token.toUpperCase()) {
+      total += 1;
+    }
+  }
+  return total;
+}
+
+function countExclamations(text: string): number {
+  const matches = text.match(/!/g);
+  return matches === null ? 0 : matches.length;
+}
+
+function startsWithGreeting(loweredBody: string): boolean {
+  const start = loweredBody.slice(0, 40);
+  return GREETINGS.some((greeting) => start.startsWith(greeting));
+}
+
+function containsSignOff(loweredBody: string): boolean {
+  const tail = loweredBody.slice(-120);
+  return SIGN_OFFS.some((signOff) => tail.includes(signOff));
+}
+
+function computeMetrics(body: string): DraftMetrics {
+  const words = toWords(body);
+  const sentences = toSentences(body);
+  const paragraphs = toParagraphs(body);
+  const loweredBody = body.toLowerCase();
+
+  const sentenceWordCounts = sentences.map((sentence) => toWords(sentence).length);
+  const longestSentenceWordCount = sentenceWordCounts.reduce(
+    (max, count) => (count > max ? count : max),
+    0,
+  );
+
+  const wordCount = words.length;
+  const sentenceCount = sentences.length;
+  const averageWordsPerSentence =
+    sentenceCount === 0 ? 0 : Math.round((wordCount / sentenceCount) * 10) / 10;
+  const estimatedReadingTimeSeconds = Math.round((wordCount / WORDS_PER_MINUTE) * 60);
+  const fillerWordCount = words.filter((word) => FILLER_WORDS.includes(word)).length;
+
+  return {
+    characterCount: body.length,
+    wordCount,
+    sentenceCount,
+    paragraphCount: paragraphs.length,
+    averageWordsPerSentence,
+    longestSentenceWordCount,
+    estimatedReadingTimeSeconds,
+    fillerWordCount,
+    weakPhraseCount: countPhrases(loweredBody, WEAK_PHRASES),
+    adverbCount: countAdverbs(words),
+    exclamationCount: countExclamations(body),
+    allCapsWordCount: countAllCapsWords(body),
+    hasGreeting: startsWithGreeting(loweredBody),
+    hasSignOff: containsSignOff(loweredBody),
+  };
+}
+
+function buildSuggestions(subject: string | undefined, metrics: DraftMetrics): Suggestion[] {
+  const suggestions: Suggestion[] = [];
+
+  const trimmedSubject = subject === undefined ? "" : subject.trim();
+  if (trimmedSubject.length === 0) {
+    suggestions.push({
+      id: "subject-missing",
+      category: "structure",
+      severity: "warning",
+      message: "Add a subject line so recipients can scan and find the email.",
+    });
+  } else if (trimmedSubject.length > RECOMMENDED_SUBJECT_MAX) {
+    suggestions.push({
+      id: "subject-too-long",
+      category: "length",
+      severity: "suggestion",
+      message: `Shorten the subject to ${RECOMMENDED_SUBJECT_MAX} characters or fewer so it is not truncated.`,
+    });
+  }
+
+  if (!metrics.hasGreeting) {
+    suggestions.push({
+      id: "greeting-missing",
+      category: "structure",
+      severity: "suggestion",
+      message: "Open with a short greeting to set a friendly tone.",
+    });
+  }
+
+  if (!metrics.hasSignOff) {
+    suggestions.push({
+      id: "sign-off-missing",
+      category: "structure",
+      severity: "suggestion",
+      message: "Close with a sign-off so the message feels complete.",
+    });
+  }
+
+  if (metrics.longestSentenceWordCount >= VERY_LONG_SENTENCE_WORDS) {
+    suggestions.push({
+      id: "sentence-very-long",
+      category: "clarity",
+      severity: "warning",
+      message: "Break up very long sentences to make the draft easier to read.",
+      detail: `The longest sentence has ${metrics.longestSentenceWordCount} words.`,
+    });
+  } else if (metrics.averageWordsPerSentence > LONG_SENTENCE_WORDS) {
+    suggestions.push({
+      id: "sentences-long",
+      category: "clarity",
+      severity: "suggestion",
+      message: "Aim for shorter sentences to improve readability.",
+      detail: `Average sentence length is ${metrics.averageWordsPerSentence} words.`,
+    });
+  }
+
+  if (metrics.fillerWordCount > 0) {
+    suggestions.push({
+      id: "filler-words",
+      category: "clarity",
+      severity: "suggestion",
+      message: "Remove filler words to make the message more direct.",
+      detail: `Found ${metrics.fillerWordCount} filler word(s).`,
+    });
+  }
+
+  if (metrics.weakPhraseCount > 0) {
+    suggestions.push({
+      id: "weak-phrases",
+      category: "tone",
+      severity: "suggestion",
+      message: "Replace hedging phrases with confident, direct wording.",
+      detail: `Found ${metrics.weakPhraseCount} hedging phrase(s).`,
+    });
+  }
+
+  if (metrics.exclamationCount > 2) {
+    suggestions.push({
+      id: "too-many-exclamations",
+      category: "tone",
+      severity: "suggestion",
+      message: "Reduce exclamation marks to keep a professional tone.",
+      detail: `Found ${metrics.exclamationCount} exclamation marks.`,
+    });
+  }
+
+  if (metrics.allCapsWordCount > 0) {
+    suggestions.push({
+      id: "all-caps",
+      category: "professionalism",
+      severity: "warning",
+      message: "Avoid ALL-CAPS words, which can read as shouting.",
+      detail: `Found ${metrics.allCapsWordCount} all-caps word(s).`,
+    });
+  }
+
+  if (metrics.wordCount < 10) {
+    suggestions.push({
+      id: "body-very-short",
+      category: "length",
+      severity: "suggestion",
+      message: "Add more detail so the recipient has enough context to act.",
+    });
+  }
+
+  if (suggestions.length === 0) {
+    suggestions.push({
+      id: "looks-good",
+      category: "clarity",
+      severity: "info",
+      message: "No issues detected. This draft looks clear and ready to send.",
+    });
+  }
+
+  return suggestions;
+}
+
+function computeScore(suggestions: readonly Suggestion[]): number {
+  let score = 100;
+  for (const suggestion of suggestions) {
+    score -= SEVERITY_PENALTY[suggestion.severity];
+  }
+  if (score < 0) {
+    return 0;
+  }
+  if (score > 100) {
+    return 100;
+  }
+  return score;
+}
+
+/**
+ * Analyse an email draft and return a score, metrics, and suggestions.
+ *
+ * The function is pure and synchronous: the same input always yields the same
+ * result, and it performs no network or file access.
+ */
+export function improveDraft(input: DraftInput): DraftImproverResult {
+  if (typeof input.body !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_INPUT",
+        message: "A draft with a string body is required.",
+      },
+    };
+  }
+
+  const body = input.body.trim();
+  if (body.length === 0) {
+    return {
+      ok: false,
+      error: { code: "EMPTY_DRAFT", message: "The draft body is empty." },
+    };
+  }
+
+  const metrics = computeMetrics(body);
+  const suggestions = buildSuggestions(input.subject, metrics);
+  const analysis: DraftAnalysis = {
+    score: computeScore(suggestions),
+    metrics,
+    suggestions,
+  };
+  return { ok: true, analysis };
+}

--- a/tools/v2/individual/draft-improver/services/fixtures.ts
+++ b/tools/v2/individual/draft-improver/services/fixtures.ts
@@ -1,0 +1,47 @@
+import type { DraftInput } from "./types";
+
+/**
+ * Deterministic sample drafts used for local review and manual exploration of
+ * the engine. These are static fixtures only: they involve no network access,
+ * secrets, or real user data.
+ */
+export interface DraftFixture {
+  id: string;
+  label: string;
+  input: DraftInput;
+}
+
+export const DRAFT_FIXTURES: readonly DraftFixture[] = [
+  {
+    id: "clean",
+    label: "Clear, well-structured note",
+    input: {
+      subject: "Project kickoff on Thursday",
+      body: "Hi Sam,\n\nThanks for the update. Let's meet Thursday at 10am to agree on scope and owners.\n\nBest,\nAlex",
+    },
+  },
+  {
+    id: "rambling",
+    label: "Long, hedging, filler-heavy draft",
+    input: {
+      subject: "quick thoughts about the thing we sort of discussed and maybe some next steps",
+      body: "I just wanted to actually reach out because I think we should probably really sync sometime soon, and I guess it would be basically great if we could maybe find a time that works for everyone so that we can go over literally everything in one very long conversation.",
+    },
+  },
+  {
+    id: "shouty",
+    label: "All-caps and excessive punctuation",
+    input: {
+      subject: "URGENT",
+      body: "PLEASE respond ASAP!!! This is REALLY important!!!",
+    },
+  },
+  {
+    id: "empty",
+    label: "Empty body (error case)",
+    input: {
+      subject: "No content",
+      body: "   ",
+    },
+  },
+];

--- a/tools/v2/individual/draft-improver/services/types.ts
+++ b/tools/v2/individual/draft-improver/services/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Type definitions for the Draft Improver core engine.
+ *
+ * Draft Improver is an isolated V2 tooling workspace. Nothing in this folder
+ * imports from, or wires into, the main application. The engine is pure and
+ * deterministic: the same input always produces the same output, and it makes
+ * no network calls and reads no secrets or real user data.
+ */
+
+/** Raw draft supplied by a caller. */
+export interface DraftInput {
+  /** Optional subject line. */
+  subject?: string;
+  /** Draft body text. Required and expected to be non-empty. */
+  body: string;
+}
+
+/** Broad grouping used to organise suggestions in a UI. */
+export type SuggestionCategory = "clarity" | "tone" | "length" | "structure" | "professionalism";
+
+/** How strongly a suggestion should be surfaced. */
+export type SuggestionSeverity = "info" | "suggestion" | "warning";
+
+/** A single, actionable improvement hint. */
+export interface Suggestion {
+  /** Stable identifier, useful as a UI key and for de-duplication. */
+  id: string;
+  category: SuggestionCategory;
+  severity: SuggestionSeverity;
+  /** Short, human-readable summary. */
+  message: string;
+  /** Optional longer explanation of why this was flagged. */
+  detail?: string;
+}
+
+/** Deterministic measurements computed from a draft. */
+export interface DraftMetrics {
+  characterCount: number;
+  wordCount: number;
+  sentenceCount: number;
+  paragraphCount: number;
+  averageWordsPerSentence: number;
+  longestSentenceWordCount: number;
+  estimatedReadingTimeSeconds: number;
+  fillerWordCount: number;
+  weakPhraseCount: number;
+  adverbCount: number;
+  exclamationCount: number;
+  allCapsWordCount: number;
+  hasGreeting: boolean;
+  hasSignOff: boolean;
+}
+
+/** Full analysis returned for a valid draft. */
+export interface DraftAnalysis {
+  /** Overall quality score from 0 (poor) to 100 (excellent). */
+  score: number;
+  metrics: DraftMetrics;
+  suggestions: Suggestion[];
+}
+
+/** Reasons the engine can reject an input. */
+export type DraftImproverErrorCode = "EMPTY_DRAFT" | "INVALID_INPUT";
+
+export interface DraftImproverError {
+  code: DraftImproverErrorCode;
+  message: string;
+}
+
+/**
+ * Result of a single improveDraft call.
+ *
+ * The engine is synchronous, so there is no "loading" result here; loading is
+ * a concern for a future UI layer, which can show a spinner while it awaits the
+ * (near-instant) call. Success and error states are modelled explicitly.
+ */
+export type DraftImproverResult =
+  | { ok: true; analysis: DraftAnalysis }
+  | { ok: false; error: DraftImproverError };


### PR DESCRIPTION
## What
Implements the core feature engine for the V2 individual Draft Improver tool. Given an email draft, it returns a quality score (0-100), a set of deterministic metrics, and a list of actionable suggestions across clarity, tone, length, structure, and professionalism.

## Where
Everything lives inside `tools/v2/individual/draft-improver/` and is self-contained:
- `services/types.ts` — input/output types and a discriminated result union (success vs. error).
- `services/draft-improver.ts` — `improveDraft()`, a pure, synchronous function implementing the heuristics and scoring.
- `services/fixtures.ts` — deterministic sample drafts for local review.
- `index.ts` — the folder-local public API surface.
- `docs/engine.md` — documents inputs, outputs, the synchronous loading model, error states, and limitations.

## Notes
- Pure and deterministic: no network calls, no file access, no secrets, and no real user data.
- Not wired into the main application; a future integration can decide how to surface it in the UI.
- No new dependencies. The existing scaffold `README.md` and `specs.md` are left untouched.

Closes #485