### PR TITLE
test(manager-review-queue): expand execution-contract coverage and add testing doc

### DIFF
--- a/tools/v2/team/manager-review-queue/docs/testing.md
+++ b/tools/v2/team/manager-review-queue/docs/testing.md
@@ -1,0 +1,49 @@
+# Testing
+
+The Manager Review Queue tool has two complementary test suites, both scoped to
+this folder and free of UI, network, or database dependencies.
+
+## Suites
+
+- `tests/contract.test.ts` and `tests/contract-coverage.test.ts` — Vitest suites
+  for the non-UI execution contract (`createReviewQueueContract`,
+  `applyReviewOperation`, and the input validators). Together they cover fetch
+  filtering and pagination, status transitions, store persistence, and every
+  `ReviewErrorCode` path.
+- `tests/review-guards.test.mjs` — Node's built-in test runner suite for the
+  input guards and sanitizers in `guards/review-guards.mjs`.
+
+## Running
+
+Vitest suites, from the repository root, using this tool's local config:
+
+    npx vitest run --config tools/v2/team/manager-review-queue/vitest.config.ts
+
+Guard suite (no dependencies required):
+
+    node --test tools/v2/team/manager-review-queue/tests/review-guards.test.mjs
+
+## Contract coverage matrix
+
+| Area         | Case                             | Expected                             |
+| :----------- | :------------------------------- | :----------------------------------- |
+| fetch        | no filters or paging             | all items, full totalCount           |
+| fetch        | offset + limit                   | correct slice, full totalCount       |
+| fetch        | minRiskScore filter              | only items at or above the threshold |
+| fetch        | status filter                    | only that status                     |
+| fetch        | negative or NaN limit            | INVALID_INPUT                        |
+| fetch        | limit above MAX_QUEUE_SIZE       | INVALID_INPUT                        |
+| fetch        | negative offset                  | INVALID_INPUT                        |
+| updateStatus | pending to approved or escalated | success                              |
+| updateStatus | escalated to approved            | success                              |
+| updateStatus | change persists on next fetch    | success                              |
+| updateStatus | empty or whitespace itemId       | INVALID_INPUT                        |
+| updateStatus | unknown target status            | INVALID_INPUT                        |
+| updateStatus | unknown itemId                   | ITEM_NOT_FOUND                       |
+| updateStatus | terminal source status           | INVALID_TRANSITION                   |
+| operation    | unrecognised operation           | INVALID_INPUT                        |
+
+## Notes
+
+All fixtures are synthetic and deterministic. The contract runs with its
+simulated network delay disabled in tests for speed and repeatability.

--- a/tools/v2/team/manager-review-queue/tests/contract-coverage.test.ts
+++ b/tools/v2/team/manager-review-queue/tests/contract-coverage.test.ts
@@ -1,0 +1,184 @@
+/**
+ * contract-coverage.test.ts — Manager Review Queue
+ *
+ * Additional coverage for the non-UI execution contract, complementing
+ * contract.test.ts. Exercises fetch filtering/pagination, allowed status
+ * transitions, store persistence, the input validators, and the
+ * unrecognised-operation path. No UI, network, or database is involved.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { createReviewQueueContract } from "../services/execution.service";
+import {
+  applyReviewOperation,
+  validateFetchInput,
+  validateUpdateStatusInput,
+  ReviewErrorCode,
+  MAX_QUEUE_SIZE,
+} from "../contract";
+import type { ReviewOperation } from "../contract";
+import type { ReviewItem } from "../types";
+
+const seed = (): ReviewItem[] => [
+  {
+    id: "a1",
+    submitterId: "u1",
+    contentSnippet: "one",
+    submittedAt: "2026-06-18T10:00:00Z",
+    status: "pending",
+    riskScore: 10,
+  },
+  {
+    id: "a2",
+    submitterId: "u2",
+    contentSnippet: "two",
+    submittedAt: "2026-06-18T11:00:00Z",
+    status: "pending",
+    riskScore: 80,
+  },
+  {
+    id: "a3",
+    submitterId: "u3",
+    contentSnippet: "three",
+    submittedAt: "2026-06-18T12:00:00Z",
+    status: "escalated",
+    riskScore: 90,
+  },
+  {
+    id: "a4",
+    submitterId: "u4",
+    contentSnippet: "four",
+    submittedAt: "2026-06-18T13:00:00Z",
+    status: "approved",
+    riskScore: 30,
+  },
+];
+
+describe("fetch — filters and pagination", () => {
+  it("returns all items when no filters or paging are supplied", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({ operation: "fetch", input: {} });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "fetch") {
+      expect(res.value.result.totalCount).toBe(4);
+      expect(res.value.result.items).toHaveLength(4);
+    }
+  });
+
+  it("applies offset and limit while reporting the full total", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({
+      operation: "fetch",
+      input: { offset: 1, limit: 2 },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "fetch") {
+      expect(res.value.result.totalCount).toBe(4);
+      expect(res.value.result.items.map((i) => i.id)).toEqual(["a2", "a3"]);
+    }
+  });
+
+  it("filters by minRiskScore", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({
+      operation: "fetch",
+      input: { filters: { minRiskScore: 80 } },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "fetch") {
+      expect(res.value.result.items.map((i) => i.id)).toEqual(["a2", "a3"]);
+    }
+  });
+
+  it("rejects a negative offset", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({ operation: "fetch", input: { offset: -1 } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+});
+
+describe("updateStatus — transitions and persistence", () => {
+  it("moves a pending item to escalated", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({
+      operation: "updateStatus",
+      input: { itemId: "a1", newStatus: "escalated" },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "updateStatus") {
+      expect(res.value.item.status).toBe("escalated");
+    }
+  });
+
+  it("allows moving an escalated item to approved", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({
+      operation: "updateStatus",
+      input: { itemId: "a3", newStatus: "approved" },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "updateStatus") {
+      expect(res.value.item.status).toBe("approved");
+    }
+  });
+
+  it("persists the new status in the backing store", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    await contract.execute({
+      operation: "updateStatus",
+      input: { itemId: "a1", newStatus: "approved" },
+    });
+    const res = await contract.execute({
+      operation: "fetch",
+      input: { filters: { status: "approved" } },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.value.operation === "fetch") {
+      expect(res.value.result.items.map((i) => i.id)).toContain("a1");
+    }
+  });
+
+  it("rejects an unknown target status", async () => {
+    const contract = createReviewQueueContract(seed(), 0);
+    const res = await contract.execute({
+      operation: "updateStatus",
+      input: { itemId: "a1", newStatus: "archived" as unknown as ReviewItem["status"] },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+});
+
+describe("contract primitives", () => {
+  it("validateFetchInput accepts a well-formed input", () => {
+    const res = validateFetchInput({ limit: 10, offset: 0 });
+    expect(res.ok).toBe(true);
+  });
+
+  it("validateFetchInput rejects a NaN limit", () => {
+    const res = validateFetchInput({ limit: Number.NaN });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+
+  it("validateFetchInput rejects a limit above MAX_QUEUE_SIZE", () => {
+    const res = validateFetchInput({ limit: MAX_QUEUE_SIZE + 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+
+  it("validateUpdateStatusInput rejects a whitespace itemId", () => {
+    const res = validateUpdateStatusInput({ itemId: "   ", newStatus: "approved" });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+
+  it("applyReviewOperation returns InvalidInput for an unrecognised operation", () => {
+    const store = new Map<string, ReviewItem>();
+    const res = applyReviewOperation(store, { operation: "delete" } as unknown as ReviewOperation);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe(ReviewErrorCode.InvalidInput);
+  });
+});


### PR DESCRIPTION
## What

Strengthens the testing and documentation for the Manager Review Queue tool, without touching any existing source or test files.

- **`tests/contract-coverage.test.ts`** — a Vitest suite that complements the existing `contract.test.ts` by covering branches it did not exercise:
  - `fetch`: returns everything with no filters/paging, applies offset + limit while still reporting the full total, filters by `minRiskScore`, and rejects a negative offset.
  - `updateStatus`: allows `pending -> escalated` and `escalated -> approved`, verifies the change persists in the backing store on the next fetch, and rejects an unknown target status.
  - Primitives: `validateFetchInput` (NaN limit, limit above `MAX_QUEUE_SIZE`), `validateUpdateStatusInput` (whitespace `itemId`), and `applyReviewOperation` for an unrecognised operation.
- **`docs/testing.md`** — documents both test suites (the Vitest contract suites and the Node `review-guards.test.mjs` suite), how to run each, and a coverage matrix mapping cases to expected outcomes.

## Notes

- Additive only — no existing files were modified.
- Fixtures are synthetic and deterministic; the simulated network delay is disabled in tests.

Closes #628