### PR TITLE
test(email-template-library): expand execution-contract coverage and add testing doc

### DIFF
--- a/tools/v2/individual/email-template-library/docs/testing.md
+++ b/tools/v2/individual/email-template-library/docs/testing.md
@@ -1,0 +1,47 @@
+# Testing
+
+The Email Template Library ships with framework-free unit tests. They run on
+Node's built-in test runner using native TypeScript type stripping, so no
+bundler, transpile step, database, or network access is required.
+
+## Running the tests
+
+From the repository root, run either test file:
+
+    node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/service.test.ts
+    node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/execution-contract.test.ts
+
+Or run every test in the folder at once:
+
+    node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/
+
+## Coverage
+
+`service.test.ts` drives the JSON fixtures under `fixtures/` (a successful
+render, missing render variables, and an unknown template) and confirms that
+`list` results are cloned so a caller cannot mutate the source catalog.
+
+`execution-contract.test.ts` covers the remaining branches of the contract:
+
+| Area     | Case                             | Expected result          |
+| :------- | :------------------------------- | :----------------------- |
+| list     | no filter                        | every template returned  |
+| list     | matching categoryId              | only that category       |
+| list     | unknown categoryId               | empty list               |
+| get      | known id                         | one template             |
+| render   | declared values supplied         | placeholders substituted |
+| render   | unknown placeholder              | left untouched           |
+| get      | unknown id                       | TEMPLATE_NOT_FOUND       |
+| render   | omitted variable                 | MISSING_VARIABLES        |
+| render   | non-string values                | INVALID_REQUEST          |
+| envelope | foreign tool                     | INVALID_REQUEST          |
+| envelope | unknown operation                | INVALID_REQUEST          |
+| envelope | version other than 1             | UNSUPPORTED_VERSION      |
+| catalog  | invalid template entry           | INVALID_TEMPLATE         |
+| factory  | invalid catalog                  | constructor throws       |
+| factory  | source mutated post-construction | snapshot unaffected      |
+
+## Notes
+
+All templates used in the tests are fake and deterministic, so the suite is
+repeatable and side-effect free.

--- a/tools/v2/individual/email-template-library/tests/execution-contract.test.ts
+++ b/tools/v2/individual/email-template-library/tests/execution-contract.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createEmailTemplateLibraryService, executeEmailTemplateLibrary } from "../index.ts";
+import type { EmailTemplate, EmailTemplateLibraryRequest } from "../types/index.ts";
+
+const TOOL = "email-template-library";
+const VERSION = 1;
+
+function catalog(): EmailTemplate[] {
+  return [
+    {
+      id: "template-follow-up",
+      name: "Friendly follow-up",
+      categoryId: "follow-up",
+      subject: "Following up, {{firstName}}",
+      body: "Hello {{firstName}},\n\nAbout {{topic}}.",
+      variables: [
+        { key: "firstName", label: "First name" },
+        { key: "topic", label: "Topic" },
+      ],
+    },
+    {
+      id: "template-welcome",
+      name: "Welcome note",
+      categoryId: "onboarding",
+      subject: "Welcome aboard",
+      body: "We are glad you are here.",
+      variables: [],
+    },
+  ];
+}
+
+function run(request: unknown, templates: readonly EmailTemplate[] = catalog()) {
+  return executeEmailTemplateLibrary(request as EmailTemplateLibraryRequest, templates);
+}
+
+test("list returns every template by default", () => {
+  const res = run({ tool: TOOL, version: VERSION, operation: "list" });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "list") {
+    assert.equal(res.result.templates.length, 2);
+  }
+});
+
+test("list filters by categoryId", () => {
+  const res = run({ tool: TOOL, version: VERSION, operation: "list", categoryId: "onboarding" });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "list") {
+    assert.equal(res.result.templates.length, 1);
+    assert.equal(res.result.templates[0].id, "template-welcome");
+  }
+});
+
+test("list with an unknown categoryId returns no templates", () => {
+  const res = run({ tool: TOOL, version: VERSION, operation: "list", categoryId: "missing" });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "list") {
+    assert.equal(res.result.templates.length, 0);
+  }
+});
+
+test("get returns a single template by id", () => {
+  const res = run({
+    tool: TOOL,
+    version: VERSION,
+    operation: "get",
+    templateId: "template-welcome",
+  });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "get") {
+    assert.equal(res.result.template.name, "Welcome note");
+  }
+});
+
+test("render substitutes declared variables", () => {
+  const res = run({
+    tool: TOOL,
+    version: VERSION,
+    operation: "render",
+    templateId: "template-follow-up",
+    values: { firstName: "Sam", topic: "the launch" },
+  });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "render") {
+    assert.equal(res.result.subject, "Following up, Sam");
+    assert.equal(res.result.body, "Hello Sam,\n\nAbout the launch.");
+  }
+});
+
+test("render leaves unknown placeholders untouched", () => {
+  const templates: EmailTemplate[] = [
+    {
+      id: "template-raw",
+      name: "Raw",
+      categoryId: null,
+      subject: "Hi {{firstName}}",
+      body: "Ref {{unknownKey}} stays.",
+      variables: [{ key: "firstName", label: "First name" }],
+    },
+  ];
+  const res = run(
+    {
+      tool: TOOL,
+      version: VERSION,
+      operation: "render",
+      templateId: "template-raw",
+      values: { firstName: "Sam" },
+    },
+    templates,
+  );
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "render") {
+    assert.equal(res.result.body, "Ref {{unknownKey}} stays.");
+  }
+});
+
+test("rejects an unsupported version", () => {
+  const res = run({ tool: TOOL, version: 2, operation: "list" });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "UNSUPPORTED_VERSION");
+  }
+});
+
+test("rejects a foreign tool envelope", () => {
+  const res = run({ tool: "other-tool", version: VERSION, operation: "list" });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "INVALID_REQUEST");
+  }
+});
+
+test("rejects an unknown operation", () => {
+  const res = run({ tool: TOOL, version: VERSION, operation: "purge" });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "INVALID_REQUEST");
+  }
+});
+
+test("rejects render values that are not strings", () => {
+  const res = run({
+    tool: TOOL,
+    version: VERSION,
+    operation: "render",
+    templateId: "template-follow-up",
+    values: { firstName: 42 },
+  });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "INVALID_REQUEST");
+  }
+});
+
+test("reports an unknown template id", () => {
+  const res = run({ tool: TOOL, version: VERSION, operation: "get", templateId: "nope" });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "TEMPLATE_NOT_FOUND");
+    assert.equal(res.error.details?.templateId, "nope");
+  }
+});
+
+test("reports missing render variables", () => {
+  const res = run({
+    tool: TOOL,
+    version: VERSION,
+    operation: "render",
+    templateId: "template-follow-up",
+    values: { firstName: "Sam" },
+  });
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "MISSING_VARIABLES");
+    assert.deepEqual(res.error.details?.missingVariables, ["topic"]);
+  }
+});
+
+test("rejects a catalog that contains an invalid template", () => {
+  const badCatalog: EmailTemplate[] = [
+    { id: "", name: "", categoryId: null, subject: "s", body: "b", variables: [] },
+  ];
+  const res = run({ tool: TOOL, version: VERSION, operation: "list" }, badCatalog);
+  assert.equal(res.status, "error");
+  if (res.status === "error") {
+    assert.equal(res.error.code, "INVALID_TEMPLATE");
+  }
+});
+
+test("createEmailTemplateLibraryService executes against a snapshot", () => {
+  const service = createEmailTemplateLibraryService(catalog());
+  const res = service.execute({
+    tool: TOOL,
+    version: VERSION,
+    operation: "get",
+    templateId: "template-follow-up",
+  });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "get") {
+    assert.equal(res.result.template.id, "template-follow-up");
+  }
+});
+
+test("createEmailTemplateLibraryService throws on an invalid catalog", () => {
+  const badCatalog: EmailTemplate[] = [
+    { id: "", name: "x", categoryId: null, subject: "s", body: "b", variables: [] },
+  ];
+  assert.throws(() => createEmailTemplateLibraryService(badCatalog));
+});
+
+test("createEmailTemplateLibraryService isolates its source snapshot", () => {
+  const source = catalog();
+  const service = createEmailTemplateLibraryService(source);
+  source[0].name = "mutated after construction";
+  const res = service.execute({
+    tool: TOOL,
+    version: VERSION,
+    operation: "get",
+    templateId: "template-follow-up",
+  });
+  assert.equal(res.status, "ok");
+  if (res.status === "ok" && res.result.operation === "get") {
+    assert.equal(res.result.template.name, "Friendly follow-up");
+  }
+});


### PR DESCRIPTION
## Summary

Strengthens the testing and documentation for the Email Template Library tool. The folder already shipped a fixture-driven `service.test.ts`; this adds broader unit coverage and a short testing guide, with no changes to the library's runtime code.

## Changes

- `tests/execution-contract.test.ts` — 16 focused unit tests covering branches the fixture suite did not exercise:
  - `list` with no filter, a matching `categoryId`, and an unknown `categoryId`
  - `get` for a known id
  - `render` substitution, and preservation of unknown `{{placeholders}}`
  - every documented error code: `INVALID_REQUEST` (foreign tool, unknown operation, non-string values), `UNSUPPORTED_VERSION`, `INVALID_TEMPLATE`, `TEMPLATE_NOT_FOUND`, `MISSING_VARIABLES`
  - the `createEmailTemplateLibraryService` factory: throws on an invalid catalog and isolates its source snapshot
- `docs/testing.md` — how to run the tests plus a coverage matrix.

## Testing

Both suites pass locally (3 + 16 tests) using Node's built-in runner:

    node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/service.test.ts
    node --experimental-strip-types --test tools/v2/individual/email-template-library/tests/execution-contract.test.ts

No runtime/library code changed and no new dependencies added.

Closes #493