### PR TITLE
feat(tracing): propagate trace-context to api and dependencies

### DIFF
--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { MemoryApiRepository } from "./memory-repository";
 import { ValidatedApiRepository, registerRecordSchema } from "./repository";
 import type { ApiRepository } from "./repository";
@@ -10,6 +11,175 @@ import {
   stellarAddressSchema,
 } from "./domain";
 import { ApiError } from "./errors";
+
+export interface TraceContext {
+  traceId: string;
+  spanId: string;
+  traceFlags: string;
+  tracestate?: string;
+  baggage?: Record<string, string>;
+}
+
+export const traceContextStorage = new AsyncLocalStorage<TraceContext>();
+
+function generateHexId(bytes: number): string {
+  const array = new Uint8Array(bytes);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function parseTraceParent(
+  header: string | null | undefined,
+): { traceId: string; spanId: string; traceFlags: string } | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  if (trimmed.length < 55) return null;
+
+  const parts = trimmed.split("-");
+  if (parts.length < 4) return null;
+
+  const [version, traceId, parentId, traceFlags] = parts;
+  if (!/^[a-f0-9]{2}$/i.test(version)) return null;
+  if (!/^[a-f0-9]{32}$/i.test(traceId) || traceId === "00000000000000000000000000000000")
+    return null;
+  if (!/^[a-f0-9]{16}$/i.test(parentId) || parentId === "0000000000000000") return null;
+  if (!/^[a-f0-9]{2}$/i.test(traceFlags)) return null;
+
+  return {
+    traceId: traceId.toLowerCase(),
+    spanId: parentId.toLowerCase(),
+    traceFlags: traceFlags.toLowerCase(),
+  };
+}
+
+const SENSITIVE_KEYWORDS = [
+  "auth",
+  "key",
+  "secret",
+  "token",
+  "password",
+  "cookie",
+  "session",
+  "jwt",
+  "private",
+  "credential",
+  "pwd",
+  "sig",
+  "cert",
+];
+
+function isSensitiveBaggageKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SENSITIVE_KEYWORDS.some((keyword) => lower.includes(keyword));
+}
+
+export function parseBaggage(
+  header: string | null | undefined,
+): Record<string, string> | undefined {
+  if (!header) return undefined;
+  const baggage: Record<string, string> = {};
+  const pairs = header.split(",");
+  for (const pair of pairs) {
+    const trimmedPair = pair.trim();
+    if (!trimmedPair) continue;
+    const [kvPart] = trimmedPair.split(";");
+    const eqIdx = kvPart.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = kvPart.substring(0, eqIdx).trim();
+    const value = kvPart.substring(eqIdx + 1).trim();
+    if (!key) continue;
+
+    if (isSensitiveBaggageKey(key)) {
+      continue;
+    }
+    baggage[key] = value;
+  }
+  return Object.keys(baggage).length > 0 ? baggage : undefined;
+}
+
+export function serializeBaggage(baggage: Record<string, string>): string {
+  return Object.entries(baggage)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+}
+
+export function serializeTraceParent(context: TraceContext): string {
+  return `00-${context.traceId}-${context.spanId}-${context.traceFlags}`;
+}
+
+export function getCurrentTraceContext(): TraceContext {
+  const context = traceContextStorage.getStore();
+  if (context) return context;
+  return {
+    traceId: generateHexId(16),
+    spanId: generateHexId(8),
+    traceFlags: "01",
+  };
+}
+
+export function createChildTraceContext(parent: TraceContext): TraceContext {
+  return {
+    traceId: parent.traceId,
+    spanId: generateHexId(8),
+    traceFlags: parent.traceFlags,
+    tracestate: parent.tracestate,
+    baggage: parent.baggage ? { ...parent.baggage } : undefined,
+  };
+}
+
+export function traceRepository(repo: ApiRepository, parentContext: TraceContext): ApiRepository {
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function") {
+        return function (this: any, ...args: any[]) {
+          const childContext = createChildTraceContext(parentContext);
+          return traceContextStorage.run(childContext, () => {
+            return value.apply(target, args);
+          });
+        };
+      }
+      return value;
+    },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+if (originalFetch) {
+  globalThis.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const context = traceContextStorage.getStore();
+    if (context) {
+      let headers: Headers;
+      if (input instanceof Request) {
+        headers = new Headers(input.headers);
+      } else {
+        headers = new Headers(init?.headers);
+      }
+
+      if (!headers.has("traceparent")) {
+        headers.set("traceparent", serializeTraceParent(context));
+      }
+      if (context.tracestate && !headers.has("tracestate")) {
+        headers.set("tracestate", context.tracestate);
+      }
+      if (context.baggage && Object.keys(context.baggage).length > 0 && !headers.has("baggage")) {
+        headers.set("baggage", serializeBaggage(context.baggage));
+      }
+
+      if (input instanceof Request) {
+        const newRequest = new Request(input, { headers });
+        return originalFetch.call(this, newRequest, init);
+      } else {
+        const newInit: RequestInit = {
+          ...init,
+          headers,
+        };
+        return originalFetch.call(this, input, newInit);
+      }
+    }
+    return originalFetch.call(this, input, init);
+  };
+}
 
 // Register schemas once at module init for Issue #1508 record validation
 registerRecordSchema("mailboxPolicy", mailboxPolicySchema);
@@ -33,6 +203,7 @@ export interface AnonymousApiContext {
   principal: null;
   isAuthenticated: false;
   requestId?: string;
+  traceContext: TraceContext;
 }
 
 export interface AuthenticatedApiContext {
@@ -40,6 +211,7 @@ export interface AuthenticatedApiContext {
   principal: ApiPrincipal;
   isAuthenticated: true;
   requestId?: string;
+  traceContext: TraceContext;
 }
 
 export type ApiContext = AnonymousApiContext | AuthenticatedApiContext;
@@ -82,20 +254,25 @@ export function createApiContext(
   repository: ApiRepository,
   principal?: ApiPrincipal | null,
   requestId?: string,
+  traceContext?: TraceContext,
 ): ApiContext {
+  const finalTraceContext = traceContext ?? getCurrentTraceContext();
+  const tracedRepo = traceRepository(repository, finalTraceContext);
   if (principal) {
     return {
-      repository,
+      repository: tracedRepo,
       principal,
       isAuthenticated: true,
       requestId,
+      traceContext: finalTraceContext,
     };
   }
   return {
-    repository,
+    repository: tracedRepo,
     principal: null,
     isAuthenticated: false,
     requestId,
+    traceContext: finalTraceContext,
   };
 }
 
@@ -175,5 +352,31 @@ export async function getApiContext(request?: Request): Promise<ApiContext> {
 
   const principal = request ? extractPrincipal(request) : null;
   const requestId = request ? request.headers.get("x-request-id")?.trim() || undefined : undefined;
-  return createApiContext(repo, principal, requestId);
+
+  let traceContext: TraceContext;
+  if (request) {
+    const traceparent = request.headers.get("traceparent");
+    const parsed = parseTraceParent(traceparent);
+    if (parsed) {
+      traceContext = {
+        traceId: parsed.traceId,
+        spanId: generateHexId(8),
+        traceFlags: parsed.traceFlags,
+        tracestate: request.headers.get("tracestate")?.trim() || undefined,
+        baggage: parseBaggage(request.headers.get("baggage")),
+      };
+    } else {
+      traceContext = {
+        traceId: generateHexId(16),
+        spanId: generateHexId(8),
+        traceFlags: "01",
+      };
+    }
+  } else {
+    traceContext = getCurrentTraceContext();
+  }
+
+  traceContextStorage.enterWith(traceContext);
+
+  return createApiContext(repo, principal, requestId, traceContext);
 }

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -33,13 +33,13 @@ export function parseTraceParent(
 ): { traceId: string; spanId: string; traceFlags: string } | null {
   if (!header) return null;
   const trimmed = header.trim();
-  if (trimmed.length < 55) return null;
+  if (trimmed.length !== 55) return null;
 
   const parts = trimmed.split("-");
-  if (parts.length < 4) return null;
+  if (parts.length !== 4) return null;
 
   const [version, traceId, parentId, traceFlags] = parts;
-  if (!/^[a-f0-9]{2}$/i.test(version)) return null;
+  if (version !== "00") return null;
   if (!/^[a-f0-9]{32}$/i.test(traceId) || traceId === "00000000000000000000000000000000")
     return null;
   if (!/^[a-f0-9]{16}$/i.test(parentId) || parentId === "0000000000000000") return null;
@@ -145,41 +145,43 @@ export function traceRepository(repo: ApiRepository, parentContext: TraceContext
 }
 
 const originalFetch = globalThis.fetch;
-if (originalFetch) {
-  globalThis.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    const context = traceContextStorage.getStore();
-    if (context) {
-      let headers: Headers;
-      if (input instanceof Request) {
-        headers = new Headers(input.headers);
-      } else {
-        headers = new Headers(init?.headers);
-      }
+export const fetchRef = {
+  fetch: originalFetch,
+};
 
-      if (!headers.has("traceparent")) {
-        headers.set("traceparent", serializeTraceParent(context));
-      }
-      if (context.tracestate && !headers.has("tracestate")) {
-        headers.set("tracestate", context.tracestate);
-      }
-      if (context.baggage && Object.keys(context.baggage).length > 0 && !headers.has("baggage")) {
-        headers.set("baggage", serializeBaggage(context.baggage));
-      }
-
-      if (input instanceof Request) {
-        const newRequest = new Request(input, { headers });
-        return originalFetch.call(this, newRequest, init);
-      } else {
-        const newInit: RequestInit = {
-          ...init,
-          headers,
-        };
-        return originalFetch.call(this, input, newInit);
-      }
+globalThis.fetch = function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const context = traceContextStorage.getStore();
+  if (context) {
+    let headers: Headers;
+    if (input instanceof Request) {
+      headers = new Headers(input.headers);
+    } else {
+      headers = new Headers(init?.headers);
     }
-    return originalFetch.call(this, input, init);
-  };
-}
+
+    if (!headers.has("traceparent")) {
+      headers.set("traceparent", serializeTraceParent(context));
+    }
+    if (context.tracestate && !headers.has("tracestate")) {
+      headers.set("tracestate", context.tracestate);
+    }
+    if (context.baggage && Object.keys(context.baggage).length > 0 && !headers.has("baggage")) {
+      headers.set("baggage", serializeBaggage(context.baggage));
+    }
+
+    if (input instanceof Request) {
+      const newRequest = new Request(input, { headers });
+      return fetchRef.fetch.call(this, newRequest, init);
+    } else {
+      const newInit: RequestInit = {
+        ...init,
+        headers,
+      };
+      return fetchRef.fetch.call(this, input, newInit);
+    }
+  }
+  return fetchRef.fetch.call(this, input, init);
+};
 
 // Register schemas once at module init for Issue #1508 record validation
 registerRecordSchema("mailboxPolicy", mailboxPolicySchema);

--- a/tests/unit/api/trace-context.test.ts
+++ b/tests/unit/api/trace-context.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseTraceParent,
+  parseBaggage,
+  serializeTraceParent,
+  serializeBaggage,
+  traceContextStorage,
+  traceRepository,
+  type TraceContext,
+} from "../../../src/server/api/context";
+import type { ApiRepository } from "../../../src/server/api/repository";
+
+describe("Trace Context Parser and Serializer", () => {
+  it("parses valid traceparent headers correctly", () => {
+    const header = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const parsed = parseTraceParent(header);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(parsed?.spanId).toBe("00f067aa0ba902b7");
+    expect(parsed?.traceFlags).toBe("01");
+  });
+
+  it("ignores malformed traceparent headers safely", () => {
+    const invalidHeaders = [
+      "",
+      "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7", // missing flags
+      "00-00000000000000000000000000000000-00f067aa0ba902b7-01", // all zeros traceId
+      "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01", // all zeros spanId
+      "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra", // malformed length
+      "00-4bf92f3577b34da6a3ce929d0e0e473g-00f067aa0ba902b7-01", // non-hex
+    ];
+
+    for (const header of invalidHeaders) {
+      expect(parseTraceParent(header)).toBeNull();
+    }
+  });
+
+  it("parses baggage headers and filters sensitive keys", () => {
+    const header = "userId=alice,sessionToken=12345,api-key=secretKey,appName=stealth,authSign=xyz";
+    const parsed = parseBaggage(header);
+    expect(parsed).toBeDefined();
+    expect(parsed?.userId).toBe("alice");
+    expect(parsed?.appName).toBe("stealth");
+    // Sensitive keys should be filtered out
+    expect(parsed?.sessionToken).toBeUndefined();
+    expect(parsed?.["api-key"]).toBeUndefined();
+    expect(parsed?.authSign).toBeUndefined();
+  });
+
+  it("returns undefined if all baggage keys are filtered or empty", () => {
+    const header = "authToken=abc,secret=123";
+    expect(parseBaggage(header)).toBeUndefined();
+  });
+});
+
+describe("Repository Context Instrumentation via Proxy", () => {
+  it("creates child span context for repository calls", async () => {
+    const parentContext: TraceContext = {
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+      traceFlags: "01",
+      tracestate: "rojo=1",
+      baggage: { userId: "alice" },
+    };
+
+    let activeContextInRepoCall: TraceContext | undefined;
+    const mockRepo = {
+      getPolicy: async (owner: string) => {
+        activeContextInRepoCall = traceContextStorage.getStore();
+        return null;
+      },
+    } as unknown as ApiRepository;
+
+    const tracedRepo = traceRepository(mockRepo, parentContext);
+    await tracedRepo.getPolicy("test-owner");
+
+    expect(activeContextInRepoCall).toBeDefined();
+    expect(activeContextInRepoCall?.traceId).toBe(parentContext.traceId);
+    expect(activeContextInRepoCall?.spanId).not.toBe(parentContext.spanId); // new spanId generated
+    expect(activeContextInRepoCall?.spanId).toMatch(/^[a-f0-9]{16}$/);
+    expect(activeContextInRepoCall?.traceFlags).toBe(parentContext.traceFlags);
+    expect(activeContextInRepoCall?.tracestate).toBe(parentContext.tracestate);
+    expect(activeContextInRepoCall?.baggage).toEqual(parentContext.baggage);
+  });
+});
+
+describe("Global Fetch Header Injection Integration", () => {
+  it("injects trace context headers into outgoing fetch requests", async () => {
+    const fetchContext: TraceContext = {
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+      traceFlags: "01",
+      tracestate: "rojo=1",
+      baggage: { userId: "alice" },
+    };
+
+    const spyFetch = vi.fn().mockResolvedValue(new Response());
+    const originalFetch = globalThis.fetch;
+    // Temporarily swap global fetch with spy to verify injection
+    globalThis.fetch = spyFetch;
+
+    try {
+      await traceContextStorage.run(fetchContext, async () => {
+        await fetch("https://stellar.service/txn", { method: "POST" });
+      });
+
+      expect(spyFetch).toHaveBeenCalled();
+      const [calledUrl, calledInit] = spyFetch.mock.calls[0];
+      const headers = new Headers(calledInit?.headers);
+
+      expect(headers.get("traceparent")).toBe(serializeTraceParent(fetchContext));
+      expect(headers.get("tracestate")).toBe("rojo=1");
+      expect(headers.get("baggage")).toBe(serializeBaggage(fetchContext.baggage!));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("injects trace context headers into outgoing fetch requests when using Request object", async () => {
+    const fetchContext: TraceContext = {
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      spanId: "00f067aa0ba902b7",
+      traceFlags: "01",
+      tracestate: "rojo=1",
+      baggage: { userId: "alice" },
+    };
+
+    const spyFetch = vi.fn().mockResolvedValue(new Response());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = spyFetch;
+
+    try {
+      await traceContextStorage.run(fetchContext, async () => {
+        const req = new Request("https://stellar.service/txn", { method: "POST" });
+        await fetch(req);
+      });
+
+      expect(spyFetch).toHaveBeenCalled();
+      const [calledReq, calledInit] = spyFetch.mock.calls[0];
+      expect(calledReq).toBeInstanceOf(Request);
+      const headers = (calledReq as Request).headers;
+
+      expect(headers.get("traceparent")).toBe(serializeTraceParent(fetchContext));
+      expect(headers.get("tracestate")).toBe("rojo=1");
+      expect(headers.get("baggage")).toBe(serializeBaggage(fetchContext.baggage!));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not inject trace headers if trace context is absent", async () => {
+    const spyFetch = vi.fn().mockResolvedValue(new Response());
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = spyFetch;
+
+    try {
+      await fetch("https://stellar.service/txn");
+
+      expect(spyFetch).toHaveBeenCalled();
+      const [calledUrl, calledInit] = spyFetch.mock.calls[0];
+      const headers = new Headers(calledInit?.headers);
+      expect(headers.has("traceparent")).toBe(false);
+      expect(headers.has("tracestate")).toBe(false);
+      expect(headers.has("baggage")).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/unit/api/trace-context.test.ts
+++ b/tests/unit/api/trace-context.test.ts
@@ -6,6 +6,7 @@ import {
   serializeBaggage,
   traceContextStorage,
   traceRepository,
+  fetchRef,
   type TraceContext,
 } from "../../../src/server/api/context";
 import type { ApiRepository } from "../../../src/server/api/repository";
@@ -95,9 +96,9 @@ describe("Global Fetch Header Injection Integration", () => {
     };
 
     const spyFetch = vi.fn().mockResolvedValue(new Response());
-    const originalFetch = globalThis.fetch;
-    // Temporarily swap global fetch with spy to verify injection
-    globalThis.fetch = spyFetch;
+    const originalFetch = fetchRef.fetch;
+    // Temporarily swap underlying fetch with spy to verify injection
+    fetchRef.fetch = spyFetch;
 
     try {
       await traceContextStorage.run(fetchContext, async () => {
@@ -112,7 +113,7 @@ describe("Global Fetch Header Injection Integration", () => {
       expect(headers.get("tracestate")).toBe("rojo=1");
       expect(headers.get("baggage")).toBe(serializeBaggage(fetchContext.baggage!));
     } finally {
-      globalThis.fetch = originalFetch;
+      fetchRef.fetch = originalFetch;
     }
   });
 
@@ -126,8 +127,8 @@ describe("Global Fetch Header Injection Integration", () => {
     };
 
     const spyFetch = vi.fn().mockResolvedValue(new Response());
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = spyFetch;
+    const originalFetch = fetchRef.fetch;
+    fetchRef.fetch = spyFetch;
 
     try {
       await traceContextStorage.run(fetchContext, async () => {
@@ -144,14 +145,14 @@ describe("Global Fetch Header Injection Integration", () => {
       expect(headers.get("tracestate")).toBe("rojo=1");
       expect(headers.get("baggage")).toBe(serializeBaggage(fetchContext.baggage!));
     } finally {
-      globalThis.fetch = originalFetch;
+      fetchRef.fetch = originalFetch;
     }
   });
 
   it("does not inject trace headers if trace context is absent", async () => {
     const spyFetch = vi.fn().mockResolvedValue(new Response());
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = spyFetch;
+    const originalFetch = fetchRef.fetch;
+    fetchRef.fetch = spyFetch;
 
     try {
       await fetch("https://stellar.service/txn");
@@ -163,7 +164,7 @@ describe("Global Fetch Header Injection Integration", () => {
       expect(headers.has("tracestate")).toBe(false);
       expect(headers.has("baggage")).toBe(false);
     } finally {
-      globalThis.fetch = originalFetch;
+      fetchRef.fetch = originalFetch;
     }
   });
 });


### PR DESCRIPTION
Closes #1520

# PR Description

I implemented distributed trace-context propagation following the W3C Trace Context specification. This change allows operations to be traced end-to-end across API handlers, storage (KV/Durable Objects), and external dependencies (like Stellar SDK and relays).

Previously, requests only had process-local request IDs, making it impossible to correlate operations across network boundaries. To solve this, I designed a context propagation pipeline:
1. When an API request arrives, `getApiContext` extracts the W3C `traceparent` (and optional `tracestate` and `baggage`) headers from the request.
2. If valid headers are present, I join the trace by generating a new child span ID while keeping the same trace ID. If the headers are invalid or missing, I generate a brand new trace context.
3. I filter the baggage attributes case-insensitively, removing any keys that contain sensitive keywords (such as credentials, tokens, cookies, auth keys, session keys, and secrets) to prevent security leaks.
4. I store the active trace context in `AsyncLocalStorage`.
5. I wrap the database repository (`ApiRepository`) in an ES6 `Proxy`. Every time a repository method is called, the proxy automatically generates a child trace context and runs the repository method inside it.
6. I patch the global `fetch` handler. When an outgoing HTTP call is made within a traced execution flow, the wrapper automatically serializes and injects `traceparent`, `tracestate`, and the sanitized `baggage` headers. This transparently handles outgoing requests made by the Stellar SDK or other HTTP clients.

# Changes Made
- Modified `src/server/api/context.ts` to implement W3C Trace Context parsing, validation, and serialization helpers.
- Integrated `AsyncLocalStorage` to store request-scoped trace contexts.
- Added a `Proxy` wrapper to the repository factory (`createApiContext`) to automatically create child trace spans for database operations.
- Intercepted global `fetch` to transparently inject W3C trace headers into outgoing HTTP calls (handling both string URL inputs and `Request` instances).
- Created a new unit test suite in `tests/unit/api/trace-context.test.ts` to test parsing, malformed traceparent handling, sensitive baggage filtering, repository proxy spans, and fetch header injection.