### PR TITLE
feat(auth): unify challenge expiration and clock-skew handling

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -57,9 +57,19 @@ client/server clock-skew tolerance on both ends of the window. Deployments can c
 with `STEALTH_AUTH_CHALLENGE_LIFETIME_MS` and `STEALTH_AUTH_CLOCK_SKEW_MS`; both values are integer
 milliseconds. The complete configuration rules are documented in [`src/config/README.md`](../../src/config/README.md).
 
-Challenges older than the configured window fail with the machine-readable error code
-`expired_challenge`. Challenges dated farther into the future than the allowed skew fail with
-`challenge_not_yet_valid`. Both errors use HTTP 422 and the standard API error envelope.
+The same window governs signed requests, so a request and the challenge it carries are never judged
+against different durations.
+
+A challenge is validated against the expiry it was issued with. Reconfiguring
+`STEALTH_AUTH_CHALLENGE_LIFETIME_MS` therefore applies to challenges issued afterwards and never
+retroactively extends or shortens ones already in flight; the configured lifetime is the fallback
+when no expiry was stamped.
+
+Challenges older than the window fail with the machine-readable error code `expired_challenge` and
+the reason `AUTH_EXPIRED`. Challenges dated farther into the future than the allowed skew fail with
+`challenge_not_yet_valid` and the reason `AUTH_NOT_YET_VALID`. Both errors use HTTP 422 and the
+standard API error envelope, and carry the reason in `details.reason` so a client can tell "your
+clock is behind" from "your clock is ahead" without parsing prose.
 
 ### Authentication nonce lifecycle
 

--- a/docs/security/api-authentication-v1.md
+++ b/docs/security/api-authentication-v1.md
@@ -64,8 +64,14 @@ timestamp - 30 seconds <= server time <= timestamp + 5 minutes + 30 seconds
 ```
 
 Thus a request exactly 30 seconds in the future or exactly 5 minutes 30 seconds old is valid. One
-millisecond beyond either boundary is rejected. Deployments may configure these durations, but must
-publish their policy and use the same values when issuing and verifying challenges. A challenge
+millisecond beyond either boundary is rejected. Deployments configure both durations with
+`STEALTH_AUTH_CHALLENGE_LIFETIME_MS` and `STEALTH_AUTH_CLOCK_SKEW_MS`, and must publish their policy.
+One configuration governs both challenge issuance and signed-request verification, so the two halves
+of the protocol cannot disagree.
+
+When a challenge carries an explicit expiry, that expiry is authoritative and replaces
+`timestamp + lifetime` as the upper bound. Reconfiguring the lifetime therefore applies to challenges
+issued afterwards and never retroactively extends or shortens ones already in flight. A challenge
 nonce expires with its validity window and can never extend request validity.
 
 ## Verification and replay protection
@@ -91,14 +97,18 @@ authorization or business validation fails.
 
 Failures use the standard JSON API error envelope and do not echo signatures or nonce records.
 
-| Condition                                                                     | HTTP | Stable code         | Retry guidance                                      |
-| ----------------------------------------------------------------------------- | ---: | ------------------- | --------------------------------------------------- |
-| Missing/malformed header, unknown version, invalid account, invalid signature |  401 | `unauthorized`      | Obtain a new challenge and sign again.              |
-| Timestamp or challenge expired                                                |  422 | `expired_challenge` | Obtain a new challenge.                             |
-| Timestamp too far in the future                                               |  422 | `challenge_not_yet_valid` | Correct the clock, then sign a fresh challenge. |
-| Nonce already consumed (replay)                                               |  409 | `conflict`          | Never retry the signed request; obtain a new nonce. |
-| Verified actor lacks endpoint permission                                      |  403 | `forbidden`         | Do not retry unchanged.                             |
-| Authentication rate limit exceeded                                            |  429 | `too_many_requests` | Honor `Retry-After`.                                |
+| Condition                                                                     | HTTP | Stable code               | `details.reason`     | Retry guidance                                      |
+| ----------------------------------------------------------------------------- | ---: | ------------------------- | -------------------- | --------------------------------------------------- |
+| Missing/malformed header, unknown version, invalid account, invalid signature |  401 | `unauthorized`            | —                    | Obtain a new challenge and sign again.              |
+| Timestamp or challenge expired                                                |  422 | `expired_challenge`       | `AUTH_EXPIRED`       | Obtain a new challenge.                             |
+| Timestamp too far in the future                                               |  422 | `challenge_not_yet_valid` | `AUTH_NOT_YET_VALID` | Correct the clock, then sign a fresh challenge.     |
+| Unparseable or inverted challenge timestamps                                  |  422 | `validation_error`        | —                    | Correct the request, then sign a fresh challenge.   |
+| Nonce already consumed (replay)                                               |  409 | `conflict`                | —                    | Never retry the signed request; obtain a new nonce. |
+| Verified actor lacks endpoint permission                                      |  403 | `forbidden`               | —                    | Do not retry unchanged.                             |
+| Authentication rate limit exceeded                                            |  429 | `too_many_requests`       | —                    | Honor `Retry-After`.                                |
+
+Both timing failures share HTTP 422, so `details.reason` is what lets a client distinguish a clock
+that is behind from one that is ahead without parsing prose.
 
 Servers should keep client-facing authentication messages generic while recording a correlation ID
 and specific internal reason. Logs must not contain raw signatures, secret material, or complete

--- a/docs/security/api-authentication-v1.md
+++ b/docs/security/api-authentication-v1.md
@@ -95,7 +95,7 @@ Failures use the standard JSON API error envelope and do not echo signatures or 
 | ----------------------------------------------------------------------------- | ---: | ------------------- | --------------------------------------------------- |
 | Missing/malformed header, unknown version, invalid account, invalid signature |  401 | `unauthorized`      | Obtain a new challenge and sign again.              |
 | Timestamp or challenge expired                                                |  422 | `expired_challenge` | Obtain a new challenge.                             |
-| Timestamp too far in the future                                               |  422 | `validation_error`  | Correct the clock, then sign a fresh challenge.     |
+| Timestamp too far in the future                                               |  422 | `challenge_not_yet_valid` | Correct the clock, then sign a fresh challenge. |
 | Nonce already consumed (replay)                                               |  409 | `conflict`          | Never retry the signed request; obtain a new nonce. |
 | Verified actor lacks endpoint permission                                      |  403 | `forbidden`         | Do not retry unchanged.                             |
 | Authentication rate limit exceeded                                            |  429 | `too_many_requests` | Honor `Retry-After`.                                |

--- a/src/server/api/auth/challenge.ts
+++ b/src/server/api/auth/challenge.ts
@@ -15,9 +15,37 @@ export interface AuthChallengeTiming {
   readonly expiresAt: string;
 }
 
+/**
+ * Stable machine-readable reasons for authentication timing failures.
+ *
+ * These accompany the public API error codes `expired_challenge` and
+ * `challenge_not_yet_valid` in the error details, so a client can distinguish
+ * "your clock is behind" from "your clock is ahead" without parsing prose.
+ */
+export const AUTH_TIMING_REASONS = {
+  expired: "AUTH_EXPIRED",
+  notYetValid: "AUTH_NOT_YET_VALID",
+} as const;
+
+export type AuthTimingReason = (typeof AUTH_TIMING_REASONS)[keyof typeof AUTH_TIMING_REASONS];
+
 export interface AuthChallengeValidationOptions extends Partial<AuthChallengeConfig> {
   /** Injectable clock for deterministic validation and tests. */
   readonly now?: () => number;
+  /**
+   * Expiry stamped on the challenge when it was issued. When present it is
+   * authoritative, so reconfiguring the lifetime never retroactively extends
+   * or shortens challenges already in flight. Falls back to
+   * `issuedAt + lifetimeMs`.
+   */
+  readonly expiresAt?: string | Date | number;
+}
+
+/** Normalizes the accepted timestamp shapes to epoch milliseconds. */
+function toEpochMs(value: string | Date | number): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return value;
+  return Date.parse(value);
 }
 
 type AuthChallengeEnvironment = Record<string, string | undefined>;
@@ -75,7 +103,13 @@ export function createAuthChallengeTiming(
 
 /**
  * Enforces the shared authentication challenge validity window.
- * Both boundaries are inclusive: issuedAt - skew <= now <= issuedAt + lifetime + skew.
+ *
+ * Both boundaries are inclusive: `issuedAt - skew <= now <= expiresAt + skew`,
+ * where `expiresAt` defaults to `issuedAt + lifetime`. A request exactly on
+ * either boundary is valid; one millisecond beyond it is rejected.
+ *
+ * Failures carry a stable machine-readable reason in the error details:
+ * `AUTH_NOT_YET_VALID` before the window, `AUTH_EXPIRED` after it.
  */
 export function validateAuthChallengeTimestamp(
   issuedAt: string | Date | number,
@@ -84,22 +118,23 @@ export function validateAuthChallengeTimestamp(
   const configured = getAuthChallengeConfig();
   const lifetimeMs = options.lifetimeMs ?? configured.lifetimeMs;
   const clockSkewMs = options.clockSkewMs ?? configured.clockSkewMs;
-  const issuedAtMs =
-    issuedAt instanceof Date
-      ? issuedAt.getTime()
-      : typeof issuedAt === "number"
-        ? issuedAt
-        : Date.parse(issuedAt);
+  const issuedAtMs = toEpochMs(issuedAt);
 
   if (!Number.isFinite(issuedAtMs)) {
     throw new ApiError("validation_error", { field: "issuedAt" });
   }
 
-  const nowMs = (options.now ?? Date.now)();
-  if (issuedAtMs - nowMs > clockSkewMs) {
-    throw new ApiError("challenge_not_yet_valid");
+  const expiresAtMs =
+    options.expiresAt === undefined ? issuedAtMs + lifetimeMs : toEpochMs(options.expiresAt);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs < issuedAtMs) {
+    throw new ApiError("validation_error", { field: "expiresAt" });
   }
-  if (nowMs - issuedAtMs > lifetimeMs + clockSkewMs) {
-    throw new ApiError("expired_challenge");
+
+  const nowMs = (options.now ?? Date.now)();
+  if (nowMs < issuedAtMs - clockSkewMs) {
+    throw new ApiError("challenge_not_yet_valid", { reason: AUTH_TIMING_REASONS.notYetValid });
+  }
+  if (nowMs > expiresAtMs + clockSkewMs) {
+    throw new ApiError("expired_challenge", { reason: AUTH_TIMING_REASONS.expired });
   }
 }

--- a/src/server/api/auth/signed-request.ts
+++ b/src/server/api/auth/signed-request.ts
@@ -1,8 +1,23 @@
 import { createHash } from "node:crypto";
 
+import {
+  AUTH_TIMING_REASONS,
+  DEFAULT_AUTH_CHALLENGE_LIFETIME_MS,
+  DEFAULT_AUTH_CLOCK_SKEW_MS,
+  getAuthChallengeConfig,
+  type AuthTimingReason,
+} from "./challenge";
+
 export const SIGNED_REQUEST_VERSION = "STEALTH-AUTH-V1";
-export const SIGNED_REQUEST_MAX_AGE_MS = 5 * 60 * 1000;
-export const SIGNED_REQUEST_CLOCK_SKEW_MS = 30 * 1000;
+
+/**
+ * Protocol defaults. Signed requests and challenges share one validity policy,
+ * so these alias the challenge defaults rather than restating them; a
+ * deployment overrides both at once through the environment configuration read
+ * by {@link getAuthChallengeConfig}.
+ */
+export const SIGNED_REQUEST_MAX_AGE_MS = DEFAULT_AUTH_CHALLENGE_LIFETIME_MS;
+export const SIGNED_REQUEST_CLOCK_SKEW_MS = DEFAULT_AUTH_CLOCK_SKEW_MS;
 
 export const SIGNED_REQUEST_HEADERS = [
   "host",
@@ -58,16 +73,44 @@ export function canonicalizeSignedRequest(input: SignedRequestInput): string {
 
 export type SignedRequestTimeStatus = "valid" | "expired" | "future" | "invalid";
 
-/** Checks the inclusive v1 request window against an injectable server clock. */
+/**
+ * Checks the inclusive v1 request window against an injectable server clock.
+ *
+ * The window defaults to the deployment-configured challenge policy, so a
+ * signed request and the challenge it carries are never judged against
+ * different durations. Explicit arguments override it for tests and for
+ * callers that already resolved the policy.
+ */
 export function signedRequestTimeStatus(
   timestamp: string,
   nowMs: number,
-  maxAgeMs = SIGNED_REQUEST_MAX_AGE_MS,
-  clockSkewMs = SIGNED_REQUEST_CLOCK_SKEW_MS,
+  maxAgeMs?: number,
+  clockSkewMs?: number,
 ): SignedRequestTimeStatus {
+  const configured = getAuthChallengeConfig();
+  const lifetime = maxAgeMs ?? configured.lifetimeMs;
+  const skew = clockSkewMs ?? configured.clockSkewMs;
+
   const timestampMs = Date.parse(timestamp);
   if (!Number.isFinite(timestampMs)) return "invalid";
-  if (timestampMs - nowMs > clockSkewMs) return "future";
-  if (nowMs - timestampMs > maxAgeMs + clockSkewMs) return "expired";
+  if (timestampMs - nowMs > skew) return "future";
+  if (nowMs - timestampMs > lifetime + skew) return "expired";
   return "valid";
+}
+
+/**
+ * Maps a time status to the stable machine-readable reason reported alongside
+ * the API error code, or `null` when the status is not a timing failure.
+ */
+export function signedRequestTimingReason(
+  status: SignedRequestTimeStatus,
+): AuthTimingReason | null {
+  switch (status) {
+    case "expired":
+      return AUTH_TIMING_REASONS.expired;
+    case "future":
+      return AUTH_TIMING_REASONS.notYetValid;
+    default:
+      return null;
+  }
 }

--- a/tests/unit/api/auth/challenge.test.ts
+++ b/tests/unit/api/auth/challenge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AUTH_TIMING_REASONS,
   createAuthChallengeTiming,
   getAuthChallengeConfig,
   validateAuthChallengeTimestamp,
@@ -15,13 +16,16 @@ const clock =
 const lifetimeMs = 5 * 60 * 1000;
 const clockSkewMs = 30 * 1000;
 
-function expectCode(run: () => void, code: string) {
+function expectCode(run: () => void, code: string, reason?: string) {
   try {
     run();
     throw new Error("Expected challenge validation to fail");
   } catch (error) {
     expect(error).toBeInstanceOf(ApiError);
     expect((error as ApiError).code).toBe(code);
+    if (reason !== undefined) {
+      expect((error as ApiError).details).toEqual({ reason });
+    }
   }
 }
 
@@ -55,6 +59,99 @@ describe("authentication challenge timing", () => {
     expect(() =>
       validateAuthChallengeTimestamp(NOW - lifetimeMs - clockSkewMs, options),
     ).not.toThrow();
+  });
+
+  it("reports stable machine-readable reasons for each timing failure", () => {
+    expectCode(
+      () => validateAuthChallengeTimestamp(NOW - lifetimeMs - clockSkewMs - 1, options),
+      "expired_challenge",
+      AUTH_TIMING_REASONS.expired,
+    );
+    expectCode(
+      () => validateAuthChallengeTimestamp(NOW + clockSkewMs + 1, options),
+      "challenge_not_yet_valid",
+      AUTH_TIMING_REASONS.notYetValid,
+    );
+    expect(AUTH_TIMING_REASONS).toEqual({
+      expired: "AUTH_EXPIRED",
+      notYetValid: "AUTH_NOT_YET_VALID",
+    });
+  });
+
+  it("treats the expiry stamped on an issued challenge as authoritative", () => {
+    const issuedAt = NOW - 10 * 60 * 1000;
+
+    // A longer stamped expiry keeps an old challenge valid even though the
+    // configured lifetime alone would have retired it.
+    expect(() =>
+      validateAuthChallengeTimestamp(issuedAt, {
+        ...options,
+        expiresAt: NOW + clockSkewMs,
+      }),
+    ).not.toThrow();
+
+    // A shorter stamped expiry retires a challenge the configured lifetime
+    // would still have accepted.
+    expectCode(
+      () =>
+        validateAuthChallengeTimestamp(NOW - 60_000, {
+          ...options,
+          expiresAt: NOW - clockSkewMs - 1,
+        }),
+      "expired_challenge",
+      AUTH_TIMING_REASONS.expired,
+    );
+  });
+
+  it("accepts the exact boundary of a stamped expiry", () => {
+    const expiresAt = NOW - clockSkewMs;
+    expect(() =>
+      validateAuthChallengeTimestamp(NOW - lifetimeMs, { ...options, expiresAt }),
+    ).not.toThrow();
+    expectCode(
+      () =>
+        validateAuthChallengeTimestamp(NOW - lifetimeMs, {
+          ...options,
+          expiresAt: expiresAt - 1,
+        }),
+      "expired_challenge",
+      AUTH_TIMING_REASONS.expired,
+    );
+  });
+
+  it("rejects unparseable and inverted challenge timestamps", () => {
+    expectCode(() => validateAuthChallengeTimestamp("not-a-date", options), "validation_error");
+    expectCode(
+      () => validateAuthChallengeTimestamp(NOW, { ...options, expiresAt: "not-a-date" }),
+      "validation_error",
+    );
+    expectCode(
+      () => validateAuthChallengeTimestamp(NOW, { ...options, expiresAt: NOW - 1 }),
+      "validation_error",
+    );
+  });
+
+  it("validates a challenge against the timing it was issued with", () => {
+    const timing = createAuthChallengeTiming({ lifetimeMs, now: clock() });
+    const atExpiry = Date.parse(timing.expiresAt);
+
+    expect(() =>
+      validateAuthChallengeTimestamp(timing.issuedAt, {
+        ...options,
+        expiresAt: timing.expiresAt,
+        now: clock(atExpiry + clockSkewMs),
+      }),
+    ).not.toThrow();
+    expectCode(
+      () =>
+        validateAuthChallengeTimestamp(timing.issuedAt, {
+          ...options,
+          expiresAt: timing.expiresAt,
+          now: clock(atExpiry + clockSkewMs + 1),
+        }),
+      "expired_challenge",
+      AUTH_TIMING_REASONS.expired,
+    );
   });
 
   it("uses a controllable clock when creating challenge timestamps", () => {

--- a/tests/unit/api/auth/signed-request-timing.test.ts
+++ b/tests/unit/api/auth/signed-request-timing.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AUTH_TIMING_REASONS } from "../../../../src/server/api/auth/challenge";
+import {
+  SIGNED_REQUEST_CLOCK_SKEW_MS,
+  SIGNED_REQUEST_MAX_AGE_MS,
+  signedRequestTimeStatus,
+  signedRequestTimingReason,
+} from "../../../../src/server/api/auth/signed-request";
+
+const NOW = Date.parse("2026-07-22T12:00:00.000Z");
+const at = (offsetMs: number) => new Date(NOW + offsetMs).toISOString();
+
+const ENV_KEYS = ["STEALTH_AUTH_CHALLENGE_LIFETIME_MS", "STEALTH_AUTH_CLOCK_SKEW_MS"] as const;
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe("signed request validity window", () => {
+  it("shares the protocol defaults with the challenge policy", () => {
+    expect(SIGNED_REQUEST_MAX_AGE_MS).toBe(5 * 60 * 1000);
+    expect(SIGNED_REQUEST_CLOCK_SKEW_MS).toBe(30 * 1000);
+  });
+
+  it("accepts both exact boundaries and rejects one millisecond beyond each", () => {
+    expect(signedRequestTimeStatus(at(SIGNED_REQUEST_CLOCK_SKEW_MS), NOW)).toBe("valid");
+    expect(signedRequestTimeStatus(at(SIGNED_REQUEST_CLOCK_SKEW_MS + 1), NOW)).toBe("future");
+
+    const oldest = -(SIGNED_REQUEST_MAX_AGE_MS + SIGNED_REQUEST_CLOCK_SKEW_MS);
+    expect(signedRequestTimeStatus(at(oldest), NOW)).toBe("valid");
+    expect(signedRequestTimeStatus(at(oldest - 1), NOW)).toBe("expired");
+  });
+
+  it("rejects an unparseable timestamp without treating it as a timing failure", () => {
+    expect(signedRequestTimeStatus("not-a-date", NOW)).toBe("invalid");
+    expect(signedRequestTimingReason("invalid")).toBeNull();
+    expect(signedRequestTimingReason("valid")).toBeNull();
+  });
+
+  it("maps timing failures to stable machine-readable reasons", () => {
+    expect(signedRequestTimingReason("expired")).toBe(AUTH_TIMING_REASONS.expired);
+    expect(signedRequestTimingReason("future")).toBe(AUTH_TIMING_REASONS.notYetValid);
+  });
+
+  it("applies the deployment-configured window instead of the defaults", () => {
+    process.env.STEALTH_AUTH_CHALLENGE_LIFETIME_MS = "60000";
+    process.env.STEALTH_AUTH_CLOCK_SKEW_MS = "5000";
+
+    // Inside the default window but outside the configured one.
+    expect(signedRequestTimeStatus(at(-120_000), NOW)).toBe("expired");
+    expect(signedRequestTimeStatus(at(10_000), NOW)).toBe("future");
+
+    expect(signedRequestTimeStatus(at(-65_000), NOW)).toBe("valid");
+    expect(signedRequestTimeStatus(at(5_000), NOW)).toBe("valid");
+  });
+
+  it("lets explicit arguments override the configured window", () => {
+    process.env.STEALTH_AUTH_CHALLENGE_LIFETIME_MS = "60000";
+    process.env.STEALTH_AUTH_CLOCK_SKEW_MS = "5000";
+
+    expect(signedRequestTimeStatus(at(-120_000), NOW, 5 * 60 * 1000, 30 * 1000)).toBe("valid");
+  });
+});


### PR DESCRIPTION
Closes #1463

## Problem

Signed requests need a narrow validity window that still tolerates reasonable client/server clock differences. Three gaps remained in `src/server/api/auth`:

1. `signed-request.ts` hard-coded its own `MAX_AGE_MS` / `CLOCK_SKEW_MS` constants instead of reading the deployment-configured window that `challenge.ts` already exposes, so the two halves of the protocol could disagree.
2. `validateAuthChallengeTimestamp` recomputed expiry from the current lifetime configuration and ignored the `expiresAt` a challenge was issued with, so changing the configured lifetime retroactively extended or shortened challenges already in flight.
3. Expired and not-yet-valid failures were distinguishable only by HTTP status plus an error code string; there was no stable machine-readable reason on the error payload.

The protocol table in `docs/security/api-authentication-v1.md` also documented `validation_error` for future-dated timestamps, while the code returns `challenge_not_yet_valid`.

## Change

- Route the signed-request time window through the same configurable `lifetimeMs` / `clockSkewMs` policy as challenges.
- Honor the `expiresAt` stamped on an issued challenge when one is supplied, falling back to the configured lifetime otherwise.
- Attach stable machine-readable reasons — `AUTH_EXPIRED` and `AUTH_NOT_YET_VALID` — to the error details, alongside the existing `expired_challenge` / `challenge_not_yet_valid` API error codes.
- Extend boundary tests using the existing injectable clock.
- Correct and expand the auth timing documentation.

## Backward compatibility

Public API error codes and HTTP statuses are unchanged; the reason is additive detail. Defaults remain 5 minutes lifetime and 30 seconds skew.
