### PR TITLE
refactor(deadline-detector): validate detector inputs

### DIFF
--- a/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
+++ b/tools/v2/individual/deadline-detector/services/deadline-detector.service.ts
@@ -127,11 +127,25 @@ function titleFromMessage(message: DeadlineMessage): string {
   return cleaned || "Untitled deadline";
 }
 
+/**
+ * Detects reviewable deadline candidates from synthetic messages.
+ *
+ * Deterministic for a given messages array and options, which keeps
+ * fixture-based tests stable. Throws on non-array input or an invalid
+ * options.now value so callers fail fast instead of receiving silent garbage.
+ */
 export function detectDeadlines(
   messages: DeadlineMessage[],
   options: DeadlineDetectorServiceOptions = {},
 ): DeadlineDetectionResult {
+  if (!Array.isArray(messages)) {
+    throw new TypeError("detectDeadlines expects an array of messages.");
+  }
+
   const now = new Date(options.now ?? new Date().toISOString());
+  if (Number.isNaN(now.getTime())) {
+    throw new RangeError("detectDeadlines received an invalid options.now value.");
+  }
   const defaultTimezone = options.defaultTimezone ?? "UTC";
 
   const deadlines = messages.map((message): DetectedDeadline => {


### PR DESCRIPTION
## What
Add fail-fast input validation to the deadline detection service and document the detectDeadlines contract.

## Why
detectDeadlines previously trusted its inputs. A non-array messages value, or an options.now that cannot be parsed (for example an unexpected date string), produced a silent Invalid Date that flowed through the urgency and status classification and yielded incorrect, hard-to-debug results instead of a clear failure.

## Changes
- Throw a TypeError when messages is not an array.
- Throw a RangeError when options.now cannot be parsed into a valid date.
- Add a short JSDoc describing the deterministic contract and the new guards.

## Behaviour and scope
- Detection output for valid input is unchanged: the existing synthetic fixtures produce identical results (verified locally against the sample fixture).
- No type changes, no new dependencies, and all work stays inside tools/v2/individual/deadline-detector/.

Closes #480