### PR TITLE
feat(crypto): add typed cryptographic error taxonomy

### DIFF
--- a/src/services/crypto/errors.ts
+++ b/src/services/crypto/errors.ts
@@ -61,9 +61,7 @@ export const CRYPTO_ERROR_REGISTRY: Record<CryptoErrorCode, CryptoErrorDefinitio
   },
 };
 
-const CRYPTO_ERROR_CODES = Object.freeze(
-  Object.keys(CRYPTO_ERROR_REGISTRY) as CryptoErrorCode[],
-);
+const CRYPTO_ERROR_CODES = Object.freeze(Object.keys(CRYPTO_ERROR_REGISTRY) as CryptoErrorCode[]);
 
 /**
  * Error thrown for any recoverable failure at the crypto boundary.
@@ -139,9 +137,7 @@ function asCryptoCode(value: string): CryptoErrorCode {
  * Typed result helpers: a union that lets callers branch on `ok` instead of
  * catching and parsing message text.
  */
-export type CryptoResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: CryptoError };
+export type CryptoResult<T> = { ok: true; value: T } | { ok: false; error: CryptoError };
 
 export function cryptoOk<T>(value: T): CryptoResult<T> {
   return { ok: true, value };

--- a/src/services/crypto/errors.ts
+++ b/src/services/crypto/errors.ts
@@ -1,0 +1,152 @@
+/**
+ * Typed cryptographic error taxonomy (#1690).
+ *
+ * Callers of the crypto boundary must be able to distinguish failure modes
+ * (parse, validation, algorithm, key, signature, commitment, decrypt) without
+ * parsing error message text. None of the public messages below may contain
+ * key material, plaintext, or other sensitive values.
+ */
+
+export type CryptoErrorCode =
+  | "crypto_parse_error"
+  | "crypto_validation_error"
+  | "crypto_algorithm_error"
+  | "crypto_key_error"
+  | "crypto_signature_error"
+  | "crypto_commitment_error"
+  | "crypto_decrypt_error";
+
+export interface CryptoErrorDefinition {
+  readonly code: CryptoErrorCode;
+  readonly publicMessage: string;
+  /** Whether the failure is safe to surface to a client (never reveals secrets). */
+  readonly safe: boolean;
+}
+
+export const CRYPTO_ERROR_REGISTRY: Record<CryptoErrorCode, CryptoErrorDefinition> = {
+  crypto_parse_error: {
+    code: "crypto_parse_error",
+    publicMessage: "The encrypted envelope could not be parsed",
+    safe: true,
+  },
+  crypto_validation_error: {
+    code: "crypto_validation_error",
+    publicMessage: "The envelope failed input validation",
+    safe: true,
+  },
+  crypto_algorithm_error: {
+    code: "crypto_algorithm_error",
+    publicMessage: "The requested cryptographic algorithm is unsupported",
+    safe: true,
+  },
+  crypto_key_error: {
+    code: "crypto_key_error",
+    publicMessage: "A required cryptographic key was missing or unusable",
+    safe: true,
+  },
+  crypto_signature_error: {
+    code: "crypto_signature_error",
+    publicMessage: "The envelope signature is invalid",
+    safe: true,
+  },
+  crypto_commitment_error: {
+    code: "crypto_commitment_error",
+    publicMessage: "The content commitment did not match the payload",
+    safe: true,
+  },
+  crypto_decrypt_error: {
+    code: "crypto_decrypt_error",
+    publicMessage: "The message could not be decrypted",
+    safe: true,
+  },
+};
+
+const CRYPTO_ERROR_CODES = Object.freeze(
+  Object.keys(CRYPTO_ERROR_REGISTRY) as CryptoErrorCode[],
+);
+
+/**
+ * Error thrown for any recoverable failure at the crypto boundary.
+ * The message is always a non-secret, registry-defined value.
+ */
+export class CryptoError extends Error {
+  readonly code: CryptoErrorCode;
+  readonly safe: boolean;
+
+  constructor(code: CryptoErrorCode, details?: string) {
+    const definition = CRYPTO_ERROR_REGISTRY[code];
+    // Never interpolate caller-supplied details into the message; the public
+    // message is fixed and safe, while structured details stay out of `.message`.
+    super(definition.publicMessage);
+    this.name = "CryptoError";
+    this.code = code;
+    this.safe = definition.safe;
+    if (details !== undefined) {
+      this.details = redact(details);
+    }
+  }
+
+  /** Optional structured context. Always redacted to avoid leaking secrets. */
+  details?: string;
+}
+
+/**
+ * Strip anything that looks like hex/base64 key material, plaintext, or
+ * high-entropy blobs from a value before it is attached to a thrown error.
+ * This is a defense-in-depth helper so callers cannot accidentally leak a key
+ * or plaintext through error details.
+ */
+export function redact(value: string): string {
+  return value
+    .replace(/[0-9a-fA-F]{16,}/g, "[redacted-hex]")
+    .replace(/[A-Za-z0-9+/]{16,}={0,2}/g, "[redacted-b64]");
+}
+
+/**
+ * Map an arbitrary internal error to a stable, non-secret {@link CryptoError}.
+ *
+ * Mapping strategy:
+ * - A `CryptoError` is returned unchanged (its code/message are already safe).
+ * - An `Error` with a recognizable code-ish marker is coerced to the matching
+ *   taxonomy entry when the code is known.
+ * - Anything else (generic `Error`, `SyntaxError`, non-Error) becomes a generic
+ *   `crypto_parse_error`/`crypto_decrypt_error` style failure with NO secret
+ *   leakage: the original message is discarded and only the safe public message
+ *   is surfaced.
+ */
+export function toCryptoError(error: unknown, fallback: CryptoErrorCode): CryptoError {
+  if (error instanceof CryptoError) {
+    return error;
+  }
+
+  if (error instanceof Error && isKnownCryptoCode(error.message)) {
+    return new CryptoError(asCryptoCode(error.message));
+  }
+
+  // Never reuse the raw message — it may contain plaintext or key material.
+  return new CryptoError(fallback);
+}
+
+function isKnownCryptoCode(value: string): value is CryptoErrorCode {
+  return (CRYPTO_ERROR_CODES as string[]).includes(value);
+}
+
+function asCryptoCode(value: string): CryptoErrorCode {
+  return value as CryptoErrorCode;
+}
+
+/**
+ * Typed result helpers: a union that lets callers branch on `ok` instead of
+ * catching and parsing message text.
+ */
+export type CryptoResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: CryptoError };
+
+export function cryptoOk<T>(value: T): CryptoResult<T> {
+  return { ok: true, value };
+}
+
+export function cryptoFail<T = never>(error: CryptoError): CryptoResult<T> {
+  return { ok: false, error };
+}

--- a/tests/unit/crypto/errors.test.ts
+++ b/tests/unit/crypto/errors.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CRYPTO_ERROR_REGISTRY,
+  CryptoError,
+  cryptoFail,
+  cryptoOk,
+  redact,
+  toCryptoError,
+  type CryptoErrorCode,
+} from "../../../src/services/crypto/errors";
+
+const ALL_CODES = Object.keys(CRYPTO_ERROR_REGISTRY) as CryptoErrorCode[];
+
+describe("crypto error taxonomy (#1690)", () => {
+  it("defines a stable code per required failure category", () => {
+    for (const code of [
+      "crypto_parse_error",
+      "crypto_validation_error",
+      "crypto_algorithm_error",
+      "crypto_key_error",
+      "crypto_signature_error",
+      "crypto_commitment_error",
+      "crypto_decrypt_error",
+    ] as CryptoErrorCode[]) {
+      expect(ALL_CODES).toContain(code);
+      expect(CRYPTO_ERROR_REGISTRY[code].safe).toBe(true);
+    }
+  });
+
+  it("every public message is safe (non-empty, no secret-looking content)", () => {
+    for (const code of ALL_CODES) {
+      const message = CRYPTO_ERROR_REGISTRY[code].publicMessage;
+      expect(message.length).toBeGreaterThan(0);
+      // The public message must not itself contain high-entropy blobs.
+      expect(redact(message)).toBe(message);
+    }
+  });
+
+  it("CryptoError exposes the code and a fixed non-secret message", () => {
+    const error = new CryptoError("crypto_signature_error");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("crypto_signature_error");
+    expect(error.safe).toBe(true);
+    expect(error.message).toBe(CRYPTO_ERROR_REGISTRY.crypto_signature_error.publicMessage);
+    expect(error.message).not.toMatch(/[0-9a-fA-F]{16,}/);
+  });
+
+  it("redacts high-entropy hex and base64 from details", () => {
+    const details = redact("key=deadbeefdeadbeefdeadbeefdeadbeef and b64=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIz");
+    expect(details).not.toContain("deadbeef");
+    expect(details).toContain("[redacted-hex]");
+    expect(details).toContain("[redacted-b64]");
+  });
+
+  it("attaches redacted details without leaking into the message", () => {
+    const error = new CryptoError("crypto_key_error", "secret=00112233445566778899aabbccddeeff");
+    expect(error.details).toContain("[redacted-hex]");
+    expect(error.message).toBe(CRYPTO_ERROR_REGISTRY.crypto_key_error.publicMessage);
+    expect(error.message).not.toContain("00112233");
+  });
+
+  it("callers can branch on the code without parsing message text", () => {
+    const error = new CryptoError("crypto_commitment_error");
+    switch (error.code) {
+      case "crypto_commitment_error":
+        expect(true).toBe(true);
+        break;
+      default:
+        throw new Error("should not reach default");
+    }
+  });
+
+  it("toCryptoError passes through an existing CryptoError", () => {
+    const original = new CryptoError("crypto_algorithm_error");
+    const mapped = toCryptoError(original, "crypto_decrypt_error");
+    expect(mapped).toBe(original);
+    expect(mapped.code).toBe("crypto_algorithm_error");
+  });
+
+  it("toCryptoError discards raw messages and uses the safe fallback", () => {
+    const generic = new Error("AES key 0011223344556677 failed to unwrap plaintext 'hello'");
+    const mapped = toCryptoError(generic, "crypto_decrypt_error");
+    expect(mapped).toBeInstanceOf(CryptoError);
+    expect(mapped.code).toBe("crypto_decrypt_error");
+    expect(mapped.message).toBe(CRYPTO_ERROR_REGISTRY.crypto_decrypt_error.publicMessage);
+    expect(mapped.message).not.toContain("hello");
+    expect(mapped.message).not.toContain("00112233");
+  });
+
+  it("toCryptoError coerces a known code marker", () => {
+    const mapped = toCryptoError(
+      new Error("crypto_signature_error"),
+      "crypto_decrypt_error",
+    );
+    expect(mapped.code).toBe("crypto_signature_error");
+  });
+
+  it("typed result helpers distinguish success and failure", () => {
+    const ok = cryptoOk({ sealed: true });
+    const fail = cryptoFail<string>(new CryptoError("crypto_decrypt_error"));
+
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.value).toEqual({ sealed: true });
+
+    expect(fail.ok).toBe(false);
+    if (!fail.ok) expect(fail.error.code).toBe("crypto_decrypt_error");
+  });
+});

--- a/tests/unit/crypto/errors.test.ts
+++ b/tests/unit/crypto/errors.test.ts
@@ -47,7 +47,9 @@ describe("crypto error taxonomy (#1690)", () => {
   });
 
   it("redacts high-entropy hex and base64 from details", () => {
-    const details = redact("key=deadbeefdeadbeefdeadbeefdeadbeef and b64=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIz");
+    const details = redact(
+      "key=deadbeefdeadbeefdeadbeefdeadbeef and b64=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIz",
+    );
     expect(details).not.toContain("deadbeef");
     expect(details).toContain("[redacted-hex]");
     expect(details).toContain("[redacted-b64]");
@@ -89,10 +91,7 @@ describe("crypto error taxonomy (#1690)", () => {
   });
 
   it("toCryptoError coerces a known code marker", () => {
-    const mapped = toCryptoError(
-      new Error("crypto_signature_error"),
-      "crypto_decrypt_error",
-    );
+    const mapped = toCryptoError(new Error("crypto_signature_error"), "crypto_decrypt_error");
     expect(mapped.code).toBe("crypto_signature_error");
   });
 


### PR DESCRIPTION
## Summary

Implements **#1690**. `sealEnvelope` and the send pipeline previously threw generic `Error`s and collapsed encryption failures into a single message, so callers could not distinguish failure modes without parsing text.

This PR adds a typed crypto error taxonomy in `src/services/crypto/errors.ts`.

## Changes
- **`CryptoError`** with stable, non-secret codes: `crypto_parse_error`, `crypto_validation_error`, `crypto_algorithm_error`, `crypto_key_error`, `crypto_signature_error`, `crypto_commitment_error`, `crypto_decrypt_error`.
- **`CRYPTO_ERROR_REGISTRY`** with fixed public messages that contain no key material or plaintext.
- **`redact()`** — strips high-entropy hex/base64 from error details as defense-in-depth.
- **`toCryptoError()`** — maps arbitrary internal errors to a stable `CryptoError`, discarding raw messages that may contain secrets.
- **`CryptoResult<T>`** (`cryptoOk` / `cryptoFail`) typed helpers so callers branch on `ok` rather than message text.

## Acceptance criteria
- [x] Stable codes cover parse, validation, algorithm, key, signature, commitment, and decrypt failures
- [x] Public messages contain no sensitive values
- [x] Callers can branch without parsing message text
- [x] Tests verify error mapping and redaction

## Testing
- `bun run test` green (10 new tests in `tests/unit/crypto/errors.test.ts`)
- `tsc --noEmit` clean

Fixes #1690