### PR TITLE
test(deadline-detector): assert engine output against fixtures

### DIFF
--- a/tools/v2/individual/deadline-detector/docs/TEST_PLAN.md
+++ b/tools/v2/individual/deadline-detector/docs/TEST_PLAN.md
@@ -18,6 +18,21 @@ Expected result:
 - missed rows are marked overdue
 - ignored rows do not schedule dates
 
+## Automated Engine Output Test
+
+Run from the repository root:
+
+    node --test tools/v2/individual/deadline-detector/tests/deadline-detection.test.mjs
+
+This test executes the detector against the sample fixture and asserts that:
+
+- detectDeadlines returns one deadline per source message
+- every expected deadline is reproduced field by field, covering status, urgency, due date and time, timezone, confidence, and the review flag
+- the summary status counts add up to the total
+- sortDetectedDeadlines orders by urgency without mutating its input
+
+Where the fixture test confirms the sample data is well formed, this test confirms the engine actually reproduces that data.
+
 ## Manual Review Checklist
 
 1. Confirm all changed files are under

--- a/tools/v2/individual/deadline-detector/tests/deadline-detection.test.mjs
+++ b/tools/v2/individual/deadline-detector/tests/deadline-detection.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { detectDeadlines, sortDetectedDeadlines } from "../services/deadline-detector.service.ts";
+
+const fixtureUrl = new URL("../fixtures/sample-deadline-messages.json", import.meta.url);
+const fixture = JSON.parse(readFileSync(fixtureUrl, "utf8"));
+
+const options = {
+  now: fixture.runContext.now,
+  defaultTimezone: fixture.runContext.timezone,
+};
+const result = detectDeadlines(fixture.sourceMessages, options);
+const byId = new Map(result.deadlines.map((deadline) => [deadline.id, deadline]));
+
+test("detectDeadlines returns one deadline per source message", () => {
+  assert.equal(result.deadlines.length, fixture.sourceMessages.length);
+  assert.equal(result.summary.totalMessages, fixture.sourceMessages.length);
+  assert.equal(result.summary.totalDeadlines, fixture.sourceMessages.length);
+});
+
+for (const expected of fixture.expectedDeadlines) {
+  test("detectDeadlines reproduces the expected result for " + expected.id, () => {
+    const actual = byId.get(expected.id);
+    assert.ok(actual, "no deadline produced for " + expected.id);
+    assert.equal(actual.sourceMessageId, expected.sourceMessageId);
+    assert.equal(actual.title, expected.title);
+    assert.equal(actual.dueDate, expected.dueDate);
+    assert.equal(actual.dueTime, expected.dueTime);
+    assert.equal(actual.timezone, expected.timezone);
+    assert.equal(actual.status, expected.status);
+    assert.equal(actual.urgency, expected.urgency);
+    assert.equal(actual.confidence, expected.confidence);
+    assert.equal(actual.reviewRequired, expected.reviewRequired);
+  });
+}
+
+test("summary status counts add up to the total", () => {
+  const s = result.summary;
+  assert.equal(s.detected + s.needsReview + s.missed + s.ignored, s.totalDeadlines);
+});
+
+test("sortDetectedDeadlines orders by urgency without mutating its input", () => {
+  const original = [...result.deadlines];
+  const sorted = sortDetectedDeadlines(result.deadlines);
+  assert.deepEqual(result.deadlines, original);
+  const rank = { overdue: 0, today: 1, soon: 2, later: 3, unknown: 4 };
+  for (let i = 1; i < sorted.length; i += 1) {
+    assert.ok(rank[sorted[i - 1].urgency] <= rank[sorted[i].urgency]);
+  }
+});


### PR DESCRIPTION
## What
Add an engine-level test that runs detectDeadlines against the sample fixture and asserts the produced deadlines, and document it in the test plan.

## Why
The existing tests/deadline-fixtures.test.mjs only validates that the sample fixture is well formed (shapes, synthetic senders, status/urgency ranges). It never calls the detector, so a regression in detectDeadlines would not be caught. This adds the missing behavioural coverage.

## Changes
- tests/deadline-detection.test.mjs: runs the detector over the fixture and checks each expected deadline field by field (status, urgency, due date and time, timezone, confidence, review flag), the summary totals, and that sortDetectedDeadlines orders by urgency without mutating its input.
- docs/TEST_PLAN.md: add an "Automated Engine Output Test" section documenting the new command and assertions.

## Notes
- Runs green locally with node --test.
- Additive only: the existing fixture test is untouched, and all work stays inside tools/v2/individual/deadline-detector/.

Closes #483