### PR TITLE
Closes #1525 Added Envelopes Documentation

### DIFF
--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -1,5 +1,3 @@
-const signedRequestSecurity = [{ StellarSignedRequest: [] }];
-
 export const openApiDocument = {
   openapi: "3.1.0",
   info: {
@@ -8,7 +6,11 @@ export const openApiDocument = {
     description:
       "Development API for mailbox policy, Stellar postage proofs, and delivery receipts.",
   },
-  servers: [{ url: "/api/v1" }],
+  servers: [
+    {
+      url: "/api/v1",
+    },
+  ],
   components: {
     securitySchemes: {
       StellarSignedRequest: {
@@ -37,6 +39,64 @@ export const openApiDocument = {
       },
     },
     schemas: {
+      ApiMeta: {
+        type: "object",
+        required: ["requestId", "timestamp"],
+        properties: {
+          requestId: {
+            type: "string",
+            description: "Unique request identifier for tracing.",
+          },
+          timestamp: {
+            type: "string",
+            format: "date-time",
+            description: "Server timestamp of the response.",
+          },
+        },
+      },
+      SuccessEnvelope: {
+        type: "object",
+        required: ["data", "meta"],
+        properties: {
+          data: {
+            type: "object",
+            description: "Operation-specific response payload.",
+          },
+          meta: {
+            $ref: "#/components/schemas/ApiMeta",
+          },
+        },
+      },
+      DomainError: {
+        type: "object",
+        required: ["code", "message"],
+        properties: {
+          code: {
+            type: "string",
+            description: "Stable domain error code.",
+            example: "bad_request",
+          },
+          message: {
+            type: "string",
+            description: "Human-readable explanation of the error.",
+          },
+          details: {
+            description: "Optional structured error details.",
+          },
+        },
+      },
+      ErrorEnvelope: {
+        type: "object",
+        required: ["error", "meta"],
+        properties: {
+          error: {
+            $ref: "#/components/schemas/DomainError",
+          },
+          meta: {
+            $ref: "#/components/schemas/ApiMeta",
+          },
+        },
+      },
       StellarAddress: {
         type: "string",
         pattern: "^G[A-Z2-7]{55}$",
@@ -53,9 +113,15 @@ export const openApiDocument = {
         type: "object",
         required: ["allowUnknown", "minimumPostage", "requireVerified"],
         properties: {
-          allowUnknown: { type: "boolean" },
-          minimumPostage: { $ref: "#/components/schemas/StroopAmount" },
-          requireVerified: { type: "boolean" },
+          allowUnknown: {
+            type: "boolean",
+          },
+          minimumPostage: {
+            $ref: "#/components/schemas/StroopAmount",
+          },
+          requireVerified: {
+            type: "boolean",
+          },
         },
       },
       ValidationErrorItem: {
@@ -99,7 +165,9 @@ export const openApiDocument = {
         properties: {
           validationErrors: {
             type: "array",
-            items: { $ref: "#/components/schemas/ValidationErrorItem" },
+            items: {
+              $ref: "#/components/schemas/ValidationErrorItem",
+            },
           },
         },
       },
@@ -134,13 +202,101 @@ export const openApiDocument = {
   },
   paths: {
     "/health": {
-      get: { operationId: "getHealth", summary: "Read service health", "x-stability": "stable" },
+      get: {
+        operationId: "getHealth",
+        summary: "Read service health",
+        "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
     },
     "/protocol": {
       get: {
         operationId: "getProtocol",
         summary: "Discover protocol capabilities",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/openapi.json": {
@@ -148,6 +304,48 @@ export const openApiDocument = {
         operationId: "getOpenApi",
         summary: "Read this OpenAPI document",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/policies/{owner}": {
@@ -155,12 +353,100 @@ export const openApiDocument = {
         operationId: "getMailboxPolicy",
         summary: "Read mailbox policy",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
       put: {
         operationId: "replaceMailboxPolicy",
         summary: "Replace mailbox policy",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/policies/{owner}/senders/{sender}": {
@@ -168,18 +454,152 @@ export const openApiDocument = {
         operationId: "getSenderOverride",
         summary: "Read a sender override",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
       put: {
         operationId: "setSenderOverride",
         summary: "Set a sender override",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
       delete: {
         operationId: "resetSenderOverride",
         summary: "Reset a sender override",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/policies/evaluate": {
@@ -192,7 +612,51 @@ export const openApiDocument = {
             description: "Policy evaluation decision",
             content: {
               "application/json": {
-                schema: { $ref: "#/components/schemas/PolicyEvaluationDecision" },
+                schema: {
+                  allOf: [
+                    {
+                      $ref: "#/components/schemas/SuccessEnvelope",
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          $ref: "#/components/schemas/PolicyEvaluationDecision",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
               },
             },
           },
@@ -203,8 +667,54 @@ export const openApiDocument = {
       post: {
         operationId: "submitPostageProof",
         summary: "Submit a postage proof",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/postage/quote": {
@@ -212,59 +722,377 @@ export const openApiDocument = {
         operationId: "quotePostage",
         summary: "Quote recipient postage requirements",
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/postage/{messageId}": {
       get: {
         operationId: "getPostageState",
         summary: "Read participant postage state",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/postage/{messageId}/settle": {
       post: {
         operationId: "settlePostage",
         summary: "Settle pending postage",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/postage/{messageId}/refund": {
       post: {
         operationId: "refundPostage",
         summary: "Mark pending postage for refund",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/receipts": {
       post: {
         operationId: "recordDelivery",
         summary: "Record message delivery",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/receipts/{messageId}": {
       get: {
         operationId: "getReceiptState",
         summary: "Read participant receipt state",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "stable",
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
       },
     },
     "/receipts/{messageId}/read": {
       post: {
         operationId: "recordReadAcknowledgment",
         summary: "Record recipient read acknowledgment",
-        security: signedRequestSecurity,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
         "x-stability": "deprecated",
         deprecated: true,
         "x-deprecation": {
           reason: "Replaced by delivery-receipts streaming.",
           sunset: "2026-12-31",
           migration: "/receipts/{messageId}",
+        },
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/update_openapi2.cjs
+++ b/update_openapi2.cjs
@@ -1,0 +1,145 @@
+const fs = require("fs");
+
+const code = fs.readFileSync("src/server/api/openapi.ts", "utf8");
+
+const schemasToAdd = `
+      ApiMeta: {
+        type: "object",
+        required: ["requestId", "timestamp"],
+        properties: {
+          requestId: {
+            type: "string",
+            description: "Unique request identifier for tracing.",
+          },
+          timestamp: {
+            type: "string",
+            format: "date-time",
+            description: "Server timestamp of the response.",
+          },
+        },
+      },
+      SuccessEnvelope: {
+        type: "object",
+        required: ["data", "meta"],
+        properties: {
+          data: {
+            type: "object",
+            description: "Operation-specific response payload.",
+          },
+          meta: { $ref: "#/components/schemas/ApiMeta" },
+        },
+      },
+      DomainError: {
+        type: "object",
+        required: ["code", "message"],
+        properties: {
+          code: {
+            type: "string",
+            description: "Stable domain error code.",
+            example: "bad_request",
+          },
+          message: {
+            type: "string",
+            description: "Human-readable explanation of the error.",
+          },
+          details: {
+            description: "Optional structured error details.",
+          },
+        },
+      },
+      ErrorEnvelope: {
+        type: "object",
+        required: ["error", "meta"],
+        properties: {
+          error: { $ref: "#/components/schemas/DomainError" },
+          meta: { $ref: "#/components/schemas/ApiMeta" },
+        },
+      },
+`;
+
+let newCode = code.replace(/schemas: \{/, "schemas: {" + schemasToAdd);
+
+const standardErrorResponses = `
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },`;
+
+const emptySuccessResponse = `
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SuccessEnvelope" },
+              },
+            },
+          },`;
+
+const replaceResponses = (match, p1, p2) => {
+  if (p2.includes("responses:")) return match;
+
+  let insert = `
+        responses: {${emptySuccessResponse}${standardErrorResponses}
+        },`;
+  return `${p1}${insert}\n${p2}`;
+};
+
+// Replace generically for all except those that already have responses
+newCode = newCode.replace(
+  /(\s+(?:get|post|put|delete|patch):\s+\{[\s\S]*?(?:"x-stability"|deprecated|sunset|migration)[^\n]+,\n)(\s*\}(?:,|(?=\n)))/g,
+  replaceResponses,
+);
+
+// Fix policies/evaluate
+const evaluateOriginal = `"200": {
+            description: "Policy evaluation decision",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/PolicyEvaluationDecision" },
+              },
+            },
+          },`;
+
+const evaluateNew = `"200": {
+            description: "Policy evaluation decision",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/SuccessEnvelope" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: { $ref: "#/components/schemas/PolicyEvaluationDecision" },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },${standardErrorResponses}`;
+
+newCode = newCode.replace(evaluateOriginal, evaluateNew);
+
+fs.writeFileSync("src/server/api/openapi.ts", newCode);
+console.log("updated openapi.ts");


### PR DESCRIPTION
# Standardize OpenAPI Data and Error Envelopes

Closes #1525 

## Description
This PR standardizes the OpenAPI specification to consistently represent the `data/meta` and `error/meta` envelopes returned by the application's response handlers across all API operations. 

Previously, the `openapi.ts` document lacked definitions for these generic response wrappers and omitted `responses` blocks for the majority of the endpoints. This made it difficult for clients to rely on a predictable response shape. 

This update resolves the inconsistency by defining shared reusable schemas for success and error envelopes and comprehensively mapping them to all documented paths.

## Changes Made
- **Created Reusable Envelope Components**: 
  - Added `ApiMeta` to document standard metadata fields (`requestId` and `timestamp`).
  - Added `DomainError` to define stable domain errors, complete with representative examples (`bad_request`).
  - Added `SuccessEnvelope` and `ErrorEnvelope` schemas to represent the root response wrappers.
- **Updated All Operations**: 
  - Standardized every API route (e.g., `/health`, `/postage`, `/receipts`, etc.) to include `responses` blocks for standard HTTP status codes (`200`, `400`, `401`, `500`).
  - Operations returning empty success payloads now cleanly reference `SuccessEnvelope`.
- **Preserved Specific Payloads via `allOf`**:
  - For operations returning structured data (like `/policies/evaluate`), the payload (`PolicyEvaluationDecision`) is dynamically merged into the generic `SuccessEnvelope` `data` property using the `allOf` OpenAPI directive.
- **Verified Coverage**: All existing OpenAPI unit tests (`openapi.examples.test.ts`, `openapi.coverage.test.ts`, `openapi.test.ts`) now pass with the added components, ensuring 100% resolution of schema `$ref` pointers.

## Acceptance Criteria Met
- All operations reference the shared envelope components.
- Request ID and timestamp are documented.
- Error examples use stable domain codes.
- OpenAPI tests validate references.

## How to Test
1. Run `npm run test` or `npx vitest run tests/unit/api/` to verify that all OpenAPI coverage and integrity tests pass locally.
2. Serve or load the `openapi.json` locally and view it in Swagger UI / Redoc to confirm that responses for all endpoints now consistently reflect the `SuccessEnvelope` and `ErrorEnvelope` structures.
