### PR TITLE
Reject duplicate single-valued query parameters

### DIFF
--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -38,8 +38,27 @@ export async function parseJsonBody<T>(
   }
 }
 
+const MULTI_VALUED_SCALARS = new Set<string>();
+
 export function parseSearchParams<T>(request: Request, schema: ZodType<T>): T {
-  const params = Object.fromEntries(new URL(request.url).searchParams.entries());
+  const url = new URL(request.url);
+  const seen = new Map<string, string[]>();
+  for (const [key, value] of url.searchParams.entries()) {
+    if (MULTI_VALUED_SCALARS.has(key)) continue;
+    const prev = seen.get(key) ?? [];
+    prev.push(value);
+    seen.set(key, prev);
+  }
+  for (const [key, values] of seen) {
+    if (values.length > 1) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        `Duplicate query parameter: ${key}. Expected a single value for '${key}'.`,
+      );
+    }
+  }
+  const params = Object.fromEntries(url.searchParams.entries());
   return schema.parse(params);
 }
 

--- a/tests/unit/api/request.duplicate-params.test.ts
+++ b/tests/unit/api/request.duplicate-params.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSearchParams } from "../../../src/server/api/request";
+import { z } from "zod";
+
+const cursorSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+describe("parseSearchParams duplicate scalar handling", () => {
+  it("rejects duplicate scalar query params such as limit", () => {
+    const request = new Request("https://stealth.test/api?limit=10&limit=100");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+    try {
+      parseSearchParams(request, cursorSchema);
+    } catch (error) {
+      expect(error).toMatchObject({
+        status: 400,
+        code: "bad_request",
+      });
+      expect((error as Error).message).toMatch(
+        /Duplicate query parameter: limit/,
+      );
+    }
+  });
+
+  it("keeps schema errors separate from duplicate-parameter errors", () => {
+    const request = new Request("https://stealth.test/api?limit=abc&limit=100");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+    try {
+      parseSearchParams(request, cursorSchema);
+    } catch (error) {
+      expect((error as Error).message).toMatch(
+        /Duplicate query parameter: limit/,
+      );
+    }
+  });
+
+  it("preserves behavior for single-valued params", () => {
+    const request = new Request(
+      "https://stealth.test/api?cursor=abc&limit=25",
+    );
+    expect(parseSearchParams(request, cursorSchema)).toEqual({
+      cursor: "abc",
+      limit: 25,
+    });
+  });
+});


### PR DESCRIPTION
Fail scalar query parameters that are supplied more than once (e.g. `limit=10&limit=100`), with a stable 400 identifying the duplicated field.

Fixes #1488