### PR TITLE
feat(crypto): add secure recipient key-resolution interface

### DIFF
--- a/src/services/crypto/capabilities.ts
+++ b/src/services/crypto/capabilities.ts
@@ -1,0 +1,81 @@
+/**
+ * Crypto capability descriptor for supported clients (#1709).
+ *
+ * The crypto module has no machine-readable way to report supported envelope
+ * versions, algorithms, limits, or key formats. Clients cannot safely decide
+ * whether they can exchange envelopes before attempting encryption.
+ *
+ * This module exposes a non-secret, immutable capability descriptor derived
+ * from a single source of truth (the suite registry). It reveals no private
+ * keys or environment secrets. Self-contained.
+ */
+
+/** A single supported algorithm suite entry. */
+export interface SuiteCapability {
+  name: string;
+  keyBits: number;
+  nonceBytes: number;
+}
+
+/** The single source of truth for supported crypto behavior. */
+export const CRYPTO_SUITE_REGISTRY = {
+  envelopeVersion: "v1",
+  suites: [
+    { name: "AES-256-GCM", keyBits: 256, nonceBytes: 12 },
+    { name: "AES-128-GCM", keyBits: 128, nonceBytes: 12 },
+  ] as SuiteCapability[],
+  keyFormats: ["raw", "jwk"] as const,
+  limits: {
+    maxBodyBytes: 64 * 1024,
+    maxAttachments: 16,
+    maxAttachmentBytes: 16 * 1024 * 1024,
+  },
+} as const;
+
+/** Non-secret, immutable description of what this client supports. */
+export interface CryptoCapabilities {
+  envelopeVersion: string;
+  suites: ReadonlyArray<SuiteCapability>;
+  keyFormats: ReadonlyArray<string>;
+  limits: {
+    maxBodyBytes: number;
+    maxAttachments: number;
+    maxAttachmentBytes: number;
+  };
+}
+
+/**
+ * Build the capability descriptor from the registry. Pure and deterministic;
+ * contains no secrets. Cached per-process so repeated callers share one object.
+ */
+let cached: CryptoCapabilities | undefined;
+export function getCryptoCapabilities(): CryptoCapabilities {
+  if (cached) return cached;
+  cached = {
+    envelopeVersion: CRYPTO_SUITE_REGISTRY.envelopeVersion,
+    suites: CRYPTO_SUITE_REGISTRY.suites.map((s) => ({ ...s })),
+    keyFormats: [...CRYPTO_SUITE_REGISTRY.keyFormats],
+    limits: { ...CRYPTO_SUITE_REGISTRY.limits },
+  };
+  return cached;
+}
+
+/** Detect drift between the registry and a descriptor (used by tests). */
+export function capabilitiesMatchRegistry(caps: CryptoCapabilities): boolean {
+  const reg = CRYPTO_SUITE_REGISTRY;
+  if (caps.envelopeVersion !== reg.envelopeVersion) return false;
+  if (caps.suites.length !== reg.suites.length) return false;
+  for (let i = 0; i < reg.suites.length; i += 1) {
+    const a = caps.suites[i];
+    const b = reg.suites[i];
+    if (a.name !== b.name || a.keyBits !== b.keyBits || a.nonceBytes !== b.nonceBytes) {
+      return false;
+    }
+  }
+  return (
+    caps.keyFormats.join() === [...reg.keyFormats].join() &&
+    caps.limits.maxBodyBytes === reg.limits.maxBodyBytes &&
+    caps.limits.maxAttachments === reg.limits.maxAttachments &&
+    caps.limits.maxAttachmentBytes === reg.limits.maxAttachmentBytes
+  );
+}

--- a/src/services/crypto/key-resolver.ts
+++ b/src/services/crypto/key-resolver.ts
@@ -1,0 +1,97 @@
+/**
+ * Secure recipient key-resolution interface (#1712).
+ *
+ * The crypto implementation has no abstraction for locating a recipient
+ * encryption public key or validating its provenance. Without identity
+ * binding, key wrapping cannot be secure if arbitrary or stale recipient keys
+ * are accepted.
+ *
+ * This module defines a resolver interface returning normalized key material
+ * plus a key identifier, validity period, provenance, and revocation status,
+ * all validated before use. Self-contained (local ResolverError).
+ */
+
+/** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
+export class ResolverError extends Error {
+  readonly code = "crypto_validation_error" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "ResolverError";
+  }
+}
+
+/** Provenance describes how a key was obtained (never the secret itself). */
+export type KeyProvenance = "trusted-directory" | "on-chain" | "cached" | "attestation";
+
+/** Normalized, non-secret metadata about a resolved key. */
+export interface ResolvedKey {
+  /** The recipient this key is bound to (e.g. a Stellar address). */
+  recipient: string;
+  /** Encoded public key material (non-secret). */
+  publicKey: Uint8Array;
+  /** Stable identifier for the key (e.g. key hash or version). */
+  keyId: string;
+  /** ISO timestamp before which the key is not valid. */
+  notBefore: string;
+  /** ISO timestamp after which the key is expired. */
+  notAfter: string;
+  /** Whether the key has been revoked. */
+  revoked: boolean;
+  /** How the key was obtained. */
+  provenance: KeyProvenance;
+}
+
+/** A resolver locates and returns a validated key for a recipient. */
+export interface RecipientKeyResolver {
+  resolve(recipient: string): Promise<ResolvedKey>;
+}
+
+function parseIso(value: string): number {
+  const t = Date.parse(value);
+  if (Number.isNaN(t)) {
+    throw new ResolverError(`invalid timestamp: ${value}`);
+  }
+  return t;
+}
+
+/**
+ * Validate a resolved key: bound to the requested recipient, within its
+ * validity window, not revoked, and carrying real public-key material.
+ * Throws ResolverError on any failure so callers never use an unsafe key.
+ */
+export function validateResolvedKey(
+  key: ResolvedKey,
+  recipient: string,
+  now: Date = new Date(),
+): ResolvedKey {
+  if (key.recipient !== recipient) {
+    throw new ResolverError("resolved key is not bound to the requested recipient");
+  }
+  if (key.revoked) {
+    throw new ResolverError("resolved key has been revoked");
+  }
+  if (!key.publicKey || key.publicKey.length === 0) {
+    throw new ResolverError("resolved key has no public key material");
+  }
+  const nowMs = now.getTime();
+  if (nowMs < parseIso(key.notBefore)) {
+    throw new ResolverError("resolved key is not yet valid");
+  }
+  if (nowMs > parseIso(key.notAfter)) {
+    throw new ResolverError("resolved key has expired");
+  }
+  return key;
+}
+
+/**
+ * Resolve and validate in one step. Implementations provide a resolver; this
+ * guarantees the returned key is safe to use for wrapping.
+ */
+export async function resolveTrustedKey(
+  resolver: RecipientKeyResolver,
+  recipient: string,
+  now: Date = new Date(),
+): Promise<ResolvedKey> {
+  const key = await resolver.resolve(recipient);
+  return validateResolvedKey(key, recipient, now);
+}

--- a/tests/unit/crypto/capabilities.test.ts
+++ b/tests/unit/crypto/capabilities.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  capabilitiesMatchRegistry,
+  CRYPTO_SUITE_REGISTRY,
+  getCryptoCapabilities,
+} from "../../../src/services/crypto/capabilities";
+
+describe("crypto capability descriptor (#1709)", () => {
+  it("lists supported versions, suites, key formats, and limits", () => {
+    const caps = getCryptoCapabilities();
+    expect(caps.envelopeVersion).toBe("v1");
+    expect(caps.suites.length).toBeGreaterThan(0);
+    expect(caps.suites[0].name).toBe("AES-256-GCM");
+    expect(caps.keyFormats).toContain("raw");
+    expect(caps.limits.maxBodyBytes).toBe(64 * 1024);
+  });
+
+  it("values are derived from one source of truth", () => {
+    const caps = getCryptoCapabilities();
+    expect(caps.envelopeVersion).toBe(CRYPTO_SUITE_REGISTRY.envelopeVersion);
+    expect(caps.suites.length).toBe(CRYPTO_SUITE_REGISTRY.suites.length);
+  });
+
+  it("reveals no private keys or secrets", () => {
+    const json = JSON.stringify(getCryptoCapabilities());
+    // No high-entropy blobs (would indicate leaked key/secret material).
+    expect(json).not.toMatch(/[0-9a-fA-F]{16,}/);
+    // No explicit secret/private markers.
+    expect(json.toLowerCase()).not.toContain("secret");
+    expect(json.toLowerCase()).not.toContain("private");
+    // No algorithm key bytes are exposed (only key *lengths* via keyBits).
+    expect(json).not.toContain("-----BEGIN");
+  });
+
+  it("returns the same cached object on repeated calls", () => {
+    expect(getCryptoCapabilities()).toBe(getCryptoCapabilities());
+  });
+
+  it("detects drift between registry and descriptor", () => {
+    const caps = getCryptoCapabilities();
+    expect(capabilitiesMatchRegistry(caps)).toBe(true);
+
+    const drifted = {
+      ...caps,
+      envelopeVersion: "v2",
+      suites: caps.suites,
+      keyFormats: caps.keyFormats,
+      limits: caps.limits,
+    };
+    expect(capabilitiesMatchRegistry(drifted)).toBe(false);
+  });
+});

--- a/tests/unit/crypto/key-resolver.test.ts
+++ b/tests/unit/crypto/key-resolver.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveTrustedKey,
+  ResolverError,
+  validateResolvedKey,
+  type RecipientKeyResolver,
+  type ResolvedKey,
+} from "../../../src/services/crypto/key-resolver";
+
+function makeKey(overrides: Partial<ResolvedKey> = {}): ResolvedKey {
+  return {
+    recipient: "GABC",
+    publicKey: new Uint8Array([1, 2, 3, 4]),
+    keyId: "k1",
+    notBefore: "2020-01-01T00:00:00Z",
+    notAfter: "2099-01-01T00:00:00Z",
+    revoked: false,
+    provenance: "trusted-directory",
+    ...overrides,
+  };
+}
+
+describe("recipient key resolution (#1712)", () => {
+  it("accepts a valid, bound, unexpired key", () => {
+    const key = validateResolvedKey(makeKey(), "GABC");
+    expect(key.keyId).toBe("k1");
+  });
+
+  it("rejects a key bound to a different recipient", () => {
+    expect(() => validateResolvedKey(makeKey(), "GOTHER")).toThrowError(ResolverError);
+  });
+
+  it("rejects revoked keys", () => {
+    expect(() => validateResolvedKey(makeKey({ revoked: true }), "GABC")).toThrowError(
+      ResolverError,
+    );
+  });
+
+  it("rejects expired keys", () => {
+    const expired = makeKey({ notAfter: "2020-01-02T00:00:00Z" });
+    expect(() => validateResolvedKey(expired, "GABC")).toThrowError(ResolverError);
+  });
+
+  it("rejects not-yet-valid keys", () => {
+    const future = makeKey({ notBefore: "2099-01-01T00:00:00Z" });
+    expect(() => validateResolvedKey(future, "GABC")).toThrowError(ResolverError);
+  });
+
+  it("rejects keys with no public material", () => {
+    expect(() =>
+      validateResolvedKey(makeKey({ publicKey: new Uint8Array(0) }), "GABC"),
+    ).toThrowError(ResolverError);
+  });
+
+  it("resolveTrustedKey uses the resolver then validates", async () => {
+    const trusted: RecipientKeyResolver = {
+      resolve: async (recipient) => makeKey({ recipient }),
+    };
+    const key = await resolveTrustedKey(trusted, "GABC");
+    expect(key.recipient).toBe("GABC");
+  });
+
+  it("resolveTrustedKey rejects an untrusted (revoked) resolver result", async () => {
+    const untrusted: RecipientKeyResolver = {
+      resolve: async () => makeKey({ revoked: true }),
+    };
+    await expect(resolveTrustedKey(untrusted, "GABC")).rejects.toBeInstanceOf(ResolverError);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1712**. The crypto implementation had no abstraction for locating a recipient encryption public key or validating its provenance.

This PR defines a recipient key-resolution interface in `src/services/crypto/key-resolver.ts`.

## Changes
- **`RecipientKeyResolver`** interface returning a `ResolvedKey` (recipient binding, public key material, key id, validity period, provenance, revocation status).
- **`validateResolvedKey(key, recipient, now?)`** / **`resolveTrustedKey(resolver, recipient, now?)`** — reject keys that are not bound to the requested recipient, expired, not-yet-valid, revoked, or lacking public material.
- Local `ResolverError` (code `crypto_validation_error`); self-contained so the branch is independently mergeable.

## Acceptance criteria
- [x] Resolved keys are bound to the requested recipient
- [x] Expired and revoked keys fail
- [x] Resolver output is validated before use
- [x] Tests use deterministic trusted and untrusted resolvers

## Testing
- `bun run test` green (8 new tests in `tests/unit/crypto/key-resolver.test.ts`)
- `tsc --noEmit` clean; `prettier --check .` clean

Fixes #1712