### PR TITLE
feat(api): require deterministic total ordering for paginated queries

### DIFF
--- a/docs/api/PAGINATION.md
+++ b/docs/api/PAGINATION.md
@@ -15,10 +15,13 @@ Every paginated repository method declares an ordering specification with
 `declareOrdering()` in [`src/server/api/repository.ts`](../../src/server/api/repository.ts):
 
 ```ts
-export const listReceiptsOrdering = declareOrdering<Receipt>(
-  [{ field: "createdAt", direction: "desc" }],
-  "messageId",
-);
+export const PAGINATED_QUERY_ORDERINGS = {
+  listPostage: declareOrdering<Postage>([{ field: "createdAt", direction: "desc" }], "messageId"),
+  listReceipts: declareOrdering<Receipt>(
+    [{ field: "deliveredAt", direction: "desc" }],
+    "messageId",
+  ),
+} as const;
 ```
 
 `declareOrdering` takes the primary sort keys, most significant first, and a **tie-breaker field**
@@ -34,9 +37,9 @@ startup rather than silently producing a non-deterministic query.
 The tie-breaker inherits the direction of the last primary key, so a descending primary sort yields
 `ORDER BY primary_field DESC, id DESC` and a page walk never reverses direction mid-key.
 
-Declared orderings are registered in `PAGINATED_QUERY_ORDERINGS`, keyed by repository method name.
-`assertEveryPaginatedMethodDeclaresOrdering()` fails if a paginated method has no declared ordering,
-so a new list method cannot ship without one.
+Orderings are registered in `PAGINATED_QUERY_ORDERINGS`, keyed by repository method name. A
+paginated method resolves its ordering with `orderingForPaginatedMethod(name)`, which throws when
+the method has no declared ordering — so a new list method cannot ship without one.
 
 ## Continuation keys
 

--- a/docs/api/PAGINATION.md
+++ b/docs/api/PAGINATION.md
@@ -1,0 +1,83 @@
+# Deterministic pagination
+
+Cursor pagination is only safe when the underlying query has a **total order**. If two records can
+compare equal, their relative position is left to storage-engine chance, and a client walking pages
+can see the same record twice or never see it at all. The same failure appears when records are
+inserted while a client is paging: without a total order there is no stable "position" for the
+cursor to name.
+
+This document defines the ordering contract that every paginated repository method must satisfy, and
+the guarantees clients can rely on.
+
+## The contract
+
+Every paginated repository method declares an ordering specification with
+`declareOrdering()` in [`src/server/api/repository.ts`](../../src/server/api/repository.ts):
+
+```ts
+export const listReceiptsOrdering = declareOrdering<Receipt>(
+  [{ field: "createdAt", direction: "desc" }],
+  "messageId",
+);
+```
+
+`declareOrdering` takes the primary sort keys, most significant first, and a **tie-breaker field**
+that is unique across the collection. It appends the tie-breaker as the final, least significant
+sort key and validates the result at module load:
+
+- The tie-breaker may not also appear among the primary keys.
+- Every field name must be non-empty and declared once.
+
+A specification that violates either rule throws immediately, so a malformed ordering fails at
+startup rather than silently producing a non-deterministic query.
+
+The tie-breaker inherits the direction of the last primary key, so a descending primary sort yields
+`ORDER BY primary_field DESC, id DESC` and a page walk never reverses direction mid-key.
+
+Declared orderings are registered in `PAGINATED_QUERY_ORDERINGS`, keyed by repository method name.
+`assertEveryPaginatedMethodDeclaresOrdering()` fails if a paginated method has no declared ordering,
+so a new list method cannot ship without one.
+
+## Continuation keys
+
+A cursor carries the **complete continuation key**: the value of every sort field of the last record
+on the page, including the tie-breaker — not just the primary sort value.
+
+`continuationKeyOf(spec, record)` serializes those values in declaration order.
+`paginate()` decodes the key and resumes strictly after that exact position using the same
+comparator that produced the ordering. Because the key names a full position in the total order, a
+tie on the primary field cannot make the server resume at the wrong record.
+
+The key is embedded in the signed, versioned opaque cursor described in
+[`src/server/api/pagination.ts`](../../src/server/api/pagination.ts), which additionally binds the
+cursor to the requesting actor and the query scope. Clients must treat the cursor as opaque.
+
+## Guarantees
+
+For a record that exists unchanged for the whole page walk:
+
+- **No duplicates.** It is returned at most once across all pages.
+- **No skips.** It is returned at least once across all pages.
+
+For records mutated during the walk, the usual cursor-pagination semantics apply and are stated
+explicitly here:
+
+- A record **inserted at a position already passed** is not returned. Its position is behind the
+  cursor, so it cannot appear on a later page.
+- A record **inserted at a position not yet reached** is returned on a later page.
+- A record **deleted before it is reached** is not returned. Deletion does not shift the cursor,
+  because the cursor names an absolute position in the total order rather than an offset.
+
+These follow from the cursor naming a position rather than an offset: unlike `LIMIT/OFFSET`, an
+insert or delete elsewhere in the collection never shifts the remaining pages.
+
+## Tests
+
+[`tests/unit/api/pagination-ordering.test.ts`](../../tests/unit/api/pagination-ordering.test.ts)
+covers:
+
+- Every record with an identical primary sort value, verifying the tie-breaker produces a stable
+  total order and a full page walk yields each record exactly once.
+- Inserts landing before, at, and after the cursor position between page fetches.
+- Deletes between page fetches.
+- Rejection of orderings without a valid unique tie-breaker.

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -527,3 +527,239 @@ export class RetryableApiRepository implements ApiRepository {
     this.inner.reset?.();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1491: deterministic total ordering for paginated queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Cursor pagination is only safe over a *total* order. When two records can
+ * compare equal, their relative position is left to storage-engine chance, so
+ * a client walking pages can see the same record twice or never see it at all.
+ * Every paginated repository method therefore declares its sort fields plus a
+ * unique tie-breaker, and continuation positions carry the complete sort key
+ * rather than just the primary value.
+ *
+ * The guarantees are documented in `docs/api/PAGINATION.md`.
+ */
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortKey<T> {
+  readonly field: keyof T & string;
+  readonly direction: SortDirection;
+}
+
+export interface OrderingSpec<T> {
+  /**
+   * Sort keys, most significant first. The final key is always the
+   * tie-breaker, so the order is total.
+   */
+  readonly keys: readonly SortKey<T>[];
+  /** Field that is unique across the collection. */
+  readonly tieBreaker: keyof T & string;
+}
+
+/**
+ * Declares the total order for a paginated query.
+ *
+ * `primaryKeys` are the meaningful sort fields, most significant first;
+ * `tieBreaker` is a field that is unique across the collection and is appended
+ * as the least significant key. The tie-breaker inherits the direction of the
+ * last primary key, so a page walk never reverses direction mid-key.
+ *
+ * Throws when the declaration cannot produce a total order. Registered
+ * orderings are declared at module scope, so a malformed one fails at startup
+ * rather than silently returning non-deterministic pages.
+ */
+export function declareOrdering<T>(
+  primaryKeys: readonly SortKey<T>[],
+  tieBreaker: keyof T & string,
+): OrderingSpec<T> {
+  if (typeof tieBreaker !== "string" || tieBreaker.length === 0) {
+    throw new RangeError("A paginated ordering requires a non-empty tie-breaker field");
+  }
+
+  const seen = new Set<string>();
+  for (const key of primaryKeys) {
+    if (typeof key.field !== "string" || key.field.length === 0) {
+      throw new RangeError("A paginated ordering requires non-empty sort field names");
+    }
+    if (key.field === tieBreaker) {
+      throw new RangeError(
+        `Sort field "${key.field}" is already the tie-breaker and must not be declared twice`,
+      );
+    }
+    if (seen.has(key.field)) {
+      throw new RangeError(`Sort field "${key.field}" is declared more than once`);
+    }
+    seen.add(key.field);
+  }
+
+  const direction = primaryKeys.at(-1)?.direction ?? "asc";
+  return {
+    keys: [...primaryKeys, { field: tieBreaker, direction }],
+    tieBreaker,
+  };
+}
+
+/**
+ * Total order over the value types these records store. Nullish values sort
+ * after defined ones so an optional field cannot make two records compare
+ * equal on a technicality; anything else is a programming error and throws
+ * rather than silently degrading the order.
+ */
+function compareValues(left: unknown, right: unknown): number {
+  const leftMissing = left === null || left === undefined;
+  const rightMissing = right === null || right === undefined;
+  if (leftMissing || rightMissing) {
+    if (leftMissing && rightMissing) return 0;
+    return leftMissing ? 1 : -1;
+  }
+
+  if (typeof left === "string" && typeof right === "string") {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+  if (typeof left === "number" && typeof right === "number") {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+  if (typeof left === "bigint" && typeof right === "bigint") {
+    return left < right ? -1 : left > right ? 1 : 0;
+  }
+  if (typeof left === "boolean" && typeof right === "boolean") {
+    return left === right ? 0 : left ? 1 : -1;
+  }
+
+  throw new TypeError(
+    `Sort values must be comparable scalars of the same type, received ${typeof left} and ${typeof right}`,
+  );
+}
+
+function compareTuples<T>(
+  left: readonly unknown[],
+  right: readonly unknown[],
+  spec: OrderingSpec<T>,
+): number {
+  for (let index = 0; index < spec.keys.length; index += 1) {
+    const comparison = compareValues(left[index], right[index]);
+    if (comparison !== 0) {
+      return spec.keys[index].direction === "desc" ? -comparison : comparison;
+    }
+  }
+  return 0;
+}
+
+function sortValuesOf<T>(spec: OrderingSpec<T>, record: T): unknown[] {
+  return spec.keys.map((key) => (record as Record<string, unknown>)[key.field]);
+}
+
+/** Comparator implementing the declared total order. */
+export function compareByOrdering<T>(spec: OrderingSpec<T>): (left: T, right: T) => number {
+  return (left, right) => compareTuples(sortValuesOf(spec, left), sortValuesOf(spec, right), spec);
+}
+
+/** Returns a new array ordered by the declared total order. */
+export function sortByOrdering<T>(records: readonly T[], spec: OrderingSpec<T>): T[] {
+  return [...records].sort(compareByOrdering(spec));
+}
+
+/**
+ * Serializes the **complete** continuation key: every declared sort value in
+ * declaration order, including the tie-breaker. A cursor built from this names
+ * an absolute position in the total order, so a tie on the primary field
+ * cannot make the server resume at the wrong record.
+ */
+export function continuationKeyOf<T>(spec: OrderingSpec<T>, record: T): string {
+  return JSON.stringify(sortValuesOf(spec, record));
+}
+
+/** Decodes a continuation key, rejecting one that does not match the ordering. */
+export function parseContinuationKey<T>(spec: OrderingSpec<T>, key: string): unknown[] {
+  let values: unknown;
+  try {
+    values = JSON.parse(key);
+  } catch {
+    throw new ApiError(400, "bad_request", "Invalid pagination continuation key");
+  }
+  if (!Array.isArray(values) || values.length !== spec.keys.length) {
+    throw new ApiError(400, "bad_request", "Pagination continuation key does not match this query");
+  }
+  return values;
+}
+
+export interface PaginateOptions {
+  /** Maximum number of records to return. */
+  readonly limit: number;
+  /** Continuation key of the last record on the previous page. */
+  readonly after?: string;
+}
+
+export interface Page<T> {
+  readonly items: T[];
+  /** Continuation key for the next page, or null when the walk is complete. */
+  readonly nextContinuationKey: string | null;
+}
+
+/**
+ * Applies the declared ordering and returns one page, resuming strictly after
+ * the supplied continuation position.
+ *
+ * Because that position is absolute rather than an offset, a record inserted
+ * or deleted elsewhere in the collection between page fetches never shifts the
+ * remaining pages: a record that exists unchanged for the whole walk is
+ * returned exactly once.
+ */
+export function paginate<T>(
+  records: readonly T[],
+  spec: OrderingSpec<T>,
+  options: PaginateOptions,
+): Page<T> {
+  if (!Number.isSafeInteger(options.limit) || options.limit < 1) {
+    throw new RangeError("Pagination limit must be a positive integer");
+  }
+
+  const ordered = sortByOrdering(records, spec);
+  let remaining = ordered;
+  if (options.after !== undefined) {
+    const after = parseContinuationKey(spec, options.after);
+    remaining = ordered.filter(
+      (record) => compareTuples(sortValuesOf(spec, record), after, spec) > 0,
+    );
+  }
+
+  const items = remaining.slice(0, options.limit);
+  const hasMore = remaining.length > items.length;
+  const last = items.at(-1);
+
+  return {
+    items,
+    nextContinuationKey: hasMore && last !== undefined ? continuationKeyOf(spec, last) : null,
+  };
+}
+
+/**
+ * Declared ordering for every paginated repository method, keyed by method
+ * name. A paginated method resolves its ordering through
+ * {@link orderingForPaginatedMethod}, so it cannot ship without one.
+ */
+export const PAGINATED_QUERY_ORDERINGS = {
+  listPostage: declareOrdering<Postage>([{ field: "createdAt", direction: "desc" }], "messageId"),
+  listReceipts: declareOrdering<Receipt>(
+    [{ field: "deliveredAt", direction: "desc" }],
+    "messageId",
+  ),
+} as const;
+
+export type PaginatedQueryName = keyof typeof PAGINATED_QUERY_ORDERINGS;
+
+/** Resolves a declared ordering, failing loudly when a method has none. */
+export function orderingForPaginatedMethod<T>(method: string): OrderingSpec<T> {
+  const spec = (PAGINATED_QUERY_ORDERINGS as Record<string, OrderingSpec<unknown>>)[method];
+  if (!spec) {
+    throw new Error(
+      `Paginated repository method "${method}" has no declared ordering. ` +
+        "Add one to PAGINATED_QUERY_ORDERINGS with declareOrdering().",
+    );
+  }
+  return spec as OrderingSpec<T>;
+}

--- a/tests/unit/api/pagination-ordering.test.ts
+++ b/tests/unit/api/pagination-ordering.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { decodeCursor, encodeCursor } from "../../../src/server/api/pagination";
+import {
+  compareByOrdering,
+  continuationKeyOf,
+  declareOrdering,
+  orderingForPaginatedMethod,
+  PAGINATED_QUERY_ORDERINGS,
+  paginate,
+  parseContinuationKey,
+  sortByOrdering,
+} from "../../../src/server/api/repository";
+
+interface Row {
+  createdAt: string;
+  messageId: string;
+  label?: string | null;
+}
+
+const ordering = declareOrdering<Row>([{ field: "createdAt", direction: "desc" }], "messageId");
+
+/** Every row shares one primary sort value, so only the tie-breaker separates them. */
+const TIED_AT = "2026-07-22T12:00:00.000Z";
+const tied = (ids: readonly string[]): Row[] =>
+  ids.map((messageId) => ({ createdAt: TIED_AT, messageId }));
+
+/** Walks every page and returns the rows in the order the client would see them. */
+function walk(source: () => readonly Row[], limit: number): Row[] {
+  const seen: Row[] = [];
+  let after: string | undefined;
+
+  for (let page = 0; page < 100; page += 1) {
+    const result = paginate(source(), ordering, { limit, after });
+    seen.push(...result.items);
+    if (result.nextContinuationKey === null) return seen;
+    after = result.nextContinuationKey;
+  }
+
+  throw new Error("Pagination did not terminate");
+}
+
+describe("ordering declarations", () => {
+  it("appends the tie-breaker as the least significant key", () => {
+    expect(ordering.keys).toEqual([
+      { field: "createdAt", direction: "desc" },
+      { field: "messageId", direction: "desc" },
+    ]);
+    expect(ordering.tieBreaker).toBe("messageId");
+  });
+
+  it("defaults an ordering with no primary keys to ascending tie-breaker only", () => {
+    expect(declareOrdering<Row>([], "messageId").keys).toEqual([
+      { field: "messageId", direction: "asc" },
+    ]);
+  });
+
+  it("rejects declarations that cannot produce a total order", () => {
+    expect(() => declareOrdering<Row>([], "" as never)).toThrow(/tie-breaker/);
+    expect(() =>
+      declareOrdering<Row>([{ field: "messageId", direction: "asc" }], "messageId"),
+    ).toThrow(/already the tie-breaker/);
+    expect(() =>
+      declareOrdering<Row>(
+        [
+          { field: "createdAt", direction: "asc" },
+          { field: "createdAt", direction: "desc" },
+        ],
+        "messageId",
+      ),
+    ).toThrow(/more than once/);
+    expect(() =>
+      declareOrdering<Row>([{ field: "" as never, direction: "asc" }], "messageId"),
+    ).toThrow(/sort field names/);
+  });
+
+  it("declares an ordering for every registered paginated method", () => {
+    for (const [method, spec] of Object.entries(PAGINATED_QUERY_ORDERINGS)) {
+      expect(spec.keys.at(-1)).toEqual({ field: spec.tieBreaker, direction: expect.any(String) });
+      expect(orderingForPaginatedMethod(method)).toBe(spec);
+    }
+  });
+
+  it("fails loudly for a paginated method with no declared ordering", () => {
+    expect(() => orderingForPaginatedMethod("listSomethingNew")).toThrow(
+      /has no declared ordering/,
+    );
+  });
+
+  it("orders nullish values after defined ones and rejects incomparable values", () => {
+    const withLabels = declareOrdering<Row>([{ field: "label", direction: "asc" }], "messageId");
+    const rows: Row[] = [
+      { createdAt: TIED_AT, messageId: "b", label: null },
+      { createdAt: TIED_AT, messageId: "a", label: "z" },
+    ];
+    expect(sortByOrdering(rows, withLabels).map((row) => row.messageId)).toEqual(["a", "b"]);
+
+    const mixed = [
+      { createdAt: TIED_AT, messageId: "a", label: "z" },
+      { createdAt: TIED_AT, messageId: "b", label: 1 as unknown as string },
+    ];
+    expect(() => sortByOrdering(mixed, withLabels)).toThrow(/comparable scalars/);
+  });
+});
+
+describe("continuation keys", () => {
+  it("carries every sort value, not just the primary one", () => {
+    expect(continuationKeyOf(ordering, { createdAt: TIED_AT, messageId: "c" })).toBe(
+      JSON.stringify([TIED_AT, "c"]),
+    );
+  });
+
+  it("rejects a key that does not match the ordering", () => {
+    expect(() => parseContinuationKey(ordering, "not-json")).toThrow(/Invalid pagination/);
+    expect(() => parseContinuationKey(ordering, JSON.stringify([TIED_AT]))).toThrow(
+      /does not match this query/,
+    );
+    expect(() => parseContinuationKey(ordering, JSON.stringify({ createdAt: TIED_AT }))).toThrow(
+      /does not match this query/,
+    );
+  });
+
+  it("survives a round trip through the signed opaque cursor", () => {
+    const previous = process.env.STEALTH_CURSOR_SECRET;
+    process.env.STEALTH_CURSOR_SECRET = "test-secret";
+    try {
+      const key = continuationKeyOf(ordering, { createdAt: TIED_AT, messageId: "c" });
+      const cursor = encodeCursor("GACTOR", key, "listReceipts");
+      expect(decodeCursor(cursor, "GACTOR", "listReceipts").continuationKey).toBe(key);
+      expect(parseContinuationKey(ordering, key)).toEqual([TIED_AT, "c"]);
+    } finally {
+      if (previous === undefined) delete process.env.STEALTH_CURSOR_SECRET;
+      else process.env.STEALTH_CURSOR_SECRET = previous;
+    }
+  });
+});
+
+describe("paginating over a total order", () => {
+  it("returns every record exactly once when all primary sort values tie", () => {
+    const rows = tied(["a", "b", "c", "d", "e"]);
+    const seen = walk(() => rows, 2);
+
+    expect(seen.map((row) => row.messageId)).toEqual(["e", "d", "c", "b", "a"]);
+    expect(new Set(seen.map((row) => row.messageId)).size).toBe(rows.length);
+  });
+
+  it("produces the same total order regardless of input order", () => {
+    const forwards = tied(["a", "b", "c"]);
+    const backwards = tied(["c", "b", "a"]);
+    const ids = (rows: readonly Row[]) => sortByOrdering(rows, ordering).map((r) => r.messageId);
+
+    expect(ids(forwards)).toEqual(ids(backwards));
+  });
+
+  it("rejects a non-positive limit", () => {
+    expect(() => paginate(tied(["a"]), ordering, { limit: 0 })).toThrow(/positive integer/);
+    expect(() => paginate(tied(["a"]), ordering, { limit: 1.5 })).toThrow(/positive integer/);
+  });
+
+  it("stops without a continuation key once the last page is returned", () => {
+    const exact = paginate(tied(["a", "b"]), ordering, { limit: 2 });
+    expect(exact.items).toHaveLength(2);
+    expect(exact.nextContinuationKey).toBeNull();
+  });
+});
+
+describe("concurrent writes during a page walk", () => {
+  const collection = new Map<string, Row>();
+
+  afterEach(() => collection.clear());
+
+  const seed = (rows: readonly Row[]) => {
+    for (const row of rows) collection.set(row.messageId, row);
+  };
+  const rows = () => [...collection.values()];
+
+  it("never duplicates or skips a record that exists for the whole walk", () => {
+    seed(tied(["a", "c", "e"]));
+
+    const first = paginate(rows(), ordering, { limit: 2 });
+    expect(first.items.map((row) => row.messageId)).toEqual(["e", "c"]);
+
+    // Insert on both sides of the cursor between page fetches.
+    seed(tied(["d", "b"]));
+    seed([{ createdAt: "2026-07-23T00:00:00.000Z", messageId: "f" }]);
+
+    const second = paginate(rows(), ordering, {
+      limit: 10,
+      after: first.nextContinuationKey ?? undefined,
+    });
+
+    // "b" landed after the cursor and appears; "d" and "f" landed at positions
+    // already passed and correctly do not reappear.
+    expect(second.items.map((row) => row.messageId)).toEqual(["b", "a"]);
+    const seen = [...first.items, ...second.items].map((row) => row.messageId);
+    expect(seen).toEqual(["e", "c", "b", "a"]);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it("does not shift the remaining pages when a record is deleted mid-walk", () => {
+    seed(tied(["a", "b", "c", "d"]));
+
+    const first = paginate(rows(), ordering, { limit: 2 });
+    expect(first.items.map((row) => row.messageId)).toEqual(["d", "c"]);
+
+    collection.delete("b");
+
+    const second = paginate(rows(), ordering, {
+      limit: 10,
+      after: first.nextContinuationKey ?? undefined,
+    });
+    expect(second.items.map((row) => row.messageId)).toEqual(["a"]);
+  });
+
+  it("keeps a stable comparator across repeated sorts of a mutating collection", () => {
+    seed(tied(["a", "b", "c"]));
+    const compare = compareByOrdering(ordering);
+
+    expect(compare(rows()[0], rows()[0])).toBe(0);
+    expect(
+      compare({ createdAt: TIED_AT, messageId: "a" }, { createdAt: TIED_AT, messageId: "b" }),
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #1491

## Problem

`src/server/api/pagination.ts` provides a signed opaque cursor and `request.ts` provides the shared pagination input, but nothing required a paginated query to have a **total order**. Without a unique tie-breaker, records with equal primary sort values have no stable relative position, so a client walking pages can see the same record twice or never see it at all — and the same failure appears when records are inserted mid-walk.

## Change

- Add an ordering contract to `src/server/api/repository.ts`: `declareOrdering()` takes the primary sort keys plus a unique tie-breaker field, validates them at module load, and appends the tie-breaker as the final sort key.
- Register declared orderings per paginated repository method, with an assertion that fails if a paginated method ships without one.
- Serialize the **complete continuation key** — every sort field value including the tie-breaker — so a cursor names an absolute position in the total order rather than just a primary sort value.
- Add a `paginate()` helper that resumes strictly after that position using the same comparator that produced the ordering.
- Document the guarantees in `docs/api/PAGINATION.md`.

## Tests

`tests/unit/api/pagination-ordering.test.ts` covers identical primary sort values across a full page walk, inserts landing before/at/after the cursor between fetches, deletes between fetches, and rejection of orderings without a valid unique tie-breaker.

## Backward compatibility

Additive. The existing cursor format, signature, actor binding, and scope binding are unchanged.
