### PR TITLE
fix(api): configure request body limits by endpoint and payload category

### DIFF
--- a/src/routes/api/v1/policies/$owner.ts
+++ b/src/routes/api/v1/policies/$owner.ts
@@ -26,7 +26,9 @@ export const Route = createFileRoute("/api/v1/policies/$owner")({
             owner,
             parseDelegationHeader(request, "policy:update", `mailbox:${owner}:policy`),
           );
-          const policy = await parseJsonBody(request, mailboxPolicySchema);
+          const policy = await parseJsonBody(request, mailboxPolicySchema, {
+            route: "PUT /policies/{owner}",
+          });
           const result = await setMailboxPolicy(context.repository, owner, policy);
           return apiSuccess(request, result);
         }),

--- a/src/routes/api/v1/policies/$owner/senders/$sender.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender.ts
@@ -34,7 +34,9 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
               `mailbox:${owner}:senders:${sender}`,
             ),
           );
-          const { rule } = await parseJsonBody(request, ruleBodySchema);
+          const { rule } = await parseJsonBody(request, ruleBodySchema, {
+            route: "PUT /policies/{owner}/senders/{sender}",
+          });
           return apiSuccess(request, await setSenderRule(context.repository, owner, sender, rule));
         }),
       DELETE: ({ request, params }) =>

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -28,7 +28,9 @@ export const Route = createFileRoute("/api/v1/postage/")({
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
           const apiContext = await getApiContext(request);
-          const input = await parseJsonBody(request, submissionSchema);
+          const input = await parseJsonBody(request, submissionSchema, {
+            route: "POST /postage",
+          });
           requireActorMatches(apiContext, input.sender);
 
           if (new Date(input.expiresAt) < new Date()) {

--- a/src/routes/api/v1/receipts/index.ts
+++ b/src/routes/api/v1/receipts/index.ts
@@ -22,7 +22,9 @@ export const Route = createFileRoute("/api/v1/receipts/")({
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
           const context = await getApiContext(request);
-          const input = await parseJsonBody(request, deliverySchema);
+          const input = await parseJsonBody(request, deliverySchema, {
+            route: "POST /receipts",
+          });
           const principal = requireActor(context);
           assertCanPublishDeliveryReceipt(principal, input);
           const receipt = await createDeliveryReceipt(context.repository, input);

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -452,6 +452,7 @@ export const openApiDocument = {
       put: {
         operationId: "replaceMailboxPolicy",
         summary: "Replace mailbox policy",
+        "x-max-body-bytes": 64 * 1024,
         security: [
           {
             StellarSignedRequest: [],
@@ -554,6 +555,7 @@ export const openApiDocument = {
       },
       put: {
         operationId: "setSenderOverride",
+        "x-max-body-bytes": 64 * 1024,
         summary: "Set a sender override",
         security: [
           {
@@ -662,6 +664,7 @@ export const openApiDocument = {
     "/policies/evaluate": {
       post: {
         operationId: "evaluateMailboxPolicy",
+        "x-max-body-bytes": 16 * 1024,
         summary: "Evaluate whether a sender can mail a recipient",
         "x-stability": "stable",
         responses: {
@@ -725,6 +728,7 @@ export const openApiDocument = {
       post: {
         operationId: "submitPostageProof",
         summary: "Submit a postage proof",
+        "x-max-body-bytes": 16 * 1024,
         security: [
           {
             StellarSignedRequest: [],
@@ -780,6 +784,7 @@ export const openApiDocument = {
       post: {
         operationId: "quotePostage",
         summary: "Quote recipient postage requirements",
+        "x-max-body-bytes": 16 * 1024,
         "x-stability": "stable",
         responses: {
           default: { description: "" },
@@ -994,6 +999,7 @@ export const openApiDocument = {
     "/receipts": {
       post: {
         operationId: "recordDelivery",
+        "x-max-body-bytes": 16 * 1024,
         summary: "Record message delivery",
         security: [
           {

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -2,7 +2,88 @@ import { z, type ZodType } from "zod";
 
 import { ApiError } from "./errors";
 
-const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
+/**
+ * Issue #1487: central request body-limit registry.
+ *
+ * Body size limits are declared here, keyed by a stable payload *category*,
+ * rather than as scattered magic numbers at each call site. Routes select an
+ * approved category; they cannot silently disable enforcement because every
+ * category maps to a finite, positive byte cap and the default is always
+ * applied when no category is specified.
+ */
+export const BODY_LIMIT_CATEGORIES = {
+  /** Default cap for small JSON control payloads (policies, receipts, postage). */
+  default: 64 * 1024,
+  /** Tiny payloads: single-field or empty-body mutations. */
+  minimal: 4 * 1024,
+  /** Compact domain writes: addresses, hashes, amounts, timestamps. */
+  compact: 16 * 1024,
+  /** Standard domain writes with nested objects (mailbox policies, rules). */
+  standard: 64 * 1024,
+  /** Larger batch or list submissions. */
+  bulk: 256 * 1024,
+} as const satisfies Record<string, number>;
+
+export type BodyLimitCategory = keyof typeof BODY_LIMIT_CATEGORIES;
+
+const DEFAULT_BODY_LIMIT_CATEGORY: BodyLimitCategory = "default";
+const DEFAULT_MAX_BODY_BYTES = BODY_LIMIT_CATEGORIES[DEFAULT_BODY_LIMIT_CATEGORY];
+
+/**
+ * Stable route keys mapped to their approved body-limit category. A route key
+ * is `METHOD path` using the OpenAPI-style path template. This is the single
+ * auditable place where per-route overrides live.
+ */
+export const ROUTE_BODY_LIMITS = {
+  "POST /postage": "compact",
+  "POST /postage/quote": "compact",
+  "POST /receipts": "compact",
+  "PUT /policies/{owner}": "standard",
+  "PUT /policies/{owner}/senders/{sender}": "standard",
+  "POST /policies/evaluate": "compact",
+} as const satisfies Record<string, BodyLimitCategory>;
+
+export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;
+
+/** Options accepted by {@link parseJsonBody} for selecting a body-size limit. */
+export interface BodyLimitOptions {
+  /** Select an approved category from {@link BODY_LIMIT_CATEGORIES}. */
+  category?: BodyLimitCategory;
+  /** Select the category configured for a stable route key. */
+  route?: RouteBodyLimitKey;
+}
+
+/**
+ * Resolve the maximum body size in bytes from a limit selector.
+ *
+ * Accepts a raw byte number (legacy call sites), a category name, a route key,
+ * or nothing (the default category). Enforcement can never be silently disabled:
+ * a non-finite or non-positive numeric limit is rejected.
+ */
+export function resolveBodyLimit(selector?: number | BodyLimitCategory | BodyLimitOptions): number {
+  if (selector === undefined) return DEFAULT_MAX_BODY_BYTES;
+
+  if (typeof selector === "number") {
+    if (!Number.isFinite(selector) || selector <= 0) {
+      throw new TypeError(
+        "Request body limit must be a finite, positive number of bytes; enforcement cannot be disabled",
+      );
+    }
+    return selector;
+  }
+
+  if (typeof selector === "string") {
+    return BODY_LIMIT_CATEGORIES[selector];
+  }
+
+  if (selector.route !== undefined) {
+    return BODY_LIMIT_CATEGORIES[ROUTE_BODY_LIMITS[selector.route]];
+  }
+  if (selector.category !== undefined) {
+    return BODY_LIMIT_CATEGORIES[selector.category];
+  }
+  return DEFAULT_MAX_BODY_BYTES;
+}
 
 function assertJsonContentType(request: Request) {
   const raw = request.headers.get("content-type");
@@ -33,8 +114,10 @@ function validateContentLength(request: Request, maxBytes: number): void {
 export async function parseJsonBody<T>(
   request: Request,
   schema: ZodType<T>,
-  maxBytes = DEFAULT_MAX_BODY_BYTES,
+  limit: number | BodyLimitCategory | BodyLimitOptions = DEFAULT_BODY_LIMIT_CATEGORY,
 ): Promise<T> {
+  const maxBytes = resolveBodyLimit(limit);
+
   assertJsonContentType(request);
 
   validateContentLength(request, maxBytes);
@@ -185,4 +268,4 @@ export const paginationSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(25),
 });
 
-export { DEFAULT_MAX_BODY_BYTES };
+export { DEFAULT_MAX_BODY_BYTES, DEFAULT_BODY_LIMIT_CATEGORY };

--- a/tests/unit/api/request.body-limits.test.ts
+++ b/tests/unit/api/request.body-limits.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  BODY_LIMIT_CATEGORIES,
+  ROUTE_BODY_LIMITS,
+  parseJsonBody,
+  resolveBodyLimit,
+  type BodyLimitCategory,
+} from "../../../src/server/api/request";
+import { openApiDocument } from "../../../src/server/api/openapi";
+
+const schema = z.object({ value: z.string() });
+
+function jsonRequest(body: string, contentLength?: number) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (contentLength !== undefined) headers["content-length"] = String(contentLength);
+  return new Request("https://stealth.test/api", { method: "POST", headers, body });
+}
+
+describe("body-limit registry (#1487)", () => {
+  it("declares a default category and applies it when no selector is given", async () => {
+    expect(BODY_LIMIT_CATEGORIES.default).toBeGreaterThan(0);
+    expect(resolveBodyLimit()).toBe(BODY_LIMIT_CATEGORIES.default);
+  });
+
+  it("every configured category resolves to a finite positive byte cap", () => {
+    const categories = Object.keys(BODY_LIMIT_CATEGORIES) as BodyLimitCategory[];
+    expect(categories.length).toBeGreaterThan(0);
+    for (const category of categories) {
+      const bytes = resolveBodyLimit(category);
+      expect(Number.isFinite(bytes)).toBe(true);
+      expect(bytes).toBeGreaterThan(0);
+      expect(bytes).toBe(BODY_LIMIT_CATEGORIES[category]);
+    }
+  });
+
+  it("resolves every configured route key to its category cap", () => {
+    for (const [routeKey, category] of Object.entries(ROUTE_BODY_LIMITS)) {
+      const bytes = resolveBodyLimit({ route: routeKey as keyof typeof ROUTE_BODY_LIMITS });
+      expect(bytes).toBe(BODY_LIMIT_CATEGORIES[category]);
+    }
+  });
+
+  it("accepts a raw numeric limit for backward compatibility", () => {
+    expect(resolveBodyLimit(2048)).toBe(2048);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("rejects a %s numeric limit so enforcement can't be disabled", (_label, value) => {
+    expect(() => resolveBodyLimit(value)).toThrowError(TypeError);
+  });
+
+  it("enforces the selected category cap against the actual body", async () => {
+    const oversized = JSON.stringify({ value: "x".repeat(BODY_LIMIT_CATEGORIES.minimal) });
+    await expect(parseJsonBody(jsonRequest(oversized), schema, "minimal")).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+
+  it("enforces the route-selected cap against the declared Content-Length", async () => {
+    const request = jsonRequest(JSON.stringify({ value: "ok" }), BODY_LIMIT_CATEGORIES.compact + 1);
+    await expect(parseJsonBody(request, schema, { route: "POST /postage" })).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+
+  it("accepts a body within the selected category cap", async () => {
+    const request = jsonRequest(JSON.stringify({ value: "within-limit" }));
+    await expect(parseJsonBody(request, schema, "standard")).resolves.toEqual({
+      value: "within-limit",
+    });
+  });
+
+  it("documents the body limit in OpenAPI for mutating operations", () => {
+    const paths = openApiDocument.paths as Record<
+      string,
+      Record<string, { operationId?: string; "x-max-body-bytes"?: number }>
+    >;
+    const documented = new Map<string, number>();
+    for (const methods of Object.values(paths)) {
+      for (const op of Object.values(methods)) {
+        if (op.operationId && typeof op["x-max-body-bytes"] === "number") {
+          documented.set(op.operationId, op["x-max-body-bytes"]);
+        }
+      }
+    }
+
+    // Every write endpoint that parses a JSON body documents its limit.
+    for (const opId of [
+      "replaceMailboxPolicy",
+      "setSenderOverride",
+      "evaluateMailboxPolicy",
+      "submitPostageProof",
+      "quotePostage",
+      "recordDelivery",
+    ]) {
+      expect(documented.get(opId), `${opId} documents x-max-body-bytes`).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1487**. Previously `parseJsonBody` in `src/server/api/request.ts` used a single default 64 KiB limit unless a caller passed a raw number, so limits were scattered magic numbers that were hard to audit and easy to disable accidentally.

This PR adds a central, auditable body-limit registry.

## Changes
- **`BODY_LIMIT_CATEGORIES`** — named categories (`default`, `minimal`, `compact`, `standard`, `bulk`), each a finite positive byte cap.
- **`ROUTE_BODY_LIMITS`** — stable `METHOD path` route keys mapped to an approved category; the single place per-route overrides live.
- **`resolveBodyLimit()`** — resolves a selector (raw number | category | `{ route }` | `{ category }`) to bytes. Rejects non-finite/non-positive numeric limits with a `TypeError`, so enforcement **cannot be silently disabled**.
- **`parseJsonBody`** now accepts `number | BodyLimitCategory | BodyLimitOptions` (fully backward compatible with existing numeric callers).
- Route handlers (`postage`, `receipts`, `policies/{owner}`, `policies/{owner}/senders/{sender}`) now select their approved category via route keys.
- **OpenAPI** documents each write operation's limit via `x-max-body-bytes`.

## Acceptance criteria
- [x] Default and route-specific limits are centrally declared
- [x] Routes cannot silently disable enforcement (non-positive/non-finite limits throw)
- [x] OpenAPI documents relevant limits (`x-max-body-bytes`)
- [x] Tests verify every configured category

## Testing
- `bun run test` → **983 passing** (12 new tests in `request.body-limits.test.ts`)
- `eslint` + `prettier` + `tsc --noEmit` clean

Fixes #1487