### PR TITLE
feat(auth): implement password login with secure server-side sessions…

### DIFF
--- a/src/components/mail/AuthModal.tsx
+++ b/src/components/mail/AuthModal.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { KeyRound, Lock, User, AlertCircle, CheckCircle2, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface AuthModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (userData: { userId: string; username: string; email: string }) => void;
+}
+
+export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!identifier.trim() || !password) {
+      setError("Please enter your email/username and password.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/v1/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        if (res.status === 429) {
+          setError("Too many failed login attempts. Please try again later.");
+        } else if (res.status === 403) {
+          if (data.error?.code === "unverified_account") {
+            setError("Your account is pending verification. Please verify your email.");
+          } else if (data.error?.code === "account_suspended") {
+            setError("Your account has been suspended. Please contact support.");
+          } else if (data.error?.code === "account_deactivated") {
+            setError("Your account is deactivated.");
+          } else {
+            setError(data.error?.message || "Access forbidden.");
+          }
+        } else {
+          setError(data.error?.message || "Invalid email/username or password.");
+        }
+        setLoading(false);
+        return;
+      }
+
+      setSuccess(true);
+      setTimeout(() => {
+        setLoading(false);
+        setSuccess(false);
+        onSuccess(data.data.user);
+        onClose();
+      }, 600);
+    } catch (err: unknown) {
+      setError("Unable to connect to login server. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <AnimatePresence>
+      <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+          className="fixed inset-0 bg-black/60 backdrop-blur-md"
+        />
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95, y: 10 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.95, y: 10 }}
+          className="relative z-[130] w-full max-w-md overflow-hidden rounded-2xl border border-white/10 bg-[#121316] p-6 text-foreground shadow-2xl"
+        >
+          <button
+            onClick={onClose}
+            className="absolute right-4 top-4 rounded-lg p-1 text-muted-foreground transition hover:bg-white/10 hover:text-foreground"
+          >
+            <X className="h-5 w-5" />
+          </button>
+
+          <div className="mb-6 flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <KeyRound className="h-6 w-6" />
+            </div>
+            <div>
+              <h2 className="text-xl font-bold tracking-tight">Sign in to Stealth</h2>
+              <p className="text-xs text-muted-foreground">
+                Enter your credentials to access your mailbox securely.
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+              <motion.div
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive"
+              >
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </motion.div>
+            )}
+
+            {success && (
+              <motion.div
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="flex items-center gap-2.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-400"
+              >
+                <CheckCircle2 className="h-4 w-4 shrink-0" />
+                <span>Authentication successful! Accessing mailbox...</span>
+              </motion.div>
+            )}
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Email or Username
+              </label>
+              <div className="relative flex items-center">
+                <User className="absolute left-3 h-4 w-4 text-muted-foreground" />
+                <input
+                  type="text"
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
+                  placeholder="alice@stealth.mail or alice_99"
+                  className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
+                  autoComplete="username"
+                  required
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Password
+              </label>
+              <div className="relative flex items-center">
+                <Lock className="absolute left-3 h-4 w-4 text-muted-foreground" />
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••••••"
+                  className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
+                  autoComplete="current-password"
+                  required
+                />
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="glow-ring flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+            >
+              {loading ? (
+                <span className="inline-flex items-center gap-2">
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+                  Authenticating...
+                </span>
+              ) : (
+                "Sign In"
+              )}
+            </button>
+          </form>
+        </motion.div>
+      </div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/mail/Topbar.tsx
+++ b/src/components/mail/Topbar.tsx
@@ -35,6 +35,7 @@ type TopbarProps = {
   onQuickAction: (action: "proofs" | "later" | "files") => void;
   onViewNotifications: () => void;
   onSignOut?: () => void;
+  onOpenLogin?: () => void;
 };
 
 const quickActions: {
@@ -60,6 +61,7 @@ export function Topbar({
   onQuickAction,
   onViewNotifications,
   onSignOut,
+  onOpenLogin,
 }: TopbarProps) {
   const [focused, setFocused] = useState(false);
   const [filterOpen, setFilterOpen] = useState(false);
@@ -439,6 +441,14 @@ export function Topbar({
                               account === "personal" ? "Protocol" : "Personal"
                             } mailbox`,
                           );
+                        }}
+                      />
+                      <AccountMenuItem
+                        icon={User}
+                        label="Sign in with password"
+                        onClick={() => {
+                          setAccountOpen(false);
+                          onOpenLogin?.();
                         }}
                       />
                       <div className="my-1 border-t border-white/5" />

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,6 +26,9 @@ import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/q
 import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
+import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
+import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -116,6 +119,21 @@ const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
   path: '/api/v1/policies/$owner',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
+  id: '/api/v1/auth/session',
+  path: '/api/v1/auth/session',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
+  id: '/api/v1/auth/logout',
+  path: '/api/v1/auth/logout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
+  id: '/api/v1/auth/login',
+  path: '/api/v1/auth/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -148,6 +166,9 @@ export interface FileRoutesByFullPath {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -171,6 +192,9 @@ export interface FileRoutesByTo {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -195,6 +219,9 @@ export interface FileRoutesById {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -220,6 +247,9 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/login'
+    | '/api/v1/auth/logout'
+    | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -243,6 +273,9 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/login'
+    | '/api/v1/auth/logout'
+    | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -266,6 +299,9 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/login'
+    | '/api/v1/auth/logout'
+    | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -290,6 +326,9 @@ export interface RootRouteChildren {
   ApiV1HealthRoute: typeof ApiV1HealthRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
+  ApiV1AuthLoginRoute: typeof ApiV1AuthLoginRoute
+  ApiV1AuthLogoutRoute: typeof ApiV1AuthLogoutRoute
+  ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -424,6 +463,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/session': {
+      id: '/api/v1/auth/session'
+      path: '/api/v1/auth/session'
+      fullPath: '/api/v1/auth/session'
+      preLoaderRoute: typeof ApiV1AuthSessionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/logout': {
+      id: '/api/v1/auth/logout'
+      path: '/api/v1/auth/logout'
+      fullPath: '/api/v1/auth/logout'
+      preLoaderRoute: typeof ApiV1AuthLogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/login': {
+      id: '/api/v1/auth/login'
+      path: '/api/v1/auth/login'
+      fullPath: '/api/v1/auth/login'
+      preLoaderRoute: typeof ApiV1AuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -502,6 +562,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1HealthRoute: ApiV1HealthRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
+  ApiV1AuthLoginRoute: ApiV1AuthLoginRoute,
+  ApiV1AuthLogoutRoute: ApiV1AuthLogoutRoute,
+  ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,

--- a/src/routes/api/v1/auth/login.ts
+++ b/src/routes/api/v1/auth/login.ts
@@ -13,7 +13,7 @@ const loginSchema = z.object({
   password: z.string().min(1, "Password is required"),
 });
 
-export const Route = createFileRoute("/api/v1/auth/login" as any)({
+export const Route = createFileRoute("/api/v1/auth/login")({
   server: {
     handlers: {
       POST: ({ request }) =>

--- a/src/routes/api/v1/auth/login.ts
+++ b/src/routes/api/v1/auth/login.ts
@@ -1,0 +1,74 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { buildDeviceFingerprint } from "@/server/api/abuse-service";
+import { authenticateWithPassword, parseSessionCookie } from "@/server/api/auth/session-service";
+import { getApiContext } from "@/server/api/context";
+import { toPublicSession, toPublicUser } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const loginSchema = z.object({
+  identifier: z.string().trim().min(1, "Identifier is required"),
+  password: z.string().min(1, "Password is required"),
+});
+
+export const Route = createFileRoute("/api/v1/auth/login" as any)({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const body = await parseJsonBody(request, loginSchema, {
+            route: "POST /auth/login" as any,
+          });
+
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+          const userAgent = request.headers.get("user-agent") ?? undefined;
+          const acceptLanguage = request.headers.get("accept-language") ?? undefined;
+          const acceptEncoding = request.headers.get("accept-encoding") ?? undefined;
+          const ipPrefix =
+            ip === "unknown"
+              ? "unknown"
+              : ip.includes(":")
+                ? ip.split(":").slice(0, 4).join(":")
+                : ip.split(".").slice(0, 3).join(".");
+
+          const fingerprint = buildDeviceFingerprint({
+            userAgent,
+            acceptLanguage,
+            acceptEncoding,
+            ipPrefix,
+          });
+
+          const currentSessionId = parseSessionCookie(request.headers.get("cookie")) ?? undefined;
+
+          const result = await authenticateWithPassword(apiContext, {
+            identifier: body.identifier,
+            password: body.password,
+            ip,
+            userAgent,
+            deviceFingerprint: fingerprint,
+            currentSessionId,
+          });
+
+          return apiSuccess(
+            request,
+            {
+              user: toPublicUser(result.user),
+              session: toPublicSession(result.session),
+            },
+            {
+              status: 200,
+              headers: {
+                "Set-Cookie": result.cookieHeader,
+              },
+            },
+          );
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/auth/logout.ts
+++ b/src/routes/api/v1/auth/logout.ts
@@ -4,7 +4,7 @@ import { logoutSession, parseSessionCookie } from "@/server/api/auth/session-ser
 import { getApiContext } from "@/server/api/context";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
 
-export const Route = createFileRoute("/api/v1/auth/logout" as any)({
+export const Route = createFileRoute("/api/v1/auth/logout")({
   server: {
     handlers: {
       POST: ({ request }) =>

--- a/src/routes/api/v1/auth/logout.ts
+++ b/src/routes/api/v1/auth/logout.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { logoutSession, parseSessionCookie } from "@/server/api/auth/session-service";
+import { getApiContext } from "@/server/api/context";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/auth/logout" as any)({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const sessionId = parseSessionCookie(request.headers.get("cookie"));
+
+          const result = await logoutSession(apiContext, sessionId);
+
+          return apiSuccess(
+            request,
+            { success: true },
+            {
+              status: 200,
+              headers: {
+                "Set-Cookie": result.cookieHeader,
+              },
+            },
+          );
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/auth/session.ts
+++ b/src/routes/api/v1/auth/session.ts
@@ -6,7 +6,7 @@ import { toPublicSession, toPublicUser } from "@/server/api/domain";
 import { ApiError } from "@/server/api/errors";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
 
-export const Route = createFileRoute("/api/v1/auth/session" as any)({
+export const Route = createFileRoute("/api/v1/auth/session")({
   server: {
     handlers: {
       GET: ({ request }) =>

--- a/src/routes/api/v1/auth/session.ts
+++ b/src/routes/api/v1/auth/session.ts
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { parseSessionCookie, validateSession } from "@/server/api/auth/session-service";
+import { getApiContext } from "@/server/api/context";
+import { toPublicSession, toPublicUser } from "@/server/api/domain";
+import { ApiError } from "@/server/api/errors";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/auth/session" as any)({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const sessionId = parseSessionCookie(request.headers.get("cookie"));
+
+          if (!sessionId) {
+            throw new ApiError(401, "unauthorized", "No active session cookie found");
+          }
+
+          const activeSession = await validateSession(apiContext, sessionId);
+          if (!activeSession) {
+            throw new ApiError(401, "unauthorized", "Session is invalid or expired");
+          }
+
+          return apiSuccess(request, {
+            user: toPublicUser(activeSession.user),
+            session: toPublicSession(activeSession.session),
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -70,6 +70,7 @@ import { useIsMobile } from "@/lib/use-media-query";
 import { RequestsTriageBoard } from "@/features/requests";
 import { ProofInspectorModal } from "@/features/proof-inspector";
 import { SenderJourney } from "@/features/sender-journey";
+import { AuthModal } from "@/components/mail/AuthModal";
 
 export const Route = createFileRoute("/")({
   head: () => ({
@@ -134,6 +135,7 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
   const [shortcutOverlayOpen, setShortcutOverlayOpen] = useState(false);
   const [proofInspectorOpen, setProofInspectorOpen] = useState(false);
   const [proofInspectorQuery, setProofInspectorQuery] = useState("");
+  const [authModalOpen, setAuthModalOpen] = useState(false);
 
   const handleOpenMessageFromInspector = useCallback((email: Email) => {
     setCustomFolder(null);
@@ -743,6 +745,7 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
                   setFolder("inbox");
                   setFilters({ ...defaultMailFilters, unreadOnly: true });
                 }}
+                onOpenLogin={() => setAuthModalOpen(true)}
               />
               <div className="flex min-h-0 min-w-0 flex-1">
                 {folder === "requests" ? (
@@ -969,6 +972,12 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
           onClose={() => setPreviewAttachment(null)}
           attachment={previewAttachment}
           senderAddress={selected?.email}
+        />
+
+        <AuthModal
+          open={authModalOpen}
+          onClose={() => setAuthModalOpen(false)}
+          onSuccess={(user) => showToast(`Signed in as ${user.username}`)}
         />
       </div>
     </MotionConfig>

--- a/src/server/api/auth/index.ts
+++ b/src/server/api/auth/index.ts
@@ -1,0 +1,7 @@
+export * from "./password";
+export * from "./session-service";
+export * from "./challenge";
+export * from "./delegation";
+export * from "./envelope";
+export * from "./nonce-service";
+export * from "./signed-request";

--- a/src/server/api/auth/password.ts
+++ b/src/server/api/auth/password.ts
@@ -1,0 +1,103 @@
+/**
+ * Constant-time password hashing and verification using Web Crypto API PBKDF2-SHA256.
+ *
+ * Implements constant-time string comparison and dummy hash calculation to ensure
+ * login execution time does not reveal whether a user account or credential exists.
+ */
+
+const PBKDF2_ITERATIONS = 100_000;
+const HASH_BYTES = 32;
+const SALT_BYTES = 16;
+const DUMMY_SALT_HEX = "00112233445566778899aabbccddeeff";
+const DUMMY_HASH_HEX = "a".repeat(64);
+
+/**
+ * Compares two strings in constant time.
+ */
+export function constantTimeCompare(a: string, b: string): boolean {
+  const len = Math.max(a.length, b.length);
+  let mismatch = a.length ^ b.length;
+  for (let i = 0; i < len; i += 1) {
+    const codeA = i < a.length ? a.charCodeAt(i) : 0;
+    const codeB = i < b.length ? b.charCodeAt(i) : 0;
+    mismatch |= codeA ^ codeB;
+  }
+  return mismatch === 0;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function buf(u: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(new ArrayBuffer(u.length));
+  out.set(u);
+  return out;
+}
+
+/**
+ * Hash a password using PBKDF2 with SHA-256.
+ */
+export async function hashPassword(
+  password: string,
+  saltHex?: string,
+): Promise<{ hash: string; salt: string }> {
+  const enc = new TextEncoder();
+  const passwordBytes = enc.encode(password);
+  const saltBytes = saltHex
+    ? hexToBytes(saltHex)
+    : crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    buf(passwordBytes),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"],
+  );
+
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt: buf(saltBytes),
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    HASH_BYTES * 8,
+  );
+
+  const hashHex = bytesToHex(new Uint8Array(derivedBits));
+  const finalSaltHex = saltHex ?? bytesToHex(saltBytes);
+
+  return { hash: hashHex, salt: finalSaltHex };
+}
+
+/**
+ * Verify a password against a stored hash and salt.
+ */
+export async function verifyPassword(
+  password: string,
+  storedHash: string,
+  saltHex: string,
+): Promise<boolean> {
+  const { hash: computedHash } = await hashPassword(password, saltHex);
+  return constantTimeCompare(computedHash, storedHash);
+}
+
+/**
+ * Performs a dummy password hash calculation to match the latency of a real verification,
+ * preventing email/username enumeration via timing side-channels. Always returns false.
+ */
+export async function dummyVerifyPassword(password: string): Promise<boolean> {
+  await verifyPassword(password, DUMMY_HASH_HEX, DUMMY_SALT_HEX);
+  return false;
+}

--- a/src/server/api/auth/session-service.ts
+++ b/src/server/api/auth/session-service.ts
@@ -68,7 +68,7 @@ export async function authenticateWithPassword(
   const rateLimitKey = `login:fail:${normalizedId}`;
   const failCount = await repo.getCounter(rateLimitKey);
   if (failCount >= MAX_LOGIN_ATTEMPTS) {
-    throw new ApiError(429, "rate_limited", "Too many login attempts. Please try again later");
+    throw new ApiError(429, "too_many_requests", "Too many login attempts. Please try again later");
   }
 
   // Lookup user by email or username
@@ -101,13 +101,13 @@ export async function authenticateWithPassword(
 
   // Account status checks
   if (user.status === "pending_verification") {
-    throw new ApiError(403, "unverified_account", "Account verification required");
+    throw new ApiError(403, "forbidden", "Account verification required");
   }
   if (user.status === "suspended") {
-    throw new ApiError(403, "account_suspended", "Account suspended");
+    throw new ApiError(403, "forbidden", "Account suspended");
   }
   if (user.status === "deactivated") {
-    throw new ApiError(403, "account_deactivated", "Account deactivated");
+    throw new ApiError(403, "forbidden", "Account deactivated");
   }
   if (user.status !== "active") {
     throw new ApiError(403, "forbidden", "Account is not active");

--- a/src/server/api/auth/session-service.ts
+++ b/src/server/api/auth/session-service.ts
@@ -1,0 +1,188 @@
+import type { ApiContext } from "../context";
+import type { Session, User } from "../domain";
+import { ApiError } from "../errors";
+import { dummyVerifyPassword, verifyPassword } from "./password";
+
+export const SESSION_COOKIE_NAME = "stealth_session";
+export const DEFAULT_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+export const MAX_LOGIN_ATTEMPTS = 5;
+const RATE_LIMIT_WINDOW_SECONDS = 900; // 15 minutes
+
+export interface AuthenticateInput {
+  identifier: string;
+  password: string;
+  ip?: string;
+  userAgent?: string;
+  deviceFingerprint?: string;
+  currentSessionId?: string;
+}
+
+export function parseSessionCookie(cookieHeader: string | null | undefined): string | null {
+  if (!cookieHeader) return null;
+  const pairs = cookieHeader.split(";");
+  for (const pair of pairs) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.substring(0, eqIdx).trim();
+    const value = trimmed.substring(eqIdx + 1).trim();
+    if (key === SESSION_COOKIE_NAME) {
+      return value || null;
+    }
+  }
+  return null;
+}
+
+export function buildSessionCookie(
+  sessionId: string,
+  maxAgeSeconds = DEFAULT_SESSION_TTL_SECONDS,
+  isProd = false,
+): string {
+  const expires = new Date(Date.now() + maxAgeSeconds * 1000).toUTCString();
+  const secureFlag = isProd ? "Secure; " : "";
+  return `${SESSION_COOKIE_NAME}=${sessionId}; HttpOnly; ${secureFlag}SameSite=Lax; Path=/; Max-Age=${maxAgeSeconds}; Expires=${expires}`;
+}
+
+export function buildClearSessionCookie(isProd = false): string {
+  const secureFlag = isProd ? "Secure; " : "";
+  return `${SESSION_COOKIE_NAME}=; HttpOnly; ${secureFlag}SameSite=Lax; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
+
+/**
+ * Validates credentials with constant-time failure behavior, checks account status,
+ * rotates session identifiers, and records session metadata.
+ */
+export async function authenticateWithPassword(
+  apiContext: ApiContext,
+  input: AuthenticateInput,
+): Promise<{ user: User; session: Session; cookieHeader: string }> {
+  const repo = apiContext.repository;
+  const normalizedId = input.identifier.trim().toLowerCase();
+
+  if (!normalizedId || !input.password) {
+    throw new ApiError(400, "bad_request", "Identifier and password are required");
+  }
+
+  // Enforce throttling on repeated login failures
+  const rateLimitKey = `login:fail:${normalizedId}`;
+  const failCount = await repo.getCounter(rateLimitKey);
+  if (failCount >= MAX_LOGIN_ATTEMPTS) {
+    throw new ApiError(429, "rate_limited", "Too many login attempts. Please try again later");
+  }
+
+  // Lookup user by email or username
+  let user = await repo.getUserByEmail(normalizedId);
+  if (!user) {
+    user = await repo.getUserByUsername(normalizedId);
+  }
+
+  let credential = user ? await repo.getCredential(user.userId) : null;
+
+  let isValidPassword = false;
+  if (user && credential && credential.authMethod === "password_hash") {
+    const parts = credential.secretHash.split(/[:$]/);
+    if (parts.length >= 2) {
+      const storedHash = parts[0];
+      const saltHex = parts[1];
+      isValidPassword = await verifyPassword(input.password, storedHash, saltHex);
+    } else {
+      await dummyVerifyPassword(input.password);
+    }
+  } else {
+    // Constant-time execution path when user or credential is missing
+    await dummyVerifyPassword(input.password);
+  }
+
+  if (!user || !credential || !isValidPassword) {
+    await repo.incrementCounter(rateLimitKey, RATE_LIMIT_WINDOW_SECONDS, 1);
+    throw new ApiError(401, "unauthorized", "Invalid email/username or password");
+  }
+
+  // Account status checks
+  if (user.status === "pending_verification") {
+    throw new ApiError(403, "unverified_account", "Account verification required");
+  }
+  if (user.status === "suspended") {
+    throw new ApiError(403, "account_suspended", "Account suspended");
+  }
+  if (user.status === "deactivated") {
+    throw new ApiError(403, "account_deactivated", "Account deactivated");
+  }
+  if (user.status !== "active") {
+    throw new ApiError(403, "forbidden", "Account is not active");
+  }
+
+  // Session fixation prevention: rotate session if a previous session exists
+  if (input.currentSessionId) {
+    await repo.deleteSession(input.currentSessionId);
+  }
+
+  // Issue opaque server-side session
+  const newSessionId = `sess_${crypto.randomUUID().replace(/-/g, "")}`;
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + DEFAULT_SESSION_TTL_SECONDS * 1000);
+
+  const session: Session = {
+    sessionId: newSessionId,
+    userId: user.userId,
+    createdAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    lastActiveAt: now.toISOString(),
+    ipAddress: input.ip ?? null,
+    userAgent: input.userAgent ?? null,
+    deviceFingerprint: input.deviceFingerprint ?? null,
+  };
+
+  await repo.createSession(session);
+
+  const isProd = import.meta.env?.PROD ?? false;
+  const cookieHeader = buildSessionCookie(newSessionId, DEFAULT_SESSION_TTL_SECONDS, isProd);
+
+  return { user, session, cookieHeader };
+}
+
+/**
+ * Validates a session by ID, enforcing expiration, account status, and activity tracking.
+ */
+export async function validateSession(
+  apiContext: ApiContext,
+  sessionId: string,
+): Promise<{ user: User; session: Session } | null> {
+  const repo = apiContext.repository;
+  const session = await repo.getSession(sessionId);
+
+  if (!session) return null;
+
+  if (new Date(session.expiresAt) < new Date()) {
+    await repo.deleteSession(sessionId);
+    return null;
+  }
+
+  const user = await repo.getUserById(session.userId);
+  if (!user || user.status !== "active") {
+    return null;
+  }
+
+  const updatedSession: Session = {
+    ...session,
+    lastActiveAt: new Date().toISOString(),
+  };
+
+  await repo.updateSession(updatedSession);
+  return { user, session: updatedSession };
+}
+
+/**
+ * Logout session by revoking the session token and generating a clearing cookie.
+ */
+export async function logoutSession(
+  apiContext: ApiContext,
+  sessionId: string | null,
+): Promise<{ cookieHeader: string }> {
+  if (sessionId) {
+    await apiContext.repository.deleteSession(sessionId);
+  }
+  const isProd = import.meta.env?.PROD ?? false;
+  return { cookieHeader: buildClearSessionCookie(isProd) };
+}

--- a/src/server/api/auth/session-service.ts
+++ b/src/server/api/auth/session-service.ts
@@ -77,7 +77,7 @@ export async function authenticateWithPassword(
     user = await repo.getUserByUsername(normalizedId);
   }
 
-  let credential = user ? await repo.getCredential(user.userId) : null;
+  const credential = user ? await repo.getCredential(user.userId) : null;
 
   let isValidPassword = false;
   if (user && credential && credential.authMethod === "password_hash") {

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,7 @@ import {
   profileSchema,
   credentialSchema,
   sessionSchema,
+  storedEnvelopeSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -12,6 +12,7 @@ import {
   userSchema,
   profileSchema,
   credentialSchema,
+  sessionSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -194,6 +195,7 @@ registerRecordSchema("receipt", 1, receiptSchema);
 registerRecordSchema("user", 1, userSchema);
 registerRecordSchema("profile", 1, profileSchema);
 registerRecordSchema("credential", 1, credentialSchema);
+registerRecordSchema("session", 1, sessionSchema);
 // v1 -> v2 (Issue #1498): records now carry a requestDigest binding the
 // lease/response to the exact request payload that created it. Legacy
 // records predate this and never bore a client-supplied payload we can

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -280,3 +280,46 @@ export function toPublicSession(session: Session): PublicSession {
     lastActiveAt: session.lastActiveAt,
   };
 }
+
+// ---------------------------------------------------------------------------
+// StoredEnvelope — durable encrypted-message record (Issue #1936 / BETA-029)
+// ---------------------------------------------------------------------------
+
+export const storedEnvelopeProtectedHeadersSchema = z
+  .object({
+    algorithm: z.string().optional(),
+    ephemeral_public_key: z.string().optional(),
+    nonce: z
+      .string()
+      .regex(/^[0-9a-fA-F]*$/)
+      .refine((val) => val.length % 2 === 0, "Nonce must be even hex")
+      .optional(),
+    mac: z.string().optional(),
+    version: z
+      .string()
+      .regex(/^v\d+$/, "Version must be v<digit>")
+      .optional(),
+    alg: z.string().optional(),
+    kid: z.string().optional(),
+    typ: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+export const storedEnvelopeSchema = z.object({
+  envelopeId: z.string().optional(),
+  messageId: hash32Schema,
+  senderId: stellarAddressSchema,
+  recipientId: stellarAddressSchema,
+  ciphertext: z
+    .string()
+    .min(1, "Ciphertext cannot be empty")
+    .max(20 * 1024 * 1024, "Ciphertext exceeds 20 MiB limit")
+    .regex(/^[A-Za-z0-9+/=]+$/, "Ciphertext must be base64 encoded"),
+  protectedHeaders: storedEnvelopeProtectedHeadersSchema,
+  contentCommitment: hash32Schema.optional(),
+  createdAt: z.string().datetime(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
+export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -239,3 +239,39 @@ export function toPublicProfile(profile: Profile): PublicProfile {
     updatedAt: profile.updatedAt,
   };
 }
+
+// ---------------------------------------------------------------------------
+// BETA-006: Server-Side Session Domain
+// ---------------------------------------------------------------------------
+
+export const sessionSchema = z.object({
+  sessionId: z.string().min(1, "Session ID cannot be empty"),
+  userId: z.string().min(1, "User ID cannot be empty"),
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  lastActiveAt: z.string().datetime(),
+  ipAddress: z.string().optional().nullable(),
+  userAgent: z.string().optional().nullable(),
+  deviceFingerprint: z.string().optional().nullable(),
+});
+
+export const publicSessionSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  lastActiveAt: z.string().datetime(),
+});
+
+export type Session = z.infer<typeof sessionSchema>;
+export type PublicSession = z.infer<typeof publicSessionSchema>;
+
+export function toPublicSession(session: Session): PublicSession {
+  return {
+    sessionId: session.sessionId,
+    userId: session.userId,
+    createdAt: session.createdAt,
+    expiresAt: session.expiresAt,
+    lastActiveAt: session.lastActiveAt,
+  };
+}

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -130,6 +130,30 @@ export const API_ERROR_REGISTRY = {
     retryable: true,
     description: "A matching operation currently holds the idempotency lease.",
   },
+  rate_limited: {
+    status: 429,
+    message: "Too many login attempts. Please try again later",
+    retryable: true,
+    description: "Login rate limit exceeded due to multiple failed attempts.",
+  },
+  unverified_account: {
+    status: 403,
+    message: "Account verification required",
+    retryable: false,
+    description: "The account is pending email or identity verification.",
+  },
+  account_suspended: {
+    status: 403,
+    message: "Account suspended",
+    retryable: false,
+    description: "The user account has been suspended by an administrator.",
+  },
+  account_deactivated: {
+    status: 403,
+    message: "Account deactivated",
+    retryable: false,
+    description: "The user account has been deactivated.",
+  },
 } as const satisfies Record<string, ApiErrorDefinition>;
 
 export type ApiErrorCode = keyof typeof API_ERROR_REGISTRY;

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -130,30 +130,6 @@ export const API_ERROR_REGISTRY = {
     retryable: true,
     description: "A matching operation currently holds the idempotency lease.",
   },
-  rate_limited: {
-    status: 429,
-    message: "Too many login attempts. Please try again later",
-    retryable: true,
-    description: "Login rate limit exceeded due to multiple failed attempts.",
-  },
-  unverified_account: {
-    status: 403,
-    message: "Account verification required",
-    retryable: false,
-    description: "The account is pending email or identity verification.",
-  },
-  account_suspended: {
-    status: 403,
-    message: "Account suspended",
-    retryable: false,
-    description: "The user account has been suspended by an administrator.",
-  },
-  account_deactivated: {
-    status: 403,
-    message: "Account deactivated",
-    retryable: false,
-    description: "The user account has been deactivated.",
-  },
 } as const satisfies Record<string, ApiErrorDefinition>;
 
 export type ApiErrorCode = keyof typeof API_ERROR_REGISTRY;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -8,6 +8,7 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  Session,
   User,
 } from "./domain";
 import { ApiError } from "./errors";
@@ -169,6 +170,27 @@ export class HybridApiRepository implements ApiRepository {
 
   async setCredential(credential: Credential): Promise<Credential> {
     return this.getStub().setCredential(credential);
+  }
+
+  // BETA-006: Session DO stubs
+  async getSession(sessionId: string): Promise<Session | null> {
+    return this.getStub().getSession(sessionId);
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    return this.getStub().createSession(session);
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    return this.getStub().updateSession(session);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    return this.getStub().deleteSession(sessionId);
+  }
+
+  async deleteUserSessions(userId: string): Promise<void> {
+    return this.getStub().deleteUserSessions(userId);
   }
 
   // Consistent layer delegated to Durable Object via RPC

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -14,6 +14,7 @@ import type {
   Receipt,
   SenderRule,
   Session,
+  StoredEnvelope,
   User,
 } from "./domain";
 import { ApiError } from "./errors";

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -7,6 +7,7 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  Session,
   User,
 } from "./domain";
 import type { ApiRepository, PostageTransitionResult, UpdateUserResult } from "./repository";
@@ -32,6 +33,9 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly usersByAddress = new Map<string, string>();
   private readonly profiles = new Map<string, Profile>();
   private readonly credentials = new Map<string, Credential>();
+
+  // BETA-006: Session storage
+  private readonly sessions = new Map<string, Session>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -280,6 +284,33 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(credential);
   }
 
+  // BETA-006: Session CRUD Methods
+  async getSession(sessionId: string): Promise<Session | null> {
+    return structuredClone(this.sessions.get(sessionId) ?? null);
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    this.sessions.set(session.sessionId, structuredClone(session));
+    return structuredClone(session);
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    this.sessions.set(session.sessionId, structuredClone(session));
+    return structuredClone(session);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+  }
+
+  async deleteUserSessions(userId: string): Promise<void> {
+    for (const [id, sess] of Array.from(this.sessions.entries())) {
+      if (sess.userId === userId) {
+        this.sessions.delete(id);
+      }
+    }
+  }
+
   async getRelayQueueDepth(_relayId: string) {
     return 0;
   }
@@ -371,5 +402,6 @@ export class MemoryApiRepository implements ApiRepository {
     this.usersByAddress.clear();
     this.profiles.clear();
     this.credentials.clear();
+    this.sessions.clear();
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -8,6 +8,7 @@ import type {
   Receipt,
   SenderRule,
   Session,
+  StoredEnvelope,
   User,
 } from "./domain";
 import type {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -9,6 +9,7 @@ import type {
   Receipt,
   SenderRule,
   Session,
+  StoredEnvelope,
   User,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
@@ -555,6 +556,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setCredential",
   "getSession",
   "updateSession",
+  "getEnvelope",
 ]);
 
 function isRetryableError(error: unknown): boolean {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -8,6 +8,7 @@ import type {
   Profile,
   Receipt,
   SenderRule,
+  Session,
   User,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
@@ -121,6 +122,13 @@ export interface ApiRepository {
   setProfile(profile: Profile): Promise<Profile>;
   getCredential(userId: string): Promise<Credential | null>;
   setCredential(credential: Credential): Promise<Credential>;
+
+  // BETA-006: Server-Side Session Domain Methods
+  getSession(sessionId: string): Promise<Session | null>;
+  createSession(session: Session): Promise<Session>;
+  updateSession(session: Session): Promise<Session>;
+  deleteSession(sessionId: string): Promise<void>;
+  deleteUserSessions(userId: string): Promise<void>;
 
   getRelayQueueDepth(relayId: string): Promise<number>;
   getRelayRetryCount(relayId: string): Promise<number>;
@@ -388,6 +396,29 @@ export class ValidatedApiRepository implements ApiRepository {
     return validateRecord<Credential>("credential", result);
   }
 
+  async getSession(sessionId: string): Promise<Session | null> {
+    const raw = await this.inner.getSession(sessionId);
+    return raw ? validateRecord<Session>("session", raw) : null;
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    const result = await this.inner.createSession(versionRecord("session", session));
+    return validateRecord<Session>("session", result);
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    const result = await this.inner.updateSession(versionRecord("session", session));
+    return validateRecord<Session>("session", result);
+  }
+
+  deleteSession(sessionId: string): Promise<void> {
+    return this.inner.deleteSession(sessionId);
+  }
+
+  deleteUserSessions(userId: string): Promise<void> {
+    return this.inner.deleteUserSessions(userId);
+  }
+
   getRelayQueueDepth(relayId: string): Promise<number> {
     return this.inner.getRelayQueueDepth(relayId);
   }
@@ -463,6 +494,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setProfile",
   "getCredential",
   "setCredential",
+  "getSession",
+  "updateSession",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -631,6 +664,26 @@ export class RetryableApiRepository implements ApiRepository {
 
   setCredential(credential: Credential): Promise<Credential> {
     return this.withRetry("setCredential", () => this.inner.setCredential(credential));
+  }
+
+  getSession(sessionId: string): Promise<Session | null> {
+    return this.withRetry("getSession", () => this.inner.getSession(sessionId));
+  }
+
+  createSession(session: Session): Promise<Session> {
+    return this.inner.createSession(session);
+  }
+
+  updateSession(session: Session): Promise<Session> {
+    return this.withRetry("updateSession", () => this.inner.updateSession(session));
+  }
+
+  deleteSession(sessionId: string): Promise<void> {
+    return this.inner.deleteSession(sessionId);
+  }
+
+  deleteUserSessions(userId: string): Promise<void> {
+    return this.inner.deleteUserSessions(userId);
   }
 
   getRelayQueueDepth(relayId: string): Promise<number> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -5,6 +5,7 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  Session,
   User,
 } from "./domain";
 import type {
@@ -321,6 +322,38 @@ export class StealthCoordinator extends DurableObjectBase {
   async setCredential(credential: Credential): Promise<Credential> {
     await this.ctx.storage.put(`credential:${credential.userId}`, credential);
     return credential;
+  }
+
+  // BETA-006: Durable Session Storage
+  async getSession(sessionId: string): Promise<Session | null> {
+    const session = (await this.ctx.storage.get(`session:${sessionId}`)) as Session | undefined;
+    return session ?? null;
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    await this.ctx.storage.put(`session:${session.sessionId}`, session);
+    return session;
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    await this.ctx.storage.put(`session:${session.sessionId}`, session);
+    return session;
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.ctx.storage.delete(`session:${sessionId}`);
+  }
+
+  async deleteUserSessions(userId: string): Promise<void> {
+    const sessionsMap = (await this.ctx.storage.list({ prefix: "session:" })) as Map<
+      string,
+      Session
+    >;
+    for (const [key, sess] of sessionsMap) {
+      if (sess && sess.userId === userId) {
+        await this.ctx.storage.delete(key);
+      }
+    }
   }
 
   async getCounter(key: string): Promise<number> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -6,6 +6,7 @@ import type {
   Profile,
   Receipt,
   Session,
+  StoredEnvelope,
   User,
 } from "./domain";
 import type {

--- a/tests/unit/api/auth/auth-routes.test.ts
+++ b/tests/unit/api/auth/auth-routes.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Route as LoginRoute } from "../../../../src/routes/api/v1/auth/login";
+import { Route as LogoutRoute } from "../../../../src/routes/api/v1/auth/logout";
+import { Route as SessionRoute } from "../../../../src/routes/api/v1/auth/session";
+import { hashPassword } from "../../../../src/server/api/auth/password";
+import type { Credential, User } from "../../../../src/server/api/domain";
+import { MemoryApiRepository } from "../../../../src/server/api/memory-repository";
+
+describe("BETA-006: Auth API Routes (/api/v1/auth/*)", () => {
+  let repo: MemoryApiRepository;
+  const validStellarAddress = `G${"A".repeat(55)}`;
+  const testPassword = "Password123!";
+
+  beforeEach(async () => {
+    repo = new MemoryApiRepository();
+    (globalThis as any).__stealthApiRepository = repo;
+
+    // Seed test user
+    const { hash, salt } = await hashPassword(testPassword);
+    const user: User = {
+      userId: "usr_route_test",
+      address: validStellarAddress,
+      email: "route_user@stealth.mail",
+      username: "route_user",
+      status: "active",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      version: 1,
+    };
+    const credential: Credential = {
+      credentialId: "cred_route_test",
+      userId: "usr_route_test",
+      authMethod: "password_hash",
+      secretHash: `${hash}:${salt}`,
+      walletKeyRef: "vault_ref",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await repo.createUser(user, credential);
+  });
+
+  it("POST /api/v1/auth/login succeeds with valid credentials and sets Set-Cookie header", async () => {
+    const handler = (LoginRoute.options.server?.handlers as any).POST;
+    const request = new Request("https://stealth.mail/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier: "route_user@stealth.mail",
+        password: testPassword,
+      }),
+    });
+
+    const response = await handler({ request });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.data.user.email).toBe("route_user@stealth.mail");
+    expect(data.data.session.sessionId).toBeDefined();
+
+    const setCookie = response.headers.get("Set-Cookie");
+    expect(setCookie).toContain("stealth_session=");
+    expect(setCookie).toContain("HttpOnly");
+  });
+
+  it("POST /api/v1/auth/login fails with 401 on invalid password", async () => {
+    const handler = (LoginRoute.options.server?.handlers as any).POST;
+    const request = new Request("https://stealth.mail/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier: "route_user@stealth.mail",
+        password: "WrongPassword!00",
+      }),
+    });
+
+    const response = await handler({ request });
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    expect(data.error.message).toBe("Invalid email/username or password");
+  });
+
+  it("GET /api/v1/auth/session returns user and session when cookie is valid", async () => {
+    // Perform login first to acquire cookie
+    const loginHandler = (LoginRoute.options.server?.handlers as any).POST;
+    const loginRequest = new Request("https://stealth.mail/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier: "route_user",
+        password: testPassword,
+      }),
+    });
+    const loginResponse = await loginHandler({ request: loginRequest });
+    const cookieHeader = loginResponse.headers.get("Set-Cookie");
+
+    // Extract cookie
+    const cookieVal = cookieHeader?.split(";")[0];
+
+    // Call session endpoint
+    const sessionHandler = (SessionRoute.options.server?.handlers as any).GET;
+    const sessionRequest = new Request("https://stealth.mail/api/v1/auth/session", {
+      method: "GET",
+      headers: { Cookie: cookieVal! },
+    });
+
+    const response = await sessionHandler({ request: sessionRequest });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.data.user.username).toBe("route_user");
+    expect(data.data.session.sessionId).toBeDefined();
+  });
+
+  it("POST /api/v1/auth/logout revokes session and clears cookie", async () => {
+    // Login first
+    const loginHandler = (LoginRoute.options.server?.handlers as any).POST;
+    const loginRequest = new Request("https://stealth.mail/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier: "route_user",
+        password: testPassword,
+      }),
+    });
+    const loginResponse = await loginHandler({ request: loginRequest });
+    const cookieHeader = loginResponse.headers.get("Set-Cookie");
+    const cookieVal = cookieHeader?.split(";")[0];
+
+    // Logout
+    const logoutHandler = (LogoutRoute.options.server?.handlers as any).POST;
+    const logoutRequest = new Request("https://stealth.mail/api/v1/auth/logout", {
+      method: "POST",
+      headers: { Cookie: cookieVal! },
+    });
+
+    const logoutResponse = await logoutHandler({ request: logoutRequest });
+    expect(logoutResponse.status).toBe(200);
+    expect(logoutResponse.headers.get("Set-Cookie")).toContain("Max-Age=0");
+
+    // Session endpoint should now return 401
+    const sessionHandler = (SessionRoute.options.server?.handlers as any).GET;
+    const sessionRequest = new Request("https://stealth.mail/api/v1/auth/session", {
+      method: "GET",
+      headers: { Cookie: cookieVal! },
+    });
+    const sessionResponse = await sessionHandler({ request: sessionRequest });
+    expect(sessionResponse.status).toBe(401);
+  });
+});

--- a/tests/unit/api/auth/password.test.ts
+++ b/tests/unit/api/auth/password.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  constantTimeCompare,
+  dummyVerifyPassword,
+  hashPassword,
+  verifyPassword,
+} from "../../../../src/server/api/auth/password";
+
+describe("BETA-006: Password Hashing & Constant-Time Utilities", () => {
+  describe("constantTimeCompare", () => {
+    it("returns true for identical strings", () => {
+      expect(constantTimeCompare("secret-token-123", "secret-token-123")).toBe(true);
+      expect(constantTimeCompare("", "")).toBe(true);
+    });
+
+    it("returns false for different strings of equal length", () => {
+      expect(constantTimeCompare("secret-token-123", "secret-token-124")).toBe(false);
+    });
+
+    it("returns false for strings of different lengths", () => {
+      expect(constantTimeCompare("secret", "secret-longer")).toBe(false);
+    });
+  });
+
+  describe("hashPassword & verifyPassword", () => {
+    it("hashes and verifies a valid password", async () => {
+      const password = "CorrectHorseBatteryStaple!99";
+      const { hash, salt } = await hashPassword(password);
+
+      expect(hash).toHaveLength(64); // SHA-256 hex output
+      expect(salt).toHaveLength(32); // 16 bytes hex output
+
+      const isValid = await verifyPassword(password, hash, salt);
+      expect(isValid).toBe(true);
+    });
+
+    it("rejects an incorrect password", async () => {
+      const password = "CorrectHorseBatteryStaple!99";
+      const wrongPassword = "WrongPassword!00";
+      const { hash, salt } = await hashPassword(password);
+
+      const isValid = await verifyPassword(wrongPassword, hash, salt);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("dummyVerifyPassword", () => {
+    it("always returns false and executes hash computation", async () => {
+      const start = performance.now();
+      const isValid = await dummyVerifyPassword("SomeRandomPassword123!");
+      const duration = performance.now() - start;
+
+      expect(isValid).toBe(false);
+      expect(duration).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/api/auth/session-service.test.ts
+++ b/tests/unit/api/auth/session-service.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  authenticateWithPassword,
+  buildClearSessionCookie,
+  buildSessionCookie,
+  logoutSession,
+  parseSessionCookie,
+  validateSession,
+  MAX_LOGIN_ATTEMPTS,
+} from "../../../../src/server/api/auth/session-service";
+import { hashPassword } from "../../../../src/server/api/auth/password";
+import { createApiContext } from "../../../../src/server/api/context";
+import type { AccountStatus, Credential, User } from "../../../../src/server/api/domain";
+import { ApiError } from "../../../../src/server/api/errors";
+import { MemoryApiRepository } from "../../../../src/server/api/memory-repository";
+
+describe("BETA-006: Password Login & Server-Side Sessions", () => {
+  let repo: MemoryApiRepository;
+  let apiContext: ReturnType<typeof createApiContext>;
+
+  let addressIndex = 0;
+  const defaultPassword = "SecurePassword!2026";
+
+  async function seedTestUser(
+    options: {
+      userId?: string;
+      email?: string;
+      username?: string;
+      password?: string;
+      status?: AccountStatus;
+    } = {},
+  ) {
+    addressIndex += 1;
+    const char = String.fromCharCode(65 + (addressIndex % 26));
+    const address = `G${char.repeat(55)}`;
+
+    const userId = options.userId ?? `usr_test_${addressIndex}`;
+    const email = options.email ?? `alice_${addressIndex}@stealth.mail`;
+    const username = options.username ?? `alice_privacy_${addressIndex}`;
+    const password = options.password ?? defaultPassword;
+    const status = options.status ?? "active";
+
+    const { hash, salt } = await hashPassword(password);
+    const secretHash = `${hash}:${salt}`;
+
+    const user: User = {
+      userId,
+      address,
+      email,
+      username,
+      status,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      version: 1,
+    };
+
+    const credential: Credential = {
+      credentialId: `cred_${userId}`,
+      userId,
+      authMethod: "password_hash",
+      secretHash,
+      walletKeyRef: `vault_${userId}`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await repo.createUser(user, credential);
+    return { user, credential, password };
+  }
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+    apiContext = createApiContext(repo);
+  });
+
+  describe("Cookie Helpers", () => {
+    it("parses stealth_session cookie from Cookie header", () => {
+      const header = "theme=dark; stealth_session=sess_123456789; locale=en";
+      expect(parseSessionCookie(header)).toBe("sess_123456789");
+    });
+
+    it("returns null when stealth_session cookie is absent", () => {
+      expect(parseSessionCookie("theme=dark; locale=en")).toBeNull();
+      expect(parseSessionCookie(null)).toBeNull();
+    });
+
+    it("builds valid HttpOnly, SameSite, Secure session cookie", () => {
+      const cookie = buildSessionCookie("sess_abc", 3600, true);
+      expect(cookie).toContain("stealth_session=sess_abc");
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Secure");
+      expect(cookie).toContain("SameSite=Lax");
+    });
+
+    it("builds clear session cookie", () => {
+      const clearCookie = buildClearSessionCookie(true);
+      expect(clearCookie).toContain("stealth_session=");
+      expect(clearCookie).toContain("Max-Age=0");
+    });
+  });
+
+  describe("authenticateWithPassword", () => {
+    it("logs in successfully using valid email and password", async () => {
+      await seedTestUser({ email: "bob@stealth.mail", password: "MyPassword!1" });
+
+      const result = await authenticateWithPassword(apiContext, {
+        identifier: "bob@stealth.mail",
+        password: "MyPassword!1",
+        ip: "127.0.0.1",
+        userAgent: "TestAgent/1.0",
+      });
+
+      expect(result.user.email).toBe("bob@stealth.mail");
+      expect(result.session.sessionId).toMatch(/^sess_/);
+      expect(result.session.userId).toBe(result.user.userId);
+      expect(result.session.ipAddress).toBe("127.0.0.1");
+      expect(result.cookieHeader).toContain(`stealth_session=${result.session.sessionId}`);
+    });
+
+    it("logs in successfully using valid username and password", async () => {
+      await seedTestUser({ username: "charlie_stealth", password: "MyPassword!1" });
+
+      const result = await authenticateWithPassword(apiContext, {
+        identifier: "Charlie_Stealth", // test case-insensitivity
+        password: "MyPassword!1",
+      });
+
+      expect(result.user.username).toBe("charlie_stealth");
+      expect(result.session.sessionId).toBeDefined();
+    });
+
+    it("does not reveal whether an email exists on invalid password or missing user", async () => {
+      await seedTestUser({ email: "exists@stealth.mail" });
+
+      // Wrong password for existing user
+      let errorExisting: ApiError | undefined;
+      try {
+        await authenticateWithPassword(apiContext, {
+          identifier: "exists@stealth.mail",
+          password: "WrongPassword!99",
+        });
+      } catch (err) {
+        errorExisting = err as ApiError;
+      }
+
+      // Non-existent user
+      let errorMissing: ApiError | undefined;
+      try {
+        await authenticateWithPassword(apiContext, {
+          identifier: "nonexistent@stealth.mail",
+          password: "WrongPassword!99",
+        });
+      } catch (err) {
+        errorMissing = err as ApiError;
+      }
+
+      expect(errorExisting?.status).toBe(401);
+      expect(errorExisting?.message).toBe("Invalid email/username or password");
+
+      expect(errorMissing?.status).toBe(401);
+      expect(errorMissing?.message).toBe("Invalid email/username or password");
+    });
+
+    it("enforces account status boundaries (pending_verification, suspended, deactivated)", async () => {
+      await seedTestUser({
+        userId: "usr_unverified",
+        email: "unverified@stealth.mail",
+        username: "unverified_usr",
+        status: "pending_verification",
+      });
+      await seedTestUser({
+        userId: "usr_suspended",
+        email: "suspended@stealth.mail",
+        username: "suspended_usr",
+        status: "suspended",
+      });
+      await seedTestUser({
+        userId: "usr_deactivated",
+        email: "deactivated@stealth.mail",
+        username: "deactivated_usr",
+        status: "deactivated",
+      });
+
+      // Unverified account
+      await expect(
+        authenticateWithPassword(apiContext, {
+          identifier: "unverified@stealth.mail",
+          password: defaultPassword,
+        }),
+      ).rejects.toThrow("Account verification required");
+
+      // Suspended account
+      await expect(
+        authenticateWithPassword(apiContext, {
+          identifier: "suspended@stealth.mail",
+          password: defaultPassword,
+        }),
+      ).rejects.toThrow("Account suspended");
+
+      // Deactivated account
+      await expect(
+        authenticateWithPassword(apiContext, {
+          identifier: "deactivated@stealth.mail",
+          password: defaultPassword,
+        }),
+      ).rejects.toThrow("Account deactivated");
+    });
+
+    it("throttles login attempts after repeated failures", async () => {
+      const identifier = "target@stealth.mail";
+      await seedTestUser({ email: identifier });
+
+      // Trigger MAX_LOGIN_ATTEMPTS failures
+      for (let i = 0; i < MAX_LOGIN_ATTEMPTS; i++) {
+        await expect(
+          authenticateWithPassword(apiContext, {
+            identifier,
+            password: "WrongPassword!",
+          }),
+        ).rejects.toThrow("Invalid email/username or password");
+      }
+
+      // Next attempt (even with correct password) should be throttled
+      let throttledError: ApiError | undefined;
+      try {
+        await authenticateWithPassword(apiContext, {
+          identifier,
+          password: defaultPassword,
+        });
+      } catch (err) {
+        throttledError = err as ApiError;
+      }
+
+      expect(throttledError?.status).toBe(429);
+      expect(throttledError?.message).toBe("Too many login attempts. Please try again later");
+    });
+
+    it("prevents session fixation and rotates session identifiers", async () => {
+      const { user } = await seedTestUser();
+
+      // Initial login
+      const firstLogin = await authenticateWithPassword(apiContext, {
+        identifier: user.email,
+        password: defaultPassword,
+      });
+
+      const oldSessionId = firstLogin.session.sessionId;
+      expect(await repo.getSession(oldSessionId)).not.toBeNull();
+
+      // Re-authenticate passing current session ID
+      const secondLogin = await authenticateWithPassword(apiContext, {
+        identifier: user.email,
+        password: defaultPassword,
+        currentSessionId: oldSessionId,
+      });
+
+      const newSessionId = secondLogin.session.sessionId;
+      expect(newSessionId).not.toBe(oldSessionId);
+
+      // Old session must be revoked
+      expect(await repo.getSession(oldSessionId)).toBeNull();
+      // New session must exist
+      expect(await repo.getSession(newSessionId)).not.toBeNull();
+    });
+  });
+
+  describe("validateSession & logoutSession", () => {
+    it("validates an active session and updates lastActiveAt", async () => {
+      const { user } = await seedTestUser();
+      const authResult = await authenticateWithPassword(apiContext, {
+        identifier: user.email,
+        password: defaultPassword,
+      });
+
+      const validated = await validateSession(apiContext, authResult.session.sessionId);
+      expect(validated).not.toBeNull();
+      expect(validated?.user.userId).toBe(user.userId);
+      expect(validated?.session.lastActiveAt).toBeDefined();
+    });
+
+    it("rejects an expired session and deletes it", async () => {
+      const { user } = await seedTestUser();
+      const authResult = await authenticateWithPassword(apiContext, {
+        identifier: user.email,
+        password: defaultPassword,
+      });
+
+      // Manually set session expiry to the past
+      const expiredSession = {
+        ...authResult.session,
+        expiresAt: new Date(Date.now() - 10000).toISOString(),
+      };
+      await repo.updateSession(expiredSession);
+
+      const validated = await validateSession(apiContext, expiredSession.sessionId);
+      expect(validated).toBeNull();
+      expect(await repo.getSession(expiredSession.sessionId)).toBeNull();
+    });
+
+    it("revokes session on logout", async () => {
+      const { user } = await seedTestUser();
+      const authResult = await authenticateWithPassword(apiContext, {
+        identifier: user.email,
+        password: defaultPassword,
+      });
+
+      const logoutResult = await logoutSession(apiContext, authResult.session.sessionId);
+      expect(logoutResult.cookieHeader).toContain("Max-Age=0");
+      expect(await repo.getSession(authResult.session.sessionId)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -395,5 +395,61 @@ export function runRepositoryContractTests(
         });
       });
     });
+
+    describe("session CRUD", () => {
+      const sampleSession = {
+        sessionId: "sess_contract_100",
+        userId: "usr_test_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-01-08T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+        ipAddress: "127.0.0.1",
+        userAgent: "ContractAgent/1.0",
+        deviceFingerprint: "fp_12345",
+      };
+
+      it("returns null for non-existent session", async () => {
+        await expect(repo.getSession("sess_missing")).resolves.toBeNull();
+      });
+
+      it("creates and retrieves a session", async () => {
+        const created = await repo.createSession(sampleSession);
+        expect(created.sessionId).toBe("sess_contract_100");
+
+        const fetched = await repo.getSession("sess_contract_100");
+        expect(fetched).toMatchObject({
+          sessionId: "sess_contract_100",
+          userId: "usr_test_1",
+        });
+      });
+
+      it("updates a session", async () => {
+        await repo.createSession(sampleSession);
+        const updated = await repo.updateSession({
+          ...sampleSession,
+          lastActiveAt: "2026-01-02T12:00:00.000Z",
+        });
+
+        expect(updated.lastActiveAt).toBe("2026-01-02T12:00:00.000Z");
+
+        const fetched = await repo.getSession("sess_contract_100");
+        expect(fetched?.lastActiveAt).toBe("2026-01-02T12:00:00.000Z");
+      });
+
+      it("deletes a session and deletes all user sessions", async () => {
+        await repo.createSession(sampleSession);
+        await repo.createSession({
+          ...sampleSession,
+          sessionId: "sess_contract_101",
+        });
+
+        await repo.deleteSession("sess_contract_100");
+        expect(await repo.getSession("sess_contract_100")).toBeNull();
+        expect(await repo.getSession("sess_contract_101")).not.toBeNull();
+
+        await repo.deleteUserSessions("usr_test_1");
+        expect(await repo.getSession("sess_contract_101")).toBeNull();
+      });
+    });
   });
 }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -190,6 +190,26 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setCredential");
     return this.inner.setCredential(credential);
   }
+  async getSession(sessionId: string) {
+    this.maybeFail("getSession");
+    return this.inner.getSession(sessionId);
+  }
+  async createSession(session: import("../../../src/server/api/domain").Session) {
+    this.maybeFail("createSession");
+    return this.inner.createSession(session);
+  }
+  async updateSession(session: import("../../../src/server/api/domain").Session) {
+    this.maybeFail("updateSession");
+    return this.inner.updateSession(session);
+  }
+  async deleteSession(sessionId: string) {
+    this.maybeFail("deleteSession");
+    return this.inner.deleteSession(sessionId);
+  }
+  async deleteUserSessions(userId: string) {
+    this.maybeFail("deleteUserSessions");
+    return this.inner.deleteUserSessions(userId);
+  }
   reset(): void {
     this.inner.reset();
   }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -212,6 +212,14 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("deleteUserSessions");
     return this.inner.deleteUserSessions(userId);
   }
+  async getEnvelope(messageId: string) {
+    this.maybeFail("getEnvelope");
+    return this.inner.getEnvelope(messageId);
+  }
+  async insertEnvelope(envelope: import("../../../src/server/api/domain").StoredEnvelope) {
+    this.maybeFail("insertEnvelope");
+    return this.inner.insertEnvelope(envelope);
+  }
   reset(): void {
     this.inner.reset();
   }


### PR DESCRIPTION
## Detailed Implementation Summary for Issue BETA-006

### 1. Goal & Product Flow
**BETA-006** implements a full vertical slice for password authentication and opaque server-side session management. Returning users can now log in using either their registered email address or Stealth username alongside their password, establishing an authenticated session and accessing their mailbox without requiring a wallet prompt.

---

### 2. Architectural Components & Changes

#### A. Domain & Schema Extensions
- **[src/server/api/domain.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/domain.ts)**:
  - Defined `sessionSchema` with strict Zod validation for `sessionId`, `userId`, `createdAt`, `expiresAt`, `lastActiveAt`, `ipAddress`, `userAgent`, and `deviceFingerprint`.
  - Added `publicSessionSchema` and `toPublicSession` projection utility for client responses.
- **[src/server/api/errors.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/errors.ts)**:
  - Registered error codes `rate_limited` (429), `unverified_account` (403), `account_suspended` (403), and `account_deactivated` (403) into `API_ERROR_REGISTRY`.

#### B. Multi-Tier Repository Infrastructure
- **[src/server/api/repository.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/repository.ts)**:
  - Extended the `ApiRepository` interface with session CRUD contracts: `getSession`, `createSession`, `updateSession`, `deleteSession`, and `deleteUserSessions`.
  - Registered `getSession` and `updateSession` under `RETRY_SAFE_OPERATIONS` in `RetryableApiRepository`.
  - Added `session` (v1) schema validation in `ValidatedApiRepository`.
- **[src/server/api/memory-repository.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/memory-repository.ts)**:
  - Added in-memory session `Map<string, Session>` storage and lifecycle operations for dev/testing.
- **[src/server/api/stealth-coordinator.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/stealth-coordinator.ts)** & **[src/server/api/kv-repository.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/kv-repository.ts)**:
  - Implemented persistent Durable Object session storage and RPC delegation stubs.
- **[src/server/api/context.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/context.ts)**:
  - Registered `sessionSchema` in the API Context repository validator.

#### C. Password Security & Side-Channel Mitigation
- **[src/server/api/auth/password.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/auth/password.ts)**:
  - Implemented `hashPassword` (PBKDF2-SHA256 with 100,000 iterations and 16-byte random salts).
  - Implemented `verifyPassword` and `constantTimeCompare` to compare digests in constant time.
  - Implemented `dummyVerifyPassword` to execute PBKDF2 calculations when a user or credential is not found, ensuring uniform timing and preventing account enumeration.

#### D. Session Management Service
- **[src/server/api/auth/session-service.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/auth/session-service.ts)**:
  - `authenticateWithPassword`: Handles login attempts by email or username, rate limits failed attempts (max 5 per 15 min window), validates account status boundaries (`pending_verification` $\rightarrow$ 403, `suspended` $\rightarrow$ 403, `deactivated` $\rightarrow$ 403), rotates session IDs on re-authentication, and issues standard `Set-Cookie: stealth_session=...; HttpOnly; SameSite=Lax; Path=/` headers.
  - `validateSession`: Validates active sessions, checks expiry, verifies user status, and updates `lastActiveAt`.
  - `logoutSession`: Revokes session tokens from the repository and issues clearing cookies (`Max-Age=0`).

#### E. HTTP API Endpoints
- **[src/routes/api/v1/auth/login.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/auth/login.ts)**: `POST /api/v1/auth/login` for user authentication.
- **[src/routes/api/v1/auth/logout.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/auth/logout.ts)**: `POST /api/v1/auth/logout` for session termination.
- **[src/routes/api/v1/auth/session.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/auth/session.ts)**: `GET /api/v1/auth/session` for active session verification.

#### F. Frontend User Interface
- **[src/components/mail/AuthModal.tsx](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/components/mail/AuthModal.tsx)**: Modal UI for password authentication with input validation and feedback for account restrictions or rate limits.
- **[src/components/mail/Topbar.tsx](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/components/mail/Topbar.tsx)** & **[src/routes/index.tsx](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/index.tsx)**: Integrated the password sign-in item into the header menu and wired the modal dialog state.

---

### 3. Automated Test Coverage & Verification

- **[tests/unit/api/auth/password.test.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/tests/unit/api/auth/password.test.ts)**:
  - Verified PBKDF2 hashing, salt extraction, verification, constant-time comparisons, and dummy hash timing.
- **[tests/unit/api/auth/session-service.test.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/tests/unit/api/auth/session-service.test.ts)**:
  - Verified login via email/username, failure behavior, throttling (5 failed attempt cap), account status gates, session fixation prevention via identifier rotation, and session expiration handling.
- **[tests/unit/api/auth/auth-routes.test.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/tests/unit/api/auth/auth-routes.test.ts)**:
  - Verified `POST /login`, `POST /logout`, and `GET /session` HTTP route handlers and cookie headers.
- **[tests/unit/api/repository-contract.ts](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/tests/unit/api/repository-contract.ts)**:
  - Added session CRUD compliance tests to the repository contract suite.

#### Verification Run Results
```bash
# Unit Auth Tests
npx vitest run tests/unit/api/auth/
Test Files  9 passed (9)
Tests       79 passed (79)

# Repository Contract Tests
npx vitest run tests/unit/api/repository-contract.test.ts
Test Files  1 passed (1)
Tests       28 passed (28)

# TypeScript Type Check
npx tsc --noEmit
Exit code 0 (No errors)
```

Closes #1913 