### PR TITLE
feat(protocol): relay request auth + replay protection (#59)

### DIFF
--- a/docs/protocol/relay-auth-replay.md
+++ b/docs/protocol/relay-auth-replay.md
@@ -1,0 +1,132 @@
+# Relay Request Authentication and Replay Protection
+
+Status: proposed
+Scope: `protocol` (relay request authentication, replay protection)
+Related: `protocol/messages/envelope_spec.md`, `protocol/relay/README.md`
+
+## 1. Motivation
+
+TLS protects a request in transit but does **not** prevent a captured, valid
+request from being replayed across time or across relays. A single signed
+envelope can be submitted to many relays, or resubmitted after a transient
+failure, producing duplicate deliveries or forged-at-relay attacks. This
+document defines the canonical, signed relay request and the mechanisms that
+make replays detectable and idempotent.
+
+## 2. Threat model
+
+- **R1 — Cross-relay replay.** An attacker captures a valid signed request and
+  replays it to a second relay after the first accepted it.
+- **R2 — Temporal replay.** An attacker replays a captured request far in the
+  future (after the originating client is gone).
+- **R3 — Duplicate delivery.** A benign retry (network timeout) causes the same
+  logical request to be delivered twice.
+- **R4 — Audience confusion.** A request signed for relay A is replayed against
+  relay B, which accepts it because it only checks the envelope signature.
+- **R5 — Clock skew.** Honest clients and relays disagree on "now", causing
+  legitimate requests to be rejected or stale ones to be accepted.
+
+## 3. Canonical signed request
+
+A relay request is the envelope payload (per `envelope_spec.md`) extended with
+four anti-replay fields:
+
+```json
+{
+  "version": "v1",
+  "sender": "GBBB...",
+  "recipient": "GCCC...",
+  "timestamp": "2026-06-17T22:00:00Z",
+  "encryption_metadata": { "...": "..." },
+  "content_commitment": "5b40cf39...",
+  "attachments": [],
+
+  "request_nonce": "a1b2c3d4e5f6...",
+  "audience": "relay:us-east-1.stealth.test",
+  "idempotency_key": "idem-9f8e7d6c5b4a",
+  "replay_window_seconds": 300
+}
+```
+
+All four new fields are **mandatory** for relay submission. They are included in
+the canonical (JCS) serialization that is signed, so a tamperer cannot strip or
+alter them without invalidating the signature.
+
+| Field                   | Type                | Purpose                                                |
+| ----------------------- | ------------------- | ------------------------------------------------------ |
+| `request_nonce`         | 16+ byte random hex | Binds a specific relay submission; unique per attempt. |
+| `audience`              | string              | Names the intended relay/authority; prevents R4.       |
+| `idempotency_key`       | string              | Stable client-chosen key; drives dedup (R3).           |
+| `replay_window_seconds` | integer             | Client-stated freshness window; clamped server-side.   |
+
+## 4. Signature coverage
+
+The Ed25519 signature covers `jcs(payload)` exactly as today, but the payload
+**now includes** the four anti-replay fields. No separate signature is added;
+the envelope signature is the request authenticator. This keeps a single
+verification path.
+
+```
+signature = sign(private_key, jcs(payload))
+```
+
+## 5. Server-side validation (fail closed)
+
+A relay MUST reject a request that fails any step:
+
+1. **Signature** — verify Ed25519 over `jcs(payload)`; reject `INVALID_SIGNATURE`.
+2. **Audience** — `audience` MUST equal the relay's configured authority id;
+   reject `AUDIENCE_MISMATCH`.
+3. **Freshness** — `now - timestamp` MUST be within
+   `[0, min(replay_window_seconds, MAX_REPLAY_WINDOW)]`; reject
+   `STALE_REQUEST` (too old) or `FUTURE_REQUEST` (too far ahead, clock skew).
+4. **Nonce uniqueness** — `request_nonce` MUST NOT already be recorded; reject
+   `REPLAY_DETECTED`.
+5. **Idempotency** — if `idempotency_key` was seen with a completed result,
+   return the original stored response with header `x-idempotency-replayed:
+true` and HTTP 200/201 (never re-execute).
+
+Order is significant: signature and audience are cheap and run first; nonce and
+idempotency checks run against the recorded state.
+
+## 6. Replay window and clock skew
+
+- `MAX_REPLAY_WINDOW` is a server constant (default **300s**).
+- A request whose `replay_window_seconds` exceeds `MAX_REPLAY_WINDOW` is
+  **clamped** to the maximum; the client's stated window is never trusted to
+  widen the server's bound.
+- `FUTURE_REQUEST` is allowed only within `CLOCK_SKEW_TOLERANCE` (default **30s**)
+  to absorb honest clock drift (R5).
+- A nonce is retained for `MAX_REPLAY_WINDOW + CLOCK_SKEW_TOLERANCE` after first
+  seen, then evicted.
+
+## 7. Negative vectors (conformance)
+
+The conformance suite (`tests/unit/protocol/relay-auth-replay.test.ts`) MUST
+reject, at minimum:
+
+- `replay/cross-relay` — valid signature but `audience` names a different relay.
+- `replay/stale` — `timestamp` older than the window.
+- `replay/future` — `timestamp` ahead beyond skew tolerance.
+- `replay/duplicate-nonce` — same `request_nonce` submitted twice.
+- `replay/tampered-nonce` — signature valid but `request_nonce` altered after
+  signing (canonicalization catches this).
+- `replay/missing-fields` — any mandatory anti-replay field absent
+  (`INVALID_REQUEST`).
+
+## 8. Stable errors
+
+| Code                | HTTP | Meaning                                      |
+| ------------------- | ---- | -------------------------------------------- |
+| `INVALID_SIGNATURE` | 401  | Envelope signature fails verification.       |
+| `AUDIENCE_MISMATCH` | 403  | `audience` does not match this relay.        |
+| `STALE_REQUEST`     | 400  | `timestamp` older than allowed window.       |
+| `FUTURE_REQUEST`    | 400  | `timestamp` too far in the future.           |
+| `REPLAY_DETECTED`   | 409  | `request_nonce` already recorded.            |
+| `INVALID_REQUEST`   | 400  | Mandatory anti-replay field missing/invalid. |
+
+## 9. Success signal
+
+Conformance tests reject every replay variant in §7 using the reference
+verifier in `src/services/crypto/relayAuth.ts`, driven by
+`protocol/vectors/relay-auth-replay.json`.

--- a/protocol/vectors/relay-auth-replay.json
+++ b/protocol/vectors/relay-auth-replay.json
@@ -1,0 +1,118 @@
+{
+  "meta": {
+    "spec": "docs/protocol/relay-auth-replay.md",
+    "purpose": "Conformance vectors for relay request authentication and replay protection (issue #59).",
+    "note": "Signing is performed by the test harness with a fixed ed25519 keypair; payloads carrying overrides are signed AFTER overrides are applied so their signature remains valid (semantics-failing cases). 'tamper' cases mutate the payload after signing to prove canonicalization catches it."
+  },
+  "base": {
+    "version": "v1",
+    "sender": "a01bcbe720d8344a40b29b5a447fd57d2dd2ce02209a0c581c7bcf9b9706bcf8",
+    "recipient": "b01bcbe720d8344a40b29b5a447fd57d2dd2ce02209a0c581c7bcf9b9706bcf9",
+    "timestamp": "NOW",
+    "encryption_metadata": { "algorithm": "AES-256-GCM", "nonce": "00", "mac": "00" },
+    "content_commitment": "5b40cf39e4a86e969d27038e8e78e86cf0f4e1f7a0756e0766a5cfbfcae29202",
+    "attachments": [],
+    "request_nonce": "nonce-base-0000000000000000",
+    "audience": "relay:test.stealth",
+    "idempotency_key": "idem-base-0000000000000000",
+    "replay_window_seconds": 300
+  },
+  "cases": [
+    {
+      "id": "relay/positive/accepted",
+      "description": "Well-formed, fresh, correctly-signed request is accepted.",
+      "overrides": {},
+      "tamper": null,
+      "preseed": null,
+      "expected": { "ok": true }
+    },
+    {
+      "id": "relay/positive/idempotent-replay",
+      "description": "Second submission with same idempotency_key returns original (x-idempotency-replayed).",
+      "overrides": { "request_nonce": "nonce-idem-0000000000000001" },
+      "tamper": null,
+      "preseed": {
+        "idempotencyKey": "idem-base-0000000000000000",
+        "idempotency": { "accepted": true, "messageId": "prior-commitment" }
+      },
+      "expected": { "ok": true, "idempotencyReplayed": true }
+    },
+    {
+      "id": "relay/negative/cross-relay",
+      "description": "Valid signature but audience names a different relay (R4).",
+      "overrides": {
+        "audience": "relay:other.stealth",
+        "request_nonce": "nonce-xrelay-000000000000",
+        "idempotency_key": "idem-xrelay-00000000000"
+      },
+      "tamper": null,
+      "preseed": null,
+      "expected": { "error": "AUDIENCE_MISMATCH" }
+    },
+    {
+      "id": "relay/negative/stale",
+      "description": "timestamp older than the replay window (R2).",
+      "overrides": {
+        "timestamp": "STALE",
+        "request_nonce": "nonce-stale-000000000000",
+        "idempotency_key": "idem-stale-00000000000"
+      },
+      "tamper": null,
+      "preseed": null,
+      "expected": { "error": "STALE_REQUEST" }
+    },
+    {
+      "id": "relay/negative/future",
+      "description": "timestamp too far in the future (R5).",
+      "overrides": {
+        "timestamp": "FUTURE",
+        "request_nonce": "nonce-future-0000000000",
+        "idempotency_key": "idem-future-000000000"
+      },
+      "tamper": null,
+      "preseed": null,
+      "expected": { "error": "FUTURE_REQUEST" }
+    },
+    {
+      "id": "relay/negative/duplicate-nonce",
+      "description": "Same request_nonce submitted twice (R1).",
+      "overrides": {
+        "request_nonce": "nonce-dup-00000000000000",
+        "idempotency_key": "idem-dup-0000000000000"
+      },
+      "tamper": null,
+      "preseed": { "nonce": "nonce-dup-00000000000000" },
+      "expected": { "error": "REPLAY_DETECTED" }
+    },
+    {
+      "id": "relay/negative/tampered-nonce",
+      "description": "Valid signature, then nonce altered after signing (canonicalization catches it).",
+      "overrides": {
+        "request_nonce": "nonce-good-0000000000000",
+        "idempotency_key": "idem-tamper-0000000000"
+      },
+      "tamper": "nonce",
+      "preseed": null,
+      "expected": { "error": "INVALID_SIGNATURE" }
+    },
+    {
+      "id": "relay/negative/missing-fields",
+      "description": "Mandatory anti-replay field absent (INVALID_REQUEST).",
+      "overrides": { "request_nonce": null, "idempotency_key": "idem-miss-00000000000" },
+      "tamper": null,
+      "preseed": null,
+      "expected": { "error": "INVALID_REQUEST" }
+    },
+    {
+      "id": "relay/negative/bad-signature",
+      "description": "Signature computed with a different key.",
+      "overrides": {
+        "request_nonce": "nonce-badsig-0000000000",
+        "idempotency_key": "idem-badsig-00000000"
+      },
+      "tamper": null,
+      "preseed": null,
+      "expected": { "error": "INVALID_SIGNATURE", "useWrongKey": true }
+    }
+  ]
+}

--- a/src/services/crypto/relayAuth.ts
+++ b/src/services/crypto/relayAuth.ts
@@ -1,0 +1,172 @@
+/**
+ * Relay request authentication and replay protection.
+ *
+ * Reference verifier for protocol/docs/protocol/relay-auth-replay.md. It
+ * validates a relay request (envelope payload + the four mandatory anti-replay
+ * fields) in a strict, fail-closed order: signature -> audience -> freshness ->
+ * nonce uniqueness -> idempotency.
+ *
+ * The module is pure and deterministic: time and the nonce store are injected so
+ * it can be driven by conformance vectors without wall-clock or global state.
+ */
+
+import { canonicalizePayload } from "./envelope";
+
+/** Server-side constants (see spec §6). */
+export const MAX_REPLAY_WINDOW_SECONDS = 300;
+export const CLOCK_SKEW_TOLERANCE_SECONDS = 30;
+
+/** Stable error codes (spec §8). */
+export type RelayAuthErrorCode =
+  | "INVALID_SIGNATURE"
+  | "AUDIENCE_MISMATCH"
+  | "STALE_REQUEST"
+  | "FUTURE_REQUEST"
+  | "REPLAY_DETECTED"
+  | "INVALID_REQUEST";
+
+export class RelayAuthError extends Error {
+  readonly code: RelayAuthErrorCode;
+  readonly httpStatus: number;
+  constructor(code: RelayAuthErrorCode, message: string) {
+    super(message);
+    this.name = "RelayAuthError";
+    this.code = code;
+    this.httpStatus = code === "INVALID_SIGNATURE" ? 401 : code === "AUDIENCE_MISMATCH" ? 403 : 409;
+  }
+}
+
+/** A relay request: the envelope payload plus the four anti-replay fields. */
+export interface RelayRequestPayload {
+  version: "v1";
+  sender: string;
+  recipient: string;
+  timestamp: string;
+  encryption_metadata: { algorithm: string; nonce: string; mac: string };
+  content_commitment: string;
+  attachments: unknown[];
+  request_nonce: string;
+  audience: string;
+  idempotency_key: string;
+  replay_window_seconds: number;
+}
+
+export interface RelayRequest {
+  payload: RelayRequestPayload;
+  /** Hex-encoded Ed25519 signature over jcs(payload). */
+  signature: { scheme: "Ed25519"; value: string };
+}
+
+/** Minimal verifier injected by the caller (e.g. ed25519 via noble/tweetnacl). */
+export type SignatureVerifier = (params: {
+  publicKey: string;
+  message: string;
+  signature: string;
+}) => boolean;
+
+export interface RelayAuthConfig {
+  /** The authority id this relay answers to (spec §5.2). */
+  audience: string;
+  /** Verifies an Ed25519 signature over the canonical payload. */
+  verify: SignatureVerifier;
+  /** Resolves the sender's Ed25519 public key (Stellar G-address). */
+  resolvePublicKey: (sender: string) => string | null;
+  /** Returns true if the nonce was already recorded. */
+  isNonceSeen: (nonce: string) => boolean;
+  /** Records a nonce as seen (called after successful validation). */
+  markNonceSeen: (nonce: string) => void;
+  /** Returns the stored result for an idempotency key, if any. */
+  getIdempotencyResult: (key: string) => unknown | null;
+  /** Stores the result against an idempotency key. */
+  storeIdempotencyResult: (key: string, result: unknown) => void;
+  /** Injectable clock (seconds since epoch) for deterministic tests. */
+  nowSeconds: () => number;
+}
+
+function parseTimestampSeconds(ts: string): number {
+  const ms = Date.parse(ts);
+  if (Number.isNaN(ms)) {
+    throw new RelayAuthError("INVALID_REQUEST", `Invalid timestamp: ${ts}`);
+  }
+  return Math.floor(ms / 1000);
+}
+
+/**
+ * Validate a relay request.
+ *
+ * Returns `{ ok: true, idempotencyReplayed: boolean, result?: unknown }`. When
+ * the idempotency key was already completed, `idempotencyReplayed` is true and
+ * `result` carries the original stored value (spec §5.5). On any failure throws
+ * `RelayAuthError` with a stable code.
+ */
+export function verifyRelayRequest(
+  request: RelayRequest,
+  config: RelayAuthConfig,
+): { ok: true; idempotencyReplayed: boolean; result?: unknown } {
+  const { payload, signature } = request;
+
+  // --- Mandatory fields (spec §3) ---
+  if (
+    typeof payload.request_nonce !== "string" ||
+    typeof payload.audience !== "string" ||
+    typeof payload.idempotency_key !== "string" ||
+    typeof payload.replay_window_seconds !== "number"
+  ) {
+    throw new RelayAuthError("INVALID_REQUEST", "Missing mandatory anti-replay field(s)");
+  }
+  if (payload.request_nonce.length < 16) {
+    throw new RelayAuthError("INVALID_REQUEST", "request_nonce too short");
+  }
+
+  // --- 1. Signature (spec §5.1) ---
+  const publicKey = config.resolvePublicKey(payload.sender);
+  if (!publicKey) {
+    throw new RelayAuthError("INVALID_SIGNATURE", "Unknown sender public key");
+  }
+  const canonical = canonicalizePayload(payload);
+  const sigOk = config.verify({
+    publicKey,
+    message: canonical,
+    signature: signature.value,
+  });
+  if (!sigOk) {
+    throw new RelayAuthError("INVALID_SIGNATURE", "Signature verification failed");
+  }
+
+  // --- 2. Audience (spec §5.2) ---
+  if (payload.audience !== config.audience) {
+    throw new RelayAuthError(
+      "AUDIENCE_MISMATCH",
+      `audience ${payload.audience} != ${config.audience}`,
+    );
+  }
+
+  // --- 3. Freshness (spec §5.3, §6) ---
+  const now = config.nowSeconds();
+  const ts = parseTimestampSeconds(payload.timestamp);
+  const delta = now - ts;
+  const window = Math.min(payload.replay_window_seconds, MAX_REPLAY_WINDOW_SECONDS);
+  if (delta > window) {
+    throw new RelayAuthError("STALE_REQUEST", "Request older than replay window");
+  }
+  if (delta < -CLOCK_SKEW_TOLERANCE_SECONDS) {
+    throw new RelayAuthError("FUTURE_REQUEST", "Timestamp too far in the future");
+  }
+
+  // --- 4. Nonce uniqueness (spec §5.4) ---
+  if (config.isNonceSeen(payload.request_nonce)) {
+    throw new RelayAuthError("REPLAY_DETECTED", "request_nonce already seen");
+  }
+
+  // --- 5. Idempotency (spec §5.5) ---
+  const prior = config.getIdempotencyResult(payload.idempotency_key);
+  if (prior !== null && prior !== undefined) {
+    return { ok: true, idempotencyReplayed: true, result: prior };
+  }
+
+  // Record presence so a subsequent identical request is idempotent.
+  config.markNonceSeen(payload.request_nonce);
+  const result = { accepted: true, messageId: payload.content_commitment };
+  config.storeIdempotencyResult(payload.idempotency_key, result);
+  return { ok: true, idempotencyReplayed: false, result };
+}

--- a/tests/unit/protocol/relay-auth-replay.test.ts
+++ b/tests/unit/protocol/relay-auth-replay.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Conformance tests for relay request authentication and replay protection
+ * (issue #59). Drives protocol/vectors/relay-auth-replay.json through the
+ * reference verifier in src/services/crypto/relayAuth.ts.
+ *
+ * Uses Node's built-in ed25519 so verification is real, not mocked. The test
+ * keypair is fixed for determinism. Time is injected so STALE/FUTURE cases are
+ * reproducible.
+ */
+import { describe, expect, it } from "vitest";
+import { createHash, createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
+
+import {
+  verifyRelayRequest,
+  RelayAuthError,
+  type RelayAuthConfig,
+  type RelayRequest,
+} from "../../../src/services/crypto/relayAuth";
+import { canonicalizePayload } from "../../../src/services/crypto/envelope";
+import vectors from "../../../protocol/vectors/relay-auth-replay.json";
+
+// Fixed ed25519 keypair (DER) for deterministic signing in tests.
+const PRIV_DER =
+  "302e020100300506032b6570042204207a08dbb372ef48aaba159e65964528b6e82c2971ec14fec43a6d5b139962a582";
+const PUB_DER =
+  "302a300506032b6570032100a01bcbe720d8344a40b29b5a447fd57d2dd2ce02209a0c581c7bcf9b9706bcf8";
+const SENDER = "a01bcbe720d8344a40b29b5a447fd57d2dd2ce02209a0c581c7bcf9b9706bcf8";
+
+const privKey = createPrivateKey({
+  key: Buffer.from(PRIV_DER, "hex"),
+  format: "der",
+  type: "pkcs8",
+});
+const pubKey = createPublicKey({
+  key: Buffer.from(PUB_DER, "hex"),
+  format: "der",
+  type: "spki",
+});
+
+/** Sign the canonical (JCS) payload — must match what verifyRelayRequest checks. */
+function signCanonical(payload: unknown): string {
+  const msg = Buffer.from(canonicalizePayload(payload));
+  return sign(null, msg, privKey).toString("hex");
+}
+
+/** In-memory nonce + idempotency store that resets per case. */
+function makeStore() {
+  const nonces = new Set<string>();
+  const idemp = new Map<string, unknown>();
+  return {
+    isNonceSeen: (n: string) => nonces.has(n),
+    markNonceSeen: (n: string) => void nonces.add(n),
+    getIdempotencyResult: (k: string) => (idemp.has(k) ? idemp.get(k) : null),
+    storeIdempotencyResult: (k: string, r: unknown) => void idemp.set(k, r),
+  };
+}
+
+function buildConfig(nowSeconds: number, store: ReturnType<typeof makeStore>): RelayAuthConfig {
+  return {
+    audience: "relay:test.stealth",
+    verify: ({ publicKey, message, signature }) => {
+      // message is the canonical JSON string; signature is hex.
+      const sig = Buffer.from(signature, "hex");
+      const msg = Buffer.from(message);
+      const key = createPublicKey({
+        key: Buffer.from(publicKey, "hex"),
+        format: "der",
+        type: "spki",
+      });
+      return verify(null, msg, key, sig);
+    },
+    resolvePublicKey: (sender: string) => (sender === SENDER ? PUB_DER : null),
+    ...store,
+    nowSeconds: () => nowSeconds,
+  };
+}
+
+const NOW_SECONDS = 1_700_000_000;
+const NOW_ISO = new Date(NOW_SECONDS * 1000).toISOString();
+
+describe("relay auth + replay protection (#59)", () => {
+  for (const c of vectors.cases as any[]) {
+    it(c.id, () => {
+      const store = makeStore();
+      const config = buildConfig(NOW_SECONDS, store);
+
+      // Build payload from base + overrides.
+      const payload: Record<string, unknown> = { ...vectors.base };
+      if (c.overrides) {
+        for (const [k, v] of Object.entries(c.overrides)) {
+          if (v === null) delete payload[k];
+          else payload[k] = v;
+        }
+      }
+      // Timestamp handling.
+      if (payload.timestamp === "NOW") payload.timestamp = NOW_ISO;
+      else if (payload.timestamp === "STALE")
+        payload.timestamp = new Date((NOW_SECONDS - 600) * 1000).toISOString();
+      else if (payload.timestamp === "FUTURE")
+        payload.timestamp = new Date((NOW_SECONDS + 600) * 1000).toISOString();
+
+      // Preseed store (duplicate nonce / idempotent replay).
+      if (c.preseed?.nonce) store.markNonceSeen(c.preseed.nonce);
+      if (c.preseed?.idempotency !== undefined) {
+        store.storeIdempotencyResult(
+          c.preseed.idempotencyKey ?? "idem-idem-000000000",
+          c.preseed.idempotency,
+        );
+      }
+
+      const signingKey = c.expected.useWrongKey
+        ? createPrivateKey({
+            key: Buffer.from(
+              "302e020100300506032b6570042204200000000000000000000000000000000000000000000000000000000000000001",
+              "hex",
+            ),
+            format: "der",
+            type: "pkcs8",
+          })
+        : privKey;
+
+      const sig = sign(null, Buffer.from(canonicalizePayload(payload)), signingKey).toString("hex");
+
+      // Tamper AFTER signing (mutate nonce; canonicalization must invalidate sig).
+      if (c.tamper === "nonce") {
+        payload.request_nonce = "nonce-tampered-after-sign";
+      }
+
+      const request: RelayRequest = {
+        payload: payload as any,
+        signature: { scheme: "Ed25519", value: sig },
+      };
+
+      if (c.expected.ok) {
+        const result = verifyRelayRequest(request, config);
+        expect(result.ok).toBe(true);
+        if (c.expected.idempotencyReplayed !== undefined) {
+          expect(result.idempotencyReplayed).toBe(c.expected.idempotencyReplayed);
+        }
+      } else {
+        let thrown: unknown;
+        try {
+          verifyRelayRequest(request, config);
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(RelayAuthError);
+        expect((thrown as RelayAuthError).code).toBe(c.expected.error);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Implements **#59** — relay request authentication and replay protection. A captured, valid signed envelope must not be replayable across relays or time; duplicate deliveries must be idempotent.

- `docs/protocol/relay-auth-replay.md`: design spec — canonical signed request (envelope payload + mandatory `request_nonce` / `audience` / `idempotency_key` / `replay_window_seconds`, covered by the existing JCS signature), fail-closed validation order (signature → audience → freshness → nonce → idempotency), clock-skew tolerance, replay-window clamping, stable error codes, threat model, and the required negative vectors.
- `src/services/crypto/relayAuth.ts`: reference verifier (`verifyRelayRequest`) — pure, deterministic, with injected time + nonce/idempotency store + signature verifier (no global state, no network, no secrets).
- `protocol/vectors/relay-auth-replay.json`: conformance vectors for every replay variant in the spec (cross-relay, stale, future, duplicate-nonce, tampered, missing-fields, bad-signature, plus positive + idempotent-replay).
- `tests/unit/protocol/relay-auth-replay.test.ts`: 9 conformance tests using **real ed25519** (node:crypto), driven by the vectors — all pass.

The existing envelope spec/signature scheme is extended, not modified.

## Acceptance criteria
- [x] Cross-relay replay prevented (audience binding)
- [x] Duplicate delivery is idempotent (idempotency key)
- [x] Replay window documented + clamped server-side
- [x] Negative vectors included (all reject)
- [x] Conformance tests reject every replay variant in the threat model

Fixes #59