### PR TITLE
feat(envelope-repo): persist encrypted envelopes with immutable IDs (…

### DIFF
--- a/protocol/schemas/envelope.schema.json
+++ b/protocol/schemas/envelope.schema.json
@@ -1,11 +1,22 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "StealthEnvelope",
-  "description": "Cryptographic signature envelope for Stealth messages",
+  "description": "Cryptographic signature envelope for Stealth messages. Includes ciphertext and an immutable message_id for durable persistence (BETA-029 / Issue #1936).",
   "type": "object",
-  "required": ["payload", "signature"],
+  "required": ["message_id", "ciphertext", "payload", "signature"],
   "additionalProperties": false,
   "properties": {
+    "message_id": {
+      "description": "Immutable 32-byte lowercase hex message identifier. Used as the primary key in the encrypted-message repository.",
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "ciphertext": {
+      "description": "Base64-encoded AES-256-GCM encrypted body. Plaintext is never stored.",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/=]+$",
+      "minLength": 1
+    },
     "payload": {
       "type": "object",
       "required": [
@@ -58,6 +69,7 @@
           }
         },
         "content_commitment": {
+          "description": "SHA-256 hex commitment over the plaintext body for integrity verification.",
           "type": "string",
           "pattern": "^[a-f0-9]{64}$"
         },

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -12,6 +12,7 @@ import {
   userSchema,
   profileSchema,
   credentialSchema,
+  storedEnvelopeSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -9,6 +9,7 @@ import {
   receiptSchema,
   idempotencyRecordSchema,
   stellarAddressSchema,
+  storedEnvelopeSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -197,6 +198,10 @@ registerRecordSchema("receipt", 1, receiptSchema);
 registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
   1: (data: any) => ({ ...data, requestDigest: "legacy:unrecoverable" }),
 });
+// Issue #1936 (BETA-029): register StoredEnvelope schema so that
+// ValidatedApiRepository can detect tampered or structurally invalid
+// envelope records at the adapter boundary before they reach any caller.
+registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+// ---------------------------------------------------------------------------
+// StoredEnvelope — durable encrypted-message record (Issue #1936 BETA-029)
+// Plaintext (subject, body) is intentionally absent from this schema.
+// ---------------------------------------------------------------------------
+
 export const stellarAddressSchema = z
   .string()
   .trim()
@@ -127,3 +132,66 @@ export const idempotencyRecordSchema = z.discriminatedUnion("state", [
 ]);
 
 export type IdempotencyRecord = z.infer<typeof idempotencyRecordSchema>;
+
+/**
+ * Zod schema for a durably stored encrypted message envelope.
+ *
+ * Design principles
+ * -----------------
+ * - `ciphertext`        : the raw encrypted body (base64url), never decrypted here.
+ * - `protectedHeaders`  : immutable encryption metadata stored alongside ciphertext
+ *                         (algorithm, ephemeral key, nonce, MAC) so the data needed
+ *                         to decrypt is co-located with the ciphertext.
+ * - `contentCommitment` : SHA-256 hex commitment over the plaintext, allowing
+ *                         integrity verification without storing plaintext.
+ * - `senderId`          : Stellar G-address of the originating party.
+ * - `recipientId`       : Stellar G-address of the intended recipient — used as
+ *                         the primary index for mailbox sync without indexing plaintext.
+ * - `createdAt`         : ISO-8601 insertion timestamp set by the server.
+ * - `$v`                : schema version for future migrations (starts at 1).
+ *
+ * Plaintext (`subject`, `body`) is **never** a field of this record.
+ */
+export const storedEnvelopeProtectedHeadersSchema = z.object({
+  algorithm: z.string().min(1).max(64),
+  ephemeral_public_key: stellarAddressSchema,
+  nonce: z
+    .string()
+    .regex(/^[a-f0-9]+$/, "Expected a hex string for nonce")
+    .min(2)
+    .max(128),
+  mac: hash32Schema,
+  version: z.string().regex(/^v[0-9]+$/),
+});
+
+export const storedEnvelopeSchema = z.object({
+  /** Immutable unique message identifier — 32-byte lowercase hex. */
+  messageId: hash32Schema,
+  /** Stellar G-address of the sender. */
+  senderId: stellarAddressSchema,
+  /** Stellar G-address of the recipient — used as the mailbox index. */
+  recipientId: stellarAddressSchema,
+  /**
+   * Encrypted body ciphertext.
+   * Base64url-encoded, no padding (RFC 4648 §5). Plaintext is never stored.
+   */
+  ciphertext: z
+    .string()
+    .min(1, "Ciphertext must not be empty")
+    .max(20 * 1024 * 1024, "Ciphertext exceeds 20 MiB limit")
+    .regex(/^[A-Za-z0-9+/=]+$/, "Ciphertext must be valid base64"),
+  /** Encryption metadata required for decryption; immutable after insert. */
+  protectedHeaders: storedEnvelopeProtectedHeadersSchema,
+  /**
+   * Hex-encoded SHA-256 commitment over the plaintext body.
+   * Enables integrity verification without storing plaintext.
+   */
+  contentCommitment: hash32Schema,
+  /** ISO-8601 server-side insertion timestamp. */
+  createdAt: z.string().datetime(),
+  /** Schema version for future migrations. */
+  $v: z.number().int().min(1).optional(),
+});
+
+export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
+export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -244,3 +244,66 @@ export function toPublicProfile(profile: Profile): PublicProfile {
     updatedAt: profile.updatedAt,
   };
 }
+
+/**
+ * Zod schema for a durably stored encrypted message envelope.
+ *
+ * Design principles
+ * -----------------
+ * - `ciphertext`        : the raw encrypted body (base64url), never decrypted here.
+ * - `protectedHeaders`  : immutable encryption metadata stored alongside ciphertext
+ *                         (algorithm, ephemeral key, nonce, MAC) so the data needed
+ *                         to decrypt is co-located with the ciphertext.
+ * - `contentCommitment` : SHA-256 hex commitment over the plaintext, allowing
+ *                         integrity verification without storing plaintext.
+ * - `senderId`          : Stellar G-address of the originating party.
+ * - `recipientId`       : Stellar G-address of the intended recipient — used as
+ *                         the primary index for mailbox sync without indexing plaintext.
+ * - `createdAt`         : ISO-8601 insertion timestamp set by the server.
+ * - `$v`                : schema version for future migrations (starts at 1).
+ *
+ * Plaintext (`subject`, `body`) is **never** a field of this record.
+ */
+export const storedEnvelopeProtectedHeadersSchema = z.object({
+  algorithm: z.string().min(1).max(64),
+  ephemeral_public_key: stellarAddressSchema,
+  nonce: z
+    .string()
+    .regex(/^[a-f0-9]+$/, "Expected a hex string for nonce")
+    .min(2)
+    .max(128),
+  mac: hash32Schema,
+  version: z.string().regex(/^v[0-9]+$/),
+});
+
+export const storedEnvelopeSchema = z.object({
+  /** Immutable unique message identifier — 32-byte lowercase hex. */
+  messageId: hash32Schema,
+  /** Stellar G-address of the sender. */
+  senderId: stellarAddressSchema,
+  /** Stellar G-address of the recipient — used as the mailbox index. */
+  recipientId: stellarAddressSchema,
+  /**
+   * Encrypted body ciphertext.
+   * Base64url-encoded, no padding (RFC 4648 §5). Plaintext is never stored.
+   */
+  ciphertext: z
+    .string()
+    .min(1, "Ciphertext must not be empty")
+    .max(20 * 1024 * 1024, "Ciphertext exceeds 20 MiB limit")
+    .regex(/^[A-Za-z0-9+/=]+$/, "Ciphertext must be valid base64"),
+  /** Encryption metadata required for decryption; immutable after insert. */
+  protectedHeaders: storedEnvelopeProtectedHeadersSchema,
+  /**
+   * Hex-encoded SHA-256 commitment over the plaintext body.
+   * Enables integrity verification without storing plaintext.
+   */
+  contentCommitment: hash32Schema,
+  /** ISO-8601 server-side insertion timestamp. */
+  createdAt: z.string().datetime(),
+  /** Schema version for future migrations. */
+  $v: z.number().int().min(1).optional(),
+});
+
+export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
+export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,4 +1,9 @@
-import type { ApiRepository, PostageTransitionResult, UpdateUserResult } from "./repository";
+import type {
+  ApiRepository,
+  InsertEnvelopeResult,
+  PostageTransitionResult,
+  UpdateUserResult,
+} from "./repository";
 import type {
   Credential,
   IdempotencyRecord,
@@ -8,6 +13,7 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  StoredEnvelope,
   User,
 } from "./domain";
 import { ApiError } from "./errors";

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,4 +1,4 @@
-import type { ApiRepository, PostageTransitionResult } from "./repository";
+import type { ApiRepository, InsertEnvelopeResult, PostageTransitionResult } from "./repository";
 import type {
   MailboxPolicy,
   SenderRule,
@@ -6,6 +6,7 @@ import type {
   PostageStatus,
   Receipt,
   IdempotencyRecord,
+  StoredEnvelope,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -184,5 +185,42 @@ export class HybridApiRepository implements ApiRepository {
 
   async getRelayDeadLetterCount(_relayId: string): Promise<number> {
     return 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1936 (BETA-029) — Durable encrypted envelope persistence
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reads from KV as the fast path, then falls back to the coordinator.
+   * Plaintext is never stored; ciphertext + headers are retrieved as-is.
+   */
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    const kvResult = await this.kv.get(this.key("envelope", messageId), "json");
+    if (kvResult) return kvResult as StoredEnvelope;
+
+    // KV miss — the coordinator is the authoritative source.
+    const coordResult = await this.getStub().getEnvelope(messageId);
+    if (coordResult) {
+      // Write-back to KV so subsequent reads hit the fast path.
+      await this.kv.put(this.key("envelope", messageId), JSON.stringify(coordResult));
+    }
+    return coordResult;
+  }
+
+  /**
+   * Delegates the atomic insert to the coordinator (the source of truth for
+   * insert-once semantics), then mirrors a successful insert to KV for fast
+   * subsequent reads. The coordinator's 409 conflict error propagates unchanged
+   * to the caller — it is never swallowed.
+   */
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    // The coordinator enforces byte-identical idempotency and conflict detection.
+    const result = await this.getStub().insertEnvelope(envelope);
+    if (result.outcome === "inserted" || result.outcome === "duplicate") {
+      // Mirror to KV so getEnvelope hits the fast path on subsequent reads.
+      await this.kv.put(this.key("envelope", envelope.messageId), JSON.stringify(result.envelope));
+    }
+    return result;
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -7,9 +7,15 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  StoredEnvelope,
   User,
 } from "./domain";
-import type { ApiRepository, PostageTransitionResult, UpdateUserResult } from "./repository";
+import type {
+  ApiRepository,
+  InsertEnvelopeResult,
+  PostageTransitionResult,
+  UpdateUserResult,
+} from "./repository";
 import { ApiError } from "./errors";
 
 function key(owner: string, sender: string) {
@@ -423,6 +429,8 @@ export class MemoryApiRepository implements ApiRepository {
     this.counters.clear();
     this.idempotency.clear();
     this.receiptLocks.clear();
+    this.envelopes.clear();
+    this.envelopeLocks.clear();
     this.usersById.clear();
     this.usersByEmail.clear();
     this.usersByUsername.clear();

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -5,8 +5,9 @@ import type {
   PostageStatus,
   Receipt,
   SenderRule,
+  StoredEnvelope,
 } from "./domain";
-import type { ApiRepository, PostageTransitionResult } from "./repository";
+import type { ApiRepository, InsertEnvelopeResult, PostageTransitionResult } from "./repository";
 import { ApiError } from "./errors";
 
 function key(owner: string, sender: string) {
@@ -21,6 +22,9 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly counters = new Map<string, number[]>();
   private readonly idempotency = new Map<string, IdempotencyRecord>();
   private readonly receiptLocks = new Map<string, Promise<void>>();
+  // Issue #1936: envelope store and per-key insert locks.
+  private readonly envelopes = new Map<string, StoredEnvelope>();
+  private readonly envelopeLocks = new Map<string, Promise<void>>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -38,6 +42,26 @@ export class MemoryApiRepository implements ApiRepository {
       release();
       if (this.receiptLocks.get(messageId) === queued) {
         this.receiptLocks.delete(messageId);
+      }
+    }
+  }
+
+  private async withEnvelopeLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.envelopeLocks.get(messageId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.envelopeLocks.set(messageId, queued);
+
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.envelopeLocks.get(messageId) === queued) {
+        this.envelopeLocks.delete(messageId);
       }
     }
   }
@@ -228,6 +252,41 @@ export class MemoryApiRepository implements ApiRepository {
     this.idempotency.set(key, structuredClone(record));
   }
 
+  // ---------------------------------------------------------------------------
+  // Issue #1936 (BETA-029) — Encrypted envelope persistence
+  // ---------------------------------------------------------------------------
+
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    return structuredClone(this.envelopes.get(messageId) ?? null);
+  }
+
+  /**
+   * Insert-only envelope persistence.
+   *
+   * Concurrency: the per-key promise chain (withEnvelopeLock) guarantees that
+   * two concurrent inserts for the same messageId are serialized. No `await`
+   * crosses the read-check-write boundary inside the lock body, so the
+   * check-then-act is atomic within the single JS microtask.
+   */
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    return this.withEnvelopeLock(envelope.messageId, async () => {
+      const existing = this.envelopes.get(envelope.messageId);
+      if (existing) {
+        // Byte-equality check: serialize both to canonical JSON for comparison.
+        const existingBytes = JSON.stringify(existing);
+        const incomingBytes = JSON.stringify(envelope);
+        if (existingBytes === incomingBytes) {
+          return { outcome: "duplicate", envelope: structuredClone(existing) };
+        }
+        // Different payload — reject. The prior record is authoritative.
+        return { outcome: "conflict" };
+      }
+      const stored = structuredClone(envelope);
+      this.envelopes.set(envelope.messageId, stored);
+      return { outcome: "inserted", envelope: structuredClone(stored) };
+    });
+  }
+
   reset() {
     this.policies.clear();
     this.postage.clear();
@@ -236,5 +295,7 @@ export class MemoryApiRepository implements ApiRepository {
     this.counters.clear();
     this.idempotency.clear();
     this.receiptLocks.clear();
+    this.envelopes.clear();
+    this.envelopeLocks.clear();
   }
 }

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -8,9 +8,24 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  StoredEnvelope,
   User,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
+
+/**
+ * Outcome of an insert-only encrypted envelope persistence operation.
+ *
+ * - "inserted" : the record was stored for the first time; it is now durable.
+ * - "duplicate": a byte-identical envelope is already durably stored under this
+ *                messageId. Safe to treat as a successful write (idempotent).
+ * - "conflict" : a record with the same messageId already exists with *different*
+ *                payload bytes. The prior record wins; this insert is rejected.
+ */
+export type InsertEnvelopeResult =
+  | { outcome: "inserted"; envelope: StoredEnvelope }
+  | { outcome: "duplicate"; envelope: StoredEnvelope }
+  | { outcome: "conflict" };
 
 /**
  * Outcome of an atomic compare-and-swap postage state transition.
@@ -508,6 +523,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setProfile",
   "getCredential",
   "setCredential",
+  "getEnvelope",
 ]);
 
 function isRetryableError(error: unknown): boolean {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -6,6 +6,7 @@ import type {
   PostageStatus,
   Receipt,
   SenderRule,
+  StoredEnvelope,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
 
@@ -62,6 +63,22 @@ export type MarkReceiptReadResult =
   | { outcome: "already-read"; readAt: string }
   | { outcome: "marked"; receipt: Receipt };
 
+/**
+ * Outcome of an atomic envelope insert.
+ *
+ * - "inserted"  : first time this messageId was seen; the record is now durable.
+ * - "duplicate" : an identical byte-for-byte record already exists for this
+ *                 messageId. The operation is idempotent; callers may treat this
+ *                 as success (retry-safe resubmission).
+ * - "conflict"  : a *different* record (differing ciphertext or headers) already
+ *                 exists for the same messageId. Callers must treat this as an
+ *                 unrecoverable integrity violation — the prior record wins.
+ */
+export type InsertEnvelopeResult =
+  | { outcome: "inserted"; envelope: StoredEnvelope }
+  | { outcome: "duplicate"; envelope: StoredEnvelope }
+  | { outcome: "conflict" };
+
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
@@ -110,6 +127,36 @@ export interface ApiRepository {
   getRelayDeadLetterCount(relayId: string): Promise<number>;
   getCounter(key: string): Promise<number>;
   incrementCounter(key: string, windowSeconds: number, amount?: number): Promise<number>;
+
+  // ---------------------------------------------------------------------------
+  // Issue #1936 (BETA-029) — Durable encrypted envelope repository
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Retrieves a stored envelope by its immutable message ID.
+   * Returns null when no envelope exists for the given ID.
+   * Plaintext is never stored or returned by this method.
+   */
+  getEnvelope(messageId: string): Promise<StoredEnvelope | null>;
+
+  /**
+   * Insert-only: persists a new encrypted envelope under an immutable message ID.
+   *
+   * Idempotency contract
+   * --------------------
+   * - "inserted" : first successful write for this messageId.
+   * - "duplicate": byte-identical payload already exists (safe retry).
+   * - "conflict" : a *different* payload is already stored (unrecoverable).
+   *
+   * Implementations MUST guarantee that concurrent inserts yield exactly one
+   * "inserted" outcome; all racing duplicates receive either "duplicate" or
+   * "conflict" depending on their byte content. A plain get-then-put is
+   * vulnerable to lost-update races and MUST NOT be used here.
+   *
+   * Plaintext MUST NOT be passed to this method; ciphertext only.
+   */
+  insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+
   reset?(): void;
 }
 
@@ -338,6 +385,21 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.incrementCounter(key, windowSeconds, amount);
   }
 
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    const raw = await this.inner.getEnvelope(messageId);
+    return raw ? validateRecord<StoredEnvelope>("storedEnvelope", raw) : null;
+  }
+
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    // Version the record before handing it to the inner adapter so that the
+    // byte-equality check in each implementation uses versioned payloads.
+    const result = await this.inner.insertEnvelope(versionRecord("storedEnvelope", envelope));
+    if (result.outcome === "inserted" || result.outcome === "duplicate") {
+      result.envelope = validateRecord<StoredEnvelope>("storedEnvelope", result.envelope);
+    }
+    return result;
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -378,6 +440,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setIdempotencyRecord",
   "transitionPostage",
   "markReceiptRead",
+  // Issue #1936: envelope reads are idempotent and safe to retry.
+  "getEnvelope",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -540,6 +604,19 @@ export class RetryableApiRepository implements ApiRepository {
 
   incrementCounter(key: string, windowSeconds: number, amount?: number): Promise<number> {
     return this.inner.incrementCounter(key, windowSeconds, amount);
+  }
+
+  // Issue #1936: reads are retry-safe; inserts are not (insert-once semantics).
+  getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    return this.withRetry("getEnvelope", () => this.inner.getEnvelope(messageId));
+  }
+
+  insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    // Never retry: a partial insert could succeed server-side but time out
+    // client-side. On retry, the stored record would be the authoritative one
+    // and the outcome would be "duplicate" (byte-equal) or "conflict" (different
+    // bytes). Callers should handle those outcomes explicitly.
+    return this.inner.insertEnvelope(envelope);
   }
 
   reset(): void {
@@ -765,6 +842,18 @@ export const PAGINATED_QUERY_ORDERINGS = {
   listPostage: declareOrdering<Postage>([{ field: "createdAt", direction: "desc" }], "messageId"),
   listReceipts: declareOrdering<Receipt>(
     [{ field: "deliveredAt", direction: "desc" }],
+    "messageId",
+  ),
+  /**
+   * Issue #1936: Recipient-indexed envelope listing.
+   * Ordered by insertion time descending so a mailbox sync walk returns the
+   * newest messages first. The tie-breaker is messageId so the walk is stable
+   * even when two envelopes share the exact same createdAt millisecond.
+   * recipientId is NOT a sort key here — callers filter by recipientId before
+   * passing the collection to `paginate`, keeping plaintext out of the ordering.
+   */
+  listEnvelopes: declareOrdering<StoredEnvelope>(
+    [{ field: "createdAt", direction: "desc" }],
     "messageId",
   ),
 } as const;

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -5,10 +5,12 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  StoredEnvelope,
   User,
 } from "./domain";
 import type {
   AcquireIdempotencyResult,
+  InsertEnvelopeResult,
   PostageTransitionResult,
   UpdateUserResult,
 } from "./repository";

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1,5 +1,10 @@
-import type { IdempotencyRecord, Postage, PostageStatus, Receipt } from "./domain";
-import type { AcquireIdempotencyResult, PostageTransitionResult } from "./repository";
+import type { IdempotencyRecord, Postage, PostageStatus, Receipt, StoredEnvelope } from "./domain";
+import type {
+  AcquireIdempotencyResult,
+  InsertEnvelopeResult,
+  PostageTransitionResult,
+} from "./repository";
+import { ApiError } from "./errors";
 
 const DurableObjectBase: any = import.meta.env.PROD
   ? (await import("cloudflare:workers")).DurableObject
@@ -42,8 +47,7 @@ export class StealthCoordinator extends DurableObjectBase {
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
     const record = (await this.ctx.storage.get(`idempotency:${key}`)) as
-      | IdempotencyRecord
-      | undefined;
+      IdempotencyRecord | undefined;
     return record ?? null;
   }
 
@@ -191,6 +195,48 @@ export class StealthCoordinator extends DurableObjectBase {
 
       await this.ctx.storage.put(`counter:${key}`, filtered);
       return filtered.length;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1936 (BETA-029) — Durable encrypted envelope store
+  // ---------------------------------------------------------------------------
+
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    const envelope = (await this.ctx.storage.get(`envelope:${messageId}`)) as
+      StoredEnvelope | undefined;
+    return envelope ?? null;
+  }
+
+  /**
+   * Atomically insert an envelope, enforcing immutable-ID semantics.
+   *
+   * runExclusive serializes concurrent inserts for the same messageId so
+   * two racing callers cannot both observe "absent" and both write — exactly
+   * one gets "inserted" and the other gets "duplicate" or "conflict".
+   */
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    return this.runExclusive(`envelope:${envelope.messageId}`, async () => {
+      const existing = (await this.ctx.storage.get(`envelope:${envelope.messageId}`)) as
+        StoredEnvelope | undefined;
+
+      if (existing) {
+        // Byte-equality check — serialize both deterministically for comparison.
+        const existingBytes = JSON.stringify(existing);
+        const incomingBytes = JSON.stringify(envelope);
+        if (existingBytes === incomingBytes) {
+          return { outcome: "duplicate" as const, envelope: existing };
+        }
+        // Different payload for same ID: reject. Prior record is authoritative.
+        throw new ApiError(
+          409,
+          "conflict",
+          `An envelope with a different payload already exists for message ${envelope.messageId}`,
+        );
+      }
+
+      await this.ctx.storage.put(`envelope:${envelope.messageId}`, envelope);
+      return { outcome: "inserted" as const, envelope };
     });
   }
 }

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -47,7 +47,8 @@ export class StealthCoordinator extends DurableObjectBase {
 
   async getIdempotencyRecord(key: string): Promise<IdempotencyRecord | null> {
     const record = (await this.ctx.storage.get(`idempotency:${key}`)) as
-      IdempotencyRecord | undefined;
+      | IdempotencyRecord
+      | undefined;
     return record ?? null;
   }
 
@@ -204,7 +205,8 @@ export class StealthCoordinator extends DurableObjectBase {
 
   async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
     const envelope = (await this.ctx.storage.get(`envelope:${messageId}`)) as
-      StoredEnvelope | undefined;
+      | StoredEnvelope
+      | undefined;
     return envelope ?? null;
   }
 
@@ -218,7 +220,8 @@ export class StealthCoordinator extends DurableObjectBase {
   async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
     return this.runExclusive(`envelope:${envelope.messageId}`, async () => {
       const existing = (await this.ctx.storage.get(`envelope:${envelope.messageId}`)) as
-        StoredEnvelope | undefined;
+        | StoredEnvelope
+        | undefined;
 
       if (existing) {
         // Byte-equality check — serialize both deterministically for comparison.

--- a/tests/unit/api/envelope-repository.test.ts
+++ b/tests/unit/api/envelope-repository.test.ts
@@ -1,0 +1,559 @@
+/**
+ * tests/unit/api/envelope-repository.test.ts
+ *
+ * Issue #1936 — BETA-029: Persist encrypted envelopes and immutable message metadata.
+ *
+ * Coverage:
+ *  - Domain rule: plaintext fields (subject, body) never accepted.
+ *  - Domain rule: storedEnvelopeSchema validates every required field.
+ *  - Insert semantics: first insert -> "inserted".
+ *  - Retry/idempotency: byte-identical resubmission -> "duplicate" (safe).
+ *  - Conflict: different payload same ID -> "conflict" (unrecoverable).
+ *  - Concurrency: exactly one winner out of N concurrent inserts.
+ *  - Tamper detection: ValidatedApiRepository rejects a corrupted record.
+ *  - Size limit: ciphertext exceeding 20 MiB is rejected by the schema.
+ *  - Index consistency: listEnvelopes ordering is stable and recipient-filtered.
+ *  - Reset: envelopes are cleared by reset().
+ *  - Contract: MemoryApiRepository satisfies ApiRepository for envelope methods.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { StoredEnvelope } from "../../../src/server/api/domain";
+import {
+  storedEnvelopeSchema,
+  storedEnvelopeProtectedHeadersSchema,
+} from "../../../src/server/api/domain";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  ValidatedApiRepository,
+  registerRecordSchema,
+  paginate,
+  PAGINATED_QUERY_ORDERINGS,
+} from "../../../src/server/api/repository";
+import { DataIntegrityError } from "../../../src/server/api/errors";
+
+// ---------------------------------------------------------------------------
+// Register schemas (mirrors context.ts — required once per test file)
+// ---------------------------------------------------------------------------
+import {
+  mailboxPolicySchema,
+  senderRuleSchema,
+  postageSchema,
+  receiptSchema,
+  idempotencyRecordSchema,
+} from "../../../src/server/api/domain";
+
+registerRecordSchema("mailboxPolicy", 1, mailboxPolicySchema);
+registerRecordSchema("senderRule", 1, senderRuleSchema);
+registerRecordSchema("postage", 1, postageSchema);
+registerRecordSchema("receipt", 1, receiptSchema);
+registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
+  1: (data: any) => ({ ...data, requestDigest: "legacy:unrecoverable" }),
+});
+registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const SENDER = `G${"A".repeat(55)}`;
+const RECIPIENT = `G${"B".repeat(55)}`;
+const EPHEMERAL_KEY = `G${"C".repeat(55)}`;
+const MSG_ID_A = "a".repeat(64);
+const MSG_ID_B = "b".repeat(64);
+const COMMITMENT = "c".repeat(64);
+const MAC = "d".repeat(64);
+const NONCE = "ab12cd34ef56"; // even-length hex
+
+function makeEnvelope(overrides: Partial<StoredEnvelope> = {}): StoredEnvelope {
+  return {
+    messageId: MSG_ID_A,
+    senderId: SENDER,
+    recipientId: RECIPIENT,
+    ciphertext: "dGVzdC1jaXBoZXJ0ZXh0", // base64 "test-ciphertext"
+    protectedHeaders: {
+      algorithm: "AES-256-GCM",
+      ephemeral_public_key: EPHEMERAL_KEY,
+      nonce: NONCE,
+      mac: MAC,
+      version: "v1",
+    },
+    contentCommitment: COMMITMENT,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Domain schema validation
+// ---------------------------------------------------------------------------
+
+describe("storedEnvelopeSchema — domain rules", () => {
+  it("accepts a valid StoredEnvelope", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope());
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a record with empty ciphertext", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ ciphertext: "" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a record with plaintext fields (subject)", () => {
+    // The schema is strict: no 'subject' field should ever be accepted.
+    const withSubject = { ...makeEnvelope(), subject: "hello" } as any;
+    // storedEnvelopeSchema uses z.object which strips unknown fields in parse.
+    // Acceptance test: parsed output must NOT contain 'subject'.
+    const result = storedEnvelopeSchema.safeParse(withSubject);
+    if (result.success) {
+      expect((result.data as any).subject).toBeUndefined();
+    }
+    // Regardless of parse success, the field must not survive.
+  });
+
+  it("rejects a record with plaintext fields (body)", () => {
+    const withBody = { ...makeEnvelope(), body: "secret message" } as any;
+    const result = storedEnvelopeSchema.safeParse(withBody);
+    if (result.success) {
+      expect((result.data as any).body).toBeUndefined();
+    }
+  });
+
+  it("rejects a record with an invalid messageId (not 64 hex chars)", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ messageId: "short" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a record with an invalid senderId (not a G-address)", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ senderId: "not-a-g-address" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a record with an invalid contentCommitment (not 64 hex chars)", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ contentCommitment: "tooshort" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a record with an invalid createdAt timestamp", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ createdAt: "not-a-timestamp" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects ciphertext with non-base64 characters", () => {
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ ciphertext: "this has spaces!" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects ciphertext exceeding 20 MiB", () => {
+    // 20 MiB + 1 byte of valid base64 characters
+    const oversized = "A".repeat(20 * 1024 * 1024 + 1);
+    const result = storedEnvelopeSchema.safeParse(makeEnvelope({ ciphertext: oversized }));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("storedEnvelopeProtectedHeadersSchema — header fields", () => {
+  it("accepts valid protected headers", () => {
+    const result = storedEnvelopeProtectedHeadersSchema.safeParse({
+      algorithm: "AES-256-GCM",
+      ephemeral_public_key: EPHEMERAL_KEY,
+      nonce: NONCE,
+      mac: MAC,
+      version: "v1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid version format", () => {
+    const result = storedEnvelopeProtectedHeadersSchema.safeParse({
+      algorithm: "AES-256-GCM",
+      ephemeral_public_key: EPHEMERAL_KEY,
+      nonce: NONCE,
+      mac: MAC,
+      version: "1", // must be 'v<digit>'
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects nonce with non-hex characters", () => {
+    const result = storedEnvelopeProtectedHeadersSchema.safeParse({
+      algorithm: "AES-256-GCM",
+      ephemeral_public_key: EPHEMERAL_KEY,
+      nonce: "GGGG", // uppercase not in [a-f0-9]
+      mac: MAC,
+      version: "v1",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. MemoryApiRepository — insert semantics
+// ---------------------------------------------------------------------------
+
+describe("MemoryApiRepository — envelope insert semantics", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("returns 'inserted' on the first insert", async () => {
+    const envelope = makeEnvelope();
+    const result = await repo.insertEnvelope(envelope);
+    expect(result.outcome).toBe("inserted");
+    if (result.outcome === "inserted") {
+      expect(result.envelope.messageId).toBe(MSG_ID_A);
+    }
+  });
+
+  it("returns 'duplicate' for a byte-identical resubmission", async () => {
+    const envelope = makeEnvelope();
+    await repo.insertEnvelope(envelope);
+
+    const retry = await repo.insertEnvelope({ ...envelope });
+    expect(retry.outcome).toBe("duplicate");
+    if (retry.outcome === "duplicate") {
+      expect(retry.envelope.messageId).toBe(MSG_ID_A);
+    }
+  });
+
+  it("returns 'conflict' when a different payload uses the same messageId", async () => {
+    await repo.insertEnvelope(makeEnvelope());
+
+    const different = makeEnvelope({ ciphertext: "ZGlmZmVyZW50" }); // different base64
+    const result = await repo.insertEnvelope(different);
+    expect(result.outcome).toBe("conflict");
+  });
+
+  it("returns null for a missing envelope", async () => {
+    await expect(repo.getEnvelope(MSG_ID_A)).resolves.toBeNull();
+  });
+
+  it("retrieves an inserted envelope by messageId", async () => {
+    const envelope = makeEnvelope();
+    await repo.insertEnvelope(envelope);
+
+    const retrieved = await repo.getEnvelope(MSG_ID_A);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.messageId).toBe(MSG_ID_A);
+    expect(retrieved?.senderId).toBe(SENDER);
+    expect(retrieved?.recipientId).toBe(RECIPIENT);
+    // Critical: plaintext fields must not exist on the retrieved record.
+    expect((retrieved as any)?.subject).toBeUndefined();
+    expect((retrieved as any)?.body).toBeUndefined();
+  });
+
+  it("isolates envelopes by messageId", async () => {
+    await repo.insertEnvelope(makeEnvelope({ messageId: MSG_ID_A }));
+    await repo.insertEnvelope(makeEnvelope({ messageId: MSG_ID_B }));
+
+    await expect(repo.getEnvelope(MSG_ID_A)).resolves.toMatchObject({ messageId: MSG_ID_A });
+    await expect(repo.getEnvelope(MSG_ID_B)).resolves.toMatchObject({ messageId: MSG_ID_B });
+  });
+
+  it("does not reflect post-write mutation of the input object", async () => {
+    const envelope = makeEnvelope();
+    await repo.insertEnvelope(envelope);
+
+    // Mutate the original reference after insert.
+    (envelope as any).senderId = "MUTATED";
+
+    const retrieved = await repo.getEnvelope(MSG_ID_A);
+    expect(retrieved?.senderId).toBe(SENDER);
+  });
+
+  it("clears all envelopes on reset()", async () => {
+    await repo.insertEnvelope(makeEnvelope());
+    repo.reset();
+    await expect(repo.getEnvelope(MSG_ID_A)).resolves.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Concurrency: exactly one winner out of N concurrent inserts
+// ---------------------------------------------------------------------------
+
+describe("MemoryApiRepository — concurrent insert safety", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("allows exactly one winner out of 10 concurrent identical inserts", async () => {
+    const envelope = makeEnvelope();
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => repo.insertEnvelope({ ...envelope })),
+    );
+
+    const inserted = results.filter((r) => r.outcome === "inserted");
+    const duplicates = results.filter((r) => r.outcome === "duplicate");
+    const conflicts = results.filter((r) => r.outcome === "conflict");
+
+    // Exactly one "inserted"; the rest must be "duplicate" (byte-identical).
+    expect(inserted).toHaveLength(1);
+    expect(duplicates).toHaveLength(9);
+    expect(conflicts).toHaveLength(0);
+
+    // The stored record is consistent.
+    await expect(repo.getEnvelope(MSG_ID_A)).resolves.toMatchObject({
+      messageId: MSG_ID_A,
+    });
+  });
+
+  it("returns 'conflict' for every racer that has a different payload", async () => {
+    // First insert wins.
+    await repo.insertEnvelope(makeEnvelope());
+
+    // 5 concurrent submissions each with different ciphertext.
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        repo.insertEnvelope(makeEnvelope({ ciphertext: `ZGlmZmVyZW50${i}AA=` })),
+      ),
+    );
+
+    // All must be "conflict" because the first insert already wrote a record.
+    for (const r of results) {
+      expect(r.outcome).toBe("conflict");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. ValidatedApiRepository — tamper detection
+// ---------------------------------------------------------------------------
+
+describe("ValidatedApiRepository — envelope tamper detection", () => {
+  let inner: MemoryApiRepository;
+  let repo: ValidatedApiRepository;
+
+  beforeEach(() => {
+    inner = new MemoryApiRepository();
+    repo = new ValidatedApiRepository(inner);
+  });
+
+  it("passes through a valid stored envelope unchanged", async () => {
+    await inner.insertEnvelope(makeEnvelope());
+    const retrieved = await repo.getEnvelope(MSG_ID_A);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.messageId).toBe(MSG_ID_A);
+  });
+
+  it("throws DataIntegrityError when the stored record has a corrupted messageId", async () => {
+    await inner.insertEnvelope(makeEnvelope());
+    // Directly corrupt the in-memory store to simulate storage tampering.
+    const envelopeMap = (inner as any)["envelopes"] as Map<string, StoredEnvelope>;
+    envelopeMap.set(MSG_ID_A, { ...makeEnvelope(), messageId: "corrupted" as any });
+
+    await expect(repo.getEnvelope(MSG_ID_A)).rejects.toBeInstanceOf(DataIntegrityError);
+  });
+
+  it("throws DataIntegrityError when ciphertext contains invalid characters", async () => {
+    await inner.insertEnvelope(makeEnvelope());
+    const envelopeMap = (inner as any)["envelopes"] as Map<string, StoredEnvelope>;
+    envelopeMap.set(MSG_ID_A, { ...makeEnvelope(), ciphertext: "<<<INVALID>>>" });
+
+    let error: unknown;
+    try {
+      await repo.getEnvelope(MSG_ID_A);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(DataIntegrityError);
+    if (error instanceof DataIntegrityError) {
+      expect(error.recordType).toBe("storedEnvelope");
+      // The error must not expose the corrupt payload.
+      expect(error.message).not.toContain("INVALID");
+    }
+  });
+
+  it("throws DataIntegrityError when contentCommitment is malformed", async () => {
+    await inner.insertEnvelope(makeEnvelope());
+    const envelopeMap = (inner as any)["envelopes"] as Map<string, StoredEnvelope>;
+    envelopeMap.set(MSG_ID_A, {
+      ...makeEnvelope(),
+      contentCommitment: "not-a-valid-hash",
+    });
+
+    await expect(repo.getEnvelope(MSG_ID_A)).rejects.toBeInstanceOf(DataIntegrityError);
+  });
+
+  it("generates a unique correlation ID per DataIntegrityError", async () => {
+    await inner.insertEnvelope(makeEnvelope());
+    const envelopeMap = (inner as any)["envelopes"] as Map<string, StoredEnvelope>;
+
+    envelopeMap.set(MSG_ID_A, { ...makeEnvelope(), messageId: "bad1" as any });
+    let e1: DataIntegrityError | undefined;
+    try {
+      await repo.getEnvelope(MSG_ID_A);
+    } catch (e) {
+      if (e instanceof DataIntegrityError) e1 = e;
+    }
+
+    envelopeMap.set(MSG_ID_A, { ...makeEnvelope(), messageId: "bad2" as any });
+    let e2: DataIntegrityError | undefined;
+    try {
+      await repo.getEnvelope(MSG_ID_A);
+    } catch (e) {
+      if (e instanceof DataIntegrityError) e2 = e;
+    }
+
+    expect(e1).toBeInstanceOf(DataIntegrityError);
+    expect(e2).toBeInstanceOf(DataIntegrityError);
+    expect(e1?.correlationId).not.toBe(e2?.correlationId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Recipient-indexed listing (index consistency without plaintext)
+// ---------------------------------------------------------------------------
+
+describe("listEnvelopes — recipient-indexed pagination ordering", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("sorts envelopes by createdAt descending with messageId tie-breaker", async () => {
+    const envelopesData: StoredEnvelope[] = [
+      makeEnvelope({
+        messageId: "1".repeat(64),
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+      makeEnvelope({
+        messageId: "2".repeat(64),
+        createdAt: "2026-01-03T00:00:00.000Z",
+      }),
+      makeEnvelope({
+        messageId: "3".repeat(64),
+        createdAt: "2026-01-02T00:00:00.000Z",
+      }),
+    ];
+
+    for (const env of envelopesData) {
+      await repo.insertEnvelope(env);
+    }
+
+    // Retrieve and sort using the declared ordering.
+    const allEnvelopes: StoredEnvelope[] = [];
+    for (const env of envelopesData) {
+      const stored = await repo.getEnvelope(env.messageId);
+      if (stored) allEnvelopes.push(stored);
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listEnvelopes;
+    const page = paginate(allEnvelopes, spec, { limit: 10 });
+
+    // Descending: newest first.
+    expect(page.items[0]?.createdAt).toBe("2026-01-03T00:00:00.000Z");
+    expect(page.items[1]?.createdAt).toBe("2026-01-02T00:00:00.000Z");
+    expect(page.items[2]?.createdAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(page.nextContinuationKey).toBeNull();
+  });
+
+  it("paginates envelopes correctly with continuation keys", async () => {
+    const envelopesData: StoredEnvelope[] = [
+      makeEnvelope({ messageId: "1".repeat(64), createdAt: "2026-01-01T00:00:00.000Z" }),
+      makeEnvelope({ messageId: "2".repeat(64), createdAt: "2026-01-02T00:00:00.000Z" }),
+      makeEnvelope({ messageId: "3".repeat(64), createdAt: "2026-01-03T00:00:00.000Z" }),
+      makeEnvelope({ messageId: "4".repeat(64), createdAt: "2026-01-04T00:00:00.000Z" }),
+    ];
+
+    for (const env of envelopesData) {
+      await repo.insertEnvelope(env);
+    }
+
+    const allEnvelopes: StoredEnvelope[] = [];
+    for (const env of envelopesData) {
+      const stored = await repo.getEnvelope(env.messageId);
+      if (stored) allEnvelopes.push(stored);
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listEnvelopes;
+
+    // Page 1: first 2
+    const page1 = paginate(allEnvelopes, spec, { limit: 2 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.nextContinuationKey).not.toBeNull();
+
+    // Page 2: remaining 2
+    const page2 = paginate(allEnvelopes, spec, {
+      limit: 2,
+      after: page1.nextContinuationKey!,
+    });
+    expect(page2.items).toHaveLength(2);
+    expect(page2.nextContinuationKey).toBeNull();
+
+    // All 4 unique, no duplicates across pages.
+    const allIds = [...page1.items, ...page2.items].map((e) => e.messageId);
+    expect(new Set(allIds).size).toBe(4);
+  });
+
+  it("filters by recipientId without indexing plaintext", async () => {
+    const otherRecipient = `G${"D".repeat(55)}`;
+
+    await repo.insertEnvelope(makeEnvelope({ messageId: "1".repeat(64) }));
+    await repo.insertEnvelope(
+      makeEnvelope({ messageId: "2".repeat(64), recipientId: otherRecipient }),
+    );
+
+    const env1 = await repo.getEnvelope("1".repeat(64));
+    const env2 = await repo.getEnvelope("2".repeat(64));
+
+    const all = [env1, env2].filter((e): e is StoredEnvelope => e !== null);
+
+    // Caller filters by recipient before pagination (plaintext never indexed).
+    const forRecipient = all.filter((e) => e.recipientId === RECIPIENT);
+    expect(forRecipient).toHaveLength(1);
+    expect(forRecipient[0]?.messageId).toBe("1".repeat(64));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Repository contract: ApiRepository interface conformance
+// ---------------------------------------------------------------------------
+
+describe("MemoryApiRepository — ApiRepository envelope contract", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("satisfies ApiRepository.getEnvelope(missing) === null", async () => {
+    await expect(repo.getEnvelope(MSG_ID_A)).resolves.toBeNull();
+  });
+
+  it("satisfies ApiRepository.insertEnvelope -> ApiRepository.getEnvelope round-trip", async () => {
+    const envelope = makeEnvelope();
+    const insertResult = await repo.insertEnvelope(envelope);
+    expect(insertResult.outcome).toBe("inserted");
+
+    const retrieved = await repo.getEnvelope(MSG_ID_A);
+    expect(retrieved).toMatchObject({
+      messageId: MSG_ID_A,
+      senderId: SENDER,
+      recipientId: RECIPIENT,
+      contentCommitment: COMMITMENT,
+    });
+  });
+
+  it("insertEnvelope is insert-only: no upsert behaviour", async () => {
+    const original = makeEnvelope();
+    await repo.insertEnvelope(original);
+
+    // A different payload cannot overwrite the original.
+    const attempt = makeEnvelope({ ciphertext: "bmV3Y2lwaGVydGV4dA==" });
+    const result = await repo.insertEnvelope(attempt);
+    expect(result.outcome).toBe("conflict");
+
+    // Original is preserved.
+    const stored = await repo.getEnvelope(MSG_ID_A);
+    expect(stored?.ciphertext).toBe(original.ciphertext);
+  });
+});

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import type { StoredEnvelope } from "../../../src/server/api/domain";
 import type { ApiRepository } from "../../../src/server/api/repository";
 
 // Issue #1494: one reusable repository conformance suite that every adapter must
@@ -264,6 +265,113 @@ export function runRepositoryContractTests(
         await expect(repo.getPolicy(owner)).resolves.toMatchObject({
           minimumPostage: "100",
         });
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Issue #1936 (BETA-029) — Envelope persistence contract
+    // Every ApiRepository adapter must satisfy these invariants.
+    // -------------------------------------------------------------------------
+
+    describe("encrypted envelope persistence (BETA-029 / Issue #1936)", () => {
+      const ephemeralKey = `G${"C".repeat(55)}`;
+      const envMessageId = "e".repeat(64);
+      const envMessageId2 = "f".repeat(64);
+      const commitment = "c".repeat(64);
+      const mac = "d".repeat(64);
+      const nonce = "ab12cd34ef56";
+
+      function makeEnvelope(overrides: Partial<StoredEnvelope> = {}): StoredEnvelope {
+        return {
+          messageId: envMessageId,
+          senderId: sender,
+          recipientId: owner,
+          ciphertext: "dGVzdC1jaXBoZXJ0ZXh0",
+          protectedHeaders: {
+            algorithm: "AES-256-GCM",
+            ephemeral_public_key: ephemeralKey,
+            nonce,
+            mac,
+            version: "v1",
+          },
+          contentCommitment: commitment,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          ...overrides,
+        };
+      }
+
+      it("returns null for a missing envelope", async () => {
+        await expect(repo.getEnvelope(envMessageId)).resolves.toBeNull();
+      });
+
+      it("returns 'inserted' on the first insert and retrieves the record", async () => {
+        const envelope = makeEnvelope();
+        const result = await repo.insertEnvelope(envelope);
+        expect(result.outcome).toBe("inserted");
+
+        const retrieved = await repo.getEnvelope(envMessageId);
+        expect(retrieved).not.toBeNull();
+        expect(retrieved?.messageId).toBe(envMessageId);
+        expect(retrieved?.senderId).toBe(sender);
+        expect(retrieved?.recipientId).toBe(owner);
+        // Plaintext must never appear in the retrieved record.
+        expect((retrieved as any)?.subject).toBeUndefined();
+        expect((retrieved as any)?.body).toBeUndefined();
+      });
+
+      it("returns 'duplicate' for a byte-identical resubmission (idempotent)", async () => {
+        const envelope = makeEnvelope();
+        await repo.insertEnvelope(envelope);
+
+        const retry = await repo.insertEnvelope({ ...envelope });
+        expect(retry.outcome).toBe("duplicate");
+        if (retry.outcome === "duplicate") {
+          expect(retry.envelope.messageId).toBe(envMessageId);
+        }
+      });
+
+      it("returns 'conflict' when a different payload uses the same messageId", async () => {
+        await repo.insertEnvelope(makeEnvelope());
+        const different = makeEnvelope({ ciphertext: "ZGlmZmVyZW50AA==" });
+        const result = await repo.insertEnvelope(different);
+        expect(result.outcome).toBe("conflict");
+      });
+
+      it("allows exactly one winner out of 5 concurrent inserts", async () => {
+        const envelope = makeEnvelope();
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () => repo.insertEnvelope({ ...envelope })),
+        );
+
+        const inserted = results.filter((r) => r.outcome === "inserted");
+        const duplicates = results.filter((r) => r.outcome === "duplicate");
+        const conflicts = results.filter((r) => r.outcome === "conflict");
+
+        expect(inserted).toHaveLength(1);
+        expect(duplicates).toHaveLength(4);
+        expect(conflicts).toHaveLength(0);
+      });
+
+      it("isolates envelopes by messageId", async () => {
+        await repo.insertEnvelope(makeEnvelope({ messageId: envMessageId }));
+        await repo.insertEnvelope(makeEnvelope({ messageId: envMessageId2 }));
+
+        await expect(repo.getEnvelope(envMessageId)).resolves.toMatchObject({
+          messageId: envMessageId,
+        });
+        await expect(repo.getEnvelope(envMessageId2)).resolves.toMatchObject({
+          messageId: envMessageId2,
+        });
+      });
+
+      it("is insert-only: a different ciphertext cannot overwrite the stored record", async () => {
+        const original = makeEnvelope();
+        await repo.insertEnvelope(original);
+
+        await repo.insertEnvelope(makeEnvelope({ ciphertext: "bmV3Y2lwaGVydGV4dA==" }));
+
+        const stored = await repo.getEnvelope(envMessageId);
+        expect(stored?.ciphertext).toBe(original.ciphertext);
       });
     });
   });

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -396,5 +396,112 @@ export function runRepositoryContractTests(
         });
       });
     });
+
+    // -------------------------------------------------------------------------
+    // Issue #1936 (BETA-029) — Envelope persistence contract
+    // Every ApiRepository adapter must satisfy these invariants.
+    // -------------------------------------------------------------------------
+
+    describe("encrypted envelope persistence (BETA-029 / Issue #1936)", () => {
+      const ephemeralKey = `G${"C".repeat(55)}`;
+      const envMessageId = "e".repeat(64);
+      const envMessageId2 = "f".repeat(64);
+      const commitment = "c".repeat(64);
+      const mac = "d".repeat(64);
+      const nonce = "ab12cd34ef56";
+
+      function makeEnvelope(overrides: Partial<StoredEnvelope> = {}): StoredEnvelope {
+        return {
+          messageId: envMessageId,
+          senderId: sender,
+          recipientId: owner,
+          ciphertext: "dGVzdC1jaXBoZXJ0ZXh0",
+          protectedHeaders: {
+            algorithm: "AES-256-GCM",
+            ephemeral_public_key: ephemeralKey,
+            nonce,
+            mac,
+            version: "v1",
+          },
+          contentCommitment: commitment,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          ...overrides,
+        };
+      }
+
+      it("returns null for a missing envelope", async () => {
+        await expect(repo.getEnvelope(envMessageId)).resolves.toBeNull();
+      });
+
+      it("returns 'inserted' on the first insert and retrieves the record", async () => {
+        const envelope = makeEnvelope();
+        const result = await repo.insertEnvelope(envelope);
+        expect(result.outcome).toBe("inserted");
+
+        const retrieved = await repo.getEnvelope(envMessageId);
+        expect(retrieved).not.toBeNull();
+        expect(retrieved?.messageId).toBe(envMessageId);
+        expect(retrieved?.senderId).toBe(sender);
+        expect(retrieved?.recipientId).toBe(owner);
+        // Plaintext must never appear in the retrieved record.
+        expect((retrieved as any)?.subject).toBeUndefined();
+        expect((retrieved as any)?.body).toBeUndefined();
+      });
+
+      it("returns 'duplicate' for a byte-identical resubmission (idempotent)", async () => {
+        const envelope = makeEnvelope();
+        await repo.insertEnvelope(envelope);
+
+        const retry = await repo.insertEnvelope({ ...envelope });
+        expect(retry.outcome).toBe("duplicate");
+        if (retry.outcome === "duplicate") {
+          expect(retry.envelope.messageId).toBe(envMessageId);
+        }
+      });
+
+      it("returns 'conflict' when a different payload uses the same messageId", async () => {
+        await repo.insertEnvelope(makeEnvelope());
+        const different = makeEnvelope({ ciphertext: "ZGlmZmVyZW50AA==" });
+        const result = await repo.insertEnvelope(different);
+        expect(result.outcome).toBe("conflict");
+      });
+
+      it("allows exactly one winner out of 5 concurrent inserts", async () => {
+        const envelope = makeEnvelope();
+        const results = await Promise.all(
+          Array.from({ length: 5 }, () => repo.insertEnvelope({ ...envelope })),
+        );
+
+        const inserted = results.filter((r) => r.outcome === "inserted");
+        const duplicates = results.filter((r) => r.outcome === "duplicate");
+        const conflicts = results.filter((r) => r.outcome === "conflict");
+
+        expect(inserted).toHaveLength(1);
+        expect(duplicates).toHaveLength(4);
+        expect(conflicts).toHaveLength(0);
+      });
+
+      it("isolates envelopes by messageId", async () => {
+        await repo.insertEnvelope(makeEnvelope({ messageId: envMessageId }));
+        await repo.insertEnvelope(makeEnvelope({ messageId: envMessageId2 }));
+
+        await expect(repo.getEnvelope(envMessageId)).resolves.toMatchObject({
+          messageId: envMessageId,
+        });
+        await expect(repo.getEnvelope(envMessageId2)).resolves.toMatchObject({
+          messageId: envMessageId2,
+        });
+      });
+
+      it("is insert-only: a different ciphertext cannot overwrite the stored record", async () => {
+        const original = makeEnvelope();
+        await repo.insertEnvelope(original);
+
+        await repo.insertEnvelope(makeEnvelope({ ciphertext: "bmV3Y2lwaGVydGV4dA==" }));
+
+        const stored = await repo.getEnvelope(envMessageId);
+        expect(stored?.ciphertext).toBe(original.ciphertext);
+      });
+    });
   });
 }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -192,6 +192,14 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setCredential");
     return this.inner.setCredential(credential);
   }
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    this.maybeFail("getEnvelope");
+    return this.inner.getEnvelope(messageId);
+  }
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    this.maybeFail("insertEnvelope");
+    return this.inner.insertEnvelope(envelope);
+  }
   reset(): void {
     this.inner.reset();
   }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -6,10 +6,12 @@ import type {
   PostageStatus,
   Receipt,
   SenderRule,
+  StoredEnvelope,
 } from "../../../src/server/api/domain";
 import type {
   AcquireIdempotencyResult,
   ApiRepository,
+  InsertEnvelopeResult,
   PostageTransitionResult,
 } from "../../../src/server/api/repository";
 import {
@@ -145,6 +147,14 @@ class FailingRepository implements ApiRepository {
   async markReceiptRead(messageId: string, actor: string, now?: Date) {
     this.maybeFail("markReceiptRead");
     return this.inner.markReceiptRead(messageId, actor, now);
+  }
+  async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
+    this.maybeFail("getEnvelope");
+    return this.inner.getEnvelope(messageId);
+  }
+  async insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult> {
+    this.maybeFail("insertEnvelope");
+    return this.inner.insertEnvelope(envelope);
   }
   reset(): void {
     this.inner.reset();
@@ -361,5 +371,52 @@ describe("RetryableApiRepository", () => {
 
     retryRepo.reset();
     expect(await memory.getPolicy(owner)).toBeNull();
+  });
+
+  it("retries getEnvelope (safe read) on transient failure", async () => {
+    failing.setFailCount("getEnvelope", 1);
+    const envelope: StoredEnvelope = {
+      messageId,
+      senderId: sender,
+      recipientId: owner,
+      ciphertext: "dGVzdA==",
+      protectedHeaders: {
+        algorithm: "AES-256-GCM",
+        ephemeral_public_key: `G${"C".repeat(55)}`,
+        nonce: "ab12cd34ef56",
+        mac: "d".repeat(64),
+        version: "v1",
+      },
+      contentCommitment: "c".repeat(64),
+      createdAt: new Date().toISOString(),
+    };
+    await failing.inner.insertEnvelope(envelope);
+
+    const result = await repo.getEnvelope(messageId);
+    expect(result).not.toBeNull();
+    expect(result?.messageId).toBe(messageId);
+    expect(failing.getCallCount("getEnvelope")).toBe(2);
+  });
+
+  it("does not retry insertEnvelope (unsafe write)", async () => {
+    failing.setFailCount("insertEnvelope", 2);
+    const envelope: StoredEnvelope = {
+      messageId,
+      senderId: sender,
+      recipientId: owner,
+      ciphertext: "dGVzdA==",
+      protectedHeaders: {
+        algorithm: "AES-256-GCM",
+        ephemeral_public_key: `G${"C".repeat(55)}`,
+        nonce: "ab12cd34ef56",
+        mac: "d".repeat(64),
+        version: "v1",
+      },
+      contentCommitment: "c".repeat(64),
+      createdAt: new Date().toISOString(),
+    };
+
+    await expect(repo.insertEnvelope(envelope)).rejects.toThrow();
+    expect(failing.getCallCount("insertEnvelope")).toBe(1);
   });
 });


### PR DESCRIPTION
…#1936)

BETA-029 - Durable encrypted-message repository

## What this adds

- StoredEnvelope domain type and Zod schema in domain.ts: stores ciphertext, protectedHeaders (algorithm, ephemeral key, nonce, MAC, version), contentCommitment, senderId, recipientId, createdAt, and \. Plaintext (subject, body) is intentionally absent from every field.

- InsertEnvelopeResult discriminated union on ApiRepository:
  - inserted  - first successful write; the record is now durable.
  - duplicate - byte-identical payload already exists (idempotent).
  - conflict  - different payload for same ID (prior record wins).

- getEnvelope / insertEnvelope on ApiRepository interface with full docstring enforcing the no-plaintext and insert-only contracts.

- MemoryApiRepository: per-key promise-chain lock (mirrors the existing 
eceiptLocks pattern) for concurrency-safe insert-once semantics; structural clone on every read and write.

- HybridApiRepository (KV): delegates insert to coordinator for atomic deduplication; mirrors successful inserts to KV for fast reads. KV miss falls back to coordinator with write-back.

- StealthCoordinator (DO): insertEnvelope inside 
unExclusive; byte-identical duplicates are idempotent; different bytes same ID throws ApiError(409, conflict) that is never swallowed.

- ValidatedApiRepository: getEnvelope validates the retrieved record at the adapter boundary; insertEnvelope versions then validates.

- RetryableApiRepository: getEnvelope is retry-safe; insertEnvelope is not (insert-once semantics; callers handle duplicate/conflict).

- RETRY_SAFE_OPERATIONS: adds getEnvelope.

- PAGINATED_QUERY_ORDERINGS: adds listEnvelopes (createdAt desc, messageId tie-breaker; recipientId filtered by callers, not indexed).

- context.ts: registers storedEnvelope schema at version 1 so ValidatedApiRepository can detect tampered records.

- protocol/schemas/envelope.schema.json: adds message_id (hex64) and ciphertext (base64, non-empty) as top-level required fields.

## Tests

- 	ests/unit/api/envelope-repository.test.ts (new, 34 tests): domain schema rules, no-plaintext invariant, insert/duplicate/conflict semantics, 10-way concurrent insert safety, tamper detection via ValidatedApiRepository (DataIntegrityError with unique correlation IDs, payload never in error message), 20-MiB size limit, recipient-indexed ordering and pagination, reset() behaviour, round-trip contract.

- 	ests/unit/api/repository-contract.ts (extended, 7 new tests): envelope conformance block run against every ApiRepository adapter.

Test result: 152 files passed, 1807 tests passed, 3 expected-fail.

Closes #1936