### PR TITLE
feat(escalation-tool): define typed execution contract, non-UI service, and fixtures

### DIFF
--- a/tools/v2/team/escalation-tool/CONTRACT.md
+++ b/tools/v2/team/escalation-tool/CONTRACT.md
@@ -1,0 +1,87 @@
+# Escalation Tool Execution Contract
+
+This document defines the stable, presentation-independent execution contract for the Escalation Tool.
+It has no React, DOM, styling, routing, transport, or database dependency.
+
+## Entry Point
+
+```ts
+import {
+  escalationToolService,
+  createEscalationToolService,
+} from "./tools/v2/team/escalation-tool";
+
+const result = await escalationToolService.execute(input);
+```
+
+The default `escalationToolService` processes escalations in memory. Applications requiring persistence supply an `EscalationRepository`:
+
+```ts
+const service = createEscalationToolService({ repository });
+const result = await service.execute(input);
+```
+
+Injectable `generateId` and `now` dependencies allow deterministic testing and clock control for backend integration.
+
+## Input: `EscalationInput`
+
+| Field              | Type                 | Required | Description                                                              |
+| ------------------ | -------------------- | -------- | ------------------------------------------------------------------------ |
+| `conversationId`   | `string`             | yes      | Non-empty ID of the conversation being escalated.                        |
+| `reason`           | `string`             | yes      | Non-empty explanation for the escalation request.                        |
+| `priority`         | `EscalationPriority` | yes      | Priority level: `"low" \| "medium" \| "high" \| "urgent"`.               |
+| `requestedBy`      | `string`             | yes      | Non-empty identity of the actor initiating the escalation.               |
+| `targetDepartment` | `string`             | no       | Target department or group (defaults to `"general-support"` if omitted). |
+| `notes`            | `string`             | no       | Additional notes or context.                                             |
+| `correlationId`    | `string`             | no       | Opaque value propagated to the output record.                            |
+
+## Output: `EscalationToolResult`
+
+The result is a discriminated union:
+
+```ts
+type EscalationToolResult =
+  | { ok: true; data: EscalationRecord }
+  | { ok: false; error: EscalationError };
+```
+
+A successful `EscalationRecord` contains:
+
+- `id`: `string` (generated unique record ID)
+- `conversationId`: `string`
+- `reason`: `string`
+- `priority`: `EscalationPriority`
+- `requestedBy`: `string`
+- `targetDepartment`: `string`
+- `status`: `"open" | "in_review" | "resolved" | "dismissed"` (defaults to `"open"`)
+- `createdAt`: `string` (ISO-8601 timestamp)
+- `notes`?: `string`
+- `correlationId`?: `string`
+
+Consumers must use `result.ok` to narrow the result.
+
+## Error Codes
+
+| Code                 | Meaning                                                                     |
+| -------------------- | --------------------------------------------------------------------------- |
+| `INVALID_INPUT`      | A required string input is missing or empty.                                |
+| `INVALID_PRIORITY`   | The priority value is not one of `"low" \| "medium" \| "high" \| "urgent"`. |
+| `PERSISTENCE_FAILED` | The injected repository threw an error while saving.                        |
+| `INTERNAL_ERROR`     | An unexpected execution error occurred.                                     |
+
+Input validation errors include a `field` dot-path attribute (e.g. `conversationId`).
+
+## Service Boundary
+
+- **Executor owns**: Input validation, payload normalization, timestamp and ID assignment, and mapping errors to typed results.
+- **Caller owns**: Authentication, authorization, routing, database transactions, UI rendering, and downstream workflow execution.
+
+## Fixtures
+
+`fixtures/execution.fixtures.ts` exports:
+
+- `successfulEscalationInput`: Valid input fixture
+- `missingConversationIdInput`: Invalid conversationId failure fixture
+- `missingReasonInput`: Invalid reason failure fixture
+- `invalidPriorityInput`: Invalid priority failure fixture
+- `failingRepository`: Mock repository simulating persistence failure

--- a/tools/v2/team/escalation-tool/README.md
+++ b/tools/v2/team/escalation-tool/README.md
@@ -6,9 +6,7 @@ This workspace is intentionally independent from the main application until a fu
 
 ## Purpose
 
-The tool is intended to support team workflows that require escalating conversations based on predefined business rules or manual review.
-
-Current work in this folder focuses on documentation and review guidance only.
+The tool supports team workflows that require escalating conversations based on predefined business rules or manual review. It exports a presentation-independent backend service contract so execution can run independently of UI concerns.
 
 ## Ownership Boundary
 
@@ -30,14 +28,32 @@ Do not modify or integrate with:
 - Database schema
 - Shared design system
 
+## Execution & Service Entry Point
+
+```ts
+import { escalationToolService } from "./tools/v2/team/escalation-tool";
+
+const result = await escalationToolService.execute({
+  conversationId: "conv-123",
+  reason: "SLA breach",
+  priority: "high",
+  requestedBy: "user-456",
+});
+```
+
+See `CONTRACT.md` for complete input, output, error code, and service boundary specifications.
+
 ## Documentation
 
+- `CONTRACT.md` — backend execution contract, error codes, and service boundaries
 - `specs.md` — tool scope and contributor expectations
-- `docs/TEST_PLAN.md` — planned validation strategy
+- `docs/TEST_PLAN.md` — validation strategy and unit test verification
 - `docs/REVIEW_NOTES.md` — reviewer guidance
 
-## Current Status
+## Testing
 
-The implementation is not yet available.
+Run isolated unit tests for this workspace:
 
-This workspace currently provides documentation and a contributor-friendly validation plan for future development.
+```bash
+npx vitest run --config tools/v2/team/escalation-tool/vitest.config.ts
+```

--- a/tools/v2/team/escalation-tool/docs/REVIEW_NOTES.md
+++ b/tools/v2/team/escalation-tool/docs/REVIEW_NOTES.md
@@ -2,46 +2,34 @@
 
 ## Purpose
 
-This contribution improves the contributor documentation for the Escalation Tool while keeping all work isolated to the tool workspace.
+This contribution defines a typed, presentation-independent execution contract for the Escalation Tool while keeping all work completely isolated inside the tool workspace.
 
 ## Scope
 
-All modified files are contained within:
+All modified and created files are contained within:
 
 ```text
 tools/v2/team/escalation-tool/
 ```
 
-No application routing, authentication, inbox workflow, database, wallet, Stellar integration, or shared UI components were modified.
+No application routing, authentication, inbox workflow, database, wallet, Stellar integration, shared UI components, styling, or layout files were modified.
 
 ## How to Review
 
-1. Read `README.md` for an overview of the tool.
-2. Review `specs.md` for ownership boundaries and scope.
-3. Read `docs/TEST_PLAN.md`.
-4. Confirm the documentation clearly explains setup, intended usage, review expectations, and known limitations.
-5. Verify all modified files remain inside:
-
-```text
-tools/v2/team/escalation-tool/
-```
+1. Read `README.md` and `CONTRACT.md` for an overview of the execution contract.
+2. Review `types/contract.ts` for typed inputs, outputs, and error codes.
+3. Inspect `services/execution.service.ts` for the non-UI service entry point.
+4. Inspect `fixtures/execution.fixtures.ts` for success and failure fixtures.
+5. Run the isolated test suite:
+   ```bash
+   npx vitest run --config tools/v2/team/escalation-tool/vitest.config.ts
+   ```
+6. Verify all files remain inside `tools/v2/team/escalation-tool/`.
 
 ## Expected Result
 
-- Documentation is complete and contributor friendly.
-- Review guidance is clear and easy to follow.
+- Non-UI service entry point is exported (`escalationToolService`, `createEscalationToolService`).
+- Typed input and output contract is documented in `CONTRACT.md`.
+- Success and failure fixtures are exported from `fixtures/execution.fixtures.ts`.
+- Unit tests pass with zero errors.
 - The workspace remains fully isolated.
-- Future implementation can proceed without modifying the main application.
-
-## Out of Scope
-
-The following are intentionally excluded from this issue:
-
-- Application routing
-- Inbox integration
-- Authentication
-- Database changes
-- Wallet integration
-- Stellar integration
-- Shared design system
-- External services

--- a/tools/v2/team/escalation-tool/docs/TEST_PLAN.md
+++ b/tools/v2/team/escalation-tool/docs/TEST_PLAN.md
@@ -2,76 +2,52 @@
 
 ## Overview
 
-The Escalation Tool implementation is not yet available.
+The Escalation Tool provides a presentation-independent execution contract and isolated service implementation.
+This document outlines the validation strategy covering automated unit tests, fixtures, contract enforcement, and isolation checks.
 
-This document provides the validation strategy for future contributors while ensuring documentation is available for independent review.
+## Automated Unit Tests
 
-## Documentation Review
+Automated tests cover:
 
-Confirm that:
+- Successful escalation creation with normalized attributes and timestamps
+- Input validation failures (missing `conversationId`, missing `reason`, empty strings)
+- Priority validation (rejecting invalid priority values)
+- Correlation ID propagation
+- Persistence error handling when an injected repository throws
+- Custom clock (`now`) and ID generator (`generateId`) dependency injection
 
-- `README.md` accurately describes the workspace.
-- `specs.md` defines scope and ownership boundaries.
-- Review notes clearly explain validation expectations.
-- All documentation remains isolated to this tool.
+Run unit tests via:
+
+```bash
+npx vitest run --config tools/v2/team/escalation-tool/vitest.config.ts
+```
+
+## Fixtures
+
+`fixtures/execution.fixtures.ts` provides deterministic fixtures for testing and consumer integration:
+
+- `successfulEscalationInput` — valid high-priority escalation request
+- `missingConversationIdInput` — invalid whitespace conversation ID
+- `missingReasonInput` — invalid empty reason string
+- `invalidPriorityInput` — invalid priority level
+- `failingRepository` — repository mock throwing persistence errors
 
 ## Manual Review Checklist
 
-1. Confirm all modified files are contained within:
+1. Confirm all modified/created files are contained within:
 
 ```text
 tools/v2/team/escalation-tool/
 ```
 
-2. Confirm no application integration has been introduced.
+2. Confirm no UI layout or styling files were changed.
+3. Verify `CONTRACT.md` documents typed inputs, outputs, error codes, and service boundaries.
+4. Verify non-UI service entry point is exported from `index.ts`.
+5. Confirm unit tests pass cleanly.
 
-3. Verify contributor guidance is complete.
+## Acceptance Criteria Verification
 
-4. Verify ownership boundaries are clearly documented.
-
-5. Confirm future integration is documented as follow-up work rather than implemented here.
-
-## Future Unit Tests
-
-When implementation begins, add tests covering:
-
-- Escalation rule evaluation
-- Escalation creation
-- Escalation status updates
-- Priority handling
-- Error handling
-- Invalid input validation
-
-## Future Integration Tests
-
-Once integration is permitted, validate:
-
-- Mailbox interaction
-- Team workflow integration
-- Notification behavior
-- Permission enforcement
-- Audit logging
-
-## Edge Cases
-
-Future tests should include:
-
-- Missing escalation target
-- Duplicate escalation requests
-- Invalid priority values
-- Empty conversation input
-- Simultaneous escalation attempts
-- Permission failures
-
-## Known Limitations
-
-- Core implementation is not yet available.
-- Automated tests cannot be added until implementation exists.
-- This document serves as the planned validation strategy for future development.
-
-## Acceptance Criteria
-
-- Documentation is complete.
-- Validation strategy is documented.
-- Scope remains isolated.
-- No application-wide integration is introduced.
+- [x] Typed input and output contract is documented (`CONTRACT.md`)
+- [x] Non-UI service entry point is exported (`escalationToolService`, `createEscalationToolService`)
+- [x] Fixtures cover success and failure cases (`fixtures/execution.fixtures.ts`)
+- [x] No styling or layout files are changed

--- a/tools/v2/team/escalation-tool/fixtures/execution.fixtures.ts
+++ b/tools/v2/team/escalation-tool/fixtures/execution.fixtures.ts
@@ -1,0 +1,44 @@
+import type { EscalationInput } from "../types/contract";
+import type { EscalationRepository } from "../services/execution.service";
+
+/** Deterministic successful escalation input. */
+export const successfulEscalationInput: EscalationInput = {
+  conversationId: "conv-102938",
+  reason: "SLA threshold breached — customer waiting over 4 hours for security review",
+  priority: "high",
+  requestedBy: "agent-alice-42",
+  targetDepartment: "compliance",
+  notes: "Customer requires verification of proof certificate",
+  correlationId: "corr-778899",
+};
+
+/** Failure fixture: missing required conversationId. */
+export const missingConversationIdInput: EscalationInput = {
+  conversationId: "   ",
+  reason: "Unresolved refund inquiry",
+  priority: "medium",
+  requestedBy: "agent-bob-12",
+};
+
+/** Failure fixture: missing required reason. */
+export const missingReasonInput: EscalationInput = {
+  conversationId: "conv-445566",
+  reason: "",
+  priority: "low",
+  requestedBy: "agent-charlie-99",
+};
+
+/** Failure fixture: invalid priority value. */
+export const invalidPriorityInput: EscalationInput = {
+  conversationId: "conv-889900",
+  reason: "Needs tier-2 tech analysis",
+  priority: "critical" as any,
+  requestedBy: "agent-dave-01",
+};
+
+/** Mock repository that simulates a persistence failure. */
+export const failingRepository: EscalationRepository = {
+  save: async () => {
+    throw new Error("Database connection timeout");
+  },
+};

--- a/tools/v2/team/escalation-tool/index.ts
+++ b/tools/v2/team/escalation-tool/index.ts
@@ -1,0 +1,25 @@
+export { createEscalationToolService, escalationToolService } from "./services";
+export type {
+  EscalationRepository,
+  EscalationToolDependencies,
+  EscalationToolService,
+} from "./services";
+
+export type {
+  EscalationErrorCode,
+  EscalationError,
+  EscalationInput,
+  EscalationPriority,
+  EscalationRecord,
+  EscalationStatus,
+  EscalationToolResult,
+  ExecuteEscalationTool,
+} from "./types";
+
+export {
+  failingRepository,
+  invalidPriorityInput,
+  missingConversationIdInput,
+  missingReasonInput,
+  successfulEscalationInput,
+} from "./fixtures/execution.fixtures";

--- a/tools/v2/team/escalation-tool/services/execution.service.ts
+++ b/tools/v2/team/escalation-tool/services/execution.service.ts
@@ -1,0 +1,108 @@
+import type {
+  EscalationErrorCode,
+  EscalationInput,
+  EscalationPriority,
+  EscalationRecord,
+  EscalationToolResult,
+} from "../types/contract";
+
+/** Optional persistence boundary for storing escalation records. */
+export interface EscalationRepository {
+  save(record: EscalationRecord): Promise<void>;
+}
+
+export interface EscalationToolDependencies {
+  repository?: EscalationRepository;
+  generateId?: () => string;
+  now?: () => Date;
+}
+
+const VALID_PRIORITIES = new Set<EscalationPriority>(["low", "medium", "high", "urgent"]);
+
+function failure(code: EscalationErrorCode, message: string, field?: string): EscalationToolResult {
+  return { ok: false, error: { code, message, ...(field ? { field } : {}) } };
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateInput(input: EscalationInput): EscalationToolResult | undefined {
+  if (!input || typeof input !== "object") {
+    return failure("INVALID_INPUT", "Input must be a valid object");
+  }
+
+  const requiredFields: Array<[keyof EscalationInput, unknown]> = [
+    ["conversationId", input.conversationId],
+    ["reason", input.reason],
+    ["requestedBy", input.requestedBy],
+  ];
+
+  for (const [field, value] of requiredFields) {
+    if (!nonEmptyString(value)) {
+      return failure("INVALID_INPUT", `${field} must be a non-empty string`, field);
+    }
+  }
+
+  if (!input.priority || !VALID_PRIORITIES.has(input.priority)) {
+    return failure(
+      "INVALID_PRIORITY",
+      `priority must be one of: ${Array.from(VALID_PRIORITIES).join(", ")}`,
+      "priority",
+    );
+  }
+}
+
+function defaultGenerateId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `esc-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+  );
+}
+
+/**
+ * Creates a presentation-independent escalation service with injectable clock, ID generation, and storage repository.
+ */
+export function createEscalationToolService(dependencies: EscalationToolDependencies = {}) {
+  const generateId = dependencies.generateId ?? defaultGenerateId;
+  const now = dependencies.now ?? (() => new Date());
+
+  async function execute(input: EscalationInput): Promise<EscalationToolResult> {
+    try {
+      const validationFailure = validateInput(input);
+      if (validationFailure) return validationFailure;
+
+      const record: EscalationRecord = {
+        id: generateId(),
+        conversationId: input.conversationId.trim(),
+        reason: input.reason.trim(),
+        priority: input.priority,
+        requestedBy: input.requestedBy.trim(),
+        targetDepartment: input.targetDepartment?.trim() || "general-support",
+        status: "open",
+        createdAt: now().toISOString(),
+        ...(input.notes !== undefined ? { notes: input.notes.trim() } : {}),
+        ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+      };
+
+      if (dependencies.repository) {
+        try {
+          await dependencies.repository.save(record);
+        } catch {
+          return failure("PERSISTENCE_FAILED", "The escalation record could not be persisted");
+        }
+      }
+
+      return { ok: true, data: record };
+    } catch {
+      return failure("INTERNAL_ERROR", "Escalation tool execution failed unexpectedly");
+    }
+  }
+
+  return { execute };
+}
+
+/** Default backend-facing entry point operating in-memory. */
+export const escalationToolService = createEscalationToolService();
+
+export type EscalationToolService = ReturnType<typeof createEscalationToolService>;

--- a/tools/v2/team/escalation-tool/services/index.ts
+++ b/tools/v2/team/escalation-tool/services/index.ts
@@ -1,0 +1,6 @@
+export { createEscalationToolService, escalationToolService } from "./execution.service";
+export type {
+  EscalationRepository,
+  EscalationToolDependencies,
+  EscalationToolService,
+} from "./execution.service";

--- a/tools/v2/team/escalation-tool/specs.md
+++ b/tools/v2/team/escalation-tool/specs.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-Provide an isolated workspace for implementing conversation escalation workflows for team users.
+Provide an isolated workspace for implementing conversation escalation workflows for team users with a stable, presentation-independent execution contract.
 
 ## Scope
 
 - Release tier: V2
 - Audience: Team
-- Status: Documentation and planning
+- Status: Stable service execution contract & isolated implementation
 - Folder ownership:
 
 ```text
@@ -32,12 +32,13 @@ Future integration should be completed only through a dedicated integration issu
 ## Recommended Structure
 
 ```text
-components/
 services/
-hooks/
+types/
+fixtures/
 tests/
 docs/
-fixtures/
+CONTRACT.md
+vitest.config.ts
 ```
 
 ## Required Issue Categories
@@ -52,4 +53,4 @@ fixtures/
 
 Future work may connect this tool to the application once a dedicated integration issue is approved.
 
-Until then, all implementation, testing, and documentation should remain completely isolated.
+Until then, all implementation, testing, and documentation remain completely isolated.

--- a/tools/v2/team/escalation-tool/tests/execution.service.test.ts
+++ b/tools/v2/team/escalation-tool/tests/execution.service.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEscalationToolService,
+  escalationToolService,
+  failingRepository,
+  invalidPriorityInput,
+  missingConversationIdInput,
+  missingReasonInput,
+  successfulEscalationInput,
+} from "../index";
+
+describe("escalationToolService execution contract", () => {
+  it("executes successfully with valid input", async () => {
+    const result = await escalationToolService.execute(successfulEscalationInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.conversationId).toBe("conv-102938");
+    expect(result.data.reason).toBe(successfulEscalationInput.reason);
+    expect(result.data.priority).toBe("high");
+    expect(result.data.requestedBy).toBe("agent-alice-42");
+    expect(result.data.targetDepartment).toBe("compliance");
+    expect(result.data.status).toBe("open");
+    expect(result.data.correlationId).toBe("corr-778899");
+    expect(result.data.id).toBeTruthy();
+    expect(result.data.createdAt).toBeTruthy();
+  });
+
+  it("fails validation when conversationId is empty or whitespace", async () => {
+    const result = await escalationToolService.execute(missingConversationIdInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe("INVALID_INPUT");
+    expect(result.error.field).toBe("conversationId");
+  });
+
+  it("fails validation when reason is empty", async () => {
+    const result = await escalationToolService.execute(missingReasonInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe("INVALID_INPUT");
+    expect(result.error.field).toBe("reason");
+  });
+
+  it("fails validation when priority is invalid", async () => {
+    const result = await escalationToolService.execute(invalidPriorityInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe("INVALID_PRIORITY");
+    expect(result.error.field).toBe("priority");
+  });
+
+  it("propagates persistence failure when repository throws", async () => {
+    const service = createEscalationToolService({ repository: failingRepository });
+    const result = await service.execute(successfulEscalationInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe("PERSISTENCE_FAILED");
+    expect(result.error.message).toContain("persisted");
+  });
+
+  it("uses custom clock and generateId dependencies when injected", async () => {
+    const customTime = new Date("2026-06-01T12:00:00.000Z");
+    const service = createEscalationToolService({
+      generateId: () => "custom-esc-id-123",
+      now: () => customTime,
+    });
+
+    const result = await service.execute(successfulEscalationInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.id).toBe("custom-esc-id-123");
+    expect(result.data.createdAt).toBe("2026-06-01T12:00:00.000Z");
+  });
+});

--- a/tools/v2/team/escalation-tool/types/contract.ts
+++ b/tools/v2/team/escalation-tool/types/contract.ts
@@ -1,0 +1,59 @@
+/**
+ * Presentation-independent execution contract for the Escalation Tool.
+ *
+ * Consumers should branch on `ok` and `error.code`, never on raw error messages.
+ */
+
+export type EscalationPriority = "low" | "medium" | "high" | "urgent";
+
+export type EscalationStatus = "open" | "in_review" | "resolved" | "dismissed";
+
+export type EscalationErrorCode =
+  | "INVALID_INPUT"
+  | "INVALID_PRIORITY"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
+
+export interface EscalationInput {
+  /** ID of the conversation being escalated. */
+  conversationId: string;
+  /** Explicit reason for escalating. */
+  reason: string;
+  /** Escalation priority level. */
+  priority: EscalationPriority;
+  /** User or actor identity initiating the escalation. */
+  requestedBy: string;
+  /** Optional target team or department (e.g. "tier2-support", "compliance"). */
+  targetDepartment?: string;
+  /** Optional context or resolution instructions. */
+  notes?: string;
+  /** Optional opaque correlation ID propagated to output. */
+  correlationId?: string;
+}
+
+export interface EscalationRecord {
+  /** Generated unique escalation record ID. */
+  id: string;
+  conversationId: string;
+  reason: string;
+  priority: EscalationPriority;
+  requestedBy: string;
+  targetDepartment: string;
+  status: EscalationStatus;
+  createdAt: string;
+  notes?: string;
+  correlationId?: string;
+}
+
+export interface EscalationError {
+  code: EscalationErrorCode;
+  message: string;
+  /** Dot-path to the field that triggered the validation error when applicable. */
+  field?: string;
+}
+
+export type EscalationToolResult =
+  | { ok: true; data: EscalationRecord }
+  | { ok: false; error: EscalationError };
+
+export type ExecuteEscalationTool = (input: EscalationInput) => Promise<EscalationToolResult>;

--- a/tools/v2/team/escalation-tool/types/index.ts
+++ b/tools/v2/team/escalation-tool/types/index.ts
@@ -1,0 +1,10 @@
+export type {
+  EscalationErrorCode,
+  EscalationError,
+  EscalationInput,
+  EscalationPriority,
+  EscalationRecord,
+  EscalationStatus,
+  EscalationToolResult,
+  ExecuteEscalationTool,
+} from "./contract";

--- a/tools/v2/team/escalation-tool/vitest.config.ts
+++ b/tools/v2/team/escalation-tool/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Closes #1359
## Description
Improves `tools/v2/team/escalation-tool` by establishing a stable, presentation-independent execution contract and non-UI service implementation so execution can run independently of UI concerns.

## Summary of Changes
- Defined typed input (`EscalationInput`), output (`EscalationRecord`), and error codes (`EscalationErrorCode`) in `types/contract.ts`.
- Implemented presentation-independent non-UI execution service entry points (`escalationToolService`, `createEscalationToolService`) with input validation, correlation ID propagation, clock/ID injection, and persistence boundary support.
- Documented execution contract, error codes, and service boundaries in `CONTRACT.md`.
- Exported deterministic success and failure fixtures in `fixtures/execution.fixtures.ts`.
- Added isolated Vitest unit test suite (`tests/execution.service.test.ts`) covering success execution, validation failures, correlation ID propagation, custom dependency injection, and persistence failure handling.
- Updated `README.md`, `specs.md`, `docs/TEST_PLAN.md`, and `docs/REVIEW_NOTES.md`.

## Acceptance Criteria Checklist
- [x] Typed input and output contract is documented (`CONTRACT.md`)
- [x] Non-UI service entry point is exported (`index.ts`)
- [x] Fixtures cover success and failure cases (`fixtures/execution.fixtures.ts`)
- [x] No styling or layout files are changed (strictly isolated within `tools/v2/team/escalation-tool/`)

## Verification
- `npx vitest run --config tools/v2/team/escalation-tool/vitest.config.ts` (6/6 passed)
- `npx tsc --noEmit` (0 errors)
- `npm run lint` (0 errors)
