### PR TITLE
feat(api): add stable retry classification and optional retry-after metadata to error responses

### DIFF
--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -33,10 +33,15 @@ export interface ValidationErrorDetails {
   validationErrors: ValidationErrorItem[];
 }
 
+export type RetryClassification = "permanent" | "transient" | "rate_limit" | "conflict";
+
 export class ApiError extends Error {
   readonly code: ApiErrorCode;
   readonly details?: unknown;
   readonly status: number;
+  readonly retryable: boolean;
+  readonly retryClassification: RetryClassification;
+  readonly retryAfterSeconds?: number;
 
   constructor(status: number, code: ApiErrorCode, message: string, details?: unknown) {
     super(message);
@@ -44,6 +49,26 @@ export class ApiError extends Error {
     this.status = status;
     this.code = code;
     this.details = details;
+
+    if (code === "too_many_requests") {
+      this.retryClassification = "rate_limit";
+      this.retryable = true;
+      if (details && typeof details === "object" && "retryAfterSeconds" in details) {
+        const val = (details as any).retryAfterSeconds;
+        if (typeof val === "number") {
+          this.retryAfterSeconds = val;
+        }
+      }
+    } else if (code === "conflict") {
+      this.retryClassification = "conflict";
+      this.retryable = true;
+    } else if (code === "internal_error") {
+      this.retryClassification = "transient";
+      this.retryable = true;
+    } else {
+      this.retryClassification = "permanent";
+      this.retryable = false;
+    }
   }
 }
 

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -130,6 +130,57 @@ export const openApiDocument = {
           },
         },
       },
+      RetryClassification: {
+        type: "string",
+        enum: ["permanent", "transient", "rate_limit", "conflict"],
+        description: "Stable machine-readable classification of retry eligibility.",
+      },
+      ErrorEnvelope: {
+        type: "object",
+        required: ["error", "meta"],
+        additionalProperties: false,
+        properties: {
+          error: {
+            type: "object",
+            required: ["code", "message", "retryable", "retryClassification"],
+            additionalProperties: false,
+            properties: {
+              code: {
+                type: "string",
+                description: "Stable domain-specific error code.",
+              },
+              message: {
+                type: "string",
+                description: "Human-readable explanation of the error.",
+              },
+              retryable: {
+                type: "boolean",
+                description: "Indicates whether the request can be retried.",
+              },
+              retryClassification: {
+                $ref: "#/components/schemas/RetryClassification",
+              },
+              retryAfter: {
+                type: "integer",
+                description: "Optional delay in seconds before retrying the request.",
+              },
+              details: {
+                type: "object",
+                description: "Structured contextual error details.",
+              },
+            },
+          },
+          meta: {
+            type: "object",
+            required: ["requestId", "timestamp"],
+            additionalProperties: false,
+            properties: {
+              requestId: { type: "string" },
+              timestamp: { type: "string", format: "date-time" },
+            },
+          },
+        },
+      },
     },
   },
   paths: {

--- a/src/server/api/response.ts
+++ b/src/server/api/response.ts
@@ -1,4 +1,4 @@
-import { normalizeApiError } from "./errors";
+import { normalizeApiError, type RetryClassification } from "./errors";
 
 interface ApiMeta {
   requestId: string;
@@ -15,6 +15,9 @@ interface ErrorEnvelope {
     code: string;
     details?: unknown;
     message: string;
+    retryable: boolean;
+    retryClassification: RetryClassification;
+    retryAfter?: number;
   };
   meta: ApiMeta;
 }
@@ -60,14 +63,22 @@ export function apiFailure(request: Request, caught: unknown) {
     error: {
       code: error.code,
       message: error.message,
+      retryable: error.retryable,
+      retryClassification: error.retryClassification,
+      ...(error.retryAfterSeconds === undefined ? {} : { retryAfter: error.retryAfterSeconds }),
       ...(error.details === undefined ? {} : { details: error.details }),
     },
     meta: meta(requestId),
   };
 
+  const headers = responseHeaders(requestId);
+  if (error.retryAfterSeconds !== undefined) {
+    headers.set("retry-after", String(error.retryAfterSeconds));
+  }
+
   return new Response(JSON.stringify(body), {
     status: error.status,
-    headers: responseHeaders(requestId),
+    headers,
   });
 }
 

--- a/tests/unit/api/errors.contract.test.ts
+++ b/tests/unit/api/errors.contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { normalizeApiError } from "../../../src/server/api/errors";
+import { ApiError, normalizeApiError } from "../../../src/server/api/errors";
 import { openApiDocument } from "../../../src/server/api/openapi";
 
 describe("validation error contract", () => {
@@ -20,6 +20,8 @@ describe("validation error contract", () => {
       status: 422,
       code: "validation_error",
       message: "Request validation failed",
+      retryable: false,
+      retryClassification: "permanent",
       details: {
         validationErrors: [
           { path: "recipient", rule: "format", message: expect.any(String) },
@@ -32,11 +34,51 @@ describe("validation error contract", () => {
     expect(apiError.details).not.toHaveProperty("formErrors");
   });
 
+  it("classifies validation errors as permanent and non-retryable", () => {
+    const schema = z.string();
+    const parsed = schema.safeParse(123);
+    const apiError = normalizeApiError(parsed.error);
+    expect(apiError.retryable).toBe(false);
+    expect(apiError.retryClassification).toBe("permanent");
+  });
+
+  it("classifies rate limit errors as rate_limited and retryable, preserving delay", () => {
+    const error = normalizeApiError(new ApiError(429, "too_many_requests", "Too many requests", { retryAfterSeconds: 15 }));
+    expect(error.retryable).toBe(true);
+    expect(error.retryClassification).toBe("rate_limit");
+    expect(error.retryAfterSeconds).toBe(15);
+  });
+
+  it("classifies conflict errors as temporary conflicts and retryable", () => {
+    const error = normalizeApiError(new ApiError(409, "conflict", "Conflict occurred"));
+    expect(error.retryable).toBe(true);
+    expect(error.retryClassification).toBe("conflict");
+  });
+
+  it("classifies internal errors as transient and retryable", () => {
+    const error = normalizeApiError(new Error("Database disconnected"));
+    expect(error.status).toBe(500);
+    expect(error.retryable).toBe(true);
+    expect(error.retryClassification).toBe("transient");
+  });
+
   it("documents the stable validation details schema in OpenAPI", () => {
     expect(openApiDocument.components.schemas.ValidationErrorDetails).toMatchObject({
       type: "object",
       required: ["validationErrors"],
     });
     expect(JSON.stringify(openApiDocument)).toContain("ValidationErrorItem");
+  });
+
+  it("documents the RetryClassification and ErrorEnvelope schemas in OpenAPI", () => {
+    expect(openApiDocument.components.schemas.RetryClassification).toMatchObject({
+      type: "string",
+      enum: expect.arrayContaining(["permanent", "transient", "rate_limit", "conflict"]),
+    });
+
+    expect(openApiDocument.components.schemas.ErrorEnvelope).toMatchObject({
+      type: "object",
+      required: ["error", "meta"],
+    });
   });
 });

--- a/tests/unit/api/errors.contract.test.ts
+++ b/tests/unit/api/errors.contract.test.ts
@@ -43,7 +43,9 @@ describe("validation error contract", () => {
   });
 
   it("classifies rate limit errors as rate_limited and retryable, preserving delay", () => {
-    const error = normalizeApiError(new ApiError(429, "too_many_requests", "Too many requests", { retryAfterSeconds: 15 }));
+    const error = normalizeApiError(
+      new ApiError(429, "too_many_requests", "Too many requests", { retryAfterSeconds: 15 }),
+    );
     expect(error.retryable).toBe(true);
     expect(error.retryClassification).toBe("rate_limit");
     expect(error.retryAfterSeconds).toBe(15);

--- a/tests/unit/api/response.test.ts
+++ b/tests/unit/api/response.test.ts
@@ -31,6 +31,28 @@ describe("API response envelopes", () => {
       error: {
         code: "conflict",
         message: "The resource already exists",
+        retryable: true,
+        retryClassification: "conflict",
+      },
+    });
+  });
+
+  it("handles rate limit errors and exposes retry-after metadata in body and headers", async () => {
+    const request = new Request("https://stealth.test/api");
+    const response = apiFailure(
+      request,
+      new ApiError(429, "too_many_requests", "Rate limit exceeded", { retryAfterSeconds: 60 }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: "too_many_requests",
+        message: "Rate limit exceeded",
+        retryable: true,
+        retryClassification: "rate_limit",
+        retryAfter: 60,
       },
     });
   });


### PR DESCRIPTION
Closes #1478 

## Description
This PR addresses the need for API clients to reliably distinguish permanent request failures from transient or conflict failures that can be retried (either immediately, after refreshing state, or after waiting). 

We introduce a machine-readable `retryClassification` and a boolean `retryable` status directly on the API error responses, along with standard `Retry-After` header/payload metadata.

### Key Changes
1. **API Error Class and Classifications (`src/server/api/errors.ts`)**:
   - Added a stable `RetryClassification` type: `"permanent" | "transient" | "rate_limit" | "conflict"`.
   - Updated `ApiError` to compute and expose `retryable`, `retryClassification`, and optional `retryAfterSeconds` properties based on status codes and error contexts:
     - `too_many_requests` (429) -> `rate_limit` (retryable)
     - `conflict` (409) -> `conflict` (retryable)
     - `internal_error` (500) -> `transient` (retryable)
     - All validation errors & bad requests (422, 400, etc.) -> `permanent` (non-retryable)

2. **HTTP Error Envelope (`src/server/api/response.ts`)**:
   - Updated `ErrorEnvelope` interface to expose `retryable`, `retryClassification`, and `retryAfter` on the `error` object.
   - Updated `apiFailure` to serialize these fields and dynamically populate the standard HTTP `Retry-After` response header when retry-after values are provided.

3. **OpenAPI Schema Definition (`src/server/api/openapi.ts`)**:
   - Registered `RetryClassification` and `ErrorEnvelope` schemas under `components.schemas` to keep API specifications in lockstep with codebase reality.

4. **Testing Coverage**:
   - **Contract Tests (`tests/unit/api/errors.contract.test.ts`)**: Added tests asserting classifications for Zod validation errors, rate limit errors, temporary conflicts, and server internal errors. Verified that the OpenAPI document defines these schemas.
   - **Unit Tests (`tests/unit/api/response.test.ts`)**: Added assertions verifying envelope structure mapping and `Retry-After` header serialization.
