### PR TITLE
test(tools): core-behavior tests + contributor docs for team-calendar-extraction (#683)

### DIFF
--- a/tools/v2/team/team-calendar-extraction/docs/CONTRIBUTING.md
+++ b/tools/v2/team/team-calendar-extraction/docs/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to Team Calendar Extraction
+
+This folder is a **self-contained V2 team tool**. It is intentionally isolated from
+the main application (shell, navigation, auth, wallet core, mail rendering engine,
+routing, Stellar core, DB schema, and the shared design system). Treat it as a
+mini-product: changes here should be reviewable on their own.
+
+## Scope boundary
+
+All work for this issue must stay inside:
+
+```text
+tools/v2/team/team-calendar-extraction/
+```
+
+Do **not** wire this tool into the main app, and do not modify app-wide code.
+If a future integration is needed, write it as a separate follow-up issue.
+
+## What the tool does
+
+Extracts calendar events from team emails in two ways:
+
+1. **ICS attachments** — parses `.ics` (text/calendar) attachments safely.
+2. **Text scan** — scans the email subject/body for meeting indicators
+   (`meeting`, `sync`, `call`, `review`, `standup`, `workshop`, `discussion`,
+   `calendar`, `zoom`, `meet.google`) and derives a lightweight event.
+
+Every extracted value is **sanitized** (HTML/script stripping, email normalization,
+filename traversal protection) and **validated** (format, length, attendee caps)
+before it becomes an event. See `docs/security-threat-model.md` and
+`docs/performance-guidelines.md` for the safety design.
+
+## Local setup
+
+```bash
+# from repo root
+bun install
+cd tools/v2/team/team-calendar-extraction
+bunx vitest run        # run this tool's tests in isolation
+```
+
+The tool has its own `vitest.config.ts`, so you can run its suite without the
+rest of the workspace. Prefer this during review.
+
+## Layout
+
+```text
+team-calendar-extraction/
+├── types/index.ts                 # CalendarEvent, EmailData, ValidationResult, ...
+├── services/
+│   ├── sanitization.ts            # HTML/text/filename sanitizers
+│   ├── validation.ts              # email + event validators (length/attendee caps)
+│   ├── ics-parser.ts              # line-length/event/size guarded ICS parser
+│   └── extraction.service.ts      # orchestrator: processTeamEmails()
+├── hooks/use-calendar-extraction.ts
+├── components/                    # TeamCalendarExtraction, EventList, StatusIndicators
+├── fixtures/calendar.fixtures.ts  # valid / malicious emails, ICS generators
+├── tests/
+│   ├── calendar-security.test.ts  # sanitization, validation, parser limits
+│   └── extraction.test.ts         # core behavior: extraction, progress, batching
+├── docs/
+│   ├── security-threat-model.md
+│   ├── performance-guidelines.md
+│   └── CONTRIBUTING.md            # this file
+└── demo.tsx
+```
+
+## Running the tests
+
+```bash
+bunx vitest run tests/calendar-security.test.ts
+bunx vitest run tests/extraction.test.ts
+```
+
+Both files must stay green. `calendar-security.test.ts` covers adversarial input
+and parser limits; `extraction.test.ts` covers the happy path, the progress
+callback, batch truncation, and empty input.
+
+## Fixtures
+
+`fixtures/calendar.fixtures.ts` exports:
+
+- `validEmails` — two benign emails (one text-scan, one with a valid `.ics`).
+- `maliciousEmails` — XSS/phishing email + path-traversal `.ics` filename.
+- `generateLargeIcsContent(n)` — produces `n` VEVENTs (use to test the 100-event cap).
+- `generateOverlyLongLineIcs()` — a VEVENT with a >1000-char property line.
+
+When adding behavior tests, reuse these fixtures before inventing new ones.
+
+## Known limitations
+
+- Text-scan extraction is heuristic: it only detects a meeting when a known
+  indicator word is present, and it derives a date from the first `YYYY-MM-DD`
+  (or `DD/MM/YYYY`) match in the sanitized body. It does **not** parse natural
+  language like "next Tuesday".
+- End time from text scan is always **start + 1 hour**.
+- ICS parser supports a flat VEVENT structure (no nested/recurrence expansion
+  beyond recording `RRULE` as text).
+- Batch processing is capped at **50 emails per call** (`MAX_EMAILS_PER_BATCH`);
+  larger inputs are truncated with a sanitization-log warning.
+- File/line/event limits: 2 MB ICS, 1000-char lines, 100 events, 2000-char
+  properties, 50 attendees.
+
+## Review notes for OSS contributors
+
+- Keep changes **inside this folder**. PRs that touch app-wide code will be
+  rejected for this issue.
+- Add or extend tests for any new behavior; this tool values small, reviewable,
+  folder-local changes.
+- Sanitization/validation are security-critical — if you change a limit or a
+  sanitizer, add a test that proves the guard still holds.
+- Run `bunx vitest run` from this folder before opening a PR.
+- Document any new known limitation in the section above.

--- a/tools/v2/team/team-calendar-extraction/tests/extraction.test.ts
+++ b/tools/v2/team/team-calendar-extraction/tests/extraction.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { processTeamEmails, extractEventFromEmailText } from "../services/extraction.service";
+import { parseIcsContent } from "../services/ics-parser";
+import {
+  validEmails,
+  generateLargeIcsContent,
+  generateOverlyLongLineIcs,
+  maliciousEmails,
+} from "../fixtures/calendar.fixtures";
+import type { EmailData } from "../types";
+
+describe("Team Calendar Extraction - Core Behavior", () => {
+  it("extracts events from a valid email batch (ICS attachment + text scan)", () => {
+    const result = processTeamEmails(validEmails);
+    // email_2 contributes a parsed ICS VEVENT; email_1 is a text-extracted sync.
+    expect(result.events.length).toBeGreaterThanOrEqual(2);
+    expect(result.stats.eventsExtracted).toBe(2);
+    expect(result.errors).toHaveLength(0);
+
+    const titles = result.events.map((e) => e.title);
+    expect(titles).toContain("Sprint Planning");
+    expect(titles.some((t) => /kickoff/i.test(t))).toBe(true);
+  });
+
+  it("emits a progress callback that reaches 100% for the full batch", () => {
+    const onProgress = vi.fn();
+    processTeamEmails(validEmails, onProgress);
+    expect(onProgress).toHaveBeenCalled();
+    const last = onProgress.mock.calls[onProgress.mock.calls.length - 1][0];
+    expect(last).toBe(100);
+  });
+
+  it("extracts a structured event from a plain meeting email (no attachment)", () => {
+    const email: EmailData = {
+      id: "email_text_1",
+      subject: "Weekly Sync",
+      from: "lead@company.com",
+      to: ["dev@company.com"],
+      body: "Let's meet on 2026-08-15 to review the roadmap. Join the call.",
+      hasAttachments: false,
+    };
+    const event = extractEventFromEmailText(email);
+    expect(event).not.toBeNull();
+    expect(event?.organizer).toBe("lead@company.com");
+    expect(event?.attendees).toContain("dev@company.com");
+    expect(event?.startDate).toMatch(/^2026-08-15T/);
+    // End is one hour after start.
+    expect(event?.endDate).toMatch(/^2026-08-15T/);
+  });
+
+  it("returns null for emails with no meeting indicator word", () => {
+    const email: EmailData = {
+      id: "email_no_meeting",
+      subject: "Lunch order",
+      from: "friend@company.com",
+      to: ["dev@company.com"],
+      body: "What do you want to eat today? I am hungry and will bring snacks.",
+      hasAttachments: false,
+    };
+    expect(extractEventFromEmailText(email)).toBeNull();
+  });
+
+  it("truncates oversized email batches to the per-batch limit (50)", () => {
+    const big: EmailData[] = Array.from({ length: 55 }, (_, i) => ({
+      id: `bulk_${i}`,
+      subject: "Daily Standup",
+      from: `person${i}@company.com`,
+      to: ["team@company.com"],
+      body: "Standup at 2026-09-01. Quick sync.",
+      hasAttachments: false,
+    }));
+    const result = processTeamEmails(big);
+    expect(result.events.length).toBeLessThanOrEqual(50);
+    expect(result.sanitizationLog.some((l) => l.includes("truncated"))).toBe(true);
+  });
+
+  it("handles empty input without throwing", () => {
+    const result = processTeamEmails([]);
+    expect(result.events).toHaveLength(0);
+    expect(result.stats.eventsExtracted).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("sanitizes malicious content while still producing safe events", () => {
+    const result = processTeamEmails(maliciousEmails);
+    result.events.forEach((event) => {
+      expect(event.title).not.toContain("<script>");
+      expect(event.description).not.toContain("<iframe");
+      expect(event.organizer).toBe("attacker@malicious.com");
+    });
+  });
+});
+
+describe("Team Calendar Extraction - ICS Parser (behavioral)", () => {
+  it("parses a well-formed VEVENT with organizer and attendees", () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:uid_core_1
+SUMMARY:Quarterly Review
+DTSTART:20261001T090000Z
+DTEND:20261001T100000Z
+LOCATION:Board Room
+ORGANIZER;CN=Boss:mailto:boss@company.com
+ATTENDEE;CN=A:mailto:a@company.com
+END:VEVENT
+END:VCALENDAR`;
+    const { events, errors } = parseIcsContent(ics);
+    expect(errors).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe("Quarterly Review");
+    expect(events[0].organizer).toBe("boss@company.com");
+    expect(events[0].attendees).toContain("a@company.com");
+  });
+
+  it("caps events at the default limit of 100", () => {
+    const { events } = parseIcsContent(generateLargeIcsContent(120));
+    expect(events).toHaveLength(100);
+  });
+
+  it("records an error for lines exceeding the length limit but still parses", () => {
+    const { events, errors } = parseIcsContent(generateOverlyLongLineIcs());
+    expect(events).toHaveLength(1);
+    expect(errors.some((e) => e.includes("maximum length"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds folder-local test coverage and contributor documentation for the **Team Calendar Extraction** tool (issue #683), per the Testing + documentation template. The tool already had strong adversarial/security tests; this adds the missing core-behavior coverage and a contributor guide.

- `tests/extraction.test.ts`: 10 core-behavior cases — happy-path batch extraction (ICS attachment + text scan), progress callback reaching 100%, text-only extraction with derived dates, no-meeting-word returns null, batch truncation at 50 emails, empty-input safety, malicious-content sanitization, and ICS parser behavioral checks (VEVENT parsing, 100-event cap, long-line error).
- `docs/CONTRIBUTING.md`: setup, usage, layout, fixtures, known limitations, and OSS review notes. Complements the existing `security-threat-model.md` + `performance-guidelines.md`.

Both test files green: **23 tests pass** (10 new + 13 existing). All changes confined to `tools/v2/team/team-calendar-extraction/`.

## Acceptance criteria
- [x] Tests live inside the tool folder
- [x] Documentation explains how the tool should be reviewed independently
- [x] Issue remains isolated from app-wide tests
- [x] Files changed limited to `tools/v2/team/team-calendar-extraction/`
- [x] Self-contained, reviewable mini-product change

Fixes #683