### PR TITLE
test(team-payment-approval): cover payment service defaults and empty-state branches

### DIFF
--- a/tools/v2/team/team-payment-approval/tests/payment-service-edge-cases.test.mjs
+++ b/tools/v2/team/team-payment-approval/tests/payment-service-edge-cases.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { paymentService } from "../services/payment.service.ts";
+
+function payment(overrides) {
+  return {
+    id: "pay-1",
+    recipient: "Vendor",
+    amount: 1000,
+    currency: "USD",
+    description: "Invoice",
+    requestedBy: "Requester",
+    requestedAt: new Date("2026-06-25T12:00:00Z"),
+    priority: "normal",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+test("getPayment returns undefined for an unknown id", () => {
+  paymentService.clear();
+  assert.equal(paymentService.getPayment("missing"), undefined);
+});
+
+test("updatePaymentStatus is a no-op when the payment does not exist", () => {
+  paymentService.clear();
+  paymentService.updatePaymentStatus("missing", "approved");
+  assert.equal(paymentService.getPayment("missing"), undefined);
+  assert.equal(paymentService.getAllPayments().length, 0);
+});
+
+test("recordDecision accumulates multiple decisions for the same payment", () => {
+  paymentService.clear();
+  paymentService.recordDecision({
+    approverId: "user-1",
+    paymentId: "pay-1",
+    decision: "approve",
+    decidedAt: new Date(),
+  });
+  paymentService.recordDecision({
+    approverId: "user-2",
+    paymentId: "pay-1",
+    decision: "reject",
+    decidedAt: new Date(),
+  });
+  const decisions = paymentService.getDecisions("pay-1");
+  assert.equal(decisions.length, 2);
+  assert.deepEqual(
+    decisions.map((d) => d.approverId),
+    ["user-1", "user-2"],
+  );
+});
+
+test("getDecisions returns an empty array for a payment with no decisions", () => {
+  paymentService.clear();
+  assert.deepEqual(paymentService.getDecisions("pay-unknown"), []);
+});
+
+test("createWorkflow defaults to requiring two approvals", () => {
+  paymentService.clear();
+  const workflow = paymentService.createWorkflow(payment({ id: "pay-1" }));
+  assert.equal(workflow.requiredApprovals, 2);
+  assert.equal(workflow.paymentId, "pay-1");
+  assert.equal(workflow.status, "pending");
+  assert.deepEqual(workflow.approvals, []);
+  assert.deepEqual(workflow.rejections, []);
+});
+
+test("getWorkflow returns undefined when no workflow exists", () => {
+  paymentService.clear();
+  assert.equal(paymentService.getWorkflow("pay-none"), undefined);
+});
+
+test("clear removes payments, decisions, and workflows", () => {
+  paymentService.clear();
+  paymentService.addPayment(payment({ id: "pay-1" }));
+  paymentService.recordDecision({
+    approverId: "user-1",
+    paymentId: "pay-1",
+    decision: "approve",
+    decidedAt: new Date(),
+  });
+  paymentService.createWorkflow(payment({ id: "pay-1" }));
+
+  paymentService.clear();
+
+  assert.equal(paymentService.getAllPayments().length, 0);
+  assert.deepEqual(paymentService.getDecisions("pay-1"), []);
+  assert.equal(paymentService.getWorkflow("pay-1"), undefined);
+});


### PR DESCRIPTION


Adds a focused unit test for `services/payment.service.ts` branches the current suite doesn't assert directly:

- `getPayment` returns `undefined` for an unknown id
- `updatePaymentStatus` is a safe no-op when the payment does not exist
- `recordDecision` accumulates multiple decisions for the same payment
- `getDecisions` returns `[]` for a payment with no decisions
- `createWorkflow` defaults to requiring two approvals when the count is omitted
- `getWorkflow` returns `undefined` when no workflow exists
- `clear()` removes payments, decisions, and workflows together

Purely additive — no production code touched. New file `tests/payment-service-edge-cases.test.mjs` uses `node:test`/`node:assert` and runs green locally via `node --test` (7/7). Prettier-clean.
Closes #694