### PR TITLE
BETA-003: canonical Stealth username validation and atomic reservation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -90,7 +90,8 @@
               "duplicate_receipt",
               "duplicate_postage",
               "invalid_quote",
-              "request_in_progress"
+              "request_in_progress",
+              "username_taken"
             ],
             "example": "invalid_state_transition"
           },
@@ -127,6 +128,74 @@
           },
           "requireVerified": {
             "type": "boolean"
+          }
+        }
+      },
+      "Username": {
+        "type": "string",
+        "description": "Canonical (normalized, lowercased, confusable-folded) Stealth username.",
+        "pattern": "^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$",
+        "minLength": 3,
+        "maxLength": 30,
+        "example": "alice"
+      },
+      "UsernameAvailability": {
+        "type": "object",
+        "required": ["username", "available"],
+        "additionalProperties": false,
+        "properties": {
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether the canonical username is currently reservable. Never reveals ownership."
+          }
+        }
+      },
+      "UsernameReservationRequest": {
+        "type": "object",
+        "required": ["username"],
+        "additionalProperties": false,
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "Raw candidate username; normalized server-side before reservation.",
+            "maxLength": 128,
+            "example": "Alice"
+          }
+        }
+      },
+      "UsernameRecord": {
+        "type": "object",
+        "required": [
+          "username",
+          "ownerAddress",
+          "stealthAddress",
+          "federationAddress",
+          "createdAt"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "username": {
+            "$ref": "#/components/schemas/Username"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/StellarAddress"
+          },
+          "stealthAddress": {
+            "type": "string",
+            "description": "Human-facing Stealth address.",
+            "example": "alice@stealth.me"
+          },
+          "federationAddress": {
+            "type": "string",
+            "description": "SEP-2 Stellar federation address (username*domain), resolved via the federation server.",
+            "example": "alice*stealth.me"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -277,7 +346,8 @@
                   "duplicate_receipt",
                   "duplicate_postage",
                   "invalid_quote",
-                  "request_in_progress"
+                  "request_in_progress",
+                  "username_taken"
                 ]
               },
               "message": {
@@ -440,6 +510,12 @@
             "message": "An equivalent request is already in progress",
             "retryable": true,
             "description": "A matching operation currently holds the idempotency lease."
+          },
+          "username_taken": {
+            "status": 409,
+            "message": "The requested username is not available",
+            "retryable": false,
+            "description": "A reservation already exists for this normalized username."
           }
         }
       }
@@ -1132,6 +1208,170 @@
                       }
                     }
                   }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/identity/usernames/{username}/availability": {
+      "get": {
+        "operationId": "getUsernameAvailability",
+        "summary": "Check canonical username availability",
+        "x-stability": "stable",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/UsernameAvailability"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — malformed, out-of-bounds-length, or reserved-word username",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/identity/usernames": {
+      "post": {
+        "operationId": "reserveUsername",
+        "summary": "Atomically reserve a canonical Stealth username",
+        "x-max-body-bytes": 4096,
+        "security": [
+          {
+            "StellarSignedRequest": []
+          }
+        ],
+        "x-stability": "stable",
+        "requestBody": {
+          "description": "Candidate username to reserve for the authenticated actor.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UsernameReservationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reserved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/UsernameRecord"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — username_taken or an in-flight idempotent duplicate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — malformed, out-of-bounds-length, or reserved-word username",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
                 }
               }
             }

--- a/protocol/federation/username_reservation.md
+++ b/protocol/federation/username_reservation.md
@@ -1,0 +1,82 @@
+# Username Reservation & Federation Mapping (Issue #1910 / BETA-003)
+
+This document specifies how a canonical Stealth username is derived, reserved,
+and mapped onto the two public-facing address forms used elsewhere in the
+protocol. It complements [`README.md`](./README.md), which covers Stealth
+address _resolution_; this document covers how a name becomes reservable and
+resolvable in the first place.
+
+## 1. Canonical form
+
+A username is never stored or compared in the form a user typed it. It is
+first reduced to a **canonical form** by the normalization pipeline defined in
+`src/features/identity/username.ts`:
+
+1. Unicode NFKC normalization (folds fullwidth/compatibility variants, e.g.
+   fullwidth Latin, to their ordinary ASCII form).
+2. Invisible/zero-width character stripping (soft hyphen, zero-width
+   space/ZWNJ/ZWJ, word joiner, BOM).
+3. Confusable folding: a curated table of common Cyrillic/Greek homoglyphs
+   (e.g. Cyrillic "а" U+0430) is folded to its Latin lookalike.
+4. Case folding (lowercase) and trimming.
+
+Every lookup, availability check, and reservation runs the candidate through
+this exact pipeline before touching storage, so "alice", "Alice", "ALICE",
+and confusable look-alikes always resolve to the single canonical value
+`alice`. Any character not recognized by the confusable table and not already
+ASCII is rejected outright by the charset rule below — the pipeline never
+guesses at an unknown homoglyph.
+
+## 2. Validation rules
+
+Applied to the canonical form:
+
+| Rule                | Value                                                 |
+| ------------------- | ----------------------------------------------------- |
+| Minimum length      | 3                                                     |
+| Maximum length      | 30                                                    |
+| Allowed characters  | `a-z`, `0-9`, `_`, `-`                                |
+| Boundary characters | must start and end with a letter or digit             |
+| Reserved words      | rejected outright (see the `RESERVED_USERNAMES` list) |
+
+Format, length, and reserved-word violations are deterministic functions of
+the input alone and are surfaced as request validation failures — they never
+reach the reservation/availability storage layer, and never need to reveal
+anything about existing reservations.
+
+## 3. Address mapping
+
+A reserved canonical username `<name>` has exactly two public forms:
+
+| Form               | Pattern             | Purpose                                                                                                                                                                                 |
+| ------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stealth address    | `<name>@stealth.me` | Human-facing, mail-style identity shown in the product.                                                                                                                                 |
+| Federation address | `<name>*stealth.me` | [SEP-2 Stellar federation](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md) address, resolvable via a `/federation?q=<name>*stealth.me&type=name` lookup. |
+
+Both forms are derived deterministically from the same canonical name and are
+persisted together on the reservation record — they can never drift apart or
+be reserved independently. Building the public `/federation` HTTP resolver
+endpoint itself (the SEP-2 server side) is tracked separately as BETA-026;
+this reservation flow only guarantees the mapping exists and is atomic.
+
+## 4. Atomicity
+
+Reservation is a single "reserve if absent" operation keyed by the canonical
+username (`ApiRepository.reserveUsernameIfAbsent`). Concurrent claims for the
+same canonical username — including case or confusable variants of each
+other — are guaranteed exactly one winner; every other caller receives a
+deterministic `username_taken` (409) response that reflects the actual
+winning owner, never its own losing payload. See
+`src/server/api/stealth-coordinator.ts` for the Durable Object implementation
+backing this guarantee in production, and
+`src/server/api/memory-repository.ts` for the development equivalent.
+
+## 5. API surface
+
+| Method | Path                                                 | Auth                                    | Purpose                                                                                                                                                              |
+| ------ | ---------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET`  | `/api/v1/identity/usernames/{username}/availability` | Public                                  | Returns `{ username, available }` for the canonical form of `{username}`. Never reveals an owner.                                                                    |
+| `POST` | `/api/v1/identity/usernames`                         | Required (`x-stealth-address` / SEP-10) | Reserves `{ username }` for the authenticated actor; returns the full `UsernameRecord`, including both address forms. Supports `X-Idempotency-Key` for safe retries. |
+
+See `openapi.json` (generated from `src/server/api/openapi.ts`) for the full
+request/response schema.

--- a/src/features/identity/components/UsernameReservationForm.tsx
+++ b/src/features/identity/components/UsernameReservationForm.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { toFederationAddress, toStealthAddress } from "../federation";
+import { useUsernameAvailability } from "../useUsernameAvailability";
+
+export interface ReservedUsername {
+  username: string;
+  ownerAddress: string;
+  stealthAddress: string;
+  federationAddress: string;
+  createdAt: string;
+}
+
+type ReserveState =
+  | { status: "idle" }
+  | { status: "reserving" }
+  | { status: "reserved"; record: ReservedUsername }
+  | { status: "error"; message: string };
+
+type Props = {
+  /** Stellar G-address of the connected wallet; reservation is scoped to this actor. */
+  walletAddress: string;
+  onReserved?: (record: ReservedUsername) => void;
+};
+
+/**
+ * Lets a visitor type a candidate handle, see live availability feedback,
+ * and reserve `username@stealth.me` for their connected wallet.
+ *
+ * Talks to the real `GET/POST /api/v1/identity/usernames` endpoints — no
+ * mock data path. Validation (length, charset, reserved words, confusables)
+ * runs client-side first via the same rules the server enforces
+ * (`src/features/identity/username.ts`), so the network round-trip only ever
+ * happens for a candidate that could actually be reserved.
+ */
+export function UsernameReservationForm({ walletAddress, onReserved }: Props) {
+  const [raw, setRaw] = useState("");
+  const availability = useUsernameAvailability(raw);
+  const [reserveState, setReserveState] = useState<ReserveState>({ status: "idle" });
+
+  const canReserve = availability.status === "available" && reserveState.status !== "reserving";
+
+  async function handleReserve() {
+    if (availability.status !== "available") return;
+
+    setReserveState({ status: "reserving" });
+    try {
+      const response = await fetch("/api/v1/identity/usernames", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-stealth-address": walletAddress,
+          "x-idempotency-key": `reserve-${availability.username}-${walletAddress}`,
+        },
+        body: JSON.stringify({ username: availability.username }),
+      });
+
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        setReserveState({
+          status: "error",
+          message: body?.error?.message ?? `HTTP ${response.status}`,
+        });
+        return;
+      }
+
+      const record = body.data as ReservedUsername;
+      setReserveState({ status: "reserved", record });
+      onReserved?.(record);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to reserve username";
+      setReserveState({ status: "error", message });
+    }
+  }
+
+  if (reserveState.status === "reserved") {
+    const { record } = reserveState;
+    return (
+      <div
+        role="status"
+        className="rounded-xl border border-emerald-400/20 bg-emerald-400/[0.06] p-4 space-y-2"
+      >
+        <div className="flex items-center gap-2 text-emerald-300">
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <p className="text-sm font-medium">Username reserved</p>
+        </div>
+        <p className="font-mono text-xs text-foreground break-all">
+          {toStealthAddress(record.username)}
+        </p>
+        <p className="text-xs text-muted-foreground break-all">
+          Federation address: {toFederationAddress(record.username)}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <label htmlFor="stealth-username" className="text-sm font-medium text-foreground">
+        Choose your Stealth username
+      </label>
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            id="stealth-username"
+            value={raw}
+            onChange={(event) => {
+              setRaw(event.target.value);
+              setReserveState({ status: "idle" });
+            }}
+            placeholder="alice"
+            aria-describedby="stealth-username-status"
+            autoComplete="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+        </div>
+        <span className="shrink-0 text-sm text-muted-foreground">@stealth.me</span>
+      </div>
+
+      <div id="stealth-username-status" aria-live="polite" className="min-h-[1.25rem] text-xs">
+        {availability.status === "checking" && (
+          <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            Checking availability…
+          </span>
+        )}
+        {availability.status === "invalid" && (
+          <span className="text-amber-300">{availability.message}</span>
+        )}
+        {availability.status === "available" && (
+          <span className="inline-flex items-center gap-1.5 text-emerald-300">
+            <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+            {availability.username}@stealth.me is available
+          </span>
+        )}
+        {availability.status === "taken" && (
+          <span className="inline-flex items-center gap-1.5 text-red-300">
+            <XCircle className="h-3 w-3" aria-hidden="true" />
+            {availability.username}@stealth.me is already taken
+          </span>
+        )}
+        {availability.status === "error" && (
+          <span className="text-red-300">{availability.message}</span>
+        )}
+      </div>
+
+      {reserveState.status === "error" && (
+        <p role="alert" className="text-xs text-red-300">
+          {reserveState.message}
+        </p>
+      )}
+
+      <Button
+        type="button"
+        onClick={handleReserve}
+        disabled={!canReserve}
+        aria-busy={reserveState.status === "reserving"}
+        className={cn("w-full")}
+      >
+        {reserveState.status === "reserving" ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Reserving…
+          </>
+        ) : (
+          "Reserve username"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/features/identity/federation.ts
+++ b/src/features/identity/federation.ts
@@ -1,0 +1,24 @@
+import type { CanonicalUsername } from "./username";
+
+/**
+ * Stealth-address / Stellar-federation mapping (Issue #1910 / BETA-003).
+ *
+ * A reserved canonical username has two public-facing forms:
+ * - `username@stealth.me` — the human-facing Stealth address shown in the
+ *   product (mail-style, matches the onboarding story).
+ * - `username*stealth.me` — the SEP-2 Stellar federation address, resolved
+ *   by a `/federation?q=...&type=name` lookup (see
+ *   https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0002.md).
+ *   Building the actual public federation HTTP resolver endpoint is tracked
+ *   separately (BETA-026); this module only defines the deterministic
+ *   mapping so every reservation carries both forms from the start.
+ */
+export const STEALTH_FEDERATION_DOMAIN = "stealth.me";
+
+export function toStealthAddress(canonicalUsername: CanonicalUsername): string {
+  return `${canonicalUsername}@${STEALTH_FEDERATION_DOMAIN}`;
+}
+
+export function toFederationAddress(canonicalUsername: CanonicalUsername): string {
+  return `${canonicalUsername}*${STEALTH_FEDERATION_DOMAIN}`;
+}

--- a/src/features/identity/index.ts
+++ b/src/features/identity/index.ts
@@ -1,0 +1,24 @@
+export {
+  RAW_USERNAME_MAX_LENGTH,
+  RESERVED_USERNAMES,
+  USERNAME_FORMAT_REGEX,
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  isReservedUsername,
+  normalizeUsername,
+  usernameSchema,
+  validateUsernameCandidate,
+} from "./username";
+export type {
+  CanonicalUsername,
+  UsernameValidationIssue,
+  UsernameValidationResult,
+} from "./username";
+
+export { STEALTH_FEDERATION_DOMAIN, toFederationAddress, toStealthAddress } from "./federation";
+
+export { useUsernameAvailability } from "./useUsernameAvailability";
+export type { UsernameAvailabilityState } from "./useUsernameAvailability";
+
+export { UsernameReservationForm } from "./components/UsernameReservationForm";
+export type { ReservedUsername } from "./components/UsernameReservationForm";

--- a/src/features/identity/useUsernameAvailability.ts
+++ b/src/features/identity/useUsernameAvailability.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from "react";
+
+import { validateUsernameCandidate } from "./username";
+
+export type UsernameAvailabilityState =
+  | { status: "idle" }
+  | { status: "invalid"; message: string }
+  | { status: "checking" }
+  | { status: "available"; username: string }
+  | { status: "taken"; username: string }
+  | { status: "error"; message: string };
+
+const DEBOUNCE_MS = 400;
+
+/**
+ * Live availability lookup for a candidate username, mirroring the shape of
+ * {@link import("../compose/usePostageQuote").usePostageQuote}: debounced,
+ * abort-on-change, and non-throwing (failures surface as `{ status: "error" }`
+ * rather than an exception, so callers can show a non-blocking message).
+ *
+ * Client-side format/reserved-word validation runs first via
+ * {@link validateUsernameCandidate} — the exact same rules the server
+ * enforces — so obviously invalid input never triggers a network request.
+ */
+export function useUsernameAvailability(raw: string): UsernameAvailabilityState {
+  const [state, setState] = useState<UsernameAvailabilityState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      setState({ status: "idle" });
+      return;
+    }
+
+    const validation = validateUsernameCandidate(trimmed);
+    if (!validation.valid) {
+      setState({ status: "invalid", message: validation.issues[0]?.message ?? "Invalid username" });
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setState({ status: "checking" });
+
+      try {
+        const response = await fetch(
+          `/api/v1/identity/usernames/${encodeURIComponent(validation.canonical)}/availability`,
+          { signal: controller.signal },
+        );
+
+        if (controller.signal.aborted) return;
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          setState({
+            status: "error",
+            message: body?.error?.message ?? `HTTP ${response.status}`,
+          });
+          return;
+        }
+
+        const body = (await response.json()) as {
+          data: { username: string; available: boolean };
+        };
+        setState(
+          body.data.available
+            ? { status: "available", username: body.data.username }
+            : { status: "taken", username: body.data.username },
+        );
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        const message = err instanceof Error ? err.message : "Failed to check availability";
+        setState({ status: "error", message });
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [raw]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return state;
+}

--- a/src/features/identity/username.ts
+++ b/src/features/identity/username.ts
@@ -1,0 +1,256 @@
+﻿import { z } from "zod";
+
+/**
+ * Canonical Stealth username rules (Issue #1910 / BETA-003).
+ *
+ * A username is reserved once, as its *canonical* form, and every lookup,
+ * availability check, and reservation attempt goes through the same
+ * normalization pipeline. This is what guarantees "alice", "Alice", "ALICE",
+ * and confusable look-alikes (e.g. Cyrillic homoglyphs of "alice") all
+ * resolve to a single identity instead of letting case or Unicode variation
+ * mint free aliases.
+ */
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 30;
+
+/** Hard cap on raw (pre-normalization) input, so pathological input never reaches the regex/Unicode passes below. */
+export const RAW_USERNAME_MAX_LENGTH = 128;
+
+/**
+ * Canonical usernames are lowercase ASCII letters, digits, hyphens, and
+ * underscores, and must start and end with a letter or digit (no leading or
+ * trailing separator).
+ */
+export const USERNAME_FORMAT_REGEX = /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/;
+
+/**
+ * Invisible/zero-width code points that carry no visual signal but can be
+ * used to smuggle a distinct byte sequence past a naive equality check (e.g.
+ * "ad" + ZERO WIDTH SPACE + "min" rendering identically to "admin").
+ * Stripped outright rather than folded, since they have no legitimate use in
+ * a handle: U+00AD (soft hyphen), U+200B-U+200D (zero-width
+ * space/ZWNJ/ZWJ), U+2060 (word joiner), U+FEFF (BOM / zero-width no-break
+ * space).
+ */
+const INVISIBLE_CHARACTERS = /[\u00AD\u200B-\u200D\u2060\uFEFF]/g;
+
+/**
+ * Curated table of common single-character homoglyphs (Unicode TR39-style
+ * "confusables") that are visually indistinguishable from a Latin letter in
+ * most UI fonts but are technically distinct code points — most notably the
+ * Cyrillic and Greek letters used in real-world username-squatting and
+ * phishing attacks. This is intentionally a small, high-confidence allowlist
+ * (keyed by numeric code point, not literal glyphs, so every mapping is
+ * auditable and immune to transcription/rendering ambiguity) rather than a
+ * full confusables-skeleton implementation — no such library is a project
+ * dependency. Every character not recognized here is rejected outright by
+ * the ASCII charset check below, so the failure mode is always "reject
+ * unknown Unicode", never "silently allow a lookalike alias".
+ *
+ * Compatibility variants (fullwidth Latin, fullwidth digits, ligatures,
+ * etc.) are already folded by the NFKC normalization step and need no entry
+ * here.
+ */
+const CYRILLIC_TO_LATIN: Readonly<Record<number, string>> = Object.freeze({
+  0x0430: "a", // CYRILLIC SMALL LETTER A
+  0x0435: "e", // CYRILLIC SMALL LETTER IE
+  0x043e: "o", // CYRILLIC SMALL LETTER O
+  0x0440: "p", // CYRILLIC SMALL LETTER ER
+  0x0441: "c", // CYRILLIC SMALL LETTER ES
+  0x0445: "x", // CYRILLIC SMALL LETTER HA
+  0x0443: "y", // CYRILLIC SMALL LETTER U
+  0x0456: "i", // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+  0x0455: "s", // CYRILLIC SMALL LETTER DZE
+  0x0458: "j", // CYRILLIC SMALL LETTER JE
+  0x0410: "a", // CYRILLIC CAPITAL LETTER A
+  0x0412: "b", // CYRILLIC CAPITAL LETTER VE
+  0x0415: "e", // CYRILLIC CAPITAL LETTER IE
+  0x041a: "k", // CYRILLIC CAPITAL LETTER KA
+  0x041c: "m", // CYRILLIC CAPITAL LETTER EM
+  0x041d: "h", // CYRILLIC CAPITAL LETTER EN
+  0x041e: "o", // CYRILLIC CAPITAL LETTER O
+  0x0420: "p", // CYRILLIC CAPITAL LETTER ER
+  0x0421: "c", // CYRILLIC CAPITAL LETTER ES
+  0x0422: "t", // CYRILLIC CAPITAL LETTER TE
+  0x0425: "x", // CYRILLIC CAPITAL LETTER HA
+  0x0405: "s", // CYRILLIC CAPITAL LETTER DZE
+  0x0408: "j", // CYRILLIC CAPITAL LETTER JE
+});
+
+const GREEK_TO_LATIN: Readonly<Record<number, string>> = Object.freeze({
+  0x03b1: "a", // GREEK SMALL LETTER ALPHA
+  0x03b2: "b", // GREEK SMALL LETTER BETA
+  0x03bf: "o", // GREEK SMALL LETTER OMICRON
+  0x03bd: "v", // GREEK SMALL LETTER NU
+  0x03c1: "p", // GREEK SMALL LETTER RHO
+  0x03c4: "t", // GREEK SMALL LETTER TAU
+  0x03c5: "u", // GREEK SMALL LETTER UPSILON
+  0x03b9: "i", // GREEK SMALL LETTER IOTA
+  0x03ba: "k", // GREEK SMALL LETTER KAPPA
+  0x03c7: "x", // GREEK SMALL LETTER CHI
+  0x0391: "a", // GREEK CAPITAL LETTER ALPHA
+  0x0392: "b", // GREEK CAPITAL LETTER BETA
+  0x0395: "e", // GREEK CAPITAL LETTER EPSILON
+  0x0396: "z", // GREEK CAPITAL LETTER ZETA
+  0x0397: "h", // GREEK CAPITAL LETTER ETA
+  0x0399: "i", // GREEK CAPITAL LETTER IOTA
+  0x039a: "k", // GREEK CAPITAL LETTER KAPPA
+  0x039c: "m", // GREEK CAPITAL LETTER MU
+  0x039d: "n", // GREEK CAPITAL LETTER NU
+  0x039f: "o", // GREEK CAPITAL LETTER OMICRON
+  0x03a1: "p", // GREEK CAPITAL LETTER RHO
+  0x03a4: "t", // GREEK CAPITAL LETTER TAU
+  0x03a5: "y", // GREEK CAPITAL LETTER UPSILON
+  0x03a7: "x", // GREEK CAPITAL LETTER CHI
+});
+
+const CONFUSABLE_FOLD_MAP: ReadonlyMap<string, string> = new Map(
+  [...Object.entries(CYRILLIC_TO_LATIN), ...Object.entries(GREEK_TO_LATIN)].map(
+    ([codePoint, latin]) => [String.fromCodePoint(Number(codePoint)), latin],
+  ),
+);
+
+function stripInvisibleCharacters(input: string): string {
+  return input.replace(INVISIBLE_CHARACTERS, "");
+}
+
+function foldConfusables(input: string): string {
+  return Array.from(input)
+    .map((char) => CONFUSABLE_FOLD_MAP.get(char) ?? char)
+    .join("");
+}
+
+/**
+ * The full normalization pipeline: Unicode compatibility decomposition
+ * (folds fullwidth/compatibility variants to their canonical ASCII form),
+ * invisible-character stripping, confusable folding, then case folding.
+ *
+ * This function is deliberately pure and side-effect free so it can run
+ * identically on the client (live availability feedback) and the server
+ * (authoritative validation before reservation).
+ */
+export function normalizeUsername(raw: string): string {
+  const nfkc = raw.normalize("NFKC");
+  const withoutInvisibles = stripInvisibleCharacters(nfkc);
+  const folded = foldConfusables(withoutInvisibles);
+  return folded.toLowerCase().trim();
+}
+
+export function isReservedUsername(canonical: string): boolean {
+  return RESERVED_USERNAMES.has(canonical);
+}
+
+/**
+ * Usernames that are never reservable regardless of who asks, because they
+ * are operationally or brand-sensitive (service mailboxes, protocol nouns,
+ * generic placeholders). Matched against the fully canonicalized value, so
+ * confusable/case variants of a reserved word are rejected too.
+ */
+export const RESERVED_USERNAMES: ReadonlySet<string> = new Set([
+  "admin",
+  "administrator",
+  "root",
+  "sysadmin",
+  "moderator",
+  "mod",
+  "staff",
+  "official",
+  "support",
+  "help",
+  "helpdesk",
+  "system",
+  "stealth",
+  "stealthmail",
+  "postmaster",
+  "webmaster",
+  "hostmaster",
+  "mailer-daemon",
+  "abuse",
+  "security",
+  "billing",
+  "sales",
+  "contact",
+  "info",
+  "noreply",
+  "no-reply",
+  "api",
+  "www",
+  "mail",
+  "smtp",
+  "imap",
+  "pop3",
+  "ftp",
+  "test",
+  "null",
+  "undefined",
+  "nobody",
+  "everyone",
+  "anonymous",
+  "guest",
+  "public",
+  "private",
+  "here",
+  "channel",
+]);
+
+/**
+ * Validates and canonicalizes a candidate username in one pass.
+ *
+ * The raw string is normalized first, so length/format/reserved-word rules
+ * are always evaluated against the canonical form a client would actually
+ * end up reserving — never the raw, potentially-aliasing input.
+ */
+export const usernameSchema = z
+  .string()
+  .trim()
+  .min(1, "Username must not be empty")
+  .max(
+    RAW_USERNAME_MAX_LENGTH,
+    `Username input must be at most ${RAW_USERNAME_MAX_LENGTH} characters`,
+  )
+  .transform((raw) => normalizeUsername(raw))
+  .pipe(
+    z
+      .string()
+      .min(USERNAME_MIN_LENGTH, `Username must be at least ${USERNAME_MIN_LENGTH} characters`)
+      .max(USERNAME_MAX_LENGTH, `Username must be at most ${USERNAME_MAX_LENGTH} characters`)
+      .regex(
+        USERNAME_FORMAT_REGEX,
+        "Username may only contain lowercase letters, numbers, hyphens, and underscores, and must start and end with a letter or number",
+      ),
+  )
+  .superRefine((value, ctx) => {
+    if (isReservedUsername(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `"${value}" is a reserved username and cannot be registered`,
+      });
+    }
+  });
+
+export type CanonicalUsername = z.infer<typeof usernameSchema>;
+
+export interface UsernameValidationIssue {
+  path: string;
+  message: string;
+}
+
+export type UsernameValidationResult =
+  | { valid: true; canonical: CanonicalUsername }
+  | { valid: false; issues: UsernameValidationIssue[] };
+
+/** Non-throwing variant of {@link usernameSchema}, convenient for UI-side live validation. */
+export function validateUsernameCandidate(raw: string): UsernameValidationResult {
+  const result = usernameSchema.safeParse(raw);
+  if (result.success) {
+    return { valid: true, canonical: result.data };
+  }
+  return {
+    valid: false,
+    issues: result.error.issues.map((issue) => ({
+      path: issue.path.join(".") || "$",
+      message: issue.message,
+    })),
+  };
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,10 +22,12 @@ import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/q
 import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1IdentityUsernamesIndexRouteImport } from './routes/api/v1/identity/usernames/index'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
+import { Route as ApiV1IdentityUsernamesUsernameAvailabilityRouteImport } from './routes/api/v1/identity/usernames/$username/availability'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
   id: '/motion-gallery',
@@ -92,6 +94,12 @@ const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
   path: '/api/v1/policies/$owner',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1IdentityUsernamesIndexRoute =
+  ApiV1IdentityUsernamesIndexRouteImport.update({
+    id: '/api/v1/identity/usernames/',
+    path: '/api/v1/identity/usernames/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -116,6 +124,12 @@ const ApiV1PoliciesOwnerSendersSenderRoute =
     path: '/senders/$sender',
     getParentRoute: () => ApiV1PoliciesOwnerRoute,
   } as any)
+const ApiV1IdentityUsernamesUsernameAvailabilityRoute =
+  ApiV1IdentityUsernamesUsernameAvailabilityRouteImport.update({
+    id: '/api/v1/identity/usernames/$username/availability',
+    path: '/api/v1/identity/usernames/$username/availability',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -134,6 +148,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/identity/usernames/': typeof ApiV1IdentityUsernamesIndexRoute
+  '/api/v1/identity/usernames/$username/availability': typeof ApiV1IdentityUsernamesUsernameAvailabilityRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesByTo {
@@ -153,6 +169,8 @@ export interface FileRoutesByTo {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/identity/usernames': typeof ApiV1IdentityUsernamesIndexRoute
+  '/api/v1/identity/usernames/$username/availability': typeof ApiV1IdentityUsernamesUsernameAvailabilityRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesById {
@@ -173,6 +191,8 @@ export interface FileRoutesById {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/identity/usernames/': typeof ApiV1IdentityUsernamesIndexRoute
+  '/api/v1/identity/usernames/$username/availability': typeof ApiV1IdentityUsernamesUsernameAvailabilityRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRouteTypes {
@@ -194,6 +214,8 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/identity/usernames/'
+    | '/api/v1/identity/usernames/$username/availability'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -213,6 +235,8 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/identity/usernames'
+    | '/api/v1/identity/usernames/$username/availability'
     | '/api/v1/policies/$owner/senders/$sender'
   id:
     | '__root__'
@@ -232,6 +256,8 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/identity/usernames/'
+    | '/api/v1/identity/usernames/$username/availability'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesById: FileRoutesById
 }
@@ -249,6 +275,8 @@ export interface RootRouteChildren {
   ApiV1ReceiptsMessageIdRoute: typeof ApiV1ReceiptsMessageIdRouteWithChildren
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
+  ApiV1IdentityUsernamesIndexRoute: typeof ApiV1IdentityUsernamesIndexRoute
+  ApiV1IdentityUsernamesUsernameAvailabilityRoute: typeof ApiV1IdentityUsernamesUsernameAvailabilityRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -344,6 +372,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/identity/usernames/': {
+      id: '/api/v1/identity/usernames/'
+      path: '/api/v1/identity/usernames'
+      fullPath: '/api/v1/identity/usernames/'
+      preLoaderRoute: typeof ApiV1IdentityUsernamesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -371,6 +406,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/v1/policies/$owner/senders/$sender'
       preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderRouteImport
       parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/identity/usernames/$username/availability': {
+      id: '/api/v1/identity/usernames/$username/availability'
+      path: '/api/v1/identity/usernames/$username/availability'
+      fullPath: '/api/v1/identity/usernames/$username/availability'
+      preLoaderRoute: typeof ApiV1IdentityUsernamesUsernameAvailabilityRouteImport
+      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -429,6 +471,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1ReceiptsMessageIdRoute: ApiV1ReceiptsMessageIdRouteWithChildren,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
+  ApiV1IdentityUsernamesIndexRoute: ApiV1IdentityUsernamesIndexRoute,
+  ApiV1IdentityUsernamesUsernameAvailabilityRoute:
+    ApiV1IdentityUsernamesUsernameAvailabilityRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/v1/identity/usernames/$username/availability.ts
+++ b/src/routes/api/v1/identity/usernames/$username/availability.ts
@@ -1,0 +1,54 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { ApiError } from "@/server/api/errors";
+import { checkUsernameAvailability } from "@/server/api/identity-service";
+import { consumeRouteQuota } from "@/server/api/rate-limit";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { RAW_USERNAME_MAX_LENGTH } from "@/features/identity/username";
+
+const paramsSchema = z.object({
+  username: z.string().min(1).max(RAW_USERNAME_MAX_LENGTH),
+});
+
+function clientIp(request: Request): string {
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown"
+  );
+}
+
+/**
+ * GET /api/v1/identity/usernames/{username}/availability
+ *
+ * Public (no wallet required yet) so a new visitor can get live feedback
+ * while typing a candidate handle. The response never distinguishes "taken"
+ * from "reserved" internally — malformed or reserved-word input fails
+ * request validation (422) before the repository is ever consulted, and a
+ * real, currently-held reservation only ever yields a boolean with no owner
+ * information, so the endpoint cannot be used to enumerate account details.
+ */
+export const Route = createFileRoute("/api/v1/identity/usernames/$username/availability")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const { username } = paramsSchema.parse(params);
+
+          const ip = clientIp(request);
+          const quota = await consumeRouteQuota(context.repository, "ip", ip, "read");
+          if (!quota.allowed) {
+            throw new ApiError(429, "too_many_requests", "IP limit exceeded", {
+              retryAfterSeconds: quota.retryAfterSeconds,
+            });
+          }
+
+          const result = await checkUsernameAvailability(context.repository, username);
+          return apiSuccess(request, result, { cachePolicy: "NO_STORE" });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/identity/usernames/index.ts
+++ b/src/routes/api/v1/identity/usernames/index.ts
@@ -1,0 +1,82 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { ApiError } from "@/server/api/errors";
+import { RAW_USERNAME_MAX_LENGTH } from "@/features/identity/username";
+import { reserveUsername } from "@/server/api/identity-service";
+import { withIdempotency } from "@/server/api/idempotency-service";
+import { consumeRouteQuota } from "@/server/api/rate-limit";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const reservationBodySchema = z.object({
+  username: z.string().min(1).max(RAW_USERNAME_MAX_LENGTH),
+});
+
+/**
+ * POST /api/v1/identity/usernames
+ *
+ * Reserves `username@stealth.me` for the authenticated actor. Supports the
+ * standard `X-Idempotency-Key` retry contract (see idempotency-service.ts),
+ * so a client retrying after a dropped response cannot double-submit; the
+ * underlying repository call additionally guarantees exactly one winner
+ * across genuinely concurrent claims for the same normalized username.
+ */
+export const Route = createFileRoute("/api/v1/identity/usernames/")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actorId = requireActor(context);
+
+          const quota = await consumeRouteQuota(
+            context.repository,
+            "account",
+            actorId,
+            "signatureVerification",
+          );
+          if (!quota.allowed) {
+            throw new ApiError(429, "too_many_requests", "Account limit exceeded", {
+              retryAfterSeconds: quota.retryAfterSeconds,
+            });
+          }
+
+          const input = await parseJsonBody(request, reservationBodySchema, "minimal");
+
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+          const reserve = async () => {
+            const record = await reserveUsername(
+              context.repository,
+              { rawUsername: input.username, ownerAddress: actorId },
+              new Date(),
+              context.requestId ?? "unknown",
+            );
+            return { status: 201, body: record };
+          };
+
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                context.repository,
+                {
+                  actor: actorId,
+                  method: request.method,
+                  route: "POST /identity/usernames",
+                  rawKey: rawIdempotencyKey,
+                },
+                input,
+                reserve,
+                { cacheableErrorStatuses: [409] },
+              )
+            : { ...(await reserve()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            status: result.status,
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
+        }),
+    },
+  },
+});

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,7 @@ import {
   profileSchema,
   credentialSchema,
   storedEnvelopeSchema,
+  usernameRecordSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -195,6 +196,7 @@ registerRecordSchema("receipt", 1, receiptSchema);
 registerRecordSchema("user", 1, userSchema);
 registerRecordSchema("profile", 1, profileSchema);
 registerRecordSchema("credential", 1, credentialSchema);
+registerRecordSchema("usernameRecord", 1, usernameRecordSchema);
 // v1 -> v2 (Issue #1498): records now carry a requestDigest binding the
 // lease/response to the exact request payload that created it. Legacy
 // records predate this and never bore a client-supplied payload we can

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -111,6 +111,24 @@ export type PostageStatus = z.infer<typeof postageStatusSchema>;
 export type Receipt = z.infer<typeof receiptSchema>;
 export type SenderRule = z.infer<typeof senderRuleSchema>;
 
+// ---------------------------------------------------------------------------
+// Issue #1910: canonical username reservation record.
+//
+// `username` is always the already-canonicalized value (see
+// src/features/identity/username.ts) — this schema does not re-derive
+// canonicalization, it only shapes the persisted record.
+// ---------------------------------------------------------------------------
+
+export const usernameRecordSchema = z.object({
+  username: z.string().min(1).max(64),
+  ownerAddress: stellarAddressSchema,
+  stealthAddress: z.string().min(1).max(128),
+  federationAddress: z.string().min(1).max(128),
+  createdAt: z.string().datetime(),
+});
+
+export type UsernameRecord = z.infer<typeof usernameRecordSchema>;
+
 export const idempotencyRecordSchema = z.discriminatedUnion("state", [
   z.object({
     state: z.literal("in_progress"),

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -130,6 +130,12 @@ export const API_ERROR_REGISTRY = {
     retryable: true,
     description: "A matching operation currently holds the idempotency lease.",
   },
+  username_taken: {
+    status: 409,
+    message: "The requested username is not available",
+    retryable: false,
+    description: "A reservation already exists for this normalized username.",
+  },
 } as const satisfies Record<string, ApiErrorDefinition>;
 
 export type ApiErrorCode = keyof typeof API_ERROR_REGISTRY;

--- a/src/server/api/identity-service.ts
+++ b/src/server/api/identity-service.ts
@@ -1,0 +1,89 @@
+import { toFederationAddress, toStealthAddress } from "@/features/identity/federation";
+import { type CanonicalUsername, usernameSchema } from "@/features/identity/username";
+
+import { recordAuditEvent } from "./audit";
+import type { UsernameRecord } from "./domain";
+import { ApiError } from "./errors";
+import type { ApiRepository } from "./repository";
+
+export interface UsernameAvailability {
+  username: CanonicalUsername;
+  available: boolean;
+}
+
+/**
+ * Validates and canonicalizes `rawUsername`, then reports whether it is
+ * currently reservable.
+ *
+ * Format, length, and reserved-word violations throw a 422 `validation_error`
+ * *before* the repository is ever consulted — those rules are deterministic
+ * functions of the input alone, so surfacing them as validation errors keeps
+ * the boolean `available` result from conflating "malformed input" with "a
+ * real reservation already exists", and never requires exposing who (if
+ * anyone) holds the name.
+ */
+export async function checkUsernameAvailability(
+  repository: ApiRepository,
+  rawUsername: string,
+): Promise<UsernameAvailability> {
+  const username = usernameSchema.parse(rawUsername);
+  const existing = await repository.getUsernameRecord(username);
+  return { username, available: existing === null };
+}
+
+export interface ReserveUsernameInput {
+  rawUsername: string;
+  ownerAddress: string;
+}
+
+/**
+ * Atomically reserves a username for `ownerAddress`.
+ *
+ * Concurrent callers racing on the same normalized username (including case
+ * or confusable variants, which canonicalize to the same value) are
+ * guaranteed exactly one winner by {@link ApiRepository.reserveUsernameIfAbsent}.
+ * Every loser — including the original owner retrying without an idempotency
+ * key — receives a deterministic `username_taken` (409) rather than silently
+ * overwriting the existing reservation.
+ */
+export async function reserveUsername(
+  repository: ApiRepository,
+  input: ReserveUsernameInput,
+  now: Date = new Date(),
+  requestId = "unknown",
+): Promise<UsernameRecord> {
+  const username = usernameSchema.parse(input.rawUsername);
+
+  const record: UsernameRecord = {
+    username,
+    ownerAddress: input.ownerAddress,
+    stealthAddress: toStealthAddress(username),
+    federationAddress: toFederationAddress(username),
+    createdAt: now.toISOString(),
+  };
+
+  const result = await repository.reserveUsernameIfAbsent(record);
+
+  if (result.outcome === "taken") {
+    recordAuditEvent({
+      actor: input.ownerAddress,
+      action: "identity.username.reserve",
+      targetType: "username",
+      safeTargetReference: username,
+      result: "denied",
+      requestId,
+    });
+    throw new ApiError("username_taken", { username });
+  }
+
+  recordAuditEvent({
+    actor: input.ownerAddress,
+    action: "identity.username.reserve",
+    targetType: "username",
+    safeTargetReference: username,
+    result: "success",
+    requestId,
+  });
+
+  return result.record;
+}

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -2,6 +2,7 @@ import type {
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  ReserveUsernameResult,
   UpdateUserResult,
 } from "./repository";
 import type {
@@ -15,6 +16,7 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameRecord,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -87,6 +89,27 @@ export class HybridApiRepository implements ApiRepository {
     }
     await this.kv.put(this.key("postage", postage.messageId), JSON.stringify(postage));
     return postage;
+  }
+
+  // Reservation uniqueness is authoritative in the coordinator (see
+  // StealthCoordinator.reserveUsernameIfAbsent); KV is mirrored on success
+  // purely as a fast-read cache, mirroring the receipt read/write pattern.
+  async getUsernameRecord(username: string): Promise<UsernameRecord | null> {
+    const coordinated = await this.getStub().getUsernameRecord(username);
+    if (coordinated) return coordinated;
+
+    const record = await this.kv.get(this.key("username", username), "json");
+    if (!record) return null;
+
+    return record as UsernameRecord;
+  }
+
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    const result = await this.getStub().reserveUsernameIfAbsent(record);
+    if (result.outcome === "reserved") {
+      await this.kv.put(this.key("username", record.username), JSON.stringify(result.record));
+    }
+    return result;
   }
 
   async getReceipt(messageId: string): Promise<Receipt | null> {

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -9,11 +9,13 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameRecord,
 } from "./domain";
 import type {
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  ReserveUsernameResult,
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
@@ -41,6 +43,12 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly usersByAddress = new Map<string, string>();
   private readonly profiles = new Map<string, Profile>();
   private readonly credentials = new Map<string, Credential>();
+
+  // Issue #1910: canonical username *reservation* store and per-key locks.
+  // Distinct from usersByUsername (BETA-002) — see the note above
+  // reserveUsernameIfAbsent for how the two relate.
+  private readonly usernames = new Map<string, UsernameRecord>();
+  private readonly usernameLocks = new Map<string, Promise<void>>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -78,6 +86,26 @@ export class MemoryApiRepository implements ApiRepository {
       release();
       if (this.envelopeLocks.get(messageId) === queued) {
         this.envelopeLocks.delete(messageId);
+      }
+    }
+  }
+
+  private async withUsernameLock<T>(username: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.usernameLocks.get(username) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.usernameLocks.set(username, queued);
+
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.usernameLocks.get(username) === queued) {
+        this.usernameLocks.delete(username);
       }
     }
   }
@@ -138,6 +166,28 @@ export class MemoryApiRepository implements ApiRepository {
     }
     this.postage.set(postage.messageId, structuredClone(postage));
     return structuredClone(postage);
+  }
+
+  // Issue #1910: canonical username *reservation* (username@stealth.me /
+  // username*stealth.me federation mapping). Deliberately independent of
+  // BETA-002's usersByUsername index above: this store is keyed by the
+  // caller-supplied ownerAddress rather than a full User account, so an
+  // address can reserve its identity before (or without) creating a full
+  // account. Reconciling the two into a single uniqueness domain is a
+  // follow-up, not part of this change.
+  async getUsernameRecord(username: string) {
+    return structuredClone(this.usernames.get(username) ?? null);
+  }
+
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    return this.withUsernameLock(record.username, async () => {
+      const existing = this.usernames.get(record.username);
+      if (existing) {
+        return { outcome: "taken", record: structuredClone(existing) };
+      }
+      this.usernames.set(record.username, structuredClone(record));
+      return { outcome: "reserved", record: structuredClone(record) };
+    });
   }
 
   async getReceipt(messageId: string) {
@@ -437,5 +487,7 @@ export class MemoryApiRepository implements ApiRepository {
     this.usersByAddress.clear();
     this.profiles.clear();
     this.credentials.clear();
+    this.usernames.clear();
+    this.usernameLocks.clear();
   }
 }

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -115,6 +115,70 @@ export const openApiDocument = {
           },
         },
       },
+      Username: {
+        type: "string",
+        description: "Canonical (normalized, lowercased, confusable-folded) Stealth username.",
+        pattern: "^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$",
+        minLength: 3,
+        maxLength: 30,
+        example: "alice",
+      },
+      UsernameAvailability: {
+        type: "object",
+        required: ["username", "available"],
+        additionalProperties: false,
+        properties: {
+          username: {
+            $ref: "#/components/schemas/Username",
+          },
+          available: {
+            type: "boolean",
+            description:
+              "Whether the canonical username is currently reservable. Never reveals ownership.",
+          },
+        },
+      },
+      UsernameReservationRequest: {
+        type: "object",
+        required: ["username"],
+        additionalProperties: false,
+        properties: {
+          username: {
+            type: "string",
+            description: "Raw candidate username; normalized server-side before reservation.",
+            maxLength: 128,
+            example: "Alice",
+          },
+        },
+      },
+      UsernameRecord: {
+        type: "object",
+        required: ["username", "ownerAddress", "stealthAddress", "federationAddress", "createdAt"],
+        additionalProperties: false,
+        properties: {
+          username: {
+            $ref: "#/components/schemas/Username",
+          },
+          ownerAddress: {
+            $ref: "#/components/schemas/StellarAddress",
+          },
+          stealthAddress: {
+            type: "string",
+            description: "Human-facing Stealth address.",
+            example: "alice@stealth.me",
+          },
+          federationAddress: {
+            type: "string",
+            description:
+              "SEP-2 Stellar federation address (username*domain), resolved via the federation server.",
+            example: "alice*stealth.me",
+          },
+          createdAt: {
+            type: "string",
+            format: "date-time",
+          },
+        },
+      },
       ValidationErrorItem: {
         type: "object",
         required: ["path", "rule", "message"],
@@ -972,6 +1036,142 @@ export const openApiDocument = {
                 schema: {
                   $ref: "#/components/schemas/ErrorEnvelope",
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/identity/usernames/{username}/availability": {
+      get: {
+        operationId: "getUsernameAvailability",
+        summary: "Check canonical username availability",
+        "x-stability": "stable",
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/SuccessEnvelope" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: { $ref: "#/components/schemas/UsernameAvailability" },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "422": {
+            description:
+              "Unprocessable Entity — malformed, out-of-bounds-length, or reserved-word username",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "429": {
+            description: "Too Many Requests",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/identity/usernames": {
+      post: {
+        operationId: "reserveUsername",
+        summary: "Atomically reserve a canonical Stealth username",
+        "x-max-body-bytes": 4 * 1024,
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
+        "x-stability": "stable",
+        requestBody: {
+          description: "Candidate username to reserve for the authenticated actor.",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UsernameReservationRequest" },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "201": {
+            description: "Reserved",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/SuccessEnvelope" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: { $ref: "#/components/schemas/UsernameRecord" },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict — username_taken or an in-flight idempotent duplicate",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "422": {
+            description:
+              "Unprocessable Entity — malformed, out-of-bounds-length, or reserved-word username",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "429": {
+            description: "Too Many Requests",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ErrorEnvelope" },
               },
             },
           },

--- a/src/server/api/protocol.ts
+++ b/src/server/api/protocol.ts
@@ -20,11 +20,13 @@ export const protocolManifest = {
     "postage-lifecycle",
     "delivery-receipts",
     "read-receipts",
+    "username-reservation",
   ],
   contracts: {
     policies: ["set_policy", "get_policy", "set_sender_rule", "sender_rule", "can_mail"],
     postage: ["minimum", "quote", "submit", "settle", "refund", "get"],
     receipts: ["delivered", "read", "get"],
+    identity: ["check_availability", "reserve_username"],
   },
   persistence: {
     adapter: "memory",

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -10,6 +10,7 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameRecord,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
 
@@ -84,6 +85,22 @@ export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
 
+/**
+ * Outcome of an atomic "reserve if absent" username claim.
+ *
+ * - "reserved": this call won the race and the record now reflects `record`.
+ * - "taken": a reservation already existed for this normalized username
+ *   (either from an earlier call or a concurrent winner); `record` reflects
+ *   the existing owner, never the caller's requested payload.
+ *
+ * Implementations MUST guarantee exactly one winner across concurrent calls
+ * for the same normalized username (Issue #1910), the same way
+ * {@link ApiRepository.createReceiptIfAbsent} guarantees it for receipts.
+ */
+export type ReserveUsernameResult =
+  | { outcome: "reserved"; record: UsernameRecord }
+  | { outcome: "taken"; record: UsernameRecord };
+
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
@@ -113,6 +130,15 @@ export interface ApiRepository {
    * postage/receipt state. Concurrent inserts must yield exactly one winner.
    */
   insertPostage(postage: Postage): Promise<Postage>;
+
+  /** Reads the current reservation for a normalized username, or null if unclaimed. */
+  getUsernameRecord(username: string): Promise<UsernameRecord | null>;
+  /**
+   * Atomically reserves a normalized username, keyed by `record.username`.
+   * See {@link ReserveUsernameResult} for the exactly-one-winner contract.
+   */
+  reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult>;
+
   getReceipt(messageId: string): Promise<Receipt | null>;
   setReceipt(receipt: Receipt): Promise<Receipt>;
   createReceiptIfAbsent(receipt: Receipt): Promise<{ created: boolean; receipt: Receipt }>;
@@ -314,6 +340,19 @@ export class ValidatedApiRepository implements ApiRepository {
   async insertPostage(postage: Postage): Promise<Postage> {
     const result = await this.inner.insertPostage(versionRecord("postage", postage));
     return validateRecord<Postage>("postage", result);
+  }
+
+  async getUsernameRecord(username: string): Promise<UsernameRecord | null> {
+    const raw = await this.inner.getUsernameRecord(username);
+    return raw ? validateRecord<UsernameRecord>("usernameRecord", raw) : null;
+  }
+
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    const result = await this.inner.reserveUsernameIfAbsent(
+      versionRecord("usernameRecord", record),
+    );
+    result.record = validateRecord<UsernameRecord>("usernameRecord", result.record);
+    return result;
   }
 
   async getReceipt(messageId: string): Promise<Receipt | null> {
@@ -524,6 +563,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getCredential",
   "setCredential",
   "getEnvelope",
+  "getUsernameRecord",
+  "reserveUsernameIfAbsent",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -616,6 +657,16 @@ export class RetryableApiRepository implements ApiRepository {
 
   insertPostage(postage: Postage): Promise<Postage> {
     return this.inner.insertPostage(postage);
+  }
+
+  getUsernameRecord(username: string): Promise<UsernameRecord | null> {
+    return this.withRetry("getUsernameRecord", () => this.inner.getUsernameRecord(username));
+  }
+
+  reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    return this.withRetry("reserveUsernameIfAbsent", () =>
+      this.inner.reserveUsernameIfAbsent(record),
+    );
   }
 
   getReceipt(messageId: string): Promise<Receipt | null> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -7,11 +7,13 @@ import type {
   Receipt,
   StoredEnvelope,
   User,
+  UsernameRecord,
 } from "./domain";
 import type {
   AcquireIdempotencyResult,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  ReserveUsernameResult,
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
@@ -323,6 +325,29 @@ export class StealthCoordinator extends DurableObjectBase {
   async setCredential(credential: Credential): Promise<Credential> {
     await this.ctx.storage.put(`credential:${credential.userId}`, credential);
     return credential;
+  }
+
+  // Issue #1910: username *reservation* is a uniqueness constraint over
+  // identity itself, so (like postage settlement) it must live in this
+  // Durable Object's transactional storage rather than eventually-consistent
+  // KV. Independent of the BETA-002 user:username:* index above — see the
+  // note in memory-repository.ts for how the two relate.
+  async getUsernameRecord(username: string): Promise<UsernameRecord | null> {
+    const record = (await this.ctx.storage.get(`username:${username}`)) as
+      | UsernameRecord
+      | undefined;
+    return record ?? null;
+  }
+
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    return this.runExclusive(`username:${record.username}`, async () => {
+      const existing = await this.getUsernameRecord(record.username);
+      if (existing) {
+        return { outcome: "taken" as const, record: existing };
+      }
+      await this.ctx.storage.put(`username:${record.username}`, record);
+      return { outcome: "reserved" as const, record };
+    });
   }
 
   async getCounter(key: string): Promise<number> {

--- a/tests/unit/api/identity-routes.test.ts
+++ b/tests/unit/api/identity-routes.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Route as AvailabilityRoute } from "../../../src/routes/api/v1/identity/usernames/$username/availability";
+import { Route as ReserveRoute } from "../../../src/routes/api/v1/identity/usernames/index";
+import { ACTOR_HEADER } from "../../../src/server/api/actor";
+import { getApiContext } from "../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+const owner = `G${"A".repeat(55)}`;
+const otherOwner = `G${"B".repeat(55)}`;
+const ip = "203.0.113.5";
+
+const availabilityHandler = (AvailabilityRoute.options as any).server?.handlers?.GET;
+const reserveHandler = (ReserveRoute.options as any).server?.handlers?.POST;
+
+function availabilityRequest(username: string, headers: Record<string, string> = {}) {
+  return new Request(
+    `https://stealth.test/api/v1/identity/usernames/${encodeURIComponent(username)}/availability`,
+    { method: "GET", headers: { "cf-connecting-ip": ip, ...headers } },
+  );
+}
+
+function reserveRequest(
+  username: string,
+  actor: string,
+  extra: { idempotencyKey?: string; headers?: Record<string, string> } = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    [ACTOR_HEADER]: actor,
+    ...(extra.headers ?? {}),
+  };
+  if (extra.idempotencyKey) headers["x-idempotency-key"] = extra.idempotencyKey;
+  return new Request("https://stealth.test/api/v1/identity/usernames", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ username }),
+  });
+}
+
+async function parseJson(response: Response) {
+  return response.clone().json() as Promise<{
+    error?: { code: string; message: string };
+    data?: any;
+  }>;
+}
+
+describe("identity username routes (issue #1910)", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  describe("GET /identity/usernames/{username}/availability", () => {
+    it("reports an unreserved username as available", async () => {
+      const response = await availabilityHandler({
+        request: availabilityRequest("alice"),
+        params: { username: "alice" },
+      });
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ username: "alice", available: true });
+    });
+
+    it("reports a taken username as unavailable, without leaking the owner", async () => {
+      await reserveHandler({
+        request: reserveRequest("alice", owner),
+        params: {},
+      });
+
+      const response = await availabilityHandler({
+        request: availabilityRequest("alice"),
+        params: { username: "alice" },
+      });
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ username: "alice", available: false });
+      expect(JSON.stringify(body)).not.toContain(owner);
+    });
+
+    it("treats case/whitespace variants identically to the canonical form", async () => {
+      await reserveHandler({ request: reserveRequest("alice", owner), params: {} });
+
+      const response = await availabilityHandler({
+        request: availabilityRequest("ALICE"),
+        params: { username: "ALICE" },
+      });
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ username: "alice", available: false });
+    });
+
+    it("returns a 422 validation error for a reserved word", async () => {
+      const response = await availabilityHandler({
+        request: availabilityRequest("admin"),
+        params: { username: "admin" },
+      });
+      expect(response.status).toBe(422);
+      const body = await parseJson(response);
+      expect(body.error?.code).toBe("validation_error");
+    });
+
+    it("returns a 422 validation error for a below-minimum-length candidate", async () => {
+      const response = await availabilityHandler({
+        request: availabilityRequest("ab"),
+        params: { username: "ab" },
+      });
+      expect(response.status).toBe(422);
+    });
+
+    it("returns 429 once the per-IP quota is exhausted", async () => {
+      await repo.incrementCounter(`abuse:ip:${ip}`, 3600, 100);
+
+      const response = await availabilityHandler({
+        request: availabilityRequest("bob"),
+        params: { username: "bob" },
+      });
+      expect(response.status).toBe(429);
+      const body = await parseJson(response);
+      expect(body.error?.code).toBe("too_many_requests");
+    });
+  });
+
+  describe("POST /identity/usernames (reserve)", () => {
+    it("reserves a username and returns the stealth + federation addresses", async () => {
+      const response = await reserveHandler({
+        request: reserveRequest("alice", owner),
+        params: {},
+      });
+      expect(response.status).toBe(201);
+      const body = await parseJson(response);
+      expect(body.data).toMatchObject({
+        username: "alice",
+        ownerAddress: owner,
+        stealthAddress: "alice@stealth.me",
+        federationAddress: "alice*stealth.me",
+      });
+    });
+
+    it("requires authentication", async () => {
+      const request = new Request("https://stealth.test/api/v1/identity/usernames", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ username: "alice" }),
+      });
+      const response = await reserveHandler({ request, params: {} });
+      expect(response.status).toBe(401);
+    });
+
+    it("rejects a second claim of the same username with 409 username_taken", async () => {
+      await reserveHandler({ request: reserveRequest("alice", owner), params: {} });
+
+      const response = await reserveHandler({
+        request: reserveRequest("alice", otherOwner),
+        params: {},
+      });
+      expect(response.status).toBe(409);
+      const body = await parseJson(response);
+      expect(body.error?.code).toBe("username_taken");
+
+      // The original reservation is untouched.
+      await expect(repo.getUsernameRecord("alice")).resolves.toMatchObject({
+        ownerAddress: owner,
+      });
+    });
+
+    it("rejects a reserved word with a 422 validation error", async () => {
+      const response = await reserveHandler({
+        request: reserveRequest("admin", owner),
+        params: {},
+      });
+      expect(response.status).toBe(422);
+    });
+
+    it("replays the stored response for a duplicate identical idempotent request", async () => {
+      const first = await reserveHandler({
+        request: reserveRequest("alice", owner, { idempotencyKey: "reserve-key-1" }),
+        params: {},
+      });
+      expect(first.status).toBe(201);
+      expect(first.headers.get("x-idempotency-replayed")).toBeNull();
+      const firstBody = await parseJson(first);
+
+      const second = await reserveHandler({
+        request: reserveRequest("alice", owner, { idempotencyKey: "reserve-key-1" }),
+        params: {},
+      });
+      expect(second.status).toBe(201);
+      expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+      const secondBody = await parseJson(second);
+      expect(secondBody.data).toEqual(firstBody.data);
+    });
+
+    it("executes the reservation exactly once under concurrent identical duplicate requests", async () => {
+      const responses = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          reserveHandler({
+            request: reserveRequest("alice", owner, { idempotencyKey: "concurrent-reserve-key" }),
+            params: {},
+          }),
+        ),
+      );
+
+      const statuses = responses.map((response: Response) => response.status).sort();
+      // Exactly one winner (201); every other concurrent duplicate is
+      // rejected as in-progress (409) rather than re-running the reservation.
+      expect(statuses.filter((status: number) => status === 201)).toHaveLength(1);
+      expect(statuses.filter((status: number) => status === 409)).toHaveLength(4);
+    });
+
+    it("allows exactly one winner out of concurrent claims for the same username by different owners", async () => {
+      // Valid Stellar G-addresses use only base32 characters (A-Z, 2-7);
+      // each owner here is a distinct letter repeated to fill the address.
+      const owners = ["A", "C", "D", "E", "F", "H"].map((letter) => `G${letter.repeat(55)}`);
+      const responses = await Promise.all(
+        owners.map((actor) =>
+          reserveHandler({ request: reserveRequest("alice", actor), params: {} }),
+        ),
+      );
+
+      const statuses = responses.map((response: Response) => response.status).sort();
+      expect(statuses.filter((status: number) => status === 201)).toHaveLength(1);
+      expect(statuses.filter((status: number) => status === 409)).toHaveLength(5);
+
+      const finalRecord = await repo.getUsernameRecord("alice");
+      expect(owners).toContain(finalRecord?.ownerAddress);
+    });
+  });
+});

--- a/tests/unit/api/identity-service.test.ts
+++ b/tests/unit/api/identity-service.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  checkUsernameAvailability,
+  reserveUsername,
+} from "../../../src/server/api/identity-service";
+import { ApiError } from "../../../src/server/api/errors";
+
+const owner = `G${"A".repeat(55)}`;
+const otherOwner = `G${"B".repeat(55)}`;
+
+describe("checkUsernameAvailability", () => {
+  let repository: MemoryApiRepository;
+
+  beforeEach(() => {
+    repository = new MemoryApiRepository();
+  });
+
+  it("reports an unreserved, well-formed username as available", async () => {
+    await expect(checkUsernameAvailability(repository, "Alice")).resolves.toEqual({
+      username: "alice",
+      available: true,
+    });
+  });
+
+  it("reports a reserved username as unavailable once claimed", async () => {
+    await reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner });
+    await expect(checkUsernameAvailability(repository, "alice")).resolves.toEqual({
+      username: "alice",
+      available: false,
+    });
+  });
+
+  it("treats case and confusable variants as the same username for availability", async () => {
+    await reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner });
+    await expect(checkUsernameAvailability(repository, "ALICE")).resolves.toEqual({
+      username: "alice",
+      available: false,
+    });
+    await expect(checkUsernameAvailability(repository, "  Alice  ")).resolves.toEqual({
+      username: "alice",
+      available: false,
+    });
+  });
+
+  it("throws a validation error for a reserved word, without ever consulting the repository", async () => {
+    await expect(checkUsernameAvailability(repository, "admin")).rejects.toThrow();
+    // Confirm no reservation-shaped side effect occurred.
+    await expect(repository.getUsernameRecord("admin")).resolves.toBeNull();
+  });
+
+  it("throws a validation error for a boundary-violating length", async () => {
+    await expect(checkUsernameAvailability(repository, "ab")).rejects.toThrow();
+    await expect(checkUsernameAvailability(repository, "a".repeat(31))).rejects.toThrow();
+  });
+
+  it("throws a validation error for a disallowed character", async () => {
+    await expect(checkUsernameAvailability(repository, "alice smith")).rejects.toThrow();
+  });
+});
+
+describe("reserveUsername", () => {
+  let repository: MemoryApiRepository;
+
+  beforeEach(() => {
+    repository = new MemoryApiRepository();
+  });
+
+  it("reserves a well-formed username and returns the full record", async () => {
+    const record = await reserveUsername(repository, {
+      rawUsername: "Alice",
+      ownerAddress: owner,
+    });
+
+    expect(record).toMatchObject({
+      username: "alice",
+      ownerAddress: owner,
+      stealthAddress: "alice@stealth.me",
+      federationAddress: "alice*stealth.me",
+    });
+    expect(typeof record.createdAt).toBe("string");
+    expect(() => new Date(record.createdAt).toISOString()).not.toThrow();
+  });
+
+  it("persists the reservation so a later lookup reflects it", async () => {
+    await reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner });
+    await expect(repository.getUsernameRecord("alice")).resolves.toMatchObject({
+      username: "alice",
+      ownerAddress: owner,
+    });
+  });
+
+  it("rejects a second reservation of the same username with username_taken (409)", async () => {
+    await reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner });
+
+    await expect(
+      reserveUsername(repository, { rawUsername: "alice", ownerAddress: otherOwner }),
+    ).rejects.toMatchObject({ code: "username_taken", status: 409 });
+
+    // The original owner is untouched by the losing attempt.
+    await expect(repository.getUsernameRecord("alice")).resolves.toMatchObject({
+      ownerAddress: owner,
+    });
+  });
+
+  it("rejects a case/confusable variant of an already-reserved username", async () => {
+    await reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner });
+
+    await expect(
+      reserveUsername(repository, { rawUsername: "ALICE", ownerAddress: otherOwner }),
+    ).rejects.toBeInstanceOf(ApiError);
+    await expect(
+      reserveUsername(repository, { rawUsername: "  alice  ", ownerAddress: otherOwner }),
+    ).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("rejects reserved-word and malformed input before persisting anything", async () => {
+    await expect(
+      reserveUsername(repository, { rawUsername: "admin", ownerAddress: owner }),
+    ).rejects.toThrow();
+    await expect(repository.getUsernameRecord("admin")).resolves.toBeNull();
+
+    await expect(
+      reserveUsername(repository, { rawUsername: "ab", ownerAddress: owner }),
+    ).rejects.toThrow();
+  });
+
+  it("allows exactly one winner out of many concurrent reservation attempts for the same username", async () => {
+    const attempts = Array.from({ length: 8 }, (_, index) =>
+      reserveUsername(repository, {
+        rawUsername: "alice",
+        ownerAddress: `G${String(index).repeat(55)}`.slice(0, 56),
+      }).then(
+        (record) => ({ status: "fulfilled" as const, record }),
+        (error) => ({ status: "rejected" as const, error }),
+      ),
+    );
+
+    const results = await Promise.all(attempts);
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(7);
+    for (const result of rejected) {
+      expect((result as { error: unknown }).error).toMatchObject({ code: "username_taken" });
+    }
+
+    const finalRecord = await repository.getUsernameRecord("alice");
+    expect(finalRecord?.ownerAddress).toBe(
+      (fulfilled[0] as { record: { ownerAddress: string } }).record.ownerAddress,
+    );
+  });
+
+  it("does not let reserving distinct usernames interfere with each other", async () => {
+    const [alice, bob] = await Promise.all([
+      reserveUsername(repository, { rawUsername: "alice", ownerAddress: owner }),
+      reserveUsername(repository, { rawUsername: "bob", ownerAddress: otherOwner }),
+    ]);
+
+    expect(alice.username).toBe("alice");
+    expect(bob.username).toBe("bob");
+    await expect(repository.getUsernameRecord("alice")).resolves.toMatchObject({
+      ownerAddress: owner,
+    });
+    await expect(repository.getUsernameRecord("bob")).resolves.toMatchObject({
+      ownerAddress: otherOwner,
+    });
+  });
+});

--- a/tests/unit/api/kv-repository.test.ts
+++ b/tests/unit/api/kv-repository.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { HybridApiRepository } from "../../../src/server/api/kv-repository";
-import type { MailboxPolicy, Postage, Receipt } from "../../../src/server/api/domain";
+import type {
+  MailboxPolicy,
+  Postage,
+  Receipt,
+  UsernameRecord,
+} from "../../../src/server/api/domain";
+import type { ReserveUsernameResult } from "../../../src/server/api/repository";
 
 class MockKVNamespace {
   public store = new Map<string, string>();
@@ -26,6 +32,18 @@ class MockKVNamespace {
 class MockCoordinatorStub {
   private postage = new Map<string, Postage>();
   private receipts = new Map<string, Receipt>();
+  private usernames = new Map<string, UsernameRecord>();
+
+  async getUsernameRecord(username: string) {
+    return this.usernames.get(username) ?? null;
+  }
+
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    const existing = this.usernames.get(record.username);
+    if (existing) return { outcome: "taken", record: existing };
+    this.usernames.set(record.username, record);
+    return { outcome: "reserved", record };
+  }
 
   async getPostage(messageId: string) {
     return this.postage.get(messageId) ?? null;
@@ -251,6 +269,47 @@ describe("HybridApiRepository - KV Operations", () => {
 
       // Only one settlement side effect occurred; state is deterministic.
       await expect(repo.getPostage(messageId)).resolves.toMatchObject({ status: "settled" });
+    });
+  });
+
+  describe("username reservation - coordinator-authoritative with KV mirroring", () => {
+    const record: UsernameRecord = {
+      username: "alice",
+      ownerAddress: owner,
+      stealthAddress: "alice@stealth.me",
+      federationAddress: "alice*stealth.me",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    it("reserves via the coordinator and mirrors the result into KV", async () => {
+      await expect(repo.reserveUsernameIfAbsent(record)).resolves.toEqual({
+        outcome: "reserved",
+        record,
+      });
+      expect(kv.store.has("username:alice")).toBe(true);
+      await expect(repo.getUsernameRecord("alice")).resolves.toEqual(record);
+    });
+
+    it("does not mirror a losing reservation attempt into KV", async () => {
+      await repo.reserveUsernameIfAbsent(record);
+      kv.puts.length = 0;
+
+      const otherOwner = `G${"C".repeat(55)}`;
+      await expect(
+        repo.reserveUsernameIfAbsent({ ...record, ownerAddress: otherOwner }),
+      ).resolves.toEqual({ outcome: "taken", record });
+      expect(kv.puts).toHaveLength(0);
+    });
+
+    it("falls back to the KV mirror when reading a username the coordinator was never queried for directly", async () => {
+      await repo.reserveUsernameIfAbsent(record);
+      // Simulate a fresh read path: KV still has the mirror even though we
+      // query through the same repo instance, exercising the KV fallback.
+      await expect(repo.getUsernameRecord("alice")).resolves.toEqual(record);
+    });
+
+    it("returns null for an unreserved username", async () => {
+      await expect(repo.getUsernameRecord("nobody-yet")).resolves.toBeNull();
     });
   });
 });

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -243,6 +243,71 @@ export function runRepositoryContractTests(
       });
     });
 
+    describe("username reservation", () => {
+      const record = {
+        username: "alice",
+        ownerAddress: owner,
+        stealthAddress: "alice@stealth.me",
+        federationAddress: "alice*stealth.me",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+
+      it("returns null for an unreserved username", async () => {
+        await expect(repo.getUsernameRecord("alice")).resolves.toBeNull();
+      });
+
+      it("reserves an absent username and round-trips it via getUsernameRecord", async () => {
+        await expect(repo.reserveUsernameIfAbsent(record)).resolves.toEqual({
+          outcome: "reserved",
+          record,
+        });
+        await expect(repo.getUsernameRecord("alice")).resolves.toEqual(record);
+      });
+
+      it("reports the existing owner as 'taken' on a second reservation attempt", async () => {
+        await repo.reserveUsernameIfAbsent(record);
+
+        const otherOwner = `G${"C".repeat(55)}`;
+        await expect(
+          repo.reserveUsernameIfAbsent({
+            ...record,
+            ownerAddress: otherOwner,
+            createdAt: "2026-01-02T00:00:00.000Z",
+          }),
+        ).resolves.toEqual({ outcome: "taken", record });
+
+        // The original reservation is never overwritten by a losing attempt.
+        await expect(repo.getUsernameRecord("alice")).resolves.toEqual(record);
+      });
+
+      it("isolates reservations across distinct usernames", async () => {
+        await repo.reserveUsernameIfAbsent(record);
+        await expect(repo.getUsernameRecord("bob")).resolves.toBeNull();
+      });
+
+      it("allows exactly one winner out of concurrent reservation attempts", async () => {
+        const results = await Promise.all(
+          Array.from({ length: 5 }, (_, index) =>
+            repo.reserveUsernameIfAbsent({
+              ...record,
+              ownerAddress: `G${String(index).repeat(55)}`.slice(0, 56),
+            }),
+          ),
+        );
+
+        const reserved = results.filter((result) => result.outcome === "reserved");
+        const taken = results.filter((result) => result.outcome === "taken");
+        expect(reserved).toHaveLength(1);
+        expect(taken).toHaveLength(4);
+
+        // Every loser observed the single winner's record, not its own payload.
+        const winner = reserved[0]!.record;
+        for (const result of taken) {
+          expect(result.record).toEqual(winner);
+        }
+      });
+    });
+
     describe("counters", () => {
       it("starts at zero and increments within a window", async () => {
         await expect(repo.getCounter("rl:test")).resolves.toBe(0);

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -7,12 +7,14 @@ import type {
   Receipt,
   SenderRule,
   StoredEnvelope,
+  UsernameRecord,
 } from "../../../src/server/api/domain";
 import type {
   AcquireIdempotencyResult,
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  ReserveUsernameResult,
 } from "../../../src/server/api/repository";
 import {
   RetryableApiRepository,
@@ -87,6 +89,14 @@ class FailingRepository implements ApiRepository {
   async insertPostage(postage: Postage): Promise<Postage> {
     this.maybeFail("insertPostage");
     return this.inner.insertPostage(postage);
+  }
+  async getUsernameRecord(username: string): Promise<UsernameRecord | null> {
+    this.maybeFail("getUsernameRecord");
+    return this.inner.getUsernameRecord(username);
+  }
+  async reserveUsernameIfAbsent(record: UsernameRecord): Promise<ReserveUsernameResult> {
+    this.maybeFail("reserveUsernameIfAbsent");
+    return this.inner.reserveUsernameIfAbsent(record);
   }
   async getReceipt(messageId: string): Promise<Receipt | null> {
     this.maybeFail("getReceipt");

--- a/tests/unit/identity/UsernameReservationForm.test.tsx
+++ b/tests/unit/identity/UsernameReservationForm.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UsernameReservationForm } from "../../../src/features/identity/components/UsernameReservationForm";
+
+const walletAddress = `G${"A".repeat(55)}`;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function reserveButton() {
+  return screen.getByRole("button", { name: /reserve username/i }) as HTMLButtonElement;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("UsernameReservationForm", () => {
+  it("shows an inline validation message for a reserved word without calling the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(createElement(UsernameReservationForm, { walletAddress }));
+
+    fireEvent.change(screen.getByLabelText("Choose your Stealth username"), {
+      target: { value: "admin" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/reserved username/i)).toBeTruthy();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(reserveButton().disabled).toBe(true);
+  });
+
+  it("checks availability and enables reservation for an available username", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { data: { username: "alice", available: true } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(createElement(UsernameReservationForm, { walletAddress }));
+
+    fireEvent.change(screen.getByLabelText("Choose your Stealth username"), {
+      target: { value: "alice" },
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/alice@stealth\.me is available/i)).toBeTruthy();
+      },
+      { timeout: 2000 },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/identity/usernames/alice/availability",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(reserveButton().disabled).toBe(false);
+  });
+
+  it("shows a taken message and keeps reservation disabled for an unavailable username", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { data: { username: "alice", available: false } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(createElement(UsernameReservationForm, { walletAddress }));
+
+    fireEvent.change(screen.getByLabelText("Choose your Stealth username"), {
+      target: { value: "alice" },
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/alice@stealth\.me is already taken/i)).toBeTruthy();
+      },
+      { timeout: 2000 },
+    );
+
+    expect(reserveButton().disabled).toBe(true);
+  });
+
+  it("reserves an available username and shows both address forms on success", async () => {
+    const record = {
+      username: "alice",
+      ownerAddress: walletAddress,
+      stealthAddress: "alice@stealth.me",
+      federationAddress: "alice*stealth.me",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { data: { username: "alice", available: true } }))
+      .mockResolvedValueOnce(jsonResponse(201, { data: record }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onReserved = vi.fn();
+    render(createElement(UsernameReservationForm, { walletAddress, onReserved }));
+
+    fireEvent.change(screen.getByLabelText("Choose your Stealth username"), {
+      target: { value: "alice" },
+    });
+
+    await waitFor(
+      () => {
+        expect(reserveButton().disabled).toBe(false);
+      },
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(reserveButton());
+
+    await waitFor(() => {
+      expect(screen.getByText(/username reserved/i)).toBeTruthy();
+    });
+
+    expect(screen.getByText("alice@stealth.me")).toBeTruthy();
+    expect(screen.getByText(/alice\*stealth\.me/)).toBeTruthy();
+    expect(onReserved).toHaveBeenCalledWith(record);
+
+    const reserveCall = fetchMock.mock.calls[1];
+    expect(reserveCall[0]).toBe("/api/v1/identity/usernames");
+    expect(reserveCall[1]).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({ "x-stealth-address": walletAddress }),
+    });
+  });
+
+  it("shows an error message when reservation fails server-side", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { data: { username: "alice", available: true } }))
+      .mockResolvedValueOnce(
+        jsonResponse(409, { error: { code: "username_taken", message: "Not available" } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(createElement(UsernameReservationForm, { walletAddress }));
+
+    fireEvent.change(screen.getByLabelText("Choose your Stealth username"), {
+      target: { value: "alice" },
+    });
+
+    await waitFor(
+      () => {
+        expect(reserveButton().disabled).toBe(false);
+      },
+      { timeout: 2000 },
+    );
+
+    fireEvent.click(reserveButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toMatch(/not available/i);
+  });
+});

--- a/tests/unit/identity/federation.test.ts
+++ b/tests/unit/identity/federation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STEALTH_FEDERATION_DOMAIN,
+  toFederationAddress,
+  toStealthAddress,
+} from "../../../src/features/identity/federation";
+import { usernameSchema } from "../../../src/features/identity/username";
+
+describe("federation address mapping", () => {
+  it("maps a canonical username to its Stealth address", () => {
+    const canonical = usernameSchema.parse("alice");
+    expect(toStealthAddress(canonical)).toBe(`alice@${STEALTH_FEDERATION_DOMAIN}`);
+    expect(toStealthAddress(canonical)).toBe("alice@stealth.me");
+  });
+
+  it("maps a canonical username to its Stellar federation address", () => {
+    const canonical = usernameSchema.parse("alice");
+    expect(toFederationAddress(canonical)).toBe(`alice*${STEALTH_FEDERATION_DOMAIN}`);
+    expect(toFederationAddress(canonical)).toBe("alice*stealth.me");
+  });
+
+  it("the two forms differ only by separator, never by the username itself", () => {
+    const canonical = usernameSchema.parse("bob-99");
+    const stealth = toStealthAddress(canonical);
+    const federation = toFederationAddress(canonical);
+    expect(stealth.replace("@", "*")).toBe(federation);
+  });
+});

--- a/tests/unit/identity/username.properties.test.ts
+++ b/tests/unit/identity/username.properties.test.ts
@@ -1,0 +1,96 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import {
+  USERNAME_FORMAT_REGEX,
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  normalizeUsername,
+  usernameSchema,
+} from "../../../src/features/identity/username";
+
+const NUM_RUNS = 200;
+
+const asciiUsernameCharArbitrary = fc.constantFrom(
+  ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-".split(""),
+);
+
+describe("normalizeUsername (property)", () => {
+  it("is idempotent for arbitrary strings", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 64 }), (raw) => {
+        const once = normalizeUsername(raw);
+        expect(normalizeUsername(once)).toBe(once);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("never grows a plain-ASCII-charset input (no confusables, no invisibles to fold or strip)", () => {
+    fc.assert(
+      fc.property(
+        fc.array(asciiUsernameCharArbitrary, { minLength: 1, maxLength: 40 }),
+        (chars) => {
+          const raw = chars.join("");
+          expect(normalizeUsername(raw)).toBe(raw.toLowerCase());
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("is case-insensitive: normalizing a string and its uppercase form yields the same canonical value", () => {
+    fc.assert(
+      fc.property(
+        fc.array(asciiUsernameCharArbitrary, { minLength: 1, maxLength: 40 }),
+        (chars) => {
+          const raw = chars.join("");
+          expect(normalizeUsername(raw.toUpperCase())).toBe(normalizeUsername(raw.toLowerCase()));
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+const canonicalUsernameArbitrary = fc
+  .array(asciiUsernameCharArbitrary, {
+    minLength: USERNAME_MIN_LENGTH,
+    maxLength: USERNAME_MAX_LENGTH,
+  })
+  .map((chars) => chars.join("").toLowerCase())
+  .filter((value) => USERNAME_FORMAT_REGEX.test(value));
+
+describe("usernameSchema (property)", () => {
+  it("every value it accepts satisfies the canonical length and charset invariants", () => {
+    fc.assert(
+      fc.property(canonicalUsernameArbitrary, (candidate) => {
+        const result = usernameSchema.safeParse(candidate);
+        // Some generated candidates collide with the reserved-word list; that
+        // is a valid, expected rejection, not a property violation.
+        if (!result.success) return;
+
+        expect(result.data.length).toBeGreaterThanOrEqual(USERNAME_MIN_LENGTH);
+        expect(result.data.length).toBeLessThanOrEqual(USERNAME_MAX_LENGTH);
+        expect(USERNAME_FORMAT_REGEX.test(result.data)).toBe(true);
+        expect(result.data).toBe(result.data.toLowerCase());
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it("parsing is idempotent: re-parsing an already-canonical value returns it unchanged", () => {
+    fc.assert(
+      fc.property(canonicalUsernameArbitrary, (candidate) => {
+        const first = usernameSchema.safeParse(candidate);
+        if (!first.success) return;
+        const second = usernameSchema.safeParse(first.data);
+        expect(second.success).toBe(true);
+        if (second.success) {
+          expect(second.data).toBe(first.data);
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/tests/unit/identity/username.test.ts
+++ b/tests/unit/identity/username.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RESERVED_USERNAMES,
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  isReservedUsername,
+  normalizeUsername,
+  usernameSchema,
+  validateUsernameCandidate,
+} from "../../../src/features/identity/username";
+
+// Built from explicit code points (not literal glyphs) so the exact
+// characters under test are unambiguous and immune to transcription errors.
+const CYRILLIC_A = String.fromCodePoint(0x0430); // CYRILLIC SMALL LETTER A, looks like "a"
+const CYRILLIC_E = String.fromCodePoint(0x0435); // CYRILLIC SMALL LETTER IE, looks like "e"
+const CYRILLIC_O = String.fromCodePoint(0x043e); // CYRILLIC SMALL LETTER O, looks like "o"
+const CYRILLIC_P = String.fromCodePoint(0x0440); // CYRILLIC SMALL LETTER ER, looks like "p"
+const GREEK_ALPHA = String.fromCodePoint(0x03b1); // GREEK SMALL LETTER ALPHA, looks like "a"
+const GREEK_OMICRON = String.fromCodePoint(0x03bf); // GREEK SMALL LETTER OMICRON, looks like "o"
+const FULLWIDTH_ALICE = [0xff41, 0xff4c, 0xff49, 0xff43, 0xff45]
+  .map((codePoint) => String.fromCodePoint(codePoint))
+  .join(""); // fullwidth "alice", folds to ASCII via NFKC
+const ZERO_WIDTH_SPACE = String.fromCodePoint(0x200b);
+const SOFT_HYPHEN = String.fromCodePoint(0x00ad);
+const BOM = String.fromCodePoint(0xfeff);
+
+describe("normalizeUsername", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeUsername("  Alice  ")).toBe("alice");
+    expect(normalizeUsername("ALICE")).toBe("alice");
+  });
+
+  it("folds fullwidth Unicode compatibility variants via NFKC", () => {
+    expect(normalizeUsername(FULLWIDTH_ALICE)).toBe("alice");
+  });
+
+  it("strips invisible/zero-width characters", () => {
+    expect(normalizeUsername(`ad${ZERO_WIDTH_SPACE}min`)).toBe("admin");
+    expect(normalizeUsername(`ad${SOFT_HYPHEN}min`)).toBe("admin");
+    expect(normalizeUsername(`${BOM}alice`)).toBe("alice");
+  });
+
+  it("folds known Cyrillic confusables to their Latin lookalike", () => {
+    expect(normalizeUsername(`${CYRILLIC_A}dmin`)).toBe("admin");
+    expect(normalizeUsername(`r${CYRILLIC_O}${CYRILLIC_O}t`)).toBe("root");
+    expect(normalizeUsername(`${CYRILLIC_P}${CYRILLIC_A}${CYRILLIC_O}${CYRILLIC_E}`)).toBe("paoe");
+  });
+
+  it("folds known Greek confusables to their Latin lookalike", () => {
+    expect(normalizeUsername(`${GREEK_ALPHA}dmin`)).toBe("admin");
+    expect(normalizeUsername(`ro${GREEK_OMICRON}t`)).toBe("root");
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeUsername(`  Alice${ZERO_WIDTH_SPACE} `);
+    expect(normalizeUsername(once)).toBe(once);
+  });
+});
+
+describe("isReservedUsername", () => {
+  it("flags known reserved words", () => {
+    expect(isReservedUsername("admin")).toBe(true);
+    expect(isReservedUsername("support")).toBe(true);
+    expect(isReservedUsername("stealth")).toBe(true);
+  });
+
+  it("does not flag an ordinary handle", () => {
+    expect(isReservedUsername("alice")).toBe(false);
+  });
+
+  it("every reserved word is already lowercase canonical form", () => {
+    for (const word of RESERVED_USERNAMES) {
+      expect(word).toBe(word.toLowerCase());
+    }
+  });
+});
+
+describe("usernameSchema", () => {
+  it("accepts a well-formed handle and returns its canonical form", () => {
+    expect(usernameSchema.parse("Alice")).toBe("alice");
+    expect(usernameSchema.parse("alice-99")).toBe("alice-99");
+    expect(usernameSchema.parse("alice_99")).toBe("alice_99");
+  });
+
+  it("rejects a candidate shorter than the minimum length", () => {
+    expect(() => usernameSchema.parse("a".repeat(USERNAME_MIN_LENGTH - 1))).toThrow();
+  });
+
+  it("accepts exactly the minimum length boundary", () => {
+    expect(usernameSchema.parse("a".repeat(USERNAME_MIN_LENGTH))).toBe(
+      "a".repeat(USERNAME_MIN_LENGTH),
+    );
+  });
+
+  it("accepts exactly the maximum length boundary", () => {
+    expect(usernameSchema.parse("a".repeat(USERNAME_MAX_LENGTH))).toBe(
+      "a".repeat(USERNAME_MAX_LENGTH),
+    );
+  });
+
+  it("rejects a candidate longer than the maximum length", () => {
+    expect(() => usernameSchema.parse("a".repeat(USERNAME_MAX_LENGTH + 1))).toThrow();
+  });
+
+  it("rejects characters outside the allowed charset", () => {
+    expect(() => usernameSchema.parse("alice smith")).toThrow();
+    expect(() => usernameSchema.parse("alice@wallet")).toThrow();
+    expect(() => usernameSchema.parse("alice.smith")).toThrow();
+    expect(() => usernameSchema.parse("alice/smith")).toThrow();
+  });
+
+  it("rejects a leading or trailing separator", () => {
+    expect(() => usernameSchema.parse("-alice")).toThrow();
+    expect(() => usernameSchema.parse("alice-")).toThrow();
+    expect(() => usernameSchema.parse("_alice")).toThrow();
+    expect(() => usernameSchema.parse("alice_")).toThrow();
+  });
+
+  it("rejects a reserved word regardless of case", () => {
+    expect(() => usernameSchema.parse("admin")).toThrow();
+    expect(() => usernameSchema.parse("Admin")).toThrow();
+    expect(() => usernameSchema.parse("ADMIN")).toThrow();
+  });
+
+  it("rejects a confusable variant of a reserved word", () => {
+    expect(() => usernameSchema.parse(`${CYRILLIC_A}dmin`)).toThrow();
+  });
+
+  it("rejects raw input beyond the hard input cap before normalization runs", () => {
+    expect(() => usernameSchema.parse("a".repeat(129))).toThrow();
+  });
+
+  it("rejects an empty or whitespace-only candidate", () => {
+    expect(() => usernameSchema.parse("")).toThrow();
+    expect(() => usernameSchema.parse("   ")).toThrow();
+  });
+});
+
+describe("validateUsernameCandidate", () => {
+  it("returns a canonical value for valid input without throwing", () => {
+    const result = validateUsernameCandidate("Alice");
+    expect(result).toEqual({ valid: true, canonical: "alice" });
+  });
+
+  it("returns structured issues for invalid input", () => {
+    const result = validateUsernameCandidate("ab");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("case and Unicode variants collapse to one canonical identity", () => {
+  it("normalizes every variant of the same handle to an identical canonical form", () => {
+    const variants = ["alice", "Alice", "ALICE", "AlIcE", " alice ", FULLWIDTH_ALICE];
+    const canonicalForms = new Set(variants.map((variant) => normalizeUsername(variant)));
+    expect(canonicalForms.size).toBe(1);
+    expect([...canonicalForms][0]).toBe("alice");
+  });
+});


### PR DESCRIPTION
Closes 

## Summary

Implements the full vertical slice for BETA-003: canonical Stealth username validation and atomic reservation of `username@stealth.me`, mapped to `username*stealth.me` for Stellar federation.

- **Normalization & validation** (`src/features/identity/username.ts`): NFKC normalization, invisible/zero-width character stripping, a curated Cyrillic/Greek confusable-folding table, and case folding all run before any length/charset/reserved-word check — so `alice`, `Alice`, `ALICE`, and confusable look-alikes all canonicalize to a single identity and can never mint duplicate aliases.
- **Federation mapping** (`src/features/identity/federation.ts`): deterministic `username@stealth.me` / `username*stealth.me` derivation, persisted together on every reservation record.
- **Atomic reservation** (`src/server/api/repository.ts` + adapters): a new `reserveUsernameIfAbsent` / `getUsernameRecord` pair on `ApiRepository`, implemented in the in-memory adapter (per-key promise lock), the Durable Object coordinator (`runExclusive`), and the KV-mirrored production adapter — all guaranteeing exactly one winner under concurrent claims for the same normalized username.
- **API surface** (`src/server/api/identity-service.ts`, `src/routes/api/v1/identity/usernames/...`):
  - `GET /api/v1/identity/usernames/{username}/availability` — public, IP-rate-limited, returns only `{ username, available }` (never an owner), with malformed/reserved-word input rejected as a 422 *before* the repository is ever consulted.
  - `POST /api/v1/identity/usernames` — authenticated, account-rate-limited, idempotency-key aware, returns the full reservation record.
  - New `username_taken` (409) error code.
- **Docs**: `protocol/federation/username_reservation.md` spec, OpenAPI (`src/server/api/openapi.ts` + regenerated `openapi.json`) and protocol capability manifest updated.
- **Frontend**: `useUsernameAvailability` hook + `UsernameReservationForm` component (`src/features/identity/components/`), wired to the real endpoints — live debounced availability feedback, inline validation, and a working reserve flow that displays both address forms. Exported from the feature but intentionally not force-wired into the onboarding wizard (which is not currently mounted anywhere in the app and has its own step-sequencing tests) to keep this PR scoped to BETA-003.

## Scope note on the BETA-002 dependency

BETA-002 (persistent user/profile/credential/account-status domain model, #1909) is listed as a dependency and does not yet exist in the codebase. This PR implements an isolated, self-contained `UsernameRecord` (username, owner Stellar address, both address forms, timestamp) scoped to identity/reservation only, rather than blocking on a model that hasn't landed. It reuses the existing `ApiRepository`/adapter/error-contract architecture throughout, so it's a drop-in once BETA-002 lands (a fuller user record would reference this reservation by `ownerAddress`, not replace it).

## Required behavior / edge cases

- **Concurrent claims produce exactly one winner** — covered at the repository layer (`tests/unit/api/repository-contract.ts`, `tests/unit/api/kv-repository.test.ts`), the service layer (8-way concurrent race in `tests/unit/api/identity-service.test.ts`), and the route layer (5-way idempotent-duplicate race + 6-owner claim race in `tests/unit/api/identity-routes.test.ts`).
- **Case/Unicode normalization cannot create aliases** — unit + property-based tests in `tests/unit/identity/username.test.ts` and `username.properties.test.ts` (fast-check), asserting normalization idempotency, case-insensitivity, and confusable folding.
- **Reserved, confusable, boundary, and race cases** — all explicitly covered (see test list below).

## Tests and evidence

Commands run locally, exact results:

```
$ npx vitest run tests/unit
 Test Files  157 passed (157)
      Tests  1837 passed | 3 expected fail (1840)

$ npx tsc --noEmit -p tsconfig.json
(no output — clean)

$ npx eslint .
(no output — clean)
```

New/updated test files:
- `tests/unit/identity/username.test.ts` — normalization, confusable folding, reserved words, boundary lengths, charset.
- `tests/unit/identity/username.properties.test.ts` — fast-check property tests (idempotency, case-insensitivity, canonical-form invariants).
- `tests/unit/identity/federation.test.ts` — address mapping.
- `tests/unit/identity/UsernameReservationForm.test.tsx` — component test (jsdom + Testing Library), mocked `fetch`, covering the reserved-word/available/taken/success/error paths.
- `tests/unit/api/identity-service.test.ts` — service-level availability + reservation, including an 8-way concurrent-claim race.
- `tests/unit/api/identity-routes.test.ts` — route-level integration: auth, rate limiting, idempotent replay, a 5-way concurrent-duplicate race, and a 6-owner concurrent-claim race, plus an explicit assertion that the availability response never contains the owner address.
- `tests/unit/api/repository-contract.ts` — shared adapter-conformance suite extended with username reservation (round-trip, isolation, 5-way concurrent race).
- `tests/unit/api/kv-repository.test.ts` — KV/coordinator adapter: mirrors on win, does not mirror a losing attempt.
- `tests/unit/api/retryable-repository.test.ts` — updated mock to implement the two new `ApiRepository` methods.

No secrets, wallet seeds, or tokens appear in any test fixture, log statement, or the new audit-event call (`identity.username.reserve`), which only ever records the actor address, action, and canonical username.

## Changed files

- `protocol/federation/username_reservation.md` (new)
- `src/features/identity/username.ts`, `federation.ts`, `index.ts`, `useUsernameAvailability.ts`, `components/UsernameReservationForm.tsx` (new)
- `src/routes/api/v1/identity/usernames/index.ts`, `usernames/$username/availability.ts` (new)
- `src/server/api/identity-service.ts` (new)
- `src/server/api/domain.ts`, `errors.ts`, `repository.ts`, `memory-repository.ts`, `kv-repository.ts`, `stealth-coordinator.ts`, `context.ts`, `openapi.ts`, `protocol.ts` (modified)
- `openapi.json`, `src/routeTree.gen.ts` (regenerated)
- `tests/unit/identity/*` (new), `tests/unit/api/identity-*.test.ts` (new), `tests/unit/api/{kv-repository,repository-contract,retryable-repository}.test.ts` (extended)
