### PR TITLE
feat(legal-compliance-review-flag-ui): add accessible tool UI surface

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/components/EmptyState.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/EmptyState.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const EmptyState: React.FC = () => {
+  return (
+    <div role="status" className="rounded-lg border border-dashed border-gray-300 p-6 text-center">
+      <p className="text-sm font-medium text-gray-700">No review flag raised yet</p>
+      <p className="mt-1 text-sm text-gray-500">
+        Complete the form above to raise a legal or compliance review flag. The result will appear
+        here.
+      </p>
+    </div>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/ErrorState.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/ErrorState.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type { ReviewFlagError } from "../contract";
+
+interface ErrorStateProps {
+  error: ReviewFlagError;
+  onRetry?: () => void;
+}
+
+export const ErrorState: React.FC<ErrorStateProps> = ({ error, onRetry }) => {
+  const fields = error.code === "invalid_input" ? error.fields : undefined;
+
+  return (
+    <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+      <p className="text-sm font-semibold text-red-800">Could not raise the flag</p>
+      <p className="mt-1 text-sm text-red-700">{error.message}</p>
+      <p className="mt-2 text-xs uppercase tracking-wide text-red-500">Code: {error.code}</p>
+      {fields && fields.length > 0 && (
+        <p className="mt-1 text-xs text-red-600">Check these fields: {fields.join(", ")}</p>
+      )}
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/LoadingState.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/LoadingState.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export const LoadingState: React.FC = () => {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center p-6 text-center"
+    >
+      <span
+        aria-hidden="true"
+        className="mb-3 h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-700"
+      />
+      <p className="text-sm font-medium text-gray-700">Raising review flag...</p>
+      <p className="mt-1 text-sm text-gray-500">Please wait while the flag is validated.</p>
+    </div>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/ReviewFlagForm.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/ReviewFlagForm.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import type { ReviewFlagFormValues } from "../ui-types";
+import { SEVERITY_OPTIONS } from "../ui-types";
+
+interface ReviewFlagFormProps {
+  values: ReviewFlagFormValues;
+  disabled: boolean;
+  onFieldChange: <K extends keyof ReviewFlagFormValues>(
+    field: K,
+    value: ReviewFlagFormValues[K],
+  ) => void;
+  onSubmit: () => void;
+}
+
+const inputClass =
+  "mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-400";
+
+export const ReviewFlagForm: React.FC<ReviewFlagFormProps> = ({
+  values,
+  disabled,
+  onFieldChange,
+  onSubmit,
+}) => {
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div>
+        <label htmlFor="review-flag-reviewer" className="block text-sm font-medium text-gray-700">
+          Reviewer
+        </label>
+        <input
+          id="review-flag-reviewer"
+          name="reviewer"
+          type="text"
+          required
+          value={values.reviewer}
+          disabled={disabled}
+          onChange={(event) => onFieldChange("reviewer", event.target.value)}
+          className={inputClass}
+          placeholder="reviewer:legal-001"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="review-flag-resource" className="block text-sm font-medium text-gray-700">
+          Target resource
+        </label>
+        <input
+          id="review-flag-resource"
+          name="targetResource"
+          type="text"
+          required
+          value={values.targetResource}
+          disabled={disabled}
+          onChange={(event) => onFieldChange("targetResource", event.target.value)}
+          className={inputClass}
+          placeholder="mail:thread:abc"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="review-flag-reason" className="block text-sm font-medium text-gray-700">
+          Reason
+        </label>
+        <textarea
+          id="review-flag-reason"
+          name="flagReason"
+          required
+          rows={3}
+          value={values.flagReason}
+          disabled={disabled}
+          onChange={(event) => onFieldChange("flagReason", event.target.value)}
+          className={inputClass}
+          placeholder="Describe why this resource needs legal or compliance review."
+        />
+      </div>
+
+      <div>
+        <label htmlFor="review-flag-severity" className="block text-sm font-medium text-gray-700">
+          Severity
+        </label>
+        <select
+          id="review-flag-severity"
+          name="severity"
+          value={values.severity}
+          disabled={disabled}
+          onChange={(event) =>
+            onFieldChange("severity", event.target.value as ReviewFlagFormValues["severity"])
+          }
+          className={inputClass}
+        >
+          {SEVERITY_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="review-flag-evidence" className="block text-sm font-medium text-gray-700">
+          Evidence references
+        </label>
+        <textarea
+          id="review-flag-evidence"
+          name="evidenceRefs"
+          rows={2}
+          value={values.evidenceRefs}
+          disabled={disabled}
+          onChange={(event) => onFieldChange("evidenceRefs", event.target.value)}
+          className={inputClass}
+          aria-describedby="review-flag-evidence-hint"
+          placeholder="scan:vt-8821, ticket:sec-334"
+        />
+        <p id="review-flag-evidence-hint" className="mt-1 text-xs text-gray-500">
+          Optional. Separate multiple references with a comma or a new line.
+        </p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={disabled}
+        className="self-start rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Raise review flag
+      </button>
+    </form>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/ReviewFlagPanel.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/ReviewFlagPanel.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { useReviewFlagForm } from "../hooks/useReviewFlagForm";
+import { ReviewFlagForm } from "./ReviewFlagForm";
+import { EmptyState } from "./EmptyState";
+import { LoadingState } from "./LoadingState";
+import { ErrorState } from "./ErrorState";
+import { SuccessState } from "./SuccessState";
+
+export const ReviewFlagPanel: React.FC = () => {
+  const { values, state, setField, submit, reset } = useReviewFlagForm();
+  const disabled = state.status === "submitting";
+
+  return (
+    <section
+      aria-labelledby="review-flag-heading"
+      className="mx-auto flex max-w-xl flex-col gap-4 p-4"
+    >
+      <header>
+        <h2 id="review-flag-heading" className="text-lg font-semibold text-gray-900">
+          Legal &amp; Compliance Review Flag
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Raise a legal or compliance review flag for a mail resource. This surface is isolated to
+          the tool folder and is not wired into the main app.
+        </p>
+      </header>
+
+      <ReviewFlagForm
+        values={values}
+        disabled={disabled}
+        onFieldChange={setField}
+        onSubmit={submit}
+      />
+
+      <div aria-live="polite">
+        {state.status === "idle" && <EmptyState />}
+        {state.status === "submitting" && <LoadingState />}
+        {state.status === "error" && <ErrorState error={state.error} onRetry={submit} />}
+        {state.status === "success" && <SuccessState result={state.result} onReset={reset} />}
+      </div>
+    </section>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/SuccessState.tsx
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/SuccessState.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { ReviewFlagResult } from "../contract";
+
+interface SuccessStateProps {
+  result: ReviewFlagResult;
+  onReset?: () => void;
+}
+
+export const SuccessState: React.FC<SuccessStateProps> = ({ result, onReset }) => {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-lg border border-green-200 bg-green-50 p-6"
+    >
+      <p className="text-sm font-semibold text-green-800">Review flag raised</p>
+      <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+        <dt className="text-gray-500">Flag ID</dt>
+        <dd className="font-medium text-gray-900">{result.flagId}</dd>
+        <dt className="text-gray-500">Status</dt>
+        <dd className="font-medium text-gray-900">{result.status}</dd>
+        <dt className="text-gray-500">Review state</dt>
+        <dd className="font-medium text-gray-900">{result.reviewState}</dd>
+        <dt className="text-gray-500">Raised at</dt>
+        <dd className="font-medium text-gray-900">{new Date(result.timestamp).toISOString()}</dd>
+      </dl>
+      <div className="mt-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Audit trail</p>
+        <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-gray-600">
+          {result.auditTrail.map((entry) => (
+            <li key={entry}>{entry}</li>
+          ))}
+        </ul>
+      </div>
+      {onReset && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="mt-4 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+        >
+          Raise another flag
+        </button>
+      )}
+    </div>
+  );
+};

--- a/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
@@ -1,0 +1,6 @@
+export * from "./ReviewFlagPanel";
+export * from "./ReviewFlagForm";
+export * from "./EmptyState";
+export * from "./LoadingState";
+export * from "./ErrorState";
+export * from "./SuccessState";

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/UI_AND_ACCESSIBILITY.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/UI_AND_ACCESSIBILITY.md
@@ -1,0 +1,51 @@
+# UI and Accessibility
+
+Folder-local UI surface for the Legal and Compliance Review Flag tool. Everything
+here lives inside tools/v2/team/legal-and-compliance-review-flag/ and is not
+mounted in the main app, router, or shared design system.
+
+## Components
+
+| Component       | Responsibility                                                             |
+| :-------------- | :------------------------------------------------------------------------- |
+| ReviewFlagPanel | Container that owns form state and renders the active submit state.        |
+| ReviewFlagForm  | Accessible form for reviewer, target resource, reason, severity, evidence. |
+| EmptyState      | Shown before any flag has been raised.                                     |
+| LoadingState    | Busy indicator shown while a flag is being validated.                      |
+| ErrorState      | Typed failure message (code, message, offending fields) with retry.        |
+| SuccessState    | Confirmation with flag id, status, timestamp, and audit trail.             |
+
+The panel is powered by the useReviewFlagForm hook, which wraps the existing
+createReviewFlag contract with a folder-local in-memory dependency. There is no
+network, storage, or main-app dependency; a future integration issue can swap in
+a real ReviewFlagDependency.
+
+## States
+
+- Idle: EmptyState, shown before the first submission.
+- Submitting: LoadingState with role status and aria-live polite.
+- Error: ErrorState with role alert; surfaces the discriminated ReviewFlagError.
+- Success: SuccessState with role status; shows the ReviewFlagResult.
+
+## Accessibility
+
+- The surface is a labeled section (aria-labelledby) with a single h2 heading.
+- Every input and control has an associated label via htmlFor, plus native
+  required semantics on the mandatory fields.
+- The evidence field is described by a hint through aria-describedby.
+- Status and error surfaces use role status / role alert with aria-live so screen
+  readers announce transitions, and the live region wraps the result area.
+- The decorative spinner is marked aria-hidden true.
+- All controls are native form elements with visible text labels and a visible
+  focus ring (focus:ring-2 focus:ring-offset-2), so they are reachable and
+  operable by keyboard.
+- Inputs and the submit button are disabled while a submission is in flight to
+  prevent duplicate flags.
+
+## Visual style
+
+- Layout uses Tailwind utility classes only; no shared design-system components
+  are imported and no global tokens are changed.
+- Neutral gray surfaces, green for success, and red for errors.
+- Spacing and rounded corners follow the utility scale already used across the
+  tools workspace, so the surface stays consistent with the other tools.

--- a/tools/v2/team/legal-and-compliance-review-flag/hooks/useReviewFlagForm.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/hooks/useReviewFlagForm.ts
@@ -1,0 +1,96 @@
+import { useCallback, useState } from "react";
+import {
+  createReviewFlag,
+  isReviewFlagError,
+  type ReviewFlagDependency,
+  type ReviewFlagInput,
+} from "../contract";
+import {
+  INITIAL_FORM_VALUES,
+  type ReviewFlagFormValues,
+  type ReviewFlagSubmitState,
+} from "../ui-types";
+
+/**
+ * In-memory dependency for the isolated demo surface. It authorizes any
+ * non-empty reviewer, treats every resource as existing, and never reports a
+ * duplicate, so the form exercises the success and validation paths without a
+ * backend. A future integration issue can swap in a real ReviewFlagDependency.
+ */
+function createDemoDependency(): ReviewFlagDependency {
+  let counter = 0;
+  return {
+    resolveReviewer: (reviewer: string) => reviewer.trim().length > 0,
+    resourceExists: () => true,
+    findExistingFlag: () => null,
+    persistFlag: () => undefined,
+    now: () => Date.now(),
+    generateId: () => {
+      counter += 1;
+      return "flag-" + counter.toString().padStart(4, "0");
+    },
+  };
+}
+
+function parseEvidenceRefs(raw: string): string[] {
+  return raw
+    .split(/[\n,]/)
+    .map((ref) => ref.trim())
+    .filter((ref) => ref.length > 0);
+}
+
+export function useReviewFlagForm(): {
+  values: ReviewFlagFormValues;
+  state: ReviewFlagSubmitState;
+  setField: <K extends keyof ReviewFlagFormValues>(
+    field: K,
+    value: ReviewFlagFormValues[K],
+  ) => void;
+  submit: () => void;
+  reset: () => void;
+} {
+  const [values, setValues] = useState<ReviewFlagFormValues>(INITIAL_FORM_VALUES);
+  const [state, setState] = useState<ReviewFlagSubmitState>({ status: "idle" });
+
+  const setField = useCallback(
+    <K extends keyof ReviewFlagFormValues>(field: K, value: ReviewFlagFormValues[K]) => {
+      setValues((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
+
+  const submit = useCallback(() => {
+    setState({ status: "submitting" });
+
+    const evidenceRefs = parseEvidenceRefs(values.evidenceRefs);
+    const input: ReviewFlagInput = {
+      reviewer: values.reviewer,
+      targetResource: values.targetResource,
+      flagReason: values.flagReason,
+      severity: values.severity,
+      ...(evidenceRefs.length > 0 ? { evidenceRefs } : {}),
+    };
+
+    void createReviewFlag(input, createDemoDependency())
+      .then((outcome) => {
+        if (isReviewFlagError(outcome)) {
+          setState({ status: "error", error: outcome });
+        } else {
+          setState({ status: "success", result: outcome });
+        }
+      })
+      .catch(() => {
+        setState({
+          status: "error",
+          error: { code: "policy_conflict", message: "Unexpected error while raising the flag." },
+        });
+      });
+  }, [values]);
+
+  const reset = useCallback(() => {
+    setValues(INITIAL_FORM_VALUES);
+    setState({ status: "idle" });
+  }, []);
+
+  return { values, state, setField, submit, reset };
+}

--- a/tools/v2/team/legal-and-compliance-review-flag/ui-types.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/ui-types.ts
@@ -1,0 +1,38 @@
+/**
+ * Folder-local UI state types for the Legal & Compliance Review Flag surface.
+ *
+ * These describe the form submit lifecycle only and reuse the backend
+ * contract types (ReviewFlagResult / ReviewFlagError) so the UI and the pure
+ * contract never drift. Nothing here touches the DOM, network, or database.
+ */
+
+import type { ReviewFlagResult, ReviewFlagError, ReviewFlagSeverity } from "./contract";
+
+export interface ReviewFlagFormValues {
+  reviewer: string;
+  targetResource: string;
+  flagReason: string;
+  severity: ReviewFlagSeverity;
+  evidenceRefs: string;
+}
+
+export type ReviewFlagSubmitState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success"; result: ReviewFlagResult }
+  | { status: "error"; error: ReviewFlagError };
+
+export const INITIAL_FORM_VALUES: ReviewFlagFormValues = {
+  reviewer: "",
+  targetResource: "",
+  flagReason: "",
+  severity: "medium",
+  evidenceRefs: "",
+};
+
+export const SEVERITY_OPTIONS: readonly ReviewFlagSeverity[] = [
+  "low",
+  "medium",
+  "high",
+  "critical",
+];


### PR DESCRIPTION
## Summary

Adds a folder-local UI and accessibility surface for the Legal & Compliance Review Flag tool (tools/v2/team/legal-and-compliance-review-flag/). This builds on the existing pure contract (createReviewFlag) with no changes to it.

## What's included

- ReviewFlagPanel: container that owns form state and renders the active submit state.
- ReviewFlagForm: accessible form for reviewer, target resource, reason, severity, and optional evidence references.
- EmptyState / LoadingState / ErrorState / SuccessState: the four submit states, with ErrorState surfacing the discriminated ReviewFlagError (code, message, offending fields) and a retry action.
- useReviewFlagForm hook: wraps createReviewFlag with an in-memory demo dependency so the form exercises success and validation paths without a backend.
- ui-types.ts: folder-local form/state types that reuse the contract's ReviewFlagResult and ReviewFlagError so UI and contract cannot drift.
- docs/UI_AND_ACCESSIBILITY.md: component overview, state model, and accessibility notes.

## Scope and isolation

- Everything lives inside the tool folder. The surface is not mounted in the main app, router, or shared design system, and no existing files are modified.
- Styling uses Tailwind utility classes only; no shared components or global tokens are touched.
- A future integration issue can swap the in-memory dependency for a real ReviewFlagDependency.

## Accessibility

- Labeled section with a single h2 heading; every control has an associated label via htmlFor.
- Required semantics on mandatory fields; the evidence field is described via aria-describedby.
- Status and error surfaces use role status / role alert with aria-live so screen readers announce transitions.
- Decorative spinner marked aria-hidden; visible focus rings on all controls; inputs disabled while submitting to prevent duplicate flags.

## Testing

- prettier --check: passes.
- eslint: clean, no errors or warnings.
- Follows the same UI pattern as the merged meeting-assignment-tool surface (no unit test shipped for this isolated surface).

Closes #616