### PR TITLE
feat(crypto): add least-privilege CryptoKey factories

### DIFF
--- a/src/services/crypto/keys.test.ts
+++ b/src/services/crypto/keys.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  createSealingKey,
+  createOpeningKey,
+  createWrappingKey,
+  createUnwrappingKey,
+  createSigningKeyPair,
+  createVerificationKey,
+  KeyUsageError,
+} from "./keys";
+
+const RAW = new Uint8Array(32).fill(7);
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function iv(): Uint8Array {
+  return new Uint8Array(12).fill(1);
+}
+
+describe("least-privilege key factories", () => {
+  it("mints a sealing key that can only encrypt", async () => {
+    const key = await createSealingKey(RAW);
+    expect(key.type).toBe("secret");
+    expect(key.usages).toEqual(["encrypt"]);
+    expect(key.extractable).toBe(false);
+  });
+
+  it("mints an opening key that can only decrypt", async () => {
+    const key = await createOpeningKey(RAW);
+    expect(key.usages).toEqual(["decrypt"]);
+    expect(key.extractable).toBe(false);
+  });
+
+  it("mints wrapping and unwrapping keys with single usages", async () => {
+    const wrap = await createWrappingKey(RAW);
+    const unwrap = await createUnwrappingKey(RAW);
+    expect(wrap.usages).toEqual(["wrapKey"]);
+    expect(unwrap.usages).toEqual(["unwrapKey"]);
+  });
+
+  it("round-trips a body between a sealing and an opening key", async () => {
+    const nonce = iv();
+    const sealing = await createSealingKey(RAW);
+    const opening = await createOpeningKey(RAW);
+    const message = encoder.encode("least privilege");
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: nonce as BufferSource },
+      sealing,
+      message as BufferSource,
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: nonce as BufferSource },
+      opening,
+      ciphertext,
+    );
+    expect(decoder.decode(plaintext)).toBe("least privilege");
+  });
+
+  it("fails predictably when a sealing key is used to decrypt", async () => {
+    const sealing = await createSealingKey(RAW);
+    await expect(
+      crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: iv() as BufferSource },
+        sealing,
+        new Uint8Array(32) as BufferSource,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects symmetric key material of the wrong length", async () => {
+    await expect(createSealingKey(new Uint8Array(16))).rejects.toBeInstanceOf(KeyUsageError);
+  });
+
+  it("generates a signing pair with split sign / verify usages", async () => {
+    const { signingKey, verificationKey } = await createSigningKeyPair();
+    expect(signingKey.type).toBe("private");
+    expect(signingKey.usages).toEqual(["sign"]);
+    expect(signingKey.extractable).toBe(false);
+    expect(verificationKey.type).toBe("public");
+    expect(verificationKey.usages).toEqual(["verify"]);
+  });
+
+  it("signs with the signing key and verifies with an imported verification key", async () => {
+    const { signingKey, verificationKey } = await createSigningKeyPair();
+    const data = encoder.encode("bind this");
+    const signature = await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      signingKey,
+      data as BufferSource,
+    );
+
+    const spki = new Uint8Array(await crypto.subtle.exportKey("spki", verificationKey));
+    const imported = await createVerificationKey(spki);
+    expect(imported.usages).toEqual(["verify"]);
+
+    const ok = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      imported,
+      signature,
+      data as BufferSource,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("fails predictably when a verification key is used to sign", async () => {
+    const { verificationKey } = await createSigningKeyPair();
+    await expect(
+      crypto.subtle.sign(
+        { name: "ECDSA", hash: "SHA-256" },
+        verificationKey,
+        new Uint8Array(8) as BufferSource,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/src/services/crypto/keys.ts
+++ b/src/services/crypto/keys.ts
@@ -1,0 +1,123 @@
+/**
+ * Least-privilege CryptoKey factories (#1692).
+ *
+ * Web Crypto keys carry an explicit usage list. The sealing path, for example,
+ * only ever calls `encrypt`, yet content keys have historically been minted
+ * with `["encrypt", "decrypt"]`. Over-broad usages weaken least-privilege
+ * guarantees and turn misuse (decrypting with a key that should only seal) into
+ * a silent success instead of a fast, predictable failure.
+ *
+ * This module centralises key creation behind explicit, single-responsibility
+ * factories. Each returns a CryptoKey whose usage set is the smallest its
+ * operation needs, so the runtime itself rejects any other operation with an
+ * InvalidAccessError. It is self-contained (its own minimal error type, no
+ * dependency on the other crypto modules) so it is independently mergeable and
+ * testable, matching the conventions of the surrounding crypto services.
+ *
+ * ## Extractability & lifetime
+ *
+ * - Symmetric content/wrapping keys are imported NON-EXTRACTABLE: the raw bytes
+ *   cannot be read back via `exportKey`, bounding blast radius on compromise.
+ * - Signing private keys are generated NON-EXTRACTABLE; the matching
+ *   verification public key is (necessarily, per Web Crypto) extractable so it
+ *   can be published.
+ * - All keys here are EPHEMERAL / SESSION-LIVED: mint one per message (content
+ *   keys) or per session (wrapping/signing) and drop the reference when done.
+ *   None of these factories persist key material.
+ */
+
+/** Minimal non-secret error carrying a stable code (no key/plaintext leakage). */
+export class KeyUsageError extends Error {
+  readonly code = "crypto_key_error" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "KeyUsageError";
+  }
+}
+
+const AES_ALGORITHM = { name: "AES-GCM", length: 256 } as const;
+const SIGNING_ALGORITHM = { name: "ECDSA", namedCurve: "P-256" } as const;
+const AES_KEY_BYTES = 32;
+
+/** Copy bytes into a fresh ArrayBuffer (an unconditionally valid BufferSource). */
+function toBuffer(bytes: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(out).set(bytes);
+  return out;
+}
+
+/** Validate and copy 256-bit symmetric key material. */
+function requireAesKeyMaterial(raw: Uint8Array): ArrayBuffer {
+  if (!(raw instanceof Uint8Array) || raw.length !== AES_KEY_BYTES) {
+    throw new KeyUsageError(`symmetric key material must be exactly ${AES_KEY_BYTES} bytes`);
+  }
+  return toBuffer(raw);
+}
+
+/**
+ * Content-encryption key for the SEALING path. Encrypt-only, non-extractable,
+ * ephemeral (mint one per message). Attempting to decrypt with it rejects.
+ */
+export async function createSealingKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", requireAesKeyMaterial(raw), AES_ALGORITHM, false, [
+    "encrypt",
+  ]);
+}
+
+/**
+ * Content-decryption key for the OPENING path. Decrypt-only, non-extractable,
+ * ephemeral. Attempting to encrypt with it rejects.
+ */
+export async function createOpeningKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", requireAesKeyMaterial(raw), AES_ALGORITHM, false, [
+    "decrypt",
+  ]);
+}
+
+/**
+ * Key-wrapping key. wrapKey-only, non-extractable, session-lived. Wraps a
+ * content key for transport; it cannot itself encrypt message bodies.
+ */
+export async function createWrappingKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", requireAesKeyMaterial(raw), AES_ALGORITHM, false, [
+    "wrapKey",
+  ]);
+}
+
+/** Key-unwrapping key. unwrapKey-only, non-extractable, session-lived. */
+export async function createUnwrappingKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", requireAesKeyMaterial(raw), AES_ALGORITHM, false, [
+    "unwrapKey",
+  ]);
+}
+
+/** A freshly generated signing key pair with least-privilege usages. */
+export interface SigningKeyPair {
+  /** ECDSA P-256 private key, sign-only, non-extractable. */
+  readonly signingKey: CryptoKey;
+  /** ECDSA P-256 public key, verify-only (safe to publish). */
+  readonly verificationKey: CryptoKey;
+}
+
+/**
+ * Generate an ECDSA P-256 signing pair. The private key can only `sign` and is
+ * non-extractable; the public key can only `verify`. Session-lived.
+ */
+export async function createSigningKeyPair(): Promise<SigningKeyPair> {
+  const pair = (await crypto.subtle.generateKey(SIGNING_ALGORITHM, false, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  return { signingKey: pair.privateKey, verificationKey: pair.publicKey };
+}
+
+/**
+ * Import a distributed verification public key (SPKI DER). verify-only and
+ * extractable (public material). Cannot sign.
+ */
+export async function createVerificationKey(spki: Uint8Array): Promise<CryptoKey> {
+  if (!(spki instanceof Uint8Array) || spki.length === 0) {
+    throw new KeyUsageError("verification key material must be non-empty bytes");
+  }
+  return crypto.subtle.importKey("spki", toBuffer(spki), SIGNING_ALGORITHM, true, ["verify"]);
+}


### PR DESCRIPTION
Adds src/services/crypto/keys.ts: explicit, single-purpose CryptoKey factories
that grant the smallest valid Web Crypto usage set per operation, so misuse
fails closed at the runtime boundary. Motivated by sealEnvelope minting its
AES-256-GCM content key with encrypt+decrypt while the seal path only encrypts.

Design:
- createSealingKey / createOpeningKey: AES-GCM, ["encrypt"] / ["decrypt"], non-extractable.
- createWrappingKey / createUnwrappingKey: AES-GCM, ["wrapKey"] / ["unwrapKey"], non-extractable.
- createSigningKeyPair: ECDSA P-256, private sign-only + non-extractable, public verify-only.
- createVerificationKey: imports an SPKI public key, verify-only.
- Self-contained (local KeyUsageError, no cross-module imports); each factory documents
  extractability and lifetime. Byte inputs funneled through a toBuffer() helper so the
  Client Checks tsc pass treats them as valid BufferSource.

Tests (keys.test.ts, 9 cases) inspect the actual .usages / .type / .extractable of every
key, round-trip seal<->open, and assert that decrypt-with-sealing-key and
sign-with-verification-key reject.

Acceptance criteria:
- [x] Each key type has the smallest valid usage list.
- [x] Incorrect operations fail predictably.
- [x] Factories document extractability and lifetime.
- [x] Unit tests inspect usage restrictions.

Note: this is a fresh take after PR #1822 (same issue) was closed unmerged; it uses a
different, runtime-enforced factory design. Scope stays inside src/services/crypto/.

Closes #1692