### PR TITLE
feat: add OpenAPI schemas for policy evaluation and postage submission

### DIFF
--- a/src/routes/api/v1/policies/evaluate.ts
+++ b/src/routes/api/v1/policies/evaluate.ts
@@ -1,25 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 
 import { getApiContext } from "@/server/api/context";
-import { stellarAddressSchema, stroopAmountSchema } from "@/server/api/domain";
+import { policyEvaluationRequestSchema } from "@/server/api/domain";
 import { evaluateMailboxPolicy } from "@/server/api/policy-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
-
-const evaluationSchema = z.object({
-  owner: stellarAddressSchema,
-  postage: stroopAmountSchema,
-  sender: stellarAddressSchema,
-  verified: z.boolean(),
-});
 
 export const Route = createFileRoute("/api/v1/policies/evaluate")({
   server: {
     handlers: {
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
-          const input = await parseJsonBody(request, evaluationSchema);
+          const input = await parseJsonBody(request, policyEvaluationRequestSchema);
           const result = await evaluateMailboxPolicy((await getApiContext()).repository, input);
 
           const reasonMessages: Record<string, string> = {

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -1,9 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 
 import { requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
-import { hash32Schema, stellarAddressSchema, stroopAmountSchema } from "@/server/api/domain";
+import { postageSubmissionSchema } from "@/server/api/domain";
 import { buildDeviceFingerprint } from "@/server/api/abuse-service";
 import { submitPostage, type SubmitPostageContext } from "@/server/api/postage-service";
 import { parseJsonBody } from "@/server/api/request";
@@ -11,20 +10,12 @@ import { apiSuccess, handleApiRequest } from "@/server/api/response";
 import { acquireIdempotency, recordIdempotency } from "@/server/api/idempotency-service";
 import { ApiError } from "@/server/api/errors";
 
-const submissionSchema = z.object({
-  amount: stroopAmountSchema,
-  messageId: hash32Schema,
-  paymentHash: hash32Schema,
-  recipient: stellarAddressSchema,
-  sender: stellarAddressSchema,
-});
-
 export const Route = createFileRoute("/api/v1/postage/")({
   server: {
     handlers: {
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
-          const input = await parseJsonBody(request, submissionSchema);
+          const input = await parseJsonBody(request, postageSubmissionSchema);
           requireActorMatches(request, input.sender);
 
           const repo = (await getApiContext()).repository;

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -33,6 +33,21 @@ export const mailboxPolicySchema = z.object({
   requireVerified: z.boolean(),
 });
 
+export const policyEvaluationRequestSchema = z.object({
+  owner: stellarAddressSchema,
+  postage: stroopAmountSchema,
+  sender: stellarAddressSchema,
+  verified: z.boolean(),
+});
+
+export const postageSubmissionSchema = z.object({
+  amount: stroopAmountSchema,
+  messageId: hash32Schema,
+  paymentHash: hash32Schema,
+  recipient: stellarAddressSchema,
+  sender: stellarAddressSchema,
+});
+
 export const postageSchema = z.object({
   amount: stroopAmountSchema,
   createdAt: z.string().datetime(),
@@ -52,6 +67,8 @@ export const receiptSchema = z.object({
 });
 
 export type MailboxPolicy = z.infer<typeof mailboxPolicySchema>;
+export type PolicyEvaluationRequest = z.infer<typeof policyEvaluationRequestSchema>;
+export type PostageSubmission = z.infer<typeof postageSubmissionSchema>;
 export type Postage = z.infer<typeof postageSchema>;
 export type PostageStatus = z.infer<typeof postageStatusSchema>;
 export type Receipt = z.infer<typeof receiptSchema>;

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -1,4 +1,159 @@
+import { z, type ZodTypeAny } from "zod";
+
+import {
+  hash32Schema,
+  mailboxPolicySchema,
+  policyEvaluationRequestSchema,
+  postageSchema,
+  postageSubmissionSchema,
+  stellarAddressSchema,
+  stroopAmountSchema,
+} from "./domain";
+
 const signedRequestSecurity = [{ StellarSignedRequest: [] }];
+
+const sharedSchemaDefinitions = [
+  ["StellarAddress", stellarAddressSchema],
+  ["Hash32", hash32Schema],
+  ["StroopAmount", stroopAmountSchema],
+  ["MailboxPolicy", mailboxPolicySchema],
+  ["PolicyEvaluationRequest", policyEvaluationRequestSchema],
+  ["PostageSubmission", postageSubmissionSchema],
+  ["Postage", postageSchema],
+] as const;
+
+function isSchemaReferenceCandidate(
+  schema: ZodTypeAny,
+  sharedSchemaMap: Map<ZodTypeAny, string>,
+  skipSchema?: ZodTypeAny,
+) {
+  return skipSchema !== schema && sharedSchemaMap.has(schema);
+}
+
+function convertStringSchema(schema: ZodTypeAny): Record<string, unknown> {
+  const def = schema._def as { checks?: Array<{ kind: string; regex?: RegExp; value?: number }> };
+  const out: Record<string, unknown> = { type: "string" };
+  for (const check of def.checks ?? []) {
+    switch (check.kind) {
+      case "regex":
+        out.pattern = check.regex?.source;
+        break;
+      case "min":
+        out.minLength = check.value;
+        break;
+      case "max":
+        out.maxLength = check.value;
+        break;
+      case "email":
+        out.format = "email";
+        break;
+      case "url":
+        out.format = "uri";
+        break;
+      case "uuid":
+        out.format = "uuid";
+        break;
+      case "datetime":
+        out.format = "date-time";
+        break;
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+export function toOpenApiSchema(
+  schema: ZodTypeAny,
+  sharedSchemaMap: Map<ZodTypeAny, string> = new Map(),
+  skipSchema?: ZodTypeAny,
+): Record<string, unknown> {
+  if (isSchemaReferenceCandidate(schema, sharedSchemaMap, skipSchema)) {
+    const name = sharedSchemaMap.get(schema);
+    return { $ref: `#/components/schemas/${name}` };
+  }
+
+  const def = schema._def as Record<string, unknown> & { typeName?: string };
+  switch (def.typeName) {
+    case z.ZodFirstPartyTypeKind.ZodString: {
+      return convertStringSchema(schema);
+    }
+    case z.ZodFirstPartyTypeKind.ZodNumber: {
+      return { type: "number" };
+    }
+    case z.ZodFirstPartyTypeKind.ZodBoolean: {
+      return { type: "boolean" };
+    }
+    case z.ZodFirstPartyTypeKind.ZodEnum: {
+      return {
+        type: "string",
+        enum: (def.values as unknown[]).slice(),
+      };
+    }
+    case z.ZodFirstPartyTypeKind.ZodLiteral: {
+      const value = def.value as unknown;
+      return { enum: [value] };
+    }
+    case z.ZodFirstPartyTypeKind.ZodOptional:
+    case z.ZodFirstPartyTypeKind.ZodNullable:
+    case z.ZodFirstPartyTypeKind.ZodDefault: {
+      return toOpenApiSchema(def.innerType as ZodTypeAny, sharedSchemaMap, skipSchema);
+    }
+    case z.ZodFirstPartyTypeKind.ZodEffects: {
+      const effectType = (def as { effect?: { type?: string } }).effect?.type;
+      if (effectType === "transform" || effectType === "preprocess") {
+        throw new Error(`Unsupported Zod construct: ${effectType}`);
+      }
+      const innerType = (def as { schema?: ZodTypeAny }).schema ?? (def as { innerType?: ZodTypeAny }).innerType;
+      if (!innerType) {
+        throw new Error(`Unsupported Zod construct: ${def.typeName ?? "unknown"}`);
+      }
+      return toOpenApiSchema(innerType, sharedSchemaMap, skipSchema);
+    }
+    case z.ZodFirstPartyTypeKind.ZodObject: {
+      const shape = (schema as z.ZodObject<any>).shape;
+      const properties: Record<string, Record<string, unknown>> = {};
+      const required: string[] = [];
+      for (const [key, value] of Object.entries(shape)) {
+        const propertySchema = toOpenApiSchema(value as ZodTypeAny, sharedSchemaMap, skipSchema);
+        properties[key] = propertySchema;
+        if (!(value as ZodTypeAny).isOptional()) {
+          required.push(key);
+        }
+      }
+      return {
+        type: "object",
+        properties,
+        required,
+      };
+    }
+    case z.ZodFirstPartyTypeKind.ZodArray: {
+      return {
+        type: "array",
+        items: toOpenApiSchema(def.type as ZodTypeAny, sharedSchemaMap, skipSchema),
+      };
+    }
+    default: {
+      throw new Error(`Unsupported Zod construct: ${def.typeName ?? "unknown"}`);
+    }
+  }
+}
+
+const sharedSchemaMap = new Map(sharedSchemaDefinitions.map(([name, schema]) => [schema, name]));
+
+const baseComponentSchemas = {
+  StellarAddress: toOpenApiSchema(stellarAddressSchema, sharedSchemaMap, stellarAddressSchema),
+  Hash32: toOpenApiSchema(hash32Schema, sharedSchemaMap, hash32Schema),
+  StroopAmount: toOpenApiSchema(stroopAmountSchema, sharedSchemaMap, stroopAmountSchema),
+  MailboxPolicy: toOpenApiSchema(mailboxPolicySchema, sharedSchemaMap, mailboxPolicySchema),
+  PolicyEvaluationRequest: toOpenApiSchema(
+    policyEvaluationRequestSchema,
+    sharedSchemaMap,
+    policyEvaluationRequestSchema,
+  ),
+  PostageSubmission: toOpenApiSchema(postageSubmissionSchema, sharedSchemaMap, postageSubmissionSchema),
+  Postage: toOpenApiSchema(postageSchema, sharedSchemaMap, postageSchema),
+};
 
 export const openApiDocument = {
   openapi: "3.1.0",
@@ -37,27 +192,7 @@ export const openApiDocument = {
       },
     },
     schemas: {
-      StellarAddress: {
-        type: "string",
-        pattern: "^G[A-Z2-7]{55}$",
-      },
-      Hash32: {
-        type: "string",
-        pattern: "^[a-f0-9]{64}$",
-      },
-      StroopAmount: {
-        type: "string",
-        pattern: "^(0|[1-9][0-9]*)$",
-      },
-      MailboxPolicy: {
-        type: "object",
-        required: ["allowUnknown", "minimumPostage", "requireVerified"],
-        properties: {
-          allowUnknown: { type: "boolean" },
-          minimumPostage: { $ref: "#/components/schemas/StroopAmount" },
-          requireVerified: { type: "boolean" },
-        },
-      },
+      ...baseComponentSchemas,
       ValidationErrorItem: {
         type: "object",
         required: ["path", "rule", "message"],
@@ -187,6 +322,14 @@ export const openApiDocument = {
         operationId: "evaluateMailboxPolicy",
         summary: "Evaluate whether a sender can mail a recipient",
         "x-stability": "stable",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/PolicyEvaluationRequest" },
+            },
+          },
+        },
         responses: {
           "200": {
             description: "Policy evaluation decision",
@@ -205,6 +348,24 @@ export const openApiDocument = {
         summary: "Submit a postage proof",
         security: signedRequestSecurity,
         "x-stability": "stable",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/PostageSubmission" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Postage proof accepted",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Postage" },
+              },
+            },
+          },
+        },
       },
     },
     "/postage/quote": {

--- a/tests/unit/api/openapi.test.ts
+++ b/tests/unit/api/openapi.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import { openApiDocument } from "../../../src/server/api/openapi";
+import { mailboxPolicySchema, stellarAddressSchema, stroopAmountSchema } from "../../../src/server/api/domain";
+import { openApiDocument, toOpenApiSchema } from "../../../src/server/api/openapi";
 
 describe("OpenAPI document", () => {
   it("publishes every v1 endpoint family", () => {
@@ -39,5 +41,41 @@ describe("OpenAPI document", () => {
     expect(openApiDocument.paths["/health"].get).not.toHaveProperty("security");
     expect(openApiDocument.paths["/policies/{owner}"].get).not.toHaveProperty("security");
     expect(openApiDocument.paths["/postage/quote"].post).not.toHaveProperty("security");
+  });
+
+  it("derives documented schemas from shared runtime Zod definitions", () => {
+    expect(openApiDocument.components.schemas.MailboxPolicy).toMatchObject({
+      type: "object",
+      required: ["allowUnknown", "minimumPostage", "requireVerified"],
+      properties: {
+        minimumPostage: { $ref: "#/components/schemas/StroopAmount" },
+      },
+    });
+
+    expect(openApiDocument.components.schemas.StroopAmount).toMatchObject({
+      type: "string",
+      pattern: "^(0|[1-9]\\d*)$",
+    });
+  });
+
+  it("converts shared runtime schemas into deterministic OpenAPI schemas", () => {
+    const first = JSON.stringify(toOpenApiSchema(mailboxPolicySchema));
+    const second = JSON.stringify(toOpenApiSchema(mailboxPolicySchema));
+
+    expect(first).toBe(second);
+    expect(toOpenApiSchema(stellarAddressSchema)).toMatchObject({
+      type: "string",
+      pattern: "^G[A-Z2-7]{55}$",
+    });
+    expect(toOpenApiSchema(stroopAmountSchema)).toMatchObject({
+      type: "string",
+      pattern: "^(0|[1-9]\\d*)$",
+    });
+  });
+
+  it("fails clearly for unsupported Zod constructs", () => {
+    expect(() => toOpenApiSchema(z.string().transform((value) => value))).toThrow(
+      /Unsupported Zod construct/i,
+    );
   });
 });


### PR DESCRIPTION
Closes #1523

## ✅ OpenAPI schema generation now uses shared Zod definitions

The OpenAPI layer now derives documented component schemas from the same runtime Zod definitions instead of maintaining separate hand-written copies.

### What changed
- Added a deterministic `toOpenApiSchema` converter in openapi.ts that maps shared Zod schemas into OpenAPI components.
- Introduced shared request schemas in domain.ts and reused them in:
  - evaluate.ts
  - index.ts
- Wired request bodies for policy evaluation and postage submission into the OpenAPI document from those shared schemas.
- Added regression tests in openapi.test.ts covering:
  - schema derivation from shared runtime definitions
  - deterministic output
  - clear failures for unsupported Zod constructs

### Verification
I verified this with:

```bash
cd /workspaces/stealth && npx vitest run tests/unit/api/openapi.test.ts tests/unit/api/errors.contract.test.ts tests/unit/api/openapi.coverage.test.ts tests/unit/api/openapi.examples.test.ts tests/unit/api/openapi.operation-ids.test.ts tests/unit/api/openapi.deprecation.test.ts
```

Result: 6 test files passed, 23 tests passed.

Made changes.