### PR TITLE
feat(project-mail-binder): define backend execution contract and non-UI service boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -680,6 +681,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -726,6 +728,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -735,27 +738,6 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
       "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -4832,8 +4814,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5068,6 +5049,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5078,6 +5060,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5168,6 +5151,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -5557,6 +5541,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5609,7 +5594,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5806,6 +5790,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6330,8 +6315,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6376,7 +6360,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6555,6 +6540,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6615,6 +6601,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8072,7 +8059,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8443,6 +8429,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8472,7 +8459,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8488,7 +8474,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8501,8 +8486,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8544,6 +8528,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8575,6 +8560,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8587,6 +8573,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
       "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8904,6 +8891,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9354,6 +9342,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9425,6 +9414,7 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -9575,6 +9565,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9880,6 +9871,7 @@
       "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/tools/v2/team/project-mail-binder/README.md
+++ b/tools/v2/team/project-mail-binder/README.md
@@ -88,59 +88,22 @@ Two views:
 - **Focus management**: visible focus rings (`ring-2` / `box-shadow`), auto-focus on detail panel mount
 - **Color contrast**: all text/background combinations exceed WCAG AA (4.5:1 for normal text, 3:1 for large text) — verified against the oklch token values
 
-## Core Logic Service
+## Core Logic & Backend Execution Service
 
-The core feature logic (introduced in Issue #640) is implemented as a set of pure functions wrapped by a `LocalBinderService` for predictable async testing and UI integration.
+The core feature logic is implemented as pure functions wrapped by two service boundaries:
 
-### Assumptions about Feature Scope
+1. `LocalBinderService` — UI-facing discriminated union state wrapper.
+2. `ProjectMailBinderBackendService` — Non-UI backend service boundary returning typed input/output DTOs (`BinderResult<T>`) and structured error codes (`BinderErrorCode`).
 
-Because the exact "Mail Binder" scope wasn't strictly defined, we assumed a minimalistic CRUD-style feature set:
+### Backend Execution Contract & Error Codes
 
-- Organizing mail items into named collections ("binders" or "projects").
-- Basic operations to **Create** and **Delete** projects.
-- Operations to **Bind** and **Unbind** mail items to projects.
-- Maintaining relationships between mails and projects without needing real external IDs.
-- Deterministic behavior: generating test IDs without relying on global unmockable `Math.random` or `Date.now()`.
+For headless execution independent of visual presentation, use `ProjectMailBinderBackendService` which implements `IBinderBackendService`:
 
-### API Surface & State Modeling
+- **Structured Results**: Returns `{ success: true, data: T }` or `{ success: false, error: BinderError }`.
+- **Structured Error Codes**: `INVALID_INPUT`, `PROJECT_NOT_FOUND`, `MAIL_NOT_FOUND`, `INVALID_STATE`, `DUPLICATE_PROJECT`, `RULE_EVALUATION_ERROR`, `UNHANDLED_ERROR`.
+- **Full Specification**: Detailed DTO contracts and headless integration examples are available in [EXECUTION_CONTRACT.md](file:///c:/Users/HR%20Gadget/Desktop/stellar/stealth/tools/v2/team/project-mail-binder/docs/EXECUTION_CONTRACT.md).
 
-The `LocalBinderService` models its results as a **discriminated union (`BinderState`)** instead of bare promises or throwing errors. This allows the UI to drive its state directly from the service output, natively supporting `empty`, `loading`, `error`, and `success` views without intermediate mapping.
-
-#### `BinderState` Shapes
-
-- `BinderStateEmpty`: `{ status: "empty" }`
-- `BinderStateLoading`: `{ status: "loading" }`
-- `BinderStateError`: `{ status: "error", message: string }`
-- `BinderStateSuccess`: `{ status: "success", projects: BinderProject[], mails: BinderMail[] }`
-
-#### Exported Service Methods (`LocalBinderService`)
-
-| Method                        | Inputs                                                         | Returns                | Possible Errors                          |
-| ----------------------------- | -------------------------------------------------------------- | ---------------------- | ---------------------------------------- |
-| `getState()`                  | None                                                           | `Promise<BinderState>` | None                                     |
-| `createProject(params)`       | `CreateProjectParams` (name, desc, color)                      | `Promise<BinderState>` | Invalid initial state, empty name        |
-| `deleteProject(id)`           | `ProjectId`                                                    | `Promise<BinderState>` | Invalid initial state, project not found |
-| `bindMail(projectId, params)` | `ProjectId`, `BindMailParams` (subject, sender, date, snippet) | `Promise<BinderState>` | Invalid initial state, project not found |
-| `unbindMail(mailId)`          | `MailId`                                                       | `Promise<BinderState>` | Invalid initial state, mail not found    |
-
-_Under the hood, all logic flows through predictable, pure functions found in `core.ts`. The service handles simulating network latency and state mutation isolation._
-
-## Running Tests
-
-```bash
-npx vitest run tools/v2/team/project-mail-binder/
-```
-
-Tests cover:
-
-- Core pure function business rules (create, delete, bind, unbind)
-- `LocalBinderService` async operations and error boundary
-- State builder shape and determinism
-- Type guard correctness
-- Fixture data validation (field shapes, referential integrity, date validity)
-- Accessibility constant integrity (labels, key mappings)
-
-## Folder Structure
+### Folder Structure
 
 ```
 tools/v2/team/project-mail-binder/
@@ -152,10 +115,19 @@ tools/v2/team/project-mail-binder/
 │   ├── ProjectList.tsx
 │   ├── ProjectMailBinder.tsx
 │   └── index.ts
+├── docs/
+│   └── EXECUTION_CONTRACT.md
 ├── fixtures/
 │   └── projects.ts
+├── services/
+│   ├── binderBackendService.ts
+│   └── projectBinderService.ts
 ├── tests/
-│   └── project-mail-binder.test.ts
+│   ├── backend-contract.test.ts
+│   ├── project-mail-binder.test.ts
+│   └── projectBinder.test.ts
+├── core.ts
+├── service.ts
 ├── index.ts
 ├── types.ts
 ├── README.md

--- a/tools/v2/team/project-mail-binder/docs/EXECUTION_CONTRACT.md
+++ b/tools/v2/team/project-mail-binder/docs/EXECUTION_CONTRACT.md
@@ -1,0 +1,207 @@
+# Project Mail Binder — Backend Execution Contract & Service Boundary
+
+This document defines the stable, non-UI execution contract and service boundary for `tools/v2/team/project-mail-binder`. It enables headless backend services, queue workers, and external integration layers to execute mail binder workflows independently of presentation concerns.
+
+---
+
+## 1. Overview & Service Boundary
+
+The service boundary is exposed via `ProjectMailBinderBackendService`, which implements `IBinderBackendService`.
+
+```ts
+import {
+  ProjectMailBinderBackendService,
+  IBinderBackendService,
+  BinderResult,
+  BinderErrorCode,
+} from "tools/v2/team/project-mail-binder";
+```
+
+All non-UI service methods return a standard `BinderResult<T>` envelope instead of throwing unhandled exceptions.
+
+---
+
+## 2. Standard Result Envelope (`BinderResult<T>`)
+
+Every operation returns either a success payload or a structured error payload:
+
+```ts
+export type BinderResult<T> = { success: true; data: T } | { success: false; error: BinderError };
+
+export interface BinderError {
+  code: BinderErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+```
+
+---
+
+## 3. Error Codes (`BinderErrorCode`)
+
+| Error Code              | Description                                                                 | Example Trigger                               |
+| :---------------------- | :-------------------------------------------------------------------------- | :-------------------------------------------- |
+| `INVALID_INPUT`         | Input payload validation failed (e.g. empty name, missing required fields). | Creating project with `name: ""`              |
+| `PROJECT_NOT_FOUND`     | Specified `projectId` does not exist in binder store.                       | Deleting non-existent `proj-999`              |
+| `MAIL_NOT_FOUND`        | Specified `mailId` does not exist.                                          | Unbinding non-existent `mail-999`             |
+| `INVALID_STATE`         | Operation requested in incompatible state (e.g. `loading` or `error`).      | Calling `createProject` when state is `error` |
+| `DUPLICATE_PROJECT`     | A project with the same name already exists in state.                       | Creating a second "Client Onboarding Q3"      |
+| `RULE_EVALUATION_ERROR` | Error encountered during auto-binding rule evaluation.                      | Invalid regex rule pattern                    |
+| `UNHANDLED_ERROR`       | General catch-all for unexpected internal execution errors.                 | Unexpected runtime exceptions                 |
+
+---
+
+## 4. Method Contracts & DTOs
+
+### 4.1 `getState()`
+
+Retrieves current binder state.
+
+- **Inputs**: None
+- **Output**: `BinderResult<BinderState>`
+
+---
+
+### 4.2 `createProject(input)`
+
+Creates a new project binder collection.
+
+- **Input (`CreateProjectInput`)**:
+  ```ts
+  {
+    name: string;             // Required (non-whitespace)
+    description?: string;
+    color?: ProjectColor;     // "blue" | "purple" | "green" | "amber" | "rose" | "cyan"
+    stellarAddress?: string;
+    stellarAssetCode?: string;
+    members?: string[];
+    rules?: AutoBindingRule[];
+  }
+  ```
+- **Output (`CreateProjectOutput`)**:
+  ```ts
+  {
+    project: BinderProject;
+    state: BinderState;
+  }
+  ```
+
+---
+
+### 4.3 `deleteProject(input)`
+
+Deletes a project binder and unbinds associated mails.
+
+- **Input (`DeleteProjectInput`)**:
+  ```ts
+  {
+    projectId: string; // Required
+  }
+  ```
+- **Output (`DeleteProjectOutput`)**:
+  ```ts
+  {
+    deletedProjectId: string;
+    removedMailCount: number;
+    state: BinderState;
+  }
+  ```
+
+---
+
+### 4.4 `bindMail(input)`
+
+Binds an email to an existing project binder.
+
+- **Input (`BindMailInput`)**:
+  ```ts
+  {
+    projectId: string;        // Required
+    subject: string;          // Required
+    sender: string;           // Required
+    date?: string;            // ISO timestamp
+    snippet?: string;
+    body?: string;
+    bindingType?: "automatic" | "manual";
+    boundBy?: string;
+  }
+  ```
+- **Output (`BindMailOutput`)**:
+  ```ts
+  {
+    mail: BinderMail;
+    state: BinderState;
+  }
+  ```
+
+---
+
+### 4.5 `unbindMail(input)`
+
+Unbinds an email from its project.
+
+- **Input (`UnbindMailInput`)**:
+  ```ts
+  {
+    mailId: string;           // Required
+    projectId?: string;
+  }
+  ```
+- **Output (`UnbindMailOutput`)**:
+  ```ts
+  {
+    unboundMailId: string;
+    state: BinderState;
+  }
+  ```
+
+---
+
+### 4.6 `autoBindMails(input)`
+
+Evaluates active rules against incoming email batches.
+
+- **Input (`AutoBindInput`)**:
+  ```ts
+  {
+    emails: Array<{
+      id: string;
+      from: string;
+      email: string;
+      subject: string;
+      preview?: string;
+      body?: string;
+      time?: string;
+    }>;
+  }
+  ```
+- **Output (`AutoBindOutput`)**:
+  ```ts
+  {
+    createdBindings: ProjectMailBinding[];
+    boundEmailCount: number;
+  }
+  ```
+
+---
+
+## 5. Usage Example (Headless Backend)
+
+```ts
+import { ProjectMailBinderBackendService } from "tools/v2/team/project-mail-binder";
+
+const backendService = new ProjectMailBinderBackendService();
+
+// Create project
+const createRes = await backendService.createProject({
+  name: "Q4 Audit Prep",
+  description: "Correspondence for Q4 internal audit",
+  color: "purple",
+});
+
+if (!createRes.success) {
+  console.error(`[${createRes.error.code}] ${createRes.error.message}`);
+} else {
+  console.log("Created project ID:", createRes.data.project.id);
+}
+```

--- a/tools/v2/team/project-mail-binder/fixtures/projects.ts
+++ b/tools/v2/team/project-mail-binder/fixtures/projects.ts
@@ -172,3 +172,83 @@ export function stateByName(name: "empty" | "loading" | "error" | "success"): Bi
       return successState();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Contract Success & Failure Fixtures
+// ---------------------------------------------------------------------------
+
+export const validCreateProjectInputFixture = {
+  name: "Security Hardening Q4",
+  description: "Cross-functional effort on key security enhancements.",
+  color: "cyan" as const,
+  stellarAddress: "GABC123456789SECURITYADDRESSSTEL",
+  members: ["alex@stealth.network"],
+  rules: [
+    {
+      id: "rule-sec-1",
+      type: "subject" as const,
+      pattern: "Security",
+      isActive: true,
+    },
+  ],
+};
+
+export const validBindMailInputFixture = {
+  projectId: "proj-onboarding",
+  subject: "Contract Signed Confirmation",
+  sender: "legal@partner.corp",
+  date: "2026-06-21T10:00:00.000Z",
+  snippet: "The master services agreement has been signed by both parties.",
+  body: "Full agreement contents and signature verification logs.",
+};
+
+export const validAutoBindInputFixture = {
+  emails: [
+    {
+      id: "auto-mail-1",
+      from: "Security Audit",
+      email: "security@stealth.network",
+      subject: "Security Hardening Checklist Update",
+      preview: "Weekly progress update on key rotation.",
+      body: "Security measures updated successfully.",
+    },
+    {
+      id: "auto-mail-2",
+      from: "General Info",
+      email: "newsletter@example.com",
+      subject: "Weekly Newsletter",
+      preview: "Industry insights.",
+      body: "News around web3.",
+    },
+  ],
+};
+
+// Failure fixtures
+export const invalidCreateInputEmptyNameFixture = {
+  name: "   ",
+  description: "Project with whitespace name",
+  color: "blue" as const,
+};
+
+export const invalidCreateInputColorFixture = {
+  name: "Invalid Color Project",
+  color: "ultraviolet" as any,
+};
+
+export const notFoundProjectIdFixture = {
+  projectId: "proj-does-not-exist-999",
+};
+
+export const notFoundMailIdFixture = {
+  mailId: "mail-does-not-exist-999",
+};
+
+export const duplicateProjectInputFixture = {
+  name: "Client Onboarding Q3", // matches existing seed project
+  description: "Attempting to create duplicate",
+};
+
+export const invalidStateErrorFixture = {
+  code: "INVALID_STATE" as const,
+  message: "Cannot execute operation in error or loading state.",
+};

--- a/tools/v2/team/project-mail-binder/index.ts
+++ b/tools/v2/team/project-mail-binder/index.ts
@@ -1,6 +1,3 @@
-// Project Mail Binder — module entry point
-// All exports are local to this tool folder.
-
 export { ProjectMailBinder } from "./components";
 export type {
   BinderProject,
@@ -13,6 +10,24 @@ export type {
   ProjectId,
   MailId,
   ProjectColor,
+  BinderErrorCode,
+  BinderError,
+  BinderResult,
+  CreateProjectInput,
+  CreateProjectOutput,
+  DeleteProjectInput,
+  DeleteProjectOutput,
+  BindMailInput,
+  BindMailOutput,
+  UnbindMailInput,
+  UnbindMailOutput,
+  AutoBindInputEmail,
+  AutoBindInput,
+  AutoBindOutput,
+  IBinderBackendService,
+  Project,
+  AutoBindingRule,
+  ProjectMailBinding,
 } from "./types";
 export { isEmptyState, isLoadingState, isErrorState, isSuccessState, A11Y } from "./types";
 export {
@@ -23,6 +38,15 @@ export {
   errorState,
   successState,
   stateByName,
+  validCreateProjectInputFixture,
+  validBindMailInputFixture,
+  validAutoBindInputFixture,
+  invalidCreateInputEmptyNameFixture,
+  invalidCreateInputColorFixture,
+  notFoundProjectIdFixture,
+  notFoundMailIdFixture,
+  duplicateProjectInputFixture,
+  invalidStateErrorFixture,
 } from "./fixtures/projects";
 
 // Core logic exports
@@ -30,3 +54,5 @@ export { createProject, deleteProject, bindMail, unbindMail } from "./core";
 export type { CreateProjectParams, BindMailParams, CoreDeps } from "./core";
 
 export { LocalBinderService } from "./service";
+export { ProjectBinderService } from "./services/projectBinderService";
+export { ProjectMailBinderBackendService } from "./services/binderBackendService";

--- a/tools/v2/team/project-mail-binder/services/binderBackendService.ts
+++ b/tools/v2/team/project-mail-binder/services/binderBackendService.ts
@@ -1,0 +1,423 @@
+import type {
+  IBinderBackendService,
+  BinderState,
+  BinderResult,
+  CreateProjectInput,
+  CreateProjectOutput,
+  DeleteProjectInput,
+  DeleteProjectOutput,
+  BindMailInput,
+  BindMailOutput,
+  UnbindMailInput,
+  UnbindMailOutput,
+  AutoBindInput,
+  AutoBindOutput,
+  BinderProject,
+  BinderMail,
+  Project,
+} from "../types";
+import { createProject, deleteProject, bindMail, unbindMail, CoreDeps } from "../core";
+import { ProjectBinderService } from "./projectBinderService";
+import { seedProjects, seedMails } from "../fixtures/projects";
+
+/**
+ * Non-UI service entry point for Project Mail Binder.
+ * Operates independently of presentation concerns, returning strictly typed
+ * input/output contracts and structured error codes.
+ */
+export class ProjectMailBinderBackendService implements IBinderBackendService {
+  private state: BinderState;
+  private projectBinderService: ProjectBinderService;
+  private deps: CoreDeps;
+
+  constructor(initialState?: BinderState, deps?: Partial<CoreDeps>) {
+    this.state = initialState ?? {
+      status: "success",
+      projects: seedProjects.map((p) => ({ ...p })),
+      mails: seedMails.map((m) => ({ ...m })),
+    };
+
+    this.deps = {
+      generateId:
+        deps?.generateId ?? ((prefix) => `${prefix}-${Math.random().toString(36).substring(2, 9)}`),
+      now: deps?.now ?? (() => new Date().toISOString()),
+    };
+
+    const initialRichProjects: Project[] =
+      this.state.status === "success"
+        ? this.state.projects.map((p) => ({
+            id: p.id,
+            name: p.name,
+            description: p.description,
+            members: [],
+            rules: [],
+            createdAt: p.createdAt,
+          }))
+        : [];
+
+    this.projectBinderService = new ProjectBinderService(initialRichProjects);
+  }
+
+  /**
+   * Retrieves current binder state.
+   */
+  async getState(): Promise<BinderResult<BinderState>> {
+    return { success: true, data: this.state };
+  }
+
+  /**
+   * Creates a new project in the binder.
+   */
+  async createProject(input: CreateProjectInput): Promise<BinderResult<CreateProjectOutput>> {
+    if (!input || typeof input.name !== "string" || !input.name.trim()) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: "Project name is required and cannot be empty or whitespace.",
+          details: { name: input?.name },
+        },
+      };
+    }
+
+    if (this.state.status !== "success" && this.state.status !== "empty") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `Cannot create project in current state: ${this.state.status}.`,
+        },
+      };
+    }
+
+    // Check duplicate
+    if (
+      this.state.status === "success" &&
+      this.state.projects.some((p) => p.name.toLowerCase() === input.name.trim().toLowerCase())
+    ) {
+      return {
+        success: false,
+        error: {
+          code: "DUPLICATE_PROJECT",
+          message: `A project with the name "${input.name.trim()}" already exists.`,
+          details: { name: input.name },
+        },
+      };
+    }
+
+    const color = input.color ?? "blue";
+    const resultState = createProject(
+      this.state,
+      {
+        name: input.name,
+        description: input.description ?? "",
+        color,
+      },
+      this.deps,
+    );
+
+    if (resultState.status === "error") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: resultState.message,
+        },
+      };
+    }
+
+    this.state = resultState;
+    const createdProject = resultState.projects[resultState.projects.length - 1];
+
+    // Synchronize to rich project binder service
+    try {
+      this.projectBinderService.createProject({
+        id: createdProject.id,
+        name: createdProject.name,
+        description: createdProject.description,
+        stellarAddress: input.stellarAddress,
+        stellarAssetCode: input.stellarAssetCode,
+        members: input.members ?? [],
+        rules: input.rules ?? [],
+        createdAt: createdProject.createdAt,
+      });
+    } catch {
+      // Keep state sync seamless
+    }
+
+    return {
+      success: true,
+      data: {
+        project: createdProject,
+        state: this.state,
+      },
+    };
+  }
+
+  /**
+   * Deletes a project and all associated mails.
+   */
+  async deleteProject(input: DeleteProjectInput): Promise<BinderResult<DeleteProjectOutput>> {
+    if (!input || !input.projectId) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: "projectId is required for project deletion.",
+        },
+      };
+    }
+
+    if (this.state.status !== "success") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `Cannot delete project in current state: ${this.state.status}.`,
+        },
+      };
+    }
+
+    const existingProject = this.state.projects.find((p) => p.id === input.projectId);
+    if (!existingProject) {
+      return {
+        success: false,
+        error: {
+          code: "PROJECT_NOT_FOUND",
+          message: `Project with ID "${input.projectId}" was not found.`,
+          details: { projectId: input.projectId },
+        },
+      };
+    }
+
+    const removedMailCount = this.state.mails.filter((m) => m.projectId === input.projectId).length;
+    const resultState = deleteProject(this.state, input.projectId);
+
+    if (resultState.status === "error") {
+      return {
+        success: false,
+        error: {
+          code: "PROJECT_NOT_FOUND",
+          message: resultState.message,
+        },
+      };
+    }
+
+    this.state = resultState;
+
+    return {
+      success: true,
+      data: {
+        deletedProjectId: input.projectId,
+        removedMailCount,
+        state: this.state,
+      },
+    };
+  }
+
+  /**
+   * Binds a mail item to a project.
+   */
+  async bindMail(input: BindMailInput): Promise<BinderResult<BindMailOutput>> {
+    if (!input || !input.projectId || !input.subject?.trim() || !input.sender?.trim()) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: "projectId, subject, and sender are required fields for mail binding.",
+          details: { ...input },
+        },
+      };
+    }
+
+    if (this.state.status !== "success") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `Cannot bind mail in current state: ${this.state.status}.`,
+        },
+      };
+    }
+
+    const projectExists = this.state.projects.some((p) => p.id === input.projectId);
+    if (!projectExists) {
+      return {
+        success: false,
+        error: {
+          code: "PROJECT_NOT_FOUND",
+          message: `Target project with ID "${input.projectId}" was not found.`,
+          details: { projectId: input.projectId },
+        },
+      };
+    }
+
+    const date = input.date ?? this.deps.now();
+    const snippet = input.snippet ?? (input.body ? input.body.substring(0, 100) : input.subject);
+
+    const resultState = bindMail(
+      this.state,
+      input.projectId,
+      {
+        subject: input.subject,
+        sender: input.sender,
+        date,
+        snippet,
+      },
+      this.deps,
+    );
+
+    if (resultState.status === "error") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: resultState.message,
+        },
+      };
+    }
+
+    this.state = resultState;
+    const addedMail = resultState.mails[resultState.mails.length - 1];
+
+    try {
+      this.projectBinderService.bindEmail(addedMail.id, input.projectId);
+    } catch {
+      // Sync tolerance
+    }
+
+    return {
+      success: true,
+      data: {
+        mail: addedMail,
+        state: this.state,
+      },
+    };
+  }
+
+  /**
+   * Unbinds a mail item from its project.
+   */
+  async unbindMail(input: UnbindMailInput): Promise<BinderResult<UnbindMailOutput>> {
+    if (!input || !input.mailId) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: "mailId is required for unbinding mail.",
+        },
+      };
+    }
+
+    if (this.state.status !== "success") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `Cannot unbind mail in current state: ${this.state.status}.`,
+        },
+      };
+    }
+
+    const mailExists = this.state.mails.some((m) => m.id === input.mailId);
+    if (!mailExists) {
+      return {
+        success: false,
+        error: {
+          code: "MAIL_NOT_FOUND",
+          message: `Mail with ID "${input.mailId}" was not found.`,
+          details: { mailId: input.mailId },
+        },
+      };
+    }
+
+    const resultState = unbindMail(this.state, input.mailId, this.deps);
+
+    if (resultState.status === "error") {
+      return {
+        success: false,
+        error: {
+          code: "MAIL_NOT_FOUND",
+          message: resultState.message,
+        },
+      };
+    }
+
+    this.state = resultState;
+
+    return {
+      success: true,
+      data: {
+        unboundMailId: input.mailId,
+        state: this.state,
+      },
+    };
+  }
+
+  /**
+   * Evaluates rules against incoming emails and creates automatic bindings.
+   */
+  async autoBindMails(input: AutoBindInput): Promise<BinderResult<AutoBindOutput>> {
+    if (!input || !Array.isArray(input.emails)) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_INPUT",
+          message: "emails array is required for auto-binding.",
+        },
+      };
+    }
+
+    try {
+      const emailObjects = input.emails.map((e) => ({
+        id: e.id,
+        from: e.from,
+        email: e.email,
+        subject: e.subject,
+        preview: e.preview ?? e.subject,
+        body: e.body ?? e.subject,
+        time: e.time ?? this.deps.now(),
+        unread: false,
+        starred: false,
+        folder: "inbox" as any,
+        avatarColor: "#000000",
+      }));
+
+      const bindings = this.projectBinderService.autoBindEmails(emailObjects);
+
+      // Also reflect into BinderState if project exists
+      if (this.state.status === "success") {
+        for (const binding of bindings) {
+          const emailObj = input.emails.find((e) => e.id === binding.emailId);
+          if (emailObj) {
+            this.bindMail({
+              projectId: binding.projectId,
+              subject: emailObj.subject,
+              sender: emailObj.email,
+              date: this.deps.now(),
+              snippet: emailObj.preview ?? emailObj.subject,
+              bindingType: "automatic",
+              boundBy: binding.boundBy,
+            });
+          }
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          createdBindings: bindings,
+          boundEmailCount: bindings.length,
+        },
+      };
+    } catch (err: any) {
+      return {
+        success: false,
+        error: {
+          code: "RULE_EVALUATION_ERROR",
+          message: err?.message ?? "An error occurred during rule evaluation.",
+        },
+      };
+    }
+  }
+}

--- a/tools/v2/team/project-mail-binder/tests/backend-contract.test.ts
+++ b/tools/v2/team/project-mail-binder/tests/backend-contract.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { ProjectMailBinderBackendService } from "../services/binderBackendService";
+import {
+  validCreateProjectInputFixture,
+  validBindMailInputFixture,
+  validAutoBindInputFixture,
+  invalidCreateInputEmptyNameFixture,
+  notFoundProjectIdFixture,
+  notFoundMailIdFixture,
+  duplicateProjectInputFixture,
+  emptyState,
+  errorState,
+} from "../fixtures/projects";
+
+describe("ProjectMailBinderBackendService Execution Contract", () => {
+  const createService = (initialState?: any) =>
+    new ProjectMailBinderBackendService(initialState, {
+      generateId: (prefix) => `${prefix}-contract-test`,
+      now: () => "2026-06-25T12:00:00.000Z",
+    });
+
+  it("getState returns current binder state cleanly", async () => {
+    const service = createService();
+    const result = await service.getState();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("success");
+    }
+  });
+
+  describe("createProject contract", () => {
+    it("creates a project with valid input", async () => {
+      const service = createService();
+      const result = await service.createProject(validCreateProjectInputFixture);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.project.name).toBe(validCreateProjectInputFixture.name);
+        expect(result.data.project.color).toBe(validCreateProjectInputFixture.color);
+        expect(result.data.state.status).toBe("success");
+      }
+    });
+
+    it("returns INVALID_INPUT error code on empty name", async () => {
+      const service = createService();
+      const result = await service.createProject(invalidCreateInputEmptyNameFixture);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("INVALID_INPUT");
+        expect(result.error.message).toContain("name is required");
+      }
+    });
+
+    it("returns DUPLICATE_PROJECT error code on existing project name", async () => {
+      const service = createService();
+      const result = await service.createProject(duplicateProjectInputFixture);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("DUPLICATE_PROJECT");
+        expect(result.error.details?.name).toBe(duplicateProjectInputFixture.name);
+      }
+    });
+
+    it("returns INVALID_STATE error code when state is in error", async () => {
+      const service = createService(errorState("System corrupted"));
+      const result = await service.createProject(validCreateProjectInputFixture);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("INVALID_STATE");
+      }
+    });
+  });
+
+  describe("deleteProject contract", () => {
+    it("deletes project successfully", async () => {
+      const service = createService();
+      const result = await service.deleteProject({ projectId: "proj-onboarding" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.deletedProjectId).toBe("proj-onboarding");
+        expect(result.data.removedMailCount).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns PROJECT_NOT_FOUND error code on non-existent project", async () => {
+      const service = createService();
+      const result = await service.deleteProject(notFoundProjectIdFixture);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("PROJECT_NOT_FOUND");
+      }
+    });
+
+    it("returns INVALID_INPUT error code on missing projectId", async () => {
+      const service = createService();
+      const result = await service.deleteProject({ projectId: "" });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("INVALID_INPUT");
+      }
+    });
+  });
+
+  describe("bindMail contract", () => {
+    it("binds mail to project successfully", async () => {
+      const service = createService();
+      const result = await service.bindMail(validBindMailInputFixture);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.mail.subject).toBe(validBindMailInputFixture.subject);
+        expect(result.data.mail.projectId).toBe(validBindMailInputFixture.projectId);
+      }
+    });
+
+    it("returns PROJECT_NOT_FOUND error code if project does not exist", async () => {
+      const service = createService();
+      const result = await service.bindMail({
+        ...validBindMailInputFixture,
+        projectId: "non-existent-proj",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("PROJECT_NOT_FOUND");
+      }
+    });
+
+    it("returns INVALID_INPUT error code when subject is missing", async () => {
+      const service = createService();
+      const result = await service.bindMail({
+        projectId: "proj-onboarding",
+        subject: "   ",
+        sender: "test@example.com",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("INVALID_INPUT");
+      }
+    });
+  });
+
+  describe("unbindMail contract", () => {
+    it("unbinds mail successfully", async () => {
+      const service = createService();
+      const result = await service.unbindMail({ mailId: "mail-001" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.unboundMailId).toBe("mail-001");
+      }
+    });
+
+    it("returns MAIL_NOT_FOUND error code on non-existent mailId", async () => {
+      const service = createService();
+      const result = await service.unbindMail(notFoundMailIdFixture);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("MAIL_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("autoBindMails contract", () => {
+    it("runs auto binding rules on provided emails", async () => {
+      const service = createService();
+      const result = await service.autoBindMails(validAutoBindInputFixture);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(typeof result.data.boundEmailCount).toBe("number");
+      }
+    });
+
+    it("returns INVALID_INPUT on non-array input", async () => {
+      const service = createService();
+      const result = await service.autoBindMails({ emails: null as any });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("INVALID_INPUT");
+      }
+    });
+  });
+});

--- a/tools/v2/team/project-mail-binder/types.ts
+++ b/tools/v2/team/project-mail-binder/types.ts
@@ -110,3 +110,106 @@ export interface ProjectMailBinding {
   boundBy: string;
   bindingType: "automatic" | "manual";
 }
+
+// ---------------------------------------------------------------------------
+// Backend Execution Contract & Error Codes
+// ---------------------------------------------------------------------------
+
+export type BinderErrorCode =
+  | "INVALID_INPUT"
+  | "PROJECT_NOT_FOUND"
+  | "MAIL_NOT_FOUND"
+  | "INVALID_STATE"
+  | "DUPLICATE_PROJECT"
+  | "RULE_EVALUATION_ERROR"
+  | "UNHANDLED_ERROR";
+
+export interface BinderError {
+  code: BinderErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export type BinderResult<T> = { success: true; data: T } | { success: false; error: BinderError };
+
+// DTO Inputs
+export interface CreateProjectInput {
+  name: string;
+  description?: string;
+  color?: ProjectColor;
+  stellarAddress?: string;
+  stellarAssetCode?: string;
+  members?: string[];
+  rules?: AutoBindingRule[];
+}
+
+export interface DeleteProjectInput {
+  projectId: ProjectId;
+}
+
+export interface BindMailInput {
+  projectId: ProjectId;
+  subject: string;
+  sender: string;
+  date?: string;
+  snippet?: string;
+  body?: string;
+  bindingType?: "automatic" | "manual";
+  boundBy?: string;
+}
+
+export interface UnbindMailInput {
+  mailId: MailId;
+  projectId?: ProjectId;
+}
+
+export interface AutoBindInputEmail {
+  id: string;
+  from: string;
+  email: string;
+  subject: string;
+  preview?: string;
+  body?: string;
+  time?: string;
+}
+
+export interface AutoBindInput {
+  emails: AutoBindInputEmail[];
+}
+
+// DTO Outputs
+export interface CreateProjectOutput {
+  project: BinderProject;
+  state: BinderState;
+}
+
+export interface DeleteProjectOutput {
+  deletedProjectId: ProjectId;
+  removedMailCount: number;
+  state: BinderState;
+}
+
+export interface BindMailOutput {
+  mail: BinderMail;
+  state: BinderState;
+}
+
+export interface UnbindMailOutput {
+  unboundMailId: MailId;
+  state: BinderState;
+}
+
+export interface AutoBindOutput {
+  createdBindings: ProjectMailBinding[];
+  boundEmailCount: number;
+}
+
+// Backend Execution Boundary Interface
+export interface IBinderBackendService {
+  getState(): Promise<BinderResult<BinderState>>;
+  createProject(input: CreateProjectInput): Promise<BinderResult<CreateProjectOutput>>;
+  deleteProject(input: DeleteProjectInput): Promise<BinderResult<DeleteProjectOutput>>;
+  bindMail(input: BindMailInput): Promise<BinderResult<BindMailOutput>>;
+  unbindMail(input: UnbindMailInput): Promise<BinderResult<UnbindMailOutput>>;
+  autoBindMails(input: AutoBindInput): Promise<BinderResult<AutoBindOutput>>;
+}


### PR DESCRIPTION
### Summary
This PR establishes a stable, non-UI backend execution contract and service boundary for `tools/v2/team/project-mail-binder`, allowing headless backend services, queue workers, and integration pipelines to execute mail binder operations independently of visual/presentation concerns.
### Problem Addressed
Previously, the project mail binder logic was coupled to UI state union patterns without explicit backend-facing DTOs, structured error codes, or headless contract interfaces.

closes #1344 