### PR TITLE
feat(team-security-flagging): expose execution lifecycle states

### DIFF
--- a/tools/v2/team/team-security-flagging/README.md
+++ b/tools/v2/team/team-security-flagging/README.md
@@ -173,11 +173,11 @@ For a future UI or orchestration layer that needs lifecycle feedback, use
 `executeSecurityFlaggingWithState(input, dependencies, onState)`. It emits the
 following deterministic, folder-local states in order:
 
-| State | When emitted | Shape |
-| --- | --- | --- |
-| `loading` | Before authorization, duplicate checks, or persistence | `{ status: "loading" }` |
-| `success` | A flag was persisted | `{ status: "success", result: { ok: true, data } }` |
-| `error` | Validation or a service boundary failed | `{ status: "error", result: { ok: false, error } }` |
+| State     | When emitted                                           | Shape                                               |
+| --------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `loading` | Before authorization, duplicate checks, or persistence | `{ status: "loading" }`                             |
+| `success` | A flag was persisted                                   | `{ status: "success", result: { ok: true, data } }` |
+| `error`   | Validation or a service boundary failed                | `{ status: "error", result: { ok: false, error } }` |
 
 The observer is optional and has no DOM, network, or application-shell
 dependency. Invalid observer values throw a `TypeError` before execution.

--- a/tools/v2/team/team-security-flagging/README.md
+++ b/tools/v2/team/team-security-flagging/README.md
@@ -166,6 +166,22 @@ of these stable codes: `INVALID_INPUT`, `UNAUTHORIZED_REPORTER`,
 `DUPLICATE_FLAG`, `PERSISTENCE_FAILED`, or `INTERNAL_ERROR`. Callers should
 branch on `error.code`, not the human-readable message.
 
+### Loading and error states
+
+`executeSecurityFlagging` returns the terminal success or error output only.
+For a future UI or orchestration layer that needs lifecycle feedback, use
+`executeSecurityFlaggingWithState(input, dependencies, onState)`. It emits the
+following deterministic, folder-local states in order:
+
+| State | When emitted | Shape |
+| --- | --- | --- |
+| `loading` | Before authorization, duplicate checks, or persistence | `{ status: "loading" }` |
+| `success` | A flag was persisted | `{ status: "success", result: { ok: true, data } }` |
+| `error` | Validation or a service boundary failed | `{ status: "error", result: { ok: false, error } }` |
+
+The observer is optional and has no DOM, network, or application-shell
+dependency. Invalid observer values throw a `TypeError` before execution.
+
 Authorization, duplicate lookup, persistence, ID generation, and time are
 caller-supplied service boundaries. This makes execution deterministic in tests
 and independent of databases, transports, and presentation code.

--- a/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
+++ b/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
@@ -55,9 +55,7 @@ export type SecurityFlaggingExecutionState =
   | { status: "success"; result: Extract<SecurityFlaggingOutput, { ok: true }> }
   | { status: "error"; result: Extract<SecurityFlaggingOutput, { ok: false }> };
 
-export type SecurityFlaggingStateObserver = (
-  state: SecurityFlaggingExecutionState,
-) => void;
+export type SecurityFlaggingStateObserver = (state: SecurityFlaggingExecutionState) => void;
 
 /** I/O and environmental behavior supplied by the backend caller. */
 export interface SecurityFlaggingDependencies {

--- a/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
+++ b/tools/v2/team/team-security-flagging/contract/execution-contract.d.ts
@@ -49,6 +49,16 @@ export type SecurityFlaggingOutput =
   | { ok: true; data: SecurityFlaggingRecord }
   | { ok: false; error: SecurityFlaggingError };
 
+/** Lifecycle updates emitted by executeSecurityFlaggingWithState. */
+export type SecurityFlaggingExecutionState =
+  | { status: "loading" }
+  | { status: "success"; result: Extract<SecurityFlaggingOutput, { ok: true }> }
+  | { status: "error"; result: Extract<SecurityFlaggingOutput, { ok: false }> };
+
+export type SecurityFlaggingStateObserver = (
+  state: SecurityFlaggingExecutionState,
+) => void;
+
 /** I/O and environmental behavior supplied by the backend caller. */
 export interface SecurityFlaggingDependencies {
   authorizeReporter(reporterEmail: string): boolean | Promise<boolean>;

--- a/tools/v2/team/team-security-flagging/index.ts
+++ b/tools/v2/team/team-security-flagging/index.ts
@@ -2,14 +2,18 @@
 export {
   createSecurityFlaggingExecutor,
   executeSecurityFlagging,
+  executeSecurityFlaggingWithState,
   SecurityFlaggingErrorCode,
+  SecurityFlaggingExecutionStatus,
 } from "./services/security-flagging-execution.service.mjs";
 export type {
   SecurityFlaggingDependencies,
   SecurityFlaggingError,
   SecurityFlaggingErrorCode as SecurityFlaggingErrorCodeType,
   SecurityFlaggingExecutor,
+  SecurityFlaggingExecutionState,
   SecurityFlaggingInput,
   SecurityFlaggingOutput,
   SecurityFlaggingRecord,
+  SecurityFlaggingStateObserver,
 } from "./contract/execution-contract";

--- a/tools/v2/team/team-security-flagging/services/security-flagging-execution.service.mjs
+++ b/tools/v2/team/team-security-flagging/services/security-flagging-execution.service.mjs
@@ -20,6 +20,17 @@ export const SecurityFlaggingErrorCode = Object.freeze({
   INTERNAL_ERROR: "INTERNAL_ERROR",
 });
 
+/**
+ * Presentation-independent lifecycle states for a future caller.
+ * `loading` is emitted before any dependency is invoked; the terminal state
+ * contains the same result returned by the executor.
+ */
+export const SecurityFlaggingExecutionStatus = Object.freeze({
+  LOADING: "loading",
+  SUCCESS: "success",
+  ERROR: "error",
+});
+
 function failure(code, message, details = {}) {
   return { ok: false, error: { code, message, ...details } };
 }
@@ -113,4 +124,24 @@ export function createSecurityFlaggingExecutor(dependencies) {
 /** One-shot non-UI service entry point. */
 export function executeSecurityFlagging(input, dependencies) {
   return createSecurityFlaggingExecutor(dependencies).execute(input);
+}
+
+/**
+ * Execute while reporting deterministic lifecycle updates to a caller-supplied
+ * observer. The observer is optional and intentionally has no UI dependency.
+ */
+export async function executeSecurityFlaggingWithState(input, dependencies, onState) {
+  if (onState !== undefined && typeof onState !== "function") {
+    throw new TypeError("Security flagging state observer must be a function");
+  }
+
+  onState?.({ status: SecurityFlaggingExecutionStatus.LOADING });
+  const result = await executeSecurityFlagging(input, dependencies);
+  onState?.({
+    status: result.ok
+      ? SecurityFlaggingExecutionStatus.SUCCESS
+      : SecurityFlaggingExecutionStatus.ERROR,
+    result,
+  });
+  return result;
 }

--- a/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
+++ b/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
@@ -73,9 +73,13 @@ test("missing dependencies are rejected during construction", () => {
 
 test("stateful entry point reports loading then the terminal success state", async () => {
   const states = [];
-  const result = await executeSecurityFlaggingWithState(cases.success.input, dependencies(), (state) => {
-    states.push(state);
-  });
+  const result = await executeSecurityFlaggingWithState(
+    cases.success.input,
+    dependencies(),
+    (state) => {
+      states.push(state);
+    },
+  );
 
   assert.equal(result.ok, true);
   assert.deepEqual(states, [

--- a/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
+++ b/tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 import {
   createSecurityFlaggingExecutor,
   executeSecurityFlagging,
+  executeSecurityFlaggingWithState,
   SecurityFlaggingErrorCode,
+  SecurityFlaggingExecutionStatus,
 } from "../services/security-flagging-execution.service.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -67,4 +69,32 @@ test("duplicate failures expose the existing flag id", async () => {
 
 test("missing dependencies are rejected during construction", () => {
   assert.throws(() => createSecurityFlaggingExecutor(), TypeError);
+});
+
+test("stateful entry point reports loading then the terminal success state", async () => {
+  const states = [];
+  const result = await executeSecurityFlaggingWithState(cases.success.input, dependencies(), (state) => {
+    states.push(state);
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(states, [
+    { status: SecurityFlaggingExecutionStatus.LOADING },
+    { status: SecurityFlaggingExecutionStatus.SUCCESS, result },
+  ]);
+});
+
+test("stateful entry point reports a terminal error state", async () => {
+  const states = [];
+  const result = await executeSecurityFlaggingWithState(
+    { ...cases.success.input, severity: "urgent" },
+    dependencies(),
+    (state) => states.push(state),
+  );
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(states, [
+    { status: SecurityFlaggingExecutionStatus.LOADING },
+    { status: SecurityFlaggingExecutionStatus.ERROR, result },
+  ]);
 });


### PR DESCRIPTION
## Summary

Implements the isolated core feature engine for **#700 — Team Security Flagging**.

- Adds a folder-local execution lifecycle API for future UI/orchestration work.
- Reports deterministic `loading`, `success`, and `error` states.
- Keeps validation, authorization, duplicate detection, persistence, ID generation, and clock behavior dependency-injected.
- Documents inputs, terminal outputs, loading states, and stable error states.
- Adds local coverage for successful and failed lifecycle transitions.

## Scope

All changes are contained within:

`tools/v2/team/team-security-flagging/`

No main-app routing, inbox architecture, authentication, wallet, database schema, Stellar integration, or design-system code was changed.

## Testing

- `node --test tools/v2/team/team-security-flagging/tests/security-flagging.test.mjs tools/v2/team/team-security-flagging/tests/execution-contract.test.mjs`
- Result: 57 passing tests

## Notes

This remains an isolated V2 tool with no live network calls, secrets, or production data. Future mail-app/UI integration should be handled in a separate follow-up issue.

Closes #700