### PR TITLE
Closes #1721 Implemented deterministic cryptographic test-vector inje…

### DIFF
--- a/src/services/crypto/envelope.ts
+++ b/src/services/crypto/envelope.ts
@@ -7,6 +7,8 @@
  * plaintext is never returned, logged, or attached to thrown errors.
  */
 
+import { getCryptoTestVectors } from "./testing";
+
 export interface EnvelopeAttachment {
   filename: string;
   content_type: string;
@@ -99,14 +101,23 @@ export async function sealEnvelope(input: SealEnvelopeInput): Promise<SealedEnve
     throw new Error("Cannot seal an empty message body");
   }
 
-  const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
-    "encrypt",
-    "decrypt",
-  ]);
-  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const { generateKey, getRandomValues, now } = getCryptoTestVectors();
+
+  const key = generateKey
+    ? await generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"])
+    : await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+        "encrypt",
+        "decrypt",
+      ]);
+  const ivArray = new Uint8Array(12);
+  const iv = getRandomValues ? getRandomValues(ivArray) : crypto.getRandomValues(ivArray);
   const plaintext = new TextEncoder().encode(body);
   const ciphertext = new Uint8Array(
-    await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext),
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv as BufferSource },
+      key,
+      plaintext as BufferSource,
+    ),
   );
 
   // AES-GCM appends a 16-byte auth tag to the end of the ciphertext.
@@ -131,7 +142,7 @@ export async function sealEnvelope(input: SealEnvelopeInput): Promise<SealedEnve
     version: "v1",
     sender: input.sender,
     recipient: input.recipient,
-    timestamp: new Date().toISOString(),
+    timestamp: now ? now().toISOString() : new Date().toISOString(),
     encryption_metadata: {
       algorithm: "AES-256-GCM",
       nonce: toHex(iv),

--- a/src/services/crypto/key-resolver.ts
+++ b/src/services/crypto/key-resolver.ts
@@ -11,6 +11,8 @@
  * all validated before use. Self-contained (local ResolverError).
  */
 
+import { getCryptoTestVectors } from "./testing";
+
 /** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
 export class ResolverError extends Error {
   readonly code = "crypto_validation_error" as const;
@@ -62,7 +64,7 @@ function parseIso(value: string): number {
 export function validateResolvedKey(
   key: ResolvedKey,
   recipient: string,
-  now: Date = new Date(),
+  now: Date = getCryptoTestVectors().now ? getCryptoTestVectors().now!() : new Date(),
 ): ResolvedKey {
   if (key.recipient !== recipient) {
     throw new ResolverError("resolved key is not bound to the requested recipient");
@@ -90,7 +92,7 @@ export function validateResolvedKey(
 export async function resolveTrustedKey(
   resolver: RecipientKeyResolver,
   recipient: string,
-  now: Date = new Date(),
+  now: Date = getCryptoTestVectors().now ? getCryptoTestVectors().now!() : new Date(),
 ): Promise<ResolvedKey> {
   const key = await resolver.resolve(recipient);
   return validateResolvedKey(key, recipient, now);

--- a/src/services/crypto/nonce.ts
+++ b/src/services/crypto/nonce.ts
@@ -45,22 +45,12 @@ export const NONCE_LENGTHS = {
 
 export type NonceAlgorithm = keyof typeof NONCE_LENGTHS;
 
-/** A test-only deterministic generator; undefined means use production CSPRNG. */
-export type NonceGenerator = (length: number) => Uint8Array;
-
-let injectedGenerator: NonceGenerator | undefined;
-
-/**
- * Test seam: install a deterministic generator. Passing `undefined` restores
- * production behavior. MUST NOT be used outside tests.
- */
-export function __setNonceGeneratorForTesting(generator: NonceGenerator | undefined): void {
-  injectedGenerator = generator;
-}
+import { getCryptoTestVectors } from "./testing";
 
 function randomBytes(length: number): Uint8Array {
-  if (injectedGenerator) {
-    return injectedGenerator(length);
+  const { getRandomValues } = getCryptoTestVectors();
+  if (getRandomValues) {
+    return getRandomValues(new Uint8Array(length));
   }
   if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
     throw new NonceError("crypto_algorithm_error", "secure random source unavailable");

--- a/src/services/crypto/random.ts
+++ b/src/services/crypto/random.ts
@@ -27,7 +27,13 @@ export const MESSAGE_ID_BYTES = 16;
 /** Encoding used for the identifier string. */
 export type MessageIdEncoding = "hex" | "base64url";
 
+import { getCryptoTestVectors } from "./testing";
+
 function getRandomBytes(length: number): Uint8Array {
+  const { getRandomValues } = getCryptoTestVectors();
+  if (getRandomValues) {
+    return getRandomValues(new Uint8Array(length));
+  }
   if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
     throw new CryptoIdError("cryptographically secure random source is unavailable");
   }

--- a/src/services/crypto/testing.ts
+++ b/src/services/crypto/testing.ts
@@ -8,9 +8,14 @@ export interface CryptoTestVectors {
   getRandomValues?: (array: Uint8Array) => Uint8Array;
   now?: () => Date;
   generateKey?: (
-    algorithm: AlgorithmIdentifier | RsaHashedKeyGenParams | EcKeyGenParams | HmacKeyGenParams | AesKeyGenParams,
+    algorithm:
+      | AlgorithmIdentifier
+      | RsaHashedKeyGenParams
+      | EcKeyGenParams
+      | HmacKeyGenParams
+      | AesKeyGenParams,
     extractable: boolean,
-    keyUsages: KeyUsage[]
+    keyUsages: KeyUsage[],
   ) => Promise<any>;
 }
 

--- a/src/services/crypto/testing.ts
+++ b/src/services/crypto/testing.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependency injection for deterministic cryptographic tests.
+ *
+ * NEVER EXPORT THIS FROM PUBLIC INDEX. NEVER USE IN PRODUCTION.
+ */
+
+export interface CryptoTestVectors {
+  getRandomValues?: (array: Uint8Array) => Uint8Array;
+  now?: () => Date;
+  generateKey?: (
+    algorithm: AlgorithmIdentifier | RsaHashedKeyGenParams | EcKeyGenParams | HmacKeyGenParams | AesKeyGenParams,
+    extractable: boolean,
+    keyUsages: KeyUsage[]
+  ) => Promise<any>;
+}
+
+let currentVectors: CryptoTestVectors = {};
+
+export function setCryptoTestVectors(vectors: CryptoTestVectors): void {
+  currentVectors = { ...currentVectors, ...vectors };
+}
+
+export function resetCryptoTestVectors(): void {
+  currentVectors = {};
+}
+
+export function getCryptoTestVectors(): CryptoTestVectors {
+  return currentVectors;
+}

--- a/tests/unit/crypto/nonce.test.ts
+++ b/tests/unit/crypto/nonce.test.ts
@@ -1,18 +1,18 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
-  __setNonceGeneratorForTesting,
   decodeNonce,
   encodeNonce,
   generateNonce,
   validateNonceLength,
   NONCE_LENGTHS,
 } from "../../../src/services/crypto/nonce";
+import { setCryptoTestVectors, resetCryptoTestVectors } from "../../../src/services/crypto/testing";
 
 describe("secure nonce helpers (#1694)", () => {
   afterEach(() => {
     // Always restore production randomness.
-    __setNonceGeneratorForTesting(undefined);
+    resetCryptoTestVectors();
   });
 
   it("derives nonce length from the algorithm suite", () => {
@@ -29,11 +29,12 @@ describe("secure nonce helpers (#1694)", () => {
 
   it("accepts a deterministic injection for tests without weakening production", () => {
     let counter = 0;
-    __setNonceGeneratorForTesting((length: number) => {
-      const bytes = new Uint8Array(length);
-      for (let i = 0; i < length; i += 1) bytes[i] = (counter + i) & 0xff;
-      counter += 1;
-      return bytes;
+    setCryptoTestVectors({
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i += 1) array[i] = (counter + i) & 0xff;
+        counter += 1;
+        return array;
+      },
     });
 
     const nonce = generateNonce("AES-256-GCM");


### PR DESCRIPTION
…ction without production downgrades

# Add deterministic cryptographic test-vector injection

Closes #1721 

## Context and Problem
Our interoperability and regression tests require deterministic nonces, keys, and timestamps to assert exact byte-for-byte correctness on cryptographic envelopes. However, the current implementations in the crypto modules directly call global randomness and `Date` APIs. This makes it difficult to reproducibly generate the exact same envelopes in a testing environment without relying on unsafe, global mocking that could easily downgrade the security of our production entry points.

## Proposed Solution
This PR introduces a safe, internal dependency injection framework for cryptographic operations to isolate test hooks completely from production code. 

By centralizing the injection logic into a new, unexported `testing.ts` module, we can inject mocked behaviors safely. Production operations naturally fallback to secure platform defaults when these test hooks are undefined. 

## Changes Made
- **[NEW] `src/services/crypto/testing.ts`**: Created a centralized internal state manager for the test hooks. It exposes safe setter and getter methods (`setCryptoTestVectors`, `resetCryptoTestVectors`, `getCryptoTestVectors`) for `getRandomValues`, `now`, and `generateKey`. 
- **`src/services/crypto/random.ts`**: Refactored `getRandomBytes` to consult `getCryptoTestVectors().getRandomValues` before falling back to `crypto.getRandomValues`.
- **`src/services/crypto/nonce.ts`**: Removed the one-off `__setNonceGeneratorForTesting` function. Updated `randomBytes` to utilize the new centralized `getCryptoTestVectors().getRandomValues`.
- **`src/services/crypto/envelope.ts`**: Updated `sealEnvelope` to leverage `testing.ts` hooks for AES-GCM key generation, IV generation, and envelope timestamping. Falls back smoothly to `crypto.subtle.generateKey`, `crypto.getRandomValues`, and `new Date()` securely.
- **`src/services/crypto/key-resolver.ts`**: Updated validation function default parameters to pull the current time from `getCryptoTestVectors().now` if specified.
- **`tests/unit/crypto/nonce.test.ts`**: Updated the tests to use the new `setCryptoTestVectors` implementation, validating that the test suite cleanly adapts to the new framework. 

## Security Impact
- **No Production Downgrades**: The test vectors reside within a module (`testing.ts`) that will never be exported via the public `crypto` index. Production logic safely defaults to the native Web Crypto and `Date` APIs because the test vectors are `undefined` by default.
- **No Input Tampering**: The hooks cannot be manipulated or activated via message inputs.

## Testing
- Verified that all 72 tests across 9 suites in the `tests/unit/crypto/` directory pass cleanly with the new internal structure.
