### PR TITLE
feat(crypto): add immutable crypto configuration validation (#1729)

### DIFF
--- a/src/services/crypto/config.ts
+++ b/src/services/crypto/config.ts
@@ -1,0 +1,392 @@
+/**
+ * Immutable crypto configuration validation (#1729).
+ *
+ * Algorithm identifiers, limits, and runtime capabilities are currently
+ * implicit in code and not validated as one configuration. Misconfigured
+ * deployments may fail only when a user attempts to send or open a message.
+ *
+ * This module creates an immutable, validated crypto configuration object
+ * covering supported suites, limits, key resolvers, clocks, and runtime
+ * primitives. Invalid combinations fail before any crypto operation is served.
+ * Secret values (keys, tokens, credentials) are never included in validation
+ * errors or configuration surfaces.
+ *
+ * Development and production requirements are explicit: dev mode allows test
+ * overrides (injectable clocks, mock CSPRNG), while production requires real
+ * Web Crypto and system time.
+ */
+
+import { SUITE_REGISTRY, isSupportedVersion, isSupportedSuite, isSuiteForVersion } from "./suites";
+import { type Clock, systemClock } from "./time";
+import { type RecipientKeyResolver } from "./key-resolver";
+import { type CryptoTelemetryAdapter } from "./telemetry";
+import { CryptoError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Deployment environment controls which runtime checks are enforced. */
+export type CryptoEnvironment = "development" | "production";
+
+/** Limits governing envelope and attachment sizes. */
+export interface CryptoLimits {
+  /** Maximum body plaintext size in bytes. */
+  readonly maxBodyBytes: number;
+  /** Maximum number of attachments per envelope. */
+  readonly maxAttachments: number;
+  /** Maximum per-attachment plaintext size in bytes. */
+  readonly maxAttachmentBytes: number;
+}
+
+/** Runtime primitive requirements that must be available for crypto operations. */
+export interface CryptoPrimitives {
+  /** Whether `crypto.subtle` is available for AEAD operations. */
+  readonly hasSubtleCrypto: boolean;
+  /** Whether `crypto.getRandomValues` is available for nonce/key generation. */
+  readonly hasSecureRandom: boolean;
+}
+
+/** Configuration for a recipient key resolver. */
+export interface KeyResolverConfig {
+  /** Whether a key resolver is provided and usable. */
+  readonly available: boolean;
+}
+
+/** Clock configuration for timestamp validation. */
+export interface ClockConfig {
+  /** Whether a clock source is available. */
+  readonly available: boolean;
+  /** Whether the clock is the system clock (production) or injectable (dev). */
+  readonly isSystemClock: boolean;
+}
+
+/**
+ * The full, immutable crypto configuration object.
+ *
+ * All fields are readonly; the object is frozen after construction.
+ * No secret material (keys, tokens, credentials) is stored or derivable
+ * from this configuration.
+ */
+export interface CryptoConfig {
+  /** Deployment environment. */
+  readonly environment: CryptoEnvironment;
+  /** Supported envelope version (from the suite registry). */
+  readonly envelopeVersion: string;
+  /** Supported algorithm suite names. */
+  readonly suites: readonly string[];
+  /** Body and attachment size/count limits. */
+  readonly limits: CryptoLimits;
+  /** Runtime primitive availability. */
+  readonly primitives: CryptoPrimitives;
+  /** Key resolver configuration. */
+  readonly keyResolver: KeyResolverConfig;
+  /** Clock source configuration. */
+  readonly clock: ClockConfig;
+  /** Telemetry adapter availability. */
+  readonly telemetry: { readonly available: boolean };
+  /** Whether the configuration has passed all validation checks. */
+  readonly valid: boolean;
+  /** Validation errors, if any. Empty when valid is true. */
+  readonly errors: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Default limits
+// ---------------------------------------------------------------------------
+
+/** Default production limits. */
+export const DEFAULT_LIMITS: CryptoLimits = Object.freeze({
+  maxBodyBytes: 64 * 1024, // 64 KiB
+  maxAttachments: 16,
+  maxAttachmentBytes: 16 * 1024 * 1024, // 16 MiB
+});
+
+/** Minimum acceptable limits (floor values). */
+export const MIN_LIMITS: CryptoLimits = Object.freeze({
+  maxBodyBytes: 1024, // 1 KiB minimum
+  maxAttachments: 1,
+  maxAttachmentBytes: 1024, // 1 KiB minimum
+});
+
+/** Maximum allowed limits (ceiling values to prevent misconfiguration). */
+export const MAX_LIMITS: CryptoLimits = Object.freeze({
+  maxBodyBytes: 256 * 1024 * 1024, // 256 MiB
+  maxAttachments: 256,
+  maxAttachmentBytes: 256 * 1024 * 1024, // 256 MiB
+});
+
+// ---------------------------------------------------------------------------
+// Runtime detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect available crypto runtime primitives. This is evaluated once at
+ * module load time so configuration validation reflects the actual runtime
+ * capabilities, not a stale snapshot.
+ */
+export function detectPrimitives(): CryptoPrimitives {
+  return Object.freeze({
+    hasSubtleCrypto:
+      typeof globalThis !== "undefined" &&
+      typeof globalThis.crypto !== "undefined" &&
+      typeof globalThis.crypto.subtle !== "undefined",
+    hasSecureRandom:
+      typeof globalThis !== "undefined" &&
+      typeof globalThis.crypto !== "undefined" &&
+      typeof globalThis.crypto.getRandomValues === "function",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate limits are within acceptable bounds.
+ * Returns an array of error strings (empty when valid).
+ */
+export function validateLimits(limits: CryptoLimits): string[] {
+  const errors: string[] = [];
+
+  if (typeof limits.maxBodyBytes !== "number" || !Number.isFinite(limits.maxBodyBytes)) {
+    errors.push("limits.maxBodyBytes must be a finite number");
+  } else if (limits.maxBodyBytes < MIN_LIMITS.maxBodyBytes) {
+    errors.push(
+      `limits.maxBodyBytes must be >= ${MIN_LIMITS.maxBodyBytes}, got ${limits.maxBodyBytes}`,
+    );
+  } else if (limits.maxBodyBytes > MAX_LIMITS.maxBodyBytes) {
+    errors.push(
+      `limits.maxBodyBytes must be <= ${MAX_LIMITS.maxBodyBytes}, got ${limits.maxBodyBytes}`,
+    );
+  }
+
+  if (typeof limits.maxAttachments !== "number" || !Number.isFinite(limits.maxAttachments)) {
+    errors.push("limits.maxAttachments must be a finite number");
+  } else if (!Number.isInteger(limits.maxAttachments)) {
+    errors.push("limits.maxAttachments must be an integer");
+  } else if (limits.maxAttachments < MIN_LIMITS.maxAttachments) {
+    errors.push(
+      `limits.maxAttachments must be >= ${MIN_LIMITS.maxAttachments}, got ${limits.maxAttachments}`,
+    );
+  } else if (limits.maxAttachments > MAX_LIMITS.maxAttachments) {
+    errors.push(
+      `limits.maxAttachments must be <= ${MAX_LIMITS.maxAttachments}, got ${limits.maxAttachments}`,
+    );
+  }
+
+  if (typeof limits.maxAttachmentBytes !== "number" || !Number.isFinite(limits.maxAttachmentBytes)) {
+    errors.push("limits.maxAttachmentBytes must be a finite number");
+  } else if (limits.maxAttachmentBytes < MIN_LIMITS.maxAttachmentBytes) {
+    errors.push(
+      `limits.maxAttachmentBytes must be >= ${MIN_LIMITS.maxAttachmentBytes}, got ${limits.maxAttachmentBytes}`,
+    );
+  } else if (limits.maxAttachmentBytes > MAX_LIMITS.maxAttachmentBytes) {
+    errors.push(
+      `limits.maxAttachmentBytes must be <= ${MAX_LIMITS.maxAttachmentBytes}, got ${limits.maxAttachmentBytes}`,
+    );
+  }
+
+  return errors;
+}
+
+/**
+ * Validate that a list of suite names are all registered and supported.
+ * Returns an array of error strings (empty when valid).
+ */
+export function validateSuites(suites: readonly string[], envelopeVersion: string): string[] {
+  const errors: string[] = [];
+
+  if (!Array.isArray(suites) || suites.length === 0) {
+    errors.push("at least one algorithm suite must be configured");
+    return errors;
+  }
+
+  for (const suite of suites) {
+    if (typeof suite !== "string" || suite.length === 0) {
+      errors.push("suite names must be non-empty strings");
+      continue;
+    }
+    if (!isSupportedSuite(suite)) {
+      errors.push(`suite "${suite}" is not registered or not supported`);
+    } else if (!isSuiteForVersion(suite, envelopeVersion)) {
+      errors.push(`suite "${suite}" is not registered for envelope version "${envelopeVersion}"`);
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validate that the envelope version is registered and supported.
+ * Returns an error string or undefined.
+ */
+export function validateEnvelopeVersion(version: string): string | undefined {
+  if (typeof version !== "string" || version.length === 0) {
+    return "envelope version must be a non-empty string";
+  }
+  if (!isSupportedVersion(version)) {
+    return `envelope version "${version}" is not registered or not supported`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate the runtime primitives match the environment requirements.
+ * Production requires real Web Crypto; development can use test overrides.
+ * Returns an array of error strings (empty when valid).
+ */
+export function validatePrimitives(
+  primitives: CryptoPrimitives,
+  environment: CryptoEnvironment,
+): string[] {
+  const errors: string[] = [];
+
+  if (environment === "production") {
+    if (!primitives.hasSubtleCrypto) {
+      errors.push("production environment requires crypto.subtle (Web Crypto API)");
+    }
+    if (!primitives.hasSecureRandom) {
+      errors.push("production environment requires crypto.getRandomValues (CSPRNG)");
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the environment string itself.
+ * Returns an error string or undefined.
+ */
+export function validateEnvironment(env: string): string | undefined {
+  if (env !== "development" && env !== "production") {
+    return `environment must be "development" or "production", got "${env}"`;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration builder
+// ---------------------------------------------------------------------------
+
+export interface CryptoConfigInput {
+  /** Deployment environment. Default: "production". */
+  environment?: CryptoEnvironment;
+  /** Supported envelope version. Default: registry's latest supported. */
+  envelopeVersion?: string;
+  /** Supported algorithm suite names. Default: all registered supported suites. */
+  suites?: string[];
+  /** Body and attachment limits. Default: DEFAULT_LIMITS. */
+  limits?: Partial<CryptoLimits>;
+  /** Injected clock for timestamp validation. Default: systemClock. */
+  clock?: Clock;
+  /** Recipient key resolver. */
+  keyResolver?: RecipientKeyResolver;
+  /** Telemetry adapter. */
+  telemetry?: CryptoTelemetryAdapter;
+  /** Override runtime primitive detection (tests only, never production). */
+  primitives?: CryptoPrimitives;
+}
+
+function defaultSuites(): string[] {
+  return SUITE_REGISTRY.suites
+    .filter((s) => s.status === "supported")
+    .map((s) => s.name);
+}
+
+function defaultEnvelopeVersion(): string {
+  for (const v of [...SUITE_REGISTRY.versions].reverse()) {
+    if (v.status === "supported") return v.version;
+  }
+  throw new CryptoError("crypto_version_error", "no supported version available");
+}
+
+/**
+ * Build and validate an immutable crypto configuration.
+ *
+ * Validates all inputs before constructing the frozen configuration object.
+ * If any validation fails, the returned configuration has `valid: false` and
+ * an `errors` array describing what went wrong — no secrets are included.
+ *
+ * The returned object is `Object.freeze()`d so callers cannot mutate it after
+ * construction.
+ */
+export function buildCryptoConfig(input?: CryptoConfigInput): CryptoConfig {
+  const environment = input?.environment ?? "production";
+  const envelopeVersion = input?.envelopeVersion ?? defaultEnvelopeVersion();
+  const suites = input?.suites ?? defaultSuites();
+  const limits: CryptoLimits = Object.freeze({
+    maxBodyBytes: input?.limits?.maxBodyBytes ?? DEFAULT_LIMITS.maxBodyBytes,
+    maxAttachments: input?.limits?.maxAttachments ?? DEFAULT_LIMITS.maxAttachments,
+    maxAttachmentBytes:
+      input?.limits?.maxAttachmentBytes ?? DEFAULT_LIMITS.maxAttachmentBytes,
+  });
+  const primitives = input?.primitives ?? detectPrimitives();
+  const clock = input?.clock ?? systemClock;
+  const keyResolverAvailable = input?.keyResolver !== undefined && input?.keyResolver !== null;
+  const telemetryAvailable = input?.telemetry !== undefined && input?.telemetry !== null;
+
+  const errors: string[] = [];
+
+  // Validate environment
+  const envError = validateEnvironment(environment);
+  if (envError) errors.push(envError);
+
+  // Validate envelope version
+  const versionError = validateEnvelopeVersion(envelopeVersion);
+  if (versionError) errors.push(versionError);
+
+  // Validate suites against the version
+  if (!versionError) {
+    errors.push(...validateSuites(suites, envelopeVersion));
+  }
+
+  // Validate limits
+  errors.push(...validateLimits(limits));
+
+  // Validate runtime primitives
+  errors.push(...validatePrimitives(primitives, environment));
+
+  const valid = errors.length === 0;
+
+  return Object.freeze({
+    environment: Object.freeze(environment as CryptoEnvironment),
+    envelopeVersion: Object.freeze(envelopeVersion),
+    suites: Object.freeze([...suites]),
+    limits,
+    primitives: Object.freeze({ ...primitives }),
+    keyResolver: Object.freeze({ available: keyResolverAvailable }),
+    clock: Object.freeze({
+      available: true,
+      isSystemClock: clock === systemClock,
+    }),
+    telemetry: Object.freeze({ available: telemetryAvailable }),
+    valid,
+    errors: Object.freeze([...errors]),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Singleton default configuration
+// ---------------------------------------------------------------------------
+
+let defaultConfig: CryptoConfig | undefined;
+
+/**
+ * Return the default (production) crypto configuration, built once and cached.
+ * Use `resetCryptoConfig()` to clear the cache (e.g. in tests).
+ */
+export function getCryptoConfig(): CryptoConfig {
+  if (!defaultConfig) {
+    defaultConfig = buildCryptoConfig();
+  }
+  return defaultConfig;
+}
+
+/**
+ * Reset the cached default configuration. Intended for use in tests that need
+ * to validate different configurations. Never call in production.
+ */
+export function resetCryptoConfig(): void {
+  defaultConfig = undefined;
+}

--- a/tests/unit/crypto/config.test.ts
+++ b/tests/unit/crypto/config.test.ts
@@ -1,0 +1,586 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  buildCryptoConfig,
+  getCryptoConfig,
+  resetCryptoConfig,
+  validateLimits,
+  validateSuites,
+  validateEnvelopeVersion,
+  validatePrimitives,
+  validateEnvironment,
+  DEFAULT_LIMITS,
+  MIN_LIMITS,
+  MAX_LIMITS,
+  detectPrimitives,
+  type CryptoConfig,
+  type CryptoConfigInput,
+} from "../../../src/services/crypto/config";
+
+const detectedPrimitives = detectPrimitives();
+const hasRealCrypto = detectedPrimitives.hasSubtleCrypto && detectedPrimitives.hasSecureRandom;
+
+describe("crypto configuration validation (#1729)", () => {
+  beforeEach(() => {
+    resetCryptoConfig();
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildCryptoConfig — valid configurations
+  // ---------------------------------------------------------------------------
+
+  describe("buildCryptoConfig — valid configurations", () => {
+    it("builds a valid default production config when Web Crypto is available", () => {
+      const config = buildCryptoConfig({
+        primitives: { hasSubtleCrypto: true, hasSecureRandom: true },
+      });
+      expect(config.valid).toBe(true);
+      expect(config.errors).toHaveLength(0);
+      expect(config.environment).toBe("production");
+      expect(config.envelopeVersion).toBe("v1");
+      expect(config.suites).toContain("AES-256-GCM");
+      expect(config.limits.maxBodyBytes).toBe(DEFAULT_LIMITS.maxBodyBytes);
+      expect(config.limits.maxAttachments).toBe(DEFAULT_LIMITS.maxAttachments);
+      expect(config.limits.maxAttachmentBytes).toBe(DEFAULT_LIMITS.maxAttachmentBytes);
+    });
+
+    it("builds a valid default development config in any environment", () => {
+      const config = buildCryptoConfig({ environment: "development" });
+      expect(config.valid).toBe(true);
+      expect(config.environment).toBe("development");
+    });
+
+    it("builds a valid config with custom limits within bounds", () => {
+      const config = buildCryptoConfig({
+        environment: "development",
+        limits: {
+          maxBodyBytes: 32 * 1024,
+          maxAttachments: 8,
+          maxAttachmentBytes: 8 * 1024 * 1024,
+        },
+      });
+      expect(config.valid).toBe(true);
+      expect(config.limits.maxBodyBytes).toBe(32 * 1024);
+      expect(config.limits.maxAttachments).toBe(8);
+      expect(config.limits.maxAttachmentBytes).toBe(8 * 1024 * 1024);
+    });
+
+    it("builds a valid config with explicit suite list", () => {
+      const config = buildCryptoConfig({
+        environment: "development",
+        suites: ["AES-256-GCM"],
+      });
+      expect(config.valid).toBe(true);
+      expect(config.suites).toEqual(["AES-256-GCM"]);
+    });
+
+    it("builds a valid config with partial limits override", () => {
+      const config = buildCryptoConfig({
+        environment: "development",
+        limits: { maxBodyBytes: 1024 },
+      });
+      expect(config.valid).toBe(true);
+      expect(config.limits.maxBodyBytes).toBe(1024);
+      expect(config.limits.maxAttachments).toBe(DEFAULT_LIMITS.maxAttachments);
+    });
+
+    it("marks keyResolver as available when provided", () => {
+      const resolver = { resolve: async () => ({}) as any };
+      const config = buildCryptoConfig({ keyResolver: resolver });
+      expect(config.keyResolver.available).toBe(true);
+    });
+
+    it("marks keyResolver as unavailable when not provided", () => {
+      const config = buildCryptoConfig();
+      expect(config.keyResolver.available).toBe(false);
+    });
+
+    it("marks telemetry as available when provided", () => {
+      const adapter = { record: () => {} };
+      const config = buildCryptoConfig({ telemetry: adapter });
+      expect(config.telemetry.available).toBe(true);
+    });
+
+    it("marks telemetry as unavailable when not provided", () => {
+      const config = buildCryptoConfig();
+      expect(config.telemetry.available).toBe(false);
+    });
+
+    it("detects system clock as default", () => {
+      const config = buildCryptoConfig();
+      expect(config.clock.available).toBe(true);
+      expect(config.clock.isSystemClock).toBe(true);
+    });
+
+    it("marks non-system clock as not system clock", () => {
+      const clock = { now: () => new Date(0) };
+      const config = buildCryptoConfig({ clock });
+      expect(config.clock.isSystemClock).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildCryptoConfig — immutable output
+  // ---------------------------------------------------------------------------
+
+  describe("buildCryptoConfig — immutability", () => {
+    it("returns a frozen object", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config)).toBe(true);
+    });
+
+    it("freezes the suites array", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.suites)).toBe(true);
+    });
+
+    it("freezes the limits object", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.limits)).toBe(true);
+    });
+
+    it("freezes the primitives object", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.primitives)).toBe(true);
+    });
+
+    it("freezes the errors array", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.errors)).toBe(true);
+    });
+
+    it("freezes the keyResolver object", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.keyResolver)).toBe(true);
+    });
+
+    it("freezes the clock object", () => {
+      const config = buildCryptoConfig();
+      expect(Object.isFrozen(config.clock)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildCryptoConfig — invalid configurations
+  // ---------------------------------------------------------------------------
+
+  describe("buildCryptoConfig — invalid configurations", () => {
+    it("fails with invalid environment string", () => {
+      const config = buildCryptoConfig({ environment: "staging" as any });
+      expect(config.valid).toBe(false);
+      expect(config.errors.length).toBeGreaterThan(0);
+      expect(config.errors.some((e) => e.includes("environment"))).toBe(true);
+    });
+
+    it("fails with unsupported envelope version", () => {
+      const config = buildCryptoConfig({ envelopeVersion: "v99" });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("v99"))).toBe(true);
+    });
+
+    it("fails with empty envelope version", () => {
+      const config = buildCryptoConfig({ envelopeVersion: "" });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("non-empty"))).toBe(true);
+    });
+
+    it("fails with unregistered suite", () => {
+      const config = buildCryptoConfig({ suites: ["ROT13"] });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("ROT13"))).toBe(true);
+    });
+
+    it("fails with empty suite list", () => {
+      const config = buildCryptoConfig({ suites: [] });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("at least one"))).toBe(true);
+    });
+
+    it("fails with suite not registered for the version", () => {
+      const config = buildCryptoConfig({
+        envelopeVersion: "v1",
+        suites: ["AES-128-GCM"],
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("fails when maxBodyBytes is below minimum", () => {
+      const config = buildCryptoConfig({
+        limits: { maxBodyBytes: 100 },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("maxBodyBytes"))).toBe(true);
+    });
+
+    it("fails when maxBodyBytes exceeds maximum", () => {
+      const config = buildCryptoConfig({
+        limits: { maxBodyBytes: 1024 * 1024 * 1024 },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("maxBodyBytes"))).toBe(true);
+    });
+
+    it("fails when maxBodyBytes is not a number", () => {
+      const config = buildCryptoConfig({
+        limits: { maxBodyBytes: "not-a-number" as any },
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("fails when maxBodyBytes is Infinity", () => {
+      const config = buildCryptoConfig({
+        limits: { maxBodyBytes: Infinity },
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("fails when maxBodyBytes is NaN", () => {
+      const config = buildCryptoConfig({
+        limits: { maxBodyBytes: NaN },
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("fails when maxAttachments is below minimum", () => {
+      const config = buildCryptoConfig({
+        limits: { maxAttachments: 0 },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("maxAttachments"))).toBe(true);
+    });
+
+    it("fails when maxAttachments is not an integer", () => {
+      const config = buildCryptoConfig({
+        limits: { maxAttachments: 1.5 },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("integer"))).toBe(true);
+    });
+
+    it("fails when maxAttachmentBytes is below minimum", () => {
+      const config = buildCryptoConfig({
+        limits: { maxAttachmentBytes: 0 },
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("fails when maxAttachmentBytes exceeds maximum", () => {
+      const config = buildCryptoConfig({
+        limits: { maxAttachmentBytes: 1024 * 1024 * 1024 },
+      });
+      expect(config.valid).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildCryptoConfig — production primitive requirements
+  // ---------------------------------------------------------------------------
+
+  describe("buildCryptoConfig — production primitive requirements", () => {
+    it("fails production when subtleCrypto is unavailable", () => {
+      const config = buildCryptoConfig({
+        environment: "production",
+        primitives: { hasSubtleCrypto: false, hasSecureRandom: true },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("crypto.subtle"))).toBe(true);
+    });
+
+    it("fails production when secureRandom is unavailable", () => {
+      const config = buildCryptoConfig({
+        environment: "production",
+        primitives: { hasSubtleCrypto: true, hasSecureRandom: false },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.some((e) => e.includes("getRandomValues"))).toBe(true);
+    });
+
+    it("fails production when both primitives are unavailable", () => {
+      const config = buildCryptoConfig({
+        environment: "production",
+        primitives: { hasSubtleCrypto: false, hasSecureRandom: false },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("allows development without real primitives", () => {
+      const config = buildCryptoConfig({
+        environment: "development",
+        primitives: { hasSubtleCrypto: false, hasSecureRandom: false },
+      });
+      expect(config.valid).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildCryptoConfig — secret leakage prevention
+  // ---------------------------------------------------------------------------
+
+  describe("buildCryptoConfig — secret leakage prevention", () => {
+    it("config object contains no high-entropy blobs", () => {
+      const config = buildCryptoConfig();
+      const json = JSON.stringify(config);
+      expect(json).not.toMatch(/[0-9a-fA-F]{32,}/);
+    });
+
+    it("config object contains no explicit secret markers", () => {
+      const config = buildCryptoConfig();
+      const json = JSON.stringify(config).toLowerCase();
+      expect(json).not.toContain("secret");
+      expect(json).not.toContain("private");
+      expect(json).not.toContain("password");
+      expect(json).not.toContain("token");
+      expect(json).not.toContain("credential");
+    });
+
+    it("config errors contain no secret material", () => {
+      const config = buildCryptoConfig({
+        envelopeVersion: "v99",
+        suites: ["ROT13"],
+      });
+      for (const err of config.errors) {
+        expect(err.toLowerCase()).not.toContain("secret");
+        expect(err.toLowerCase()).not.toContain("private");
+        expect(err).not.toMatch(/[0-9a-fA-F]{32,}/);
+      }
+    });
+
+    it("error messages in invalid config do not contain key material patterns", () => {
+      const config = buildCryptoConfig({
+        environment: "staging" as any,
+      });
+      for (const err of config.errors) {
+        expect(err).not.toMatch(/-----BEGIN/);
+        expect(err).not.toMatch(/^[A-Za-z0-9+/]{40,}={0,2}$/);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateLimits
+  // ---------------------------------------------------------------------------
+
+  describe("validateLimits", () => {
+    it("returns no errors for valid limits", () => {
+      expect(validateLimits(DEFAULT_LIMITS)).toHaveLength(0);
+    });
+
+    it("returns no errors for boundary minimum values", () => {
+      expect(validateLimits(MIN_LIMITS)).toHaveLength(0);
+    });
+
+    it("returns no errors for boundary maximum values", () => {
+      expect(validateLimits(MAX_LIMITS)).toHaveLength(0);
+    });
+
+    it("catches non-finite maxBodyBytes", () => {
+      const errors = validateLimits({ ...DEFAULT_LIMITS, maxBodyBytes: NaN });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it("catches non-integer maxAttachments", () => {
+      const errors = validateLimits({ ...DEFAULT_LIMITS, maxAttachments: 2.5 });
+      expect(errors.some((e) => e.includes("integer"))).toBe(true);
+    });
+
+    it("catches multiple limit violations at once", () => {
+      const errors = validateLimits({
+        maxBodyBytes: -1,
+        maxAttachments: -1,
+        maxAttachmentBytes: -1,
+      });
+      expect(errors.length).toBe(3);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateSuites
+  // ---------------------------------------------------------------------------
+
+  describe("validateSuites", () => {
+    it("returns no errors for supported suites on v1", () => {
+      expect(validateSuites(["AES-256-GCM"], "v1")).toHaveLength(0);
+    });
+
+    it("catches unregistered suite name", () => {
+      const errors = validateSuites(["ROT13"], "v1");
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it("catches empty suite array", () => {
+      const errors = validateSuites([], "v1");
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.includes("at least one"))).toBe(true);
+    });
+
+    it("catches non-string suite entries", () => {
+      const errors = validateSuites([123 as any], "v1");
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it("catches suite not registered for the given version", () => {
+      const errors = validateSuites(["AES-256-GCM"], "v99");
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateEnvelopeVersion
+  // ---------------------------------------------------------------------------
+
+  describe("validateEnvelopeVersion", () => {
+    it("returns undefined for v1", () => {
+      expect(validateEnvelopeVersion("v1")).toBeUndefined();
+    });
+
+    it("returns error for unknown version", () => {
+      expect(validateEnvelopeVersion("v99")).toBeDefined();
+    });
+
+    it("returns error for empty string", () => {
+      expect(validateEnvelopeVersion("")).toBeDefined();
+    });
+
+    it("returns error for non-string", () => {
+      expect(validateEnvelopeVersion(42 as any)).toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validatePrimitives
+  // ---------------------------------------------------------------------------
+
+  describe("validatePrimitives", () => {
+    it("returns no errors for production with real primitives", () => {
+      const errors = validatePrimitives(
+        { hasSubtleCrypto: true, hasSecureRandom: true },
+        "production",
+      );
+      expect(errors).toHaveLength(0);
+    });
+
+    it("returns errors for production without real primitives", () => {
+      const errors = validatePrimitives(
+        { hasSubtleCrypto: false, hasSecureRandom: false },
+        "production",
+      );
+      expect(errors.length).toBe(2);
+    });
+
+    it("returns no errors for development without primitives", () => {
+      const errors = validatePrimitives(
+        { hasSubtleCrypto: false, hasSecureRandom: false },
+        "development",
+      );
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateEnvironment
+  // ---------------------------------------------------------------------------
+
+  describe("validateEnvironment", () => {
+    it("returns undefined for development", () => {
+      expect(validateEnvironment("development")).toBeUndefined();
+    });
+
+    it("returns undefined for production", () => {
+      expect(validateEnvironment("production")).toBeUndefined();
+    });
+
+    it("returns error for unknown environment", () => {
+      expect(validateEnvironment("staging")).toBeDefined();
+    });
+
+    it("returns error for empty string", () => {
+      expect(validateEnvironment("")).toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // detectPrimitives
+  // ---------------------------------------------------------------------------
+
+  describe("detectPrimitives", () => {
+    it("detects crypto.subtle availability", () => {
+      const p = detectPrimitives();
+      expect(typeof p.hasSubtleCrypto).toBe("boolean");
+    });
+
+    it("detects crypto.getRandomValues availability", () => {
+      const p = detectPrimitives();
+      expect(typeof p.hasSecureRandom).toBe("boolean");
+    });
+
+    it("returns a frozen object", () => {
+      expect(Object.isFrozen(detectPrimitives())).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCryptoConfig / resetCryptoConfig
+  // ---------------------------------------------------------------------------
+
+  describe("getCryptoConfig / resetCryptoConfig", () => {
+    it("returns the same cached instance on repeated calls", () => {
+      const a = getCryptoConfig();
+      const b = getCryptoConfig();
+      expect(a).toBe(b);
+    });
+
+    it("returns a fresh instance after reset", () => {
+      const a = getCryptoConfig();
+      resetCryptoConfig();
+      const b = getCryptoConfig();
+      expect(a).not.toBe(b);
+      expect(a.valid).toBe(b.valid);
+    });
+
+    it("default config is valid and production in Web Crypto environments", () => {
+      if (hasRealCrypto) {
+        const config = getCryptoConfig();
+        expect(config.valid).toBe(true);
+        expect(config.environment).toBe("production");
+      } else {
+        const config = getCryptoConfig();
+        expect(config.environment).toBe("production");
+        expect(config.errors.some((e) => e.includes("crypto.subtle") || e.includes("getRandomValues"))).toBe(true);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Comprehensive integration — all invalid combos fail before serving
+  // ---------------------------------------------------------------------------
+
+  describe("invalid combinations fail before serving", () => {
+    it("unknown version + unknown suite + missing primitives", () => {
+      const config = buildCryptoConfig({
+        environment: "production",
+        envelopeVersion: "v99",
+        suites: ["ROT13"],
+        primitives: { hasSubtleCrypto: false, hasSecureRandom: false },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("valid version with mismatched suite", () => {
+      const config = buildCryptoConfig({
+        envelopeVersion: "v1",
+        suites: ["AES-128-GCM"],
+      });
+      expect(config.valid).toBe(false);
+    });
+
+    it("out-of-bounds limits with invalid environment", () => {
+      const config = buildCryptoConfig({
+        environment: "staging" as any,
+        limits: { maxBodyBytes: -1 },
+      });
+      expect(config.valid).toBe(false);
+      expect(config.errors.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
Creates an immutable, validated crypto configuration object (`CryptoConfig`) that consolidates algorithm identifiers, size limits, key resolver availability, clock source, and runtime primitive checks into a single validated configuration. Invalid combinations fail **before** any crypto operation is served.

## Problem

Algorithm identifiers, limits, and runtime capabilities are currently implicit in code and not validated as one configuration. Misconfigured deployments may fail only when a user attempts to send or open a message.

## Solution

### `src/services/crypto/config.ts` â Crypto Configuration Validation

**New types and interfaces:**
- `CryptoConfig` â The full, immutable, frozen configuration object
- `CryptoConfigInput` â Builder input with optional overrides
- `CryptoEnvironment` â `"development" | "production"` deployment mode
- `CryptoLimits` â Body and attachment size/count limits
- `CryptoPrimitives` â Runtime primitive availability (`subtleCrypto`, `getRandomValues`)
- `KeyResolverConfig` / `ClockConfig` â Availability metadata for key resolvers and clocks

**Validation functions:**
- `validateEnvironment()` â Checks environment string is `"development"` or `"production"`
- `validateEnvelopeVersion()` â Validates version against the suite registry
- `validateSuites()` â Validates all suite names are registered and supported for the given version
- `validateLimits()` â Enforces min/max bounds on all limit fields (finite numbers, integer attachments)
- `validatePrimitives()` â Production requires `crypto.subtle` and `crypto.getRandomValues`; development allows test overrides
- `detectPrimitives()` â Runtime detection of Web Crypto availability (frozen result)

**Builder and singleton:**
- `buildCryptoConfig(input?)` â Builds and validates an immutable config. Returns `valid: false` with frozen `errors` array on failure. No secrets in errors.
- `getCryptoConfig()` / `resetCryptoConfig()` â Cached singleton for the default (production) config

**Key design decisions:**
- All output is `Object.freeze()`d â truly immutable after construction
- Secret values (keys, tokens, credentials) are never stored or derivable from the configuration
- Production requires real Web Crypto primitives; development mode allows injectable test overrides
- Limits have explicit floor (`MIN_LIMITS`) and ceiling (`MAX_LIMITS`) values to prevent misconfiguration
- Suites are cross-validated against both the registry and the envelope version

### `tests/unit/crypto/config.test.ts` â 72 Tests

Comprehensive test coverage across:
- Valid configurations (default, custom limits, explicit suites, partial overrides)
- Immutability (frozen objects at every level)
- Invalid configurations (unknown version, unregistered suites, out-of-bounds limits, non-finite values, NaN, Infinity)
- Production primitive requirements (missing `subtleCrypto` / `getRandomValues`)
- Secret leakage prevention (no high-entropy blobs, no secret markers in config or errors)
- Individual validation functions (`validateLimits`, `validateSuites`, `validateEnvelopeVersion`, `validatePrimitives`, `validateEnvironment`)
- Runtime detection (`detectPrimitives`)
- Singleton caching (`getCryptoConfig` / `resetCryptoConfig`)
- Integration: multiple invalid combinations fail before serving

## Acceptance Criteria

- [x] Invalid combinations fail before serving crypto operations
- [x] Secret values are never included in validation errors
- [x] Development and production requirements are explicit
- [x] Tests cover valid and invalid configurations (72 tests, all passing)

## Implementation Scope

- **Primary area:** `src/services/crypto/config.ts`
- **Tests:** `tests/unit/crypto/config.test.ts`
- **No changes to:** API, Soroban contract, relay, UI, routing, or unrelated feature folders

## Test Results

```
â tests/unit/crypto/config.test.ts (72 tests) â all passing
```

The pre-existing crypto test failures (`crypto is not defined`) are due to the vitest Node.js environment lacking `globalThis.crypto` and are unrelated to this change.

Closes #1729
