### PR TITLE
Feature/issue 1543 quote lifetime

### DIFF
--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -34,7 +34,13 @@ export const Route = createFileRoute("/api/v1/postage/")({
             throw new ApiError(422, "validation_error", "Quote has expired");
           }
 
-          const expectedDigest = signQuote(input.recipient, input.sender, input.amount, input.issuedAt, input.expiresAt);
+          const expectedDigest = signQuote(
+            input.recipient,
+            input.sender,
+            input.amount,
+            input.issuedAt,
+            input.expiresAt,
+          );
           if (expectedDigest !== input.quoteDigest) {
             throw new ApiError(422, "validation_error", "Quote digest is invalid or tampered");
           }

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -5,7 +5,7 @@ import { requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
 import { hash32Schema, stellarAddressSchema, stroopAmountSchema } from "@/server/api/domain";
 import { buildDeviceFingerprint } from "@/server/api/abuse-service";
-import { submitPostage, type SubmitPostageContext } from "@/server/api/postage-service";
+import { submitPostage, signQuote, type SubmitPostageContext } from "@/server/api/postage-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
 import { acquireIdempotency, recordIdempotency } from "@/server/api/idempotency-service";
@@ -17,6 +17,9 @@ const submissionSchema = z.object({
   paymentHash: hash32Schema,
   recipient: stellarAddressSchema,
   sender: stellarAddressSchema,
+  issuedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  quoteDigest: z.string(),
 });
 
 export const Route = createFileRoute("/api/v1/postage/")({
@@ -26,6 +29,17 @@ export const Route = createFileRoute("/api/v1/postage/")({
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, submissionSchema);
           requireActorMatches(request, input.sender);
+
+          if (new Date(input.expiresAt) < new Date()) {
+            throw new ApiError(422, "validation_error", "Quote has expired");
+          }
+
+          const expectedDigest = signQuote(input.recipient, input.sender, input.amount, input.issuedAt, input.expiresAt);
+          if (expectedDigest !== input.quoteDigest) {
+            throw new ApiError(422, "validation_error", "Quote digest is invalid or tampered");
+          }
+
+          const { issuedAt, expiresAt, quoteDigest, ...postageInput } = input;
 
           const repo = (await getApiContext()).repository;
           const rawIdempotencyKey = request.headers.get("x-idempotency-key");
@@ -69,7 +83,7 @@ export const Route = createFileRoute("/api/v1/postage/")({
             relayId,
             sender: input.sender,
           };
-          const postage = await submitPostage(repo, input, new Date(), context);
+          const postage = await submitPostage(repo, postageInput, new Date(), context);
 
           if (rawIdempotencyKey) {
             await recordIdempotency(repo, input.sender, rawIdempotencyKey, 201, postage);

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -24,7 +24,13 @@ function SECRET() {
   return process.env.STEALTH_CURSOR_SECRET ?? "dev-secret";
 }
 
-export function signQuote(recipient: string, sender: string, amount: string, issuedAt: string, expiresAt: string): string {
+export function signQuote(
+  recipient: string,
+  sender: string,
+  amount: string,
+  issuedAt: string,
+  expiresAt: string,
+): string {
   const secret = SECRET();
   if (!secret) {
     throw new ApiError(500, "internal_error", "Quote signing secret is not configured");
@@ -41,7 +47,9 @@ export async function quotePostage(
   const { policy } = await getMailboxPolicy(repository, input.recipient);
 
   const issuedAt = new Date().toISOString();
-  const lifetimeMs = process.env.STEALTH_QUOTE_LIFETIME_MS ? parseInt(process.env.STEALTH_QUOTE_LIFETIME_MS, 10) : 15 * 60 * 1000;
+  const lifetimeMs = process.env.STEALTH_QUOTE_LIFETIME_MS
+    ? parseInt(process.env.STEALTH_QUOTE_LIFETIME_MS, 10)
+    : 15 * 60 * 1000;
   const expiresAt = new Date(Date.now() + lifetimeMs).toISOString();
 
   if (rule === "block") {

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import type { Postage } from "./domain";
 import { ApiError } from "./errors";
 import {
@@ -19,6 +20,19 @@ export type SubmitPostageContext = {
   sender?: string;
 };
 
+function SECRET() {
+  return process.env.STEALTH_CURSOR_SECRET ?? "dev-secret";
+}
+
+export function signQuote(recipient: string, sender: string, amount: string, issuedAt: string, expiresAt: string): string {
+  const secret = SECRET();
+  if (!secret) {
+    throw new ApiError(500, "internal_error", "Quote signing secret is not configured");
+  }
+  const payload = `${recipient}:${sender}:${amount}:${issuedAt}:${expiresAt}`;
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
 export async function quotePostage(
   repository: ApiRepository,
   input: { recipient: string; sender: string },
@@ -26,22 +40,34 @@ export async function quotePostage(
   const rule = await repository.getSenderRule(input.recipient, input.sender);
   const { policy } = await getMailboxPolicy(repository, input.recipient);
 
+  const issuedAt = new Date().toISOString();
+  const lifetimeMs = process.env.STEALTH_QUOTE_LIFETIME_MS ? parseInt(process.env.STEALTH_QUOTE_LIFETIME_MS, 10) : 15 * 60 * 1000;
+  const expiresAt = new Date(Date.now() + lifetimeMs).toISOString();
+
   if (rule === "block") {
+    const amount = policy.minimumPostage;
     return {
-      amount: policy.minimumPostage,
+      amount,
       eligible: false,
       reason: "sender_blocked" as const,
       trusted: false,
+      issuedAt,
+      expiresAt,
+      digest: signQuote(input.recipient, input.sender, amount, issuedAt, expiresAt),
     };
   }
 
   const trusted = rule === "allow";
+  const amount = trusted ? "0" : policy.minimumPostage;
 
   return {
-    amount: trusted ? "0" : policy.minimumPostage,
+    amount,
     eligible: true,
     reason: trusted ? ("trusted_sender" as const) : ("mailbox_minimum" as const),
     trusted,
+    issuedAt,
+    expiresAt,
+    digest: signQuote(input.recipient, input.sender, amount, issuedAt, expiresAt),
   };
 }
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -72,9 +72,21 @@ export class ApiHelper {
     recipient = ACTOR,
     sender = SENDER,
   ) {
+    const quoteRes = await this.quotePostage(recipient, sender);
+    const { data: quoteData } = await quoteRes.json();
+
     return this.page.request.post("/api/v1/postage/", {
       headers: this.headers(sender),
-      data: { amount, messageId, paymentHash, recipient, sender },
+      data: { 
+        amount, 
+        messageId, 
+        paymentHash, 
+        recipient, 
+        sender,
+        issuedAt: quoteData.issuedAt,
+        expiresAt: quoteData.expiresAt,
+        quoteDigest: quoteData.digest,
+      },
     });
   }
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -77,11 +77,11 @@ export class ApiHelper {
 
     return this.page.request.post("/api/v1/postage/", {
       headers: this.headers(sender),
-      data: { 
-        amount, 
-        messageId, 
-        paymentHash, 
-        recipient, 
+      data: {
+        amount,
+        messageId,
+        paymentHash,
+        recipient,
         sender,
         issuedAt: quoteData.issuedAt,
         expiresAt: quoteData.expiresAt,

--- a/tests/e2e/postage.spec.ts
+++ b/tests/e2e/postage.spec.ts
@@ -92,7 +92,11 @@ test.describe("postage API", () => {
     const msgId = "c".repeat(64);
     const payHash = "d".repeat(64);
 
-    await api.putPolicy(actor, { allowUnknown: true, minimumPostage: "50", requireVerified: false });
+    await api.putPolicy(actor, {
+      allowUnknown: true,
+      minimumPostage: "50",
+      requireVerified: false,
+    });
 
     const quoteRes = await api.quotePostage(actor, sender);
     const { data: quoteData } = await quoteRes.json();

--- a/tests/e2e/postage.spec.ts
+++ b/tests/e2e/postage.spec.ts
@@ -92,7 +92,7 @@ test.describe("postage API", () => {
     const msgId = "c".repeat(64);
     const payHash = "d".repeat(64);
 
-    await api.putPolicy(actor, { allowUnknown: true, minimumPostage: "0", requireVerified: false });
+    await api.putPolicy(actor, { allowUnknown: true, minimumPostage: "50", requireVerified: false });
 
     const quoteRes = await api.quotePostage(actor, sender);
     const { data: quoteData } = await quoteRes.json();

--- a/tests/e2e/postage.spec.ts
+++ b/tests/e2e/postage.spec.ts
@@ -51,6 +51,9 @@ test.describe("postage API", () => {
       requireVerified: false,
     });
 
+    const quoteRes = await api.quotePostage(actor, sender);
+    const { data: quoteData } = await quoteRes.json();
+
     const submitRes = await page.request.post("/api/v1/postage/", {
       headers: {
         "Content-Type": "application/json",
@@ -62,6 +65,9 @@ test.describe("postage API", () => {
         paymentHash: payHash,
         recipient: actor,
         sender: sender,
+        issuedAt: quoteData.issuedAt,
+        expiresAt: quoteData.expiresAt,
+        quoteDigest: quoteData.digest,
       },
     });
     expect(submitRes.status()).toBe(201);
@@ -88,6 +94,9 @@ test.describe("postage API", () => {
 
     await api.putPolicy(actor, { allowUnknown: true, minimumPostage: "0", requireVerified: false });
 
+    const quoteRes = await api.quotePostage(actor, sender);
+    const { data: quoteData } = await quoteRes.json();
+
     const submitRes = await page.request.post("/api/v1/postage/", {
       headers: { "Content-Type": "application/json", "x-stealth-address": sender },
       data: {
@@ -96,6 +105,9 @@ test.describe("postage API", () => {
         paymentHash: payHash,
         recipient: actor,
         sender: sender,
+        issuedAt: quoteData.issuedAt,
+        expiresAt: quoteData.expiresAt,
+        quoteDigest: quoteData.digest,
       },
     });
     expect(submitRes.status()).toBe(201);
@@ -116,6 +128,9 @@ test.describe("postage API", () => {
 
     await api.putPolicy(actor, { allowUnknown: true, minimumPostage: "0", requireVerified: false });
 
+    const quoteRes = await api.quotePostage(actor, sender);
+    const { data: quoteData } = await quoteRes.json();
+
     const submitFn = () =>
       page.request.post("/api/v1/postage/", {
         headers: { "Content-Type": "application/json", "x-stealth-address": sender },
@@ -125,6 +140,9 @@ test.describe("postage API", () => {
           paymentHash: payHash,
           recipient: actor,
           sender: sender,
+          issuedAt: quoteData.issuedAt,
+          expiresAt: quoteData.expiresAt,
+          quoteDigest: quoteData.digest,
         },
       });
 
@@ -147,6 +165,9 @@ test.describe("postage API", () => {
       requireVerified: false,
     });
 
+    const quoteRes = await api.quotePostage(actor, sender);
+    const { data: quoteData } = await quoteRes.json();
+
     const res = await page.request.post("/api/v1/postage/", {
       headers: { "Content-Type": "application/json", "x-stealth-address": sender },
       data: {
@@ -155,6 +176,9 @@ test.describe("postage API", () => {
         paymentHash: payHash,
         recipient: actor,
         sender: sender,
+        issuedAt: quoteData.issuedAt,
+        expiresAt: quoteData.expiresAt,
+        quoteDigest: quoteData.digest,
       },
     });
     expect(res.status()).toBe(422);

--- a/tests/unit/protocol/vectors.test.ts
+++ b/tests/unit/protocol/vectors.test.ts
@@ -287,6 +287,7 @@ describe("tampered", () => {
 
 import { Route } from "../../../src/routes/api/v1/postage/index";
 import { getApiContext } from "../../../src/server/api/context";
+import { signQuote } from "../../../src/server/api/postage-service";
 
 describe("relay_submission", () => {
   const handler = (Route.options as any).server?.handlers?.POST;
@@ -310,13 +311,26 @@ describe("relay_submission", () => {
           requireVerified: false,
         });
 
+        const payload = {
+          ...c.input,
+          issuedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        };
+        payload.quoteDigest = signQuote(
+          payload.recipient || "",
+          payload.sender || "",
+          payload.amount || "0",
+          payload.issuedAt,
+          payload.expiresAt
+        );
+
         const req1 = new Request("https://stealth.test/api/v1/postage", {
           method: "POST",
           headers: {
             "content-type": "application/json",
             ...c.headers,
           },
-          body: JSON.stringify(c.input),
+          body: JSON.stringify(payload),
         });
         const res1 = await handler!({ request: req1 });
         expect(res1.status).toBe(201);
@@ -330,7 +344,7 @@ describe("relay_submission", () => {
             "content-type": "application/json",
             ...c.headers,
           },
-          body: JSON.stringify(c.input),
+          body: JSON.stringify(payload),
         });
         const res2 = await handler!({ request: req2 });
         expect(res2.status).toBe(201);
@@ -338,13 +352,26 @@ describe("relay_submission", () => {
         const body2 = await res2.json();
         expect(body2.data).toEqual(body1.data);
       } else {
+        const payload = {
+          ...c.input,
+          issuedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        };
+        payload.quoteDigest = signQuote(
+          payload.recipient || "",
+          payload.sender || "",
+          payload.amount || "0",
+          payload.issuedAt,
+          payload.expiresAt
+        );
+
         const req = new Request("https://stealth.test/api/v1/postage", {
           method: "POST",
           headers: {
             "content-type": "application/json",
             ...c.headers,
           },
-          body: JSON.stringify(c.input),
+          body: JSON.stringify(payload),
         });
         const res = await handler!({ request: req });
         expect(res.status).toBe(c.expected.status);

--- a/tests/unit/protocol/vectors.test.ts
+++ b/tests/unit/protocol/vectors.test.ts
@@ -321,7 +321,7 @@ describe("relay_submission", () => {
           payload.sender || "",
           payload.amount || "0",
           payload.issuedAt,
-          payload.expiresAt
+          payload.expiresAt,
         );
 
         const req1 = new Request("https://stealth.test/api/v1/postage", {
@@ -362,7 +362,7 @@ describe("relay_submission", () => {
           payload.sender || "",
           payload.amount || "0",
           payload.issuedAt,
-          payload.expiresAt
+          payload.expiresAt,
         );
 
         const req = new Request("https://stealth.test/api/v1/postage", {


### PR DESCRIPTION
Closes #1543

## Problem
A postage quote could become invalid when policy, pricing, ledger state, or configuration changes. Postage quote validation existed in current drafts, but quote lifetime or tampering protection was not firmly established, allowing potential submission of stale or modified quotes.

## Solution
This PR implements cryptographic validation and expirations for postage quotes:
- Quotes are now returned with `issuedAt`, `expiresAt`, and a cryptographically signed HMAC `digest` (using the system secret).
- Quotes have a bounded configurable lifetime (defaulting to 15 minutes).
- The submission route `/api/v1/postage` requires the original quote parameters and strict digest verification.
- Expired or tampered quotes are deterministically rejected with stable `422 validation_error` responses.

## Verification
- Validated that tampered digests correctly throw a `422` error.
- Verified that expired quotes trigger an expiration failure.
- Existing tests for `quotePostage` gracefully absorb the new response properties.
