### PR TITLE
test(email-translator): cover translation core and document testing

### DIFF
--- a/ tools/v2/individual/email-translator/docs/email-translator-testing.md 
+++ b/ tools/v2/individual/email-translator/docs/email-translator-testing.md 
@@ -1,0 +1,97 @@
+# Email Translator — testing & review notes
+
+This document explains how the Email Translator tool is tested, how to run the
+tests, what they cover, and the known limitations a reviewer should be aware of.
+Everything described here lives entirely under
+`tools/v2/individual/email-translator/` and is isolated from the main
+application's test suite.
+
+## What is under test
+
+The tests target the folder-local core feature logic in
+`services/emailTranslationCore.ts` (`createEmailTranslationCore`). This is the
+piece that makes the tool "email-aware": it splits an email body into lines,
+translates only the human-authored content, and preserves quoted replies
+(`> ...`), blank lines, and signatures verbatim.
+
+The lower-level pieces it builds on are exercised indirectly:
+
+- `services/languages.ts` — supported-language lookup (`getLanguageByCode`).
+- `services/translationProvider.ts` — the `TranslationProvider` interface.
+- `types/index.ts` — `TranslationRequest` / `TranslationResult` shapes.
+
+## How to run
+
+From the tool folder:
+
+    cd tools/v2/individual/email-translator
+    bun x vitest run          # or: npx vitest run
+
+Vitest is configured in `vitest.config.ts` to run only this folder's tests
+(`include: ["tests/**/*.test.ts"]`, `environment: "node"`), so it does not pull
+in or depend on the main application's test setup.
+
+## Test approach: a deterministic injected provider
+
+The bundled `MockTranslationProvider` intentionally simulates network latency
+(an 800ms delay per line) and "translates" by reversing the letters in each
+word. That is fine for a live UI demo but makes unit assertions slow and hard to
+read.
+
+`createEmailTranslationCore(provider?)` accepts an injected provider, so the
+tests pass a tiny `FakeTranslationProvider` that:
+
+- resolves immediately (no timers, so tests are fast and deterministic), and
+- echoes each line back with a visible `<targetLanguage>` tag.
+
+This lets the tests assert exactly which lines were sent for translation and
+which were preserved untouched, without depending on wall-clock timing or the
+mock's word-reversal behaviour.
+
+## Coverage
+
+The suite (`tests/emailTranslationCore.test.ts`) covers:
+
+- **Empty input** — empty and whitespace-only bodies resolve to `EMPTY_BODY`.
+- **Unsupported target** — an unknown target language resolves to
+  `UNSUPPORTED_TARGET_LANGUAGE`.
+- **Unsupported source** — an unknown source language (when supplied) resolves
+  to `UNSUPPORTED_SOURCE_LANGUAGE`.
+- **Quote / blank preservation** — quoted lines (`^\s*>`) and blank lines are
+  copied verbatim and counted in `preservedLineCount`; only content lines are
+  sent to the provider and counted in `translatedLineCount`.
+- **Source-language default** — the provider receives `auto` when no source is
+  given, and the explicit source otherwise.
+- **Detected language** — a `detectedLanguage` reported by the provider is
+  surfaced on the result.
+- **All-quoted body** — a body containing only quoted lines is preserved and the
+  provider is never called.
+- **Language catalog** — `SUPPORTED_LANGUAGE_CODES` contains the expected codes.
+
+## Fixtures
+
+The tests build their sample email bodies inline (small, self-descriptive
+strings) rather than reading shared fixtures, keeping each case readable in
+isolation. If future tests need larger sample emails, add them under this
+folder's `fixtures/` directory (per the contributor rules in `README.md`) rather
+than in any main-app test helper.
+
+## Known limitations
+
+- **Core logic only.** These tests cover the non-UI translation core. The React
+  components and hooks are not exercised here; component tests would need a DOM
+  environment (`jsdom`) that this folder's `vitest.config.ts` does not currently
+  enable.
+- **No real provider.** Translation quality is out of scope — there is no live
+  translation backend, and the default provider is a deterministic mock. Wiring
+  a security-reviewed external provider is a separate future issue.
+- **Line-based model.** Quote detection is purely line-prefix based (`>`), which
+  matches common email clients but does not parse MIME parts, HTML email, or
+  inline "On <date> wrote:" headers beyond the quoted lines themselves.
+
+## Reviewer checklist
+
+- Tests live only under `tools/v2/individual/email-translator/` and touch no
+  main-app files.
+- `bun x vitest run` (or `npx vitest run`) passes from the tool folder.
+- No network access or real timers are required; the suite is deterministic.

--- a/ tools/v2/individual/email-translator/tests/emailTranslationCore.test.ts 
+++ b/ tools/v2/individual/email-translator/tests/emailTranslationCore.test.ts 
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmailTranslationCore,
+  SUPPORTED_LANGUAGE_CODES,
+} from "../services/emailTranslationCore";
+import type { TranslationProvider } from "../services/translationProvider";
+import type { TranslationRequest, TranslationResult } from "../types";
+
+/**
+ * Deterministic, dependency-free translation provider for tests.
+ *
+ * The bundled MockTranslationProvider sleeps 800ms per line and reverses words,
+ * which makes assertions slow and awkward. This fake resolves immediately and
+ * echoes the input with a visible target-language tag, so the tests can assert
+ * exactly which lines were translated and which were preserved.
+ */
+class FakeTranslationProvider implements TranslationProvider {
+  public readonly requests: TranslationRequest[] = [];
+
+  constructor(private readonly detectedLanguage?: string) {}
+
+  async translate(request: TranslationRequest): Promise<TranslationResult> {
+    this.requests.push(request);
+    return {
+      translatedText: `<${request.targetLanguage}>${request.text}`,
+      sourceLanguage: request.sourceLanguage,
+      targetLanguage: request.targetLanguage,
+      detectedLanguage: this.detectedLanguage,
+      confidence: 1,
+    };
+  }
+
+  async detectLanguage(): Promise<{ language: string; confidence: number }> {
+    return { language: this.detectedLanguage ?? "en", confidence: 1 };
+  }
+}
+
+describe("createEmailTranslationCore", () => {
+  it("rejects an empty or whitespace-only body", async () => {
+    const core = createEmailTranslationCore(new FakeTranslationProvider());
+
+    for (const body of ["", "   ", "\n\n", "  \n \t\n"]) {
+      const result = await core.translateBody(body, { targetLanguage: "fr" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("EMPTY_BODY");
+      }
+    }
+  });
+
+  it("rejects an unsupported target language", async () => {
+    const core = createEmailTranslationCore(new FakeTranslationProvider());
+
+    const result = await core.translateBody("Hello", { targetLanguage: "xx" });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNSUPPORTED_TARGET_LANGUAGE");
+    }
+  });
+
+  it("rejects an unsupported source language when one is provided", async () => {
+    const core = createEmailTranslationCore(new FakeTranslationProvider());
+
+    const result = await core.translateBody("Hello", {
+      sourceLanguage: "xx",
+      targetLanguage: "fr",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("UNSUPPORTED_SOURCE_LANGUAGE");
+    }
+  });
+
+  it("translates content lines and preserves quotes and blank lines verbatim", async () => {
+    const fake = new FakeTranslationProvider();
+    const core = createEmailTranslationCore(fake);
+
+    const body = [
+      "Hello there,",
+      "",
+      "> On Monday you wrote:",
+      ">> nested quote",
+      "  > indented quote",
+      "Please review the draft.",
+    ].join("\n");
+
+    const result = await core.translateBody(body, { targetLanguage: "fr" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.translatedLineCount).toBe(2);
+    expect(result.preservedLineCount).toBe(4);
+    expect(result.translatedBody.split("\n")).toEqual([
+      "<fr>Hello there,",
+      "",
+      "> On Monday you wrote:",
+      ">> nested quote",
+      "  > indented quote",
+      "<fr>Please review the draft.",
+    ]);
+
+    // Only the two content lines are sent to the provider.
+    expect(fake.requests.map((request) => request.text)).toEqual([
+      "Hello there,",
+      "Please review the draft.",
+    ]);
+  });
+
+  it("defaults the source language to auto and forwards an explicit source", async () => {
+    const autoFake = new FakeTranslationProvider();
+    const autoCore = createEmailTranslationCore(autoFake);
+    await autoCore.translateBody("Hello", { targetLanguage: "fr" });
+    expect(autoFake.requests[0]?.sourceLanguage).toBe("auto");
+
+    const explicitFake = new FakeTranslationProvider();
+    const explicitCore = createEmailTranslationCore(explicitFake);
+    await explicitCore.translateBody("Hello", {
+      sourceLanguage: "en",
+      targetLanguage: "fr",
+    });
+    expect(explicitFake.requests[0]?.sourceLanguage).toBe("en");
+  });
+
+  it("propagates a detected language reported by the provider", async () => {
+    const core = createEmailTranslationCore(new FakeTranslationProvider("de"));
+
+    const result = await core.translateBody("Guten Tag", { targetLanguage: "en" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.detectedLanguage).toBe("de");
+  });
+
+  it("preserves an all-quoted body without calling the provider", async () => {
+    const fake = new FakeTranslationProvider();
+    const core = createEmailTranslationCore(fake);
+
+    const body = ["> quoted one", "> quoted two"].join("\n");
+    const result = await core.translateBody(body, { targetLanguage: "fr" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.translatedLineCount).toBe(0);
+    expect(result.preservedLineCount).toBe(2);
+    expect(result.translatedBody).toBe(body);
+    expect(fake.requests).toHaveLength(0);
+  });
+
+  it("exposes the supported language codes catalog", () => {
+    expect(SUPPORTED_LANGUAGE_CODES).toContain("en");
+    expect(SUPPORTED_LANGUAGE_CODES).toContain("fr");
+    expect(SUPPORTED_LANGUAGE_CODES).toContain("zh-TW");
+    expect(SUPPORTED_LANGUAGE_CODES).not.toContain("xx");
+  });
+});


### PR DESCRIPTION
## What this adds

Issue #498 asks for folder-local test coverage of the Email Translator's core
behaviour plus documentation of setup, usage, fixtures, and known limitations.

This adds:

- `tests/emailTranslationCore.test.ts` — Vitest coverage for
  `createEmailTranslationCore`: empty-body rejection, unsupported source/target
  languages, quote-line and blank-line preservation with correct
  translated/preserved line counts, source-language defaulting to `auto`,
  detected-language propagation, and the supported-language catalog. The tests
  inject a small deterministic provider so they are fast and have no network or
  timing dependencies.
- `docs/email-translator-testing.md` — how to run the tests, what they cover,
  the deterministic-provider approach, fixtures guidance, known limitations, and
  a reviewer checklist.

## Scope

Everything stays under `tools/v2/individual/email-translator/` and does not
touch the main application or its test setup (`vitest.config.ts` already scopes
runs to this folder). No production code is changed.

## Testing

    cd tools/v2/individual/email-translator
    bun x vitest run

Closes #498