### PR TITLE
perf(changelog): cache date formatting, precompute unread state, memoize entries

### DIFF
--- a/src/features/changelog/ChangelogPanel.tsx
+++ b/src/features/changelog/ChangelogPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, memo } from "react";
 import { ExternalLink, CheckCircle2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -6,7 +6,27 @@ import { Badge } from "@/components/ui/badge";
 import { useChangelog } from "./useChangelog";
 import { CATEGORY_CONFIG, groupEntriesByRelease } from "./helpers";
 
-function CategoryBadge({ category }: { category: string }) {
+// `Intl`-backed date formatting is one of the more expensive calls a
+// component can make on every render; entries are a small, static set of
+// (version, date) pairs, so a plain module-level cache avoids reformatting
+// the same date over and over across re-renders and across mounts within
+// the same session.
+const dateFormatCache = new Map<string, string>();
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+function formatReleaseDate(date: string): string {
+  let formatted = dateFormatCache.get(date);
+  if (formatted === undefined) {
+    formatted = dateFormatter.format(new Date(date));
+    dateFormatCache.set(date, formatted);
+  }
+  return formatted;
+}
+
+const CategoryBadge = memo(function CategoryBadge({ category }: { category: string }) {
   const config = CATEGORY_CONFIG[category];
   if (!config) {
     return (
@@ -26,9 +46,9 @@ function CategoryBadge({ category }: { category: string }) {
       {config.label}
     </span>
   );
-}
+});
 
-function ReleaseHeader({
+const ReleaseHeader = memo(function ReleaseHeader({
   version,
   date,
   hasUnread,
@@ -37,11 +57,7 @@ function ReleaseHeader({
   date: string;
   hasUnread: boolean;
 }) {
-  const formattedDate = new Date(date).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  const formattedDate = formatReleaseDate(date);
 
   return (
     <div className="flex items-center justify-between gap-3">
@@ -66,9 +82,15 @@ function ReleaseHeader({
       </time>
     </div>
   );
-}
+});
 
-function ChangelogEntry({ entry, isUnread }: { entry: any; isUnread: boolean }) {
+const ChangelogEntry = memo(function ChangelogEntry({
+  entry,
+  isUnread,
+}: {
+  entry: any;
+  isUnread: boolean;
+}) {
   return (
     <article
       className={cn(
@@ -119,7 +141,7 @@ function ChangelogEntry({ entry, isUnread }: { entry: any; isUnread: boolean }) 
       </div>
     </article>
   );
-}
+});
 
 export function ChangelogPanel() {
   const { entries, markAllSeen, isEntryUnread, hasUnread } = useChangelog();
@@ -129,6 +151,21 @@ export function ChangelogPanel() {
   }, [markAllSeen]);
 
   const grouped = useMemo(() => groupEntriesByRelease(entries), [entries]);
+
+  // isEntryUnread only depends on the (stable, mount-time) initial seen
+  // version, so each entry's unread state is computed once here instead of
+  // being recomputed by calling the helper again for every entry on every
+  // render (previously called both per-group, via `.some`, and per-entry
+  // inside the render loop below).
+  const unreadByVersion = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const entry of entries) {
+      if (!map.has(entry.version)) {
+        map.set(entry.version, isEntryUnread(entry.version));
+      }
+    }
+    return map;
+  }, [entries, isEntryUnread]);
 
   const isEmpty = entries.length === 0;
 
@@ -173,7 +210,7 @@ export function ChangelogPanel() {
         <div className="space-y-6">
           {Object.entries(grouped).map(([key, groupEntries]) => {
             const [version, date] = key.split("|");
-            const hasUnreadInGroup = groupEntries.some((e) => isEntryUnread(e.version));
+            const hasUnreadInGroup = unreadByVersion.get(version) ?? false;
 
             return (
               <section key={key} className="space-y-3">
@@ -183,7 +220,7 @@ export function ChangelogPanel() {
                     <ChangelogEntry
                       key={entry.id}
                       entry={entry}
-                      isUnread={isEntryUnread(entry.version)}
+                      isUnread={unreadByVersion.get(entry.version) ?? false}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

Hotspot identified before changing anything, in `src/features/changelog/ChangelogPanel.tsx`:

- `ReleaseHeader` called `new Date(date).toLocaleDateString(...)` on every render for every release group. `Intl`-backed date formatting is comparatively expensive, and entries are a small, static set (`data.ts`) — replaced with a shared `Intl.DateTimeFormat` instance plus a module-level cache keyed by the raw date string, so a given date is formatted at most once per session.
- `isEntryUnread(version)` was called once per group (via `.some`) **and again per entry** inside the render loop — recomputing the same comparison redundantly on every render. Replaced both call sites with a single `useMemo`'d `Map<version, unread>`, built once per `entries`/`isEntryUnread` change.
- `ReleaseHeader`, `ChangelogEntry`, and `CategoryBadge` were plain function components re-created and re-rendered on every `ChangelogPanel` render even when their own props hadn't changed — wrapped all three in `React.memo`.

**No visible behavior change:** same empty/populated states, same unread badge / "All read" logic, same grouping. `isEntryUnread`'s semantics (compare against the seen version captured at mount) are unchanged — only how many times it's evaluated per render changed.

Closes #998

## Test plan
- [ ] Could not run `bun x tsc --noEmit` / `bun run lint` locally (no `node_modules`, disk space constraint in my environment) — please run both
- [ ] Manually verify empty, populated, and unread/all-read states render identically to before