### PR TITLE
[Contacts Import] Close keyboard and screen-reader gaps

### DIFF
--- a/src/features/contacts/import/BulkWriteProgressPanel.tsx
+++ b/src/features/contacts/import/BulkWriteProgressPanel.tsx
@@ -12,13 +12,13 @@ type Props = {
 function StatusIcon({ status }: { status: PolicyWriteJob["status"] }) {
   switch (status) {
     case "running":
-      return <Loader2 className="h-3.5 w-3.5 animate-spin text-sky-400" />;
+      return <Loader2 className="h-3.5 w-3.5 animate-spin text-sky-400" aria-hidden="true" />;
     case "success":
-      return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" />;
+      return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" aria-hidden="true" />;
     case "failed":
-      return <XCircle className="h-3.5 w-3.5 text-red-400" />;
+      return <XCircle className="h-3.5 w-3.5 text-red-400" aria-hidden="true" />;
     default:
-      return <div className="h-3.5 w-3.5 rounded-full border border-white/20" />;
+      return <div className="h-3.5 w-3.5 rounded-full border border-white/20" aria-hidden="true" />;
   }
 }
 
@@ -58,7 +58,14 @@ export function BulkWriteProgressPanel({ progress, onPause, onResume, onCancel }
 
       {/* progress bar */}
       <div className="space-y-1.5">
-        <div className="flex h-2 overflow-hidden rounded-full bg-white/[0.06]">
+        <div
+          role="progressbar"
+          aria-label="Import progress"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="flex h-2 overflow-hidden rounded-full bg-white/[0.06]"
+        >
           <div
             className="h-full rounded-full bg-emerald-400 transition-all duration-500"
             style={{ width: `${(progress.succeeded / Math.max(progress.total, 1)) * 100}%` }}
@@ -77,7 +84,7 @@ export function BulkWriteProgressPanel({ progress, onPause, onResume, onCancel }
       </div>
 
       {/* counts */}
-      <div className="grid grid-cols-3 gap-2 text-center text-xs">
+      <div className="grid grid-cols-3 gap-2 text-center text-xs" aria-hidden="true">
         <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
           <span className="block text-emerald-400 text-sm font-semibold">{progress.succeeded}</span>
           <span className="text-muted-foreground">Allowed</span>
@@ -96,7 +103,7 @@ export function BulkWriteProgressPanel({ progress, onPause, onResume, onCancel }
 
       {/* errors */}
       {progress.errors.length > 0 && (
-        <div className="max-h-24 overflow-y-auto space-y-1 rounded-xl border border-red-400/20 bg-red-400/[0.04] p-3">
+        <div className="max-h-24 overflow-y-auto space-y-1 rounded-xl border border-red-400/20 bg-red-400/[0.04] p-3" role="region" aria-label="Migration errors" aria-live="polite">
           <p className="text-[11px] font-medium text-red-300">Errors</p>
           {progress.errors.slice(0, 5).map((err, i) => (
             <p key={i} className="text-[10px] text-red-200/70 font-mono">
@@ -118,7 +125,7 @@ export function BulkWriteProgressPanel({ progress, onPause, onResume, onCancel }
             onClick={onPause}
             className="flex items-center justify-center gap-2 flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm text-muted-foreground transition hover:bg-white/[0.04] hover:text-foreground"
           >
-            <PauseCircle className="h-4 w-4" />
+            <PauseCircle className="h-4 w-4" aria-hidden="true" />
             Pause
           </button>
         )}
@@ -128,14 +135,14 @@ export function BulkWriteProgressPanel({ progress, onPause, onResume, onCancel }
               onClick={onResume}
               className="flex items-center justify-center gap-2 flex-1 rounded-xl bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
             >
-              <PlayCircle className="h-4 w-4" />
+              <PlayCircle className="h-4 w-4" aria-hidden="true" />
               Resume
             </button>
             <button
               onClick={onCancel}
               className="flex items-center justify-center gap-2 flex-1 rounded-xl border border-red-400/20 px-4 py-2.5 text-sm text-red-300 transition hover:bg-red-400/[0.06]"
             >
-              <XCircle className="h-4 w-4" />
+              <XCircle className="h-4 w-4" aria-hidden="true" />
               Cancel
             </button>
           </>

--- a/src/features/contacts/import/ContactMigrationDialog.tsx
+++ b/src/features/contacts/import/ContactMigrationDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, MotionConfig } from "framer-motion";
 import { AlertCircle, Users, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 import { ImportSourcePicker } from "./ImportSourcePicker";
 import { IdentityReviewTable } from "./IdentityReviewTable";
 import { BulkWriteProgressPanel } from "./BulkWriteProgressPanel";
@@ -197,6 +198,7 @@ export function ContactMigrationDialog({
   }
 
   const stepIndex = VISIBLE_STEPS.indexOf(step);
+  const dialogRef = useFocusTrap(open, onClose);
 
   return (
     <AnimatePresence>
@@ -208,32 +210,42 @@ export function ContactMigrationDialog({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
+            aria-hidden="true"
             className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
           />
-          <motion.div
-            key="migration-panel"
-            initial={{ opacity: 0, scale: 0.96, y: 12 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: 8 }}
-            transition={{ type: "spring", stiffness: 300, damping: 28 }}
-            className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(580px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl"
-          >
-            {/* header */}
-            <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
-              <div className="flex items-center gap-2.5">
-                <Users className="h-4 w-4 text-muted-foreground" />
-                <h2 className="text-sm font-semibold text-foreground">Contact migration</h2>
+          <MotionConfig reducedMotion="user">
+            <motion.div
+              key="migration-panel"
+              ref={dialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Contact migration"
+              tabIndex={-1}
+              initial={{ opacity: 0, scale: 0.96, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96, y: 8 }}
+              transition={{ type: "spring", stiffness: 300, damping: 28 }}
+              className="glass-strong fixed left-1/2 top-1/2 z-50 w-[min(580px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl outline-none"
+            >
+              {/* header */}
+              <div className="flex items-center justify-between border-b border-white/5 px-5 py-4">
+                <div className="flex items-center gap-2.5">
+                  <Users className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  <h2 className="text-sm font-semibold text-foreground" id="migration-title">
+                    Contact migration
+                  </h2>
+                </div>
+                <button
+                  onClick={onClose}
+                  aria-label="Close dialog"
+                  className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
               </div>
-              <button
-                onClick={onClose}
-                className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-white/[0.06] hover:text-foreground"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
 
             {/* step label */}
-            <div className="px-5 pt-3 pb-0">
+            <div className="px-5 pt-3 pb-0" aria-live="polite" aria-atomic="true">
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-medium text-muted-foreground">
                   Step {stepIndex + 1} of {VISIBLE_STEPS.length}
@@ -357,6 +369,7 @@ export function ContactMigrationDialog({
               </AnimatePresence>
             </div>
           </motion.div>
+          </MotionConfig>
         </>
       )}
     </AnimatePresence>

--- a/src/features/contacts/import/IdentityReviewTable.tsx
+++ b/src/features/contacts/import/IdentityReviewTable.tsx
@@ -122,18 +122,19 @@ export function IdentityReviewTable({ rows, onChange }: Props) {
 
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
-          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <input
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search by name or address…"
+            aria-label="Search contacts"
             className="w-full rounded-lg border border-white/10 bg-white/[0.04] py-1.5 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-white/20"
           />
         </div>
       </div>
 
       {/* filter tabs */}
-      <div className="flex flex-wrap gap-1.5 text-[11px]">
+      <div className="flex flex-wrap gap-1.5 text-[11px]" role="tablist" aria-label="Filter by match status">
         {[
           { key: "all", label: `All (${rows.length})` },
           { key: "exact", label: `Matched (${exact.length})` },
@@ -143,6 +144,8 @@ export function IdentityReviewTable({ rows, onChange }: Props) {
         ].map((t) => (
           <button
             key={t.key}
+            role="tab"
+            aria-selected={filter === t.key}
             onClick={() => setFilter(t.key)}
             className={cn(
               "rounded-md border px-2 py-0.5 transition",
@@ -157,10 +160,15 @@ export function IdentityReviewTable({ rows, onChange }: Props) {
       </div>
 
       {/* rows */}
-      <div className="max-h-[320px] overflow-y-auto space-y-1.5 pr-0.5">
+      <div
+        className="max-h-[320px] overflow-y-auto space-y-1.5 pr-0.5"
+        role="region"
+        aria-label="Contacts list"
+        tabIndex={0}
+      >
         {filtered.length === 0 && (
-          <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
-            <Users className="h-6 w-6" />
+          <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground" aria-live="polite">
+            <Users className="h-6 w-6" aria-hidden="true" />
             <p className="text-xs">No contacts in this filter.</p>
           </div>
         )}
@@ -224,13 +232,13 @@ export function IdentityReviewTable({ rows, onChange }: Props) {
               <div className="flex items-center gap-2 text-[10px]">
                 {row.match && (
                   <span className={cn("flex items-center gap-1", meta.color)}>
-                    {meta.icon}
+                    <span aria-hidden="true">{meta.icon}</span>
                     {meta.label}: {row.match.reason}
                   </span>
                 )}
                 {row.error && (
                   <span className="flex items-center gap-1 text-red-400">
-                    <AlertCircle className="h-3 w-3 shrink-0" />
+                    <AlertCircle className="h-3 w-3 shrink-0" aria-hidden="true" />
                     {row.error}
                   </span>
                 )}

--- a/src/features/contacts/import/ImportSourcePicker.tsx
+++ b/src/features/contacts/import/ImportSourcePicker.tsx
@@ -75,6 +75,20 @@ export function ImportSourcePicker({ onSelectSource }: Props) {
     [handleFile],
   );
 
+  const triggerFilePicker = useCallback(() => {
+    fileRef.current?.click();
+  }, []);
+
+  const handleDropZoneKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        triggerFilePicker();
+      }
+    },
+    [triggerFilePicker],
+  );
+
   if (mode === "csv-input") {
     return (
       <div className="space-y-5">
@@ -99,10 +113,14 @@ export function ImportSourcePicker({ onSelectSource }: Props) {
         <div
           onDragOver={(e) => e.preventDefault()}
           onDrop={handleDrop}
-          onClick={() => fileRef.current?.click()}
-          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-white/10 bg-white/[0.02] px-4 py-6 transition hover:bg-white/[0.04]"
+          onClick={triggerFilePicker}
+          onKeyDown={handleDropZoneKeyDown}
+          role="button"
+          tabIndex={0}
+          aria-label="Upload CSV file. Drag and drop or press Enter to browse."
+          className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-white/10 bg-white/[0.02] px-4 py-6 transition hover:bg-white/[0.04] focus-visible:border-white/30 focus-visible:outline-none"
         >
-          <Upload className="h-5 w-5 text-muted-foreground" />
+          <Upload className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
           <p className="text-xs text-muted-foreground">
             Drag & drop a <span className="text-foreground">.csv</span> file or click to browse
           </p>
@@ -111,6 +129,8 @@ export function ImportSourcePicker({ onSelectSource }: Props) {
             type="file"
             accept=".csv,.tsv,text/csv,text/tab-separated-values"
             className="hidden"
+            tabIndex={-1}
+            aria-hidden="true"
             onChange={(e) => {
               const f = e.target.files?.[0];
               if (f) handleFile(f);
@@ -182,7 +202,7 @@ export function ImportSourcePicker({ onSelectSource }: Props) {
                 : "border-white/10 bg-white/[0.025] hover:bg-white/[0.05] hover:border-white/20",
             )}
           >
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] text-muted-foreground">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] text-muted-foreground" aria-hidden="true">
               {s.icon}
             </span>
             <div className="min-w-0 flex-1">


### PR DESCRIPTION
Closes #992

## Summary
Improve the existing Contacts Import surface by closing keyboard and screen-reader gaps identified during an a11y audit. All changes are in-place, no new components or tools introduced.

## Changes

### ContactMigrationDialog.tsx
- Added `useFocusTrap` hook for Tab/Shift+Tab trapping, Escape close, focus restoration
- Added `role="dialog"`, `aria-modal="true"`, `aria-label="Contact migration"` to the panel
- Added `aria-hidden="true"` on backdrop; `aria-label="Close dialog"` on close button
- Wrapped panel in `<MotionConfig reducedMotion="user">` for reduced-motion support
- Added `aria-live="polite"` on the step indicator for screen-reader step announcements

### ImportSourcePicker.tsx
- Made drag/drop file upload zone keyboard accessible (`role="button"`, `tabIndex`, `onKeyDown`)
- Added `aria-hidden="true"` to decorative icons throughout

### IdentityReviewTable.tsx
- Added `role="tablist"` / `role="tab"` / `aria-selected` on filter buttons
- Added `aria-label="Search contacts"` on the search input
- Added `role="region"` / `aria-label="Contacts list"` / `tabIndex={0}` on scrollable list
- Added `aria-live="polite"` on empty-state; `aria-hidden="true"` on decorative icons

### BulkWriteProgressPanel.tsx
- Added `role="progressbar"` with `aria-valuenow/min/max` on the progress bar
- Added `aria-hidden="true"` on all decorative status icons, count cards, and button icons
- Added `aria-live="polite"` on the error region
