### PR TITLE
feat(email-ownership-tracker): add core ownership tracking engine

### DIFF
--- a/tools/v1/team/email-ownership-tracker/README.md
+++ b/tools/v1/team/email-ownership-tracker/README.md
@@ -1,15 +1,72 @@
 # Email Ownership Tracker
 
-This folder is the isolated workspace for the Email Ownership Tracker tool.
+Email Ownership Tracker is an isolated V1 team tool workspace for reconstructing
+the ownership history of email threads from a stream of ownership events.
 
 ## Ownership Boundary
 
-All work for this tool must stay inside:
+All work for this tool must stay inside the folder
+tools/v1/team/email-ownership-tracker/. Do not wire this tool into the main app,
+routing, inbox architecture, wallet core, Stellar core, database schema, or the
+shared design system unless a future integration issue explicitly allows it.
 
-`text
-.\tools\v1\team\email-ownership-tracker\
-`
+## What This Issue Adds
 
-Do not wire this tool into the main app, routing, inbox architecture, wallet core, Stellar core, database schema, or existing design system unless a future integration issue explicitly allows it.
+This issue implements the folder-local core feature engine only:
 
-See specs.md for the issue categories and contributor expectations.
+- types/ defines the ownership event, history, anomaly, and report contracts.
+- services/ provides a deterministic trackOwnership engine plus a
+  sortOwnershipEvents helper.
+- fixtures/ holds synthetic sample ownership events with an expected report.
+- tests/ adds a standalone Node test that validates the fixture contract.
+
+No UI, routing, mailbox, reminder, calendar, or database behavior is included.
+
+## Reviewer Setup
+
+No app install is required to review the fixture contract. From the repository
+root, run:
+
+    node --test tools/v1/team/email-ownership-tracker/tests/ownership-fixtures.test.mjs
+
+## Engine Contract
+
+trackOwnership(events) accepts an array of OwnershipEvent values and returns an
+OwnershipReport.
+
+### Input: OwnershipEvent
+
+- id is a stable event identifier.
+- threadId is the thread the event applies to.
+- action is one of assigned, reassigned, released, or claimed.
+- actor is who performed the action.
+- owner is the resulting owner, or null for a release.
+- previousOwner is an optional expected prior owner used for validation.
+- timestamp is an ISO timestamp.
+- note is optional free text.
+
+### Output: OwnershipReport
+
+- records has one entry per thread with the current owner, state (owned or
+  unassigned), handoff count, first and last event times, and ordered history.
+- anomalies lists non-fatal data issues (see below).
+- summary totals events, threads, owners, handoffs, and anomalies.
+
+### States and Anomalies
+
+Events are processed in the order received. Malformed input is reported as an
+anomaly instead of throwing, so a caller can surface it for manual review:
+
+- release-without-owner: a release arrived with no active owner.
+- duplicate-owner-assignment: a thread was assigned to its current owner.
+- reassign-without-existing-owner: a reassignment arrived with no owner.
+- owner-mismatch: an event previousOwner did not match the tracked owner.
+- out-of-order-timestamp: an event predates the previous event on its thread.
+
+## Known Limitations
+
+- The engine reconstructs history only; it never writes to a mailbox, reminder,
+  calendar, or database.
+- Ownership identity resolution and permissions are deferred to a future
+  integration issue.
+- All fixture data is synthetic and uses the reserved .test suffix.

--- a/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-events.json
+++ b/tools/v1/team/email-ownership-tracker/fixtures/sample-ownership-events.json
@@ -1,0 +1,137 @@
+{
+  "tool": "email-ownership-tracker",
+  "version": 1,
+  "runContext": {
+    "now": "2026-07-07T09:00:00Z",
+    "timezone": "Africa/Lagos"
+  },
+  "sourceEvents": [
+    {
+      "id": "evt-001",
+      "threadId": "thread-support-001",
+      "action": "assigned",
+      "actor": "lead@team.test",
+      "owner": "alice@team.test",
+      "previousOwner": null,
+      "timestamp": "2026-07-01T09:00:00Z",
+      "note": "Initial triage assignment."
+    },
+    {
+      "id": "evt-002",
+      "threadId": "thread-support-001",
+      "action": "reassigned",
+      "actor": "alice@team.test",
+      "owner": "bob@team.test",
+      "previousOwner": "alice@team.test",
+      "timestamp": "2026-07-03T14:30:00Z",
+      "note": "Handed off for escalation."
+    },
+    {
+      "id": "evt-003",
+      "threadId": "thread-support-001",
+      "action": "released",
+      "actor": "bob@team.test",
+      "owner": null,
+      "previousOwner": "bob@team.test",
+      "timestamp": "2026-07-05T16:00:00Z",
+      "note": "Resolved and released."
+    },
+    {
+      "id": "evt-004",
+      "threadId": "thread-sales-002",
+      "action": "claimed",
+      "actor": "carol@team.test",
+      "owner": "carol@team.test",
+      "previousOwner": null,
+      "timestamp": "2026-07-02T10:00:00Z",
+      "note": "Claimed inbound lead."
+    },
+    {
+      "id": "evt-005",
+      "threadId": "thread-sales-002",
+      "action": "claimed",
+      "actor": "carol@team.test",
+      "owner": "carol@team.test",
+      "previousOwner": "carol@team.test",
+      "timestamp": "2026-07-02T10:05:00Z",
+      "note": "Duplicate claim on an already-owned thread."
+    },
+    {
+      "id": "evt-006",
+      "threadId": "thread-sales-002",
+      "action": "reassigned",
+      "actor": "carol@team.test",
+      "owner": "dave@team.test",
+      "previousOwner": "carol@team.test",
+      "timestamp": "2026-07-04T11:00:00Z",
+      "note": "Reassigned to account executive."
+    },
+    {
+      "id": "evt-007",
+      "threadId": "thread-billing-003",
+      "action": "released",
+      "actor": "erin@team.test",
+      "owner": null,
+      "previousOwner": null,
+      "timestamp": "2026-07-06T08:00:00Z",
+      "note": "Release recorded with no active owner."
+    }
+  ],
+  "expectedReport": {
+    "records": [
+      {
+        "threadId": "thread-support-001",
+        "currentOwner": null,
+        "state": "unassigned",
+        "handoffCount": 1,
+        "firstEventAt": "2026-07-01T09:00:00Z",
+        "lastEventAt": "2026-07-05T16:00:00Z",
+        "historyEventIds": ["evt-001", "evt-002", "evt-003"]
+      },
+      {
+        "threadId": "thread-sales-002",
+        "currentOwner": "dave@team.test",
+        "state": "owned",
+        "handoffCount": 1,
+        "firstEventAt": "2026-07-02T10:00:00Z",
+        "lastEventAt": "2026-07-04T11:00:00Z",
+        "historyEventIds": ["evt-004", "evt-005", "evt-006"]
+      },
+      {
+        "threadId": "thread-billing-003",
+        "currentOwner": null,
+        "state": "unassigned",
+        "handoffCount": 0,
+        "firstEventAt": "2026-07-06T08:00:00Z",
+        "lastEventAt": "2026-07-06T08:00:00Z",
+        "historyEventIds": ["evt-007"]
+      }
+    ],
+    "anomalies": [
+      {
+        "eventId": "evt-005",
+        "threadId": "thread-sales-002",
+        "code": "duplicate-owner-assignment"
+      },
+      {
+        "eventId": "evt-007",
+        "threadId": "thread-billing-003",
+        "code": "release-without-owner"
+      }
+    ],
+    "summary": {
+      "totalEvents": 7,
+      "totalThreads": 3,
+      "ownedThreads": 1,
+      "unassignedThreads": 2,
+      "totalHandoffs": 2,
+      "anomalies": 2
+    }
+  },
+  "reviewNotes": [
+    "All actors and threads are synthetic; addresses use the reserved .test suffix.",
+    "historyEventIds lists the ordered event ids applied to each thread.",
+    "Duplicate claims and releases without an owner are surfaced as anomalies, not errors.",
+    "The engine reconstructs history only and performs no mailbox, reminder, or database writes."
+  ]
+}

--- a/tools/v1/team/email-ownership-tracker/index.ts
+++ b/tools/v1/team/email-ownership-tracker/index.ts
@@ -1,0 +1,15 @@
+export { sortOwnershipEvents, trackOwnership } from "./services";
+export type {
+  ActorId,
+  OwnershipAction,
+  OwnershipAnomaly,
+  OwnershipAnomalyCode,
+  OwnershipEvent,
+  OwnershipEventId,
+  OwnershipHistoryEntry,
+  OwnershipRecord,
+  OwnershipReport,
+  OwnershipState,
+  OwnershipSummary,
+  ThreadId,
+} from "./types";

--- a/tools/v1/team/email-ownership-tracker/services/email-ownership-tracker.service.ts
+++ b/tools/v1/team/email-ownership-tracker/services/email-ownership-tracker.service.ts
@@ -1,0 +1,202 @@
+import type {
+  ActorId,
+  OwnershipAnomaly,
+  OwnershipEvent,
+  OwnershipHistoryEntry,
+  OwnershipRecord,
+  OwnershipReport,
+  OwnershipState,
+} from "../types";
+
+interface ThreadAccumulator {
+  threadId: string;
+  currentOwner: ActorId | null;
+  handoffCount: number;
+  firstEventAt: string;
+  lastEventAt: string;
+  previousTimestamp: string;
+  history: OwnershipHistoryEntry[];
+}
+
+function compareByTimestamp(a: OwnershipEvent, b: OwnershipEvent): number {
+  return a.timestamp.localeCompare(b.timestamp);
+}
+
+/** Return a timestamp-sorted copy of the events without mutating the input. */
+export function sortOwnershipEvents(events: OwnershipEvent[]): OwnershipEvent[] {
+  return [...events].sort(compareByTimestamp);
+}
+
+function toHistoryEntry(
+  event: OwnershipEvent,
+  previousOwner: ActorId | null,
+): OwnershipHistoryEntry {
+  return {
+    eventId: event.id,
+    action: event.action,
+    actor: event.actor,
+    owner: event.owner,
+    previousOwner,
+    timestamp: event.timestamp,
+    note: event.note ?? null,
+  };
+}
+
+/**
+ * Reconstruct per-thread ownership history from a flat list of ownership
+ * events. Events are processed in the order received so that malformed or
+ * out-of-order input is reported as an anomaly rather than silently reordered.
+ */
+export function trackOwnership(events: OwnershipEvent[]): OwnershipReport {
+  const threads = new Map<string, ThreadAccumulator>();
+  const anomalies: OwnershipAnomaly[] = [];
+
+  for (const event of events) {
+    let accumulator = threads.get(event.threadId);
+    if (!accumulator) {
+      accumulator = {
+        threadId: event.threadId,
+        currentOwner: null,
+        handoffCount: 0,
+        firstEventAt: event.timestamp,
+        lastEventAt: event.timestamp,
+        previousTimestamp: event.timestamp,
+        history: [],
+      };
+      threads.set(event.threadId, accumulator);
+    } else if (event.timestamp.localeCompare(accumulator.previousTimestamp) < 0) {
+      anomalies.push({
+        eventId: event.id,
+        threadId: event.threadId,
+        code: "out-of-order-timestamp",
+        message:
+          "Event " +
+          event.id +
+          " is older than the previous event on thread " +
+          event.threadId +
+          ".",
+      });
+    }
+
+    const previousOwner = accumulator.currentOwner;
+
+    if (event.previousOwner !== undefined && event.previousOwner !== previousOwner) {
+      anomalies.push({
+        eventId: event.id,
+        threadId: event.threadId,
+        code: "owner-mismatch",
+        message:
+          "Event " +
+          event.id +
+          " expected owner " +
+          String(event.previousOwner) +
+          " but the thread owner was " +
+          String(previousOwner) +
+          ".",
+      });
+    }
+
+    switch (event.action) {
+      case "assigned":
+      case "claimed": {
+        if (previousOwner !== null && previousOwner === event.owner) {
+          anomalies.push({
+            eventId: event.id,
+            threadId: event.threadId,
+            code: "duplicate-owner-assignment",
+            message:
+              "Event " +
+              event.id +
+              " re-assigned thread " +
+              event.threadId +
+              " to its current owner.",
+          });
+        } else if (previousOwner !== null && event.owner !== null) {
+          accumulator.handoffCount += 1;
+        }
+        accumulator.currentOwner = event.owner;
+        break;
+      }
+      case "reassigned": {
+        if (previousOwner === null) {
+          anomalies.push({
+            eventId: event.id,
+            threadId: event.threadId,
+            code: "reassign-without-existing-owner",
+            message:
+              "Event " +
+              event.id +
+              " reassigned thread " +
+              event.threadId +
+              " with no current owner.",
+          });
+        } else if (event.owner !== null && event.owner !== previousOwner) {
+          accumulator.handoffCount += 1;
+        }
+        accumulator.currentOwner = event.owner;
+        break;
+      }
+      case "released": {
+        if (previousOwner === null) {
+          anomalies.push({
+            eventId: event.id,
+            threadId: event.threadId,
+            code: "release-without-owner",
+            message:
+              "Event " +
+              event.id +
+              " released thread " +
+              event.threadId +
+              " with no current owner.",
+          });
+        }
+        accumulator.currentOwner = null;
+        break;
+      }
+    }
+
+    accumulator.history.push(toHistoryEntry(event, previousOwner));
+    if (event.timestamp.localeCompare(accumulator.firstEventAt) < 0) {
+      accumulator.firstEventAt = event.timestamp;
+    }
+    if (event.timestamp.localeCompare(accumulator.lastEventAt) > 0) {
+      accumulator.lastEventAt = event.timestamp;
+    }
+    accumulator.previousTimestamp = event.timestamp;
+  }
+
+  const records: OwnershipRecord[] = [];
+  let ownedThreads = 0;
+  let totalHandoffs = 0;
+
+  for (const accumulator of threads.values()) {
+    const state: OwnershipState = accumulator.currentOwner === null ? "unassigned" : "owned";
+    if (state === "owned") {
+      ownedThreads += 1;
+    }
+    totalHandoffs += accumulator.handoffCount;
+
+    records.push({
+      threadId: accumulator.threadId,
+      currentOwner: accumulator.currentOwner,
+      state,
+      handoffCount: accumulator.handoffCount,
+      firstEventAt: accumulator.firstEventAt,
+      lastEventAt: accumulator.lastEventAt,
+      history: accumulator.history,
+    });
+  }
+
+  return {
+    records,
+    anomalies,
+    summary: {
+      totalEvents: events.length,
+      totalThreads: records.length,
+      ownedThreads,
+      unassignedThreads: records.length - ownedThreads,
+      totalHandoffs,
+      anomalies: anomalies.length,
+    },
+  };
+}

--- a/tools/v1/team/email-ownership-tracker/services/index.ts
+++ b/tools/v1/team/email-ownership-tracker/services/index.ts
@@ -1,0 +1,1 @@
+export { sortOwnershipEvents, trackOwnership } from "./email-ownership-tracker.service";

--- a/tools/v1/team/email-ownership-tracker/tests/ownership-fixtures.test.mjs
+++ b/tools/v1/team/email-ownership-tracker/tests/ownership-fixtures.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(currentDir, "..", "fixtures", "sample-ownership-events.json");
+
+const allowedActions = new Set(["assigned", "reassigned", "released", "claimed"]);
+const allowedStates = new Set(["owned", "unassigned"]);
+const allowedAnomalyCodes = new Set([
+  "release-without-owner",
+  "duplicate-owner-assignment",
+  "reassign-without-existing-owner",
+  "owner-mismatch",
+  "out-of-order-timestamp",
+]);
+
+async function loadFixture() {
+  const raw = await readFile(fixturePath, "utf8");
+  return JSON.parse(raw);
+}
+
+test("sample ownership fixture follows the local ownership contract", async () => {
+  const fixture = await loadFixture();
+
+  assert.equal(fixture.tool, "email-ownership-tracker");
+  assert.ok(Array.isArray(fixture.sourceEvents), "sourceEvents must be an array");
+  assert.match(fixture.runContext.now, /^\d{4}-\d{2}-\d{2}T/);
+
+  const report = fixture.expectedReport;
+  assert.ok(Array.isArray(report.records), "expectedReport.records must be an array");
+  assert.ok(Array.isArray(report.anomalies), "expectedReport.anomalies must be an array");
+
+  const eventIds = new Set();
+  for (const event of fixture.sourceEvents) {
+    assert.ok(event.id, "source event needs a stable id");
+    assert.ok(!eventIds.has(event.id), event.id + " must be unique");
+    eventIds.add(event.id);
+    assert.ok(event.actor.endsWith(".test"), event.id + " must use synthetic actor data");
+    assert.ok(allowedActions.has(event.action), event.id + " has invalid action");
+    assert.match(event.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+    assert.ok(
+      event.owner === null || event.owner.endsWith(".test"),
+      event.id + " owner must be synthetic or null",
+    );
+  }
+
+  const threadIds = new Set();
+  let ownedThreads = 0;
+  let totalHandoffs = 0;
+  for (const record of report.records) {
+    assert.ok(record.threadId, "record needs a threadId");
+    assert.ok(!threadIds.has(record.threadId), record.threadId + " must be unique");
+    threadIds.add(record.threadId);
+    assert.ok(allowedStates.has(record.state), record.threadId + " has invalid state");
+    assert.equal(typeof record.handoffCount, "number");
+    assert.ok(record.handoffCount >= 0, record.threadId + " handoffCount must be >= 0");
+    assert.ok(Array.isArray(record.historyEventIds), record.threadId + " needs historyEventIds");
+    assert.ok(record.historyEventIds.length > 0, record.threadId + " history must not be empty");
+
+    for (const id of record.historyEventIds) {
+      assert.ok(eventIds.has(id), record.threadId + " references unknown event " + id);
+    }
+
+    if (record.state === "owned") {
+      ownedThreads += 1;
+      assert.ok(record.currentOwner, "owned threads need a currentOwner");
+    } else {
+      assert.equal(record.currentOwner, null, "unassigned threads must have a null owner");
+    }
+
+    totalHandoffs += record.handoffCount;
+  }
+
+  const seenCodes = new Set();
+  for (const anomaly of report.anomalies) {
+    assert.ok(allowedAnomalyCodes.has(anomaly.code), "invalid anomaly code " + anomaly.code);
+    assert.ok(eventIds.has(anomaly.eventId), "anomaly references unknown event " + anomaly.eventId);
+    assert.ok(
+      threadIds.has(anomaly.threadId),
+      "anomaly references unknown thread " + anomaly.threadId,
+    );
+    seenCodes.add(anomaly.code);
+  }
+
+  assert.ok(ownedThreads >= 1, "fixture must include at least one owned thread");
+  assert.ok(threadIds.size - ownedThreads >= 1, "fixture must include an unassigned thread");
+  assert.ok(seenCodes.size >= 2, "fixture must exercise at least two anomaly codes");
+
+  assert.equal(report.summary.totalEvents, fixture.sourceEvents.length);
+  assert.equal(report.summary.totalThreads, report.records.length);
+  assert.equal(report.summary.ownedThreads, ownedThreads);
+  assert.equal(report.summary.unassignedThreads, threadIds.size - ownedThreads);
+  assert.equal(report.summary.totalHandoffs, totalHandoffs);
+  assert.equal(report.summary.anomalies, report.anomalies.length);
+});

--- a/tools/v1/team/email-ownership-tracker/types/index.ts
+++ b/tools/v1/team/email-ownership-tracker/types/index.ts
@@ -1,0 +1,14 @@
+export type {
+  ActorId,
+  OwnershipAction,
+  OwnershipAnomaly,
+  OwnershipAnomalyCode,
+  OwnershipEvent,
+  OwnershipEventId,
+  OwnershipHistoryEntry,
+  OwnershipRecord,
+  OwnershipReport,
+  OwnershipState,
+  OwnershipSummary,
+  ThreadId,
+} from "./ownership";

--- a/tools/v1/team/email-ownership-tracker/types/ownership.ts
+++ b/tools/v1/team/email-ownership-tracker/types/ownership.ts
@@ -1,0 +1,67 @@
+export type ThreadId = string;
+export type ActorId = string;
+export type OwnershipEventId = string;
+
+export type OwnershipAction = "assigned" | "reassigned" | "released" | "claimed";
+
+export type OwnershipState = "owned" | "unassigned";
+
+export type OwnershipAnomalyCode =
+  | "release-without-owner"
+  | "duplicate-owner-assignment"
+  | "reassign-without-existing-owner"
+  | "owner-mismatch"
+  | "out-of-order-timestamp";
+
+export interface OwnershipEvent {
+  id: OwnershipEventId;
+  threadId: ThreadId;
+  action: OwnershipAction;
+  actor: ActorId;
+  owner: ActorId | null;
+  previousOwner?: ActorId | null;
+  timestamp: string;
+  note?: string;
+}
+
+export interface OwnershipHistoryEntry {
+  eventId: OwnershipEventId;
+  action: OwnershipAction;
+  actor: ActorId;
+  owner: ActorId | null;
+  previousOwner: ActorId | null;
+  timestamp: string;
+  note: string | null;
+}
+
+export interface OwnershipRecord {
+  threadId: ThreadId;
+  currentOwner: ActorId | null;
+  state: OwnershipState;
+  handoffCount: number;
+  firstEventAt: string;
+  lastEventAt: string;
+  history: OwnershipHistoryEntry[];
+}
+
+export interface OwnershipAnomaly {
+  eventId: OwnershipEventId;
+  threadId: ThreadId;
+  code: OwnershipAnomalyCode;
+  message: string;
+}
+
+export interface OwnershipSummary {
+  totalEvents: number;
+  totalThreads: number;
+  ownedThreads: number;
+  unassignedThreads: number;
+  totalHandoffs: number;
+  anomalies: number;
+}
+
+export interface OwnershipReport {
+  records: OwnershipRecord[];
+  anomalies: OwnershipAnomaly[];
+  summary: OwnershipSummary;
+}


### PR DESCRIPTION
## Summary

Adds the folder-local core feature engine for the Email Ownership Tracker tool (`tools/v1/team/email-ownership-tracker/`), per issue #435.

## What's included

- **`types/`** — ownership event, history, anomaly, record, summary, and report contracts.
- **`services/`** — a deterministic `trackOwnership(events)` engine plus a `sortOwnershipEvents(events)` helper.
- **`fixtures/`** — a synthetic sample of ownership events with an expected report (all actors use the reserved `.test` suffix).
- **`tests/`** — a standalone Node test that validates the fixture contract.
- **`README.md`** — documents the tool boundary, engine contract, states, and anomalies.

## Behavior

`trackOwnership` reconstructs per-thread ownership history from a flat list of events, processed in the order received. Malformed input (release without an owner, duplicate assignment, reassign without an existing owner, owner mismatch, out-of-order timestamps) is surfaced as a non-fatal anomaly rather than throwing.

## Scope / boundaries

History reconstruction only. No UI, routing, mailbox, reminder, calendar, or database wiring, and no changes outside the tool folder.

## How to verify

No app install required. From the repo root:

    node --test tools/v1/team/email-ownership-tracker/tests/ownership-fixtures.test.mjs

Prettier is clean (`prettier --check`) and the test passes (`pass 1 / fail 0`).

Closes #435