### PR TITLE
remove filename

### DIFF
--- a/src/services/crypto/envelope.test.ts
+++ b/src/services/crypto/envelope.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { sealEnvelope } from "./envelope";
+
+describe("services/crypto/envelope", () => {
+  const defaultInput = {
+    sender: "alice@example.com",
+    recipient: "bob@example.com",
+    body: "Hello Bob",
+  };
+
+  it("should successfully seal an envelope without attachments", async () => {
+    const result = await sealEnvelope(defaultInput);
+    expect(result).toBeDefined();
+    expect(result.payload.attachments).toHaveLength(0);
+  });
+
+  it("should successfully seal an envelope with an attachment providing data", async () => {
+    const data = new TextEncoder().encode("Hello Attachment").buffer;
+    const result = await sealEnvelope({
+      ...defaultInput,
+      attachments: [
+        {
+          filename: "test.txt",
+          content_type: "text/plain",
+          size_bytes: 16,
+          data,
+        },
+      ],
+    });
+    expect(result.payload.attachments).toHaveLength(1);
+    expect(result.payload.attachments[0].content_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("should successfully seal an envelope with an attachment providing only content_hash", async () => {
+    const dummyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; // sha256 empty string
+    const result = await sealEnvelope({
+      ...defaultInput,
+      attachments: [
+        {
+          filename: "test.txt",
+          content_type: "text/plain",
+          size_bytes: 0,
+          content_hash: dummyHash,
+        },
+      ],
+    });
+    expect(result.payload.attachments).toHaveLength(1);
+    expect(result.payload.attachments[0].content_hash).toBe(dummyHash);
+  });
+
+  it("should fail when neither data nor content_hash is provided for an attachment", async () => {
+    await expect(
+      sealEnvelope({
+        ...defaultInput,
+        attachments: [
+          {
+            filename: "test.txt",
+            content_type: "text/plain",
+            size_bytes: 100,
+          },
+        ],
+      }),
+    ).rejects.toThrow(/must include either data bytes or a validated content_hash/);
+  });
+
+  it("should fail when both data and content_hash are provided but they mismatch", async () => {
+    const data = new TextEncoder().encode("Hello Attachment").buffer;
+    const invalidHash = "invalidhash00000000000000000000000000000000000000000000000000000";
+    await expect(
+      sealEnvelope({
+        ...defaultInput,
+        attachments: [
+          {
+            filename: "test.txt",
+            content_type: "text/plain",
+            size_bytes: 16,
+            data,
+            content_hash: invalidHash,
+          },
+        ],
+      }),
+    ).rejects.toThrow(/Mismatch between supplied bytes and content_hash/);
+  });
+
+  it("should succeed when both data and content_hash are provided and they match", async () => {
+    const data = new TextEncoder().encode("Hello Attachment").buffer;
+    // Hash of "Hello Attachment"
+    const validHash = "c7a829ba2c1bb8283e3391b4501a1c8f1d3c1de5bf5cb5cff0207ed2a15c82ff";
+
+    const result = await sealEnvelope({
+      ...defaultInput,
+      attachments: [
+        {
+          filename: "test.txt",
+          content_type: "text/plain",
+          size_bytes: 16,
+          data,
+          content_hash: validHash,
+        },
+      ],
+    });
+    expect(result.payload.attachments).toHaveLength(1);
+    expect(result.payload.attachments[0].content_hash).toBe(validHash);
+  });
+});

--- a/src/services/crypto/envelope.ts
+++ b/src/services/crypto/envelope.ts
@@ -45,6 +45,7 @@ export interface SealEnvelopeInput {
     content_type: string;
     size_bytes: number;
     data?: ArrayBuffer;
+    content_hash?: string;
   }>;
 }
 
@@ -114,11 +115,21 @@ export async function sealEnvelope(input: SealEnvelopeInput): Promise<SealedEnve
 
   const attachments: EnvelopeAttachment[] = [];
   for (const attachment of input.attachments ?? []) {
-    const hash = attachment.data
-      ? await sha256Hex(new Uint8Array(attachment.data))
-      : await sha256Hex(
-          new TextEncoder().encode(attachment.filename + ":" + attachment.size_bytes),
+    let hash: string;
+    if (attachment.data) {
+      hash = await sha256Hex(new Uint8Array(attachment.data));
+      if (attachment.content_hash && hash !== attachment.content_hash) {
+        throw new Error(
+          `Mismatch between supplied bytes and content_hash for attachment ${attachment.filename}`,
         );
+      }
+    } else if (attachment.content_hash) {
+      hash = attachment.content_hash;
+    } else {
+      throw new Error(
+        `Attachment ${attachment.filename} must include either data bytes or a validated content_hash`,
+      );
+    }
     attachments.push({
       filename: attachment.filename,
       content_type: attachment.content_type,


### PR DESCRIPTION
Close #1699 
---

### Summary of the issue
When `attachment.data` is absent, the `envelope.ts` crypto service hashes the `filename` and `size_bytes` as a fallback to record the `content_hash`. This synthesized hash creates false integrity claims, as it is not a genuine cryptographic commitment to the attachment's actual content.
---
### Root cause
The fallback logic inside the `sealEnvelope` function incorrectly assumes that metadata (filename + size) is an acceptable substitute for a content digest when the payload bytes are not immediately available. This allows an attachment descriptor to be sealed without actual cryptographic proof of its content.
---
### Solution implemented
Removed the metadata-based fallback hashing mechanism. The system now enforces strict validation, requiring callers to explicitly provide either the raw `data` bytes or an externally verified `content_hash`. If both are provided, the system ensures they cryptographically match before sealing.
---
### Key changes made
- **`src/services/crypto/envelope.ts`**: Updated the `SealEnvelopeInput` interface to include an optional `content_hash` field for attachments.
- **`src/services/crypto/envelope.ts`**: Replaced the ternary fallback logic in `sealEnvelope` with strict validation that computes the hash from `data`, uses the supplied `content_hash`, or explicitly fails.
- **`src/services/crypto/envelope.test.ts`**: Added a new test suite covering missing inputs, valid explicit inputs, and mismatched payload scenarios to prevent future regressions.
---
### Any trade-offs or considerations
Callers interacting with `sealEnvelope` must now explicitly compute the hash if they choose to omit the payload `data` inside the envelope payload builder. This adds slightly more responsibility to the caller but significantly increases system integrity guarantees.
---
### Testing steps (how to verify the fix)
1. Provide an attachment with only `filename` and `size_bytes` -> Validates that it throws an error (`Attachment <name> must include either data bytes or a validated content_hash`).
2. Provide an attachment with `data` and an incorrect `content_hash` -> Validates that it throws a mismatch error.
3. Provide an attachment with only an explicitly valid `content_hash` -> Validates that it generates the sealed envelope successfully.
4. Run tests: `npx vitest run src/services/crypto/envelope.test.ts` to ensure edge cases pass.
---
_Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch.Thank you!_
