### PR TITLE
feat(policies): add contract spec regeneration check

### DIFF
--- a/contracts/soroban/policies/README.md
+++ b/contracts/soroban/policies/README.md
@@ -33,6 +33,46 @@ encoding, version semantics, and failure-path guarantees—is documented in
 [`docs/events.md`](docs/events.md) and pinned by the `event_schema` tests in
 `src/lib.rs`.
 
+## Contract Spec Regeneration Check
+
+`spec.json` feeds `scripts/generate-contract-bindings.mjs`, which emits the
+typed TypeScript client for this contract. If the contract interface changes
+without regenerating `spec.json`, the bindings silently drift from on-chain
+reality.
+
+The `spec_check` tests in `src/lib.rs` prevent that drift:
+
+- `spec_json_matches_contract_interface` decodes the XDR spec entries that the
+  soroban-sdk macros embed in the crate — the same entries a wasm build
+  publishes in its `contractspecv0` section — renders the canonical
+  `spec.json`, and fails if the committed file differs (whitespace-insensitive).
+- `spec_covers_every_public_contract_function` scans the contract source for
+  `pub fn` declarations and fails if any function is missing a spec entry, so a
+  new function cannot slip past the check.
+- `spec_covers_every_public_contract_type` does the same for the public
+  `#[contracttype]` and `#[contracterror]` declarations, so a new struct, enum,
+  or error type cannot slip past either.
+
+The check runs as part of `cargo test --workspace`, so CI fails on drift
+without an extra build step.
+
+After an interface change, regenerate and verify with:
+
+```sh
+cd contracts/soroban
+UPDATE_SPEC=1 cargo test -p stealth-policies spec_json   # rewrites spec.json
+cargo test -p stealth-policies                           # verifies
+node ../../scripts/generate-contract-bindings.mjs        # refreshes TS bindings
+```
+
+Struct fields in `spec.json` are alphabetized because the on-chain XDR spec
+sorts map keys; declaration order in Rust does not affect the ledger contract.
+The comparison ignores whitespace, so reformatting `spec.json` never triggers a
+false drift failure.
+
+The check is additive: it observes the interface the macros already export and
+does not alter any function signature, type layout, or error discriminant.
+
 ## Precedence
 
 1. Block always denies, regardless of price or mailbox defaults.

--- a/contracts/soroban/policies/spec.json
+++ b/contracts/soroban/policies/spec.json
@@ -8,16 +8,16 @@
           "type": "bool"
         },
         {
-          "name": "require_verified",
-          "type": "bool"
+          "name": "minimum_postage",
+          "type": "i128"
         },
         {
           "name": "require_receipt",
           "type": "bool"
         },
         {
-          "name": "minimum_postage",
-          "type": "i128"
+          "name": "require_verified",
+          "type": "bool"
         }
       ]
     },

--- a/contracts/soroban/policies/src/lib.rs
+++ b/contracts/soroban/policies/src/lib.rs
@@ -1431,3 +1431,320 @@ mod auth_boundaries {
         assert_eq!(env.auths(), []);
     }
 }
+
+#[cfg(test)]
+mod spec_check {
+    // Contract spec regeneration check.
+    //
+    // spec.json feeds scripts/generate-contract-bindings.mjs, which emits the
+    // typed TypeScript clients used against the ledger. If the contract
+    // interface changes without regenerating spec.json, the bindings silently
+    // drift from on-chain reality. This module decodes the XDR spec entries
+    // that the soroban-sdk macros embed in the crate — the same entries a wasm
+    // build publishes in its contractspecv0 section — renders the canonical
+    // spec.json from them, and fails if the committed file differs.
+    //
+    // To regenerate after an interface change:
+    //   UPDATE_SPEC=1 cargo test -p stealth-policies spec_json
+    extern crate std;
+
+    use std::format;
+    use std::string::{String, ToString};
+    use std::vec::Vec;
+
+    use soroban_sdk::xdr::{Limits, ReadXdr, ScSpecEntry, ScSpecTypeDef, ScSpecUdtUnionCaseV0};
+
+    use super::{
+        DelegateScope, Error, MailboxPolicy, PoliciesContract, PolicyDecision, PolicyReason,
+        SenderRule, VersionedMailboxPolicy,
+    };
+
+    const SPEC_JSON: &str = include_str!("../spec.json");
+    const LIB_RS: &str = include_str!("lib.rs");
+
+    /// The `#[contract]` struct carries no spec entry of its own; every other
+    /// public type in this file is part of the contract interface.
+    const CONTRACT_STRUCT: &str = "PoliciesContract";
+
+    /// Every spec entry the contract exports, in canonical spec.json order.
+    /// Adding a public contract function or type requires adding its entry
+    /// here; the coverage tests below enforce that.
+    fn entries() -> Vec<ScSpecEntry> {
+        let xdrs: Vec<Vec<u8>> = std::vec![
+            MailboxPolicy::spec_xdr().to_vec(),
+            VersionedMailboxPolicy::spec_xdr().to_vec(),
+            DelegateScope::spec_xdr().to_vec(),
+            PolicyDecision::spec_xdr().to_vec(),
+            SenderRule::spec_xdr().to_vec(),
+            PolicyReason::spec_xdr().to_vec(),
+            Error::spec_xdr().to_vec(),
+            PoliciesContract::spec_xdr_set_policy().to_vec(),
+            PoliciesContract::spec_xdr_set_policy_as().to_vec(),
+            PoliciesContract::spec_xdr_get_policy().to_vec(),
+            PoliciesContract::spec_xdr_get_versioned_policy().to_vec(),
+            PoliciesContract::spec_xdr_policy_version().to_vec(),
+            PoliciesContract::spec_xdr_set_delegate().to_vec(),
+            PoliciesContract::spec_xdr_delegate_scope().to_vec(),
+            PoliciesContract::spec_xdr_set_sender_rule().to_vec(),
+            PoliciesContract::spec_xdr_set_sender_rule_as().to_vec(),
+            PoliciesContract::spec_xdr_set_sender_tier().to_vec(),
+            PoliciesContract::spec_xdr_set_sender_tier_as().to_vec(),
+            PoliciesContract::spec_xdr_sender_rule().to_vec(),
+            PoliciesContract::spec_xdr_sender_tier().to_vec(),
+            PoliciesContract::spec_xdr_can_mail().to_vec(),
+            PoliciesContract::spec_xdr_evaluate().to_vec(),
+        ];
+        xdrs.iter()
+            .map(|xdr| {
+                ScSpecEntry::from_xdr(xdr.as_slice(), Limits::none())
+                    .expect("embedded contract spec entry must decode")
+            })
+            .collect()
+    }
+
+    /// Render a type using the grammar consumed by
+    /// scripts/generate-contract-bindings.mjs.
+    fn render_type(def: &ScSpecTypeDef) -> String {
+        match def {
+            ScSpecTypeDef::Void => "void".to_string(),
+            ScSpecTypeDef::Bool => "bool".to_string(),
+            ScSpecTypeDef::U32 => "u32".to_string(),
+            ScSpecTypeDef::I32 => "i32".to_string(),
+            ScSpecTypeDef::U64 => "u64".to_string(),
+            ScSpecTypeDef::I64 => "i64".to_string(),
+            ScSpecTypeDef::U128 => "u128".to_string(),
+            ScSpecTypeDef::I128 => "i128".to_string(),
+            ScSpecTypeDef::Address => "address".to_string(),
+            ScSpecTypeDef::BytesN(b) if b.n == 32 => "bytes32".to_string(),
+            ScSpecTypeDef::Option(o) => format!("option:{}", render_type(&o.value_type)),
+            ScSpecTypeDef::Udt(u) => format!("udt:{}", u.name.to_utf8_string_lossy()),
+            ScSpecTypeDef::Result(r) => {
+                // Contract errors appear as the built-in error type in XDR;
+                // this crate has exactly one #[contracterror] enum, `Error`.
+                let err = match &*r.error_type {
+                    ScSpecTypeDef::Error => "Error".to_string(),
+                    ScSpecTypeDef::Udt(u) => u.name.to_utf8_string_lossy(),
+                    other => std::panic!("unsupported error type in spec: {other:?}"),
+                };
+                format!("result:{}:{}", render_type(&r.ok_type), err)
+            }
+            other => std::panic!("type not covered by the spec.json grammar: {other:?}"),
+        }
+    }
+
+    fn render_name_type_list(items: &[(String, String)], indent: &str) -> String {
+        let rendered: Vec<String> = items
+            .iter()
+            .map(|(name, ty)| format!("{{ \"name\": \"{name}\", \"type\": \"{ty}\" }}"))
+            .collect();
+        render_array(&rendered, indent)
+    }
+
+    fn render_case_list(items: &[(String, u32)], indent: &str) -> String {
+        let rendered: Vec<String> = items
+            .iter()
+            .map(|(name, value)| format!("{{ \"name\": \"{name}\", \"value\": {value} }}"))
+            .collect();
+        render_array(&rendered, indent)
+    }
+
+    /// Arrays with zero or one element stay inline; longer arrays go one
+    /// element per line. The committed file may use a different indentation
+    /// style — the comparison below ignores whitespace entirely.
+    fn render_array(rendered: &[String], indent: &str) -> String {
+        match rendered {
+            [] => "[]".to_string(),
+            [only] if !only.contains('\n') => format!("[{only}]"),
+            many => {
+                let inner = many
+                    .iter()
+                    .map(|item| format!("{indent}  {item}"))
+                    .collect::<Vec<_>>()
+                    .join(",\n");
+                format!("[\n{inner}\n{indent}]")
+            }
+        }
+    }
+
+    /// Render the canonical spec.json for the current contract interface.
+    fn render_spec_json() -> String {
+        let mut structs: Vec<String> = Vec::new();
+        let mut enums: Vec<String> = Vec::new();
+        let mut errors: Vec<(String, u32)> = Vec::new();
+        let mut functions: Vec<String> = Vec::new();
+
+        for entry in entries() {
+            match entry {
+                ScSpecEntry::UdtStructV0(s) => {
+                    let fields: Vec<(String, String)> = s
+                        .fields
+                        .iter()
+                        .map(|f| (f.name.to_utf8_string_lossy(), render_type(&f.type_)))
+                        .collect();
+                    structs.push(format!(
+                        "{{\n      \"name\": \"{}\",\n      \"fields\": {}\n    }}",
+                        s.name.to_utf8_string_lossy(),
+                        render_name_type_list(&fields, "      "),
+                    ));
+                }
+                ScSpecEntry::UdtUnionV0(u) => {
+                    let cases: Vec<(String, u32)> = u
+                        .cases
+                        .iter()
+                        .enumerate()
+                        .map(|(index, case)| match case {
+                            ScSpecUdtUnionCaseV0::VoidV0(v) => {
+                                (v.name.to_utf8_string_lossy(), index as u32)
+                            }
+                            ScSpecUdtUnionCaseV0::TupleV0(t) => std::panic!(
+                                "tuple union case {} is not covered by the spec.json grammar",
+                                t.name.to_utf8_string_lossy()
+                            ),
+                        })
+                        .collect();
+                    enums.push(format!(
+                        "{{\n      \"name\": \"{}\",\n      \"cases\": {}\n    }}",
+                        u.name.to_utf8_string_lossy(),
+                        render_case_list(&cases, "      "),
+                    ));
+                }
+                ScSpecEntry::UdtErrorEnumV0(e) => {
+                    for case in e.cases.iter() {
+                        errors.push((case.name.to_utf8_string_lossy(), case.value));
+                    }
+                }
+                ScSpecEntry::FunctionV0(f) => {
+                    let inputs: Vec<(String, String)> = f
+                        .inputs
+                        .iter()
+                        .map(|i| (i.name.to_utf8_string_lossy(), render_type(&i.type_)))
+                        .collect();
+                    let output = match f.outputs.iter().next() {
+                        Some(def) => render_type(def),
+                        None => "void".to_string(),
+                    };
+                    functions.push(format!(
+                        "{{\n      \"name\": \"{}\",\n      \"inputs\": {},\n      \"output\": \"{}\"\n    }}",
+                        f.name.0.to_utf8_string_lossy(),
+                        render_name_type_list(&inputs, "      "),
+                        output,
+                    ));
+                }
+                other => std::panic!("unexpected spec entry: {other:?}"),
+            }
+        }
+
+        format!(
+            "{{\n  \"structs\": {},\n  \"enums\": {},\n  \"errors\": {},\n  \"functions\": {}\n}}\n",
+            render_array(&structs, "  "),
+            render_array(&enums, "  "),
+            render_case_list(&errors, "  "),
+            render_array(&functions, "  "),
+        )
+    }
+
+    fn strip_whitespace(text: &str) -> String {
+        text.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// Leading identifier of a declaration, for example `Foo` in
+    /// `pub struct Foo {`.
+    fn leading_identifier(rest: &str) -> &str {
+        let end = rest
+            .find(|c: char| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    /// Sorted, de-duplicated identifiers declared in this file with any of the
+    /// given declaration prefixes, excluding the `#[contract]` struct.
+    fn declared_in_source(prefixes: &[&str]) -> Vec<&'static str> {
+        let mut declared: Vec<&str> = LIB_RS
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim_start();
+                prefixes
+                    .iter()
+                    .find_map(|prefix| trimmed.strip_prefix(*prefix))
+                    .map(leading_identifier)
+            })
+            .filter(|name| !name.is_empty() && *name != CONTRACT_STRUCT)
+            .collect();
+        declared.sort_unstable();
+        declared.dedup();
+        declared
+    }
+
+    #[test]
+    fn spec_json_matches_contract_interface() {
+        let expected = render_spec_json();
+        if std::env::var("UPDATE_SPEC").is_ok() {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("spec.json");
+            std::fs::write(&path, &expected).expect("failed to write spec.json");
+            // SPEC_JSON was captured at compile time; skip the comparison on
+            // the regeneration run and let the next plain run verify it.
+            return;
+        }
+        // Whitespace-insensitive: no value in this document contains spaces,
+        // so formatting cannot mask real drift and cannot cause false alarms.
+        assert_eq!(
+            strip_whitespace(SPEC_JSON),
+            strip_whitespace(&expected),
+            "spec.json is out of date with the contract interface.\n\
+             Regenerate it with: UPDATE_SPEC=1 cargo test -p stealth-policies spec_json\n\
+             Expected content:\n{expected}"
+        );
+    }
+
+    #[test]
+    fn spec_covers_every_public_contract_function() {
+        // Every `pub fn` in this file lives in the #[contractimpl] block, so
+        // scanning the source catches a new contract function that was not
+        // added to the entries() list above (and therefore not to spec.json).
+        let source_fns = declared_in_source(&["pub fn "]);
+
+        let mut spec_fns: Vec<String> = entries()
+            .iter()
+            .filter_map(|entry| match entry {
+                ScSpecEntry::FunctionV0(f) => Some(f.name.0.to_utf8_string_lossy()),
+                _ => None,
+            })
+            .collect();
+        spec_fns.sort_unstable();
+
+        assert_eq!(
+            source_fns,
+            spec_fns.iter().map(String::as_str).collect::<Vec<_>>(),
+            "public contract functions and spec entries differ.\n\
+             Add the missing spec_xdr_* entry to spec_check::entries() and \
+             regenerate spec.json with: UPDATE_SPEC=1 cargo test -p stealth-policies spec_json"
+        );
+    }
+
+    #[test]
+    fn spec_covers_every_public_contract_type() {
+        // Public structs and enums other than the #[contract] struct are part
+        // of the ledger-facing interface, so each one needs a spec entry.
+        // Private types such as DataKey are storage details and are excluded.
+        let source_types = declared_in_source(&["pub struct ", "pub enum "]);
+
+        let mut spec_types: Vec<String> = entries()
+            .iter()
+            .filter_map(|entry| match entry {
+                ScSpecEntry::UdtStructV0(s) => Some(s.name.to_utf8_string_lossy()),
+                ScSpecEntry::UdtUnionV0(u) => Some(u.name.to_utf8_string_lossy()),
+                ScSpecEntry::UdtErrorEnumV0(e) => Some(e.name.to_utf8_string_lossy()),
+                _ => None,
+            })
+            .collect();
+        spec_types.sort_unstable();
+
+        assert_eq!(
+            source_types,
+            spec_types.iter().map(String::as_str).collect::<Vec<_>>(),
+            "public contract types and spec entries differ.\n\
+             Add the missing spec_xdr entry to spec_check::entries() and \
+             regenerate spec.json with: UPDATE_SPEC=1 cargo test -p stealth-policies spec_json"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1390

## Problem

`contracts/soroban/policies/spec.json` feeds `scripts/generate-contract-bindings.mjs`, which emits the typed TypeScript client used against the ledger. Nothing verified that the committed spec still matched the contract interface, so an interface change could silently ship bindings that disagree with on-chain reality.

The `postage` contract already has this protection. `policies` did not.

## Change

- Add a `spec_check` test module to `contracts/soroban/policies/src/lib.rs` that decodes the XDR spec entries the soroban-sdk macros embed in the crate — the same entries a wasm build publishes in its `contractspecv0` section — renders the canonical `spec.json`, and fails if the committed file differs.
- Add coverage guards so a new public contract function, type, or error cannot slip past the check.
- Document the regeneration workflow in `contracts/soroban/policies/README.md`.

## Backward compatibility

The check only observes the interface the macros already export. No function signature, type layout, error discriminant, or storage key changes.

## Verification

Runs inside `cargo test --workspace`, which CI already executes — no new build step.
