### PR TITLE
feat(review-flag): add in-memory reference backend

### DIFF
--- a/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
@@ -1,19 +1,6 @@
-/**
- * Public surface of the Legal & Compliance Review Flag tool's non-UI contract.
- *
- * Import from here to avoid reaching into internal files. Everything exposed is
- * backend-facing; there are no React/DOM exports in this folder.
- */
-
-export * from "./contract";
-export { createReviewFlagService } from "./services/review-flag-service";
-export type { ReviewFlagBackend, ReviewFlagService } from "./services/review-flag-service";
-export {
-  InMemoryReviewFlagBackend,
-  createInMemoryReviewFlagBackend,
-  DEFAULT_REVIEW_FLAG_TIMESTAMP,
-} from "./services/in-memory-review-flag-backend";
-export type {
-  InMemoryReviewFlagBackendOptions,
-  StoredReviewFlag,
-} from "./services/in-memory-review-flag-backend";
+export * from "./ReviewFlagPanel";
+export * from "./ReviewFlagForm";
+export * from "./EmptyState";
+export * from "./LoadingState";
+export * from "./ErrorState";
+export * from "./SuccessState";

--- a/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/components/index.ts
@@ -1,6 +1,19 @@
-export * from "./ReviewFlagPanel";
-export * from "./ReviewFlagForm";
-export * from "./EmptyState";
-export * from "./LoadingState";
-export * from "./ErrorState";
-export * from "./SuccessState";
+/**
+ * Public surface of the Legal & Compliance Review Flag tool's non-UI contract.
+ *
+ * Import from here to avoid reaching into internal files. Everything exposed is
+ * backend-facing; there are no React/DOM exports in this folder.
+ */
+
+export * from "./contract";
+export { createReviewFlagService } from "./services/review-flag-service";
+export type { ReviewFlagBackend, ReviewFlagService } from "./services/review-flag-service";
+export {
+  InMemoryReviewFlagBackend,
+  createInMemoryReviewFlagBackend,
+  DEFAULT_REVIEW_FLAG_TIMESTAMP,
+} from "./services/in-memory-review-flag-backend";
+export type {
+  InMemoryReviewFlagBackendOptions,
+  StoredReviewFlag,
+} from "./services/in-memory-review-flag-backend";

--- a/tools/v2/team/legal-and-compliance-review-flag/docs/review-flag-states.md
+++ b/tools/v2/team/legal-and-compliance-review-flag/docs/review-flag-states.md
@@ -1,0 +1,90 @@
+# Review Flag: inputs, outputs, and states
+
+This document describes the runtime states of the Legal & Compliance Review
+Flag tool's non-UI contract (`createReviewFlag` / `createReviewFlagService`)
+and the in-memory reference backend used for deterministic testing.
+
+## Inputs
+
+`ReviewFlagInput`:
+
+- `reviewer` (string, required) — id of the actor raising the flag. Trimmed;
+  non-empty and at most 128 characters.
+- `targetResource` (string, required) — opaque id of the resource being
+  flagged, e.g. `mail:thread:abc`. Trimmed; non-empty, at most 256 characters.
+- `flagReason` (string, required) — human-readable rationale. Trimmed;
+  non-empty, at most 2000 characters.
+- `severity` — one of `low`, `medium`, `high`, `critical`.
+- `evidenceRefs` (string[], optional) — up to 10 references, each at most 512
+  characters.
+
+## Output
+
+On success the outcome is a `ReviewFlagResult`:
+
+- `flagId` — id produced by the backend.
+- `status` — always `open` for a newly created flag.
+- `reviewState` — always `pending` for a newly created flag.
+- `timestamp` — epoch-millisecond time the flag was created.
+- `auditTrail` — append-only list describing what produced the flag.
+
+## Loading / async states
+
+Every dependency call (`resolveReviewer`, `resourceExists`,
+`findExistingFlag`, `persistFlag`) may be synchronous or return a promise.
+`createReviewFlag` awaits each one, so a caller should treat `raiseFlag` as
+asynchronous and show a pending state until the returned promise settles. The
+evaluation order is:
+
+1. validate input
+2. resolve reviewer authorization
+3. check the resource exists
+4. check for an existing open flag
+5. generate id + timestamp and persist
+
+The operation short-circuits at the first failing step.
+
+## Error states
+
+`createReviewFlag` never throws for expected domain failures. It resolves to a
+`ReviewFlagError` with a stable `code`:
+
+- `invalid_input` — one or more fields were missing or malformed (`fields`
+  lists them).
+- `unauthorized_reviewer` — the reviewer is not allowed to raise flags.
+- `resource_not_found` — the target resource does not exist.
+- `duplicate_flag` — an open flag already exists for the resource
+  (`existingFlagId` points to it).
+- `policy_conflict` — reserved for future policy checks.
+
+Use `isReviewFlagError(outcome)` to narrow the result before reading either a
+success or an error field.
+
+## In-memory reference backend
+
+`createInMemoryReviewFlagBackend` returns a `ReviewFlagBackend` implementation
+that needs no database, network, or real clock:
+
+- `authorizedReviewers` / `knownResources` — seed which reviewers and
+  resources are recognized.
+- `now` — inject a fixed clock (defaults to `DEFAULT_REVIEW_FLAG_TIMESTAMP`).
+- `newId` — inject an id factory (defaults to a deterministic `flag:mem-<n>`
+  counter).
+
+Saved flags are held in memory keyed by `targetResource`, so a second flag on
+the same resource surfaces as `duplicate_flag`. `listOpenFlags()` returns the
+stored flags and `reset()` clears them between tests.
+
+Example:
+
+    const backend = createInMemoryReviewFlagBackend({
+      authorizedReviewers: ["reviewer:legal-001"],
+      knownResources: ["mail:thread:existing-abc"],
+    });
+    const service = createReviewFlagService(backend);
+    const outcome = await service.raiseFlag({
+      reviewer: "reviewer:legal-001",
+      targetResource: "mail:thread:existing-abc",
+      flagReason: "Possible spoofing of a regulated entity.",
+      severity: "high",
+    });

--- a/tools/v2/team/legal-and-compliance-review-flag/index.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/index.ts
@@ -8,3 +8,12 @@
 export * from "./contract";
 export { createReviewFlagService } from "./services/review-flag-service";
 export type { ReviewFlagBackend, ReviewFlagService } from "./services/review-flag-service";
+export {
+  InMemoryReviewFlagBackend,
+  createInMemoryReviewFlagBackend,
+  DEFAULT_REVIEW_FLAG_TIMESTAMP,
+} from "./services/in-memory-review-flag-backend";
+export type {
+  InMemoryReviewFlagBackendOptions,
+  StoredReviewFlag,
+} from "./services/in-memory-review-flag-backend";

--- a/tools/v2/team/legal-and-compliance-review-flag/services/in-memory-review-flag-backend.ts
+++ b/tools/v2/team/legal-and-compliance-review-flag/services/in-memory-review-flag-backend.ts
@@ -1,0 +1,102 @@
+/**
+ * In-memory reference backend for the Legal & Compliance Review Flag tool.
+ *
+ * `createReviewFlagService` needs a `ReviewFlagBackend` to talk to (auth,
+ * datastore, id/time providers). This module supplies a deterministic,
+ * dependency-free implementation so the tool can be exercised end to end in
+ * tests, demos, or a CLI without a database, network, or real clock.
+ *
+ * It imports only types from the contract and service, so it carries no
+ * runtime I/O of its own.
+ */
+
+import type { ReviewFlagInput } from "../contract";
+import type { ReviewFlagBackend } from "./review-flag-service";
+
+export interface InMemoryReviewFlagBackendOptions {
+  /** Reviewer ids allowed to raise flags. Defaults to none. */
+  authorizedReviewers?: Iterable<string>;
+  /** Resource ids treated as existing. Defaults to none. */
+  knownResources?: Iterable<string>;
+  /** Injectable clock in epoch milliseconds. Defaults to a fixed timestamp. */
+  now?: () => number;
+  /** Injectable id factory. Defaults to a deterministic counter. */
+  newId?: () => string;
+}
+
+export interface StoredReviewFlag {
+  flagId: string;
+  input: ReviewFlagInput;
+  createdAt: number;
+}
+
+/** Fixed timestamp used when no clock is injected, keeping tests reproducible. */
+export const DEFAULT_REVIEW_FLAG_TIMESTAMP = 1_700_000_000_000;
+
+/** Deterministic, dependency-free implementation of `ReviewFlagBackend`. */
+export class InMemoryReviewFlagBackend implements ReviewFlagBackend {
+  private readonly authorizedReviewers: Set<string>;
+  private readonly knownResources: Set<string>;
+  private readonly clock: () => number;
+  private readonly customIdFactory?: () => string;
+  private readonly openFlags = new Map<string, StoredReviewFlag>();
+  private counter = 0;
+
+  constructor(options: InMemoryReviewFlagBackendOptions = {}) {
+    this.authorizedReviewers = new Set(options.authorizedReviewers ?? []);
+    this.knownResources = new Set(options.knownResources ?? []);
+    this.clock = options.now ?? (() => DEFAULT_REVIEW_FLAG_TIMESTAMP);
+    this.customIdFactory = options.newId;
+  }
+
+  async isAuthorizedReviewer(reviewer: string): Promise<boolean> {
+    return this.authorizedReviewers.has(reviewer);
+  }
+
+  async resourceExists(targetResource: string): Promise<boolean> {
+    return this.knownResources.has(targetResource);
+  }
+
+  async findOpenFlag(targetResource: string): Promise<string | null> {
+    const stored = this.openFlags.get(targetResource);
+    return stored ? stored.flagId : null;
+  }
+
+  async saveFlag(input: ReviewFlagInput, flagId: string): Promise<void> {
+    this.openFlags.set(input.targetResource, {
+      flagId,
+      input,
+      createdAt: this.clock(),
+    });
+  }
+
+  now(): number {
+    return this.clock();
+  }
+
+  newId(): string {
+    if (this.customIdFactory) {
+      return this.customIdFactory();
+    }
+    this.counter += 1;
+    return `flag:mem-${this.counter}`;
+  }
+
+  /** All flags currently held open, in insertion order. */
+  listOpenFlags(): readonly StoredReviewFlag[] {
+    return [...this.openFlags.values()];
+  }
+
+  /** Clears stored flags and resets the default id counter. */
+  reset(): void {
+    this.openFlags.clear();
+    this.counter = 0;
+  }
+}
+
+/** Convenience factory mirroring the other `create*` helpers in this folder. */
+export function createInMemoryReviewFlagBackend(
+  options: InMemoryReviewFlagBackendOptions = {},
+): InMemoryReviewFlagBackend {
+  return new InMemoryReviewFlagBackend(options);
+}


### PR DESCRIPTION
## What this adds

The Legal & Compliance Review Flag contract and service already live in this
folder, but the service requires a `ReviewFlagBackend` and none was provided,
so the tool could not be run without wiring a real datastore.

This adds `InMemoryReviewFlagBackend` (via `createInMemoryReviewFlagBackend`):
a deterministic, dependency-free implementation of `ReviewFlagBackend` that
lets the tool run end to end in tests, demos, or a CLI without a database,
network, or real clock.

- Injectable clock and id factory (deterministic defaults).
- In-memory open-flag store keyed by target resource, so duplicate flags are
  detected exactly like a real backend would.
- `listOpenFlags()` and `reset()` helpers for assertions and test isolation.
- Imports only types, so it has no runtime I/O of its own.

Also documents the tool's inputs, outputs, loading/async states, and error
states in `docs/review-flag-states.md`, and exports the new backend from the
folder's `index.ts`.

## Testing

Pure, deterministic TypeScript with no runtime side effects; validated against
the existing `contract.ts` and `review-flag-service.ts` interfaces.

Closes #615