### PR TITLE
feat(crypto): add envelope timestamp validation with bounded skew

### DIFF
--- a/src/services/crypto/time.ts
+++ b/src/services/crypto/time.ts
@@ -1,0 +1,86 @@
+/**
+ * Envelope timestamp validation with bounded clock skew (#1710).
+ *
+ * `sealEnvelope` writes the current ISO timestamp, but the crypto folder had no
+ * validation for malformed, stale, or excessively future timestamps. Signatures
+ * and replay controls need a clear temporal validity policy.
+ *
+ * This module parses strict UTC ISO-8601 timestamps and validates them against
+ * configurable maximum age and future-skew bounds using an injectable clock, so
+ * tests are deterministic. Self-contained (local TimestampError).
+ */
+
+/** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
+export class TimestampError extends Error {
+  readonly code = "crypto_validation_error" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "TimestampError";
+  }
+}
+
+/** A clock abstraction so tests can control "now". */
+export interface Clock {
+  now(): Date;
+}
+
+export const systemClock: Clock = {
+  now: () => new Date(),
+};
+
+export interface TimestampPolicy {
+  /** Maximum allowed age of a timestamp (milliseconds). */
+  maxAgeMs: number;
+  /** Maximum allowed future skew of a timestamp (milliseconds). */
+  maxFutureSkewMs: number;
+  /** Clock used to evaluate "now" (defaults to the system clock). */
+  clock?: Clock;
+}
+
+/**
+ * Parse a strict UTC ISO-8601 timestamp.
+ * Rejects empty, non-UTC (must end in Z or +00:00), or unparseable values.
+ */
+export function parseUtcTimestamp(value: string): Date {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TimestampError("timestamp must be a non-empty string");
+  }
+  const trimmed = value.trim();
+  // Require an explicit UTC designator: trailing 'Z' or '(+|-)HH:MM' offset of 00:00.
+  const hasZ = trimmed.endsWith("Z");
+  const utcOffset = /[+-]\d{2}:\d{2}$/.exec(trimmed);
+  const isUtcOffset =
+    utcOffset !== null && (utcOffset[0] === "+00:00" || utcOffset[0] === "-00:00");
+  if (!hasZ && !isUtcOffset) {
+    throw new TimestampError("timestamp must be UTC (end with Z or +00:00)");
+  }
+
+  const normalized = hasZ ? trimmed.slice(0, -1) + "+00:00" : trimmed;
+  const ms = Date.parse(normalized);
+  if (Number.isNaN(ms)) {
+    throw new TimestampError("timestamp is not a valid ISO-8601 date");
+  }
+  return new Date(ms);
+}
+
+/**
+ * Validate a timestamp against the policy. Throws TimestampError when the value
+ * is malformed, too old (age > maxAgeMs), or too far in the future
+ * (skew > maxFutureSkewMs). Boundary values (exactly at the limit) are allowed.
+ */
+export function validateTimestamp(value: string, policy: TimestampPolicy): Date {
+  const date = parseUtcTimestamp(value);
+  const clock = policy.clock ?? systemClock;
+  const nowMs = clock.now().getTime();
+  const tsMs = date.getTime();
+  const age = nowMs - tsMs;
+  const skew = tsMs - nowMs;
+
+  if (age > policy.maxAgeMs) {
+    throw new TimestampError("timestamp is too old");
+  }
+  if (skew > policy.maxFutureSkewMs) {
+    throw new TimestampError("timestamp is too far in the future");
+  }
+  return date;
+}

--- a/tests/unit/crypto/time.test.ts
+++ b/tests/unit/crypto/time.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseUtcTimestamp,
+  TimestampError,
+  validateTimestamp,
+  type Clock,
+} from "../../../src/services/crypto/time";
+
+const ANCHOR = new Date("2026-07-23T12:00:00.000Z");
+
+function fixedClock(): Clock {
+  return { now: () => new Date(ANCHOR) };
+}
+
+describe("envelope timestamp validation (#1710)", () => {
+  it("accepts a well-formed UTC timestamp within bounds", () => {
+    const ts = "2026-07-23T11:59:00.000Z";
+    const date = validateTimestamp(ts, {
+      maxAgeMs: 60_000,
+      maxFutureSkewMs: 60_000,
+      clock: fixedClock(),
+    });
+    expect(date.getTime()).toBe(Date.parse("2026-07-23T11:59:00.000Z"));
+  });
+
+  it("rejects empty timestamps", () => {
+    expect(() =>
+      validateTimestamp("  ", { maxAgeMs: 60_000, maxFutureSkewMs: 60_000, clock: fixedClock() }),
+    ).toThrowError(TimestampError);
+  });
+
+  it("rejects non-UTC timestamps (no Z / non-zero offset)", () => {
+    expect(() => parseUtcTimestamp("2026-07-23T12:00:00.000+02:00")).toThrowError(TimestampError);
+    expect(() => parseUtcTimestamp("2026-07-23T12:00:00")).toThrowError(TimestampError);
+  });
+
+  it("accepts a +00:00 offset as UTC", () => {
+    const date = parseUtcTimestamp("2026-07-23T12:00:00.000+00:00");
+    expect(date.getTime()).toBe(Date.parse("2026-07-23T12:00:00.000Z"));
+  });
+
+  it("rejects unparseable timestamps", () => {
+    expect(() => parseUtcTimestamp("not-a-dateZ")).toThrowError(TimestampError);
+  });
+
+  it("rejects timestamps older than maxAge (boundary exclusive)", () => {
+    const ts = "2026-07-23T11:58:59.000Z"; // 61s before anchor
+    expect(() =>
+      validateTimestamp(ts, { maxAgeMs: 60_000, maxFutureSkewMs: 0, clock: fixedClock() }),
+    ).toThrowError(TimestampError);
+  });
+
+  it("allows a timestamp exactly at the maxAge boundary", () => {
+    const ts = "2026-07-23T11:59:00.000Z"; // exactly 60s before anchor
+    const date = validateTimestamp(ts, {
+      maxAgeMs: 60_000,
+      maxFutureSkewMs: 0,
+      clock: fixedClock(),
+    });
+    expect(date).toBeInstanceOf(Date);
+  });
+
+  it("rejects timestamps further in the future than maxFutureSkew", () => {
+    const ts = "2026-07-23T12:01:01.000Z"; // 61s after anchor
+    expect(() =>
+      validateTimestamp(ts, { maxAgeMs: 0, maxFutureSkewMs: 60_000, clock: fixedClock() }),
+    ).toThrowError(TimestampError);
+  });
+
+  it("allows a timestamp exactly at the future-skew boundary", () => {
+    const ts = "2026-07-23T12:01:00.000Z"; // exactly 60s after anchor
+    const date = validateTimestamp(ts, {
+      maxAgeMs: 0,
+      maxFutureSkewMs: 60_000,
+      clock: fixedClock(),
+    });
+    expect(date).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#1710**. `sealEnvelope` wrote the current ISO timestamp, but the crypto folder had no validation for malformed, stale, or excessively future timestamps.

This PR adds `src/services/crypto/time.ts`: `parseUtcTimestamp`, `validateTimestamp`, and an injectable `Clock`.

## Changes
- Strict UTC ISO-8601 parsing; non-UTC (no `Z` / non-zero offset) and unparseable values fail.
- Configurable `maxAgeMs` and `maxFutureSkewMs` with an injectable clock; boundary values are allowed (inclusive), so behavior is deterministic.
- Local `TimestampError` (`crypto_validation_error`); self-contained.

## Acceptance criteria
- [x] Malformed and non-UTC timestamps fail
- [x] Maximum age and future skew are configurable
- [x] Boundary behavior is deterministic
- [x] Tests use a controllable clock

## Testing
- `bun run test` green (9 new tests in `tests/unit/crypto/time.test.ts`)
- `tsc --noEmit` clean on crypto files; `prettier --check .` clean

Fixes #1710