### PR TITLE
feat(email-template-library): add placeholder consistency analysis

### DIFF
--- a/tools/v2/individual/email-template-library/services/templateAnalysis.ts
+++ b/tools/v2/individual/email-template-library/services/templateAnalysis.ts
@@ -1,0 +1,105 @@
+/**
+ * Template placeholder analysis for the Email Template Library (#490).
+ *
+ * The library renders templates by substituting `{{ key }}` placeholders with
+ * caller-supplied values. That works, but template AUTHORS have no way to know
+ * whether a template is internally consistent before it ships:
+ *
+ * - A placeholder used in the subject/body but NOT declared in `variables` will
+ *   render literally (the caller can never supply a value for it) — an authoring
+ *   bug that render-time errors cannot surface because the caller does not know
+ *   the key exists.
+ * - A declared variable that is never referenced in the subject/body is dead
+ *   metadata that clutters the render form.
+ *
+ * This module is a pure, folder-local analysis helper that reconciles the
+ * placeholders actually referenced by a template against its declared variables.
+ * It performs no I/O, makes no network calls, and is deterministic for a given
+ * template.
+ *
+ * Inputs:  an `EmailTemplate` (or its `subject` + `body` + `variables`).
+ * Outputs: an `EmailTemplateAnalysis` describing referenced keys, undeclared
+ *          placeholders, unused declared variables, and an `isConsistent` flag.
+ * Errors:  none thrown — malformed strings simply yield no placeholders.
+ */
+
+import type { EmailTemplate, TemplateVariable } from "../types/index.ts";
+
+/** Matches `{{ key }}` placeholders; the key allows word chars, dot and dash. */
+const PLACEHOLDER_PATTERN = /\{\{\s*([\w.-]+)\s*\}\}/g;
+
+export interface EmailTemplateAnalysis {
+  /** Unique placeholder keys referenced in subject/body, in first-seen order. */
+  referencedKeys: string[];
+  /** Declared variable keys, in declaration order. */
+  declaredKeys: string[];
+  /** Referenced keys that are NOT declared in `variables` (authoring errors). */
+  undeclaredPlaceholders: string[];
+  /** Declared keys that are never referenced in subject/body (dead metadata). */
+  unusedVariables: string[];
+  /**
+   * True iff every referenced placeholder is declared. Unused declared
+   * variables are a soft warning and do NOT make a template inconsistent.
+   */
+  isConsistent: boolean;
+}
+
+/** Extract unique `{{ key }}` placeholder keys from a string, in first-seen order. */
+export function extractPlaceholders(text: string): string[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const match of Array.from(text.matchAll(PLACEHOLDER_PATTERN))) {
+    const key = match[1];
+    if (!seen.has(key)) {
+      seen.add(key);
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Analyze a template's placeholders against its declared variables.
+ *
+ * Accepts either a full {@link EmailTemplate} or the minimal fields needed, so
+ * it can be reused during authoring before a template object is finalized.
+ */
+export function analyzeTemplate(
+  template: Pick<EmailTemplate, "subject" | "body" | "variables">,
+): EmailTemplateAnalysis {
+  const subject = typeof template.subject === "string" ? template.subject : "";
+  const body = typeof template.body === "string" ? template.body : "";
+  const variables: readonly TemplateVariable[] = Array.isArray(template.variables)
+    ? template.variables
+    : [];
+
+  const referencedSeen = new Set<string>();
+  const referencedKeys: string[] = [];
+  for (const key of [...extractPlaceholders(subject), ...extractPlaceholders(body)]) {
+    if (!referencedSeen.has(key)) {
+      referencedSeen.add(key);
+      referencedKeys.push(key);
+    }
+  }
+
+  const declaredKeys: string[] = [];
+  const declaredSet = new Set<string>();
+  for (const variable of variables) {
+    if (variable && typeof variable.key === "string" && !declaredSet.has(variable.key)) {
+      declaredSet.add(variable.key);
+      declaredKeys.push(variable.key);
+    }
+  }
+
+  const undeclaredPlaceholders = referencedKeys.filter((key) => !declaredSet.has(key));
+  const unusedVariables = declaredKeys.filter((key) => !referencedSeen.has(key));
+
+  return {
+    referencedKeys,
+    declaredKeys,
+    undeclaredPlaceholders,
+    unusedVariables,
+    isConsistent: undeclaredPlaceholders.length === 0,
+  };
+}

--- a/tools/v2/individual/email-template-library/tests/templateAnalysis.test.ts
+++ b/tools/v2/individual/email-template-library/tests/templateAnalysis.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analyzeTemplate, extractPlaceholders } from "../services/templateAnalysis.ts";
+import type { EmailTemplate } from "../types/index.ts";
+
+function template(overrides: Partial<EmailTemplate> = {}): EmailTemplate {
+  return {
+    id: "t1",
+    name: "Test",
+    categoryId: null,
+    subject: "Hello {{ name }}",
+    body: "Hi {{ name }}, your order {{ orderId }} shipped.",
+    variables: [
+      { key: "name", label: "Name" },
+      { key: "orderId", label: "Order ID" },
+    ],
+    ...overrides,
+  };
+}
+
+test("extractPlaceholders returns unique keys in first-seen order", () => {
+  assert.deepEqual(extractPlaceholders("{{ a }} {{b}} then {{ a }} and {{c}}"), ["a", "b", "c"]);
+});
+
+test("extractPlaceholders tolerates empty/non-string input", () => {
+  assert.deepEqual(extractPlaceholders(""), []);
+  assert.deepEqual(extractPlaceholders(undefined as unknown as string), []);
+});
+
+test("a fully-declared template is consistent with no warnings", () => {
+  const analysis = analyzeTemplate(template());
+  assert.deepEqual(analysis.referencedKeys, ["name", "orderId"]);
+  assert.deepEqual(analysis.declaredKeys, ["name", "orderId"]);
+  assert.deepEqual(analysis.undeclaredPlaceholders, []);
+  assert.deepEqual(analysis.unusedVariables, []);
+  assert.equal(analysis.isConsistent, true);
+});
+
+test("undeclared placeholders make a template inconsistent", () => {
+  const analysis = analyzeTemplate(
+    template({
+      body: "Hi {{ name }}, ref {{ trackingCode }}",
+      variables: [{ key: "name", label: "Name" }],
+    }),
+  );
+  assert.deepEqual(analysis.undeclaredPlaceholders, ["trackingCode"]);
+  assert.equal(analysis.isConsistent, false);
+});
+
+test("unused declared variables are a soft warning, still consistent", () => {
+  const analysis = analyzeTemplate(
+    template({
+      subject: "Hello {{ name }}",
+      body: "No other placeholders here.",
+      variables: [
+        { key: "name", label: "Name" },
+        { key: "orderId", label: "Order ID" },
+      ],
+    }),
+  );
+  assert.deepEqual(analysis.unusedVariables, ["orderId"]);
+  assert.deepEqual(analysis.undeclaredPlaceholders, []);
+  assert.equal(analysis.isConsistent, true);
+});
+
+test("placeholders in subject are detected too", () => {
+  const analysis = analyzeTemplate(
+    template({
+      subject: "Order {{ orderId }} for {{ name }}",
+      body: "static body",
+      variables: [
+        { key: "name", label: "Name" },
+        { key: "orderId", label: "Order ID" },
+      ],
+    }),
+  );
+  assert.deepEqual(analysis.referencedKeys, ["orderId", "name"]);
+  assert.equal(analysis.isConsistent, true);
+});
+
+test("analysis is deterministic for identical input", () => {
+  const a = analyzeTemplate(template());
+  const b = analyzeTemplate(template());
+  assert.deepEqual(a, b);
+});


### PR DESCRIPTION
## Summary

Adds a folder-local **placeholder consistency analysis** helper for the Email
Template Library V2 individual tool (#490).

The library renders `{{ key }}` placeholders from a values map, but template
authors have no way to verify a template is internally consistent before it
ships. This pure core helper reconciles the placeholders actually referenced in
a template's subject/body against its declared `variables`:

- **undeclared placeholders** — used in the template but not declared, so a
  caller can never supply them (an authoring error; render-time validation
  cannot surface it because the caller does not know the key exists).
- **unused variables** — declared but never referenced (dead metadata; a soft
  warning, not an inconsistency).

## Deliverables

- `services/templateAnalysis.ts` — `extractPlaceholders()` and
  `analyzeTemplate()` returning `referencedKeys`, `declaredKeys`,
  `undeclaredPlaceholders`, `unusedVariables`, and an `isConsistent` flag. Pure,
  deterministic, no I/O, no network, throws nothing.
- `tests/templateAnalysis.test.ts` — 7 `node:test` unit tests (subject+body
  extraction, undeclared/unused detection, ordering, determinism), matching the
  folder's framework-free test convention.

## Acceptance criteria

- [x] Core logic implemented without linking into the main app.
- [x] Inputs, outputs, and error behavior documented (JSDoc + typed result).
- [x] No live network calls, secrets, or production data.
- [x] Files changed limited to `tools/v2/individual/email-template-library/`.
- [x] Self-contained, reviewable mini-product change.

Fixes #490
