### PR TITLE
feat(auth): add delegated authorization support for mailbox operations

### DIFF
--- a/src/server/api/actor.ts
+++ b/src/server/api/actor.ts
@@ -1,5 +1,6 @@
 import { stellarAddressSchema } from "./domain";
 import { ApiError } from "./errors";
+import { assertActorAuthorized, type DelegatedAuthorization } from "./auth/delegation";
 
 export const ACTOR_HEADER = "x-stealth-address";
 
@@ -17,10 +18,11 @@ export function requireActor(request: Request) {
   return result.data;
 }
 
-export function requireActorMatches(request: Request, expectedAddress: string) {
+export function requireActorMatches(
+  request: Request,
+  expectedAddress: string,
+  authorization?: DelegatedAuthorization,
+) {
   const actor = requireActor(request);
-  if (actor !== expectedAddress) {
-    throw new ApiError(403, "forbidden", "The authenticated actor cannot modify this resource");
-  }
-  return actor;
+  return assertActorAuthorized(actor, expectedAddress, authorization);
 }

--- a/src/server/api/auth/delegation.ts
+++ b/src/server/api/auth/delegation.ts
@@ -1,0 +1,74 @@
+import { ApiError } from "../errors";
+
+export interface MailboxDelegation {
+  grantor: string;
+  delegate: string;
+  allowedActions: readonly string[];
+  resourceScope: readonly string[];
+  issuedAt: string;
+  expiresAt: string;
+  revoked: boolean;
+}
+
+export interface DelegatedAuthorization {
+  action: string;
+  resource: string;
+  delegations: readonly MailboxDelegation[];
+  now?: Date;
+}
+
+function forbidden(message: string): never {
+  throw new ApiError(403, "forbidden", message);
+}
+
+export function assertDelegationCanBeIssued(actor: string, delegation: MailboxDelegation) {
+  if (actor !== delegation.grantor) {
+    forbidden("Only the mailbox owner can issue or expand a delegation");
+  }
+
+  const issuedAt = Date.parse(delegation.issuedAt);
+  const expiresAt = Date.parse(delegation.expiresAt);
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || expiresAt <= issuedAt) {
+    forbidden("Delegation expiry must be later than its issue time");
+  }
+
+  if (delegation.allowedActions.length === 0 || delegation.resourceScope.length === 0) {
+    forbidden("Delegations must include at least one action and resource");
+  }
+
+  return delegation;
+}
+
+export function assertActorAuthorized(
+  actor: string,
+  owner: string,
+  authorization?: DelegatedAuthorization,
+) {
+  if (actor === owner) return actor;
+  if (!authorization) forbidden("The authenticated actor cannot modify this resource");
+
+  const now = (authorization.now ?? new Date()).getTime();
+  const candidates = authorization.delegations.filter(
+    (delegation) => delegation.grantor === owner && delegation.delegate === actor,
+  );
+
+  for (const delegation of candidates) {
+    if (delegation.revoked) forbidden("The delegation has been revoked");
+
+    const issuedAt = Date.parse(delegation.issuedAt);
+    const expiresAt = Date.parse(delegation.expiresAt);
+    if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || now < issuedAt) {
+      forbidden("The delegation is not yet valid");
+    }
+    if (now >= expiresAt) forbidden("The delegation has expired");
+
+    if (
+      delegation.allowedActions.includes(authorization.action) &&
+      delegation.resourceScope.includes(authorization.resource)
+    ) {
+      return actor;
+    }
+  }
+
+  forbidden("The authenticated actor is outside the delegated action or resource scope");
+}

--- a/tests/unit/api/actor.test.ts
+++ b/tests/unit/api/actor.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it } from "vitest";
 
 import { ACTOR_HEADER, requireActor, requireActorMatches } from "../../../src/server/api/actor";
+import {
+  assertDelegationCanBeIssued,
+  type MailboxDelegation,
+} from "../../../src/server/api/auth/delegation";
 
 const owner = `G${"A".repeat(55)}`;
 const sender = `G${"B".repeat(55)}`;
+const resource = `mailbox:${owner}:policy`;
+const now = new Date("2026-07-21T12:00:00.000Z");
+
+function delegation(overrides: Partial<MailboxDelegation> = {}): MailboxDelegation {
+  return {
+    grantor: owner,
+    delegate: sender,
+    allowedActions: ["policy:update"],
+    resourceScope: [resource],
+    issuedAt: "2026-07-21T11:00:00.000Z",
+    expiresAt: "2026-07-21T13:00:00.000Z",
+    revoked: false,
+    ...overrides,
+  };
+}
+
+function delegatedRequest() {
+  return new Request("https://stealth.test/api", { headers: { [ACTOR_HEADER]: sender } });
+}
 
 describe("API actor guard", () => {
   it("requires a valid actor header", () => {
@@ -28,5 +51,66 @@ describe("API actor guard", () => {
     });
 
     expect(requireActorMatches(request, owner)).toBe(owner);
+  });
+
+  it("allows a valid delegation within its action, resource, and time window", () => {
+    expect(
+      requireActorMatches(delegatedRequest(), owner, {
+        action: "policy:update",
+        resource,
+        delegations: [delegation()],
+        now,
+      }),
+    ).toBe(sender);
+  });
+
+  it.each([
+    ["action", { action: "policy:delete", resource }],
+    ["resource", { action: "policy:update", resource: `mailbox:${owner}:other` }],
+  ])("rejects an over-scoped %s", (_scope, requestScope) => {
+    expect(() =>
+      requireActorMatches(delegatedRequest(), owner, {
+        ...requestScope,
+        delegations: [delegation()],
+        now,
+      }),
+    ).toThrowError(expect.objectContaining({ status: 403 }));
+  });
+
+  it("rejects an expired delegation", () => {
+    expect(() =>
+      requireActorMatches(delegatedRequest(), owner, {
+        action: "policy:update",
+        resource,
+        delegations: [delegation({ expiresAt: "2026-07-21T12:00:00.000Z" })],
+        now,
+      }),
+    ).toThrowError(expect.objectContaining({ status: 403, message: "The delegation has expired" }));
+  });
+
+  it("rejects a revoked delegation", () => {
+    expect(() =>
+      requireActorMatches(delegatedRequest(), owner, {
+        action: "policy:update",
+        resource,
+        delegations: [delegation({ revoked: true })],
+        now,
+      }),
+    ).toThrowError(
+      expect.objectContaining({ status: 403, message: "The delegation has been revoked" }),
+    );
+  });
+
+  it("rejects a delegate attempting to expand its own authority", () => {
+    expect(() =>
+      assertDelegationCanBeIssued(
+        sender,
+        delegation({
+          grantor: owner,
+          allowedActions: ["policy:update", "policy:delete"],
+          expiresAt: "2026-07-22T13:00:00.000Z",
+        }),
+      ),
+    ).toThrowError(expect.objectContaining({ status: 403 }));
   });
 });


### PR DESCRIPTION
Closes #1468

## Problem
Authorization previously only supported direct equality between the 
acting identity and an expected address. Team, recovery, and delegated 
mailbox workflows need narrowly scoped authority without sharing the 
owner's credentials.

## Changes
- Added `MailboxDelegation` model with:
  - `grantor` — the owner delegating authority
  - `delegate` — who receives it
  - `actions` — scoped list of allowed actions
  - `resources` — scoped resource(s) the delegation applies to
  - `issue time` and `expiry`
  - `revocation` state
- Extended `requireActorMatches` to evaluate scoped delegations, not 
  just direct owner-equality checks.
- Added validation on delegation issuance restricting it to the owner 
  only, preventing a delegate from expanding its own authority (e.g. 
  re-delegating with broader scope or actions).

## Tests
Added coverage for:
- Valid delegation within scope and time window → allowed
- Over-scoped action → rejected
- Over-scoped resource → rejected
- Expired delegation → rejected
- Revoked delegation → rejected
- Delegate attempting to expand its own authority → rejected

9 auth tests passing. TypeScript, ESLint, and Prettier all clean.

## Acceptance criteria
- [x] Delegations are action- and resource-scoped
- [x] Expired and revoked delegations are rejected
- [x] A delegate cannot expand its own authority
- [x] Tests cover valid, over-scoped, expired, and revoked grants

## Files changed
- `src/server/api/auth` (delegation model + `requireActorMatches` update)
- corresponding test file(s)