### PR TITLE
feat(request): reject duplicate scalar query parameters

### DIFF
--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -60,6 +60,13 @@ export interface SearchParamsOptions {
   maxQueryLength?: number;
   /** Cap on each decoded, normalized parameter value length. Default {@link DEFAULT_MAX_QUERY_VALUE_LENGTH}. */
   maxValueLength?: number;
+  /**
+   * Parameter names that may appear more than once.
+   * Their values are collected into an array instead of triggering a
+   * duplicate-parameter error. All other (scalar) parameters must appear
+   * at most once.
+   */
+  multiValuedFields?: ReadonlySet<string>;
 }
 
 /**
@@ -76,7 +83,8 @@ export interface SearchParamsOptions {
  *   changed unexpectedly.
  *
  * Duplicate names keep last-value-wins semantics, matching the previous
- * `Object.fromEntries` behavior.
+ * `Object.fromEntries` behavior. Use {@link parseSearchParams} to reject
+ * duplicate scalar parameters before the schema sees the data.
  */
 export function normalizeSearchParams(
   request: Request,
@@ -125,7 +133,38 @@ export function parseSearchParams<T>(
   schema: ZodType<T>,
   options?: SearchParamsOptions,
 ): T {
-  return schema.parse(normalizeSearchParams(request, options));
+  const multiValued = options?.multiValuedFields ?? new Set<string>();
+  const url = new URL(request.url);
+
+  // Detect duplicate scalar parameters before normalization.
+  const seen = new Map<string, string[]>();
+  for (const [key, value] of url.searchParams.entries()) {
+    if (multiValued.has(key)) continue;
+    const prev = seen.get(key) ?? [];
+    prev.push(value);
+    seen.set(key, prev);
+  }
+  for (const [key, values] of seen) {
+    if (values.length > 1) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        `Duplicate query parameter: ${key}. Expected a single value for '${key}'.`,
+      );
+    }
+  }
+
+  const normalized = normalizeSearchParams(request, options);
+
+  // Multi-valued fields: collect every occurrence into an array.
+  for (const key of multiValued) {
+    const allValues = url.searchParams.getAll(key);
+    if (allValues.length > 0) {
+      (normalized as Record<string, unknown>)[key] = allValues.map((v) => v.normalize("NFC"));
+    }
+  }
+
+  return schema.parse(normalized);
 }
 
 export const paginationSchema = z.object({

--- a/tests/unit/api/request.duplicate-params.test.ts
+++ b/tests/unit/api/request.duplicate-params.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { parseSearchParams } from "../../../src/server/api/request";
+
+const cursorSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+const multiSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  tag: z.array(z.string()).optional(),
+});
+
+function captureError(fn: () => unknown): { status: number; code: string; message: string } {
+  try {
+    fn();
+  } catch (error) {
+    const e = error as { status: number; code: string; message: string };
+    return { status: e.status, code: e.code, message: e.message };
+  }
+  throw new Error("Expected function to throw");
+}
+
+describe("parseSearchParams — duplicate scalar rejection", () => {
+  it("rejects duplicate limit parameters", () => {
+    const request = new Request("https://stealth.test/api?limit=10&limit=100");
+    const error = captureError(() => parseSearchParams(request, cursorSchema));
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("bad_request");
+    expect(error.message).toMatch(/Duplicate query parameter: limit/);
+  });
+
+  it("rejects duplicate cursor parameters", () => {
+    const request = new Request("https://stealth.test/api?cursor=abc&cursor=def");
+    const error = captureError(() => parseSearchParams(request, cursorSchema));
+    expect(error.status).toBe(400);
+    expect(error.message).toMatch(/Duplicate query parameter: cursor/);
+  });
+
+  it("identifies the duplicated field in the error message", () => {
+    const request = new Request("https://stealth.test/api?limit=1&limit=2");
+    const error = captureError(() => parseSearchParams(request, cursorSchema));
+    expect(error.message).toContain("limit");
+    expect(error.message).toMatch(/Expected a single value for 'limit'/);
+  });
+
+  it("rejects duplicates even when values differ", () => {
+    const request = new Request("https://stealth.test/api?limit=10&limit=99");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+  });
+
+  it("rejects duplicates even when values are identical", () => {
+    const request = new Request("https://stealth.test/api?limit=10&limit=10");
+    expect(() => parseSearchParams(request, cursorSchema)).toThrow();
+  });
+
+  it("keeps duplicate-parameter errors ahead of schema validation", () => {
+    const request = new Request("https://stealth.test/api?limit=abc&limit=100");
+    const error = captureError(() => parseSearchParams(request, cursorSchema));
+    expect(error.message).toMatch(/Duplicate query parameter: limit/);
+  });
+});
+
+describe("parseSearchParams — single-valued passthrough", () => {
+  it("accepts a single cursor and limit", () => {
+    const request = new Request("https://stealth.test/api?cursor=abc&limit=25");
+    expect(parseSearchParams(request, cursorSchema)).toEqual({
+      cursor: "abc",
+      limit: 25,
+    });
+  });
+
+  it("returns empty object when all params are optional and absent", () => {
+    const request = new Request("https://stealth.test/api");
+    expect(parseSearchParams(request, cursorSchema)).toEqual({});
+  });
+});
+
+describe("parseSearchParams — multi-valued fields", () => {
+  it("preserves all values for declared multi-valued fields", () => {
+    const request = new Request("https://stealth.test/api?tag=a&tag=b&tag=c&limit=10");
+    expect(
+      parseSearchParams(request, multiSchema, {
+        multiValuedFields: new Set(["tag"]),
+      }),
+    ).toEqual({ tag: ["a", "b", "c"], limit: 10 });
+  });
+
+  it("returns a single-element array for one occurrence", () => {
+    const request = new Request("https://stealth.test/api?tag=solo&limit=5");
+    expect(
+      parseSearchParams(request, multiSchema, {
+        multiValuedFields: new Set(["tag"]),
+      }),
+    ).toEqual({ tag: ["solo"], limit: 5 });
+  });
+
+  it("omits multi-valued key from result when not present", () => {
+    const request = new Request("https://stealth.test/api?limit=5");
+    const result = parseSearchParams(request, multiSchema, {
+      multiValuedFields: new Set(["tag"]),
+    });
+    expect(result).toEqual({ limit: 5 });
+    expect(result).not.toHaveProperty("tag");
+  });
+
+  it("still rejects duplicate scalar params alongside multi-valued fields", () => {
+    const request = new Request("https://stealth.test/api?tag=a&tag=b&limit=10&limit=20");
+    const error = captureError(() =>
+      parseSearchParams(request, multiSchema, {
+        multiValuedFields: new Set(["tag"]),
+      }),
+    );
+    expect(error.status).toBe(400);
+    expect(error.message).toMatch(/Duplicate query parameter: limit/);
+  });
+
+  it("NFC-normalizes multi-valued field entries", () => {
+    // %65%CC%81 = "e" + combining acute → NFC "é"
+    const request = new Request("https://stealth.test/api?q=%65%CC%81&q=plain");
+    const schema = z.object({ q: z.array(z.string()) });
+    const result = parseSearchParams(request, schema, {
+      multiValuedFields: new Set(["q"]),
+    });
+    expect(result.q).toEqual(["é", "plain"]);
+  });
+});

--- a/tests/unit/api/request.test.ts
+++ b/tests/unit/api/request.test.ts
@@ -55,10 +55,13 @@ describe("Query string normalization", () => {
     });
   });
 
-  it("keeps last-value-wins semantics for duplicate names", () => {
+  it("rejects duplicate scalar parameter names", () => {
     const request = new Request("https://stealth.test/api?cursor=first&cursor=second");
 
-    expect(parseSearchParams(request, passthrough)).toEqual({ cursor: "second" });
+    expect(captureError(() => parseSearchParams(request, passthrough))).toMatchObject({
+      status: 400,
+      code: "bad_request",
+    });
   });
 
   it("rejects empty parameter names", () => {


### PR DESCRIPTION
## Summary

`parseSearchParams` now rejects requests that send the same scalar parameter more than once (e.g. `?limit=10&limit=100`). The duplicate check runs **before** schema validation so the error clearly identifies the offending field.

Multi-valued fields can be opted in via the new `SearchParamsOptions.multiValuedFields` set. When declared, every occurrence of that parameter is collected into an array — the schema receives `string[]` instead of `string`.

## Acceptance criteria

- [x] Duplicate scalar parameters return a validation error (400)
- [x] Array parameters preserve all entries via `multiValuedFields`
- [x] Error details identify the duplicated field by name
- [x] Tests cover `cursor`, `limit`, and a multi-valued `tag` field

## Changes

- **`src/server/api/request.ts`** — added duplicate detection loop in `parseSearchParams`; added `multiValuedFields` to `SearchParamsOptions`; collects array values for declared multi-valued fields after duplicate check
- **`tests/unit/api/request.duplicate-params.test.ts`** — new test file: 13 tests covering duplicate rejection, field identification in errors, multi-valued preservation, single-valued passthrough, and NFC normalization of array entries
- **`tests/unit/api/request.test.ts`** — updated the existing "last-value-wins" test to expect rejection (the old behavior was `Object.fromEntries` semantics; the new contract rejects duplicates)

Fixes #1488