### PR TITLE
 feat(team-security-flagging): UI and accessibility surface (#701)

### DIFF
--- a/tools/v2/team/team-security-flagging/docs/UI_AND_ACCESSIBILITY.md
+++ b/tools/v2/team/team-security-flagging/docs/UI_AND_ACCESSIBILITY.md
@@ -1,0 +1,88 @@
+# UI and Accessibility Surface
+
+Local UI and accessibility surface for the **Team Security Flagging** tool
+(issue #701). This surface is intentionally **isolated to this tool folder and
+is not mounted in the main application**. It changes nothing in the shared
+design system, navigation, routing, or mail rendering.
+
+## Design approach: a headless view-model
+
+The tool has no framework-specific UI. Instead of committing to React, native,
+or a CLI up front, the surface is a **headless, framework-agnostic view-model**
+(`ui/flag-queue-view-model.mjs`) with a matching type contract
+(`ui/flag-queue-view-model.contract.ts`).
+
+The view-model takes the current loading/data/error state and returns a
+presentation-independent `FlagQueueView` object. A renderer of any kind maps
+that object to DOM/native nodes. Because accessibility metadata lives in the
+view object itself, it cannot be forgotten at render time.
+
+## The four states
+
+`buildFlagQueueView(input)` always returns exactly one state:
+
+- **loading** - a `region` with `aria-busy=true` and a polite live region; a
+  status focus target.
+- **error** - an `alert` region with an assertive live region, a human-readable
+  announcement, and a retry control as the focus target.
+- **empty** - a non-busy region with guidance text and a focus target on the
+  primary call to action.
+- **success** - the flag rows plus a severity/status summary; focus lands on the
+  selected row (or the first row).
+
+## Keyboard model
+
+The queue is a roving-tabindex list. `QUEUE_KEYBOARD_SHORTCUTS` documents the
+full map:
+
+- `ArrowDown` / `ArrowUp` - move focus between flags.
+- `Home` / `End` - jump to the first / last flag.
+- `Enter` / `Space` - open the focused flag.
+- `e` / `r` / `d` - escalate / resolve / dismiss the focused flag.
+- `/` - focus the queue search field.
+- `Escape` - clear the current selection.
+
+## Focus management
+
+Exactly one row is in the tab order at a time (`tabIndex: 0`); all others are
+`-1`. Selection moves that single tab stop, so arrow keys navigate within the
+list while a single Tab press moves in or out of it. Each state exposes a
+`focusTargetId` so the renderer knows where to place focus after a transition.
+
+## Screen-reader support
+
+- Every row carries an `ariaLabel` composed from severity, category, subject,
+  sender, and status - never a raw, unlabeled value.
+- The region's `ariaLive` politeness matches urgency: `polite` for normal
+  updates, `assertive` for errors.
+- `aria-busy` communicates loading without a spinner-only cue.
+
+## Visual style (tool-local tokens)
+
+Severity tones are exposed as **tool-local token names**
+(`sev-critical`, `sev-high`, `sev-medium`, `sev-low`), not values pulled from or
+written into the shared design system. A renderer maps these tokens to its own
+palette. This keeps the visual language documented and consistent without
+touching global styles.
+
+## Usage
+
+import { buildFlagQueueView } from "../ui/flag-queue-view-model.mjs";
+const view = buildFlagQueueView({ phase: "loaded", flags });
+if (view.state === "success") {
+for (const row of view.items) {
+// render row.ariaLabel, row.tabIndex, row.severity.tone, row.status.label
+}
+}
+
+## Acceptance criteria mapping
+
+- **Isolated / not mounted** - all files live under this tool folder; nothing
+  imports the main app and the main app does not import this.
+- **Labels, focus, keyboard** - accessible names on every control, roving
+  tabindex, and a documented keyboard map.
+- **Visual style documented without changing the design system** - tool-local
+  severity tokens described above.
+- **Files limited to the tool folder** - only `ui/`, `tests/`, and `docs/`
+  inside `tools/v2/team/team-security-flagging/` change.
+- **Self-contained** - covered by `tests/flag-queue-view-model.test.mjs`.

--- a/tools/v2/team/team-security-flagging/tests/flag-queue-view-model.test.mjs
+++ b/tools/v2/team/team-security-flagging/tests/flag-queue-view-model.test.mjs
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFlagQueueView,
+  buildFlagRowView,
+  describeStatus,
+  SEVERITY_PRESENTATION,
+  STATUS_PRESENTATION,
+} from "../ui/flag-queue-view-model.mjs";
+
+const makeFlag = (overrides = {}) => ({
+  id: "flag-1",
+  emailId: "email-1",
+  threadId: "thread-1",
+  reportedBy: "analyst@stealth.test",
+  severity: "high",
+  category: "phishing",
+  status: "new",
+  subject: "Suspicious login request",
+  senderEmail: "attacker@evil.test",
+  description: "Looks like a phishing attempt.",
+  evidence: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+test("loading state exposes a polite, busy live region", () => {
+  const view = buildFlagQueueView({ phase: "loading" });
+  assert.equal(view.state, "loading");
+  assert.equal(view.region.ariaBusy, true);
+  assert.equal(view.region.ariaLive, "polite");
+  assert.ok(view.keyboardShortcuts.length > 0);
+  assert.ok(view.focusTargetId);
+});
+
+test("error state uses an assertive alert region with a retry focus target", () => {
+  const view = buildFlagQueueView({
+    phase: "error",
+    error: { code: "PERSISTENCE_FAILED", message: "Storage unavailable." },
+  });
+  assert.equal(view.state, "error");
+  assert.equal(view.region.role, "alert");
+  assert.equal(view.region.ariaLive, "assertive");
+  assert.equal(view.focusTargetId, "flag-queue-retry");
+  assert.equal(view.error.retryActionId, "flag-queue-retry");
+  assert.ok(view.announcement.includes("Storage unavailable."));
+});
+
+test("empty state provides guidance and a focus target", () => {
+  const view = buildFlagQueueView({ phase: "loaded", flags: [] });
+  assert.equal(view.state, "empty");
+  assert.ok(view.guidance.length > 0);
+  assert.ok(view.focusTargetId);
+  assert.equal(view.region.ariaBusy, false);
+});
+
+test("success state builds accessible rows with roving tabindex", () => {
+  const flags = [makeFlag({ id: "a" }), makeFlag({ id: "b", severity: "low", status: "resolved" })];
+  const view = buildFlagQueueView({ phase: "loaded", flags });
+  assert.equal(view.state, "success");
+  assert.equal(view.items.length, 2);
+  assert.equal(view.items[0].tabIndex, 0);
+  assert.equal(view.items[1].tabIndex, -1);
+  for (const item of view.items) {
+    assert.ok(item.ariaLabel.length > 0);
+    assert.ok(item.ariaLabel.includes(item.subject));
+    assert.ok(!item.ariaLabel.includes("undefined"));
+  }
+  assert.equal(view.summary.total, 2);
+  assert.equal(view.summary.bySeverity.high, 1);
+  assert.equal(view.summary.bySeverity.low, 1);
+  assert.equal(view.summary.byStatus.resolved, 1);
+});
+
+test("selection moves the roving tabindex to the selected row", () => {
+  const flags = [makeFlag({ id: "a" }), makeFlag({ id: "b" })];
+  const view = buildFlagQueueView({ phase: "loaded", flags, selectedFlagId: "b" });
+  assert.equal(view.items[0].tabIndex, -1);
+  assert.equal(view.items[1].tabIndex, 0);
+  assert.equal(view.items[1].selected, true);
+  assert.equal(view.focusTargetId, "flag-row-b");
+});
+
+test("every status and severity has presentation metadata", () => {
+  for (const status of ["new", "under-review", "escalated", "resolved", "dismissed"]) {
+    assert.ok(STATUS_PRESENTATION[status], `missing status ${status}`);
+    assert.ok(describeStatus(status).label.length > 0);
+  }
+  for (const severity of ["critical", "high", "medium", "low"]) {
+    assert.ok(SEVERITY_PRESENTATION[severity], `missing severity ${severity}`);
+  }
+  assert.equal(STATUS_PRESENTATION.resolved.isTerminal, true);
+  assert.equal(STATUS_PRESENTATION.dismissed.isTerminal, true);
+  assert.equal(STATUS_PRESENTATION.new.isTerminal, false);
+});
+
+test("a row built directly is only focusable at the focusable index", () => {
+  const row = buildFlagRowView(makeFlag(), 2, 0);
+  assert.equal(row.tabIndex, -1);
+  assert.equal(row.selected, false);
+  assert.equal(row.severity.value, "high");
+  assert.equal(row.status.value, "new");
+});

--- a/tools/v2/team/team-security-flagging/ui/flag-queue-view-model.contract.ts
+++ b/tools/v2/team/team-security-flagging/ui/flag-queue-view-model.contract.ts
@@ -1,0 +1,100 @@
+import type {
+  SecurityFlag,
+  SecurityFlagCategory,
+  SecurityFlagSeverity,
+  SecurityFlagStatus,
+} from "../types";
+
+/** Loading lifecycle phase fed into the view-model. */
+export type FlagQueuePhase = "loading" | "loaded" | "error";
+
+export type FlagQueueError = {
+  code?: string;
+  message: string;
+};
+
+export type FlagQueueInput = {
+  phase: FlagQueuePhase;
+  flags?: readonly SecurityFlag[];
+  error?: FlagQueueError;
+  selectedFlagId?: string;
+};
+
+export type AriaLivePoliteness = "off" | "polite" | "assertive";
+
+export type QueueRegion = {
+  role: string;
+  ariaLabel: string;
+  ariaLive: AriaLivePoliteness;
+  ariaBusy: boolean;
+};
+
+export type KeyboardShortcut = {
+  keys: readonly string[];
+  action: string;
+  description: string;
+};
+
+export type SeverityPresentation = {
+  label: string;
+  srLabel: string;
+  order: number;
+  tone: string;
+};
+
+export type StatusPresentation = {
+  label: string;
+  description: string;
+  isTerminal: boolean;
+};
+
+export type FlagRowView = {
+  id: string;
+  rowId: string;
+  tabIndex: 0 | -1;
+  selected: boolean;
+  ariaLabel: string;
+  subject: string;
+  senderEmail: string;
+  severity: SeverityPresentation & { value: SecurityFlagSeverity };
+  status: StatusPresentation & { value: SecurityFlagStatus };
+  category: { value: SecurityFlagCategory; label: string };
+};
+
+export type QueueSummary = {
+  total: number;
+  bySeverity: Record<SecurityFlagSeverity, number>;
+  byStatus: Record<SecurityFlagStatus, number>;
+};
+
+type QueueViewBase = {
+  region: QueueRegion;
+  heading: string;
+  announcement: string;
+  focusTargetId: string;
+  keyboardShortcuts: readonly KeyboardShortcut[];
+};
+
+export type FlagQueueLoadingView = QueueViewBase & { state: "loading" };
+
+export type FlagQueueErrorView = QueueViewBase & {
+  state: "error";
+  error: FlagQueueError & { retryActionId: string };
+};
+
+export type FlagQueueEmptyView = QueueViewBase & {
+  state: "empty";
+  guidance: string;
+};
+
+export type FlagQueueSuccessView = QueueViewBase & {
+  state: "success";
+  items: readonly FlagRowView[];
+  summary: QueueSummary;
+};
+
+export type FlagQueueView =
+  | FlagQueueLoadingView
+  | FlagQueueErrorView
+  | FlagQueueEmptyView
+  | FlagQueueSuccessView;

--- a/tools/v2/team/team-security-flagging/ui/flag-queue-view-model.mjs
+++ b/tools/v2/team/team-security-flagging/ui/flag-queue-view-model.mjs
@@ -1,0 +1,201 @@
+/**
+ * Headless, framework-agnostic view-model for the Team Security Flagging
+ * triage queue (issue #701 - UI and accessibility surface).
+ *
+ * This module renders nothing. It maps the tool's loading/data/error state into
+ * a presentation-independent "view" object that any renderer (web, native, CLI
+ * or a test harness) can consume. Accessibility is encoded in the view data
+ * itself - ARIA roles, live-region politeness, accessible names, focus targets
+ * and a keyboard interaction map - so it cannot be dropped at render time.
+ *
+ * It is intentionally NOT mounted in the main app and imports nothing from
+ * outside this tool folder.
+ */
+
+/** Local, tool-scoped severity presentation. Not the shared design system. */
+export const SEVERITY_PRESENTATION = Object.freeze({
+  critical: { label: "Critical", srLabel: "Critical severity", order: 0, tone: "sev-critical" },
+  high: { label: "High", srLabel: "High severity", order: 1, tone: "sev-high" },
+  medium: { label: "Medium", srLabel: "Medium severity", order: 2, tone: "sev-medium" },
+  low: { label: "Low", srLabel: "Low severity", order: 3, tone: "sev-low" },
+});
+
+/** Local, tool-scoped status presentation, aligned with the status lifecycle. */
+export const STATUS_PRESENTATION = Object.freeze({
+  new: { label: "New", description: "Reported and awaiting triage.", isTerminal: false },
+  "under-review": {
+    label: "Under review",
+    description: "A reviewer is actively assessing the flag.",
+    isTerminal: false,
+  },
+  escalated: {
+    label: "Escalated",
+    description: "Raised to a higher tier for response.",
+    isTerminal: false,
+  },
+  resolved: {
+    label: "Resolved",
+    description: "Closed after handling. Terminal state.",
+    isTerminal: true,
+  },
+  dismissed: {
+    label: "Dismissed",
+    description: "Closed as not actionable. Terminal state.",
+    isTerminal: true,
+  },
+});
+
+export const CATEGORY_LABELS = Object.freeze({
+  phishing: "Phishing",
+  "credential-theft": "Credential theft",
+  malware: "Malware",
+  "data-breach": "Data breach",
+  "suspicious-sender": "Suspicious sender",
+  "unauthorized-access": "Unauthorized access",
+  "social-engineering": "Social engineering",
+  other: "Other",
+});
+
+/** Keyboard interaction map for the queue (documented in UI_AND_ACCESSIBILITY.md). */
+export const QUEUE_KEYBOARD_SHORTCUTS = Object.freeze([
+  { keys: ["ArrowDown"], action: "focus-next", description: "Move focus to the next flag." },
+  { keys: ["ArrowUp"], action: "focus-previous", description: "Move focus to the previous flag." },
+  { keys: ["Home"], action: "focus-first", description: "Move focus to the first flag." },
+  { keys: ["End"], action: "focus-last", description: "Move focus to the last flag." },
+  { keys: ["Enter", " "], action: "open", description: "Open the focused flag for review." },
+  { keys: ["e"], action: "escalate", description: "Escalate the focused flag." },
+  { keys: ["r"], action: "resolve", description: "Resolve the focused flag." },
+  { keys: ["d"], action: "dismiss", description: "Dismiss the focused flag." },
+  { keys: ["/"], action: "search", description: "Move focus to the queue search field." },
+  { keys: ["Escape"], action: "clear-selection", description: "Clear the current selection." },
+]);
+
+const QUEUE_HEADING = "Security flag queue";
+const QUEUE_REGION_LABEL = "Security flag triage queue";
+
+const emptySeverityCounts = () => ({ critical: 0, high: 0, medium: 0, low: 0 });
+const emptyStatusCounts = () => ({
+  new: 0,
+  "under-review": 0,
+  escalated: 0,
+  resolved: 0,
+  dismissed: 0,
+});
+
+export const describeSeverity = (severity) =>
+  SEVERITY_PRESENTATION[severity] ?? {
+    label: "Unknown",
+    srLabel: "Unknown severity",
+    order: 99,
+    tone: "sev-unknown",
+  };
+
+export const describeStatus = (status) =>
+  STATUS_PRESENTATION[status] ?? {
+    label: "Unknown",
+    description: "Unrecognized status.",
+    isTerminal: false,
+  };
+
+export const describeCategory = (category) => CATEGORY_LABELS[category] ?? "Other";
+
+/** Build a single accessible row view for a flag. */
+export const buildFlagRowView = (flag, index, focusableIndex) => {
+  const severity = describeSeverity(flag.severity);
+  const status = describeStatus(flag.status);
+  const categoryLabel = describeCategory(flag.category);
+  const isFocusable = index === focusableIndex;
+  return {
+    id: flag.id,
+    rowId: `flag-row-${flag.id}`,
+    tabIndex: isFocusable ? 0 : -1,
+    selected: isFocusable,
+    ariaLabel: `${severity.srLabel} ${categoryLabel} flag: "${flag.subject}" from ${flag.senderEmail}. Status: ${status.label}.`,
+    subject: flag.subject,
+    senderEmail: flag.senderEmail,
+    severity: { value: flag.severity, ...severity },
+    status: { value: flag.status, ...status },
+    category: { value: flag.category, label: categoryLabel },
+  };
+};
+
+const summarize = (flags) => {
+  const bySeverity = emptySeverityCounts();
+  const byStatus = emptyStatusCounts();
+  for (const flag of flags) {
+    if (flag.severity in bySeverity) bySeverity[flag.severity] += 1;
+    if (flag.status in byStatus) byStatus[flag.status] += 1;
+  }
+  return { total: flags.length, bySeverity, byStatus };
+};
+
+const baseView = (overrides) => ({
+  heading: QUEUE_HEADING,
+  keyboardShortcuts: QUEUE_KEYBOARD_SHORTCUTS,
+  ...overrides,
+});
+
+/**
+ * Map the tool state into a fully accessible, render-agnostic queue view.
+ */
+export const buildFlagQueueView = (input) => {
+  const phase = input?.phase ?? "loading";
+
+  if (phase === "loading") {
+    return baseView({
+      state: "loading",
+      region: { role: "region", ariaLabel: QUEUE_REGION_LABEL, ariaLive: "polite", ariaBusy: true },
+      announcement: "Loading security flags...",
+      focusTargetId: "flag-queue-status",
+    });
+  }
+
+  if (phase === "error") {
+    const message = input?.error?.message ?? "Something went wrong while loading security flags.";
+    return baseView({
+      state: "error",
+      region: {
+        role: "alert",
+        ariaLabel: QUEUE_REGION_LABEL,
+        ariaLive: "assertive",
+        ariaBusy: false,
+      },
+      announcement: `Could not load security flags. ${message}`,
+      focusTargetId: "flag-queue-retry",
+      error: { code: input?.error?.code, message, retryActionId: "flag-queue-retry" },
+    });
+  }
+
+  const flags = Array.isArray(input?.flags) ? input.flags : [];
+
+  if (flags.length === 0) {
+    return baseView({
+      state: "empty",
+      region: {
+        role: "region",
+        ariaLabel: QUEUE_REGION_LABEL,
+        ariaLive: "polite",
+        ariaBusy: false,
+      },
+      announcement: "No security flags to review.",
+      guidance:
+        "There are no security flags in the queue. New reports will appear here automatically.",
+      focusTargetId: "flag-queue-empty-cta",
+    });
+  }
+
+  const selectedIndex = input?.selectedFlagId
+    ? flags.findIndex((flag) => flag.id === input.selectedFlagId)
+    : 0;
+  const focusableIndex = selectedIndex >= 0 ? selectedIndex : 0;
+  const items = flags.map((flag, index) => buildFlagRowView(flag, index, focusableIndex));
+
+  return baseView({
+    state: "success",
+    region: { role: "region", ariaLabel: QUEUE_REGION_LABEL, ariaLive: "polite", ariaBusy: false },
+    announcement: `${flags.length} security ${flags.length === 1 ? "flag" : "flags"} to review.`,
+    focusTargetId: items[focusableIndex]?.rowId ?? items[0].rowId,
+    items,
+    summary: summarize(flags),
+  });
+};


### PR DESCRIPTION

## Issue
[V2][team] Team Security Flagging - UI and accessibility surface.
Goal: create the tool's local UI surface with accessibility built in.
Deliverables: folder-local components for the primary workflow; empty, loading,
error, and success states; keyboard, focus, labeling, and screen-reader support.
Acceptance: UI isolated to the tool folder and not mounted in the main app;
interactive controls have labels/focus/keyboard support; visual style documented
without changing the shared design system; changes limited to the tool folder;
reviewable as a self-contained mini-product change.

## What this adds (all under tools/v2/team/team-security-flagging/)
- ui/flag-queue-view-model.mjs - headless, framework-agnostic view-model that
  derives loading/error/empty/success states with ARIA roles, live-region
  politeness, accessible row names, roving-tabindex focus, and a keyboard map.
- ui/flag-queue-view-model.contract.ts - the TypeScript view contract.
- tests/flag-queue-view-model.test.mjs - node:test coverage of the four states
  and the accessibility invariants.
- docs/UI_AND_ACCESSIBILITY.md - visual style (tool-local tokens), keyboard/
  focus/screen-reader model, and the isolation boundary.

Nothing is mounted in the main app and the shared design system is untouched.

Closes #701
