### PR TITLE
feat(meeting-assignment-tool): add folder-local UI and accessibility surface

### DIFF
--- a/tools/v2/team/meeting-assignment-tool/components/AssignmentList.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/AssignmentList.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import type { MeetingAssignment } from "../types";
+import { AssignmentRow } from "./AssignmentRow";
+
+interface AssignmentListProps {
+  assignments: MeetingAssignment[];
+}
+
+export const AssignmentList: React.FC<AssignmentListProps> = ({ assignments }) => {
+  return (
+    <ul className="flex flex-col gap-2" aria-label="Meeting assignments">
+      {assignments.map((assignment) => (
+        <AssignmentRow key={assignment.meetingId} assignment={assignment} />
+      ))}
+    </ul>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/AssignmentRow.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/AssignmentRow.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { MeetingAssignment } from "../types";
+
+interface AssignmentRowProps {
+  assignment: MeetingAssignment;
+}
+
+const REASON_LABEL: Record<MeetingAssignment["reason"], string> = {
+  matched: "Matched",
+  capacity: "No capacity",
+  skill_mismatch: "No skill match",
+};
+
+export const AssignmentRow: React.FC<AssignmentRowProps> = ({ assignment }) => {
+  const isAssigned = assignment.status === "assigned";
+  return (
+    <li className="flex items-center justify-between gap-4 rounded-md border border-gray-200 p-4">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-gray-900">{assignment.meetingTitle}</p>
+        <p className="mt-0.5 text-xs text-gray-500">
+          {new Date(assignment.scheduledAt).toLocaleString()} - {assignment.durationMinutes} min -
+          priority {assignment.priority}
+        </p>
+      </div>
+      <div className="text-right">
+        <p className="text-sm text-gray-900">
+          {isAssigned ? assignment.assigneeName : "Unassigned"}
+        </p>
+        <span
+          className={
+            isAssigned
+              ? "mt-1 inline-block rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800"
+              : "mt-1 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+          }
+        >
+          {REASON_LABEL[assignment.reason]}
+        </span>
+      </div>
+    </li>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/AssignmentSummaryCard.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/AssignmentSummaryCard.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import type { AssignmentSummary } from "../types";
+
+interface AssignmentSummaryCardProps {
+  summary: AssignmentSummary;
+}
+
+export const AssignmentSummaryCard: React.FC<AssignmentSummaryCardProps> = ({ summary }) => {
+  return (
+    <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Assignment summary">
+      <div className="rounded-md bg-gray-50 p-3">
+        <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Total</dt>
+        <dd className="mt-1 text-lg font-semibold text-gray-900">{summary.total}</dd>
+      </div>
+      <div className="rounded-md bg-gray-50 p-3">
+        <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Assigned</dt>
+        <dd className="mt-1 text-lg font-semibold text-green-700">{summary.assigned}</dd>
+      </div>
+      <div className="rounded-md bg-gray-50 p-3">
+        <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Unassigned</dt>
+        <dd className="mt-1 text-lg font-semibold text-amber-700">{summary.unassigned}</dd>
+      </div>
+      <div className="rounded-md bg-gray-50 p-3">
+        <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">Coverage</dt>
+        <dd className="mt-1 text-lg font-semibold text-gray-900">{summary.coveragePercent}%</dd>
+      </div>
+    </dl>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/EmptyState.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export const EmptyState: React.FC = () => {
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 p-8 text-center"
+    >
+      <p className="text-lg font-medium text-gray-900">No meetings to assign</p>
+      <p className="mt-1 text-sm text-gray-500">
+        There are no meetings in the queue right now. New meetings will appear here for assignment.
+      </p>
+    </div>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/ErrorState.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/ErrorState.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export const ErrorState: React.FC<ErrorStateProps> = ({
+  message = "Something went wrong while assigning meetings.",
+  onRetry,
+}) => {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 p-8 text-center"
+    >
+      <p className="text-base font-semibold text-red-800">Unable to assign meetings</p>
+      <p className="mt-1 text-sm text-red-700">{message}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/LoadingState.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/LoadingState.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export const LoadingState: React.FC = () => {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center p-8 text-center"
+    >
+      <span
+        aria-hidden="true"
+        className="mb-3 h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-700"
+      />
+      <p className="text-base font-medium text-gray-900">Assigning meetings...</p>
+      <p className="text-sm text-gray-500">
+        Please wait while we match meetings to available team members.
+      </p>
+    </div>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/MeetingAssignmentPanel.tsx
+++ b/tools/v2/team/meeting-assignment-tool/components/MeetingAssignmentPanel.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useMeetingAssignments } from "../hooks/useMeetingAssignments";
+import { AssignmentList } from "./AssignmentList";
+import { AssignmentSummaryCard } from "./AssignmentSummaryCard";
+import { EmptyState } from "./EmptyState";
+import { ErrorState } from "./ErrorState";
+import { LoadingState } from "./LoadingState";
+
+export const MeetingAssignmentPanel: React.FC = () => {
+  const { state, reload } = useMeetingAssignments();
+
+  return (
+    <section
+      aria-labelledby="meeting-assignment-heading"
+      className="mx-auto flex max-w-2xl flex-col gap-4 p-4"
+    >
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h2 id="meeting-assignment-heading" className="text-lg font-semibold text-gray-900">
+            Meeting Assignment
+          </h2>
+          <p className="text-sm text-gray-500">
+            Assign meetings to team members based on skills, workload, and capacity.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reload}
+          disabled={state.status === "loading"}
+          className="shrink-0 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Reassign
+        </button>
+      </header>
+
+      {state.status === "loading" && <LoadingState />}
+
+      {state.status === "error" && <ErrorState message={state.message} onRetry={reload} />}
+
+      {state.status === "success" && state.data.assignments.length === 0 && <EmptyState />}
+
+      {state.status === "success" && state.data.assignments.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <AssignmentSummaryCard summary={state.data.summary} />
+          <AssignmentList assignments={state.data.assignments} />
+        </div>
+      )}
+    </section>
+  );
+};

--- a/tools/v2/team/meeting-assignment-tool/components/index.ts
+++ b/tools/v2/team/meeting-assignment-tool/components/index.ts
@@ -1,0 +1,7 @@
+export * from "./MeetingAssignmentPanel";
+export * from "./AssignmentList";
+export * from "./AssignmentRow";
+export * from "./AssignmentSummaryCard";
+export * from "./EmptyState";
+export * from "./ErrorState";
+export * from "./LoadingState";

--- a/tools/v2/team/meeting-assignment-tool/docs/UI_AND_ACCESSIBILITY.md
+++ b/tools/v2/team/meeting-assignment-tool/docs/UI_AND_ACCESSIBILITY.md
@@ -1,0 +1,50 @@
+# UI and Accessibility
+
+Folder-local UI surface for the Meeting Assignment Tool. Everything here lives
+inside `tools/v2/team/meeting-assignment-tool/` and is not mounted in the main
+app, router, or shared design system.
+
+## Components
+
+| Component                          | Responsibility                                                    |
+| :--------------------------------- | :---------------------------------------------------------------- |
+| `MeetingAssignmentPanel`           | Container that drives the workflow and renders the correct state. |
+| `LoadingState`                     | Busy indicator shown while assignments are computed.              |
+| `ErrorState`                       | Failure message with a retry action.                              |
+| `EmptyState`                       | Shown when there are no meetings to assign.                       |
+| `AssignmentSummaryCard`            | Totals: assigned, unassigned, and coverage percentage.            |
+| `AssignmentList` / `AssignmentRow` | The per-meeting assignment results.                               |
+
+The panel is powered by the `useMeetingAssignments` hook, which wraps the
+existing `createMeetingAssignmentService` and exposes a
+`LoadState<AssignmentResult>` plus a `reload` callback.
+
+## States
+
+- Loading: `LoadingState` with `role="status"` and `aria-live="polite"`.
+- Error: `ErrorState` with `role="alert"` and a retry button.
+- Empty: `EmptyState` when `assignments.length === 0`.
+- Success: summary card plus the assignment list.
+
+## Accessibility
+
+- The panel is a labeled `section` (`aria-labelledby`) with a single `h2`.
+- Status and error surfaces use `role="status"` / `role="alert"` with
+  `aria-live` so screen readers announce transitions.
+- The decorative spinner is marked `aria-hidden="true"`.
+- All interactive controls are native `button` elements with visible text
+  labels and a visible focus ring (`focus:ring-2 focus:ring-offset-2`), so they
+  are reachable and operable by keyboard.
+- The Reassign control is disabled while loading to prevent duplicate runs.
+- Results use a real list (`ul` / `li`) and a description list (`dl` / `dt` /
+  `dd`) for the summary, giving assistive technology meaningful structure.
+
+## Visual style
+
+- Layout uses Tailwind utility classes only; no shared design-system components
+  are imported.
+- Neutral gray surfaces, green for assigned/success, amber for unassigned, and
+  red for errors.
+- Spacing and rounded corners follow the utility scale already used across the
+  tools workspace, so the surface stays consistent without changing global
+  tokens.

--- a/tools/v2/team/meeting-assignment-tool/hooks/useMeetingAssignments.ts
+++ b/tools/v2/team/meeting-assignment-tool/hooks/useMeetingAssignments.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from "react";
+import type { AssignmentResult, LoadState } from "../types";
+import { createMeetingAssignmentService } from "../services/meetingAssignmentService";
+
+/**
+ * Drives the Meeting Assignment UI state machine.
+ *
+ * Returns a LoadState<AssignmentResult> that moves through loading -> success
+ * or loading -> error, plus a reload callback to run the assignment again. All
+ * data comes from the folder-local service and fixtures; there is no network,
+ * storage, or main-app dependency.
+ */
+export function useMeetingAssignments(): {
+  state: LoadState<AssignmentResult>;
+  reload: () => void;
+} {
+  const [state, setState] = useState<LoadState<AssignmentResult>>({ status: "loading" });
+  const [nonce, setNonce] = useState(0);
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+
+    const service = createMeetingAssignmentService({ simulateDelay: true });
+    service
+      .assign()
+      .then((data) => {
+        if (!cancelled) setState({ status: "success", data });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Failed to assign meetings.";
+          setState({ status: "error", message });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [nonce]);
+
+  return { state, reload };
+}


### PR DESCRIPTION
## What

Adds the folder-local user-interface surface for the Meeting Assignment Tool, with accessibility built in. All work stays inside `tools/v2/team/meeting-assignment-tool/` and is not mounted in the main app, router, or shared design system.

### Components (`components/`)
- **`MeetingAssignmentPanel`** — container that runs the assignment workflow and renders the correct state.
- **`LoadingState`**, **`ErrorState`**, **`EmptyState`** — the non-success states.
- **`AssignmentSummaryCard`** — totals for assigned, unassigned, and coverage %.
- **`AssignmentList`** / **`AssignmentRow`** — the per-meeting results.
- Barrel export via `components/index.ts`.

### Hook (`hooks/`)
- **`useMeetingAssignments`** wraps the existing `createMeetingAssignmentService` and exposes the already-defined `LoadState<AssignmentResult>` (loading → success/error) plus a `reload` callback.

### Docs
- **`docs/UI_AND_ACCESSIBILITY.md`** documents the components, the four states, the accessibility approach, and the visual style — without changing the shared design system.

## Accessibility
- Labeled `section` (`aria-labelledby`) with a single `h2`.
- `role="status"` / `role="alert"` with `aria-live` so screen readers announce loading and error transitions.
- Decorative spinner marked `aria-hidden="true"`.
- Native `button` controls with visible text labels and a visible focus ring; the Reassign control is disabled while loading.
- Results use list (`ul`/`li`) and description-list (`dl`/`dt`/`dd`) semantics.

## Scope
- Additive, folder-local only; no existing files modified and nothing wired into the main app.
- Data comes from the tool's local service/fixtures — no network, storage, or auth.

Closes #631