### PR TITLE
Add privacy-preserving recipient key entries and threat model documen…

### DIFF
--- a/src/services/crypto/recipient-privacy.ts
+++ b/src/services/crypto/recipient-privacy.ts
@@ -1,0 +1,253 @@
+/**
+ * RECIPIENT PRIVACY THREAT MODEL & COMPATIBILITY DOCUMENTATION
+ *
+ * Threat Model:
+ * 1. Social/Organizational Metadata Leakage:
+ *    - In traditional multi-recipient envelopes, the identities/addresses of all recipients
+ *      are visible in plaintext. Unrelated observers (e.g., relay nodes, network eavesdroppers)
+ *      can map communication graphs and organizational structures.
+ *    - Mitigation: This module replaces plaintext recipient identifiers with blinded recipient
+ *      identifiers (`blindedRecipientId`) derived from an ECDH-derived shared secret. Observers
+ *      cannot link the blinded ID to any specific identity without possessing either the sender's
+ *      ephemeral private key or the recipient's private key.
+ * 2. Active Enumeration / Dictionary Attack:
+ *    - If blinded IDs were derived via simple hashing (e.g. `SHA256(recipient_address)`), an observer
+ *      could precompute hashes for all potential recipients (dictionary attack).
+ *    - Mitigation: Blinded IDs are derived dynamically using a per-recipient ECDH key agreement.
+ *      The resulting shared secret serves as the key for HKDF-expand, making the blinded ID
+ *      indistinguishable from random noise to anyone without the private keys.
+ * 3. Collision and False-Match Handling:
+ *    - Since blinded IDs are derived using cryptographically strong functions, the probability
+ *      of a 256-bit collision between unrelated keys is < 1 in 2^128 (negligible).
+ *    - In the case of intentional or accidental false-matches:
+ *      - The recipient first filters entries by checking `blindedRecipientId`.
+ *      - If a matching ID is found, the recipient attempts AES-256-GCM decryption of `wrappedKey`.
+ *      - Authenticated decryption (AES-GCM tag verification) will fail for incorrect keys,
+ *        guaranteeing that false matches fail closed safely without exposing or accepting incorrect key material.
+ *
+ * Compatibility:
+ * - Uses standard W3C Web Cryptography API (`crypto.subtle`), supported natively in all modern
+ *   browsers and Node.js (16+).
+ * - Utilizes standard P-256 ECDH for key agreement, HKDF-SHA256 for key derivation, and AES-256-GCM
+ *   for authenticated key wrapping.
+ */
+
+import { CryptoError } from "./errors";
+import { toHex, fromHex, toBase64, fromBase64 } from "./codec";
+
+/**
+ * A privacy-preserving entry in an envelope's recipient list.
+ */
+export interface PrivacyPreservingRecipientEntry {
+  /** Base64-encoded ephemeral public key of the sender for this recipient (SPKI format). */
+  ephemeralPublicKey: string;
+  /** Hex-encoded blinded recipient identifier. */
+  blindedRecipientId: string;
+  /** Base64-encoded encrypted content-encryption key. */
+  wrappedKey: string;
+  /** Hex-encoded nonce used for AES-GCM wrapping. */
+  nonce: string;
+}
+
+const HKDF_INFO = new TextEncoder().encode("stealth-recipient-privacy-v1");
+
+/**
+ * Helper to import a P-256 SPKI public key.
+ */
+async function importPublicKey(spkiBase64: string): Promise<CryptoKey> {
+  try {
+    const rawSpki = fromBase64(spkiBase64);
+    return await crypto.subtle.importKey(
+      "spki",
+      rawSpki as BufferSource,
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      [],
+    );
+  } catch (err) {
+    throw new CryptoError("crypto_key_error", "Failed to import public key");
+  }
+}
+
+/**
+ * Helper to export a public key to SPKI base64 format.
+ */
+async function exportPublicKey(key: CryptoKey): Promise<string> {
+  const exported = await crypto.subtle.exportKey("spki", key);
+  return toBase64(new Uint8Array(exported));
+}
+
+/**
+ * Generates a standard P-256 ECDH keypair.
+ */
+export async function generateEcdhKeyPair(): Promise<CryptoKeyPair> {
+  return await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, true, [
+    "deriveKey",
+    "deriveBits",
+  ]);
+}
+
+/**
+ * Create a privacy-preserving recipient entry for a given recipient.
+ *
+ * @param recipientPublicKey The recipient's P-256 public key.
+ * @param contentKey The symmetric content key (AES-256-GCM) to wrap.
+ * @returns The privacy-preserving recipient entry.
+ */
+export async function createPrivacyEntry(
+  recipientPublicKey: CryptoKey,
+  contentKey: CryptoKey,
+): Promise<PrivacyPreservingRecipientEntry> {
+  // 1. Generate an ephemeral P-256 keypair for ECDH
+  const ephemeralKeyPair = await generateEcdhKeyPair();
+
+  // 2. Perform ECDH to derive a shared secret
+  const sharedBits = await crypto.subtle.deriveBits(
+    {
+      name: "ECDH",
+      public: recipientPublicKey,
+    },
+    ephemeralKeyPair.privateKey,
+    256,
+  );
+  const sharedSecretBytes = new Uint8Array(sharedBits);
+
+  // 3. Derive matching and wrapping keys via HKDF-SHA256
+  // Extract
+  const prk = await crypto.subtle.importKey(
+    "raw",
+    sharedSecretBytes as BufferSource,
+    { name: "HKDF" },
+    false,
+    ["deriveKey"],
+  );
+
+  // Expand to get a 256-bit AES-GCM wrapping key
+  const wrappingKey = await crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(0),
+      info: HKDF_INFO,
+    },
+    prk,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+
+  // Derive matching key bytes to compute blinded ID
+  const matchingPrk = await crypto.subtle.importKey(
+    "raw",
+    sharedSecretBytes as BufferSource,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const blindedIdBytes = await crypto.subtle.sign("HMAC", matchingPrk, HKDF_INFO);
+
+  // 4. Wrap the content key
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const rawContentKey = await crypto.subtle.exportKey("raw", contentKey);
+  const wrappedBytes = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce as BufferSource },
+    wrappingKey,
+    rawContentKey,
+  );
+
+  return {
+    ephemeralPublicKey: await exportPublicKey(ephemeralKeyPair.publicKey),
+    blindedRecipientId: toHex(new Uint8Array(blindedIdBytes)),
+    wrappedKey: toBase64(new Uint8Array(wrappedBytes)),
+    nonce: toHex(nonce),
+  };
+}
+
+/**
+ * Locate and decrypt the recipient's privacy entry from a list of entries.
+ * Returns the decrypted content key if a matching entry is found and successfully decrypted,
+ * otherwise returns null.
+ *
+ * @param recipientPrivateKey The recipient's private key.
+ * @param entries The list of privacy-preserving entries.
+ * @returns The decrypted content key, or null if no entry matches.
+ */
+export async function locateAndDecryptEntry(
+  recipientPrivateKey: CryptoKey,
+  entries: PrivacyPreservingRecipientEntry[],
+): Promise<CryptoKey | null> {
+  for (const entry of entries) {
+    try {
+      const ephemeralKey = await importPublicKey(entry.ephemeralPublicKey);
+
+      // Perform ECDH
+      const sharedBits = await crypto.subtle.deriveBits(
+        {
+          name: "ECDH",
+          public: ephemeralKey,
+        },
+        recipientPrivateKey,
+        256,
+      );
+      const sharedSecretBytes = new Uint8Array(sharedBits);
+
+      // Verify blinded ID
+      const matchingPrk = await crypto.subtle.importKey(
+        "raw",
+        sharedSecretBytes as BufferSource,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const expectedIdBytes = await crypto.subtle.sign("HMAC", matchingPrk, HKDF_INFO);
+      const expectedId = toHex(new Uint8Array(expectedIdBytes));
+
+      if (expectedId !== entry.blindedRecipientId) {
+        continue; // Not our entry, move to next
+      }
+
+      // Found a match! Attempt decryption.
+      const prk = await crypto.subtle.importKey(
+        "raw",
+        sharedSecretBytes as BufferSource,
+        { name: "HKDF" },
+        false,
+        ["deriveKey"],
+      );
+
+      const wrappingKey = await crypto.subtle.deriveKey(
+        {
+          name: "HKDF",
+          hash: "SHA-256",
+          salt: new Uint8Array(0),
+          info: HKDF_INFO,
+        },
+        prk,
+        { name: "AES-GCM", length: 256 },
+        true,
+        ["encrypt", "decrypt"],
+      );
+
+      const decrypted = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: fromHex(entry.nonce) as BufferSource },
+        wrappingKey,
+        fromBase64(entry.wrappedKey) as BufferSource,
+      );
+
+      // Import the decrypted raw key back as a CryptoKey
+      return await crypto.subtle.importKey(
+        "raw",
+        decrypted,
+        { name: "AES-GCM", length: 256 },
+        true,
+        ["encrypt", "decrypt"],
+      );
+    } catch (err) {
+      // In case of any validation or decryption failure (e.g. false-match or corruption),
+      // we fail closed and continue search.
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/tests/unit/crypto/recipient-privacy.test.ts
+++ b/tests/unit/crypto/recipient-privacy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateEcdhKeyPair,
+  createPrivacyEntry,
+  locateAndDecryptEntry,
+  type PrivacyPreservingRecipientEntry,
+} from "../../../src/services/crypto/recipient-privacy";
+
+describe("Privacy-preserving Recipient Key Entries", () => {
+  it("allows the correct recipient to locate and decrypt their entry", async () => {
+    // 1. Generate keys
+    const recipientKeyPair = await generateEcdhKeyPair();
+    const contentKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+
+    // 2. Create the privacy entry
+    const entry = await createPrivacyEntry(recipientKeyPair.publicKey, contentKey);
+
+    expect(entry.ephemeralPublicKey).toBeDefined();
+    expect(entry.blindedRecipientId).toBeDefined();
+    expect(entry.wrappedKey).toBeDefined();
+    expect(entry.nonce).toBeDefined();
+
+    // The blinded ID should be a secure hex string, not containing the raw public key
+    expect(entry.blindedRecipientId).toMatch(/^[0-9a-f]{64}$/);
+
+    // 3. Locate and decrypt
+    const decryptedKey = await locateAndDecryptEntry(recipientKeyPair.privateKey, [entry]);
+
+    expect(decryptedKey).toBeDefined();
+    expect(decryptedKey).not.toBeNull();
+
+    // Verify the decrypted content key works
+    const rawOrig = await crypto.subtle.exportKey("raw", contentKey);
+    const rawDec = await crypto.subtle.exportKey("raw", decryptedKey!);
+    expect(new Uint8Array(rawOrig)).toEqual(new Uint8Array(rawDec));
+  });
+
+  it("does not allow an unrelated recipient to decrypt the entry", async () => {
+    const recipientKeyPair1 = await generateEcdhKeyPair();
+    const recipientKeyPair2 = await generateEcdhKeyPair();
+    const contentKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+
+    const entry = await createPrivacyEntry(recipientKeyPair1.publicKey, contentKey);
+
+    // Try decrypting with recipient 2's private key
+    const decrypted = await locateAndDecryptEntry(recipientKeyPair2.privateKey, [entry]);
+    expect(decrypted).toBeNull();
+  });
+
+  it("handles multi-recipient lists and locates the correct entry", async () => {
+    const aliceKeys = await generateEcdhKeyPair();
+    const bobKeys = await generateEcdhKeyPair();
+    const charlieKeys = await generateEcdhKeyPair();
+
+    const contentKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+
+    const entryAlice = await createPrivacyEntry(aliceKeys.publicKey, contentKey);
+    const entryBob = await createPrivacyEntry(bobKeys.publicKey, contentKey);
+
+    const entries = [entryAlice, entryBob];
+
+    // Alice should locate her entry
+    const decryptedAlice = await locateAndDecryptEntry(aliceKeys.privateKey, entries);
+    expect(decryptedAlice).not.toBeNull();
+
+    // Bob should locate his entry
+    const decryptedBob = await locateAndDecryptEntry(bobKeys.privateKey, entries);
+    expect(decryptedBob).not.toBeNull();
+
+    // Charlie should find nothing
+    const decryptedCharlie = await locateAndDecryptEntry(charlieKeys.privateKey, entries);
+    expect(decryptedCharlie).toBeNull();
+  });
+
+  it("defines and handles collision / false-match behavior safely", async () => {
+    const aliceKeys = await generateEcdhKeyPair();
+    const bobKeys = await generateEcdhKeyPair();
+
+    const contentKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+
+    const realEntry = await createPrivacyEntry(aliceKeys.publicKey, contentKey);
+
+    // Construct a malicious/colliding entry with the same blinded ID but forged key wrapper parameters
+    const forgedEntry: PrivacyPreservingRecipientEntry = {
+      ephemeralPublicKey: realEntry.ephemeralPublicKey,
+      blindedRecipientId: realEntry.blindedRecipientId, // Colliding ID
+      wrappedKey: "YQAAAAAAAAAAAAAA", // Bad key ciphertext
+      nonce: realEntry.nonce,
+    };
+
+    // Attempting to locate and decrypt should fail gracefully (fail-closed) and return null
+    // since the AES-GCM authentication tag check will fail on the forged wrappedKey.
+    const decrypted = await locateAndDecryptEntry(aliceKeys.privateKey, [forgedEntry]);
+    expect(decrypted).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1703 

This PR implements issue **#1703**, introducing an optional anonymous and privacy-preserving recipient key entry mechanism to prevent visible recipient lists from leaking social and organizational metadata.

## Key Changes

### 1. Privacy-Preserving Recipient Entries (`src/services/crypto/recipient-privacy.ts`)
- **Key Agreement (P-256 ECDH)**: Generates an ephemeral `P-256` keypair to perform a Diffie-Hellman key exchange, deriving a shared secret unique to each sender-recipient pair.
- **Blinded ID & Key Wrapping**: Uses `HKDF-SHA256` to derive:
  - A matching key used to generate a secure, observer-opaque `blindedRecipientId` (via HMAC-SHA256).
  - An AES-256-GCM encryption key to wrap the content-encryption key.
- **Local Matching & Decryption**: Implemented `locateAndDecryptEntry` allowing recipients to efficiently test candidates using ECDH and verify/decrypt their matched entry.
- **Threat Model & Compatibility Documentation**: Included inline threat-model details documenting metadata leakage protection, dictionary attack protection, false-match handling (fails closed), and runtime compatibility.

### 2. Unit Tests (`tests/unit/crypto/recipient-privacy.test.ts`)
- Covered successful key entry matching and content key decryption.
- Verified that unrelated observers and recipients cannot locate or decrypt entries.
- Validated multi-recipient lists and correct match routing.
- Tested collision/false-match behavior under forged entries (ensures it fails closed safely via authenticated decryption).