### PR TITLE
feat(audit): add structured audit service for security-sensitive API actions

### DIFF
--- a/src/server/api/actor.ts
+++ b/src/server/api/actor.ts
@@ -2,6 +2,7 @@ import { stellarAddressSchema } from "./domain";
 import { ApiError } from "./errors";
 import { assertActorAuthorized, type DelegatedAuthorization } from "./auth/delegation";
 import { extractPrincipal, type ApiContext, type ApiPrincipal } from "./context";
+import { recordAuditEvent } from "./audit";
 
 export const ACTOR_HEADER = "x-stealth-address";
 export const DELEGATION_HEADER = "x-stealth-delegation";
@@ -53,5 +54,36 @@ export function requireActorMatches(
   authorization?: DelegatedAuthorization,
 ) {
   const actor = requireActor(requestOrContext);
+  const isDelegated = actor !== expectedAddress;
+  const requestId =
+    requestOrContext && typeof requestOrContext === "object" && "headers" in requestOrContext
+      ? (requestOrContext as Request).headers.get("x-request-id")?.trim() || ""
+      : (requestOrContext as ApiContext).requestId || "";
+
+  if (isDelegated) {
+    try {
+      const res = assertActorAuthorized(actor, expectedAddress, authorization);
+      recordAuditEvent({
+        actor,
+        action: "delegation.authorize",
+        targetType: "mailbox",
+        safeTargetReference: `mailbox:${expectedAddress}`,
+        result: "success",
+        requestId,
+      });
+      return res;
+    } catch (error) {
+      recordAuditEvent({
+        actor,
+        action: "delegation.authorize",
+        targetType: "mailbox",
+        safeTargetReference: `mailbox:${expectedAddress}`,
+        result: "denied",
+        requestId,
+      });
+      throw error;
+    }
+  }
+
   return assertActorAuthorized(actor, expectedAddress, authorization);
 }

--- a/src/server/api/audit.ts
+++ b/src/server/api/audit.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const auditEventResultSchema = z.enum(["success", "denied"]);
+export type AuditEventResult = z.infer<typeof auditEventResultSchema>;
+
+export const auditEventSchema = z.object({
+  actor: z.string(),
+  action: z.string(),
+  targetType: z.string(),
+  safeTargetReference: z.string(),
+  result: auditEventResultSchema,
+  requestId: z.string(),
+  timestamp: z.string().datetime(),
+});
+
+export type AuditEvent = z.infer<typeof auditEventSchema>;
+
+/**
+ * Creates and durably forwards a structured audit event for security-sensitive actions.
+ * Audit records MUST exclude message content and secrets.
+ * Time Complexity: O(1)
+ * Space Complexity: O(1) additional memory per event
+ */
+export function recordAuditEvent(
+  params: Omit<AuditEvent, "timestamp"> & { timestamp?: string | Date },
+): void {
+  // Ensure we don't accidentally leak secrets or message content by strictly mapping properties
+  const event: AuditEvent = {
+    actor: params.actor,
+    action: params.action,
+    targetType: params.targetType,
+    safeTargetReference: params.safeTargetReference,
+    result: params.result,
+    requestId: params.requestId,
+    timestamp: params.timestamp
+      ? params.timestamp instanceof Date
+        ? params.timestamp.toISOString()
+        : params.timestamp
+      : new Date().toISOString(),
+  };
+
+  // Validate to ensure no malformed audit logs
+  auditEventSchema.parse(event);
+
+  // In this serverless/Cloudflare worker environment, we durably forward audit events
+  // to our logging pipeline via structured stdout logs.
+  console.info(JSON.stringify({ _audit: true, ...event }));
+}

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -32,12 +32,14 @@ export interface AnonymousApiContext {
   repository: ApiRepository;
   principal: null;
   isAuthenticated: false;
+  requestId?: string;
 }
 
 export interface AuthenticatedApiContext {
   repository: ApiRepository;
   principal: ApiPrincipal;
   isAuthenticated: true;
+  requestId?: string;
 }
 
 export type ApiContext = AnonymousApiContext | AuthenticatedApiContext;
@@ -79,18 +81,21 @@ export function extractPrincipal(request: Request): ApiPrincipal | null {
 export function createApiContext(
   repository: ApiRepository,
   principal?: ApiPrincipal | null,
+  requestId?: string,
 ): ApiContext {
   if (principal) {
     return {
       repository,
       principal,
       isAuthenticated: true,
+      requestId,
     };
   }
   return {
     repository,
     principal: null,
     isAuthenticated: false,
+    requestId,
   };
 }
 
@@ -169,5 +174,6 @@ export async function getApiContext(request?: Request): Promise<ApiContext> {
   }
 
   const principal = request ? extractPrincipal(request) : null;
-  return createApiContext(repo, principal);
+  const requestId = request ? request.headers.get("x-request-id")?.trim() || undefined : undefined;
+  return createApiContext(repo, principal, requestId);
 }

--- a/tests/unit/api/audit.test.ts
+++ b/tests/unit/api/audit.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { recordAuditEvent, auditEventSchema } from "../../../src/server/api/audit";
+
+describe("audit service", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a structured audit event for a successful security-sensitive action", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    recordAuditEvent({
+      actor: `G${"A".repeat(55)}`,
+      action: "policy.update",
+      targetType: "policy",
+      safeTargetReference: `mailbox:G${"A".repeat(55)}:policy`,
+      result: "success",
+      requestId: "req-abc-123",
+    });
+
+    expect(console.info).toHaveBeenCalledOnce();
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+
+    expect(logData).toMatchObject({
+      _audit: true,
+      actor: `G${"A".repeat(55)}`,
+      action: "policy.update",
+      targetType: "policy",
+      safeTargetReference: `mailbox:G${"A".repeat(55)}:policy`,
+      result: "success",
+      requestId: "req-abc-123",
+    });
+    expect(logData.timestamp).toBeDefined();
+    expect(() => new Date(logData.timestamp).toISOString()).not.toThrow();
+  });
+
+  it("emits a structured audit event for a denied security-sensitive action", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    recordAuditEvent({
+      actor: `G${"B".repeat(55)}`,
+      action: "delegation.authorize",
+      targetType: "mailbox",
+      safeTargetReference: `mailbox:G${"A".repeat(55)}`,
+      result: "denied",
+      requestId: "req-denied-456",
+    });
+
+    expect(console.info).toHaveBeenCalledOnce();
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+
+    expect(logData.result).toBe("denied");
+    expect(logData._audit).toBe(true);
+    expect(logData.action).toBe("delegation.authorize");
+  });
+
+  it("excludes message content and secrets from audit records", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    recordAuditEvent({
+      actor: `G${"A".repeat(55)}`,
+      action: "postage.submit",
+      targetType: "postage",
+      safeTargetReference: `postage:${"a".repeat(64)}`,
+      result: "success",
+      requestId: "req-789",
+    });
+
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+
+    expect(logData).not.toHaveProperty("secret");
+    expect(logData).not.toHaveProperty("messageContent");
+    expect(logData).not.toHaveProperty("seed");
+    expect(logData).not.toHaveProperty("privateKey");
+  });
+
+  it("uses a generated ISO timestamp when none is provided", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const before = new Date().toISOString();
+
+    recordAuditEvent({
+      actor: `G${"A".repeat(55)}`,
+      action: "receipt.publish",
+      targetType: "receipt",
+      safeTargetReference: `receipt:${"b".repeat(64)}`,
+      result: "success",
+      requestId: "req-ts-test",
+    });
+
+    const after = new Date().toISOString();
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+
+    expect(logData.timestamp >= before).toBe(true);
+    expect(logData.timestamp <= after).toBe(true);
+  });
+
+  it("accepts an explicit Date as timestamp", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const ts = new Date("2026-01-01T00:00:00.000Z");
+
+    recordAuditEvent({
+      actor: `G${"A".repeat(55)}`,
+      action: "policy.update",
+      targetType: "policy",
+      safeTargetReference: `mailbox:G${"A".repeat(55)}:policy`,
+      result: "success",
+      requestId: "req-explicit-ts",
+      timestamp: ts,
+    });
+
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+    expect(logData.timestamp).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("rejects an invalid result value via schema validation", () => {
+    expect(() => {
+      recordAuditEvent({
+        actor: `G${"A".repeat(55)}`,
+        action: "policy.update",
+        targetType: "policy",
+        safeTargetReference: `mailbox:G${"A".repeat(55)}:policy`,
+        result: "unknown" as any,
+        requestId: "req-bad",
+      });
+    }).toThrow();
+  });
+
+  it("conforms output to the auditEventSchema", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    recordAuditEvent({
+      actor: `G${"A".repeat(55)}`,
+      action: "senderRule.update",
+      targetType: "senderRule",
+      safeTargetReference: `mailbox:G${"A".repeat(55)}:senders:G${"B".repeat(55)}`,
+      result: "success",
+      requestId: "req-schema-check",
+    });
+
+    const logData = JSON.parse(vi.mocked(console.info).mock.calls[0][0] as string);
+    const { _audit, ...eventFields } = logData;
+
+    expect(_audit).toBe(true);
+    expect(() => auditEventSchema.parse(eventFields)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1512

## PR Description

Before this change, the API had no shared audit trail. Authentication checks, delegation validation, policy changes, postage transitions, and receipt publication all happened without any durable accountability record separate from debug logs. That meant there was no structured, queryable record of who did what, whether they were allowed to do it, and when it happened.

This PR adds a typed audit service at `src/server/api/audit.ts` and wires it into the delegation authorization path in `src/server/api/actor.ts`. It also threads a `requestId` through `ApiContext` so that every audit event carries the same correlation ID that appears in the API response envelope.

### How it works

The `recordAuditEvent` function accepts seven fields: `actor`, `action`, `targetType`, `safeTargetReference`, `result`, `requestId`, and `timestamp`. I deliberately map only these seven named fields onto the output object rather than spreading the caller's input. This structurally guarantees that message content, secret seeds, private keys, or any other sensitive data cannot leak into the audit log even if a caller passes extra properties. The TypeScript type enforces this at compile time too.

The `result` field is a zod enum of `"success" | "denied"`. Any other value fails validation before the event reaches `console.info`, so malformed audit records never make it to the log pipeline. The entire event is validated against `auditEventSchema` before emission.

Audit events are emitted as structured JSON via `console.info` with `_audit: true` as a top-level discriminator field. In the Cloudflare Workers environment this codebase runs on, `console.info` output is captured by the Workers Log Drain and can be forwarded to any structured log ingestor such as Datadog or Splunk. This is the correct durable forwarding mechanism for this deployment target.

In `actor.ts`, the `requireActorMatches` function now detects when the authenticated actor differs from the resource owner (i.e., a delegation is in play). When that is the case, it wraps the existing `assertActorAuthorized` call in a try/catch. If authorization passes, it emits `result: "success"`. If it throws, it emits `result: "denied"` and re-throws, so the original error propagates unchanged. Calls where the actor is the owner (no delegation) are not audited since those are routine ownership checks, not security-sensitive escalation events.

The `requestId` is extracted from the `x-request-id` header in `getApiContext` and stored on `ApiContext`. This is consistent with how `response.ts` already reads and echoes this header in every API response envelope. Storing it on context means audit events emitted later in the request lifecycle can carry the same ID without needing to re-read the request object.

### Why this matters

Security-sensitive operations need a durable, queryable record that is separate from debug logs. Delegation in particular (where one Stellar address acts on behalf of another) is exactly the kind of action that regulators and incident responders care about. With this in place, every denied delegation attempt and every successful delegation authorization produces a timestamped, actor-attributed, action-typed record that can be queried, alerted on, and audited after the fact.

## Changes Made

- Created `src/server/api/audit.ts` with the `recordAuditEvent` function and the `AuditEvent` / `AuditEventResult` types, backed by zod schemas for runtime validation.
- Modified `src/server/api/actor.ts` to import `recordAuditEvent` and emit audit events from `requireActorMatches` whenever a delegated actor is attempting to authorize against a resource owner.
- Modified `src/server/api/context.ts` to add an optional `requestId` field to `AnonymousApiContext` and `AuthenticatedApiContext`, update `createApiContext` to accept and attach it, and update `getApiContext` to extract it from the `x-request-id` request header.
- Created `tests/unit/api/audit.test.ts` with seven focused unit tests covering: success event emission, denied event emission, exclusion of secrets from the audit record, auto-generated ISO timestamp, explicit `Date` timestamp, schema validation rejection of invalid result values, and full conformance of emitted output to `auditEventSchema`.

## Testing

Node.js and the bun runtime are not available in this environment, so tests were validated by manual review. The test file follows the exact import path pattern (`../../../src/server/api/audit`) used by every other test in `tests/unit/api/`. The vitest version in `package.json` is `^4.1.8`.

To run the tests in an environment with the runtime installed:

```bash
npx vitest run tests/unit/api/audit.test.ts
```