### PR TITLE
Feat/improved policy evaluation vector tests

### DIFF
--- a/src/routes/api/v1/policies/evaluate.ts
+++ b/src/routes/api/v1/policies/evaluate.ts
@@ -20,7 +20,8 @@ export const Route = createFileRoute("/api/v1/policies/evaluate")({
       POST: ({ request }) =>
         handleApiRequest(request, async () => {
           const input = await parseJsonBody(request, evaluationSchema);
-          const result = await evaluateMailboxPolicy((await getApiContext()).repository, input);
+          const context = await getApiContext(request);
+          const result = await evaluateMailboxPolicy(context.repository, input);
 
           const reasonMessages: Record<string, string> = {
             sender_allowed: "Sender is explicitly allowed by the recipient.",
@@ -35,6 +36,8 @@ export const Route = createFileRoute("/api/v1/policies/evaluate")({
             allowed: result.allowed,
             reasonCode: result.reason,
             message: reasonMessages[result.reason] ?? "Unknown policy evaluation result.",
+            source: result.source ?? "default",
+            rule: result.rule ?? "default",
           };
 
           return apiSuccess(request, decision);

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -54,19 +54,19 @@ export async function evaluateMailboxPolicy(
   },
 ) {
   const rule = await repository.getSenderRule(input.owner, input.sender);
-  if (rule === "allow") return { allowed: true, reason: "sender_allowed" as const, rule };
-  if (rule === "block") return { allowed: false, reason: "sender_blocked" as const, rule };
+  const { policy, source } = await getMailboxPolicy(repository, input.owner);
+  if (rule === "allow") return { allowed: true, policy, source, reason: "sender_allowed" as const, rule };
+  if (rule === "block") return { allowed: false, policy, source, reason: "sender_blocked" as const, rule };
 
-  const { policy } = await getMailboxPolicy(repository, input.owner);
   if (!policy.allowUnknown) {
-    return { allowed: false, policy, reason: "unknown_senders_disabled" as const, rule };
+    return { allowed: false, policy, source, reason: "unknown_senders_disabled" as const, rule };
   }
   if (policy.requireVerified && !input.verified) {
-    return { allowed: false, policy, reason: "verification_required" as const, rule };
+    return { allowed: false, policy, source, reason: "verification_required" as const, rule };
   }
   if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
-    return { allowed: false, policy, reason: "insufficient_postage" as const, rule };
+    return { allowed: false, policy, source, reason: "insufficient_postage" as const, rule };
   }
 
-  return { allowed: true, policy, reason: "policy_satisfied" as const, rule };
+  return { allowed: true, policy, source, reason: "policy_satisfied" as const, rule };
 }

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -55,8 +55,10 @@ export async function evaluateMailboxPolicy(
 ) {
   const rule = await repository.getSenderRule(input.owner, input.sender);
   const { policy, source } = await getMailboxPolicy(repository, input.owner);
-  if (rule === "allow") return { allowed: true, policy, source, reason: "sender_allowed" as const, rule };
-  if (rule === "block") return { allowed: false, policy, source, reason: "sender_blocked" as const, rule };
+  if (rule === "allow")
+    return { allowed: true, policy, source, reason: "sender_allowed" as const, rule };
+  if (rule === "block")
+    return { allowed: false, policy, source, reason: "sender_blocked" as const, rule };
 
   if (!policy.allowUnknown) {
     return { allowed: false, policy, source, reason: "unknown_senders_disabled" as const, rule };

--- a/tests/unit/api/policy-evaluate.vectors.test.ts
+++ b/tests/unit/api/policy-evaluate.vectors.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Route as EvaluateRoute } from "../../../src/routes/api/v1/policies/evaluate";
+import { ACTOR_HEADER, DELEGATION_HEADER } from "../../../src/server/api/actor";
+import type { MailboxDelegation } from "../../../src/server/api/auth/delegation";
+import { getApiContext } from "../../../src/server/api/context";
+import type { MailboxPolicy, SenderRule } from "../../../src/server/api/domain";
+import type { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+const evaluateHandler = (EvaluateRoute.options as any).server?.handlers?.POST;
+
+const owner = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+const delegate = `G${"D".repeat(55)}`;
+
+function createEvaluateRequest(
+  body: unknown,
+  options?: {
+    actor?: string;
+    delegation?: MailboxDelegation;
+    requestId?: string;
+    traceparent?: string;
+  },
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+
+  if (options?.actor) {
+    headers[ACTOR_HEADER] = options.actor;
+  }
+  if (options?.delegation) {
+    headers[DELEGATION_HEADER] = JSON.stringify(options.delegation);
+  }
+  if (options?.requestId) {
+    headers["x-request-id"] = options.requestId;
+  }
+  if (options?.traceparent) {
+    headers["traceparent"] = options.traceparent;
+  }
+
+  return new Request("https://stealth.test/api/v1/policies/evaluate", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+interface RouteVectorFixture {
+  name: string;
+  policy: MailboxPolicy | null;
+  senderRule: SenderRule | null;
+  input: {
+    owner?: string;
+    postage?: unknown;
+    sender?: string;
+    verified?: unknown;
+  };
+  headers?: {
+    actor?: string;
+    delegation?: MailboxDelegation;
+    requestId?: string;
+    traceparent?: string;
+  };
+  expectedStatus: number;
+  expectedDecision?: {
+    allowed: boolean;
+    reasonCode: string;
+    message: string;
+    source: "configured" | "default";
+    rule: SenderRule;
+  };
+  expectedError?: {
+    code: string;
+  };
+}
+
+const basePolicy: MailboxPolicy = {
+  allowUnknown: false,
+  minimumPostage: "0",
+  requireVerified: true,
+};
+
+const routeVectors: RouteVectorFixture[] = [
+  {
+    name: "trusted sender (allow rule) explicitly allowed",
+    policy: basePolicy,
+    senderRule: "allow",
+    input: { owner, postage: "0", sender, verified: false },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "sender_allowed",
+      message: "Sender is explicitly allowed by the recipient.",
+      source: "configured",
+      rule: "allow",
+    },
+  },
+  {
+    name: "blocked sender (block rule) explicitly blocked",
+    policy: basePolicy,
+    senderRule: "block",
+    input: { owner, postage: "0", sender, verified: false },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: false,
+      reasonCode: "sender_blocked",
+      message: "Sender is explicitly blocked by the recipient.",
+      source: "configured",
+      rule: "block",
+    },
+  },
+  {
+    name: "unknown sender rejected when recipient policy disables unknown senders",
+    policy: { ...basePolicy, allowUnknown: false },
+    senderRule: null,
+    input: { owner, postage: "0", sender, verified: false },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: false,
+      reasonCode: "unknown_senders_disabled",
+      message: "Recipient does not accept mail from unknown senders.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "verification required when sender is unverified",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: true },
+    senderRule: null,
+    input: { owner, postage: "1000", sender, verified: false },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: false,
+      reasonCode: "verification_required",
+      message: "Recipient requires sender verification.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "insufficient postage when provided amount is lower than policy minimum",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "5000" },
+    senderRule: null,
+    input: { owner, postage: "100", sender, verified: true },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: false,
+      reasonCode: "insufficient_postage",
+      message: "Provided postage is insufficient for this recipient.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "policy satisfied when all criteria (verification, postage) are met",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: true, minimumPostage: "500" },
+    senderRule: null,
+    input: { owner, postage: "1000", sender, verified: true },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "policy_satisfied",
+      message: "Sender satisfies all recipient mailbox policies.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "missing policy defaults to defaultMailboxPolicy (blocks unknown unverified senders)",
+    policy: null,
+    senderRule: null,
+    input: { owner, postage: "0", sender, verified: false },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: false,
+      reasonCode: "unknown_senders_disabled",
+      message: "Recipient does not accept mail from unknown senders.",
+      source: "default",
+      rule: "default",
+    },
+  },
+  {
+    name: "missing policy allows verified sender when allowed by explicit sender rule",
+    policy: null,
+    senderRule: "allow",
+    input: { owner, postage: "0", sender, verified: true },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "sender_allowed",
+      message: "Sender is explicitly allowed by the recipient.",
+      source: "default",
+      rule: "allow",
+    },
+  },
+  {
+    name: "evaluates policy for delegated actor with valid delegation header",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "0" },
+    senderRule: null,
+    input: { owner, postage: "100", sender: delegate, verified: true },
+    headers: {
+      actor: delegate,
+      delegation: {
+        grantor: owner,
+        delegate,
+        allowedActions: ["policy:evaluate"],
+        resourceScope: [`mailbox:${owner}:policy`],
+        issuedAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2029-01-01T00:00:00.000Z",
+        revoked: false,
+      },
+    },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "policy_satisfied",
+      message: "Sender satisfies all recipient mailbox policies.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "boundary test: zero postage meeting zero minimum postage policy",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "0" },
+    senderRule: null,
+    input: { owner, postage: "0", sender, verified: true },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "policy_satisfied",
+      message: "Sender satisfies all recipient mailbox policies.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+  {
+    name: "boundary test: max i128 postage string passes evaluation",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "1000" },
+    senderRule: null,
+    input: { owner, postage: "170141183460469231731687303715884105727", sender, verified: true },
+    expectedStatus: 200,
+    expectedDecision: {
+      allowed: true,
+      reasonCode: "policy_satisfied",
+      message: "Sender satisfies all recipient mailbox policies.",
+      source: "configured",
+      rule: "default",
+    },
+  },
+];
+
+describe("POST /api/v1/policies/evaluate vector suite", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  describe("table-driven decision branch vectors", () => {
+    for (const vector of routeVectors) {
+      it(`evaluates branch vector: ${vector.name}`, async () => {
+        if (vector.policy !== null) {
+          await repo.setPolicy(owner, vector.policy);
+        }
+        if (vector.senderRule !== null) {
+          await repo.setSenderRule(owner, vector.input.sender!, vector.senderRule);
+        }
+
+        const request = createEvaluateRequest(vector.input, vector.headers);
+        const response = await evaluateHandler({ request });
+
+        expect(response.status).toBe(vector.expectedStatus);
+
+        const body = await response.json();
+
+        if (vector.expectedDecision) {
+          // Failure diagnostic helper
+          if (
+            body.data?.allowed !== vector.expectedDecision.allowed ||
+            body.data?.reasonCode !== vector.expectedDecision.reasonCode
+          ) {
+            throw new Error(
+              `Decision mismatch for branch vector '${vector.name}':\n` +
+                `  Expected: allowed=${vector.expectedDecision.allowed}, reasonCode='${vector.expectedDecision.reasonCode}', source='${vector.expectedDecision.source}', rule='${vector.expectedDecision.rule}'\n` +
+                `  Received: allowed=${body.data?.allowed}, reasonCode='${body.data?.reasonCode}', source='${body.data?.source}', rule='${body.data?.rule}'`,
+            );
+          }
+
+          expect(body.data).toEqual(vector.expectedDecision);
+        }
+      });
+    }
+  });
+
+  describe("input validation edge cases", () => {
+    it.each([
+      [
+        "invalid owner address",
+        { owner: "INVALID_ADDR", postage: "100", sender, verified: true },
+        422,
+      ],
+      [
+        "invalid sender address",
+        { owner, postage: "100", sender: "INVALID_SENDER", verified: true },
+        422,
+      ],
+      [
+        "negative postage string",
+        { owner, postage: "-100", sender, verified: true },
+        422,
+      ],
+      [
+        "non-integer postage string",
+        { owner, postage: "123.45", sender, verified: true },
+        422,
+      ],
+      [
+        "missing verified boolean field",
+        { owner, postage: "100", sender },
+        422,
+      ],
+    ])("rejects malformed payload '%s' with HTTP %i", async (_label, invalidBody, expectedStatus) => {
+      const request = createEvaluateRequest(invalidBody);
+      const response = await evaluateHandler({ request });
+
+      expect(response.status).toBe(expectedStatus);
+      const body = await response.json();
+      expect(body.error?.code).toBe("validation_error");
+    });
+  });
+
+  describe("request correlation & tracing propagation", () => {
+    it("preserves trace parent and request id headers during evaluation", async () => {
+      const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+      const requestId = "req-test-eval-123";
+
+      const request = createEvaluateRequest(
+        { owner, postage: "0", sender, verified: true },
+        { requestId, traceparent },
+      );
+
+      const response = await evaluateHandler({ request });
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/unit/api/policy-evaluate.vectors.test.ts
+++ b/tests/unit/api/policy-evaluate.vectors.test.ts
@@ -306,29 +306,20 @@ describe("POST /api/v1/policies/evaluate vector suite", () => {
         { owner, postage: "100", sender: "INVALID_SENDER", verified: true },
         422,
       ],
-      [
-        "negative postage string",
-        { owner, postage: "-100", sender, verified: true },
-        422,
-      ],
-      [
-        "non-integer postage string",
-        { owner, postage: "123.45", sender, verified: true },
-        422,
-      ],
-      [
-        "missing verified boolean field",
-        { owner, postage: "100", sender },
-        422,
-      ],
-    ])("rejects malformed payload '%s' with HTTP %i", async (_label, invalidBody, expectedStatus) => {
-      const request = createEvaluateRequest(invalidBody);
-      const response = await evaluateHandler({ request });
+      ["negative postage string", { owner, postage: "-100", sender, verified: true }, 422],
+      ["non-integer postage string", { owner, postage: "123.45", sender, verified: true }, 422],
+      ["missing verified boolean field", { owner, postage: "100", sender }, 422],
+    ])(
+      "rejects malformed payload '%s' with HTTP %i",
+      async (_label, invalidBody, expectedStatus) => {
+        const request = createEvaluateRequest(invalidBody);
+        const response = await evaluateHandler({ request });
 
-      expect(response.status).toBe(expectedStatus);
-      const body = await response.json();
-      expect(body.error?.code).toBe("validation_error");
-    });
+        expect(response.status).toBe(expectedStatus);
+        const body = await response.json();
+        expect(body.error?.code).toBe("validation_error");
+      },
+    );
   });
 
   describe("request correlation & tracing propagation", () => {

--- a/tests/unit/api/policy-service.vectors.test.ts
+++ b/tests/unit/api/policy-service.vectors.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
 import { evaluateMailboxPolicy } from "../../../src/server/api/policy-service";
-import type { MailboxPolicy } from "../../../src/server/api/domain";
+import type { MailboxPolicy, SenderRule } from "../../../src/server/api/domain";
 
 // Table-driven vectors for every decision branch of evaluateMailboxPolicy.
-// Each vector asserts the exact decision AND reason code so a regression
+// Each vector asserts the exact decision, reason code, source, and rule so a regression
 // identifies the mismatched branch. Reusable by protocol/integration tests.
-interface PolicyVector {
+export interface PolicyServiceVector {
   name: string;
-  policy: MailboxPolicy;
-  senderRule: "allow" | "block" | null;
+  policy: MailboxPolicy | null;
+  senderRule: SenderRule | null;
   input: { postage: string; sender: string; verified: boolean };
-  expected: { allowed: boolean; reason: string };
+  expected: {
+    allowed: boolean;
+    reason: string;
+    source?: "configured" | "default";
+    rule?: SenderRule;
+  };
 }
 
 const owner = `G${"A".repeat(55)}`;
 const sender = `G${"B".repeat(55)}`;
-
-function makeRepo(policy: MailboxPolicy, senderRule: "allow" | "block" | null) {
-  const repository = new MemoryApiRepository();
-  // seed policy via the service contract
-  return repository;
-}
+const delegate = `G${"D".repeat(55)}`;
 
 const basePolicy: MailboxPolicy = {
   allowUnknown: false,
@@ -30,65 +30,88 @@ const basePolicy: MailboxPolicy = {
   requireVerified: true,
 };
 
-const vectors: PolicyVector[] = [
+export const policyServiceVectors: PolicyServiceVector[] = [
   {
-    name: "sender allow override short-circuits",
+    name: "sender allow override short-circuits (trusted sender)",
     policy: basePolicy,
     senderRule: "allow",
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: true, reason: "sender_allowed" },
+    expected: { allowed: true, reason: "sender_allowed", rule: "allow" },
   },
   {
-    name: "sender block override short-circuits",
+    name: "sender block override short-circuits (blocked sender)",
     policy: basePolicy,
     senderRule: "block",
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: false, reason: "sender_blocked" },
+    expected: { allowed: false, reason: "sender_blocked", rule: "block" },
   },
   {
     name: "unknown sender disabled (allowUnknown=false)",
     policy: { ...basePolicy, allowUnknown: false },
     senderRule: null,
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: false, reason: "unknown_senders_disabled" },
+    expected: { allowed: false, reason: "unknown_senders_disabled", source: "configured", rule: "default" },
   },
   {
     name: "verification required when unverified",
     policy: { ...basePolicy, allowUnknown: true, requireVerified: true },
     senderRule: null,
     input: { postage: "1000", sender, verified: false },
-    expected: { allowed: false, reason: "verification_required" },
+    expected: { allowed: false, reason: "verification_required", source: "configured", rule: "default" },
   },
   {
-    name: "insufficient postage below minimum",
+    name: "insufficient postage below minimum required postage",
     policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "500" },
     senderRule: null,
     input: { postage: "100", sender, verified: true },
-    expected: { allowed: false, reason: "insufficient_postage" },
+    expected: { allowed: false, reason: "insufficient_postage", source: "configured", rule: "default" },
   },
   {
     name: "policy satisfied (allow, verified, enough postage)",
     policy: { ...basePolicy, allowUnknown: true, requireVerified: true, minimumPostage: "500" },
     senderRule: null,
     input: { postage: "1000", sender, verified: true },
-    expected: { allowed: true, reason: "policy_satisfied" },
+    expected: { allowed: true, reason: "policy_satisfied", source: "configured", rule: "default" },
   },
   {
-    name: "default policy (no stored config) blocks unknown unverified",
-    policy: basePolicy,
+    name: "missing policy (no stored policy) falls back to default policy (blocks unknown unverified)",
+    policy: null,
     senderRule: null,
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: false, reason: "unknown_senders_disabled" },
+    expected: { allowed: false, reason: "unknown_senders_disabled", source: "default", rule: "default" },
+  },
+  {
+    name: "missing policy (no stored policy) allows verified sender with default postage",
+    policy: null,
+    senderRule: "allow",
+    input: { postage: "0", sender, verified: true },
+    expected: { allowed: true, reason: "sender_allowed", rule: "allow" },
+  },
+  {
+    name: "delegate sender evaluation with explicit allow rule",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "0" },
+    senderRule: "allow",
+    input: { postage: "0", sender: delegate, verified: true },
+    expected: { allowed: true, reason: "sender_allowed", rule: "allow" },
+  },
+  {
+    name: "extreme postage value (soroban i128 max) satisfies policy",
+    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "1000000" },
+    senderRule: null,
+    input: { postage: "170141183460469231731687303715884105727", sender, verified: true },
+    expected: { allowed: true, reason: "policy_satisfied", source: "configured", rule: "default" },
   },
 ];
 
-describe("policy evaluation decision vectors", () => {
-  for (const vector of vectors) {
+describe("policy evaluation decision vectors (service level)", () => {
+  for (const vector of policyServiceVectors) {
     it(`branch: ${vector.name}`, async () => {
-      const repository = makeRepo(vector.policy, vector.senderRule);
-      await repository.setPolicy(owner, vector.policy);
-      if (vector.senderRule) {
-        await repository.setSenderRule(owner, sender, vector.senderRule);
+      const repository = new MemoryApiRepository();
+      if (vector.policy !== null) {
+        await repository.setPolicy(owner, vector.policy);
+      }
+      if (vector.senderRule !== null) {
+        await repository.setSenderRule(owner, vector.input.sender, vector.senderRule);
       }
 
       const result = await evaluateMailboxPolicy(repository, {
@@ -98,13 +121,29 @@ describe("policy evaluation decision vectors", () => {
         verified: vector.input.verified,
       });
 
+      // Branch mismatch diagnostics
+      if (result.allowed !== vector.expected.allowed || result.reason !== vector.expected.reason) {
+        throw new Error(
+          `Decision branch mismatch for '${vector.name}': ` +
+            `expected decision allowed=${vector.expected.allowed}, reason='${vector.expected.reason}'; ` +
+            `received allowed=${result.allowed}, reason='${result.reason}'`,
+        );
+      }
+
       expect(result.allowed).toBe(vector.expected.allowed);
       expect(result.reason).toBe(vector.expected.reason);
+
+      if (vector.expected.source !== undefined) {
+        expect(result.source).toBe(vector.expected.source);
+      }
+      if (vector.expected.rule !== undefined) {
+        expect(result.rule).toBe(vector.expected.rule);
+      }
     });
   }
 
-  it("covers all known reason codes", () => {
-    const reasons = new Set(vectors.map((v) => v.expected.reason));
+  it("covers all known reason codes across vector suite", () => {
+    const reasons = new Set(policyServiceVectors.map((v) => v.expected.reason));
     expect(reasons).toEqual(
       new Set([
         "sender_allowed",

--- a/tests/unit/api/policy-service.vectors.test.ts
+++ b/tests/unit/api/policy-service.vectors.test.ts
@@ -50,21 +50,36 @@ export const policyServiceVectors: PolicyServiceVector[] = [
     policy: { ...basePolicy, allowUnknown: false },
     senderRule: null,
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: false, reason: "unknown_senders_disabled", source: "configured", rule: "default" },
+    expected: {
+      allowed: false,
+      reason: "unknown_senders_disabled",
+      source: "configured",
+      rule: "default",
+    },
   },
   {
     name: "verification required when unverified",
     policy: { ...basePolicy, allowUnknown: true, requireVerified: true },
     senderRule: null,
     input: { postage: "1000", sender, verified: false },
-    expected: { allowed: false, reason: "verification_required", source: "configured", rule: "default" },
+    expected: {
+      allowed: false,
+      reason: "verification_required",
+      source: "configured",
+      rule: "default",
+    },
   },
   {
     name: "insufficient postage below minimum required postage",
     policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "500" },
     senderRule: null,
     input: { postage: "100", sender, verified: true },
-    expected: { allowed: false, reason: "insufficient_postage", source: "configured", rule: "default" },
+    expected: {
+      allowed: false,
+      reason: "insufficient_postage",
+      source: "configured",
+      rule: "default",
+    },
   },
   {
     name: "policy satisfied (allow, verified, enough postage)",
@@ -78,7 +93,12 @@ export const policyServiceVectors: PolicyServiceVector[] = [
     policy: null,
     senderRule: null,
     input: { postage: "0", sender, verified: false },
-    expected: { allowed: false, reason: "unknown_senders_disabled", source: "default", rule: "default" },
+    expected: {
+      allowed: false,
+      reason: "unknown_senders_disabled",
+      source: "default",
+      rule: "default",
+    },
   },
   {
     name: "missing policy (no stored policy) allows verified sender with default postage",
@@ -96,7 +116,12 @@ export const policyServiceVectors: PolicyServiceVector[] = [
   },
   {
     name: "extreme postage value (soroban i128 max) satisfies policy",
-    policy: { ...basePolicy, allowUnknown: true, requireVerified: false, minimumPostage: "1000000" },
+    policy: {
+      ...basePolicy,
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "1000000",
+    },
     senderRule: null,
     input: { postage: "170141183460469231731687303715884105727", sender, verified: true },
     expected: { allowed: true, reason: "policy_satisfied", source: "configured", rule: "default" },


### PR DESCRIPTION
- Closes #1333 

### Description

#### Summary
Addresses reliability, tracing correlation, and regression test coverage for `POST /api/v1/policies/evaluate`.

#### Changes
- **Request Context Propagation**: Updated `POST /api/v1/policies/evaluate` to pass `request` to `getApiContext(request)`, propagating tracing headers (`traceparent`), `x-request-id`, and delegation principal headers to repository operations.
- **Enriched Decision Payload**: Included policy `source` (`configured` | `default`) and `rule` (`allow` | `block` | `default`) in evaluation responses.
- **Service & Route Vectors**: Added table-driven vector tests covering all decision branches (`sender_allowed`, `sender_blocked`, `unknown_senders_disabled`, `verification_required`, `insufficient_postage`, `policy_satisfied`, `missing_policy`), delegated principal headers, boundary values (0 postage, Soroban i128 max string), and Zod input validation (HTTP 422 `validation_error`).

#### Verification
- `bun test tests/unit/api/policy-evaluate.vectors.test.ts` (17 pass)
- `bun test tests/unit/api/policy-service.vectors.test.ts` (11 pass)
- `bun test tests/unit/api/policy-routes.security.test.ts tests/unit/api/policy-service.test.ts` (30 pass)

<img width="1081" height="170" alt="image" src="https://github.com/user-attachments/assets/28dc846d-cf6d-48b9-886f-9667afdbdf94" />