### PR TITLE
security(crypto): make content-encryption keys non-extractable by default (#1691)

### DIFF
--- a/src/services/crypto/__tests__/content-key.test.ts
+++ b/src/services/crypto/__tests__/content-key.test.ts
@@ -1,0 +1,38 @@
+import { generateContentKey } from '../content-key';
+
+describe('Content Key Security - Non-extractable default (#1691)', () => {
+  it('should generate content-encryption keys as non-extractable by default', async () => {
+    const key = await generateContentKey();
+    
+    expect(key).toBeDefined();
+    expect(key.extractable).toBe(false);
+    expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
+  });
+
+  it('should fail when attempting to export a default non-extractable key', async () => {
+    const key = await generateContentKey();
+
+    // Exporting non-extractable key should reject in Web Crypto API
+    await expect(crypto.subtle.exportKey('raw', key)).rejects.toThrow();
+  });
+
+  it('should allow encrypt and decrypt operations with non-extractable key', async () => {
+    const key = await generateContentKey();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const data = new TextEncoder().encode('Hello, Stealth Mail!');
+
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      data
+    );
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      encrypted
+    );
+
+    expect(new TextDecoder().decode(decrypted)).toBe('Hello, Stealth Mail!');
+  });
+});

--- a/src/services/crypto/__tests__/content-key.test.ts
+++ b/src/services/crypto/__tests__/content-key.test.ts
@@ -1,38 +1,30 @@
-import { generateContentKey } from '../content-key';
+import { generateContentKey } from "../content-key";
 
-describe('Content Key Security - Non-extractable default (#1691)', () => {
-  it('should generate content-encryption keys as non-extractable by default', async () => {
+describe("Content Key Security - Non-extractable default (#1691)", () => {
+  it("should generate content-encryption keys as non-extractable by default", async () => {
     const key = await generateContentKey();
-    
+
     expect(key).toBeDefined();
     expect(key.extractable).toBe(false);
-    expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
+    expect(key.usages).toEqual(expect.arrayContaining(["encrypt", "decrypt"]));
   });
 
-  it('should fail when attempting to export a default non-extractable key', async () => {
+  it("should fail when attempting to export a default non-extractable key", async () => {
     const key = await generateContentKey();
 
     // Exporting non-extractable key should reject in Web Crypto API
-    await expect(crypto.subtle.exportKey('raw', key)).rejects.toThrow();
+    await expect(crypto.subtle.exportKey("raw", key)).rejects.toThrow();
   });
 
-  it('should allow encrypt and decrypt operations with non-extractable key', async () => {
+  it("should allow encrypt and decrypt operations with non-extractable key", async () => {
     const key = await generateContentKey();
     const iv = crypto.getRandomValues(new Uint8Array(12));
-    const data = new TextEncoder().encode('Hello, Stealth Mail!');
+    const data = new TextEncoder().encode("Hello, Stealth Mail!");
 
-    const encrypted = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      data
-    );
+    const encrypted = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, data);
 
-    const decrypted = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      encrypted
-    );
+    const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, encrypted);
 
-    expect(new TextDecoder().decode(decrypted)).toBe('Hello, Stealth Mail!');
+    expect(new TextDecoder().decode(decrypted)).toBe("Hello, Stealth Mail!");
   });
 });

--- a/src/services/crypto/content-key.ts
+++ b/src/services/crypto/content-key.ts
@@ -1,0 +1,62 @@
+export interface ContentKeyOptions {
+  length?: 128 | 192 | 256;
+  /**
+   * Whether the key can be exported using exportKey.
+   * Defaults to false for security hardening (Issue #1691).
+   */
+  extractable?: boolean;
+  usages?: KeyUsage[];
+}
+
+/**
+ * Generates an AES-GCM content-encryption key.
+ * By default, keys are non-extractable (`extractable: false`).
+ */
+export async function generateContentKey(
+  options: ContentKeyOptions = {}
+): Promise<CryptoKey> {
+  const {
+    length = 256,
+    extractable = false, // Enforce non-extractable by default
+    usages = ['encrypt', 'decrypt'],
+  } = options;
+
+  return await crypto.subtle.generateKey(
+    {
+      name: 'AES-GCM',
+      length,
+    },
+    extractable,
+    usages
+  );
+}
+
+/**
+ * Seals content into an envelope by encrypting payload data with a non-extractable AES key
+ * and wrapping the content key for the intended recipient.
+ */
+export async function sealEnvelope(
+  payload: Uint8Array,
+  recipientPublicKey: CryptoKey
+): Promise<{ encryptedData: ArrayBuffer; wrappedKey: ArrayBuffer; iv: Uint8Array }> {
+  // Generate non-extractable content key within the wrapping boundary
+  const contentKey = await generateContentKey({ extractable: false });
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+
+  // Encrypt payload using non-extractable key
+  const encryptedData = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    contentKey,
+    payload
+  );
+
+  // Wrap key within the boundary using Web Crypto wrapKey
+  const wrappedKey = await crypto.subtle.wrapKey(
+    'raw',
+    contentKey,
+    recipientPublicKey,
+    { name: 'RSA-OAEP' }
+  );
+
+  return { encryptedData, wrappedKey, iv };
+}

--- a/src/services/crypto/content-key.ts
+++ b/src/services/crypto/content-key.ts
@@ -12,22 +12,20 @@ export interface ContentKeyOptions {
  * Generates an AES-GCM content-encryption key.
  * By default, keys are non-extractable (`extractable: false`).
  */
-export async function generateContentKey(
-  options: ContentKeyOptions = {}
-): Promise<CryptoKey> {
+export async function generateContentKey(options: ContentKeyOptions = {}): Promise<CryptoKey> {
   const {
     length = 256,
     extractable = false, // Enforce non-extractable by default
-    usages = ['encrypt', 'decrypt'],
+    usages = ["encrypt", "decrypt"],
   } = options;
 
   return await crypto.subtle.generateKey(
     {
-      name: 'AES-GCM',
+      name: "AES-GCM",
       length,
     },
     extractable,
-    usages
+    usages,
   );
 }
 
@@ -37,26 +35,19 @@ export async function generateContentKey(
  */
 export async function sealEnvelope(
   payload: Uint8Array,
-  recipientPublicKey: CryptoKey
+  recipientPublicKey: CryptoKey,
 ): Promise<{ encryptedData: ArrayBuffer; wrappedKey: ArrayBuffer; iv: Uint8Array }> {
   // Generate non-extractable content key within the wrapping boundary
   const contentKey = await generateContentKey({ extractable: false });
   const iv = crypto.getRandomValues(new Uint8Array(12));
 
   // Encrypt payload using non-extractable key
-  const encryptedData = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
-    contentKey,
-    payload
-  );
+  const encryptedData = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, contentKey, payload);
 
   // Wrap key within the boundary using Web Crypto wrapKey
-  const wrappedKey = await crypto.subtle.wrapKey(
-    'raw',
-    contentKey,
-    recipientPublicKey,
-    { name: 'RSA-OAEP' }
-  );
+  const wrappedKey = await crypto.subtle.wrapKey("raw", contentKey, recipientPublicKey, {
+    name: "RSA-OAEP",
+  });
 
   return { encryptedData, wrappedKey, iv };
 }


### PR DESCRIPTION
## Description
Fixes #1691

This PR updates content key generation in `src/services/crypto/content-key.ts` to default to `extractable: false`. This ensures raw key material cannot be accidentally exposed or exported outside the crypto wrapping boundary.

## Changes Introduced
- Updated `generateContentKey()` options so `extractable` defaults to `false`.
- Isolated any required key operations inside `src/services/crypto/` wrapping boundaries.
- Added unit tests in `src/services/crypto/__tests__/content-key.test.ts` asserting:
  - Key `extractable` property is `false` by default.
  - Attempting `crypto.subtle.exportKey('raw', key)` rejects as expected.
  - Encryption and decryption operate normally with non-extractable keys.

## Checklist
- [x] Content keys are non-extractable outside the wrapping boundary (`extractable === false`).
- [x] Public functions do not expose raw key material or unnecessary `CryptoKey` instances.
- [x] Changes are strictly confined to `src/services/crypto/`.
- [x] All unit tests pass locally.

## Verification / Testing
Run crypto unit tests:
```bash
npm test src/services/crypto
