### PR TITLE
feat(tools): add template catalog validation core

### DIFF
--- a/tools/v2/individual/email-template-library/services/templateCatalog.ts
+++ b/tools/v2/individual/email-template-library/services/templateCatalog.ts
@@ -1,0 +1,97 @@
+/**
+ * Email template catalog validation core (#490).
+ *
+ * The existing service validates each template in isolation and renders by
+ * substituting {{variable}} tokens. It does not enforce catalog-level
+ * invariants that a robust template library needs:
+ *   - Template IDs must be unique across the catalog (duplicate IDs would make
+ *     get/render ambiguous).
+ *   - Each template's variable `key`s must be unique within that template
+ *     (duplicate keys make substitution order-dependent and confusing).
+ *   - `categoryId` references, when present, should point at a known category
+ *     so list-by-category cannot silently return nothing.
+ *
+ * This pure, folder-local module provides that cross-template validation. It
+ * performs no I/O, no network, and imports only folder-local types. It is
+ * deterministic and safe to run at service construction time.
+ */
+
+import type { EmailTemplate } from "../types";
+
+export interface CatalogValidationIssue {
+  templateId?: string;
+  code: "DUPLICATE_TEMPLATE_ID" | "DUPLICATE_VARIABLE_KEY" | "UNKNOWN_CATEGORY";
+  message: string;
+}
+
+export interface CatalogValidationResult {
+  ok: boolean;
+  issues: CatalogValidationIssue[];
+}
+
+const VARIABLE_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+
+/**
+ * Validate a template catalog as a whole.
+ *
+ * @param templates  The full catalog of templates.
+ * @param knownCategoryIds  Optional set of valid category ids for referential
+ *   integrity checks on `categoryId`. When omitted, category checks are skipped.
+ */
+export function validateTemplateCatalog(
+  templates: readonly EmailTemplate[],
+  knownCategoryIds?: ReadonlySet<string>,
+): CatalogValidationResult {
+  const issues: CatalogValidationIssue[] = [];
+  const seenIds = new Map<string, number>();
+
+  for (const template of templates) {
+    const id = template.id;
+    seenIds.set(id, (seenIds.get(id) ?? 0) + 1);
+
+    // Duplicate variable keys within a single template.
+    const seenKeys = new Set<string>();
+    for (const variable of template.variables) {
+      if (!VARIABLE_KEY_PATTERN.test(variable.key)) {
+        issues.push({
+          templateId: id,
+          code: "DUPLICATE_VARIABLE_KEY",
+          message: `Variable key '${variable.key}' is not a valid identifier.`,
+        });
+        continue;
+      }
+      if (seenKeys.has(variable.key)) {
+        issues.push({
+          templateId: id,
+          code: "DUPLICATE_VARIABLE_KEY",
+          message: `Duplicate variable key '${variable.key}' in template '${id}'.`,
+        });
+      }
+      seenKeys.add(variable.key);
+    }
+
+    // Referential integrity for categoryId.
+    if (knownCategoryIds && template.categoryId !== null) {
+      if (!knownCategoryIds.has(template.categoryId)) {
+        issues.push({
+          templateId: id,
+          code: "UNKNOWN_CATEGORY",
+          message: `Template '${id}' references unknown category '${template.categoryId}'.`,
+        });
+      }
+    }
+  }
+
+  // Duplicate template IDs across the catalog.
+  for (const [id, count] of Array.from(seenIds.entries())) {
+    if (count > 1) {
+      issues.push({
+        templateId: id,
+        code: "DUPLICATE_TEMPLATE_ID",
+        message: `Template id '${id}' is duplicated ${count} times in the catalog.`,
+      });
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}

--- a/tools/v2/individual/email-template-library/tests/templateCatalog.test.ts
+++ b/tools/v2/individual/email-template-library/tests/templateCatalog.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { EmailTemplate } from "../types";
+import { validateTemplateCatalog } from "../services/templateCatalog";
+
+function template(id: string, overrides: Partial<EmailTemplate> = {}): EmailTemplate {
+  return {
+    id,
+    name: `Template ${id}`,
+    categoryId: null,
+    subject: "Subject",
+    body: "Body {{x}}",
+    variables: [{ key: "x", label: "X" }],
+    ...overrides,
+  };
+}
+
+describe("validateTemplateCatalog (#490)", () => {
+  it("accepts a clean catalog", () => {
+    const result = validateTemplateCatalog([template("a"), template("b")]);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("flags duplicate template ids", () => {
+    const result = validateTemplateCatalog([template("a"), template("a")]);
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "DUPLICATE_TEMPLATE_ID", templateId: "a" }),
+      ]),
+    );
+  });
+
+  it("flags duplicate variable keys within a template", () => {
+    const t = template("a", {
+      variables: [
+        { key: "x", label: "X" },
+        { key: "x", label: "X again" },
+      ],
+    });
+    const result = validateTemplateCatalog([t]);
+    expect(result.ok).toBe(false);
+    expect(
+      result.issues.some((i) => i.code === "DUPLICATE_VARIABLE_KEY" && i.templateId === "a"),
+    ).toBe(true);
+  });
+
+  it("flags invalid variable key identifiers", () => {
+    const t = template("a", { variables: [{ key: "1bad", label: "Bad" }] });
+    const result = validateTemplateCatalog([t]);
+    expect(
+      result.issues.some(
+        (i) => i.code === "DUPLICATE_VARIABLE_KEY" && /not a valid identifier/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags unknown category references when categories are provided", () => {
+    const t = template("a", { categoryId: "missing" });
+    const result = validateTemplateCatalog([t], new Set(["known"]));
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "UNKNOWN_CATEGORY", templateId: "a" }),
+      ]),
+    );
+  });
+
+  it("skips category checks when no known categories are supplied", () => {
+    const t = template("a", { categoryId: "anything" });
+    const result = validateTemplateCatalog([t]);
+    expect(result.issues.every((i) => i.code !== "UNKNOWN_CATEGORY")).toBe(true);
+  });
+
+  it("is deterministic for the same input", () => {
+    const catalog = [
+      template("a"),
+      template("a", {
+        variables: [
+          { key: "x", label: "X" },
+          { key: "x", label: "Y" },
+        ],
+      }),
+    ];
+    expect(validateTemplateCatalog(catalog)).toEqual(validateTemplateCatalog(catalog));
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#490** (Email Template Library core feature engine). The existing service validates each template in isolation and renders by substituting {{variable}} tokens, but it does not enforce catalog-level invariants. This PR adds the folder-local core: cross-template validation enforcing unique template ids, unique variable keys per template (with identifier format checks), and categoryId referential integrity against a known-category set.

Adds `tools/v2/individual/email-template-library/services/templateCatalog.ts` and `templateCatalog.test.ts` (7 tests). Pure, no I/O, no network, deterministic.

## Acceptance criteria
- [x] Core logic implemented without linking into the main app (folder-local only)
- [x] Inputs, outputs, loading/error states documented (typed result union)
- [x] No live network calls, secrets, or production data
- [x] Files limited to tools/v2/individual/email-template-library/
- [x] Reviewable as a self-contained mini-product change

Fixes #490