### PR TITLE
test(internal-comment-thread): add edge-case coverage and review docs 

### DIFF
--- a/tools/v1/team/internal-comment-thread/docs/testing-and-review.md
+++ b/tools/v1/team/internal-comment-thread/docs/testing-and-review.md
@@ -1,0 +1,86 @@
+# Internal Comment Thread — Testing & Review Guide
+
+This document explains how the Internal Comment Thread tool is tested and how an
+OSS contributor can review it independently, without wiring it into the main
+mail app. Everything referenced here stays inside
+`tools/v1/team/internal-comment-thread/`.
+
+## How to run the tests
+
+From the repository root:
+
+    bun x vitest run tools/v1/team/internal-comment-thread
+
+The suite is pure, deterministic TypeScript — no network, no database, and no
+secrets are required.
+
+## What is covered
+
+Tests live in two folder-local files:
+
+- `service.test.ts` — happy-path behavior of `CommentThreadService`:
+  - Listing threads for a target.
+  - Creating a thread with its initial comment.
+  - Adding a comment to an existing thread.
+  - Updating a thread's status.
+  - Soft-deleting a comment.
+  - Rejecting thread creation for an unknown author.
+- `service.edge-cases.test.ts` — error paths and edge cases that are easy to
+  regress:
+  - `getThread` returns `null` for an unknown thread id.
+  - `getThreadsForTarget` returns an empty list when nothing matches.
+  - A newly created thread is retrievable by id and by target.
+  - `addComment` rejects for a missing thread and for an unknown author.
+  - `addComment` validates the thread **before** the author.
+  - `updateThreadStatus` rejects for a missing thread and supports `archived`.
+  - `deleteComment` rejects for a missing thread and for a missing comment.
+  - Separate `CommentThreadService` instances stay isolated from each other.
+
+## Fixtures
+
+Deterministic mock data lives in `fixtures.ts`:
+
+- `mockUsers`: `u-1` (Alice, admin) and `u-2` (Bob, member).
+- `mockThreads`: one open thread `th-1` on target `txn-123` / `transaction`.
+- `mockComments`: two comments (`c-1`, `c-2`) on `th-1`.
+
+`CommentThreadService` loads these fixtures in its constructor, so every
+`new CommentThreadService()` starts from the same known state.
+
+## Important caveat for test authors
+
+`CommentThreadService` stores the fixture **objects by reference**. Mutating
+operations (`deleteComment` sets `isDeleted`, `updateThreadStatus` sets
+`status`, `addComment` touches `updatedAt`) therefore mutate the shared fixture
+objects, and that state is **not** reset by creating a new service instance
+within the same test file.
+
+Because Vitest isolates module state per test file, this does not leak between
+`service.test.ts` and `service.edge-cases.test.ts`. Within a single file,
+though, any test that mutates `th-1`, `c-1`, or `c-2` is ordered after the
+read-only tests so it cannot affect earlier assertions. New tests should follow
+the same rule, or assert only on freshly created threads.
+
+## Known limitations
+
+- **In-memory only.** There is no durable storage; all state is lost when the
+  process ends. A future integration issue will introduce a real storage
+  adapter.
+- **Simulated latency.** Each service call awaits a fixed 50 ms timer to model
+  async behavior; timing is not meant to reflect real backends.
+- **No UI/DOM tests.** Coverage targets the service layer. The
+  `useCommentThread` React hook is documented in `README.md` but is not
+  exercised here, since that would require a DOM/React testing environment the
+  isolated tool intentionally avoids for now.
+- **Flat membership.** Role-based permissions and cross-team visibility are out
+  of scope per `specs.md`.
+
+## Reviewer checklist
+
+- [ ] Tests run green with the command above.
+- [ ] No file outside `tools/v1/team/internal-comment-thread/` is changed.
+- [ ] No imports from `src/`, `tools/v2/`, or sibling tool folders.
+- [ ] New tests assert on freshly created threads, or are ordered after the
+      read-only tests (see the caveat above).
+- [ ] No comment body text is exposed on any external delivery path (the spec's
+      firm rule).

--- a/tools/v1/team/internal-comment-thread/service.edge-cases.test.ts
+++ b/tools/v1/team/internal-comment-thread/service.edge-cases.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { CommentThreadService } from "./service";
+
+/**
+ * Edge-case and error-path coverage for CommentThreadService.
+ *
+ * These tests are intentionally separate from `service.test.ts` (which covers
+ * the happy paths) and focus on the branches that are easy to regress:
+ * not-found errors, argument precedence, empty results, and per-instance
+ * fixture isolation. See `docs/testing-and-review.md` for the full plan and the
+ * shared-fixture caveat that dictates the ordering of the mutating tests.
+ */
+describe("CommentThreadService (edge cases)", () => {
+  let service: CommentThreadService;
+
+  beforeEach(() => {
+    service = new CommentThreadService();
+  });
+
+  it("returns null when getting a thread that does not exist", async () => {
+    const thread = await service.getThread("th-does-not-exist");
+    expect(thread).toBeNull();
+  });
+
+  it("returns an empty list for a target with no threads", async () => {
+    const threads = await service.getThreadsForTarget("txn-999", "transaction");
+    expect(threads).toEqual([]);
+  });
+
+  it("makes a newly created thread retrievable by id and by target", async () => {
+    const created = await service.createThread("doc-777", "document", "Kickoff note", "u-1");
+
+    const byId = await service.getThread(created.id);
+    expect(byId?.id).toBe(created.id);
+    expect(byId?.comments).toHaveLength(1);
+
+    const byTarget = await service.getThreadsForTarget("doc-777", "document");
+    expect(byTarget).toHaveLength(1);
+    expect(byTarget[0].id).toBe(created.id);
+  });
+
+  it("throws when adding a comment to a missing thread", async () => {
+    await expect(service.addComment("th-missing", "u-1", "Hello")).rejects.toThrow(
+      "Thread not found",
+    );
+  });
+
+  it("throws when adding a comment with an unknown author", async () => {
+    await expect(service.addComment("th-1", "u-unknown", "Hello")).rejects.toThrow(
+      "Author not found",
+    );
+  });
+
+  it("checks the thread before the author when adding a comment", async () => {
+    await expect(service.addComment("th-missing", "u-unknown", "Hello")).rejects.toThrow(
+      "Thread not found",
+    );
+  });
+
+  it("throws when updating the status of a missing thread", async () => {
+    await expect(service.updateThreadStatus("th-missing", "resolved")).rejects.toThrow(
+      "Thread not found",
+    );
+  });
+
+  it("throws when deleting a comment from a missing thread", async () => {
+    await expect(service.deleteComment("th-missing", "c-1")).rejects.toThrow("Thread not found");
+  });
+
+  it("throws when deleting a comment that does not exist", async () => {
+    await expect(service.deleteComment("th-1", "c-unknown")).rejects.toThrow("Comment not found");
+  });
+
+  it("supports moving a thread to the archived status", async () => {
+    const updated = await service.updateThreadStatus("th-1", "archived");
+    expect(updated.status).toBe("archived");
+
+    const fetched = await service.getThread("th-1");
+    expect(fetched?.status).toBe("archived");
+  });
+
+  it("keeps separate service instances isolated from each other", async () => {
+    const other = new CommentThreadService();
+
+    await service.createThread("doc-isolated", "document", "Only in the first instance", "u-1");
+
+    const inService = await service.getThreadsForTarget("doc-isolated", "document");
+    expect(inService).toHaveLength(1);
+
+    const inOther = await other.getThreadsForTarget("doc-isolated", "document");
+    expect(inOther).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Adds folder-local error-path/edge-case tests and a testing & review guide for the Internal Comment Thread tool. No existing files touched; work stays inside tools/v1/team/internal-comment-thread/.

Closes #443