### PR TITLE
Encrypt attachment bytes instead of storing only attachment hashes

### DIFF
--- a/src/services/crypto/envelope.test.ts
+++ b/src/services/crypto/envelope.test.ts
@@ -29,6 +29,11 @@ describe("services/crypto/envelope", () => {
     });
     expect(result.payload.attachments).toHaveLength(1);
     expect(result.payload.attachments[0].content_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.payload.attachments[0].ciphertext).toBeDefined();
+    expect(result.payload.attachments[0].encryption_metadata).toBeDefined();
+    expect(result.payload.attachments[0].encryption_metadata?.algorithm).toBe("AES-256-GCM");
+    expect(result.payload.attachments[0].encryption_metadata?.nonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(result.payload.attachments[0].encryption_metadata?.mac).toMatch(/^[0-9a-f]{32}$/);
   });
 
   it("should successfully seal an envelope with an attachment providing only content_hash", async () => {
@@ -46,6 +51,8 @@ describe("services/crypto/envelope", () => {
     });
     expect(result.payload.attachments).toHaveLength(1);
     expect(result.payload.attachments[0].content_hash).toBe(dummyHash);
+    expect(result.payload.attachments[0].ciphertext).toBeUndefined();
+    expect(result.payload.attachments[0].encryption_metadata).toBeUndefined();
   });
 
   it("should fail when neither data nor content_hash is provided for an attachment", async () => {
@@ -101,5 +108,7 @@ describe("services/crypto/envelope", () => {
     });
     expect(result.payload.attachments).toHaveLength(1);
     expect(result.payload.attachments[0].content_hash).toBe(validHash);
+    expect(result.payload.attachments[0].ciphertext).toBeDefined();
+    expect(result.payload.attachments[0].encryption_metadata).toBeDefined();
   });
 });

--- a/src/services/crypto/envelope.ts
+++ b/src/services/crypto/envelope.ts
@@ -12,6 +12,8 @@ export interface EnvelopeAttachment {
   content_type: string;
   size_bytes: number;
   content_hash: string;
+  encryption_metadata?: EncryptionMetadata;
+  ciphertext?: string;
 }
 
 export interface EncryptionMetadata {
@@ -116,13 +118,30 @@ export async function sealEnvelope(input: SealEnvelopeInput): Promise<SealedEnve
   const attachments: EnvelopeAttachment[] = [];
   for (const attachment of input.attachments ?? []) {
     let hash: string;
+    let encMetadata: EncryptionMetadata | undefined;
+    let ciphertextStr: string | undefined;
+
     if (attachment.data) {
-      hash = await sha256Hex(new Uint8Array(attachment.data));
+      const dataBytes = new Uint8Array(attachment.data);
+      hash = await sha256Hex(dataBytes);
       if (attachment.content_hash && hash !== attachment.content_hash) {
         throw new Error(
           `Mismatch between supplied bytes and content_hash for attachment ${attachment.filename}`,
         );
       }
+
+      const attIv = crypto.getRandomValues(new Uint8Array(12));
+      const attCiphertext = new Uint8Array(
+        await crypto.subtle.encrypt({ name: "AES-GCM", iv: attIv }, key, dataBytes),
+      );
+      const attTag = attCiphertext.slice(attCiphertext.length - GCM_TAG_BYTES);
+
+      encMetadata = {
+        algorithm: "AES-256-GCM",
+        nonce: toHex(attIv),
+        mac: toHex(attTag),
+      };
+      ciphertextStr = toBase64(attCiphertext);
     } else if (attachment.content_hash) {
       hash = attachment.content_hash;
     } else {
@@ -135,6 +154,8 @@ export async function sealEnvelope(input: SealEnvelopeInput): Promise<SealedEnve
       content_type: attachment.content_type,
       size_bytes: attachment.size_bytes,
       content_hash: hash,
+      ...(encMetadata ? { encryption_metadata: encMetadata } : {}),
+      ...(ciphertextStr ? { ciphertext: ciphertextStr } : {}),
     });
   }
 


### PR DESCRIPTION
Close #1698 
---

## Summary of the issue
When sealing an envelope with attachments, the current implementation only calculates and stores the content descriptor and hash, but completely ignores the attachment data bytes, meaning attachments are neither encrypted nor included in the final payload. Messages thus cannot provide confidential delivery for their attachments.
---
## Root cause
The `sealEnvelope` function loops through the attachment inputs to build descriptors, but intentionally omitted the steps for initializing encryption parameters, encrypting the byte stream, and attaching the resulting ciphertexts to the finalized output.
---
## Solution implemented
Updated `sealEnvelope` to fully protect attachment data within the payload structure:
1. Reused the primary AES-256-GCM message key while dynamically generating a unique 12-byte initialization vector (`iv`) for every individual attachment.
2. Encrypted the attachment data and extracted the resulting authentication tag (MAC).
3. Attached the `encryption_metadata` and the base64-encoded `ciphertext` directly into the attachment descriptor inside the payload, fully fulfilling the fail-closed / extensibility strategy documented in the envelope spec. 
---
## Key changes made
- **`src/services/crypto/envelope.ts`**: 
  - Added `encryption_metadata` and `ciphertext` to the `EnvelopeAttachment` interface.
  - Implemented the AES-256-GCM encryption logic within the attachments iteration loop and accurately mapped the metadata to each attachment descriptor.
- **`src/services/crypto/envelope.test.ts`**:
  - Expanded unit test assertions across the entire test suite to ensure `ciphertext` and precisely formatted `encryption_metadata` (algorithm, nonce, mac) are properly produced.
---
## Any trade-offs or considerations
By packing the ciphertexts securely inside the payload's `attachments` list, we successfully avoid cross-boundary regressions or API updates (e.g., in `sendPipeline.ts` or the Relay components), as the existing architecture gracefully serializes the entire `payload` into JCS form. The payload size will grow proportionally to the attachment sizes; however, this operates cleanly within the expected payload design spec. 
---
## Testing steps (how to verify the fix)
1. Run `npx vitest run src/services/crypto/envelope.test.ts` to execute isolated unit tests for zero, single, and multiple attachment cases.
2. Attach a file in the compose UI locally (if integrated) and observe that the relay payload explicitly contains encrypted ciphertexts under the attachment descriptors.
3. Validate there are no lint or type errors by executing `npm run lint` and `npx tsc --noEmit`.
---
_Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch. Thank you!_
