### PR TITLE
feat(idempotency): durable, payload-bound idempotency for postage mutations

### DIFF
--- a/docs/api/SETTLEMENT_IDEMPOTENCY.md
+++ b/docs/api/SETTLEMENT_IDEMPOTENCY.md
@@ -2,7 +2,14 @@
 
 ## Overview
 
-The postage settlement endpoint (`POST /api/v1/postage/:messageId/settle`) implements idempotency to ensure safe retry behavior during network failures, race conditions, or other transient errors.
+The postage settlement and refund endpoints (`POST /api/v1/postage/:messageId/settle` and
+`POST /api/v1/postage/:messageId/refund`) implement idempotency to ensure safe retry behavior
+during network failures, race conditions, or other transient errors.
+
+Idempotency records are persisted durably (via the same Durable Object storage that backs
+settlement's compare-and-swap transitions), so this behavior survives worker restarts and is
+consistent across every Worker instance that reaches the same Durable Object — not just a single
+in-memory process.
 
 ## Problem Statement
 
@@ -27,11 +34,16 @@ X-Idempotency-Key: unique-settlement-request-id
 
 ### Key Properties
 
-- **Actor-scoped**: Keys are scoped per recipient, preventing cross-actor collisions
+- **Actor-, method-, and route-scoped**: Keys are hashed together with the recipient, HTTP
+  method, and route template, so the same raw key can never collide across actors or endpoints
 - **SHA-256 hashed**: Raw keys are hashed to protect against key leakage in logs
+- **Payload-bound**: Every lease and cached response is bound to a canonical digest of the
+  request payload. Reusing a key for a *different* payload (e.g. a different `messageId`) never
+  blocks behind or replays the wrong response — it fails closed with `409 idempotency_mismatch`
 - **Success replay**: Successful settlements (200) are cached and replayed
 - **Error replay**: Terminal-state errors (409 conflict) are cached and replayed
-- **Transient errors**: Non-terminal errors (500, network failures) are NOT cached, allowing retry
+- **Transient errors**: Non-terminal errors (500, network failures) are NOT cached; the lease is
+  released immediately so an identical retry with the same key can proceed right away
 
 ### Request Flow
 
@@ -307,6 +319,7 @@ async function settleWithRetry(messageId, maxRetries = 3) {
 The same idempotency pattern is also used in:
 
 - `POST /api/v1/postage/` (postage submission)
+- `POST /api/v1/postage/:messageId/refund`
 
 Future endpoints that modify critical state should adopt this pattern.
 

--- a/docs/api/SETTLEMENT_IDEMPOTENCY.md
+++ b/docs/api/SETTLEMENT_IDEMPOTENCY.md
@@ -38,7 +38,7 @@ X-Idempotency-Key: unique-settlement-request-id
   method, and route template, so the same raw key can never collide across actors or endpoints
 - **SHA-256 hashed**: Raw keys are hashed to protect against key leakage in logs
 - **Payload-bound**: Every lease and cached response is bound to a canonical digest of the
-  request payload. Reusing a key for a *different* payload (e.g. a different `messageId`) never
+  request payload. Reusing a key for a _different_ payload (e.g. a different `messageId`) never
   blocks behind or replays the wrong response — it fails closed with `409 idempotency_mismatch`
 - **Success replay**: Successful settlements (200) are cached and replayed
 - **Error replay**: Terminal-state errors (409 conflict) are cached and replayed

--- a/src/routes/api/v1/postage/$messageId/refund.ts
+++ b/src/routes/api/v1/postage/$messageId/refund.ts
@@ -5,7 +5,20 @@ import { getApiContext } from "@/server/api/context";
 import { hash32Schema } from "@/server/api/domain";
 import { getPostage, resolvePostage } from "@/server/api/postage-service";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { withIdempotency } from "@/server/api/idempotency-service";
 
+/**
+ * POST /api/v1/postage/:messageId/refund
+ *
+ * Refunds postage for a message, returning escrow to the sender.
+ *
+ * ## Idempotency
+ *
+ * Mirrors the settlement endpoint: supports idempotent refunds via the
+ * optional `X-Idempotency-Key` header, scoped per recipient. A matching
+ * completed record is replayed; a matching in-flight request is rejected as
+ * in-progress; the same key reused with a different message id conflicts.
+ */
 export const Route = createFileRoute("/api/v1/postage/$messageId/refund")({
   server: {
     handlers: {
@@ -19,8 +32,32 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/refund")({
           const messageId = hash32Schema.parse(params.messageId);
           const current = await getPostage(repository, messageId);
           requireActorMatches(context, current.recipient);
-          const postage = await resolvePostage(context, messageId, "refunded");
-          return apiSuccess(request, postage);
+
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+          const refund = async () => {
+            const postage = await resolvePostage(context, messageId, "refunded");
+            return { status: 200, body: postage };
+          };
+
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                repository,
+                {
+                  actor: current.recipient,
+                  method: request.method,
+                  route: "POST /postage/{messageId}/refund",
+                  rawKey: rawIdempotencyKey,
+                },
+                { messageId },
+                refund,
+                { cacheableErrorStatuses: [409] },
+              )
+            : { ...(await refund()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            status: result.status,
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
         }),
     },
   },

--- a/src/routes/api/v1/postage/$messageId/settle.ts
+++ b/src/routes/api/v1/postage/$messageId/settle.ts
@@ -5,8 +5,7 @@ import { getApiContext } from "@/server/api/context";
 import { hash32Schema } from "@/server/api/domain";
 import { getPostage, resolvePostage } from "@/server/api/postage-service";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
-import { acquireIdempotency, recordIdempotency } from "@/server/api/idempotency-service";
-import { ApiError } from "@/server/api/errors";
+import { withIdempotency } from "@/server/api/idempotency-service";
 
 /**
  * POST /api/v1/postage/:messageId/settle
@@ -53,71 +52,30 @@ export const Route = createFileRoute("/api/v1/postage/$messageId/settle")({
 
           // Check for idempotency key to enable safe retries
           const rawIdempotencyKey = request.headers.get("x-idempotency-key");
-          if (rawIdempotencyKey) {
-            const result = await acquireIdempotency(
-              repository,
-              current.recipient,
-              rawIdempotencyKey,
-            );
-
-            if (result.status === "in_progress") {
-              throw new ApiError(409, "conflict", "Request is already in progress");
-            }
-
-            if (result.status === "completed") {
-              // Replay the previous response (success or failure)
-              return apiSuccess(request, result.record.body, {
-                status: result.record.status,
-                headers: { "x-idempotency-replayed": "true" },
-              });
-            }
-          }
-
-          try {
+          const settle = async () => {
             const postage = await resolvePostage(context, messageId, "settled");
+            return { status: 200, body: postage };
+          };
 
-            // Record successful settlement for idempotent replay
-            if (rawIdempotencyKey) {
-              await recordIdempotency(
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
                 repository,
-                current.recipient,
-                rawIdempotencyKey,
-                200,
-                postage,
-              );
-            }
+                {
+                  actor: current.recipient,
+                  method: request.method,
+                  route: "POST /postage/{messageId}/settle",
+                  rawKey: rawIdempotencyKey,
+                },
+                { messageId },
+                settle,
+                { cacheableErrorStatuses: [409] },
+              )
+            : { ...(await settle()), replayed: false };
 
-            return apiSuccess(request, postage);
-          } catch (error) {
-            // Record terminal-state errors for idempotent replay
-            // This ensures retry-after-failure returns the same error
-            if (
-              rawIdempotencyKey &&
-              error &&
-              typeof error === "object" &&
-              "status" in error &&
-              "code" in error &&
-              "message" in error
-            ) {
-              const apiError = error as {
-                status: number;
-                code: string;
-                message: string;
-                details?: unknown;
-              };
-              // Only cache terminal-state errors (409 conflict), not transient failures
-              if (apiError.status === 409) {
-                await recordIdempotency(repository, current.recipient, rawIdempotencyKey, 409, {
-                  error: {
-                    code: apiError.code,
-                    message: apiError.message,
-                    details: apiError.details,
-                  },
-                });
-              }
-            }
-            throw error;
-          }
+          return apiSuccess(request, result.body, {
+            status: result.status,
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
         }),
     },
   },

--- a/src/routes/api/v1/postage/index.ts
+++ b/src/routes/api/v1/postage/index.ts
@@ -8,7 +8,7 @@ import { buildDeviceFingerprint } from "@/server/api/abuse-service";
 import { submitPostage, signQuote, type SubmitPostageContext } from "@/server/api/postage-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
-import { acquireIdempotency, recordIdempotency } from "@/server/api/idempotency-service";
+import { withIdempotency } from "@/server/api/idempotency-service";
 import { ApiError } from "@/server/api/errors";
 
 const submissionSchema = z.object({
@@ -51,19 +51,6 @@ export const Route = createFileRoute("/api/v1/postage/")({
           const { issuedAt, expiresAt, quoteDigest, ...postageInput } = input;
 
           const repo = apiContext.repository;
-          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
-          if (rawIdempotencyKey) {
-            const result = await acquireIdempotency(repo, input.sender, rawIdempotencyKey);
-            if (result.status === "completed") {
-              return apiSuccess(request, result.record.body, {
-                status: result.record.status,
-                headers: { "x-idempotency-replayed": "true" },
-              });
-            }
-            if (result.status === "in_progress") {
-              throw new ApiError(409, "conflict", "Request is already in progress");
-            }
-          }
 
           const ip =
             request.headers.get("cf-connecting-ip") ??
@@ -92,13 +79,37 @@ export const Route = createFileRoute("/api/v1/postage/")({
             relayId,
             sender: input.sender,
           };
-          const postage = await submitPostage(apiContext, postageInput, new Date(), submitContext);
 
-          if (rawIdempotencyKey) {
-            await recordIdempotency(repo, input.sender, rawIdempotencyKey, 201, postage);
-          }
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+          const submit = async () => {
+            const postage = await submitPostage(
+              apiContext,
+              postageInput,
+              new Date(),
+              submitContext,
+            );
+            return { status: 201, body: postage };
+          };
 
-          return apiSuccess(request, postage, { status: 201 });
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                repo,
+                {
+                  actor: input.sender,
+                  method: request.method,
+                  route: "POST /postage",
+                  rawKey: rawIdempotencyKey,
+                },
+                input,
+                submit,
+                { cacheableErrorStatuses: [409] },
+              )
+            : { ...(await submit()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            status: result.status,
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
         }),
     },
   },

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -188,7 +188,15 @@ registerRecordSchema("mailboxPolicy", 1, mailboxPolicySchema);
 registerRecordSchema("senderRule", 1, senderRuleSchema);
 registerRecordSchema("postage", 1, postageSchema);
 registerRecordSchema("receipt", 1, receiptSchema);
-registerRecordSchema("idempotencyRecord", 1, idempotencyRecordSchema);
+// v1 -> v2 (Issue #1498): records now carry a requestDigest binding the
+// lease/response to the exact request payload that created it. Legacy
+// records predate this and never bore a client-supplied payload we can
+// recompute, so they are stamped with a sentinel that can never equal a
+// real digest — any replay attempt against one fails closed as a conflict
+// rather than silently matching or replaying the wrong response.
+registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
+  1: (data: any) => ({ ...data, requestDigest: "legacy:unrecoverable" }),
+});
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -109,6 +109,10 @@ export type SenderRule = z.infer<typeof senderRuleSchema>;
 export const idempotencyRecordSchema = z.discriminatedUnion("state", [
   z.object({
     state: z.literal("in_progress"),
+    // Issue #1498: canonical digest of the request that acquired this lease,
+    // so a same-key-different-payload retry is detected as a conflict
+    // instead of blocking behind (or later replaying) an unrelated request.
+    requestDigest: z.string(),
     createdAt: z.string().datetime(),
     recoveryExpiryAt: z.string().datetime(),
   }),
@@ -116,6 +120,7 @@ export const idempotencyRecordSchema = z.discriminatedUnion("state", [
     state: z.literal("completed"),
     status: z.number(),
     body: z.unknown(),
+    requestDigest: z.string(),
     createdAt: z.string().datetime(),
     completedAt: z.string().datetime(),
   }),

--- a/src/server/api/idempotency-service.ts
+++ b/src/server/api/idempotency-service.ts
@@ -1,53 +1,73 @@
 import { createHash } from "node:crypto";
-import type { ApiRepository } from "./repository";
+import type { ApiRepository, AcquireIdempotencyResult } from "./repository";
 import type { IdempotencyRecord } from "./domain";
 import { canonicalize } from "./envelope";
+import { ApiError } from "./errors";
+
+const DEFAULT_LEASE_MS = 30000;
 
 /**
- * Issue #1501: canonicalize request bodies before computing idempotency
- * digests so semantically identical JSON (different key order) hashes the same,
- * while genuinely different values still conflict. Array order, numeric/string
- * distinctions, and the actor scope all remain significant.
+ * Issue #1498: idempotency records are persisted keyed by actor, HTTP
+ * method, and route template (in addition to the client-supplied key), so
+ * the same raw key cannot collide across unrelated endpoints or verbs.
+ *
+ * Issue #1501: canonicalize the raw key before hashing so semantically
+ * identical JSON (different key order) hashes the same, while genuinely
+ * different values still conflict. Array order, numeric/string
+ * distinctions, and the actor/method/route scope all remain significant.
  */
-export function hashIdempotencyKey(actor: string, rawKey: unknown): string {
-  const canonical = canonicalize(rawKey);
-  return createHash("sha256").update(`${actor}:${canonical}`).digest("hex");
+export function hashIdempotencyKey(
+  actor: string,
+  method: string,
+  route: string,
+  rawKey: unknown,
+): string {
+  const canonicalKey = canonicalize(rawKey);
+  return createHash("sha256").update(`${actor}:${method}:${route}:${canonicalKey}`).digest("hex");
 }
 
+/** Canonical digest of a request payload, bound into the stored lease/response. */
+export function computeRequestDigest(rawBody: unknown): string {
+  return createHash("sha256").update(canonicalize(rawBody)).digest("hex");
+}
+
+export interface IdempotencyScope {
+  actor: string;
+  method: string;
+  route: string;
+  rawKey: string;
+}
+
+/**
+ * Acquires an idempotency lease for the given scope, binding it to a
+ * canonical digest of `rawBody`. Callers use the low-level result to decide
+ * how to react; most routes should prefer {@link withIdempotency} instead.
+ */
 export async function acquireIdempotency(
   repository: ApiRepository,
-  actor: string,
-  rawKey: string,
-  leaseMs: number = 30000, // default 30s lease
-): Promise<import("./repository").AcquireIdempotencyResult> {
-  const keyHash = hashIdempotencyKey(actor, rawKey);
-  return repository.acquireIdempotencyRecord(keyHash, leaseMs);
+  scope: IdempotencyScope,
+  rawBody: unknown,
+  leaseMs: number = DEFAULT_LEASE_MS,
+): Promise<AcquireIdempotencyResult> {
+  const keyHash = hashIdempotencyKey(scope.actor, scope.method, scope.route, scope.rawKey);
+  const requestDigest = computeRequestDigest(rawBody);
+  return repository.acquireIdempotencyRecord(keyHash, requestDigest, leaseMs);
 }
 
-// Restored to fix CI compatibility with imports that still use checkIdempotency
-export async function checkIdempotency(
-  repository: ApiRepository,
-  actor: string,
-  rawKey: string,
-): Promise<IdempotencyRecord | null> {
-  const result = await acquireIdempotency(repository, actor, rawKey);
-  if (result.status === "completed") {
-    return result.record;
-  }
-  return null;
-}
-
+/** Records the terminal outcome of an operation for future idempotent replay. */
 export async function recordIdempotency(
   repository: ApiRepository,
-  actor: string,
-  rawKey: string,
+  scope: IdempotencyScope,
+  rawBody: unknown,
   status: number,
   body: unknown,
 ): Promise<void> {
-  const keyHash = hashIdempotencyKey(actor, rawKey);
+  const keyHash = hashIdempotencyKey(scope.actor, scope.method, scope.route, scope.rawKey);
+  const requestDigest = computeRequestDigest(rawBody);
   const now = new Date().toISOString();
 
-  // Get the existing record to preserve the original createdAt, or fallback to now
+  // Preserve the original createdAt across the in_progress -> completed
+  // transition, falling back to now if the lease record is somehow absent.
   const existing = await repository.getIdempotencyRecord(keyHash);
   const createdAt = existing ? existing.createdAt : now;
 
@@ -55,8 +75,114 @@ export async function recordIdempotency(
     state: "completed",
     status,
     body,
+    requestDigest,
     createdAt,
     completedAt: now,
   };
   await repository.setIdempotencyRecord(keyHash, record);
+}
+
+/**
+ * Releases an in-flight lease without recording a completed response, so an
+ * immediate retry with the same key/payload can re-acquire right away
+ * instead of waiting out the full lease TTL. Used after a transient failure
+ * that was deliberately left uncached (see {@link WithIdempotencyOptions}).
+ */
+async function releaseIdempotencyLease(
+  repository: ApiRepository,
+  scope: IdempotencyScope,
+  rawBody: unknown,
+): Promise<void> {
+  const keyHash = hashIdempotencyKey(scope.actor, scope.method, scope.route, scope.rawKey);
+  const requestDigest = computeRequestDigest(rawBody);
+  const existing = await repository.getIdempotencyRecord(keyHash);
+  const createdAt = existing ? existing.createdAt : new Date().toISOString();
+
+  await repository.setIdempotencyRecord(keyHash, {
+    state: "in_progress",
+    requestDigest,
+    createdAt,
+    // Already expired, so the next acquire treats the lease as abandoned
+    // and proceeds immediately rather than blocking for up to leaseMs.
+    recoveryExpiryAt: new Date(0).toISOString(),
+  });
+}
+
+export interface IdempotentOutcome<T> {
+  status: number;
+  body: T;
+  /** True when this response was replayed from a prior request rather than freshly computed. */
+  replayed: boolean;
+}
+
+export interface WithIdempotencyOptions {
+  leaseMs?: number;
+  /**
+   * ApiError statuses whose response should also be cached and replayed
+   * (e.g. a deterministic 409 for an already-settled resource). Statuses
+   * not listed here are treated as transient and are never cached, so a
+   * failed attempt can be retried with the same key.
+   */
+  cacheableErrorStatuses?: readonly number[];
+}
+
+/**
+ * Runs a mutating operation under a durable idempotency lease.
+ *
+ * - No prior record for this actor/method/route/key: runs `operation` once
+ *   and persists its outcome for future replay.
+ * - A matching in-flight lease: throws `request_in_progress` (409) so a
+ *   concurrent duplicate can never execute the operation twice.
+ * - A matching completed record: replays the stored response without
+ *   re-running `operation`.
+ * - The same key reused with a different request payload: throws
+ *   `idempotency_mismatch` (409) rather than blocking behind or replaying
+ *   an unrelated request's response.
+ */
+export async function withIdempotency<T>(
+  repository: ApiRepository,
+  scope: IdempotencyScope,
+  rawBody: unknown,
+  operation: () => Promise<{ status: number; body: T }>,
+  options: WithIdempotencyOptions = {},
+): Promise<IdempotentOutcome<T>> {
+  const acquireResult = await acquireIdempotency(
+    repository,
+    scope,
+    rawBody,
+    options.leaseMs ?? DEFAULT_LEASE_MS,
+  );
+
+  if (acquireResult.status === "conflict") {
+    throw new ApiError("idempotency_mismatch");
+  }
+  if (acquireResult.status === "in_progress") {
+    throw new ApiError("request_in_progress");
+  }
+  if (acquireResult.status === "completed") {
+    return {
+      status: acquireResult.record.status,
+      body: acquireResult.record.body as T,
+      replayed: true,
+    };
+  }
+
+  try {
+    const result = await operation();
+    await recordIdempotency(repository, scope, rawBody, result.status, result.body);
+    return { ...result, replayed: false };
+  } catch (error) {
+    const cacheable = options.cacheableErrorStatuses ?? [];
+    if (error instanceof ApiError && cacheable.includes(error.status)) {
+      await recordIdempotency(repository, scope, rawBody, error.status, {
+        error: { code: error.code, message: error.message, details: error.details },
+      });
+    } else {
+      // Transient failure: don't leave a live lease behind, or a legitimate
+      // retry with the same key would be wrongly rejected as in-progress
+      // until the lease expires.
+      await releaseIdempotencyLease(repository, scope, rawBody);
+    }
+    throw error;
+  }
 }

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -147,9 +147,10 @@ export class HybridApiRepository implements ApiRepository {
 
   async acquireIdempotencyRecord(
     key: string,
+    requestDigest: string,
     leaseMs: number,
   ): Promise<import("./repository").AcquireIdempotencyResult> {
-    return this.getStub().acquireIdempotencyRecord(key, leaseMs);
+    return this.getStub().acquireIdempotencyRecord(key, requestDigest, leaseMs);
   }
 
   async setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void> {

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -186,12 +186,19 @@ export class MemoryApiRepository implements ApiRepository {
 
   async acquireIdempotencyRecord(
     key: string,
+    requestDigest: string,
     leaseMs: number,
   ): Promise<import("./repository").AcquireIdempotencyResult> {
     const existing = this.idempotency.get(key);
     const now = Date.now();
 
     if (existing) {
+      // Same key, different payload: never block behind or replay a
+      // response for a different logical request (Issue #1498).
+      if (existing.requestDigest !== requestDigest) {
+        return { status: "conflict" };
+      }
+
       if (existing.state === "completed") {
         return { status: "completed", record: structuredClone(existing) };
       }
@@ -205,6 +212,7 @@ export class MemoryApiRepository implements ApiRepository {
     // Acquire the lock
     this.idempotency.set(key, {
       state: "in_progress",
+      requestDigest,
       createdAt: new Date(now).toISOString(),
       recoveryExpiryAt: new Date(now + leaseMs).toISOString(),
     });

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -27,7 +27,14 @@ export type PostageTransitionResult =
 export type AcquireIdempotencyResult =
   | { status: "acquired" }
   | { status: "in_progress" }
-  | { status: "completed"; record: IdempotencyRecord & { state: "completed" } };
+  | { status: "completed"; record: IdempotencyRecord & { state: "completed" } }
+  /**
+   * A record already exists for this actor/method/route/key, but it was
+   * created for a request with a different canonical body digest. Issue
+   * #1498: reusing an idempotency key for a different payload must never
+   * block behind, or replay the response of, an unrelated request.
+   */
+  | { status: "conflict" };
 
 /**
  * Outcome of an atomic read-receipt publication.
@@ -88,7 +95,11 @@ export interface ApiRepository {
   setReceipt(receipt: Receipt): Promise<Receipt>;
   createReceiptIfAbsent(receipt: Receipt): Promise<{ created: boolean; receipt: Receipt }>;
   markReceiptRead(messageId: string, actor: string, now?: Date): Promise<MarkReceiptReadResult>;
-  acquireIdempotencyRecord(key: string, leaseMs: number): Promise<AcquireIdempotencyResult>;
+  acquireIdempotencyRecord(
+    key: string,
+    requestDigest: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult>;
   getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null>;
   setIdempotencyRecord(key: string, record: IdempotencyRecord): Promise<void>;
 
@@ -271,11 +282,15 @@ export class ValidatedApiRepository implements ApiRepository {
     return result;
   }
 
-  acquireIdempotencyRecord(key: string, leaseMs: number): Promise<AcquireIdempotencyResult> {
+  acquireIdempotencyRecord(
+    key: string,
+    requestDigest: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult> {
     // Acquire does not take an object payload to insert, it creates one internally.
     // The internal DO logic is responsible for its own fields.
     // For reads via this repo wrapper, we could validate the returned record.
-    return this.inner.acquireIdempotencyRecord(key, leaseMs).then((result) => {
+    return this.inner.acquireIdempotencyRecord(key, requestDigest, leaseMs).then((result) => {
       if (result.status === "completed") {
         result.record = validateRecord<IdempotencyRecord & { state: "completed" }>(
           "idempotencyRecord",
@@ -475,8 +490,12 @@ export class RetryableApiRepository implements ApiRepository {
     );
   }
 
-  acquireIdempotencyRecord(key: string, leaseMs: number): Promise<AcquireIdempotencyResult> {
-    return this.inner.acquireIdempotencyRecord(key, leaseMs);
+  acquireIdempotencyRecord(
+    key: string,
+    requestDigest: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult> {
+    return this.inner.acquireIdempotencyRecord(key, requestDigest, leaseMs);
   }
 
   getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -51,13 +51,23 @@ export class StealthCoordinator extends DurableObjectBase {
     await this.ctx.storage.put(`idempotency:${key}`, record);
   }
 
-  async acquireIdempotencyRecord(key: string, leaseMs: number): Promise<AcquireIdempotencyResult> {
+  async acquireIdempotencyRecord(
+    key: string,
+    requestDigest: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult> {
     return this.runExclusive(`idempotency:${key}`, async () => {
       const storageKey = `idempotency:${key}`;
       const existing = (await this.ctx.storage.get(storageKey)) as IdempotencyRecord | undefined;
       const now = Date.now();
 
       if (existing) {
+        // Same key, different payload: never block behind or replay a
+        // response for a different logical request (Issue #1498).
+        if (existing.requestDigest !== requestDigest) {
+          return { status: "conflict" };
+        }
+
         if (existing.state === "completed") {
           return {
             status: "completed",
@@ -75,6 +85,7 @@ export class StealthCoordinator extends DurableObjectBase {
 
       await this.ctx.storage.put(storageKey, {
         state: "in_progress",
+        requestDigest,
         createdAt: new Date(now).toISOString(),
         recoveryExpiryAt: new Date(now + leaseMs).toISOString(),
       });

--- a/tests/unit/api/idempotency-canonicalization.test.ts
+++ b/tests/unit/api/idempotency-canonicalization.test.ts
@@ -1,40 +1,84 @@
 import { describe, expect, it } from "vitest";
 
-import { hashIdempotencyKey } from "../../../src/server/api/idempotency-service";
+import {
+  hashIdempotencyKey,
+  computeRequestDigest,
+} from "../../../src/server/api/idempotency-service";
 
 // Issue #1501: canonicalize request bodies before computing idempotency digests.
 const actor = "owner-A";
+const method = "POST";
+const route = "POST /test-route";
 
 describe("idempotency key canonicalization", () => {
   it("produces the same digest for object-key reordering", () => {
     const a = { b: 1, a: 2, c: 3 };
     const b = { c: 3, a: 2, b: 1 };
-    expect(hashIdempotencyKey(actor, a)).toBe(hashIdempotencyKey(actor, b));
+    expect(hashIdempotencyKey(actor, method, route, a)).toBe(
+      hashIdempotencyKey(actor, method, route, b),
+    );
   });
 
   it("keeps array order significant", () => {
     const a = [1, 2, 3];
     const b = [3, 2, 1];
-    expect(hashIdempotencyKey(actor, a)).not.toBe(hashIdempotencyKey(actor, b));
+    expect(hashIdempotencyKey(actor, method, route, a)).not.toBe(
+      hashIdempotencyKey(actor, method, route, b),
+    );
   });
 
   it("keeps numeric vs string distinctions significant", () => {
-    expect(hashIdempotencyKey(actor, 1)).not.toBe(hashIdempotencyKey(actor, "1"));
+    expect(hashIdempotencyKey(actor, method, route, 1)).not.toBe(
+      hashIdempotencyKey(actor, method, route, "1"),
+    );
   });
 
   it("keeps nested structure significant", () => {
     const a = { x: { y: 1 } };
     const b = { x: { y: 2 } };
-    expect(hashIdempotencyKey(actor, a)).not.toBe(hashIdempotencyKey(actor, b));
+    expect(hashIdempotencyKey(actor, method, route, a)).not.toBe(
+      hashIdempotencyKey(actor, method, route, b),
+    );
   });
 
   it("binds the digest to the actor", () => {
     const payload = { b: 1, a: 2 };
-    expect(hashIdempotencyKey("owner-A", payload)).not.toBe(hashIdempotencyKey("owner-B", payload));
+    expect(hashIdempotencyKey("owner-A", method, route, payload)).not.toBe(
+      hashIdempotencyKey("owner-B", method, route, payload),
+    );
+  });
+
+  it("binds the digest to the method and route (issue #1498)", () => {
+    const payload = { b: 1, a: 2 };
+    expect(hashIdempotencyKey(actor, "POST", route, payload)).not.toBe(
+      hashIdempotencyKey(actor, "PUT", route, payload),
+    );
+    expect(hashIdempotencyKey(actor, method, "POST /other-route", payload)).not.toBe(
+      hashIdempotencyKey(actor, method, route, payload),
+    );
   });
 
   it("is deterministic across calls", () => {
     const payload = { z: [1, 2], a: "x", m: { n: true } };
-    expect(hashIdempotencyKey(actor, payload)).toBe(hashIdempotencyKey(actor, payload));
+    expect(hashIdempotencyKey(actor, method, route, payload)).toBe(
+      hashIdempotencyKey(actor, method, route, payload),
+    );
+  });
+});
+
+describe("request digest canonicalization", () => {
+  it("produces the same digest for object-key reordering", () => {
+    expect(computeRequestDigest({ b: 1, a: 2 })).toBe(computeRequestDigest({ a: 2, b: 1 }));
+  });
+
+  it("distinguishes genuinely different payloads", () => {
+    expect(computeRequestDigest({ amount: "100" })).not.toBe(
+      computeRequestDigest({ amount: "200" }),
+    );
+  });
+
+  it("is deterministic across calls", () => {
+    const payload = { z: [1, 2], a: "x" };
+    expect(computeRequestDigest(payload)).toBe(computeRequestDigest(payload));
   });
 });

--- a/tests/unit/api/idempotency-service.test.ts
+++ b/tests/unit/api/idempotency-service.test.ts
@@ -2,59 +2,79 @@ import { describe, expect, it } from "vitest";
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
 import {
   hashIdempotencyKey,
+  computeRequestDigest,
   acquireIdempotency,
   recordIdempotency,
+  withIdempotency,
+  type IdempotencyScope,
 } from "../../../src/server/api/idempotency-service";
+import { ApiError } from "../../../src/server/api/errors";
 
 const actor1 = `G${"A".repeat(55)}`;
 const actor2 = `G${"B".repeat(55)}`;
 const rawKey = "test-idempotency-key-123";
+const method = "POST";
+const route = "POST /test-route";
+
+function scope(overrides: Partial<IdempotencyScope> = {}): IdempotencyScope {
+  return { actor: actor1, method, route, rawKey, ...overrides };
+}
 
 describe("Idempotency Service", () => {
   it("generates deterministic SHA-256 hashes without leaking raw keys", () => {
-    const hash = hashIdempotencyKey(actor1, rawKey);
+    const hash = hashIdempotencyKey(actor1, method, route, rawKey);
     expect(hash).toMatch(/^[a-f0-9]{64}$/); // standard sha256 output format
     expect(hash).not.toContain(rawKey);
 
     // Verify determinism
-    const hash2 = hashIdempotencyKey(actor1, rawKey);
+    const hash2 = hashIdempotencyKey(actor1, method, route, rawKey);
     expect(hash).toBe(hash2);
   });
 
   it("ensures actor isolation (no collision for same key under different actors)", () => {
-    const hashA1 = hashIdempotencyKey(actor1, rawKey);
-    const hashA2 = hashIdempotencyKey(actor2, rawKey);
+    const hashA1 = hashIdempotencyKey(actor1, method, route, rawKey);
+    const hashA2 = hashIdempotencyKey(actor2, method, route, rawKey);
     expect(hashA1).not.toBe(hashA2);
+  });
+
+  it("scopes the key by method and route (issue #1498)", () => {
+    const hashPost = hashIdempotencyKey(actor1, "POST", route, rawKey);
+    const hashPut = hashIdempotencyKey(actor1, "PUT", route, rawKey);
+    const hashOtherRoute = hashIdempotencyKey(actor1, method, "POST /other-route", rawKey);
+    expect(hashPost).not.toBe(hashPut);
+    expect(hashPost).not.toBe(hashOtherRoute);
   });
 
   it("acquires lease and blocks concurrent followers", async () => {
     const repository = new MemoryApiRepository();
+    const body = { amount: 1 };
 
     // First request acquires successfully
-    const acquire1 = await acquireIdempotency(repository, actor1, rawKey);
+    const acquire1 = await acquireIdempotency(repository, scope(), body);
     expect(acquire1.status).toBe("acquired");
 
-    // Second concurrent request gets blocked
-    const acquire2 = await acquireIdempotency(repository, actor1, rawKey);
+    // Second concurrent request with the same payload gets blocked
+    const acquire2 = await acquireIdempotency(repository, scope(), body);
     expect(acquire2.status).toBe("in_progress");
 
     // Different actor can acquire their own
-    const acquireOther = await acquireIdempotency(repository, actor2, rawKey);
+    const acquireOther = await acquireIdempotency(repository, scope({ actor: actor2 }), body);
     expect(acquireOther.status).toBe("acquired");
   });
 
   it("returns cached response after completion", async () => {
     const repository = new MemoryApiRepository();
+    const body = { amount: 1 };
 
     // Acquire lock
-    await acquireIdempotency(repository, actor1, rawKey);
+    await acquireIdempotency(repository, scope(), body);
 
     // Complete it
     const responseBody = { success: true, test: "data" };
-    await recordIdempotency(repository, actor1, rawKey, 201, responseBody);
+    await recordIdempotency(repository, scope(), body, 201, responseBody);
 
     // Follower sees completed response
-    const acquire2 = await acquireIdempotency(repository, actor1, rawKey);
+    const acquire2 = await acquireIdempotency(repository, scope(), body);
     expect(acquire2.status).toBe("completed");
     if (acquire2.status === "completed") {
       expect(acquire2.record.status).toBe(201);
@@ -65,13 +85,148 @@ describe("Idempotency Service", () => {
 
   it("recovers abandoned leases after expiry", async () => {
     const repository = new MemoryApiRepository();
+    const body = { amount: 1 };
 
-    // Acquire lock with 0ms lease (expires instantly)
-    const acquire1 = await acquireIdempotency(repository, actor1, rawKey, -100);
+    // Acquire lock with a negative lease (expires instantly)
+    const acquire1 = await acquireIdempotency(repository, scope(), body, -100);
     expect(acquire1.status).toBe("acquired");
 
     // Because it expired in the past, a follower should immediately acquire it
-    const acquire2 = await acquireIdempotency(repository, actor1, rawKey, 30000);
+    const acquire2 = await acquireIdempotency(repository, scope(), body, 30000);
     expect(acquire2.status).toBe("acquired");
+  });
+
+  describe("payload digest binding (issue #1498)", () => {
+    it("computes distinct digests for distinct canonical payloads", () => {
+      expect(computeRequestDigest({ a: 1 })).not.toBe(computeRequestDigest({ a: 2 }));
+      expect(computeRequestDigest({ a: 1, b: 2 })).toBe(computeRequestDigest({ b: 2, a: 1 }));
+    });
+
+    it("returns conflict when an in-flight lease is reused with a different payload", async () => {
+      const repository = new MemoryApiRepository();
+      await acquireIdempotency(repository, scope(), { amount: 1 });
+
+      const result = await acquireIdempotency(repository, scope(), { amount: 2 });
+      expect(result.status).toBe("conflict");
+    });
+
+    it("returns conflict when a completed record is reused with a different payload", async () => {
+      const repository = new MemoryApiRepository();
+      await acquireIdempotency(repository, scope(), { amount: 1 });
+      await recordIdempotency(repository, scope(), { amount: 1 }, 200, { ok: true });
+
+      const result = await acquireIdempotency(repository, scope(), { amount: 2 });
+      expect(result.status).toBe("conflict");
+    });
+  });
+
+  describe("withIdempotency", () => {
+    it("runs the operation once and replays it for an identical retry", async () => {
+      const repository = new MemoryApiRepository();
+      let executions = 0;
+      const operation = async () => {
+        executions += 1;
+        return { status: 201, body: { executions } };
+      };
+
+      const first = await withIdempotency(repository, scope(), { amount: 1 }, operation);
+      expect(first).toEqual({ status: 201, body: { executions: 1 }, replayed: false });
+
+      const second = await withIdempotency(repository, scope(), { amount: 1 }, operation);
+      expect(second).toEqual({ status: 201, body: { executions: 1 }, replayed: true });
+      expect(executions).toBe(1);
+    });
+
+    it("throws idempotency_mismatch (409) when the key is reused with a different payload", async () => {
+      const repository = new MemoryApiRepository();
+      const operation = async () => ({ status: 201, body: { ok: true } });
+
+      await withIdempotency(repository, scope(), { amount: 1 }, operation);
+
+      await expect(
+        withIdempotency(repository, scope(), { amount: 2 }, operation),
+      ).rejects.toMatchObject({ code: "idempotency_mismatch", status: 409 });
+    });
+
+    it("throws request_in_progress (409) for a concurrent identical duplicate", async () => {
+      const repository = new MemoryApiRepository();
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const operation = async () => {
+        await gate;
+        return { status: 201, body: { ok: true } };
+      };
+
+      const first = withIdempotency(repository, scope(), { amount: 1 }, operation);
+      await Promise.resolve(); // let the first call acquire its lease
+
+      await expect(
+        withIdempotency(repository, scope(), { amount: 1 }, operation),
+      ).rejects.toMatchObject({ code: "request_in_progress", status: 409 });
+
+      releaseFirst();
+      await expect(first).resolves.toMatchObject({ status: 201, replayed: false });
+    });
+
+    it("caches only the configured error statuses for replay", async () => {
+      const repository = new MemoryApiRepository();
+      let executions = 0;
+      const failing = async () => {
+        executions += 1;
+        throw new ApiError(409, "conflict", "already settled");
+      };
+
+      await expect(
+        withIdempotency(repository, scope(), { amount: 1 }, failing, {
+          cacheableErrorStatuses: [409],
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+
+      // Replayed from the cached error without re-running the operation.
+      const replay = await withIdempotency(repository, scope(), { amount: 1 }, failing, {
+        cacheableErrorStatuses: [409],
+      });
+      expect(replay.replayed).toBe(true);
+      expect(executions).toBe(1);
+    });
+
+    it("does not cache statuses outside cacheableErrorStatuses, allowing retry", async () => {
+      const repository = new MemoryApiRepository();
+      let executions = 0;
+      const flaky = async () => {
+        executions += 1;
+        if (executions === 1) {
+          throw new ApiError(500, "internal_error", "transient");
+        }
+        return { status: 201, body: { ok: true } };
+      };
+
+      await expect(
+        withIdempotency(repository, scope(), { amount: 1 }, flaky, {
+          cacheableErrorStatuses: [409],
+        }),
+      ).rejects.toMatchObject({ status: 500 });
+
+      const retry = await withIdempotency(repository, scope(), { amount: 1 }, flaky, {
+        cacheableErrorStatuses: [409],
+      });
+      expect(retry).toEqual({ status: 201, body: { ok: true }, replayed: false });
+      expect(executions).toBe(2);
+    });
+
+    it("treats different keys as independent operations", async () => {
+      const repository = new MemoryApiRepository();
+      let executions = 0;
+      const operation = async () => {
+        executions += 1;
+        return { status: 200, body: { executions } };
+      };
+
+      await withIdempotency(repository, scope({ rawKey: "key-a" }), { amount: 1 }, operation);
+      await withIdempotency(repository, scope({ rawKey: "key-b" }), { amount: 1 }, operation);
+      expect(executions).toBe(2);
+    });
   });
 });

--- a/tests/unit/api/postage-refund-idempotency.test.ts
+++ b/tests/unit/api/postage-refund-idempotency.test.ts
@@ -3,10 +3,34 @@ import { describe, expect, it } from "vitest";
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
 import { resolvePostage, getPostage } from "../../../src/server/api/postage-service";
 import { createApiContext } from "../../../src/server/api/context";
-import { checkIdempotency, recordIdempotency } from "../../../src/server/api/idempotency-service";
+import {
+  acquireIdempotency,
+  recordIdempotency,
+  type IdempotencyScope,
+} from "../../../src/server/api/idempotency-service";
 
 const recipient = `G${"A".repeat(55)}`;
 const sender = `G${"B".repeat(55)}`;
+
+const refundScope = (recipientAddress: string, key: string): IdempotencyScope => ({
+  actor: recipientAddress,
+  method: "POST",
+  route: "POST /postage/{messageId}/refund",
+  rawKey: key,
+});
+
+/** Mirrors the refund route: refund has no request body, so the message id is the payload. */
+async function checkIdempotency(
+  repository: MemoryApiRepository,
+  recipientAddress: string,
+  key: string,
+  messageId: string,
+) {
+  const result = await acquireIdempotency(repository, refundScope(recipientAddress, key), {
+    messageId,
+  });
+  return result.status === "completed" ? result.record : null;
+}
 
 describe("Postage Refund Idempotency", () => {
   describe("resolvePostage - deterministic terminal states", () => {
@@ -244,7 +268,7 @@ describe("Postage Refund Idempotency", () => {
       });
 
       // First request: no idempotency record exists
-      const firstCheck = await checkIdempotency(repository, recipient, idempotencyKey);
+      const firstCheck = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(firstCheck).toBeNull();
 
       // Perform refund
@@ -256,10 +280,16 @@ describe("Postage Refund Idempotency", () => {
       expect(refundedPostage.status).toBe("refunded");
 
       // Record the success for replay
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, refundedPostage);
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        refundedPostage,
+      );
 
       // Second request: idempotency record exists
-      const secondCheck = await checkIdempotency(repository, recipient, idempotencyKey);
+      const secondCheck = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(secondCheck).not.toBeNull();
       expect((secondCheck as any)?.status).toBe(200);
       expect((secondCheck as any)?.body).toEqual(refundedPostage);
@@ -307,16 +337,27 @@ describe("Postage Refund Idempotency", () => {
         message: string;
         details: unknown;
       };
-      await recordIdempotency(repository, recipient, idempotencyKey, 409, {
-        error: {
-          code: apiError.code,
-          message: apiError.message,
-          details: apiError.details,
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, idempotencyKey),
+        { messageId },
+        409,
+        {
+          error: {
+            code: apiError.code,
+            message: apiError.message,
+            details: apiError.details,
+          },
         },
-      });
+      );
 
       // Second attempt: retrieve cached error
-      const replayedRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const replayedRecord = await checkIdempotency(
+        repository,
+        recipient,
+        idempotencyKey,
+        messageId,
+      );
       expect(replayedRecord).not.toBeNull();
       expect((replayedRecord as any)?.status).toBe(409);
 
@@ -333,18 +374,35 @@ describe("Postage Refund Idempotency", () => {
       const idempotencyKey = "shared-key-refund-123";
 
       // Recipient 1 records a refund
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, {
-        messageId: "x".repeat(64),
-        status: "refunded",
-      });
+      const messageId = "x".repeat(64);
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        {
+          messageId,
+          status: "refunded",
+        },
+      );
 
       // Recipient 1 can retrieve their record
-      const recipient1Check = await checkIdempotency(repository, recipient, idempotencyKey);
+      const recipient1Check = await checkIdempotency(
+        repository,
+        recipient,
+        idempotencyKey,
+        messageId,
+      );
       expect(recipient1Check).not.toBeNull();
       expect((recipient1Check as any)?.status).toBe(200);
 
       // Recipient 2 cannot see recipient 1's idempotency record (actor isolation)
-      const recipient2Check = await checkIdempotency(repository, recipient2, idempotencyKey);
+      const recipient2Check = await checkIdempotency(
+        repository,
+        recipient2,
+        idempotencyKey,
+        messageId,
+      );
       expect(recipient2Check).toBeNull();
     });
   });
@@ -367,10 +425,16 @@ describe("Postage Refund Idempotency", () => {
 
       // First request completes successfully
       const firstResult = await resolvePostage(createApiContext(repository), messageId, "refunded");
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, firstResult);
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        firstResult,
+      );
 
       // Network failure occurs, client retries with same idempotency key
-      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(retryRecord).not.toBeNull();
       expect((retryRecord as any)?.status).toBe(200);
 
@@ -414,16 +478,22 @@ describe("Postage Refund Idempotency", () => {
         message: string;
         details: unknown;
       };
-      await recordIdempotency(repository, recipient, idempotencyKey, 409, {
-        error: {
-          code: apiError.code,
-          message: apiError.message,
-          details: apiError.details,
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, idempotencyKey),
+        { messageId },
+        409,
+        {
+          error: {
+            code: apiError.code,
+            message: apiError.message,
+            details: apiError.details,
+          },
         },
-      });
+      );
 
       // Network failure, client retries with same idempotency key
-      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(retryRecord).not.toBeNull();
       expect((retryRecord as any)?.status).toBe(409);
 
@@ -466,15 +536,27 @@ describe("Postage Refund Idempotency", () => {
 
       // Refund first postage with key1
       const result1 = await resolvePostage(createApiContext(repository), messageId1, "refunded");
-      await recordIdempotency(repository, recipient, key1, 200, result1);
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, key1),
+        { messageId: messageId1 },
+        200,
+        result1,
+      );
 
       // Refund second postage with key2
       const result2 = await resolvePostage(createApiContext(repository), messageId2, "refunded");
-      await recordIdempotency(repository, recipient, key2, 200, result2);
+      await recordIdempotency(
+        repository,
+        refundScope(recipient, key2),
+        { messageId: messageId2 },
+        200,
+        result2,
+      );
 
       // Each key retrieves its own result
-      const check1 = await checkIdempotency(repository, recipient, key1);
-      const check2 = await checkIdempotency(repository, recipient, key2);
+      const check1 = await checkIdempotency(repository, recipient, key1, messageId1);
+      const check2 = await checkIdempotency(repository, recipient, key2, messageId2);
 
       expect((check1 as any)?.body).toEqual(result1);
       expect((check2 as any)?.body).toEqual(result2);

--- a/tests/unit/api/postage-settle-refund-idempotency-route.test.ts
+++ b/tests/unit/api/postage-settle-refund-idempotency-route.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Route as SettleRoute } from "../../../src/routes/api/v1/postage/$messageId/settle";
+import { Route as RefundRoute } from "../../../src/routes/api/v1/postage/$messageId/refund";
+import { ACTOR_HEADER } from "../../../src/server/api/actor";
+import { getApiContext } from "../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+const recipient = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+
+const settleHandler = (SettleRoute.options as any).server?.handlers?.POST;
+const refundHandler = (RefundRoute.options as any).server?.handlers?.POST;
+
+function request(messageId: string, idempotencyKey?: string) {
+  const headers: Record<string, string> = { [ACTOR_HEADER]: recipient };
+  if (idempotencyKey) headers["x-idempotency-key"] = idempotencyKey;
+  return new Request(`https://stealth.test/api/v1/postage/${messageId}/settle`, {
+    method: "POST",
+    headers,
+  });
+}
+
+async function parseJson(response: Response) {
+  return response.clone().json() as Promise<{
+    error?: { code: string; message: string };
+    data?: any;
+  }>;
+}
+
+describe("postage settle/refund idempotency (route-level, issue #1498)", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  async function seedPostage(messageId: string, amount = "100") {
+    await repo.setPostage({
+      amount,
+      createdAt: "2026-06-14T12:00:00.000Z",
+      messageId,
+      paymentHash: "b".repeat(64),
+      recipient,
+      sender,
+      status: "pending",
+    });
+  }
+
+  describe("settle", () => {
+    it("replays the stored response for a duplicate identical request", async () => {
+      const messageId = "a".repeat(64);
+      await seedPostage(messageId);
+
+      const first = await settleHandler({
+        request: request(messageId, "settle-key-1"),
+        params: { messageId },
+      });
+      expect(first.status).toBe(200);
+      expect(first.headers.get("x-idempotency-replayed")).toBeNull();
+      const firstBody = await parseJson(first);
+      expect(firstBody.data.status).toBe("settled");
+
+      const second = await settleHandler({
+        request: request(messageId, "settle-key-1"),
+        params: { messageId },
+      });
+      expect(second.status).toBe(200);
+      expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+      const secondBody = await parseJson(second);
+      expect(secondBody.data).toEqual(firstBody.data);
+
+      // Only ever settled once.
+      const finalPostage = await repo.getPostage(messageId);
+      expect(finalPostage?.status).toBe("settled");
+    });
+
+    it("returns 409 idempotency_mismatch when the key is reused for a different message", async () => {
+      const messageId1 = "a".repeat(64);
+      const messageId2 = "c".repeat(64);
+      await seedPostage(messageId1);
+      await seedPostage(messageId2);
+
+      const first = await settleHandler({
+        request: request(messageId1, "shared-settle-key"),
+        params: { messageId: messageId1 },
+      });
+      expect(first.status).toBe(200);
+
+      const second = await settleHandler({
+        request: request(messageId2, "shared-settle-key"),
+        params: { messageId: messageId2 },
+      });
+      expect(second.status).toBe(409);
+      const body = await parseJson(second);
+      expect(body.error?.code).toBe("idempotency_mismatch");
+
+      // The second message must remain untouched by the rejected request.
+      const postage2 = await repo.getPostage(messageId2);
+      expect(postage2?.status).toBe("pending");
+    });
+
+    it("executes the operation exactly once under concurrent identical duplicates", async () => {
+      const messageId = "a".repeat(64);
+      await seedPostage(messageId);
+
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          settleHandler({
+            request: request(messageId, "concurrent-settle-key"),
+            params: { messageId },
+          }),
+        ),
+      );
+
+      const statuses = responses.map((response: Response) => response.status).sort();
+      // Exactly one winner (200); every other concurrent duplicate is
+      // rejected as in-progress (409) rather than re-running the settlement.
+      expect(statuses.filter((status: number) => status === 200)).toHaveLength(1);
+      expect(statuses.filter((status: number) => status === 409)).toHaveLength(4);
+
+      const finalPostage = await repo.getPostage(messageId);
+      expect(finalPostage?.status).toBe("settled");
+    });
+  });
+
+  describe("refund", () => {
+    function refundRequest(messageId: string, idempotencyKey?: string) {
+      const headers: Record<string, string> = { [ACTOR_HEADER]: recipient };
+      if (idempotencyKey) headers["x-idempotency-key"] = idempotencyKey;
+      return new Request(`https://stealth.test/api/v1/postage/${messageId}/refund`, {
+        method: "POST",
+        headers,
+      });
+    }
+
+    it("replays the stored response for a duplicate identical request", async () => {
+      const messageId = "a".repeat(64);
+      await seedPostage(messageId);
+
+      const first = await refundHandler({
+        request: refundRequest(messageId, "refund-key-1"),
+        params: { messageId },
+      });
+      expect(first.status).toBe(200);
+
+      const second = await refundHandler({
+        request: refundRequest(messageId, "refund-key-1"),
+        params: { messageId },
+      });
+      expect(second.status).toBe(200);
+      expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+
+      const finalPostage = await repo.getPostage(messageId);
+      expect(finalPostage?.status).toBe("refunded");
+    });
+
+    it("returns 409 idempotency_mismatch when the key is reused for a different message", async () => {
+      const messageId1 = "a".repeat(64);
+      const messageId2 = "c".repeat(64);
+      await seedPostage(messageId1);
+      await seedPostage(messageId2);
+
+      await refundHandler({
+        request: refundRequest(messageId1, "shared-refund-key"),
+        params: { messageId: messageId1 },
+      });
+
+      const second = await refundHandler({
+        request: refundRequest(messageId2, "shared-refund-key"),
+        params: { messageId: messageId2 },
+      });
+      expect(second.status).toBe(409);
+      const body = await parseJson(second);
+      expect(body.error?.code).toBe("idempotency_mismatch");
+    });
+  });
+});

--- a/tests/unit/api/postage-settlement-idempotency.test.ts
+++ b/tests/unit/api/postage-settlement-idempotency.test.ts
@@ -3,10 +3,34 @@ import { describe, expect, it } from "vitest";
 import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
 import { resolvePostage, getPostage } from "../../../src/server/api/postage-service";
 import { createApiContext } from "../../../src/server/api/context";
-import { checkIdempotency, recordIdempotency } from "../../../src/server/api/idempotency-service";
+import {
+  acquireIdempotency,
+  recordIdempotency,
+  type IdempotencyScope,
+} from "../../../src/server/api/idempotency-service";
 
 const recipient = `G${"A".repeat(55)}`;
 const sender = `G${"B".repeat(55)}`;
+
+const settleScope = (recipientAddress: string, key: string): IdempotencyScope => ({
+  actor: recipientAddress,
+  method: "POST",
+  route: "POST /postage/{messageId}/settle",
+  rawKey: key,
+});
+
+/** Mirrors the settle route: settlement has no request body, so the message id is the payload. */
+async function checkIdempotency(
+  repository: MemoryApiRepository,
+  recipientAddress: string,
+  key: string,
+  messageId: string,
+) {
+  const result = await acquireIdempotency(repository, settleScope(recipientAddress, key), {
+    messageId,
+  });
+  return result.status === "completed" ? result.record : null;
+}
 
 describe("Postage Settlement Idempotency", () => {
   describe("resolvePostage - deterministic terminal states", () => {
@@ -208,7 +232,7 @@ describe("Postage Settlement Idempotency", () => {
       });
 
       // First request: no idempotency record exists
-      const firstCheck = await checkIdempotency(repository, recipient, idempotencyKey);
+      const firstCheck = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(firstCheck).toBeNull();
 
       // Perform settlement
@@ -220,10 +244,16 @@ describe("Postage Settlement Idempotency", () => {
       expect(settledPostage.status).toBe("settled");
 
       // Record the success for replay
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, settledPostage);
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        settledPostage,
+      );
 
       // Second request: idempotency record exists
-      const secondCheck = await checkIdempotency(repository, recipient, idempotencyKey);
+      const secondCheck = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(secondCheck).not.toBeNull();
       expect((secondCheck as any)?.status).toBe(200);
       expect((secondCheck as any)?.body).toEqual(settledPostage);
@@ -271,16 +301,27 @@ describe("Postage Settlement Idempotency", () => {
         message: string;
         details: unknown;
       };
-      await recordIdempotency(repository, recipient, idempotencyKey, 409, {
-        error: {
-          code: apiError.code,
-          message: apiError.message,
-          details: apiError.details,
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId },
+        409,
+        {
+          error: {
+            code: apiError.code,
+            message: apiError.message,
+            details: apiError.details,
+          },
         },
-      });
+      );
 
       // Second attempt: retrieve cached error
-      const replayedRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const replayedRecord = await checkIdempotency(
+        repository,
+        recipient,
+        idempotencyKey,
+        messageId,
+      );
       expect(replayedRecord).not.toBeNull();
       expect((replayedRecord as any)?.status).toBe(409);
 
@@ -295,21 +336,55 @@ describe("Postage Settlement Idempotency", () => {
       const repository = new MemoryApiRepository();
       const recipient2 = `G${"C".repeat(55)}`;
       const idempotencyKey = "shared-key-123";
+      const messageId = "x".repeat(64);
 
       // Recipient 1 records a settlement
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, {
-        messageId: "x".repeat(64),
-        status: "settled",
-      });
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        { messageId, status: "settled" },
+      );
 
       // Recipient 1 can retrieve their record
-      const recipient1Check = await checkIdempotency(repository, recipient, idempotencyKey);
+      const recipient1Check = await checkIdempotency(
+        repository,
+        recipient,
+        idempotencyKey,
+        messageId,
+      );
       expect(recipient1Check).not.toBeNull();
       expect((recipient1Check as any)?.status).toBe(200);
 
       // Recipient 2 cannot see recipient 1's idempotency record (actor isolation)
-      const recipient2Check = await checkIdempotency(repository, recipient2, idempotencyKey);
+      const recipient2Check = await checkIdempotency(
+        repository,
+        recipient2,
+        idempotencyKey,
+        messageId,
+      );
       expect(recipient2Check).toBeNull();
+    });
+
+    it("returns conflict when the same key is reused to settle a different message", async () => {
+      const repository = new MemoryApiRepository();
+      const idempotencyKey = "reused-key-across-messages";
+      const messageId1 = "d1".repeat(32);
+      const messageId2 = "d2".repeat(32);
+
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId: messageId1 },
+        200,
+        { messageId: messageId1, status: "settled" },
+      );
+
+      const result = await acquireIdempotency(repository, settleScope(recipient, idempotencyKey), {
+        messageId: messageId2,
+      });
+      expect(result.status).toBe("conflict");
     });
   });
 
@@ -331,10 +406,16 @@ describe("Postage Settlement Idempotency", () => {
 
       // First request completes successfully
       const firstResult = await resolvePostage(createApiContext(repository), messageId, "settled");
-      await recordIdempotency(repository, recipient, idempotencyKey, 200, firstResult);
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId },
+        200,
+        firstResult,
+      );
 
       // Network failure occurs, client retries with same idempotency key
-      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(retryRecord).not.toBeNull();
       expect((retryRecord as any)?.status).toBe(200);
 
@@ -378,16 +459,22 @@ describe("Postage Settlement Idempotency", () => {
         message: string;
         details: unknown;
       };
-      await recordIdempotency(repository, recipient, idempotencyKey, 409, {
-        error: {
-          code: apiError.code,
-          message: apiError.message,
-          details: apiError.details,
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, idempotencyKey),
+        { messageId },
+        409,
+        {
+          error: {
+            code: apiError.code,
+            message: apiError.message,
+            details: apiError.details,
+          },
         },
-      });
+      );
 
       // Network failure, client retries with same idempotency key
-      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey);
+      const retryRecord = await checkIdempotency(repository, recipient, idempotencyKey, messageId);
       expect(retryRecord).not.toBeNull();
       expect((retryRecord as any)?.status).toBe(409);
 
@@ -430,15 +517,27 @@ describe("Postage Settlement Idempotency", () => {
 
       // Settle first postage with key1
       const result1 = await resolvePostage(createApiContext(repository), messageId1, "settled");
-      await recordIdempotency(repository, recipient, key1, 200, result1);
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, key1),
+        { messageId: messageId1 },
+        200,
+        result1,
+      );
 
       // Settle second postage with key2
       const result2 = await resolvePostage(createApiContext(repository), messageId2, "settled");
-      await recordIdempotency(repository, recipient, key2, 200, result2);
+      await recordIdempotency(
+        repository,
+        settleScope(recipient, key2),
+        { messageId: messageId2 },
+        200,
+        result2,
+      );
 
       // Each key retrieves its own result
-      const check1 = await checkIdempotency(repository, recipient, key1);
-      const check2 = await checkIdempotency(repository, recipient, key2);
+      const check1 = await checkIdempotency(repository, recipient, key1, messageId1);
+      const check2 = await checkIdempotency(repository, recipient, key2, messageId2);
 
       expect((check1 as any)?.body).toEqual(result1);
       expect((check2 as any)?.body).toEqual(result2);

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -189,12 +189,56 @@ export function runRepositoryContractTests(
           state: "completed",
           status: 200,
           body: { ok: true },
+          requestDigest: "digest-1",
           createdAt: "2026-01-01T00:00:00.000Z",
           completedAt: "2026-01-01T00:00:01.000Z",
         });
         await expect(repo.getIdempotencyRecord("key-1")).resolves.toMatchObject({
           status: 200,
         });
+      });
+
+      // Issue #1498: acquiring a lease binds it to a canonical request digest,
+      // so a same-key-different-payload retry never blocks behind or replays
+      // an unrelated request's response.
+      it("acquires, blocks concurrent followers, and replays the completed response", async () => {
+        const acquired = await repo.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+        expect(acquired).toEqual({ status: "acquired" });
+
+        const inProgress = await repo.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+        expect(inProgress).toEqual({ status: "in_progress" });
+
+        await repo.setIdempotencyRecord("key-2", {
+          state: "completed",
+          status: 200,
+          body: { ok: true },
+          requestDigest: "digest-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-01T00:00:01.000Z",
+        });
+
+        const completed = await repo.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+        expect(completed).toMatchObject({ status: "completed", record: { body: { ok: true } } });
+      });
+
+      it("returns conflict when the same key is reused with a different payload digest", async () => {
+        await repo.acquireIdempotencyRecord("key-3", "digest-a", 30_000);
+
+        const conflict = await repo.acquireIdempotencyRecord("key-3", "digest-b", 30_000);
+        expect(conflict).toEqual({ status: "conflict" });
+      });
+
+      it("only lets one of many concurrent duplicate acquires win", async () => {
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () =>
+            repo.acquireIdempotencyRecord("key-4", "digest-a", 30_000),
+          ),
+        );
+
+        const acquired = results.filter((result) => result.status === "acquired");
+        const inProgress = results.filter((result) => result.status === "in_progress");
+        expect(acquired).toHaveLength(1);
+        expect(inProgress).toHaveLength(4);
       });
     });
 

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -94,9 +94,13 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setReceipt");
     return this.inner.setReceipt(receipt);
   }
-  async acquireIdempotencyRecord(key: string, leaseMs: number): Promise<AcquireIdempotencyResult> {
+  async acquireIdempotencyRecord(
+    key: string,
+    requestDigest: string,
+    leaseMs: number,
+  ): Promise<AcquireIdempotencyResult> {
     this.maybeFail("acquireIdempotencyRecord");
-    return this.inner.acquireIdempotencyRecord(key, leaseMs);
+    return this.inner.acquireIdempotencyRecord(key, requestDigest, leaseMs);
   }
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
     this.maybeFail("getIdempotencyRecord");
@@ -256,7 +260,7 @@ describe("RetryableApiRepository", () => {
   it("does not retry acquireIdempotencyRecord (unsafe write)", async () => {
     failing.setFailCount("acquireIdempotencyRecord", 2);
 
-    await expect(repo.acquireIdempotencyRecord("key", 30_000)).rejects.toThrow();
+    await expect(repo.acquireIdempotencyRecord("key", "digest", 30_000)).rejects.toThrow();
     expect(failing.getCallCount("acquireIdempotencyRecord")).toBe(1);
   });
 

--- a/tests/unit/api/stealth-coordinator.test.ts
+++ b/tests/unit/api/stealth-coordinator.test.ts
@@ -45,6 +45,7 @@ describe("StealthCoordinator - Durable Object Operations", () => {
     const record: IdempotencyRecord = {
       state: "completed",
       body: { ok: true },
+      requestDigest: "digest-1",
       createdAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
       status: 201,
@@ -53,6 +54,74 @@ describe("StealthCoordinator - Durable Object Operations", () => {
     expect(await coordinator.getIdempotencyRecord("key-1")).toBeNull();
     await coordinator.setIdempotencyRecord("key-1", record);
     expect(await coordinator.getIdempotencyRecord("key-1")).toEqual(record);
+  });
+
+  describe("idempotency lease acquisition (issue #1498)", () => {
+    it("acquires, blocks concurrent followers, and replays after completion", async () => {
+      const first = await coordinator.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+      expect(first).toEqual({ status: "acquired" });
+
+      const second = await coordinator.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+      expect(second).toEqual({ status: "in_progress" });
+
+      await coordinator.setIdempotencyRecord("key-2", {
+        state: "completed",
+        status: 200,
+        body: { ok: true },
+        requestDigest: "digest-a",
+        createdAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      });
+
+      const third = await coordinator.acquireIdempotencyRecord("key-2", "digest-a", 30_000);
+      expect(third).toMatchObject({ status: "completed", record: { body: { ok: true } } });
+    });
+
+    it("returns conflict when the same key is reused with a different payload digest", async () => {
+      await coordinator.acquireIdempotencyRecord("key-3", "digest-a", 30_000);
+
+      const mismatchWhileInProgress = await coordinator.acquireIdempotencyRecord(
+        "key-3",
+        "digest-b",
+        30_000,
+      );
+      expect(mismatchWhileInProgress).toEqual({ status: "conflict" });
+
+      await coordinator.setIdempotencyRecord("key-3", {
+        state: "completed",
+        status: 200,
+        body: { ok: true },
+        requestDigest: "digest-a",
+        createdAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      });
+
+      const mismatchAfterCompletion = await coordinator.acquireIdempotencyRecord(
+        "key-3",
+        "digest-b",
+        30_000,
+      );
+      expect(mismatchAfterCompletion).toEqual({ status: "conflict" });
+    });
+
+    it("survives independent API contexts sharing the same durable storage", async () => {
+      // Simulates two separate Worker invocations reaching the same Durable
+      // Object storage: a fresh StealthCoordinator instance, backed by the
+      // same underlying storage, must observe state left by the other.
+      await coordinator.acquireIdempotencyRecord("key-4", "digest-a", 30_000);
+      await coordinator.setIdempotencyRecord("key-4", {
+        state: "completed",
+        status: 200,
+        body: { settled: true },
+        requestDigest: "digest-a",
+        createdAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      });
+
+      const independentContext = new StealthCoordinator(state as any, {});
+      const replay = await independentContext.acquireIdempotencyRecord("key-4", "digest-a", 30_000);
+      expect(replay).toMatchObject({ status: "completed", record: { body: { settled: true } } });
+    });
   });
 
   it("handles counter sliding window rate-limiting", async () => {

--- a/tests/unit/api/validated-repository.test.ts
+++ b/tests/unit/api/validated-repository.test.ts
@@ -16,7 +16,9 @@ registerRecordSchema("mailboxPolicy", 1, mailboxPolicySchema);
 registerRecordSchema("senderRule", 1, senderRuleSchema);
 registerRecordSchema("postage", 1, postageSchema);
 registerRecordSchema("receipt", 1, receiptSchema);
-registerRecordSchema("idempotencyRecord", 1, idempotencyRecordSchema);
+registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
+  1: (data: any) => ({ ...data, requestDigest: "legacy:unrecoverable" }),
+});
 
 const owner = `G${"A".repeat(55)}`;
 const sender = `G${"B".repeat(55)}`;


### PR DESCRIPTION
## Summary

Idempotency records were already persisted durably (Durable Object storage,
surviving restarts and shared across Worker instances), but the key hash
only bound to `actor:rawKey` — not the request payload, method, or route.
A reused key with a **different** payload would silently replay the wrong
cached response instead of failing closed, and refund had no idempotency
support at all despite being as payment-critical as settle.

- Bind every lease/response to a canonical digest of the request payload;
  a reused key with a different payload now returns `409 idempotency_mismatch`
  instead of an incorrect replay or block
- Scope the key hash by actor + HTTP method + route template, not actor alone
- Add `withIdempotency()`, a single entry point that acquires the lease,
  replays completed records, records terminal outcomes, and — critically —
  releases the lease on an uncached transient failure, so a legitimate
  retry isn't blocked for the full lease TTL
- Wire postage submit and settle onto the new helper, and add the same
  idempotency support to postage **refund**, which previously had none
- Bump the `idempotencyRecord` schema to v2 with a migration for legacy
  records predating `requestDigest`

Closes #1498

## Acceptance criteria

- [x] Duplicate identical requests replay the stored response
- [x] A reused key with a different payload returns 409
- [x] Concurrent duplicates execute the operation once
- [x] Behavior survives independent API contexts (Durable Object storage,
      verified with two independent coordinator instances sharing storage)

## Test plan

- [x] `npx vitest run tests/unit` — 1688 passing, 3 pre-existing expected-fail
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed files — clean
- [x] New coverage: digest-mismatch conflicts, concurrent-duplicate races,
      transient-failure lease release, and route-level tests for settle/refund
