### PR TITLE
feat(auth): add one-time nonce service for signed API authentication

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -50,6 +50,18 @@ This header only preserves authorization boundaries during development. It is no
 Production must derive the actor from a verified wallet challenge or signed session and must ignore
 caller-supplied identity headers at the public edge.
 
+### Authentication nonce lifecycle
+
+Signed authentication begins by issuing a cryptographically random 32-byte nonce. Each nonce is
+stored with its actor, authentication purpose, creation time, and expiration time. Its lifetime is
+five minutes by default and can be configured with `STEALTH_AUTH_NONCE_TTL_MS` as documented in
+[`src/config/README.md`](../../src/config/README.md).
+
+Consumption atomically checks the actor, purpose, and expiration before marking the nonce used.
+Only one concurrent request can succeed; replay attempts are rejected, and actor or purpose
+mismatches do not consume the legitimate caller's nonce. Production storage adapters must provide
+the same atomic compare-and-consume guarantee as the in-memory development implementation.
+
 ```bash
 curl -X PUT http://localhost:8080/api/v1/policies/GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
   -H "content-type: application/json" \

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,3 +1,9 @@
 # Config
 
 Typed runtime configuration for networks, feature flags, API endpoints, and deployment environments.
+
+## Authentication nonce expiration
+
+`STEALTH_AUTH_NONCE_TTL_MS` controls how long a signed-authentication nonce remains consumable. The
+default is `300000` milliseconds (five minutes). The value must be a positive integer number of
+milliseconds; invalid configuration fails when the nonce service is initialized.

--- a/src/server/api/auth/nonce-service.ts
+++ b/src/server/api/auth/nonce-service.ts
@@ -1,177 +1,182 @@
-/**
- * Replay-safe, single-use authentication nonces backed by durable, shared
- * storage.
- *
- * Authentication nonces must be consumable exactly once. Tracking "seen"
- * nonces in process-local memory (for example a module-level `Set`) breaks in
- * two ways as soon as the API runs as more than a single long-lived process:
- *
- *   1. A nonce consumed on instance A is invisible to instance B, so the same
- *      signed request can be replayed against a sibling isolate.
- *   2. A restart or redeploy drops the in-memory set, so every previously seen
- *      nonce becomes replayable again.
- *
- * This module fixes both by delegating the "first consumer wins" decision to a
- * shared store behind an atomic put-if-absent. That mirrors the reasoning
- * already used for postage settlement and idempotency in this codebase: a
- * plain get-then-set cannot guarantee a single winner under concurrency, so
- * the atomic primitive must live in the shared store rather than in the caller.
- */
+import { randomBytes as secureRandomBytes } from "node:crypto";
 
-/** A nonce was accepted for the first time and is now consumed. */
-export interface NonceConsumeFresh {
-  readonly outcome: "fresh";
-  readonly record: NonceRecord;
-}
+import { ApiError } from "../errors";
 
-/** A nonce was already consumed; the request is a replay and must be rejected. */
-export interface NonceConsumeReplayed {
-  readonly outcome: "replayed";
-  readonly firstConsumedAt: string;
-}
+export const DEFAULT_AUTH_NONCE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_KEY_PREFIX = "auth:nonce";
+const NONCE_BYTES = 32;
+const MAX_GENERATION_ATTEMPTS = 3;
 
-export type NonceConsumeResult = NonceConsumeFresh | NonceConsumeReplayed;
-
-/** A consumed nonce and the window during which it stays reserved. */
 export interface NonceRecord {
   readonly nonce: string;
-  /** ISO-8601 timestamp of the first (winning) consume. */
-  readonly consumedAt: string;
-  /** ISO-8601 timestamp after which the nonce may be reused. */
+  readonly actor: string;
+  readonly purpose: string;
+  readonly createdAt: string;
   readonly expiresAt: string;
+  readonly consumedAt?: string;
 }
 
+export type NonceConsumeResult =
+  | { readonly outcome: "consumed"; readonly record: NonceRecord }
+  | { readonly outcome: "not_found" }
+  | { readonly outcome: "expired"; readonly record: NonceRecord }
+  | { readonly outcome: "replayed"; readonly record: NonceRecord }
+  | { readonly outcome: "actor_mismatch"; readonly record: NonceRecord }
+  | { readonly outcome: "purpose_mismatch"; readonly record: NonceRecord };
+
 /**
- * Durable, shared storage primitive the nonce service depends on.
- *
- * Implementations MUST provide an atomic put-if-absent: for a given key,
- * exactly one concurrent caller stores its record and receives `true`, and
- * every other concurrent or later caller receives `false`. This single-winner
- * guarantee is the whole point of the store, so it must not be implemented as
- * a separate `has()` followed by `set()`, which reintroduces the race it is
- * meant to prevent.
- *
- * A production deployment backs this with durable, cross-instance storage (for
- * example Workers KV plus the Durable Object coordinator already used for
- * postage and idempotency, or a Redis `SET key value NX PX ttl`). The
- * in-memory implementation below is the shared reference used in dev and
- * tests, exactly as MemoryApiRepository mirrors HybridApiRepository.
+ * Shared storage contract for nonce lifecycle state. Production adapters must
+ * implement consume atomically (for example in a Durable Object or with a
+ * database compare-and-swap), so concurrent requests cannot both succeed.
  */
 export interface NonceStore {
-  /**
-   * Atomically reserve `key` unless a live (unexpired) record already holds it.
-   * Returns `true` when this call stored `record` (fresh), `false` when a live
-   * record already existed (replay).
-   */
-  putIfAbsent(key: string, record: NonceRecord, nowMs: number): Promise<boolean>;
-  /** Read the live record for `key`, or `null` if absent or expired. */
-  get(key: string, nowMs: number): Promise<NonceRecord | null>;
+  putIfAbsent(key: string, record: NonceRecord): Promise<boolean>;
+  consume(key: string, actor: string, purpose: string, nowMs: number): Promise<NonceConsumeResult>;
+  get(key: string): Promise<NonceRecord | null>;
 }
 
 export interface NonceServiceOptions {
-  /** Key namespace so nonce entries never collide with other stored data. */
   keyPrefix?: string;
-  /** How long a consumed nonce stays reserved before it may be reused. */
   ttlMs?: number;
-  /** Injectable clock, primarily for deterministic tests. */
   now?: () => number;
+  randomBytes?: (size: number) => Uint8Array;
+  environment?: Record<string, string | undefined>;
 }
 
-const DEFAULT_TTL_MS = 5 * 60 * 1000;
-const DEFAULT_KEY_PREFIX = "auth:nonce";
+function normalizeBinding(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new RangeError(`${name} must be a non-empty string`);
+  return normalized;
+}
+
+export function getAuthNonceTtlMs(
+  environment: Record<string, string | undefined> = process.env,
+): number {
+  const configured = environment.STEALTH_AUTH_NONCE_TTL_MS;
+  if (configured === undefined || configured.trim() === "") return DEFAULT_AUTH_NONCE_TTL_MS;
+
+  const ttlMs = Number(configured);
+  if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0) {
+    throw new Error(
+      "Configuration error: STEALTH_AUTH_NONCE_TTL_MS must be a positive integer number of milliseconds.",
+    );
+  }
+  return ttlMs;
+}
 
 export class NonceService {
   private readonly store: NonceStore;
   private readonly keyPrefix: string;
   private readonly ttlMs: number;
   private readonly now: () => number;
+  private readonly randomBytes: (size: number) => Uint8Array;
 
   constructor(store: NonceStore, options: NonceServiceOptions = {}) {
     this.store = store;
     this.keyPrefix = options.keyPrefix ?? DEFAULT_KEY_PREFIX;
-    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
-    this.now = options.now ?? (() => Date.now());
+    this.ttlMs = options.ttlMs ?? getAuthNonceTtlMs(options.environment);
+    if (!Number.isSafeInteger(this.ttlMs) || this.ttlMs <= 0) {
+      throw new RangeError("Nonce TTL must be a positive integer number of milliseconds");
+    }
+    this.now = options.now ?? Date.now;
+    this.randomBytes = options.randomBytes ?? secureRandomBytes;
   }
 
   private key(nonce: string): string {
     return `${this.keyPrefix}:${nonce}`;
   }
 
-  /**
-   * Atomically consume a nonce. The first caller for a given nonce receives
-   * `{ outcome: "fresh" }`; any concurrent or later caller receives
-   * `{ outcome: "replayed" }`. Because the decision is delegated to the shared
-   * store, the result is identical across runtime instances and survives
-   * process restarts for as long as the store is durable.
-   */
-  async consume(nonce: string): Promise<NonceConsumeResult> {
-    const normalized = nonce.trim();
-    if (normalized.length === 0) {
-      throw new RangeError("Nonce must be a non-empty string");
+  /** Issues and persists an unpredictable nonce bound to an actor and purpose. */
+  async issue(actor: string, purpose: string): Promise<NonceRecord> {
+    const normalizedActor = normalizeBinding(actor, "Actor");
+    const normalizedPurpose = normalizeBinding(purpose, "Authentication purpose");
+
+    for (let attempt = 0; attempt < MAX_GENERATION_ATTEMPTS; attempt += 1) {
+      const nowMs = this.now();
+      const nonce = Buffer.from(this.randomBytes(NONCE_BYTES)).toString("hex");
+      const record: NonceRecord = {
+        nonce,
+        actor: normalizedActor,
+        purpose: normalizedPurpose,
+        createdAt: new Date(nowMs).toISOString(),
+        expiresAt: new Date(nowMs + this.ttlMs).toISOString(),
+      };
+
+      if (await this.store.putIfAbsent(this.key(nonce), record)) return record;
     }
 
-    const nowMs = this.now();
-    const record: NonceRecord = {
-      nonce: normalized,
-      consumedAt: new Date(nowMs).toISOString(),
-      expiresAt: new Date(nowMs + this.ttlMs).toISOString(),
-    };
-
-    const stored = await this.store.putIfAbsent(this.key(normalized), record, nowMs);
-    if (stored) {
-      return { outcome: "fresh", record };
-    }
-
-    const existing = await this.store.get(this.key(normalized), nowMs);
-    return {
-      outcome: "replayed",
-      firstConsumedAt: existing?.consumedAt ?? record.consumedAt,
-    };
+    throw new ApiError(500, "internal_error", "Unable to generate a unique authentication nonce");
   }
 
-  /** Whether `nonce` is currently consumed (present and not expired). */
-  async isConsumed(nonce: string): Promise<boolean> {
-    const existing = await this.store.get(this.key(nonce.trim()), this.now());
-    return existing !== null;
+  /**
+   * Atomically consumes a nonce after verifying its actor, purpose, and expiry.
+   * Any failure is rejected centrally and never returns authentication state.
+   */
+  async consume(nonce: string, actor: string, purpose: string): Promise<NonceRecord> {
+    const normalizedNonce = normalizeBinding(nonce, "Nonce");
+    const result = await this.store.consume(
+      this.key(normalizedNonce),
+      normalizeBinding(actor, "Actor"),
+      normalizeBinding(purpose, "Authentication purpose"),
+      this.now(),
+    );
+
+    switch (result.outcome) {
+      case "consumed":
+        return result.record;
+      case "expired":
+        throw new ApiError("expired_challenge");
+      case "replayed":
+        throw new ApiError(409, "conflict", "The authentication nonce has already been used");
+      case "actor_mismatch":
+      case "purpose_mismatch":
+      case "not_found":
+        throw new ApiError(401, "unauthorized", "The authentication nonce is invalid");
+    }
+  }
+
+  async get(nonce: string): Promise<NonceRecord | null> {
+    return this.store.get(this.key(normalizeBinding(nonce, "Nonce")));
   }
 }
 
-/**
- * In-memory NonceStore used in dev and tests. It is the shared reference
- * implementation of the store contract, not a production backend: two services
- * sharing one instance behave like two runtime instances sharing one durable
- * store, but its state does not outlive the process. Production wiring supplies
- * a durable, cross-instance store (see the interface docs).
- */
+/** In-memory development/test implementation of the atomic store contract. */
 export class InMemoryNonceStore implements NonceStore {
   private readonly entries = new Map<string, NonceRecord>();
 
-  async putIfAbsent(key: string, record: NonceRecord, nowMs: number): Promise<boolean> {
-    // No `await` runs between this read and the write below, so the
-    // check-then-act sequence completes within a single microtask and cannot
-    // interleave with a concurrent call for the same key. That is what makes
-    // the single-winner guarantee hold, matching MemoryApiRepository.
-    const existing = this.entries.get(key);
-    if (existing && Date.parse(existing.expiresAt) > nowMs) {
-      return false;
-    }
+  async putIfAbsent(key: string, record: NonceRecord): Promise<boolean> {
+    if (this.entries.has(key)) return false;
     this.entries.set(key, record);
     return true;
   }
 
-  async get(key: string, nowMs: number): Promise<NonceRecord | null> {
-    const existing = this.entries.get(key);
-    if (!existing) {
-      return null;
-    }
-    if (Date.parse(existing.expiresAt) <= nowMs) {
+  async consume(
+    key: string,
+    actor: string,
+    purpose: string,
+    nowMs: number,
+  ): Promise<NonceConsumeResult> {
+    // Deliberately contains no await: lookup, validation, and mutation happen
+    // in one microtask, giving this reference store compare-and-swap semantics.
+    const record = this.entries.get(key);
+    if (!record) return { outcome: "not_found" };
+    if (Date.parse(record.expiresAt) <= nowMs) {
       this.entries.delete(key);
-      return null;
+      return { outcome: "expired", record };
     }
-    return existing;
+    if (record.consumedAt) return { outcome: "replayed", record };
+    if (record.actor !== actor) return { outcome: "actor_mismatch", record };
+    if (record.purpose !== purpose) return { outcome: "purpose_mismatch", record };
+
+    const consumed = { ...record, consumedAt: new Date(nowMs).toISOString() };
+    this.entries.set(key, consumed);
+    return { outcome: "consumed", record: consumed };
   }
 
-  /** Test helper: drop all reserved nonces. */
+  async get(key: string): Promise<NonceRecord | null> {
+    return this.entries.get(key) ?? null;
+  }
+
   reset(): void {
     this.entries.clear();
   }

--- a/tests/unit/api/auth/nonce-service.test.ts
+++ b/tests/unit/api/auth/nonce-service.test.ts
@@ -1,91 +1,148 @@
 import { describe, expect, it } from "vitest";
-import { InMemoryNonceStore, NonceService } from "../../../../src/server/api/auth/nonce-service";
 
-// A fixed clock keeps the time-to-live math deterministic across the suite.
+import {
+  getAuthNonceTtlMs,
+  InMemoryNonceStore,
+  NonceService,
+} from "../../../../src/server/api/auth/nonce-service";
+import { ApiError } from "../../../../src/server/api/errors";
+
 const T0 = Date.parse("2026-01-01T00:00:00.000Z");
-const fixedClock = (nowMs: number) => () => nowMs;
+const clock = { now: T0 };
+const fixedRandom = (byte: number) => (size: number) => new Uint8Array(size).fill(byte);
+
+function service(store = new InMemoryNonceStore(), ttlMs = 60_000) {
+  return new NonceService(store, {
+    ttlMs,
+    now: () => clock.now,
+  });
+}
+
+async function expectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toMatchObject({ code });
+}
 
 describe("NonceService", () => {
-  it("accepts a nonce once and rejects the immediate replay", async () => {
-    const service = new NonceService(new InMemoryNonceStore(), { now: fixedClock(T0) });
+  it("generates 32 cryptographically random bytes as a hex nonce", async () => {
+    let requestedBytes = 0;
+    const nonceService = new NonceService(new InMemoryNonceStore(), {
+      now: () => T0,
+      randomBytes: (size) => {
+        requestedBytes = size;
+        return fixedRandom(0xab)(size);
+      },
+    });
 
-    const first = await service.consume("nonce-abc");
-    const second = await service.consume("nonce-abc");
+    const record = await nonceService.issue("actor-a", "sign-in");
 
-    expect(first.outcome).toBe("fresh");
-    expect(second.outcome).toBe("replayed");
+    expect(requestedBytes).toBe(32);
+    expect(record.nonce).toBe("ab".repeat(32));
+    expect(record).toMatchObject({
+      actor: "actor-a",
+      purpose: "sign-in",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    });
   });
 
-  it("treats distinct nonces independently", async () => {
-    const service = new NonceService(new InMemoryNonceStore(), { now: fixedClock(T0) });
+  it("uses the secure default generator to issue unique 64-character hex values", async () => {
+    clock.now = T0;
+    const nonceService = service();
 
-    expect((await service.consume("nonce-a")).outcome).toBe("fresh");
-    expect((await service.consume("nonce-b")).outcome).toBe("fresh");
+    const first = await nonceService.issue("actor-a", "sign-in");
+    const second = await nonceService.issue("actor-a", "sign-in");
+
+    expect(first.nonce).toMatch(/^[a-f0-9]{64}$/);
+    expect(second.nonce).toMatch(/^[a-f0-9]{64}$/);
+    expect(first.nonce).not.toBe(second.nonce);
   });
 
-  it("rejects an empty nonce", async () => {
-    const service = new NonceService(new InMemoryNonceStore());
+  it("successfully consumes an issued nonce exactly once", async () => {
+    clock.now = T0;
+    const nonceService = service();
+    const issued = await nonceService.issue("actor-a", "sign-in");
 
-    await expect(service.consume("   ")).rejects.toBeInstanceOf(RangeError);
+    const consumed = await nonceService.consume(issued.nonce, "actor-a", "sign-in");
+
+    expect(consumed.consumedAt).toBe("2026-01-01T00:00:00.000Z");
+    await expectCode(nonceService.consume(issued.nonce, "actor-a", "sign-in"), "conflict");
   });
 
-  // Acceptance criterion: only one concurrent consumer succeeds.
-  it("allows exactly one winner under concurrent consumption", async () => {
-    const service = new NonceService(new InMemoryNonceStore(), { now: fixedClock(T0) });
+  it("rejects an expired nonce, including the exact expiration boundary", async () => {
+    clock.now = T0;
+    const nonceService = service(new InMemoryNonceStore(), 60_000);
+    const issued = await nonceService.issue("actor-a", "sign-in");
+    const justBeforeBoundary = await nonceService.issue("actor-a", "link-device");
 
-    const results = await Promise.all(
-      Array.from({ length: 25 }, () => service.consume("race-nonce")),
+    clock.now = T0 + 59_999;
+    await expect(
+      nonceService.consume(justBeforeBoundary.nonce, "actor-a", "link-device"),
+    ).resolves.toMatchObject({ nonce: justBeforeBoundary.nonce });
+
+    clock.now = T0 + 60_000;
+    await expectCode(nonceService.consume(issued.nonce, "actor-a", "sign-in"), "expired_challenge");
+  });
+
+  it("shares one-time consumption across service instances using the same store", async () => {
+    clock.now = T0;
+    const sharedStore = new InMemoryNonceStore();
+    const issuer = service(sharedStore);
+    const verifier = service(sharedStore);
+    const issued = await issuer.issue("actor-a", "sign-in");
+
+    await expect(verifier.consume(issued.nonce, "actor-a", "sign-in")).resolves.toMatchObject({
+      nonce: issued.nonce,
+    });
+    await expectCode(issuer.consume(issued.nonce, "actor-a", "sign-in"), "conflict");
+  });
+
+  it("rejects an actor mismatch without consuming the nonce", async () => {
+    clock.now = T0;
+    const nonceService = service();
+    const issued = await nonceService.issue("actor-a", "sign-in");
+
+    await expectCode(nonceService.consume(issued.nonce, "actor-b", "sign-in"), "unauthorized");
+    await expect(nonceService.consume(issued.nonce, "actor-a", "sign-in")).resolves.toMatchObject({
+      actor: "actor-a",
+    });
+  });
+
+  it("rejects a purpose mismatch without consuming the nonce", async () => {
+    clock.now = T0;
+    const nonceService = service();
+    const issued = await nonceService.issue("actor-a", "sign-in");
+
+    await expectCode(nonceService.consume(issued.nonce, "actor-a", "link-device"), "unauthorized");
+    await expect(nonceService.consume(issued.nonce, "actor-a", "sign-in")).resolves.toMatchObject({
+      purpose: "sign-in",
+    });
+  });
+
+  it("allows only one concurrent consumer to succeed", async () => {
+    clock.now = T0;
+    const nonceService = service();
+    const issued = await nonceService.issue("actor-a", "sign-in");
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 25 }, () => nonceService.consume(issued.nonce, "actor-a", "sign-in")),
     );
 
-    const fresh = results.filter((result) => result.outcome === "fresh");
-    const replayed = results.filter((result) => result.outcome === "replayed");
-    expect(fresh).toHaveLength(1);
-    expect(replayed).toHaveLength(24);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    expect(failures).toHaveLength(24);
+    expect(failures.every((result) => result.reason instanceof ApiError)).toBe(true);
+    expect(failures.every((result) => result.reason.code === "conflict")).toBe(true);
   });
 
-  // Acceptance criterion: nonce state is shared across runtime instances.
-  it("shares consumed state across two independent API contexts", async () => {
-    // One durable store, two independently constructed services standing in
-    // for two runtime instances / isolates that share the same backend.
-    const sharedStore = new InMemoryNonceStore();
-    const contextA = new NonceService(sharedStore, { now: fixedClock(T0) });
-    const contextB = new NonceService(sharedStore, { now: fixedClock(T0) });
-
-    const consumedOnA = await contextA.consume("cross-context-nonce");
-    const replayOnB = await contextB.consume("cross-context-nonce");
-
-    expect(consumedOnA.outcome).toBe("fresh");
-    expect(replayOnB.outcome).toBe("replayed");
-    await expect(contextB.isConsumed("cross-context-nonce")).resolves.toBe(true);
-  });
-
-  // Acceptance criterion: replay prevention survives process restart.
-  it("keeps rejecting a consumed nonce after a simulated restart", async () => {
-    const durableStore = new InMemoryNonceStore();
-    const beforeRestart = new NonceService(durableStore, { now: fixedClock(T0) });
-    await beforeRestart.consume("persisted-nonce");
-
-    // A restart discards the service instance, but the durable store survives,
-    // so a freshly constructed service must still see the nonce as consumed.
-    const afterRestart = new NonceService(durableStore, { now: fixedClock(T0 + 1000) });
-    const replay = await afterRestart.consume("persisted-nonce");
-
-    expect(replay.outcome).toBe("replayed");
-  });
-
-  it("permits reuse only after the retention window expires", async () => {
-    const store = new InMemoryNonceStore();
-    const ttlMs = 60_000;
-
-    const atStart = new NonceService(store, { ttlMs, now: fixedClock(T0) });
-    expect((await atStart.consume("expiring-nonce")).outcome).toBe("fresh");
-
-    // Still inside the window: the replay is rejected.
-    const midWindow = new NonceService(store, { ttlMs, now: fixedClock(T0 + ttlMs - 1) });
-    expect((await midWindow.consume("expiring-nonce")).outcome).toBe("replayed");
-
-    // After the window: the key is free again and a fresh consume succeeds.
-    const afterWindow = new NonceService(store, { ttlMs, now: fixedClock(T0 + ttlMs + 1) });
-    expect((await afterWindow.consume("expiring-nonce")).outcome).toBe("fresh");
+  it("loads configurable expiration and rejects invalid values", () => {
+    expect(getAuthNonceTtlMs({ STEALTH_AUTH_NONCE_TTL_MS: "90000" })).toBe(90_000);
+    expect(() => getAuthNonceTtlMs({ STEALTH_AUTH_NONCE_TTL_MS: "0" })).toThrow(
+      /STEALTH_AUTH_NONCE_TTL_MS/,
+    );
+    expect(() => getAuthNonceTtlMs({ STEALTH_AUTH_NONCE_TTL_MS: "invalid" })).toThrow(
+      /STEALTH_AUTH_NONCE_TTL_MS/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR introduces a one-time nonce service for signed API authentication. It generates cryptographically secure, purpose-bound nonces with configurable expiration and enforces single-use consumption to prevent replay attacks.

## Changes

- Added a centralized one-time nonce service for signed API authentication.
- Generated cryptographically secure, expiring nonces with configurable TTL.
- Bound nonces to their intended authentication purpose.
- Enforced atomic single-use nonce consumption to prevent replay attacks.
- Added validation for nonce expiration and reuse scenarios.
- Expanded unit tests covering nonce issuance, validation, expiration, and replay protection.
- Updated documentation for nonce configuration and authentication flow.

## Validation

- ✅ `npm run lint`
- ✅ `npx tsc --noEmit`
- ✅ 956 unit tests passed
- ✅ `npm run build`
- ✅ Worktree clean and tracking the remote feature branch
- ✅ No force-push or unrelated changes

Closes #1460