### PR TITLE
feat(crypto): centralize secure nonce generation and validation

### DIFF
--- a/src/services/crypto/nonce.ts
+++ b/src/services/crypto/nonce.ts
@@ -59,18 +59,19 @@ const HEX_REGEX = /^[0-9a-fA-F]*$/;
  * hex and the resulting length matches the algorithm's expected nonce length.
  * Returns a typed result so callers branch on `ok` without parsing messages.
  */
-export function decodeNonce(
-  value: string,
-  algorithm: NonceAlgorithm,
-): CryptoResult<Uint8Array> {
+export function decodeNonce(value: string, algorithm: NonceAlgorithm): CryptoResult<Uint8Array> {
   if (typeof value !== "string" || value.length === 0) {
-    return cryptoFail(new CryptoError("crypto_validation_error", "nonce must be a non-empty string"));
+    return cryptoFail(
+      new CryptoError("crypto_validation_error", "nonce must be a non-empty string"),
+    );
   }
   if (value.length % 2 !== 0) {
     return cryptoFail(new CryptoError("crypto_validation_error", "nonce hex length must be even"));
   }
   if (!HEX_REGEX.test(value)) {
-    return cryptoFail(new CryptoError("crypto_validation_error", "nonce contains non-hex characters"));
+    return cryptoFail(
+      new CryptoError("crypto_validation_error", "nonce contains non-hex characters"),
+    );
   }
 
   const bytes = new Uint8Array(value.length / 2);
@@ -81,7 +82,10 @@ export function decodeNonce(
   const expected = NONCE_LENGTHS[algorithm];
   if (bytes.length !== expected) {
     return cryptoFail(
-      new CryptoError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
+      new CryptoError(
+        "crypto_validation_error",
+        `nonce must be ${expected} bytes for ${algorithm}`,
+      ),
     );
   }
 
@@ -109,7 +113,10 @@ export function validateNonceLength(
   const expected = NONCE_LENGTHS[algorithm];
   if (nonce.length !== expected) {
     return cryptoFail(
-      new CryptoError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
+      new CryptoError(
+        "crypto_validation_error",
+        `nonce must be ${expected} bytes for ${algorithm}`,
+      ),
     );
   }
   return cryptoOk(nonce);

--- a/src/services/crypto/nonce.ts
+++ b/src/services/crypto/nonce.ts
@@ -1,0 +1,116 @@
+/**
+ * Algorithm-aware nonce helpers (#1694).
+ *
+ * Centralizes secure nonce generation and strict validation so that every
+ * crypto path uses a consistent nonce length, encoding, and uniqueness story.
+ *
+ * Production always uses `crypto.getRandomValues`. A deterministic generator
+ * can be injected for tests only; it must never be used in production paths.
+ */
+
+import { CryptoError, cryptoFail, cryptoOk, type CryptoResult } from "./errors";
+
+/** Algorithm suites and the nonce length (in bytes) each expects. */
+export const NONCE_LENGTHS = {
+  "AES-256-GCM": 12,
+  "AES-128-GCM": 12,
+  "ChaCha20-Poly1305": 12,
+} as const;
+
+export type NonceAlgorithm = keyof typeof NONCE_LENGTHS;
+
+/** A test-only deterministic generator; undefined means use production CSPRNG. */
+export type NonceGenerator = (length: number) => Uint8Array;
+
+let injectedGenerator: NonceGenerator | undefined;
+
+/**
+ * Test seam: install a deterministic generator. Passing `undefined` restores
+ * production behavior. MUST NOT be used outside tests.
+ */
+export function __setNonceGeneratorForTesting(generator: NonceGenerator | undefined): void {
+  injectedGenerator = generator;
+}
+
+function randomBytes(length: number): Uint8Array {
+  if (injectedGenerator) {
+    return injectedGenerator(length);
+  }
+  if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
+    throw new CryptoError("crypto_algorithm_error", "secure random source unavailable");
+  }
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+/** Generate a fresh nonce for the given algorithm suite. */
+export function generateNonce(algorithm: NonceAlgorithm): Uint8Array {
+  const length = NONCE_LENGTHS[algorithm];
+  const nonce = randomBytes(length);
+  if (nonce.length !== length) {
+    throw new CryptoError("crypto_algorithm_error", "nonce generation length mismatch");
+  }
+  return nonce;
+}
+
+const HEX_REGEX = /^[0-9a-fA-F]*$/;
+
+/**
+ * Decode a hex nonce string into bytes, validating that the alphabet is strict
+ * hex and the resulting length matches the algorithm's expected nonce length.
+ * Returns a typed result so callers branch on `ok` without parsing messages.
+ */
+export function decodeNonce(
+  value: string,
+  algorithm: NonceAlgorithm,
+): CryptoResult<Uint8Array> {
+  if (typeof value !== "string" || value.length === 0) {
+    return cryptoFail(new CryptoError("crypto_validation_error", "nonce must be a non-empty string"));
+  }
+  if (value.length % 2 !== 0) {
+    return cryptoFail(new CryptoError("crypto_validation_error", "nonce hex length must be even"));
+  }
+  if (!HEX_REGEX.test(value)) {
+    return cryptoFail(new CryptoError("crypto_validation_error", "nonce contains non-hex characters"));
+  }
+
+  const bytes = new Uint8Array(value.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  const expected = NONCE_LENGTHS[algorithm];
+  if (bytes.length !== expected) {
+    return cryptoFail(
+      new CryptoError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
+    );
+  }
+
+  return cryptoOk(bytes);
+}
+
+/** Encode a nonce byte array to canonical lowercase hex. */
+export function encodeNonce(nonce: Uint8Array): string {
+  let out = "";
+  for (const b of nonce) {
+    out += b.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Verify a decoded nonce is exactly the algorithm's expected length. Useful when
+ * a nonce arrives already as bytes (e.g. from a parsed structure) so it fails
+ * before any crypto call.
+ */
+export function validateNonceLength(
+  nonce: Uint8Array,
+  algorithm: NonceAlgorithm,
+): CryptoResult<Uint8Array> {
+  const expected = NONCE_LENGTHS[algorithm];
+  if (nonce.length !== expected) {
+    return cryptoFail(
+      new CryptoError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
+    );
+  }
+  return cryptoOk(nonce);
+}

--- a/src/services/crypto/nonce.ts
+++ b/src/services/crypto/nonce.ts
@@ -6,9 +6,35 @@
  *
  * Production always uses `crypto.getRandomValues`. A deterministic generator
  * can be injected for tests only; it must never be used in production paths.
+ *
+ * This module is intentionally self-contained: it defines its own minimal,
+ * non-secret error and result types so it does not depend on sibling crypto
+ * modules that may land in separate PRs.
  */
 
-import { CryptoError, cryptoFail, cryptoOk, type CryptoResult } from "./errors";
+/** Stable, non-secret failure codes for nonce operations. */
+export type NonceErrorCode = "crypto_algorithm_error" | "crypto_validation_error";
+
+/** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
+export class NonceError extends Error {
+  readonly code: NonceErrorCode;
+  constructor(code: NonceErrorCode, message: string) {
+    super(message);
+    this.name = "NonceError";
+    this.code = code;
+  }
+}
+
+/** Typed result so callers branch on `ok` instead of catching and parsing text. */
+export type NonceResult<T> = { ok: true; value: T } | { ok: false; error: NonceError };
+
+function nonceOk<T>(value: T): NonceResult<T> {
+  return { ok: true, value };
+}
+
+function nonceFail<T = never>(error: NonceError): NonceResult<T> {
+  return { ok: false, error };
+}
 
 /** Algorithm suites and the nonce length (in bytes) each expects. */
 export const NONCE_LENGTHS = {
@@ -37,7 +63,7 @@ function randomBytes(length: number): Uint8Array {
     return injectedGenerator(length);
   }
   if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
-    throw new CryptoError("crypto_algorithm_error", "secure random source unavailable");
+    throw new NonceError("crypto_algorithm_error", "secure random source unavailable");
   }
   return crypto.getRandomValues(new Uint8Array(length));
 }
@@ -47,7 +73,7 @@ export function generateNonce(algorithm: NonceAlgorithm): Uint8Array {
   const length = NONCE_LENGTHS[algorithm];
   const nonce = randomBytes(length);
   if (nonce.length !== length) {
-    throw new CryptoError("crypto_algorithm_error", "nonce generation length mismatch");
+    throw new NonceError("crypto_algorithm_error", "nonce generation length mismatch");
   }
   return nonce;
 }
@@ -59,18 +85,16 @@ const HEX_REGEX = /^[0-9a-fA-F]*$/;
  * hex and the resulting length matches the algorithm's expected nonce length.
  * Returns a typed result so callers branch on `ok` without parsing messages.
  */
-export function decodeNonce(value: string, algorithm: NonceAlgorithm): CryptoResult<Uint8Array> {
+export function decodeNonce(value: string, algorithm: NonceAlgorithm): NonceResult<Uint8Array> {
   if (typeof value !== "string" || value.length === 0) {
-    return cryptoFail(
-      new CryptoError("crypto_validation_error", "nonce must be a non-empty string"),
-    );
+    return nonceFail(new NonceError("crypto_validation_error", "nonce must be a non-empty string"));
   }
   if (value.length % 2 !== 0) {
-    return cryptoFail(new CryptoError("crypto_validation_error", "nonce hex length must be even"));
+    return nonceFail(new NonceError("crypto_validation_error", "nonce hex length must be even"));
   }
   if (!HEX_REGEX.test(value)) {
-    return cryptoFail(
-      new CryptoError("crypto_validation_error", "nonce contains non-hex characters"),
+    return nonceFail(
+      new NonceError("crypto_validation_error", "nonce contains non-hex characters"),
     );
   }
 
@@ -81,15 +105,12 @@ export function decodeNonce(value: string, algorithm: NonceAlgorithm): CryptoRes
 
   const expected = NONCE_LENGTHS[algorithm];
   if (bytes.length !== expected) {
-    return cryptoFail(
-      new CryptoError(
-        "crypto_validation_error",
-        `nonce must be ${expected} bytes for ${algorithm}`,
-      ),
+    return nonceFail(
+      new NonceError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
     );
   }
 
-  return cryptoOk(bytes);
+  return nonceOk(bytes);
 }
 
 /** Encode a nonce byte array to canonical lowercase hex. */
@@ -109,15 +130,12 @@ export function encodeNonce(nonce: Uint8Array): string {
 export function validateNonceLength(
   nonce: Uint8Array,
   algorithm: NonceAlgorithm,
-): CryptoResult<Uint8Array> {
+): NonceResult<Uint8Array> {
   const expected = NONCE_LENGTHS[algorithm];
   if (nonce.length !== expected) {
-    return cryptoFail(
-      new CryptoError(
-        "crypto_validation_error",
-        `nonce must be ${expected} bytes for ${algorithm}`,
-      ),
+    return nonceFail(
+      new NonceError("crypto_validation_error", `nonce must be ${expected} bytes for ${algorithm}`),
     );
   }
-  return cryptoOk(nonce);
+  return nonceOk(nonce);
 }

--- a/tests/unit/crypto/nonce.test.ts
+++ b/tests/unit/crypto/nonce.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  __setNonceGeneratorForTesting,
+  decodeNonce,
+  encodeNonce,
+  generateNonce,
+  validateNonceLength,
+  NONCE_LENGTHS,
+} from "../../../src/services/crypto/nonce";
+
+describe("secure nonce helpers (#1694)", () => {
+  afterEach(() => {
+    // Always restore production randomness.
+    __setNonceGeneratorForTesting(undefined);
+  });
+
+  it("derives nonce length from the algorithm suite", () => {
+    for (const algorithm of Object.keys(NONCE_LENGTHS) as (keyof typeof NONCE_LENGTHS)[]) {
+      expect(generateNonce(algorithm).length).toBe(NONCE_LENGTHS[algorithm]);
+    }
+  });
+
+  it("uses crypto.getRandomValues in production and produces distinct values", () => {
+    const a = generateNonce("AES-256-GCM");
+    const b = generateNonce("AES-256-GCM");
+    expect(a).not.toEqual(b);
+  });
+
+  it("accepts a deterministic injection for tests without weakening production", () => {
+    let counter = 0;
+    __setNonceGeneratorForTesting((length: number) => {
+      const bytes = new Uint8Array(length);
+      for (let i = 0; i < length; i += 1) bytes[i] = (counter + i) & 0xff;
+      counter += 1;
+      return bytes;
+    });
+
+    const nonce = generateNonce("AES-256-GCM");
+    expect(nonce.length).toBe(12);
+    expect([...nonce]).toEqual(Array.from({ length: 12 }, (_, i) => i & 0xff));
+  });
+
+  it("round-trips nonce encode/decode", () => {
+    const nonce = generateNonce("AES-128-GCM");
+    const encoded = encodeNonce(nonce);
+    const decoded = decodeNonce(encoded, "AES-128-GCM");
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) expect(decoded.value).toEqual(nonce);
+  });
+
+  it("rejects malformed hex (odd length)", () => {
+    const result = decodeNonce("abc", "AES-256-GCM");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("crypto_validation_error");
+  });
+
+  it("rejects non-hex characters", () => {
+    const result = decodeNonce("zzzzzzzzzzzz", "AES-256-GCM");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("crypto_validation_error");
+  });
+
+  it("rejects wrong-length nonces before any crypto call", () => {
+    const tooShort = "0011";
+    const result = decodeNonce(tooShort, "AES-256-GCM");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("crypto_validation_error");
+  });
+
+  it("rejects empty/non-string input", () => {
+    expect(decodeNonce("", "AES-256-GCM").ok).toBe(false);
+  });
+
+  it("validateNonceLength fails on length mismatch", () => {
+    const result = validateNonceLength(new Uint8Array(8), "AES-256-GCM");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("crypto_validation_error");
+  });
+
+  it("validateNonceLength passes on correct length", () => {
+    const result = validateNonceLength(new Uint8Array(12), "AES-256-GCM");
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1694**. The envelope implementation created a 12-byte AES-GCM IV inline and serialized it as hex with no shared nonce policy, so future algorithms and decrypt paths lacked consistent length, encoding, and validation.

This PR adds algorithm-aware nonce helpers in `src/services/crypto/nonce.ts`.

## Changes
- **`NONCE_LENGTHS`** — per-algorithm nonce lengths (`AES-256-GCM`, `AES-128-GCM`, `ChaCha20-Poly1305` all 12 bytes).
- **`generateNonce(algorithm)`** — derives length from the suite; production uses `crypto.getRandomValues` only.
- **`decodeNonce(value, algorithm)`** — strict hex validation (alphabet, even length, expected byte length) returning a typed `CryptoResult` that fails before any crypto call.
- **`encodeNonce`** — canonical lowercase hex.
- **`validateNonceLength`** — length check for already-decoded bytes.
- **`__setNonceGeneratorForTesting`** — test seam for deterministic injection; never used in production.

## Acceptance criteria
- [x] Nonce length is derived from the selected algorithm suite
- [x] Malformed and wrong-length nonces fail before crypto calls
- [x] Production uses `crypto.getRandomValues` only
- [x] Tests cover deterministic injection without weakening production

## Testing
- `bun run test` green (10 new tests in `tests/unit/crypto/nonce.test.ts`)
- `tsc --noEmit` clean

Fixes #1694