### PR TITLE
feat(auth): bind signed request signatures to audience (closes #1462)

### DIFF
--- a/docs/security/api-authentication-v1.md
+++ b/docs/security/api-authentication-v1.md
@@ -15,15 +15,15 @@ unknown versions rather than attempting a compatible interpretation.
 
 ## Required headers
 
-| Header                | Requirement                                                                                                                            |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `Host`                | Authority of the intended API server, without surrounding whitespace.                                                                  |
-| `X-Stealth-Address`   | Valid Stellar G-address whose authorized public key verifies the signature.                                                            |
-| `X-Stealth-Nonce`     | Lowercase hexadecimal encoding of 32 cryptographically random bytes.                                                                   |
-| `X-Stealth-Timestamp` | UTC RFC 3339 timestamp with millisecond precision, for example `2026-07-22T12:00:00.000Z`.                                             |
+| Header                | Requirement                                                                                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Host`                | Authority of the intended API server, without surrounding whitespace.                                                                                |
+| `X-Stealth-Address`   | Valid Stellar G-address whose authorized public key verifies the signature.                                                                          |
+| `X-Stealth-Nonce`     | Lowercase hexadecimal encoding of 32 cryptographically random bytes.                                                                                 |
+| `X-Stealth-Timestamp` | UTC RFC 3339 timestamp with millisecond precision, for example `2026-07-22T12:00:00.000Z`.                                                           |
 | `X-Stealth-Audience`  | Identifier of the deployment the signature is scoped to, for example `stealth-api.example.test`. Checked against the server's accepted audience set. |
-| `X-Stealth-Signature` | Base64 encoding of the 64-byte Ed25519 signature over the canonical request. It is transported but omitted from the canonical request. |
-| `Content-Type`        | Required by an endpoint when it has a body; use `application/json`. It is not signed in v1.                                            |
+| `X-Stealth-Signature` | Base64 encoding of the 64-byte Ed25519 signature over the canonical request. It is transported but omitted from the canonical request.               |
+| `Content-Type`        | Required by an endpoint when it has a body; use `application/json`. It is not signed in v1.                                                          |
 
 Header names are case-insensitive on the wire. Signed header values are trimmed and internal runs of
 ASCII space or tab become one space. Duplicate required headers are invalid and must be rejected
@@ -105,15 +105,15 @@ authorization or business validation fails.
 
 Failures use the standard JSON API error envelope and do not echo signatures or nonce records.
 
-| Condition                                                                     | HTTP | Stable code               | `details.reason`     | Retry guidance                                      |
-| ----------------------------------------------------------------------------- | ---: | ------------------------- | -------------------- | --------------------------------------------------- |
+| Condition                                                                                     | HTTP | Stable code               | `details.reason`     | Retry guidance                                      |
+| --------------------------------------------------------------------------------------------- | ---: | ------------------------- | -------------------- | --------------------------------------------------- |
 | Missing/malformed header, unknown version, wrong audience, invalid account, invalid signature |  401 | `unauthorized`            | —                    | Obtain a new challenge and sign again.              |
-| Timestamp or challenge expired                                                |  422 | `expired_challenge`       | `AUTH_EXPIRED`       | Obtain a new challenge.                             |
-| Timestamp too far in the future                                               |  422 | `challenge_not_yet_valid` | `AUTH_NOT_YET_VALID` | Correct the clock, then sign a fresh challenge.     |
-| Unparseable or inverted challenge timestamps                                  |  422 | `validation_error`        | —                    | Correct the request, then sign a fresh challenge.   |
-| Nonce already consumed (replay)                                               |  409 | `conflict`                | —                    | Never retry the signed request; obtain a new nonce. |
-| Verified actor lacks endpoint permission                                      |  403 | `forbidden`               | —                    | Do not retry unchanged.                             |
-| Authentication rate limit exceeded                                            |  429 | `too_many_requests`       | —                    | Honor `Retry-After`.                                |
+| Timestamp or challenge expired                                                                |  422 | `expired_challenge`       | `AUTH_EXPIRED`       | Obtain a new challenge.                             |
+| Timestamp too far in the future                                                               |  422 | `challenge_not_yet_valid` | `AUTH_NOT_YET_VALID` | Correct the clock, then sign a fresh challenge.     |
+| Unparseable or inverted challenge timestamps                                                  |  422 | `validation_error`        | —                    | Correct the request, then sign a fresh challenge.   |
+| Nonce already consumed (replay)                                                               |  409 | `conflict`                | —                    | Never retry the signed request; obtain a new nonce. |
+| Verified actor lacks endpoint permission                                                      |  403 | `forbidden`               | —                    | Do not retry unchanged.                             |
+| Authentication rate limit exceeded                                                            |  429 | `too_many_requests`       | —                    | Honor `Retry-After`.                                |
 
 Both timing failures share HTTP 422, so `details.reason` is what lets a client distinguish a clock
 that is behind from one that is ahead without parsing prose.

--- a/docs/security/api-authentication-v1.md
+++ b/docs/security/api-authentication-v1.md
@@ -21,6 +21,7 @@ unknown versions rather than attempting a compatible interpretation.
 | `X-Stealth-Address`   | Valid Stellar G-address whose authorized public key verifies the signature.                                                            |
 | `X-Stealth-Nonce`     | Lowercase hexadecimal encoding of 32 cryptographically random bytes.                                                                   |
 | `X-Stealth-Timestamp` | UTC RFC 3339 timestamp with millisecond precision, for example `2026-07-22T12:00:00.000Z`.                                             |
+| `X-Stealth-Audience`  | Identifier of the deployment the signature is scoped to, for example `stealth-api.example.test`. Checked against the server's accepted audience set. |
 | `X-Stealth-Signature` | Base64 encoding of the 64-byte Ed25519 signature over the canonical request. It is transported but omitted from the canonical request. |
 | `Content-Type`        | Required by an endpoint when it has a body; use `application/json`. It is not signed in v1.                                            |
 
@@ -40,7 +41,8 @@ host:<NORMALIZED VALUE>
 x-stealth-address:<NORMALIZED VALUE>
 x-stealth-nonce:<NORMALIZED VALUE>
 x-stealth-timestamp:<NORMALIZED VALUE>
-host;x-stealth-address;x-stealth-nonce;x-stealth-timestamp
+x-stealth-audience:<NORMALIZED VALUE>
+host;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience
 <LOWERCASE SHA-256 HEX OF EXACT BODY BYTES>
 ```
 
@@ -50,7 +52,11 @@ with `&`; duplicate pairs are retained. Omit `?` when there is no query. The bod
 exact bytes received, including an empty body, so JSON is not reparsed or reformatted.
 
 The fields above are all required signed fields. Method, target, authority, actor, nonce, timestamp,
-and body are therefore bound to one signature and cannot be substituted independently.
+audience, and body are therefore bound to one signature and cannot be substituted independently: a
+signature captured for one method, route, body, or audience fails verification for any other, and
+reordering an equivalent request's query parameters or header whitespace never changes its canonical
+string. `x-stealth-audience` in particular stops a signature that was scoped to one deployment (for
+example staging) from being replayed against another that happens to trust the same signing key.
 
 ## Nonces, timestamps, and challenges
 
@@ -79,14 +85,16 @@ nonce expires with its validity window and can never extend request validity.
 The server performs these checks in order, without revealing whether an account or key exists:
 
 1. Require one well-formed instance of every header and the supported version.
-2. Parse the timestamp and reject requests outside the configured time window.
-3. Validate the nonce format and load its actor-, purpose-, and expiry-bound challenge record.
-4. Recreate the canonical request from the received method, URL, headers, and exact body bytes.
-5. Resolve an authorized Ed25519 public key for `x-stealth-address`, decode the base64 signature, and
+2. Validate `x-stealth-audience` against the deployment's accepted audience set
+   (`validateSignedRequestAudience`) and reject before any other check if it does not match.
+3. Parse the timestamp and reject requests outside the configured time window.
+4. Validate the nonce format and load its actor-, purpose-, and expiry-bound challenge record.
+5. Recreate the canonical request from the received method, URL, headers, and exact body bytes.
+6. Resolve an authorized Ed25519 public key for `x-stealth-address`, decode the base64 signature, and
    verify it over the canonical request's UTF-8 bytes using a constant-time crypto implementation.
-6. Atomically consume the nonce. Only the winning consumer proceeds; concurrent or later consumers
+7. Atomically consume the nonce. Only the winning consumer proceeds; concurrent or later consumers
    are replay attempts.
-7. Derive the authenticated actor from the verified account. Never accept a bare
+8. Derive the authenticated actor from the verified account. Never accept a bare
    `x-stealth-address` as authentication at a public edge.
 
 Failed format, time, key, or signature checks must not consume the nonce, allowing the legitimate
@@ -99,7 +107,7 @@ Failures use the standard JSON API error envelope and do not echo signatures or 
 
 | Condition                                                                     | HTTP | Stable code               | `details.reason`     | Retry guidance                                      |
 | ----------------------------------------------------------------------------- | ---: | ------------------------- | -------------------- | --------------------------------------------------- |
-| Missing/malformed header, unknown version, invalid account, invalid signature |  401 | `unauthorized`            | —                    | Obtain a new challenge and sign again.              |
+| Missing/malformed header, unknown version, wrong audience, invalid account, invalid signature |  401 | `unauthorized`            | —                    | Obtain a new challenge and sign again.              |
 | Timestamp or challenge expired                                                |  422 | `expired_challenge`       | `AUTH_EXPIRED`       | Obtain a new challenge.                             |
 | Timestamp too far in the future                                               |  422 | `challenge_not_yet_valid` | `AUTH_NOT_YET_VALID` | Correct the clock, then sign a fresh challenge.     |
 | Unparseable or inverted challenge timestamps                                  |  422 | `validation_error`        | —                    | Correct the request, then sign a fresh challenge.   |
@@ -117,10 +125,17 @@ challenge records.
 ## Executable vectors
 
 [`signed-request-v1.json`](../../test-fixtures/auth/signed-request-v1.json) contains a valid request,
-an invalid signature, an expired request, accepted and rejected clock-skew boundaries, and a
-first-use/replay pair, plus a malformed request with a missing required header. Accepted vectors
-declare the expected authenticated principal. All domains, identities, messages, nonces,
-signatures, and the public key are synthetic examples. No private key or secret seed is included.
-`npm test` recreates each canonical string in memory, verifies every Ed25519 result and expected
-principal, evaluates time boundaries, exercises replay state, and confirms malformed input is
-rejected, so changes to implementation or fixtures fail together.
+an invalid signature, a request cryptographically valid but scoped to a different `x-stealth-audience`,
+an expired request, accepted and rejected clock-skew boundaries, and a first-use/replay pair, plus a
+malformed request with a missing required header. Accepted vectors declare the expected authenticated
+principal. All domains, identities, messages, nonces, signatures, and the public key are synthetic
+examples. No private key or secret seed is included. `npm test` recreates each canonical string in
+memory, verifies every Ed25519 result and expected principal, evaluates time boundaries, checks
+`validateSignedRequestAudience` against the fixture's accepted audience, exercises replay state, and
+confirms malformed input is rejected, so changes to implementation or fixtures fail together.
+
+[`signed-request-binding.test.ts`](../../tests/unit/api/auth/signed-request-binding.test.ts) signs one
+base request with a freshly generated Ed25519 key and proves end to end -- not just by comparing
+canonical strings -- that the resulting signature fails verification once the method, route, query,
+body, or audience changes, and that it still verifies for a request that is merely an equivalent
+re-encoding (reordered query parameters, differently-cased or padded header values).

--- a/src/server/api/auth/signed-request.ts
+++ b/src/server/api/auth/signed-request.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { ApiError } from "../errors";
 import {
   AUTH_TIMING_REASONS,
   DEFAULT_AUTH_CHALLENGE_LIFETIME_MS,
@@ -19,11 +20,20 @@ export const SIGNED_REQUEST_VERSION = "STEALTH-AUTH-V1";
 export const SIGNED_REQUEST_MAX_AGE_MS = DEFAULT_AUTH_CHALLENGE_LIFETIME_MS;
 export const SIGNED_REQUEST_CLOCK_SKEW_MS = DEFAULT_AUTH_CLOCK_SKEW_MS;
 
+/**
+ * Headers folded into the canonical request and therefore into the signature.
+ *
+ * `x-stealth-audience` binds a signature to the deployment it was issued for
+ * (see {@link validateSignedRequestAudience}), so a signature captured against
+ * one environment or service cannot be replayed against another that happens
+ * to share a verification key.
+ */
 export const SIGNED_REQUEST_HEADERS = [
   "host",
   "x-stealth-address",
   "x-stealth-nonce",
   "x-stealth-timestamp",
+  "x-stealth-audience",
 ] as const;
 
 export interface SignedRequestInput {
@@ -69,6 +79,28 @@ export function canonicalizeSignedRequest(input: SignedRequestInput): string {
     SIGNED_REQUEST_HEADERS.join(";"),
     bodyHash,
   ].join("\n");
+}
+
+export interface SignedRequestAudienceConfig {
+  /** The bounded set of audience values this deployment currently accepts. */
+  readonly activeAudiences: ReadonlySet<string>;
+}
+
+/**
+ * Validates the signed request's `x-stealth-audience` value against the
+ * deployment's accepted audiences. The audience is part of the canonical
+ * request (see {@link SIGNED_REQUEST_HEADERS}), so this rejects a
+ * cryptographically valid signature that was scoped to a different
+ * deployment (e.g. staging signed material replayed against production)
+ * before any signature verification happens.
+ */
+export function validateSignedRequestAudience(
+  audience: string,
+  config: SignedRequestAudienceConfig,
+): void {
+  if (!config.activeAudiences.has(audience)) {
+    throw new ApiError("unauthorized", { audience });
+  }
 }
 
 export type SignedRequestTimeStatus = "valid" | "expired" | "future" | "invalid";

--- a/test-fixtures/auth/signed-request-v1.json
+++ b/test-fixtures/auth/signed-request-v1.json
@@ -2,7 +2,8 @@
   "version": "STEALTH-AUTH-V1",
   "description": "Synthetic public interoperability vectors. No production identities, keys, nonces, or messages are present.",
   "now": "2026-07-22T12:00:00.000Z",
-  "publicKeySpkiDerBase64": "MCowBQYDK2VwAyEAG+mZbGRRoEmB4oi3/79SbRrQqrDylk+MZBfBtUhFGb0=",
+  "audience": "stealth-api.example.test",
+  "publicKeySpkiDerBase64": "MCowBQYDK2VwAyEAjgNIUVj9DzHQubklUCbvD4B0oQekAJSoji0Wr9JjWIc=",
   "vectors": [
     {
       "name": "valid signed request",
@@ -13,13 +14,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "qsrB66C5tx/mQUvYqAej/xsgWtNoYWt49tMJcLXlqgVHOMJrO8D13igjmPBQbpaaHIKwlidDzfNZlb0e5HlYBg=="
+        "signature": "2m7sY9FeamQj6TECPhZxT6CUKyYVhSxIpmduBy59u58+tyeZaWQNqhUczTSN2LbS6PvpHBw9eKEEs0Req1/QDg=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "accepted",
         "principal": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
       }
@@ -33,15 +35,37 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "10112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "A356fgB2AQ+A6Fmv9THVOdJF/T82rnjq5U+myo8eZuw2deAKm4ICXKTGciTp2CAKga4X6SOIQCZYQ/vqtGnHCg=="
+        "signature": "ijFrhXwACgvjQXsmJ3prcIleGt/ROIRiSwrE6ctFRKPBRU0kceMtLoRPilG0qLCnuG/TZ05P34RUU2zRRt5wAg=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:10112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:10112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "rejected",
         "error": "invalid_signature"
+      }
+    },
+    {
+      "name": "audience bound to a different deployment",
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.test/api/v1/messages?limit=10&cursor=alpha",
+        "headers": {
+          "host": "api.example.test",
+          "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          "x-stealth-nonce": "70112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.other-deployment.test"
+        },
+        "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
+        "signature": "+Epcdx6SQ8j6YQApu9Oe6UoBGAve54xWtP8UO2XjIkVWI9JXQp+tT9oDq8Oxb2DlHqINnmzqF6kBwn58um48CQ=="
+      },
+      "expected": {
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:70112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nx-stealth-audience:stealth-api.other-deployment.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "outcome": "rejected",
+        "error": "audience_mismatch"
       }
     },
     {
@@ -53,13 +77,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "20112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T11:54:29.999Z"
+          "x-stealth-timestamp": "2026-07-22T11:54:29.999Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "r+vWp2rIxnrsmLmCuAip4zaoZ0W6c18uWomInsZw1N7bepv4kbSOo9LKmHfBwmi8nfWqnukHh9EzV8Dm7dRBAw=="
+        "signature": "anHvPzSgB10lrWEbxEMMIGkML23OXjyD0LWKlYe2zrxEbuCCKJI7k9gH89B/VMrR5IDAsEftdMg1ooSGnXB1BQ=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:20112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T11:54:29.999Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:20112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T11:54:29.999Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "rejected",
         "error": "expired"
       }
@@ -73,13 +98,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "30112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:30.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:30.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "oZ6lzHgsvy+U7YUoj0hKv8GY5e4k5FVTNmw1hTX3IjrQhc5DfupXRk+UBEd0wr2dho49s3U8HvSqclnKUm/lCA=="
+        "signature": "oukpErySmEErvSge8IlkCl6vumCvH8m2seencbV4iJMBqg2gFwfoZqlNJ4NyiXtD3LLtNCi2DgVp5VzZKytDDA=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:30112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:30.000Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:30112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:30.000Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "accepted",
         "principal": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
       }
@@ -93,13 +119,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "40112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:30.001Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:30.001Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "A9+H0LVGA/j2thsT7Jpri1siozLO2I/+OWNdSKml4X5251Mx6Slcqq9jRTHsK/9RKR1L0uCfDuibKRQzbtVjAg=="
+        "signature": "Z2rEl4lgBh1S3xqTPBD1SVvGADq8nDE2q1Id/D7eisz/gO1cJ+NtVVPNoPiiIOFA0x9pxLwGPJ4H1mz/fgKBDA=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:40112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:30.001Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:40112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:30.001Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "rejected",
         "error": "future"
       }
@@ -113,13 +140,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "IyiCZSC1unyQGY7yw9wCwfupNn8yoLvMql9YuYZJjjlCbMC+ewdAudlttQ0hpEIKkXvSesrR5ygmPigA+wrNCw=="
+        "signature": "V6nGY7glJzFyJKm7IXsrKWE0D9I6MdAdoEuZCyG8Qj40Va9TTriT+qVXZjJw26+NpreA7BCLwgR4K4hpH14hDQ=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "accepted",
         "principal": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
       }
@@ -133,13 +161,14 @@
           "host": "api.example.test",
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
-        "signature": "IyiCZSC1unyQGY7yw9wCwfupNn8yoLvMql9YuYZJjjlCbMC+ewdAudlttQ0hpEIKkXvSesrR5ygmPigA+wrNCw=="
+        "signature": "V6nGY7glJzFyJKm7IXsrKWE0D9I6MdAdoEuZCyG8Qj40Va9TTriT+qVXZjJw26+NpreA7BCLwgR4K4hpH14hDQ=="
       },
       "expected": {
-        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
+        "canonical": "STEALTH-AUTH-V1\nPOST\n/api/v1/messages?cursor=alpha&limit=10\nhost:api.example.test\nx-stealth-address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nx-stealth-nonce:50112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\nx-stealth-timestamp:2026-07-22T12:00:00.000Z\nx-stealth-audience:stealth-api.example.test\nhost;x-stealth-address;x-stealth-nonce;x-stealth-timestamp;x-stealth-audience\n0b20edc565703904ddcdab7e7b87725c121cb35339fdaddccdc0a52a6be52036",
         "outcome": "rejected",
         "error": "replayed_nonce"
       }
@@ -152,7 +181,8 @@
         "headers": {
           "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           "x-stealth-nonce": "60112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
-          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z"
+          "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+          "x-stealth-audience": "stealth-api.example.test"
         },
         "body": "{\"recipient\":\"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD\",\"subject\":\"Synthetic example\"}",
         "signature": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="

--- a/tests/unit/api/auth/signed-request-binding.test.ts
+++ b/tests/unit/api/auth/signed-request-binding.test.ts
@@ -1,0 +1,206 @@
+import { generateKeyPairSync, sign, verify } from "node:crypto";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  canonicalizeSignedRequest,
+  validateSignedRequestAudience,
+  type SignedRequestInput,
+} from "../../../../src/server/api/auth/signed-request";
+
+/**
+ * Issue #1462: a signed request's canonical form must bind the signature to
+ * the exact method, route, body, and audience it was issued for. These tests
+ * exercise real Ed25519 signing/verification (not just string comparison) so
+ * a regression that accidentally drops a field from the canonical string --
+ * and would therefore let a signature move to a different operation -- fails
+ * here even if the two canonical strings happen to differ in some other way.
+ */
+
+const BASE: SignedRequestInput = {
+  version: "STEALTH-AUTH-V1",
+  method: "POST",
+  url: "https://api.example.test/api/v1/messages?limit=10&cursor=alpha",
+  headers: {
+    host: "api.example.test",
+    "x-stealth-address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    "x-stealth-nonce": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+    "x-stealth-timestamp": "2026-07-22T12:00:00.000Z",
+    "x-stealth-audience": "stealth-api.example.test",
+  },
+  body: '{"recipient":"GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD"}',
+};
+
+let publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"];
+let privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"];
+
+beforeAll(() => {
+  ({ publicKey, privateKey } = generateKeyPairSync("ed25519"));
+});
+
+function signRequest(input: SignedRequestInput): string {
+  return sign(null, Buffer.from(canonicalizeSignedRequest(input)), privateKey).toString("base64");
+}
+
+/** Verifies `signature` (captured for `signedFor`) against `presentedAs`. */
+function verifiesAgainst(signature: string, presentedAs: SignedRequestInput): boolean {
+  return verify(
+    null,
+    Buffer.from(canonicalizeSignedRequest(presentedAs)),
+    publicKey,
+    Buffer.from(signature, "base64"),
+  );
+}
+
+describe("signed request cross-operation substitution", () => {
+  it("binds the signature to its exact request end to end", () => {
+    const signature = signRequest(BASE);
+    expect(verifiesAgainst(signature, BASE)).toBe(true);
+  });
+
+  it("a signature for one HTTP method cannot authorize another", () => {
+    const signature = signRequest(BASE);
+    const asGet = { ...BASE, method: "GET" };
+    const asDelete = { ...BASE, method: "DELETE" };
+
+    expect(canonicalizeSignedRequest(asGet)).not.toBe(canonicalizeSignedRequest(BASE));
+    expect(verifiesAgainst(signature, asGet)).toBe(false);
+    expect(verifiesAgainst(signature, asDelete)).toBe(false);
+  });
+
+  it("a signature for one route cannot authorize another", () => {
+    const signature = signRequest(BASE);
+    const otherPath = {
+      ...BASE,
+      url: "https://api.example.test/api/v1/messages/other-resource?limit=10&cursor=alpha",
+    };
+    const otherOwner = {
+      ...BASE,
+      url: "https://api.example.test/api/v1/policies/GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBUJD",
+    };
+
+    expect(canonicalizeSignedRequest(otherPath)).not.toBe(canonicalizeSignedRequest(BASE));
+    expect(verifiesAgainst(signature, otherPath)).toBe(false);
+    expect(verifiesAgainst(signature, otherOwner)).toBe(false);
+  });
+
+  it("changing the query string invalidates the signature", () => {
+    const signature = signRequest(BASE);
+    const otherQuery = {
+      ...BASE,
+      url: "https://api.example.test/api/v1/messages?limit=10&cursor=omega",
+    };
+
+    expect(canonicalizeSignedRequest(otherQuery)).not.toBe(canonicalizeSignedRequest(BASE));
+    expect(verifiesAgainst(signature, otherQuery)).toBe(false);
+  });
+
+  it("changing the body invalidates the signature", () => {
+    const signature = signRequest(BASE);
+    const otherBody = {
+      ...BASE,
+      body: '{"recipient":"GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCUJD"}',
+    };
+    const emptyBody = { ...BASE, body: "" };
+
+    expect(canonicalizeSignedRequest(otherBody)).not.toBe(canonicalizeSignedRequest(BASE));
+    expect(verifiesAgainst(signature, otherBody)).toBe(false);
+    expect(verifiesAgainst(signature, emptyBody)).toBe(false);
+  });
+
+  it("a signature scoped to one audience cannot authorize another deployment", () => {
+    const signature = signRequest(BASE);
+    const otherAudience = {
+      ...BASE,
+      headers: { ...BASE.headers, "x-stealth-audience": "stealth-api.staging.test" },
+    };
+
+    expect(canonicalizeSignedRequest(otherAudience)).not.toBe(canonicalizeSignedRequest(BASE));
+    expect(verifiesAgainst(signature, otherAudience)).toBe(false);
+  });
+
+  it("swapping the nonce or timestamp of a different signed request invalidates it", () => {
+    const signature = signRequest(BASE);
+    const otherNonce = {
+      ...BASE,
+      headers: {
+        ...BASE.headers,
+        "x-stealth-nonce": "ff112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+      },
+    };
+    const otherTimestamp = {
+      ...BASE,
+      headers: { ...BASE.headers, "x-stealth-timestamp": "2026-07-22T12:05:00.000Z" },
+    };
+
+    expect(verifiesAgainst(signature, otherNonce)).toBe(false);
+    expect(verifiesAgainst(signature, otherTimestamp)).toBe(false);
+  });
+});
+
+describe("signed request canonicalization determinism", () => {
+  it("is identical for equivalent requests with reordered query parameters", () => {
+    const reordered = {
+      ...BASE,
+      url: "https://api.example.test/api/v1/messages?cursor=alpha&limit=10",
+    };
+    expect(canonicalizeSignedRequest(reordered)).toBe(canonicalizeSignedRequest(BASE));
+  });
+
+  it("is identical for equivalent requests with header casing and whitespace differences", () => {
+    const messyHeaders = {
+      ...BASE,
+      method: "post",
+      headers: {
+        Host: "  api.example.test  ",
+        "X-Stealth-Address": BASE.headers["x-stealth-address"],
+        "X-STEALTH-NONCE": BASE.headers["x-stealth-nonce"],
+        "x-stealth-timestamp": BASE.headers["x-stealth-timestamp"],
+        "X-Stealth-Audience": `  ${BASE.headers["x-stealth-audience"]}  `,
+      },
+    };
+    expect(canonicalizeSignedRequest(messyHeaders)).toBe(canonicalizeSignedRequest(BASE));
+  });
+
+  it("produces a signature that verifies identically across equivalent request shapes", () => {
+    const signature = signRequest(BASE);
+    const reordered = {
+      ...BASE,
+      url: "https://api.example.test/api/v1/messages?cursor=alpha&limit=10",
+    };
+    expect(verifiesAgainst(signature, reordered)).toBe(true);
+  });
+});
+
+describe("validateSignedRequestAudience", () => {
+  it("accepts an audience present in the active set", () => {
+    expect(() =>
+      validateSignedRequestAudience("stealth-api.example.test", {
+        activeAudiences: new Set(["stealth-api.example.test"]),
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts any audience within a multi-value rotation window", () => {
+    const config = {
+      activeAudiences: new Set(["stealth-api.example.test", "stealth-api.example.test.v2"]),
+    };
+    expect(() => validateSignedRequestAudience("stealth-api.example.test", config)).not.toThrow();
+    expect(() =>
+      validateSignedRequestAudience("stealth-api.example.test.v2", config),
+    ).not.toThrow();
+  });
+
+  it("rejects an audience outside the accepted set", () => {
+    expect(() =>
+      validateSignedRequestAudience("stealth-api.staging.test", {
+        activeAudiences: new Set(["stealth-api.example.test"]),
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an empty audience", () => {
+    expect(() =>
+      validateSignedRequestAudience("", { activeAudiences: new Set(["stealth-api.example.test"]) }),
+    ).toThrow();
+  });
+});

--- a/tests/unit/api/auth/signed-request-vectors.test.ts
+++ b/tests/unit/api/auth/signed-request-vectors.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalizeSignedRequest,
   signedRequestTimeStatus,
+  validateSignedRequestAudience,
   type SignedRequestInput,
 } from "../../../../src/server/api/auth/signed-request";
 
 type VectorError =
+  | "audience_mismatch"
   | "expired"
   | "future"
   | "invalid_signature"
@@ -29,6 +31,7 @@ interface Vector {
 
 interface Fixture {
   version: string;
+  audience: string;
   now: string;
   publicKeySpkiDerBase64: string;
   vectors: Vector[];
@@ -73,9 +76,25 @@ describe("signed request v1 documentation vectors", () => {
       Date.parse(fixture.now),
     );
 
-    if (vector.expected.outcome === "accepted" || vector.expected.error === "replayed_nonce") {
+    if (
+      vector.expected.outcome === "accepted" ||
+      vector.expected.error === "replayed_nonce" ||
+      vector.expected.error === "audience_mismatch"
+    ) {
       expect(time).toBe("valid");
       expect(signatureIsValid(vector)).toBe(true);
+
+      const checkAudience = () =>
+        validateSignedRequestAudience(vector.request.headers["x-stealth-audience"], {
+          activeAudiences: new Set([fixture.audience]),
+        });
+
+      if (vector.expected.error === "audience_mismatch") {
+        expect(checkAudience).toThrow();
+      } else {
+        expect(checkAudience).not.toThrow();
+      }
+
       if (vector.expected.outcome === "accepted") {
         expect(vector.expected.principal).toBe(vector.request.headers["x-stealth-address"]);
       }
@@ -107,6 +126,7 @@ describe("signed request v1 documentation vectors", () => {
         "replayed_nonce",
         "future",
         "malformed_request",
+        "audience_mismatch",
       ]),
     );
   });


### PR DESCRIPTION
## Summary

Binds the v1 signed-request canonical payload to the deployment audience,
closing the last gap identified in #1462. The canonicalizer already scoped
signatures to version, HTTP method, canonical route, and body digest — this
adds the missing `audience` field from the issue's proposed payload
(`version, method, route, body hash, nonce, issued-at, audience`) and backs
every binding property with an end-to-end cryptographic test, not just
string comparison.

## Changes

- **`src/server/api/auth/signed-request.ts`**: add `x-stealth-audience` to
  `SIGNED_REQUEST_HEADERS` so it's folded into the canonical string like the
  other signed headers, and add `validateSignedRequestAudience()` — a
  bounded active-audience-set check (mirrors `validateAuthVersion`) so a
  signature scoped to one deployment (e.g. staging) can't be replayed
  against another that trusts the same key.
- **`test-fixtures/auth/signed-request-v1.json`**: regenerated with a fresh
  Ed25519 keypair, `x-stealth-audience` on every vector, and a new
  `audience_mismatch` vector (signature is cryptographically valid, but
  scoped to the wrong deployment).
- **`tests/unit/api/auth/signed-request-binding.test.ts`** (new): signs one
  base request with a real Ed25519 key, then proves verification actually
  fails once method, route, query, body, or audience changes — and still
  succeeds for equivalent re-encodings (reordered query params, header
  casing/whitespace differences).
- **`tests/unit/api/auth/signed-request-vectors.test.ts`**: exercises the
  new audience vector and asserts `validateSignedRequestAudience` against
  the fixture's accepted audience.
- **`docs/security/api-authentication-v1.md`**: documents the new header,
  canonical-string line, verification-order step, and error table entry.

## Acceptance criteria (#1462)

- [x] A signature for one method cannot authorize another method
- [x] A signature for one route cannot authorize another route
- [x] Changing the body invalidates the signature
- [x] Canonicalization fixtures are deterministic across equivalent requests

## Out of scope

This is the canonicalization primitive only. `src/server/api/context.ts`
still authenticates purely off the `x-stealth-address` header — actual
signature verification is not yet wired into live route handlers. That gap
is already tracked separately (see the `it.fails` regressions in
`tests/unit/api/security.regression.test.ts`, issue #1555).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run` — 141 files / 1677 passed (+ 3 pre-existing,
      unrelated `it.fails` markers for #1555)

Closes #1462
