### PR TITLE
feat(api): add centralized security headers for JSON responses

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,6 +12,13 @@ The TanStack Start worker exposes versioned endpoints under `/api/v1`.
 Amounts are decimal strings in stroops because Soroban uses i128 values that can exceed JavaScript's
 safe integer range. Message IDs and payment hashes are lowercase 32-byte hexadecimal strings.
 
+## Response headers
+
+All JSON API responses include `Content-Type: application/json; charset=utf-8`, `Cache-Control`,
+`X-Request-ID`, and `X-Content-Type-Options: nosniff`. The security header is applied centrally and
+cannot be overridden by individual routes. CORS headers remain independently configurable and are
+preserved when responses are created.
+
 ## Idempotency
 
 Certain endpoints support idempotency via the optional `X-Idempotency-Key` header to ensure safe

--- a/src/routes/api/v1/openapi[.]json.ts
+++ b/src/routes/api/v1/openapi[.]json.ts
@@ -1,16 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { openApiDocument } from "@/server/api/openapi";
+import { jsonResponse } from "@/server/api/response";
 
 export const Route = createFileRoute("/api/v1/openapi.json")({
   server: {
     handlers: {
-      GET: () =>
-        new Response(JSON.stringify(openApiDocument), {
-          headers: {
-            "cache-control": "public, max-age=300",
-            "content-type": "application/json; charset=utf-8",
-          },
+      GET: ({ request }) =>
+        jsonResponse(request, openApiDocument, {
+          cachePolicy: "PUBLIC_5_MINUTES",
         }),
     },
   },

--- a/src/server/api/response.ts
+++ b/src/server/api/response.ts
@@ -24,8 +24,13 @@ interface ErrorEnvelope {
 
 export const CACHE_POLICIES = {
   NO_STORE: "no-store",
+  PUBLIC_5_MINUTES: "public, max-age=300",
   PUBLIC_IMMUTABLE: "public, max-age=31536000, immutable",
   PUBLIC_REVALIDATE: "public, max-age=0, must-revalidate",
+} as const;
+
+export const JSON_SECURITY_HEADERS = {
+  "x-content-type-options": "nosniff",
 } as const;
 
 type CachePolicy = keyof typeof CACHE_POLICIES;
@@ -58,6 +63,9 @@ function responseHeaders(
   result.set("cache-control", cacheControl);
   result.set("content-type", "application/json; charset=utf-8");
   result.set("x-request-id", requestId);
+  for (const [name, value] of Object.entries(JSON_SECURITY_HEADERS)) {
+    result.set(name, value);
+  }
   return result;
 }
 
@@ -68,9 +76,37 @@ function meta(requestId: string): ApiMeta {
   };
 }
 
+function enforceJsonSecurityHeaders(response: Response) {
+  const contentType = response.headers.get("content-type")?.toLowerCase();
+  if (!contentType?.includes("application/json")) {
+    return response;
+  }
+
+  const securedResponse = new Response(response.body, response);
+  for (const [name, value] of Object.entries(JSON_SECURITY_HEADERS)) {
+    securedResponse.headers.set(name, value);
+  }
+  return securedResponse;
+}
+
 export function apiSuccess<T>(request: Request, data: T, options: ResponseOptions = {}) {
   const requestId = getRequestId(request);
   const body: SuccessEnvelope<T> = { data, meta: meta(requestId) };
+
+  return jsonResponse(requestId, body, {
+    status: options.status ?? 200,
+    headers: options.headers,
+    cachePolicy: options.cachePolicy,
+  });
+}
+
+export function jsonResponse(
+  requestOrRequestId: Request | string,
+  body: unknown,
+  options: ResponseOptions = {},
+) {
+  const requestId =
+    typeof requestOrRequestId === "string" ? requestOrRequestId : getRequestId(requestOrRequestId);
 
   return new Response(JSON.stringify(body), {
     status: options.status ?? 200,
@@ -109,7 +145,7 @@ export async function handleApiRequest(
   handler: () => Response | Promise<Response>,
 ) {
   try {
-    return await handler();
+    return enforceJsonSecurityHeaders(await handler());
   } catch (error) {
     return apiFailure(request, error);
   }

--- a/tests/unit/api/response-cache-control.test.ts
+++ b/tests/unit/api/response-cache-control.test.ts
@@ -12,6 +12,7 @@ describe("API response cache policies", () => {
 
   it.each([
     ["NO_STORE", CACHE_POLICIES.NO_STORE],
+    ["PUBLIC_5_MINUTES", CACHE_POLICIES.PUBLIC_5_MINUTES],
     ["PUBLIC_IMMUTABLE", CACHE_POLICIES.PUBLIC_IMMUTABLE],
     ["PUBLIC_REVALIDATE", CACHE_POLICIES.PUBLIC_REVALIDATE],
   ] as const)("applies the %s cache policy", (cachePolicy, expected) => {

--- a/tests/unit/api/response.test.ts
+++ b/tests/unit/api/response.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { ApiError } from "../../../src/server/api/errors";
-import { apiFailure, apiSuccess } from "../../../src/server/api/response";
+import {
+  JSON_SECURITY_HEADERS,
+  apiFailure,
+  apiSuccess,
+  handleApiRequest,
+  jsonResponse,
+} from "../../../src/server/api/response";
 
 describe("API response envelopes", () => {
   it("preserves a caller-provided request ID", async () => {
@@ -35,6 +41,68 @@ describe("API response envelopes", () => {
         retryClassification: "conflict",
       },
     });
+  });
+
+  it.each([
+    ["success", () => apiSuccess(new Request("https://stealth.test/api"), { ready: true })],
+    [
+      "failure",
+      () =>
+        apiFailure(
+          new Request("https://stealth.test/api"),
+          new ApiError(400, "bad_request", "Invalid request"),
+        ),
+    ],
+    ["raw JSON", () => jsonResponse(new Request("https://stealth.test/api"), { openapi: "3.1.0" })],
+  ])("adds mandatory security headers to every %s response", (_kind, createResponse) => {
+    const response = createResponse();
+
+    for (const [name, value] of Object.entries(JSON_SECURITY_HEADERS)) {
+      expect(response.headers.get(name)).toBe(value);
+    }
+  });
+
+  it("preserves existing and CORS headers while enforcing mandatory response headers", () => {
+    const request = new Request("https://stealth.test/api", {
+      headers: { "x-request-id": "request-123" },
+    });
+    const response = apiSuccess(
+      request,
+      { ready: true },
+      {
+        cachePolicy: "PUBLIC_REVALIDATE",
+        headers: {
+          "access-control-allow-origin": "https://client.example",
+          etag: '"response-v1"',
+          "x-content-type-options": "caller-value",
+        },
+      },
+    );
+
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers.get("x-request-id")).toBe("request-123");
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://client.example");
+    expect(response.headers.get("etag")).toBe('"response-v1"');
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("restores mandatory headers removed by route-specific response logic", async () => {
+    const request = new Request("https://stealth.test/api");
+    const response = await handleApiRequest(request, () => {
+      const routeResponse = apiSuccess(
+        request,
+        { ready: true },
+        {
+          headers: { "access-control-allow-origin": "*" },
+        },
+      );
+      routeResponse.headers.delete("x-content-type-options");
+      return routeResponse;
+    });
+
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
   });
 
   it("handles rate limit errors and exposes retry-after metadata in body and headers", async () => {


### PR DESCRIPTION
Closes #1481

## Summary

This PR adds centralized security headers for JSON API responses to improve default response hardening.

### Changes

- Added centralized `X-Content-Type-Options: nosniff` for JSON API responses.
- Prevented route-specific code from removing mandatory security headers.
- Preserved existing Content-Type, Cache-Control, Request-ID, custom headers, and CORS behavior.
- Migrated the OpenAPI JSON response to the centralized response helper.
- Updated API documentation.
- Added and updated response tests covering the new behavior.

## Validation

- ✅ npm run lint
- ✅ npx tsc --noEmit
- ✅ npm test (954 tests passed)
- ✅ npm run build

The build completed successfully with only existing bundle-size and Freighter import warnings.