### PR TITLE
feat(crypto): add secure multi-recipient envelope encryption

### DIFF
--- a/src/services/crypto/multi-recipient.test.ts
+++ b/src/services/crypto/multi-recipient.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  sealMultiRecipient,
+  openMultiRecipient,
+  normalizeRecipients,
+  MultiRecipientError,
+} from "./multi-recipient";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function keyOf(seed: number): Uint8Array {
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = (seed * 31 + i * 7) % 256;
+  }
+  return bytes;
+}
+
+const alice = { id: "alice@example.test", keyMaterial: keyOf(1) };
+const bob = { id: "bob@example.test", keyMaterial: keyOf(2) };
+const carol = { id: "carol@example.test", keyMaterial: keyOf(3) };
+
+function tamperBase64(b64: string, byteIndex: number): string {
+  const bytes = Buffer.from(b64, "base64");
+  bytes[byteIndex] ^= 0xff;
+  return bytes.toString("base64");
+}
+
+describe("multi-recipient envelope", () => {
+  it("lets every recipient independently unwrap the same body", async () => {
+    const body = encoder.encode("wire funds to the vendor on Friday");
+    const envelope = await sealMultiRecipient(body, [alice, bob, carol]);
+    for (const r of [alice, bob, carol]) {
+      const opened = await openMultiRecipient(envelope, r.id, r.keyMaterial);
+      expect(decoder.decode(opened)).toBe("wire funds to the vendor on Friday");
+    }
+  });
+
+  it("wraps the content key once per recipient", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("hello"), [alice, bob]);
+    expect(envelope.recipients).toHaveLength(2);
+    expect(envelope.recipients[0].wrappedKey).not.toBe(envelope.recipients[1].wrappedKey);
+  });
+
+  it("prevents one recipient from using another recipient's entry", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("secret"), [alice, bob]);
+    await expect(openMultiRecipient(envelope, alice.id, bob.keyMaterial)).rejects.toMatchObject({
+      code: "crypto_decrypt_error",
+    });
+  });
+
+  it("rejects a recipient that has no wrapped-key entry", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("secret"), [alice, bob]);
+    await expect(openMultiRecipient(envelope, carol.id, carol.keyMaterial)).rejects.toMatchObject({
+      code: "crypto_key_error",
+    });
+  });
+
+  it("deduplicates duplicate recipients with identical key material", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("hi"), [
+      alice,
+      { id: "  Alice@Example.test ", keyMaterial: keyOf(1) },
+      bob,
+    ]);
+    expect(envelope.recipients.map((r) => r.recipientId)).toEqual([
+      "alice@example.test",
+      "bob@example.test",
+    ]);
+  });
+
+  it("rejects a duplicate id that carries conflicting key material", () => {
+    expect(() =>
+      normalizeRecipients([alice, { id: "alice@example.test", keyMaterial: keyOf(9) }]),
+    ).toThrowError(MultiRecipientError);
+  });
+
+  it("rejects an empty recipient list", async () => {
+    await expect(sealMultiRecipient(encoder.encode("x"), [])).rejects.toMatchObject({
+      code: "crypto_validation_error",
+    });
+  });
+
+  it("fails closed when the body ciphertext is tampered with", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("do not tamper"), [alice]);
+    const tampered = {
+      ...envelope,
+      body: { ...envelope.body, ciphertext: tamperBase64(envelope.body.ciphertext, 0) },
+    };
+    await expect(openMultiRecipient(tampered, alice.id, alice.keyMaterial)).rejects.toMatchObject({
+      code: "crypto_decrypt_error",
+    });
+  });
+
+  it("fails closed when a wrapped-key entry is tampered with", async () => {
+    const envelope = await sealMultiRecipient(encoder.encode("do not tamper"), [alice, bob]);
+    const recipients = envelope.recipients.map((e) =>
+      e.recipientId === alice.id ? { ...e, wrappedKey: tamperBase64(e.wrappedKey, 0) } : e,
+    );
+    const tampered = { ...envelope, recipients };
+    await expect(openMultiRecipient(tampered, alice.id, alice.keyMaterial)).rejects.toMatchObject({
+      code: "crypto_decrypt_error",
+    });
+  });
+});

--- a/src/services/crypto/multi-recipient.ts
+++ b/src/services/crypto/multi-recipient.ts
@@ -62,6 +62,18 @@ function copyBytes(u: Uint8Array): Uint8Array {
   return out;
 }
 
+/**
+ * Copy bytes into a fresh ArrayBuffer. Web Crypto expects a BufferSource, and
+ * an ArrayBuffer is unconditionally assignable to it; a bare Uint8Array is not,
+ * because the DOM lib types allow it to be backed by a SharedArrayBuffer. Every
+ * byte argument handed to crypto.subtle is therefore funneled through this.
+ */
+function toBuffer(u: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(u.byteLength);
+  new Uint8Array(out).set(u);
+  return out;
+}
+
 function toBase64(bytes: Uint8Array): string {
   let binary = "";
   for (const b of bytes) {
@@ -138,15 +150,15 @@ export function normalizeRecipients(recipients: readonly RecipientKey[]): Recipi
 }
 
 async function deriveWrappingKey(keyMaterial: Uint8Array, recipientId: string): Promise<CryptoKey> {
-  const ikm = await crypto.subtle.importKey("raw", copyBytes(keyMaterial), "HKDF", false, [
+  const ikm = await crypto.subtle.importKey("raw", toBuffer(keyMaterial), "HKDF", false, [
     "deriveKey",
   ]);
   return crypto.subtle.deriveKey(
     {
       name: "HKDF",
       hash: "SHA-256",
-      salt: new TextEncoder().encode(recipientId),
-      info: new TextEncoder().encode(WRAP_INFO),
+      salt: toBuffer(new TextEncoder().encode(recipientId)),
+      info: toBuffer(new TextEncoder().encode(WRAP_INFO)),
     },
     ikm,
     { name: "AES-GCM", length: 256 },
@@ -171,7 +183,7 @@ export async function sealMultiRecipient(
   const cekBytes = crypto.getRandomValues(new Uint8Array(CEK_BYTES));
   const cek = await crypto.subtle.importKey(
     "raw",
-    copyBytes(cekBytes),
+    toBuffer(cekBytes),
     { name: "AES-GCM", length: 256 },
     false,
     ["encrypt"],
@@ -179,11 +191,7 @@ export async function sealMultiRecipient(
 
   const bodyNonce = crypto.getRandomValues(new Uint8Array(GCM_NONCE_BYTES));
   const bodyCipher = new Uint8Array(
-    await crypto.subtle.encrypt(
-      { name: "AES-GCM", iv: copyBytes(bodyNonce) },
-      cek,
-      copyBytes(body),
-    ),
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv: toBuffer(bodyNonce) }, cek, toBuffer(body)),
   );
 
   const entries: WrappedKeyEntry[] = [];
@@ -192,9 +200,9 @@ export async function sealMultiRecipient(
     const wrapNonce = crypto.getRandomValues(new Uint8Array(GCM_NONCE_BYTES));
     const wrapped = new Uint8Array(
       await crypto.subtle.encrypt(
-        { name: "AES-GCM", iv: copyBytes(wrapNonce) },
+        { name: "AES-GCM", iv: toBuffer(wrapNonce) },
         wrappingKey,
-        copyBytes(cekBytes),
+        toBuffer(cekBytes),
       ),
     );
     entries.push({
@@ -244,9 +252,9 @@ export async function openMultiRecipient(
   try {
     cekBytes = new Uint8Array(
       await crypto.subtle.decrypt(
-        { name: "AES-GCM", iv: fromBase64(entry.nonce) },
+        { name: "AES-GCM", iv: toBuffer(fromBase64(entry.nonce)) },
         wrappingKey,
-        fromBase64(entry.wrappedKey),
+        toBuffer(fromBase64(entry.wrappedKey)),
       ),
     );
   } catch {
@@ -258,7 +266,7 @@ export async function openMultiRecipient(
 
   const cek = await crypto.subtle.importKey(
     "raw",
-    copyBytes(cekBytes),
+    toBuffer(cekBytes),
     { name: "AES-GCM", length: 256 },
     false,
     ["decrypt"],
@@ -267,9 +275,9 @@ export async function openMultiRecipient(
 
   try {
     const plaintext = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: fromBase64(envelope.body.nonce) },
+      { name: "AES-GCM", iv: toBuffer(fromBase64(envelope.body.nonce)) },
       cek,
-      fromBase64(envelope.body.ciphertext),
+      toBuffer(fromBase64(envelope.body.ciphertext)),
     );
     return new Uint8Array(plaintext);
   } catch {

--- a/src/services/crypto/multi-recipient.ts
+++ b/src/services/crypto/multi-recipient.ts
@@ -1,0 +1,281 @@
+/**
+ * Multi-recipient envelope encryption (#1702).
+ *
+ * The send pipeline encrypts a body for a single recipient. This module adds
+ * secure multi-recipient support using the standard envelope pattern: the body
+ * is encrypted exactly once under a random content-encryption key (CEK), and
+ * the CEK is then wrapped independently for each validated recipient. Every
+ * recipient can therefore unwrap the same CEK on its own, no recipient can use
+ * another recipient's wrapped-key entry, and any tampering fails closed.
+ *
+ * Uses only Web Crypto (AES-256-GCM for the content and for key wrapping,
+ * HKDF-SHA-256 to derive a per-recipient wrapping key bound to the recipient
+ * id). It is intentionally self-contained (its own minimal error type, no
+ * dependency on the other crypto modules) so it is independently mergeable and
+ * testable, matching the conventions of the surrounding crypto services.
+ */
+
+type MultiRecipientErrorCode =
+  | "crypto_validation_error"
+  | "crypto_key_error"
+  | "crypto_decrypt_error";
+
+/** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
+export class MultiRecipientError extends Error {
+  readonly code: MultiRecipientErrorCode;
+  constructor(code: MultiRecipientErrorCode, message: string) {
+    super(message);
+    this.name = "MultiRecipientError";
+    this.code = code;
+  }
+}
+
+export const MULTI_RECIPIENT_VERSION = "mr.v1" as const;
+
+const CEK_BYTES = 32;
+const GCM_NONCE_BYTES = 12;
+const WRAP_INFO = "stealth-multi-recipient-wrap-v1";
+
+/** A recipient's stable id plus the long-term secret used to wrap keys for it. */
+export interface RecipientKey {
+  readonly id: string;
+  readonly keyMaterial: Uint8Array;
+}
+
+/** One recipient-specific wrapped copy of the content-encryption key. */
+export interface WrappedKeyEntry {
+  readonly recipientId: string;
+  readonly nonce: string;
+  readonly wrappedKey: string;
+}
+
+/** The multi-recipient envelope placed on the wire. */
+export interface MultiRecipientEnvelope {
+  readonly version: typeof MULTI_RECIPIENT_VERSION;
+  readonly body: { readonly nonce: string; readonly ciphertext: string };
+  readonly recipients: readonly WrappedKeyEntry[];
+}
+
+function copyBytes(u: Uint8Array): Uint8Array {
+  const out = new Uint8Array(u.length);
+  out.set(u);
+  return out;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+function canonicalId(id: unknown): string {
+  if (typeof id !== "string" || id.trim() === "") {
+    throw new MultiRecipientError(
+      "crypto_validation_error",
+      "recipient id must be a non-empty string",
+    );
+  }
+  return id.trim().toLowerCase();
+}
+
+/**
+ * Validate, normalize, and deduplicate recipients. Ids are canonicalized
+ * (trimmed and lowercased). Exact duplicates (same id and identical key
+ * material) collapse to a single entry; a repeated id with conflicting key
+ * material is rejected. The result is sorted by id for deterministic output.
+ */
+export function normalizeRecipients(recipients: readonly RecipientKey[]): RecipientKey[] {
+  if (!Array.isArray(recipients) || recipients.length === 0) {
+    throw new MultiRecipientError("crypto_validation_error", "at least one recipient is required");
+  }
+  const byId = new Map<string, RecipientKey>();
+  for (const recipient of recipients) {
+    if (!recipient || typeof recipient !== "object") {
+      throw new MultiRecipientError("crypto_validation_error", "each recipient must be an object");
+    }
+    const id = canonicalId(recipient.id);
+    if (!(recipient.keyMaterial instanceof Uint8Array) || recipient.keyMaterial.length === 0) {
+      throw new MultiRecipientError(
+        "crypto_key_error",
+        "recipient key material must be non-empty bytes",
+      );
+    }
+    const existing = byId.get(id);
+    if (existing) {
+      if (!bytesEqual(existing.keyMaterial, recipient.keyMaterial)) {
+        throw new MultiRecipientError(
+          "crypto_validation_error",
+          "duplicate recipient id with conflicting key material",
+        );
+      }
+      continue;
+    }
+    byId.set(id, { id, keyMaterial: copyBytes(recipient.keyMaterial) });
+  }
+  return Array.from(byId.values()).sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+async function deriveWrappingKey(keyMaterial: Uint8Array, recipientId: string): Promise<CryptoKey> {
+  const ikm = await crypto.subtle.importKey("raw", copyBytes(keyMaterial), "HKDF", false, [
+    "deriveKey",
+  ]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new TextEncoder().encode(recipientId),
+      info: new TextEncoder().encode(WRAP_INFO),
+    },
+    ikm,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt `body` once and produce a wrapped-key entry for every validated
+ * recipient. Throws MultiRecipientError on invalid input.
+ */
+export async function sealMultiRecipient(
+  body: Uint8Array,
+  recipients: readonly RecipientKey[],
+): Promise<MultiRecipientEnvelope> {
+  if (!(body instanceof Uint8Array)) {
+    throw new MultiRecipientError("crypto_validation_error", "body must be a Uint8Array");
+  }
+  const normalized = normalizeRecipients(recipients);
+
+  const cekBytes = crypto.getRandomValues(new Uint8Array(CEK_BYTES));
+  const cek = await crypto.subtle.importKey(
+    "raw",
+    copyBytes(cekBytes),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"],
+  );
+
+  const bodyNonce = crypto.getRandomValues(new Uint8Array(GCM_NONCE_BYTES));
+  const bodyCipher = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: copyBytes(bodyNonce) },
+      cek,
+      copyBytes(body),
+    ),
+  );
+
+  const entries: WrappedKeyEntry[] = [];
+  for (const recipient of normalized) {
+    const wrappingKey = await deriveWrappingKey(recipient.keyMaterial, recipient.id);
+    const wrapNonce = crypto.getRandomValues(new Uint8Array(GCM_NONCE_BYTES));
+    const wrapped = new Uint8Array(
+      await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: copyBytes(wrapNonce) },
+        wrappingKey,
+        copyBytes(cekBytes),
+      ),
+    );
+    entries.push({
+      recipientId: recipient.id,
+      nonce: toBase64(wrapNonce),
+      wrappedKey: toBase64(wrapped),
+    });
+  }
+
+  cekBytes.fill(0);
+
+  return {
+    version: MULTI_RECIPIENT_VERSION,
+    body: { nonce: toBase64(bodyNonce), ciphertext: toBase64(bodyCipher) },
+    recipients: entries,
+  };
+}
+
+/**
+ * Unwrap the content key for a single recipient and decrypt the body. Fails
+ * closed (throws) if the recipient has no entry, the key material is wrong, or
+ * any ciphertext has been tampered with.
+ */
+export async function openMultiRecipient(
+  envelope: MultiRecipientEnvelope,
+  recipientId: string,
+  keyMaterial: Uint8Array,
+): Promise<Uint8Array> {
+  if (!envelope || envelope.version !== MULTI_RECIPIENT_VERSION) {
+    throw new MultiRecipientError("crypto_validation_error", "unsupported or malformed envelope");
+  }
+  const id = canonicalId(recipientId);
+  if (!(keyMaterial instanceof Uint8Array) || keyMaterial.length === 0) {
+    throw new MultiRecipientError(
+      "crypto_key_error",
+      "recipient key material must be non-empty bytes",
+    );
+  }
+
+  const entry = envelope.recipients.find((candidate) => candidate.recipientId === id);
+  if (!entry) {
+    throw new MultiRecipientError("crypto_key_error", "no wrapped key entry for this recipient");
+  }
+
+  const wrappingKey = await deriveWrappingKey(keyMaterial, id);
+  let cekBytes: Uint8Array;
+  try {
+    cekBytes = new Uint8Array(
+      await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: fromBase64(entry.nonce) },
+        wrappingKey,
+        fromBase64(entry.wrappedKey),
+      ),
+    );
+  } catch {
+    throw new MultiRecipientError(
+      "crypto_decrypt_error",
+      "wrapped key could not be unwrapped (tampered or wrong recipient)",
+    );
+  }
+
+  const cek = await crypto.subtle.importKey(
+    "raw",
+    copyBytes(cekBytes),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
+  );
+  cekBytes.fill(0);
+
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: fromBase64(envelope.body.nonce) },
+      cek,
+      fromBase64(envelope.body.ciphertext),
+    );
+    return new Uint8Array(plaintext);
+  } catch {
+    throw new MultiRecipientError(
+      "crypto_decrypt_error",
+      "message body could not be decrypted (tampered)",
+    );
+  }
+}


### PR DESCRIPTION

Adds `src/services/crypto/multi-recipient.ts`: secure multi-recipient envelope encryption using the standard envelope pattern. The body is encrypted exactly once under a random content-encryption key (CEK), and the CEK is wrapped independently for each validated recipient.

How it works (Web Crypto only — AES-256-GCM + HKDF-SHA-256, no new deps):
- `sealMultiRecipient(body, recipients)` — generates a random CEK, encrypts the body once, then for each recipient derives a wrapping key via HKDF salted by the recipient id and wraps the CEK under AES-GCM.
- `openMultiRecipient(envelope, recipientId, keyMaterial)` — locates that recipient's entry, unwraps the CEK, and decrypts the body. Fails closed on any authentication failure.
- `normalizeRecipients(...)` — canonicalizes ids (trim + lowercase), deduplicates exact duplicates, and rejects a repeated id with conflicting key material; output is deterministically sorted.

Acceptance criteria:
- [x] Every recipient can unwrap the same content key independently.
- [x] One recipient cannot use another recipient's entry (wrapping key is bound to the recipient id via the HKDF salt, so a mismatched id/key fails).
- [x] Duplicate recipients are normalized and deduplicated deterministically; conflicting duplicates are rejected.
- [x] Tests cover multiple recipients and partial tampering (body ciphertext and wrapped-key entry).

Scope: purely additive — a new self-contained module plus a colocated test. No existing files, API, contracts, relay, UI, or routing touched. New `multi-recipient.test.ts` runs green locally under the repo's vitest (9/9), matching the existing crypto-folder test convention.

Closes #1702
