### PR TITLE
feat(api): add verification-token lifecycle and pluggable delivery (BETA-005) #1912

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1102,7 +1102,7 @@
                     }
                   },
                   "senderBlocked": {
-                    "summary": "Policy Denied — Sender explicitly blocked",
+                    "summary": "Policy Denied ΓÇö Sender explicitly blocked",
                     "value": {
                       "data": {
                         "allowed": false,
@@ -1118,7 +1118,7 @@
                     }
                   },
                   "unknownSendersDisabled": {
-                    "summary": "Policy Denied — Unknown senders disabled by recipient policy",
+                    "summary": "Policy Denied ΓÇö Unknown senders disabled by recipient policy",
                     "value": {
                       "data": {
                         "allowed": false,
@@ -1134,7 +1134,7 @@
                     }
                   },
                   "insufficientPostage": {
-                    "summary": "Policy Denied — Postage provided is below recipient minimum requirement",
+                    "summary": "Policy Denied ΓÇö Postage provided is below recipient minimum requirement",
                     "value": {
                       "data": {
                         "allowed": false,
@@ -1150,7 +1150,7 @@
                     }
                   },
                   "verificationRequired": {
-                    "summary": "Policy Denied — Sender identity verification is required",
+                    "summary": "Policy Denied ΓÇö Sender identity verification is required",
                     "value": {
                       "data": {
                         "allowed": false,
@@ -1170,7 +1170,7 @@
             }
           },
           "400": {
-            "description": "Bad Request — Invalid request JSON structure or missing Content-Type header",
+            "description": "Bad Request ΓÇö Invalid request JSON structure or missing Content-Type header",
             "content": {
               "application/json": {
                 "schema": {
@@ -1178,7 +1178,7 @@
                 },
                 "examples": {
                   "invalidJson": {
-                    "summary": "Bad Request — Syntax error in JSON body",
+                    "summary": "Bad Request ΓÇö Syntax error in JSON body",
                     "value": {
                       "error": {
                         "code": "bad_request",
@@ -1207,7 +1207,7 @@
             }
           },
           "422": {
-            "description": "Unprocessable Entity — Request payload validation failure",
+            "description": "Unprocessable Entity ΓÇö Request payload validation failure",
             "content": {
               "application/json": {
                 "schema": {
@@ -1215,7 +1215,7 @@
                 },
                 "examples": {
                   "invalidStellarAddress": {
-                    "summary": "Validation failure — Malformed Stellar address field",
+                    "summary": "Validation failure ΓÇö Malformed Stellar address field",
                     "value": {
                       "error": {
                         "code": "validation_error",
@@ -1239,7 +1239,7 @@
                     }
                   },
                   "invalidPostageAmount": {
-                    "summary": "Validation failure — Malformed postage amount string",
+                    "summary": "Validation failure ΓÇö Malformed postage amount string",
                     "value": {
                       "error": {
                         "code": "validation_error",
@@ -1825,7 +1825,7 @@
             }
           },
           "503": {
-            "description": "Not Ready — a required dependency is unavailable",
+            "description": "Not Ready ΓÇö a required dependency is unavailable",
             "content": {
               "application/json": {
                 "schema": {
@@ -1969,7 +1969,7 @@
             }
           },
           "422": {
-            "description": "Unprocessable Entity — Request payload validation failure",
+            "description": "Unprocessable Entity ΓÇö Request payload validation failure",
             "content": {
               "application/json": {
                 "schema": {
@@ -1989,7 +1989,172 @@
             }
           },
           "503": {
-            "description": "Not Ready — a required dependency is unavailable",
+            "description": "Not Ready ΓÇö a required dependency is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/verify": {
+      "post": {
+        "operationId": "verifyAccount",
+        "summary": "Verify an account with a delivered token",
+        "description": "Consumes a single-use verification token and activates the account. Responses are generic: failures are expressed as token state and never reveal whether an account exists; replaying an already-verified token reports success so retries are safe.",
+        "security": [],
+        "x-stability": "beta",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email", "token"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "token": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generic verification result; never reveals whether the account exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/resend-verification": {
+      "post": {
+        "operationId": "resendVerificationMessage",
+        "summary": "Resend the verification message for a pending account",
+        "description": "Re-issues a verification token (invalidating the previous one) and delivers a new message. Responds identically for unknown and non-pending accounts to prevent account probing; the resend cooldown is enforced with 429.",
+        "security": [],
+        "x-stability": "beta",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generic confirmation; the message was sent or intentionally not sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Resend cooldown is still active",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The verification message could not be delivered",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import {
   runtimeConfigSchema,
   type BetaRuntimeConfig,
   type ConfigProfile,
+  type NotificationTransport,
   type PublicConfig,
 } from "./schema";
 
@@ -46,6 +47,16 @@ function parseNumber(value: unknown, fallback: number): number {
   if (typeof value === "string") {
     const parsed = parseInt(value, 10);
     if (!isNaN(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function parseBool(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const lower = value.trim().toLowerCase();
+    if (lower === "true" || lower === "1") return true;
+    if (lower === "false" || lower === "0") return false;
   }
   return fallback;
 }
@@ -173,6 +184,30 @@ export function loadRuntimeConfig(options: LoadConfigOptions = {}): BetaRuntimeC
         ? env.STEALTH_CORS_ALLOW_CREDENTIALS.toLowerCase() === "true"
         : true;
 
+  // 7. Notifications (BETA-005). The production default is SMTP; deployments
+  // must point it at their own mail server (no third-party vendor). Non-prod
+  // profiles default to the local capture sink.
+  const notificationTransport: NotificationTransport =
+    (env.STEALTH_NOTIFICATION_TRANSPORT as NotificationTransport) ?? (isProd ? "smtp" : "sink");
+  const smtpHost = (env.STEALTH_SMTP_HOST as string) ?? (isProd ? "smtp.invalid" : "localhost");
+  const smtpPort = parseNumber(env.STEALTH_SMTP_PORT, 587);
+  const smtpSecure = parseBool(env.STEALTH_SMTP_SECURE, smtpPort === 465);
+  const smtpStartTls = parseBool(env.STEALTH_SMTP_STARTTLS, smtpPort !== 465);
+  const smtpUsername = (env.STEALTH_SMTP_USERNAME as string) || undefined;
+  const smtpPassword = (env.STEALTH_SMTP_PASSWORD as string) || undefined;
+  const notificationFrom =
+    (env.STEALTH_NOTIFICATION_FROM as string) ??
+    (isProd ? "noreply@app.stealth.mail" : "stealth@localhost");
+  const verificationTokenLifetimeMs = parseNumber(
+    env.STEALTH_VERIFICATION_TOKEN_LIFETIME_MS,
+    24 * 60 * 60 * 1000,
+  );
+  const verificationResendCooldownMs = parseNumber(
+    env.STEALTH_VERIFICATION_RESEND_COOLDOWN_MS,
+    60 * 1000,
+  );
+  const verificationMaxAttempts = parseNumber(env.STEALTH_VERIFICATION_MAX_ATTEMPTS, 5);
+
   // Perform validation gates according to profile
   if (isProd) {
     if (isPlaceholderSecret(cursorSecret)) {
@@ -247,6 +282,23 @@ export function loadRuntimeConfig(options: LoadConfigOptions = {}): BetaRuntimeC
       allowedHeaders,
       allowCredentials,
     },
+    notifications: {
+      transport: notificationTransport,
+      fromAddress: notificationFrom,
+      verification: {
+        tokenLifetimeMs: verificationTokenLifetimeMs,
+        resendCooldownMs: verificationResendCooldownMs,
+        maxAttempts: verificationMaxAttempts,
+      },
+      smtp: {
+        host: smtpHost,
+        port: smtpPort,
+        secure: smtpSecure,
+        startTls: smtpStartTls,
+        username: smtpUsername,
+        password: smtpPassword,
+      },
+    },
   };
 
   const parsed = runtimeConfigSchema.safeParse(rawConfig);
@@ -283,6 +335,17 @@ export function getPublicConfig(config: BetaRuntimeConfig): PublicConfig {
     },
     contract: config.contract,
     origin: config.origin,
+    notifications: {
+      transport: config.notifications.transport,
+      fromAddress: config.notifications.fromAddress,
+      verification: config.notifications.verification,
+      smtp: {
+        host: config.notifications.smtp.host,
+        port: config.notifications.smtp.port,
+        secure: config.notifications.smtp.secure,
+        startTls: config.notifications.smtp.startTls,
+      },
+    },
   };
 }
 
@@ -314,6 +377,20 @@ export function getRedactedConfig(config: BetaRuntimeConfig): Record<string, unk
     },
     contract: config.contract,
     origin: config.origin,
+    notifications: {
+      transport: config.notifications.transport,
+      fromAddress: config.notifications.fromAddress,
+      verification: config.notifications.verification,
+      smtp: {
+        host: config.notifications.smtp.host,
+        port: config.notifications.smtp.port,
+        secure: config.notifications.smtp.secure,
+        startTls: config.notifications.smtp.startTls,
+        hasUsername: Boolean(config.notifications.smtp.username),
+        username: config.notifications.smtp.username ? "[REDACTED]" : undefined,
+        password: config.notifications.smtp.password ? "[REDACTED]" : undefined,
+      },
+    },
   };
 }
 
@@ -354,6 +431,15 @@ export function formatConfigMatrix(config: BetaRuntimeConfig): string {
     `  App URL:               ${config.origin.appUrl}`,
     `  Allowed Origins:       ${config.origin.allowedOrigins.join(", ")}`,
     `  Allowed Methods:       ${config.origin.allowedMethods.join(", ")}`,
+    `[Notifications]`,
+    `  Transport:             ${config.notifications.transport}`,
+    `  From Address:          ${config.notifications.fromAddress}`,
+    `  Token Lifetime:        ${config.notifications.verification.tokenLifetimeMs} ms`,
+    `  Resend Cooldown:       ${config.notifications.verification.resendCooldownMs} ms`,
+    `  Max Attempts:          ${config.notifications.verification.maxAttempts}`,
+    `  SMTP Host:             ${config.notifications.smtp.host}:${config.notifications.smtp.port}`,
+    `  SMTP TLS:              secure=${config.notifications.smtp.secure} starttls=${config.notifications.smtp.startTls}`,
+    `  SMTP Credentials:      ${redacted.notifications.smtp.username ? "[REDACTED]" : "None"}`,
     `======================================================`,
   ];
   return lines.join("\n");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -92,6 +92,49 @@ export const originConfigSchema = z.object({
 export type OriginConfig = z.infer<typeof originConfigSchema>;
 
 /**
+ * 7. Notifications Domain Schema (BETA-005)
+ *
+ * Delivery of account verification messages. The transport is pluggable:
+ * - "sink" captures messages in memory for local development (never used in
+ *   the production path).
+ * - "smtp" delivers through a self-hosted SMTP server; no third-party mail
+ *   vendor is required.
+ */
+export const notificationTransportSchema = z.enum(["sink", "smtp"]);
+export type NotificationTransport = z.infer<typeof notificationTransportSchema>;
+
+export const smtpConfigSchema = z.object({
+  host: z.string().min(1, "SMTP host cannot be empty"),
+  port: z.number().int().positive("SMTP port must be a positive integer"),
+  secure: z.boolean(),
+  startTls: z.boolean(),
+  username: z.string().optional(),
+  password: z.string().optional(),
+});
+export type SmtpConfig = z.infer<typeof smtpConfigSchema>;
+
+export const verificationPolicySchema = z.object({
+  tokenLifetimeMs: z
+    .number()
+    .int()
+    .positive("Verification token lifetime must be a positive integer"),
+  resendCooldownMs: z
+    .number()
+    .int()
+    .positive("Verification resend cooldown must be a positive integer"),
+  maxAttempts: z.number().int().positive("Verification max attempts must be a positive integer"),
+});
+export type VerificationPolicy = z.infer<typeof verificationPolicySchema>;
+
+export const notificationsConfigSchema = z.object({
+  transport: notificationTransportSchema,
+  fromAddress: z.string().min(1, "Notification from-address cannot be empty"),
+  verification: verificationPolicySchema,
+  smtp: smtpConfigSchema,
+});
+export type NotificationsConfig = z.infer<typeof notificationsConfigSchema>;
+
+/**
  * Public Configuration (Client-safe subset with ZERO secrets)
  */
 export const publicConfigSchema = z.object({
@@ -113,6 +156,17 @@ export const publicConfigSchema = z.object({
   }),
   contract: contractConfigSchema,
   origin: originConfigSchema,
+  notifications: z.object({
+    transport: notificationTransportSchema,
+    fromAddress: z.string(),
+    verification: verificationPolicySchema,
+    smtp: z.object({
+      host: z.string(),
+      port: z.number(),
+      secure: z.boolean(),
+      startTls: z.boolean(),
+    }),
+  }),
 });
 export type PublicConfig = z.infer<typeof publicConfigSchema>;
 
@@ -122,6 +176,8 @@ export type PublicConfig = z.infer<typeof publicConfigSchema>;
 export const secretConfigSchema = z.object({
   cursorSecret: z.string(),
   relayApiKey: z.string().optional(),
+  smtpUsername: z.string().optional(),
+  smtpPassword: z.string().optional(),
 });
 export type SecretConfig = z.infer<typeof secretConfigSchema>;
 
@@ -136,6 +192,7 @@ export const runtimeConfigSchema = z.object({
   relay: relayConfigSchema,
   contract: contractConfigSchema,
   origin: originConfigSchema,
+  notifications: notificationsConfigSchema,
 });
 export type BetaRuntimeConfig = z.infer<typeof runtimeConfigSchema>;
 export type RuntimeConfig = BetaRuntimeConfig;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,6 +26,8 @@ import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/q
 import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1AuthVerifyRouteImport } from './routes/api/v1/auth/verify'
+import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -116,6 +118,17 @@ const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
   path: '/api/v1/policies/$owner',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthVerifyRoute = ApiV1AuthVerifyRouteImport.update({
+  id: '/api/v1/auth/verify',
+  path: '/api/v1/auth/verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AuthResendVerificationRoute =
+  ApiV1AuthResendVerificationRouteImport.update({
+    id: '/api/v1/auth/resend-verification',
+    path: '/api/v1/auth/resend-verification',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -148,6 +161,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -171,6 +186,8 @@ export interface FileRoutesByTo {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -195,6 +212,8 @@ export interface FileRoutesById {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -220,6 +239,8 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/resend-verification'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -243,6 +264,8 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/resend-verification'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -266,6 +289,8 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/auth/resend-verification'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -290,6 +315,8 @@ export interface RootRouteChildren {
   ApiV1HealthRoute: typeof ApiV1HealthRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
+  ApiV1AuthResendVerificationRoute: typeof ApiV1AuthResendVerificationRoute
+  ApiV1AuthVerifyRoute: typeof ApiV1AuthVerifyRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -424,6 +451,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/verify': {
+      id: '/api/v1/auth/verify'
+      path: '/api/v1/auth/verify'
+      fullPath: '/api/v1/auth/verify'
+      preLoaderRoute: typeof ApiV1AuthVerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/resend-verification': {
+      id: '/api/v1/auth/resend-verification'
+      path: '/api/v1/auth/resend-verification'
+      fullPath: '/api/v1/auth/resend-verification'
+      preLoaderRoute: typeof ApiV1AuthResendVerificationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -502,6 +543,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1HealthRoute: ApiV1HealthRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
+  ApiV1AuthResendVerificationRoute: ApiV1AuthResendVerificationRoute,
+  ApiV1AuthVerifyRoute: ApiV1AuthVerifyRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -27,11 +27,11 @@ import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/posta
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
 import { Route as ApiV1AuthVerifyRouteImport } from './routes/api/v1/auth/verify'
-import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
+import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
+import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
-import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -129,15 +129,20 @@ const ApiV1AuthVerifyRoute = ApiV1AuthVerifyRouteImport.update({
   path: '/api/v1/auth/verify',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
+  id: '/api/v1/auth/session',
+  path: '/api/v1/auth/session',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AuthResendVerificationRoute =
   ApiV1AuthResendVerificationRouteImport.update({
     id: '/api/v1/auth/resend-verification',
     path: '/api/v1/auth/resend-verification',
     getParentRoute: () => rootRouteImport,
   } as any)
-const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
-  id: '/api/v1/auth/session',
-  path: '/api/v1/auth/session',
+const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
+  id: '/api/v1/auth/register',
+  path: '/api/v1/auth/register',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
@@ -148,11 +153,6 @@ const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
 const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
   id: '/api/v1/auth/login',
   path: '/api/v1/auth/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
-  id: '/api/v1/auth/register',
-  path: '/api/v1/auth/register',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
@@ -199,12 +199,12 @@ export interface FileRoutesByFullPath {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
-  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
-  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -230,12 +230,12 @@ export interface FileRoutesByTo {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
-  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
-  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -262,12 +262,12 @@ export interface FileRoutesById {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
-  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
-  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
+  '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
+  '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -295,12 +295,12 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
-    | '/api/v1/auth/resend-verification'
-    | '/api/v1/auth/verify'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
+    | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -326,12 +326,12 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
-    | '/api/v1/auth/resend-verification'
-    | '/api/v1/auth/verify'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
+    | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -357,12 +357,12 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
-    | '/api/v1/auth/resend-verification'
-    | '/api/v1/auth/verify'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
+    | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
+    | '/api/v1/auth/verify'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -389,12 +389,12 @@ export interface RootRouteChildren {
   ApiV1HealthRoute: typeof ApiV1HealthRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
-  ApiV1AuthResendVerificationRoute: typeof ApiV1AuthResendVerificationRoute
-  ApiV1AuthVerifyRoute: typeof ApiV1AuthVerifyRoute
   ApiV1AuthLoginRoute: typeof ApiV1AuthLoginRoute
-  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthLogoutRoute: typeof ApiV1AuthLogoutRoute
+  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
+  ApiV1AuthResendVerificationRoute: typeof ApiV1AuthResendVerificationRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
+  ApiV1AuthVerifyRoute: typeof ApiV1AuthVerifyRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -536,16 +536,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AuthVerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/auth/resend-verification': {
-      id: '/api/v1/auth/resend-verification'
-      path: '/api/v1/auth/resend-verification'
-      fullPath: '/api/v1/auth/resend-verification'
-      preLoaderRoute: typeof ApiV1AuthResendVerificationRouteImport
     '/api/v1/auth/session': {
       id: '/api/v1/auth/session'
       path: '/api/v1/auth/session'
       fullPath: '/api/v1/auth/session'
       preLoaderRoute: typeof ApiV1AuthSessionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/resend-verification': {
+      id: '/api/v1/auth/resend-verification'
+      path: '/api/v1/auth/resend-verification'
+      fullPath: '/api/v1/auth/resend-verification'
+      preLoaderRoute: typeof ApiV1AuthResendVerificationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/register': {
+      id: '/api/v1/auth/register'
+      path: '/api/v1/auth/register'
+      fullPath: '/api/v1/auth/register'
+      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/auth/logout': {
@@ -560,13 +569,6 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/auth/login'
       fullPath: '/api/v1/auth/login'
       preLoaderRoute: typeof ApiV1AuthLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/register': {
-      id: '/api/v1/auth/register'
-      path: '/api/v1/auth/register'
-      fullPath: '/api/v1/auth/register'
-      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/receipts/$messageId/read': {
@@ -665,12 +667,12 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1HealthRoute: ApiV1HealthRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
-  ApiV1AuthResendVerificationRoute: ApiV1AuthResendVerificationRoute,
-  ApiV1AuthVerifyRoute: ApiV1AuthVerifyRoute,
   ApiV1AuthLoginRoute: ApiV1AuthLoginRoute,
-  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthLogoutRoute: ApiV1AuthLogoutRoute,
+  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
+  ApiV1AuthResendVerificationRoute: ApiV1AuthResendVerificationRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
+  ApiV1AuthVerifyRoute: ApiV1AuthVerifyRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,

--- a/src/routes/api/v1/auth/resend-verification.ts
+++ b/src/routes/api/v1/auth/resend-verification.ts
@@ -1,0 +1,72 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { emailSchema } from "@/server/api/domain";
+import { ApiError } from "@/server/api/errors";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import {
+  getVerificationDeliveryConfig,
+  getVerificationNotificationAdapter,
+} from "@/server/api/verification-delivery";
+import { resendEmailVerificationToken } from "@/server/api/verification-service";
+
+const resendSchema = z.object({
+  email: emailSchema,
+});
+
+/**
+ * POST /api/v1/auth/resend-verification
+ *
+ * Re-sends the verification message for a pending account.
+ *
+ * Generic-response contract (BETA-005): unknown emails and accounts that are
+ * not pending verification receive the exact same `{ status: "sent" }`
+ * response as a successful resend, so the endpoint cannot be used to probe
+ * which addresses have accounts. The only observable divergence is the
+ * resend cooldown (429), which protects against spam and token churn.
+ */
+export const Route = createFileRoute("/api/v1/auth/resend-verification")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const input = await parseJsonBody(request, resendSchema, {
+            route: "POST /auth/resend-verification",
+          });
+
+          const delivery = await getVerificationDeliveryConfig();
+          const adapter = await getVerificationNotificationAdapter();
+
+          const outcome = await resendEmailVerificationToken(
+            apiContext,
+            input.email,
+            delivery.notifications.verification,
+            (message) => adapter.deliverVerificationEmail(message),
+            delivery.appUrl,
+          );
+
+          switch (outcome.outcome) {
+            case "sent":
+            case "noop":
+              return apiSuccess(request, { status: "sent" });
+            case "cooldown":
+              throw new ApiError(
+                429,
+                "too_many_requests",
+                "Verification resend is still on cooldown",
+                { retryAfterSeconds: outcome.retryAfterSeconds },
+              );
+            case "delivery_failed":
+              throw new ApiError(
+                503,
+                "dependency_unavailable",
+                "The verification message could not be delivered",
+              );
+          }
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/auth/verify.ts
+++ b/src/routes/api/v1/auth/verify.ts
@@ -1,0 +1,44 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { emailSchema } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { verifyEmailVerificationToken } from "@/server/api/verification-service";
+
+const verifySchema = z.object({
+  email: emailSchema,
+  token: z.string().trim().min(1, "Token cannot be empty").max(512, "Token is too long"),
+});
+
+/**
+ * POST /api/v1/auth/verify
+ *
+ * Verifies an account using the token delivered to the account email.
+ *
+ * Generic-response contract (BETA-005): the response never reveals whether an
+ * account exists — every failure is expressed as token state (`reason`), and
+ * replaying an already-verified token against an active account reports
+ * success, so duplicate clicks and retries are safe.
+ */
+export const Route = createFileRoute("/api/v1/auth/verify")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const input = await parseJsonBody(request, verifySchema, {
+            route: "POST /auth/verify",
+          });
+
+          const outcome = await verifyEmailVerificationToken(apiContext, input.email, input.token);
+
+          if (outcome.outcome === "verified") {
+            return apiSuccess(request, { verified: true });
+          }
+          return apiSuccess(request, { verified: false, reason: outcome.reason });
+        }),
+    },
+  },
+});

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,7 @@ import {
   profileSchema,
   credentialSchema,
   storedEnvelopeSchema,
+  verificationTokenSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -195,6 +196,7 @@ registerRecordSchema("receipt", 1, receiptSchema);
 registerRecordSchema("user", 1, userSchema);
 registerRecordSchema("profile", 1, profileSchema);
 registerRecordSchema("credential", 1, credentialSchema);
+registerRecordSchema("verificationToken", 1, verificationTokenSchema);
 // v1 -> v2 (Issue #1498): records now carry a requestDigest binding the
 // lease/response to the exact request payload that created it. Legacy
 // records predate this and never bore a client-supplied payload we can

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -213,6 +213,48 @@ export const publicProfileSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+// ---------------------------------------------------------------------------
+// BETA-005: Verification token lifecycle domain
+// ---------------------------------------------------------------------------
+
+export const verificationPurposeSchema = z.enum(["email_verification"]);
+export type VerificationPurpose = z.infer<typeof verificationPurposeSchema>;
+
+export const verificationTokenHashSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(/^[a-f0-9]{64}$/, "Expected a 64-character lowercase hexadecimal SHA-256 hash");
+
+/**
+ * Durable record for a single verification token.
+ *
+ * Security invariants (BETA-005):
+ * - Only the SHA-256 hash of the token is ever persisted or logged. The
+ *   plaintext token exists solely in the hand-off between the issuing service
+ *   and the delivery adapter, and is never returned by the API.
+ * - `consumedAt` is set exactly once under a per-token exclusive lock, making
+ *   the token single-use even under concurrent verify requests.
+ * - `replacedAt` marks a token invalidated by a newer issue (resend), so stale
+ *   links fail closed.
+ * - `attemptCount` counts failed verification attempts; reaching `maxAttempts`
+ *   permanently locks the token (brute-force protection).
+ */
+export const verificationTokenSchema = z.object({
+  tokenHash: verificationTokenHashSchema,
+  userId: z.string().min(1, "User ID cannot be empty"),
+  purpose: verificationPurposeSchema,
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  consumedAt: z.string().datetime().nullable(),
+  replacedAt: z.string().datetime().nullable(),
+  replacedByTokenHash: verificationTokenHashSchema.nullable().optional(),
+  attemptCount: z.number().int().nonnegative(),
+  maxAttempts: z.number().int().positive(),
+});
+
+export type VerificationToken = z.infer<typeof verificationTokenSchema>;
+
 export type AccountStatus = z.infer<typeof accountStatusSchema>;
 export type User = z.infer<typeof userSchema>;
 export type Profile = z.infer<typeof profileSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -225,6 +225,8 @@ export class HybridApiRepository implements ApiRepository {
     now: Date,
   ): Promise<import("./repository").RecordVerificationAttemptResult> {
     return this.getStub().recordVerificationAttempt(tokenHash, now);
+  }
+
   // BETA-006: Session DO stubs
   async getSession(sessionId: string): Promise<Session | null> {
     return this.getStub().getSession(sessionId);

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -15,6 +15,8 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  VerificationPurpose,
+  VerificationToken,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -175,6 +177,41 @@ export class HybridApiRepository implements ApiRepository {
 
   async setCredential(credential: Credential): Promise<Credential> {
     return this.getStub().setCredential(credential);
+  }
+
+  // BETA-005: Verification token lifecycle delegated to the Durable Object
+  // so the single-winner transitions (issue/consume/attempt) execute under
+  // the coordinator's per-key exclusive locks.
+  async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
+    return this.getStub().getVerificationToken(tokenHash);
+  }
+
+  async getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null> {
+    return this.getStub().getActiveVerificationToken(userId, purpose);
+  }
+
+  async issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<import("./repository").IssueVerificationTokenResult> {
+    return this.getStub().issueVerificationToken(token, now);
+  }
+
+  async consumeVerificationToken(
+    tokenHash: string,
+    now: Date,
+  ): Promise<import("./repository").ConsumeVerificationTokenResult> {
+    return this.getStub().consumeVerificationToken(tokenHash, now);
+  }
+
+  async recordVerificationAttempt(
+    tokenHash: string,
+    now: Date,
+  ): Promise<import("./repository").RecordVerificationAttemptResult> {
+    return this.getStub().recordVerificationAttempt(tokenHash, now);
   }
 
   // Consistent layer delegated to Durable Object via RPC

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -9,17 +9,26 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  VerificationPurpose,
+  VerificationToken,
 } from "./domain";
 import type {
   ApiRepository,
+  ConsumeVerificationTokenResult,
   InsertEnvelopeResult,
+  IssueVerificationTokenResult,
   PostageTransitionResult,
+  RecordVerificationAttemptResult,
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
 
 function key(owner: string, sender: string) {
   return `${owner}:${sender}`;
+}
+
+function activeTokenKey(userId: string, purpose: string) {
+  return `${userId}:${purpose}`;
 }
 
 export class MemoryApiRepository implements ApiRepository {
@@ -41,6 +50,32 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly usersByAddress = new Map<string, string>();
   private readonly profiles = new Map<string, Profile>();
   private readonly credentials = new Map<string, Credential>();
+
+  // BETA-005: Verification tokens keyed by SHA-256 hash, plus the active-token
+  // index per (userId, purpose) and a per-key lock chain for atomic transitions.
+  private readonly verificationTokens = new Map<string, VerificationToken>();
+  private readonly activeVerificationTokens = new Map<string, string>();
+  private readonly verificationLocks = new Map<string, Promise<void>>();
+
+  private async withVerificationLock<T>(lockKey: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.verificationLocks.get(lockKey) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.verificationLocks.set(lockKey, queued);
+
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.verificationLocks.get(lockKey) === queued) {
+        this.verificationLocks.delete(lockKey);
+      }
+    }
+  }
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -309,6 +344,114 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(credential);
   }
 
+  // BETA-005 Verification Token Lifecycle Implementation
+  async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
+    return structuredClone(this.verificationTokens.get(tokenHash) ?? null);
+  }
+
+  async getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null> {
+    const tokenHash = this.activeVerificationTokens.get(activeTokenKey(userId, purpose));
+    if (!tokenHash) return null;
+    return structuredClone(this.verificationTokens.get(tokenHash) ?? null);
+  }
+
+  async issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<IssueVerificationTokenResult> {
+    return this.withVerificationLock(activeTokenKey(token.userId, token.purpose), async () => {
+      if (this.verificationTokens.has(token.tokenHash)) {
+        return {
+          outcome: "conflict",
+          token: structuredClone(this.verificationTokens.get(token.tokenHash)!),
+        };
+      }
+
+      let replacedToken: VerificationToken | null = null;
+      const activeHash = this.activeVerificationTokens.get(
+        activeTokenKey(token.userId, token.purpose),
+      );
+      if (activeHash && activeHash !== token.tokenHash) {
+        const current = this.verificationTokens.get(activeHash);
+        if (current && current.consumedAt === null && current.replacedAt === null) {
+          const invalidated: VerificationToken = {
+            ...current,
+            replacedAt: now.toISOString(),
+            replacedByTokenHash: token.tokenHash,
+          };
+          this.verificationTokens.set(activeHash, invalidated);
+          replacedToken = invalidated;
+        }
+      }
+
+      const stored = structuredClone(token);
+      this.verificationTokens.set(token.tokenHash, stored);
+      this.activeVerificationTokens.set(
+        activeTokenKey(token.userId, token.purpose),
+        token.tokenHash,
+      );
+      return {
+        outcome: "issued",
+        token: structuredClone(stored),
+        replacedToken: replacedToken ? structuredClone(replacedToken) : null,
+      };
+    });
+  }
+
+  async consumeVerificationToken(
+    tokenHash: string,
+    now: Date,
+  ): Promise<ConsumeVerificationTokenResult> {
+    return this.withVerificationLock(`token:${tokenHash}`, async () => {
+      const current = this.verificationTokens.get(tokenHash);
+      if (!current) {
+        return { outcome: "not-found" };
+      }
+      if (current.consumedAt !== null) {
+        return { outcome: "already-consumed", token: structuredClone(current) };
+      }
+      if (current.replacedAt !== null) {
+        return { outcome: "replaced", token: structuredClone(current) };
+      }
+      if (current.attemptCount >= current.maxAttempts) {
+        return { outcome: "brute-force-blocked", token: structuredClone(current) };
+      }
+      if (Date.parse(current.expiresAt) <= now.getTime()) {
+        return { outcome: "expired", token: structuredClone(current) };
+      }
+      const consumed: VerificationToken = {
+        ...current,
+        consumedAt: now.toISOString(),
+      };
+      this.verificationTokens.set(tokenHash, consumed);
+      return { outcome: "consumed", token: structuredClone(consumed) };
+    });
+  }
+
+  async recordVerificationAttempt(
+    tokenHash: string,
+    now: Date,
+  ): Promise<RecordVerificationAttemptResult> {
+    return this.withVerificationLock(`token:${tokenHash}`, async () => {
+      const current = this.verificationTokens.get(tokenHash);
+      if (!current) {
+        return { recorded: false, token: null };
+      }
+      if (current.consumedAt !== null || current.replacedAt !== null) {
+        return { recorded: false, token: structuredClone(current) };
+      }
+      const updated: VerificationToken = {
+        ...current,
+        attemptCount: current.attemptCount + 1,
+      };
+      this.verificationTokens.set(tokenHash, updated);
+      return { recorded: true, token: structuredClone(updated) };
+    });
+  }
+
   async getRelayQueueDepth(_relayId: string) {
     return 0;
   }
@@ -437,5 +580,8 @@ export class MemoryApiRepository implements ApiRepository {
     this.usersByAddress.clear();
     this.profiles.clear();
     this.credentials.clear();
+    this.verificationTokens.clear();
+    this.activeVerificationTokens.clear();
+    this.verificationLocks.clear();
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -54,6 +54,8 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly usersByAddress = new Map<string, string>();
   private readonly profiles = new Map<string, Profile>();
   private readonly credentials = new Map<string, Credential>();
+  private readonly sessions = new Map<string, Session>();
+  private readonly retiredSessions = new Map<string, RetiredSession>();
 
   // BETA-005: Verification tokens keyed by SHA-256 hash, plus the active-token
   // index per (userId, purpose) and a per-key lock chain for atomic transitions.
@@ -357,6 +359,41 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(credential);
   }
 
+  async getSession(sessionId: string): Promise<Session | null> {
+    return structuredClone(this.sessions.get(sessionId) ?? null);
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    this.sessions.set(session.sessionId, structuredClone(session));
+    return structuredClone(session);
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    this.sessions.set(session.sessionId, structuredClone(session));
+    return structuredClone(session);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+  }
+
+  async deleteUserSessions(userId: string): Promise<void> {
+    for (const [sessionId, session] of this.sessions.entries()) {
+      if (session.userId === userId) {
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    return structuredClone(this.retiredSessions.get(sessionId) ?? null);
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    this.retiredSessions.set(retiredSession.sessionId, structuredClone(retiredSession));
+    return structuredClone(retiredSession);
+  }
+
   // BETA-005 Verification Token Lifecycle Implementation
   async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
     return structuredClone(this.verificationTokens.get(tokenHash) ?? null);
@@ -594,6 +631,8 @@ export class MemoryApiRepository implements ApiRepository {
     this.usersByAddress.clear();
     this.profiles.clear();
     this.credentials.clear();
+    this.sessions.clear();
+    this.retiredSessions.clear();
     this.verificationTokens.clear();
     this.activeVerificationTokens.clear();
     this.verificationLocks.clear();

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -885,7 +885,7 @@ export const openApiDocument = {
                     },
                   },
                   senderBlocked: {
-                    summary: "Policy Denied — Sender explicitly blocked",
+                    summary: "Policy Denied ΓÇö Sender explicitly blocked",
                     value: {
                       data: {
                         allowed: false,
@@ -901,7 +901,7 @@ export const openApiDocument = {
                     },
                   },
                   unknownSendersDisabled: {
-                    summary: "Policy Denied — Unknown senders disabled by recipient policy",
+                    summary: "Policy Denied ΓÇö Unknown senders disabled by recipient policy",
                     value: {
                       data: {
                         allowed: false,
@@ -918,7 +918,7 @@ export const openApiDocument = {
                   },
                   insufficientPostage: {
                     summary:
-                      "Policy Denied — Postage provided is below recipient minimum requirement",
+                      "Policy Denied ΓÇö Postage provided is below recipient minimum requirement",
                     value: {
                       data: {
                         allowed: false,
@@ -934,7 +934,7 @@ export const openApiDocument = {
                     },
                   },
                   verificationRequired: {
-                    summary: "Policy Denied — Sender identity verification is required",
+                    summary: "Policy Denied ΓÇö Sender identity verification is required",
                     value: {
                       data: {
                         allowed: false,
@@ -955,7 +955,7 @@ export const openApiDocument = {
           },
           "400": {
             description:
-              "Bad Request — Invalid request JSON structure or missing Content-Type header",
+              "Bad Request ΓÇö Invalid request JSON structure or missing Content-Type header",
             content: {
               "application/json": {
                 schema: {
@@ -963,7 +963,7 @@ export const openApiDocument = {
                 },
                 examples: {
                   invalidJson: {
-                    summary: "Bad Request — Syntax error in JSON body",
+                    summary: "Bad Request ΓÇö Syntax error in JSON body",
                     value: {
                       error: {
                         code: "bad_request",
@@ -992,7 +992,7 @@ export const openApiDocument = {
             },
           },
           "422": {
-            description: "Unprocessable Entity — Request payload validation failure",
+            description: "Unprocessable Entity ΓÇö Request payload validation failure",
             content: {
               "application/json": {
                 schema: {
@@ -1000,7 +1000,7 @@ export const openApiDocument = {
                 },
                 examples: {
                   invalidStellarAddress: {
-                    summary: "Validation failure — Malformed Stellar address field",
+                    summary: "Validation failure ΓÇö Malformed Stellar address field",
                     value: {
                       error: {
                         code: "validation_error",
@@ -1024,7 +1024,7 @@ export const openApiDocument = {
                     },
                   },
                   invalidPostageAmount: {
-                    summary: "Validation failure — Malformed postage amount string",
+                    summary: "Validation failure ΓÇö Malformed postage amount string",
                     value: {
                       error: {
                         code: "validation_error",
@@ -1580,7 +1580,7 @@ export const openApiDocument = {
             },
           },
           "503": {
-            description: "Not Ready — a required dependency is unavailable",
+            description: "Not Ready ΓÇö a required dependency is unavailable",
             content: {
               "application/json": {
                 schema: {
@@ -1730,7 +1730,7 @@ export const openApiDocument = {
             },
           },
           "422": {
-            description: "Unprocessable Entity — Request payload validation failure",
+            description: "Unprocessable Entity ΓÇö Request payload validation failure",
             content: {
               "application/json": {
                 schema: {
@@ -1740,7 +1740,7 @@ export const openApiDocument = {
             },
           },
           "503": {
-            description: "Not Ready — a required dependency is unavailable",
+            description: "Not Ready ΓÇö a required dependency is unavailable",
             content: {
               "application/json": {
                 schema: {
@@ -1751,6 +1751,161 @@ export const openApiDocument = {
           },
           "500": {
             description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/auth/verify": {
+      post: {
+        operationId: "verifyAccount",
+        summary: "Verify an account with a delivered token",
+        description:
+          "Consumes a single-use verification token and activates the account. Responses are generic: failures are expressed as token state and never reveal whether an account exists; replaying an already-verified token reports success so retries are safe.",
+        security: [],
+        "x-stability": "beta",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["email", "token"],
+                properties: {
+                  email: { type: "string", format: "email" },
+                  token: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Generic verification result; never reveals whether the account exists",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Request validation failed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/auth/resend-verification": {
+      post: {
+        operationId: "resendVerificationMessage",
+        summary: "Resend the verification message for a pending account",
+        description:
+          "Re-issues a verification token (invalidating the previous one) and delivers a new message. Responds identically for unknown and non-pending accounts to prevent account probing; the resend cooldown is enforced with 429.",
+        security: [],
+        "x-stability": "beta",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["email"],
+                properties: {
+                  email: { type: "string", format: "email" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Generic confirmation; the message was sent or intentionally not sent",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Request validation failed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "429": {
+            description: "Resend cooldown is still active",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "503": {
+            description: "The verification message could not be delivered",
             content: {
               "application/json": {
                 schema: {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -10,6 +10,8 @@ import type {
   SenderRule,
   StoredEnvelope,
   User,
+  VerificationPurpose,
+  VerificationToken,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
 
@@ -84,6 +86,56 @@ export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
 
+/**
+ * Outcome of an atomic verification-token consumption attempt.
+ *
+ * The evaluation (existence, single-use, replacement, expiry, brute-force
+ * limit) and the consumption write happen inside one exclusive critical
+ * section per token, so concurrent verify requests observe a single winner:
+ *
+ * - "not-found": no token record exists for the given hash.
+ * - "already-consumed": the token was consumed by an earlier request.
+ * - "replaced": the token was invalidated by a newer issue (resend).
+ * - "expired": the token is past its `expiresAt`.
+ * - "brute-force-blocked": `attemptCount` reached `maxAttempts`; the token
+ *   is permanently locked without ever being consumable.
+ * - "consumed": the token was valid and is now marked consumed atomically.
+ */
+export type ConsumeVerificationTokenResult =
+  | { outcome: "not-found" }
+  | { outcome: "already-consumed"; token: VerificationToken }
+  | { outcome: "replaced"; token: VerificationToken }
+  | { outcome: "expired"; token: VerificationToken }
+  | { outcome: "brute-force-blocked"; token: VerificationToken }
+  | { outcome: "consumed"; token: VerificationToken };
+
+/**
+ * Outcome of an atomic verification-token issue.
+ *
+ * - "issued": the new token is stored and indexed as the active token for
+ *   (userId, purpose). `replacedToken` is the previous active token when one
+ *   existed and was still redeemable — it is invalidated (`replacedAt`) by
+ *   the same atomic write.
+ * - "conflict": a token with the same hash already exists (astronomically
+ *   unlikely for a 256-bit random token; fails closed rather than silently
+ *   overwriting a stored record).
+ */
+export type IssueVerificationTokenResult =
+  | { outcome: "issued"; token: VerificationToken; replacedToken: VerificationToken | null }
+  | { outcome: "conflict"; token: VerificationToken };
+
+/**
+ * Outcome of an atomic failed-attempt recording.
+ *
+ * `recorded` is false when the token no longer exists or is already in a
+ * terminal state (consumed or replaced), so a racing verify cannot inflate
+ * the counter of a token that is no longer redeemable.
+ */
+export type RecordVerificationAttemptResult = {
+  recorded: boolean;
+  token: VerificationToken | null;
+};
+
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
@@ -136,6 +188,21 @@ export interface ApiRepository {
   setProfile(profile: Profile): Promise<Profile>;
   getCredential(userId: string): Promise<Credential | null>;
   setCredential(credential: Credential): Promise<Credential>;
+
+  // BETA-005: Verification token lifecycle methods.
+  // Each token is identified by its SHA-256 hash; plaintext tokens are never
+  // accepted, stored, or returned by the persistence layer.
+  getVerificationToken(tokenHash: string): Promise<VerificationToken | null>;
+  getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null>;
+  issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<IssueVerificationTokenResult>;
+  consumeVerificationToken(tokenHash: string, now: Date): Promise<ConsumeVerificationTokenResult>;
+  recordVerificationAttempt(tokenHash: string, now: Date): Promise<RecordVerificationAttemptResult>;
 
   getRelayQueueDepth(relayId: string): Promise<number>;
   getRelayRetryCount(relayId: string): Promise<number>;
@@ -433,6 +500,61 @@ export class ValidatedApiRepository implements ApiRepository {
     return validateRecord<Credential>("credential", result);
   }
 
+  async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
+    const raw = await this.inner.getVerificationToken(tokenHash);
+    return raw ? validateRecord<VerificationToken>("verificationToken", raw) : null;
+  }
+
+  async getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null> {
+    const raw = await this.inner.getActiveVerificationToken(userId, purpose);
+    return raw ? validateRecord<VerificationToken>("verificationToken", raw) : null;
+  }
+
+  async issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<IssueVerificationTokenResult> {
+    const result = await this.inner.issueVerificationToken(
+      versionRecord("verificationToken", token),
+      now,
+    );
+    if (result.outcome === "issued" && result.replacedToken) {
+      result.replacedToken = validateRecord<VerificationToken>(
+        "verificationToken",
+        result.replacedToken,
+      );
+    }
+    if (result.outcome === "issued" || result.outcome === "conflict") {
+      result.token = validateRecord<VerificationToken>("verificationToken", result.token);
+    }
+    return result;
+  }
+
+  async consumeVerificationToken(
+    tokenHash: string,
+    now: Date,
+  ): Promise<ConsumeVerificationTokenResult> {
+    const result = await this.inner.consumeVerificationToken(tokenHash, now);
+    if (result.outcome !== "not-found") {
+      result.token = validateRecord<VerificationToken>("verificationToken", result.token);
+    }
+    return result;
+  }
+
+  async recordVerificationAttempt(
+    tokenHash: string,
+    now: Date,
+  ): Promise<RecordVerificationAttemptResult> {
+    const result = await this.inner.recordVerificationAttempt(tokenHash, now);
+    if (result.token) {
+      result.token = validateRecord<VerificationToken>("verificationToken", result.token);
+    }
+    return result;
+  }
+
   getRelayQueueDepth(relayId: string): Promise<number> {
     return this.inner.getRelayQueueDepth(relayId);
   }
@@ -524,6 +646,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getCredential",
   "setCredential",
   "getEnvelope",
+  "getVerificationToken",
+  "getActiveVerificationToken",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -692,6 +816,37 @@ export class RetryableApiRepository implements ApiRepository {
 
   setCredential(credential: Credential): Promise<Credential> {
     return this.withRetry("setCredential", () => this.inner.setCredential(credential));
+  }
+
+  getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
+    return this.withRetry("getVerificationToken", () => this.inner.getVerificationToken(tokenHash));
+  }
+
+  getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null> {
+    return this.withRetry("getActiveVerificationToken", () =>
+      this.inner.getActiveVerificationToken(userId, purpose),
+    );
+  }
+
+  issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<IssueVerificationTokenResult> {
+    return this.inner.issueVerificationToken(token, now);
+  }
+
+  consumeVerificationToken(tokenHash: string, now: Date): Promise<ConsumeVerificationTokenResult> {
+    return this.inner.consumeVerificationToken(tokenHash, now);
+  }
+
+  recordVerificationAttempt(
+    tokenHash: string,
+    now: Date,
+  ): Promise<RecordVerificationAttemptResult> {
+    return this.inner.recordVerificationAttempt(tokenHash, now);
   }
 
   getRelayQueueDepth(relayId: string): Promise<number> {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -198,6 +198,15 @@ export interface ApiRepository {
   getCredential(userId: string): Promise<Credential | null>;
   setCredential(credential: Credential): Promise<Credential>;
 
+  // BETA-006: Server-side session lifecycle methods.
+  getSession(sessionId: string): Promise<Session | null>;
+  createSession(session: Session): Promise<Session>;
+  updateSession(session: Session): Promise<Session>;
+  deleteSession(sessionId: string): Promise<void>;
+  deleteUserSessions(userId: string): Promise<void>;
+  getRetiredSession(sessionId: string): Promise<RetiredSession | null>;
+  createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession>;
+
   // BETA-005: Verification token lifecycle methods.
   // Each token is identified by its SHA-256 hash; plaintext tokens are never
   // accepted, stored, or returned by the persistence layer.
@@ -516,6 +525,41 @@ export class ValidatedApiRepository implements ApiRepository {
   async setCredential(credential: Credential): Promise<Credential> {
     const result = await this.inner.setCredential(versionRecord("credential", credential));
     return validateRecord<Credential>("credential", result);
+  }
+
+  async getSession(sessionId: string): Promise<Session | null> {
+    const raw = await this.inner.getSession(sessionId);
+    return raw ? validateRecord<Session>("session", raw) : null;
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    const result = await this.inner.createSession(versionRecord("session", session));
+    return validateRecord<Session>("session", result);
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    const result = await this.inner.updateSession(versionRecord("session", session));
+    return validateRecord<Session>("session", result);
+  }
+
+  deleteSession(sessionId: string): Promise<void> {
+    return this.inner.deleteSession(sessionId);
+  }
+
+  deleteUserSessions(userId: string): Promise<void> {
+    return this.inner.deleteUserSessions(userId);
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    const raw = await this.inner.getRetiredSession(sessionId);
+    return raw ? validateRecord<RetiredSession>("retiredSession", raw) : null;
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    const result = await this.inner.createRetiredSession(
+      versionRecord("retiredSession", retiredSession),
+    );
+    return validateRecord<RetiredSession>("retiredSession", result);
   }
 
   async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
@@ -847,6 +891,34 @@ export class RetryableApiRepository implements ApiRepository {
 
   setCredential(credential: Credential): Promise<Credential> {
     return this.withRetry("setCredential", () => this.inner.setCredential(credential));
+  }
+
+  getSession(sessionId: string): Promise<Session | null> {
+    return this.withRetry("getSession", () => this.inner.getSession(sessionId));
+  }
+
+  createSession(session: Session): Promise<Session> {
+    return this.inner.createSession(session);
+  }
+
+  updateSession(session: Session): Promise<Session> {
+    return this.withRetry("updateSession", () => this.inner.updateSession(session));
+  }
+
+  deleteSession(sessionId: string): Promise<void> {
+    return this.inner.deleteSession(sessionId);
+  }
+
+  deleteUserSessions(userId: string): Promise<void> {
+    return this.inner.deleteUserSessions(userId);
+  }
+
+  getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    return this.withRetry("getRetiredSession", () => this.inner.getRetiredSession(sessionId));
+  }
+
+  createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    return this.inner.createRetiredSession(retiredSession);
   }
 
   getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -44,6 +44,8 @@ export const ROUTE_BODY_LIMITS = {
   "PUT /policies/{owner}/senders/{sender}": "standard",
   "POST /policies/evaluate": "compact",
   "POST /relay/messages": "relay",
+  "POST /auth/verify": "minimal",
+  "POST /auth/resend-verification": "minimal",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -336,6 +336,59 @@ export class StealthCoordinator extends DurableObjectBase {
     return credential;
   }
 
+  async getSession(sessionId: string): Promise<Session | null> {
+    const session = (await this.ctx.storage.get(`session:${sessionId}`)) as Session | undefined;
+    return session ?? null;
+  }
+
+  async createSession(session: Session): Promise<Session> {
+    await this.ctx.storage.put(`session:${session.sessionId}`, session);
+    await this.ctx.storage.put(`session:user:${session.userId}:${session.sessionId}`, true);
+    return session;
+  }
+
+  async updateSession(session: Session): Promise<Session> {
+    const current = await this.getSession(session.sessionId);
+    if (current && current.userId !== session.userId) {
+      await this.ctx.storage.delete(`session:user:${current.userId}:${session.sessionId}`);
+    }
+    await this.ctx.storage.put(`session:${session.sessionId}`, session);
+    await this.ctx.storage.put(`session:user:${session.userId}:${session.sessionId}`, true);
+    return session;
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const session = await this.getSession(sessionId);
+    await this.ctx.storage.delete(`session:${sessionId}`);
+    if (session) {
+      await this.ctx.storage.delete(`session:user:${session.userId}:${sessionId}`);
+    }
+  }
+
+  async deleteUserSessions(userId: string): Promise<void> {
+    const prefix = `session:user:${userId}:`;
+    const sessionIndex = await this.ctx.storage.list({ prefix });
+    const deletes: string[] = [];
+    for (const key of sessionIndex.keys()) {
+      deletes.push(key, `session:${key.slice(prefix.length)}`);
+    }
+    if (deletes.length > 0) {
+      await this.ctx.storage.delete(deletes);
+    }
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    const retiredSession = (await this.ctx.storage.get(`retired-session:${sessionId}`)) as
+      | RetiredSession
+      | undefined;
+    return retiredSession ?? null;
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    await this.ctx.storage.put(`retired-session:${retiredSession.sessionId}`, retiredSession);
+    return retiredSession;
+  }
+
   // BETA-005: Durable verification-token lifecycle methods
   async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
     const token = (await this.ctx.storage.get(`verification-token:hash:${tokenHash}`)) as

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -7,11 +7,16 @@ import type {
   Receipt,
   StoredEnvelope,
   User,
+  VerificationPurpose,
+  VerificationToken,
 } from "./domain";
 import type {
   AcquireIdempotencyResult,
+  ConsumeVerificationTokenResult,
   InsertEnvelopeResult,
+  IssueVerificationTokenResult,
   PostageTransitionResult,
+  RecordVerificationAttemptResult,
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
@@ -323,6 +328,123 @@ export class StealthCoordinator extends DurableObjectBase {
   async setCredential(credential: Credential): Promise<Credential> {
     await this.ctx.storage.put(`credential:${credential.userId}`, credential);
     return credential;
+  }
+
+  // BETA-005: Durable verification-token lifecycle methods
+  async getVerificationToken(tokenHash: string): Promise<VerificationToken | null> {
+    const token = (await this.ctx.storage.get(`verification-token:hash:${tokenHash}`)) as
+      | VerificationToken
+      | undefined;
+    return token ?? null;
+  }
+
+  async getActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+  ): Promise<VerificationToken | null> {
+    const tokenHash = (await this.ctx.storage.get(
+      `verification-token:active:${userId}:${purpose}`,
+    )) as string | undefined;
+    if (!tokenHash) return null;
+    return this.getVerificationToken(tokenHash);
+  }
+
+  async issueVerificationToken(
+    token: VerificationToken,
+    now: Date,
+  ): Promise<IssueVerificationTokenResult> {
+    return this.runExclusive(
+      `verification-token:user:${token.userId}:${token.purpose}`,
+      async () => {
+        const existingHash = (await this.ctx.storage.get(
+          `verification-token:hash:${token.tokenHash}`,
+        )) as VerificationToken | undefined;
+        if (existingHash) {
+          return { outcome: "conflict", token: existingHash };
+        }
+
+        const activeHash = (await this.ctx.storage.get(
+          `verification-token:active:${token.userId}:${token.purpose}`,
+        )) as string | undefined;
+        let replacedToken: VerificationToken | null = null;
+        if (activeHash && activeHash !== token.tokenHash) {
+          const current = (await this.ctx.storage.get(`verification-token:hash:${activeHash}`)) as
+            | VerificationToken
+            | undefined;
+          if (current && current.consumedAt === null && current.replacedAt === null) {
+            const invalidated: VerificationToken = {
+              ...current,
+              replacedAt: now.toISOString(),
+              replacedByTokenHash: token.tokenHash,
+            };
+            await this.ctx.storage.put(`verification-token:hash:${activeHash}`, invalidated);
+            replacedToken = invalidated;
+          }
+        }
+
+        await this.ctx.storage.put(`verification-token:hash:${token.tokenHash}`, token);
+        await this.ctx.storage.put(
+          `verification-token:active:${token.userId}:${token.purpose}`,
+          token.tokenHash,
+        );
+        return { outcome: "issued", token, replacedToken };
+      },
+    );
+  }
+
+  async consumeVerificationToken(
+    tokenHash: string,
+    now: Date,
+  ): Promise<ConsumeVerificationTokenResult> {
+    return this.runExclusive(`verification-token:consume:${tokenHash}`, async () => {
+      const current = (await this.ctx.storage.get(`verification-token:hash:${tokenHash}`)) as
+        | VerificationToken
+        | undefined;
+      if (!current) {
+        return { outcome: "not-found" as const };
+      }
+      if (current.consumedAt !== null) {
+        return { outcome: "already-consumed" as const, token: current };
+      }
+      if (current.replacedAt !== null) {
+        return { outcome: "replaced" as const, token: current };
+      }
+      if (current.attemptCount >= current.maxAttempts) {
+        return { outcome: "brute-force-blocked" as const, token: current };
+      }
+      if (Date.parse(current.expiresAt) <= now.getTime()) {
+        return { outcome: "expired" as const, token: current };
+      }
+      const consumed: VerificationToken = {
+        ...current,
+        consumedAt: now.toISOString(),
+      };
+      await this.ctx.storage.put(`verification-token:hash:${tokenHash}`, consumed);
+      return { outcome: "consumed" as const, token: consumed };
+    });
+  }
+
+  async recordVerificationAttempt(
+    tokenHash: string,
+    now: Date,
+  ): Promise<RecordVerificationAttemptResult> {
+    return this.runExclusive(`verification-token:consume:${tokenHash}`, async () => {
+      const current = (await this.ctx.storage.get(`verification-token:hash:${tokenHash}`)) as
+        | VerificationToken
+        | undefined;
+      if (!current) {
+        return { recorded: false, token: null };
+      }
+      if (current.consumedAt !== null || current.replacedAt !== null) {
+        return { recorded: false, token: current };
+      }
+      const updated: VerificationToken = {
+        ...current,
+        attemptCount: current.attemptCount + 1,
+      };
+      await this.ctx.storage.put(`verification-token:hash:${tokenHash}`, updated);
+      return { recorded: true, token: updated };
+    });
   }
 
   async getCounter(key: string): Promise<number> {

--- a/src/server/api/verification-delivery.ts
+++ b/src/server/api/verification-delivery.ts
@@ -1,0 +1,63 @@
+import { loadRuntimeConfig } from "@/config";
+import type { ConfigProfile, NotificationsConfig } from "@/config/schema";
+import { createNotificationAdapter, type NotificationAdapter } from "@/services/notifications";
+
+/**
+ * BETA-005: Resolution of the delivery configuration for verification
+ * messages, resolved from the runtime config contract (BETA-001).
+ *
+ * The adapter is memoized per process so the local-development capture sink
+ * keeps buffered messages across requests; production always constructs the
+ * SMTP transport and fails fast when the deployment is misconfigured.
+ */
+
+export interface VerificationDeliveryConfig {
+  profile: ConfigProfile;
+  notifications: NotificationsConfig;
+  appUrl: string;
+}
+
+let cachedDelivery: VerificationDeliveryConfig | null = null;
+
+export async function getVerificationDeliveryConfig(): Promise<VerificationDeliveryConfig> {
+  if (cachedDelivery) return cachedDelivery;
+
+  if (import.meta.env.PROD) {
+    const { env } = await import("cloudflare:workers");
+    const config = loadRuntimeConfig({
+      profile: "production",
+      env: env as unknown as Record<string, unknown>,
+    });
+    cachedDelivery = {
+      profile: config.profile,
+      notifications: config.notifications,
+      appUrl: config.origin.appUrl,
+    };
+    return cachedDelivery;
+  }
+
+  const config = loadRuntimeConfig({ profile: "development" });
+  cachedDelivery = {
+    profile: config.profile,
+    notifications: config.notifications,
+    appUrl: config.origin.appUrl,
+  };
+  return cachedDelivery;
+}
+
+let adapterOverride: NotificationAdapter | null = null;
+
+/**
+ * Test-only seam: installs a fixed adapter (e.g. a pre-created capture sink)
+ * so route-level tests can inspect delivered messages. Never invoked by the
+ * production path.
+ */
+export function setVerificationAdapterForTesting(adapter: NotificationAdapter | null): void {
+  adapterOverride = adapter;
+}
+
+export async function getVerificationNotificationAdapter(): Promise<NotificationAdapter> {
+  if (adapterOverride) return adapterOverride;
+  const delivery = await getVerificationDeliveryConfig();
+  return createNotificationAdapter(delivery.notifications, delivery.profile);
+}

--- a/src/server/api/verification-service.ts
+++ b/src/server/api/verification-service.ts
@@ -1,0 +1,380 @@
+import type { VerificationToken } from "./domain";
+import { ApiError } from "./errors";
+import type { ApiContext } from "./context";
+import { recordAuditEvent } from "./audit";
+import type { DeliveryReceipt, VerificationEmailMessage } from "@/services/notifications/adapter";
+import type { ApiRepository } from "./repository";
+
+/**
+ * BETA-005: Verification-token lifecycle.
+ *
+ * Implements the full vertical slice for account verification:
+ *
+ * 1. Issuing hashed, single-use, expiring tokens (with replacement semantics:
+ *    a resend invalidates the previous token atomically).
+ * 2. Verification with replay safety, expiry, and brute-force attempt caps.
+ * 3. Resend with cooldown enforcement.
+ *
+ * Security invariants:
+ * - The plaintext token is generated here, handed to the delivery adapter,
+ *   and NEVER persisted, logged, or returned in an API response. Only the
+ *   SHA-256 hash is stored (see `verificationTokenSchema`).
+ * - All transitions (issue/consume/attempt) run through the repository's
+ *   atomic, per-key exclusive operations, so concurrent requests observe a
+ *   single winner.
+ * - Audit events reference the token *hash* (a safe, correlatable reference),
+ *   never the plaintext token.
+ */
+
+export interface VerificationPolicy {
+  tokenLifetimeMs: number;
+  resendCooldownMs: number;
+  maxAttempts: number;
+}
+
+export const DEFAULT_VERIFICATION_POLICY: VerificationPolicy = {
+  tokenLifetimeMs: 24 * 60 * 60 * 1000,
+  resendCooldownMs: 60 * 1000,
+  maxAttempts: 5,
+};
+
+export const VERIFICATION_PURPOSE = "email_verification" as const;
+
+/** Token size: 32 random bytes -> 43 base64url characters (~256 bits). */
+export const VERIFICATION_TOKEN_BYTES = 32;
+
+export type VerifyFailureReason =
+  | "invalid_token"
+  | "expired"
+  | "reused"
+  | "replaced"
+  | "brute_force_blocked"
+  | "activation_failed";
+
+export type VerifyOutcome =
+  | { outcome: "verified"; userId: string }
+  | { outcome: "failed"; reason: VerifyFailureReason; userId?: string };
+
+export type ResendOutcome =
+  | { outcome: "sent"; userId: string; retryAfterSeconds: number; expiresAt: Date }
+  /** Generic no-op: no pending account (or already verified) — nothing leaked. */
+  | { outcome: "noop" }
+  | { outcome: "cooldown"; userId: string; retryAfterSeconds: number }
+  | { outcome: "delivery_failed"; userId: string; retryAfterSeconds: number };
+
+export interface IssuedVerificationToken {
+  plaintextToken: string;
+  tokenHash: string;
+  expiresAt: Date;
+  replaced: boolean;
+}
+
+function requestIdOf(context: ApiContext): string {
+  return context.requestId ?? "unknown";
+}
+
+/**
+ * Generate a cryptographically secure random verification token.
+ * 256 bits of entropy via `crypto.getRandomValues`; there is no Math.random
+ * fallback — an unsupported environment fails explicitly.
+ */
+export function generateVerificationToken(): string {
+  if (typeof crypto === "undefined" || typeof crypto.getRandomValues !== "function") {
+    throw new ApiError(
+      500,
+      "internal_error",
+      "Cryptographically secure random source is unavailable",
+    );
+  }
+  const bytes = new Uint8Array(VERIFICATION_TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** SHA-256 of the plaintext token, lowercase hex — the only persisted form. */
+export async function hashVerificationToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  let out = "";
+  for (const byte of new Uint8Array(digest)) {
+    out += byte.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Issue a new verification token for a user, atomically invalidating the
+ * previous still-redeemable token for the same (user, purpose).
+ */
+export async function issueEmailVerificationToken(
+  context: ApiContext,
+  userId: string,
+  policy: VerificationPolicy = DEFAULT_VERIFICATION_POLICY,
+  now: Date = new Date(),
+): Promise<IssuedVerificationToken> {
+  const plaintextToken = generateVerificationToken();
+  const tokenHash = await hashVerificationToken(plaintextToken);
+
+  const token: VerificationToken = {
+    tokenHash,
+    userId,
+    purpose: VERIFICATION_PURPOSE,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + policy.tokenLifetimeMs).toISOString(),
+    consumedAt: null,
+    replacedAt: null,
+    replacedByTokenHash: null,
+    attemptCount: 0,
+    maxAttempts: policy.maxAttempts,
+  };
+
+  const result = await context.repository.issueVerificationToken(token, now);
+  if (result.outcome === "conflict") {
+    // 256-bit collision — fails closed rather than overwriting a stored record.
+    throw new ApiError(500, "internal_error", "Verification token generation collided");
+  }
+
+  return {
+    plaintextToken,
+    tokenHash,
+    expiresAt: new Date(token.expiresAt),
+    replaced: result.replacedToken !== null,
+  };
+}
+
+/**
+ * Verify a candidate token for the given account email.
+ *
+ * Repeat-safe: replaying a token that already verified an account that is now
+ * `active` reports success rather than an error, so retries and double-clicks
+ * are safe. Every other failure path is recorded as a brute-force attempt.
+ */
+export async function verifyEmailVerificationToken(
+  context: ApiContext,
+  email: string,
+  candidateToken: string,
+  now: Date = new Date(),
+): Promise<VerifyOutcome> {
+  const repository = context.repository;
+  const user = await repository.getUserByEmail(email);
+  const tokenHash = await hashVerificationToken(candidateToken);
+
+  const result = await repository.consumeVerificationToken(tokenHash, now);
+
+  if (result.outcome === "not-found") {
+    recordAuditEvent({
+      actor: email,
+      action: "auth.verification_failed",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    return { outcome: "failed", reason: "invalid_token" };
+  }
+
+  const tokenUserId = result.token.userId;
+  const belongsToEmail = user !== null && user.userId === tokenUserId;
+
+  if (result.outcome === "consumed") {
+    if (!belongsToEmail) {
+      recordAuditEvent({
+        actor: email,
+        action: "auth.verification_failed",
+        targetType: "verification_token",
+        safeTargetReference: tokenHash,
+        result: "denied",
+        requestId: requestIdOf(context),
+      });
+      return { outcome: "failed", reason: "invalid_token", userId: tokenUserId };
+    }
+    const activated = await activateUserIfPending(repository, tokenUserId, now);
+    if (!activated) {
+      recordAuditEvent({
+        actor: tokenUserId,
+        action: "auth.verification_activation_failed",
+        targetType: "verification_token",
+        safeTargetReference: tokenHash,
+        result: "denied",
+        requestId: requestIdOf(context),
+      });
+      return { outcome: "failed", reason: "activation_failed", userId: tokenUserId };
+    }
+    recordAuditEvent({
+      actor: tokenUserId,
+      action: "auth.verification_succeeded",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "success",
+      requestId: requestIdOf(context),
+    });
+    return { outcome: "verified", userId: tokenUserId };
+  }
+
+  // Terminal outcomes: expired / reused / replaced / brute-force blocked.
+  // A replay of an already-verified token against an active account is safe
+  // to acknowledge as success (no state change occurs).
+  if (result.outcome === "already-consumed" && belongsToEmail && user.status === "active") {
+    recordAuditEvent({
+      actor: tokenUserId,
+      action: "auth.verification_replayed",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "success",
+      requestId: requestIdOf(context),
+    });
+    return { outcome: "verified", userId: tokenUserId };
+  }
+
+  await repository.recordVerificationAttempt(tokenHash, now);
+
+  const reason: VerifyFailureReason =
+    result.outcome === "expired"
+      ? "expired"
+      : result.outcome === "replaced"
+        ? "replaced"
+        : result.outcome === "brute-force-blocked"
+          ? "brute_force_blocked"
+          : "reused";
+
+  recordAuditEvent({
+    actor: tokenUserId,
+    action: `auth.verification_failed.${reason}`,
+    targetType: "verification_token",
+    safeTargetReference: tokenHash,
+    result: "denied",
+    requestId: requestIdOf(context),
+  });
+  return { outcome: "failed", reason, userId: tokenUserId };
+}
+
+/**
+ * Resend a verification message, enforcing the resend cooldown.
+ *
+ * Generic-response contract: unknown emails and accounts that are not pending
+ * verification return `noop` without issuing a token or revealing anything.
+ */
+export async function resendEmailVerificationToken(
+  context: ApiContext,
+  email: string,
+  policy: VerificationPolicy,
+  deliver: (message: VerificationEmailMessage) => Promise<DeliveryReceipt>,
+  appUrl: string,
+  now: Date = new Date(),
+): Promise<ResendOutcome> {
+  const repository = context.repository;
+  const user = await repository.getUserByEmail(email);
+
+  if (!user || user.status !== "pending_verification") {
+    return { outcome: "noop" };
+  }
+
+  const active = await repository.getActiveVerificationToken(user.userId, VERIFICATION_PURPOSE);
+  if (active && active.consumedAt === null && active.replacedAt === null) {
+    const elapsedMs = now.getTime() - Date.parse(active.createdAt);
+    const remainingMs = policy.resendCooldownMs - elapsedMs;
+    if (remainingMs > 0) {
+      return {
+        outcome: "cooldown",
+        userId: user.userId,
+        retryAfterSeconds: Math.ceil(remainingMs / 1000),
+      };
+    }
+  }
+
+  const issued = await issueEmailVerificationToken(context, user.userId, policy, now);
+  const verificationUrl = buildVerificationUrl(appUrl, email, issued.plaintextToken);
+
+  const message: VerificationEmailMessage = {
+    to: user.email,
+    purpose: VERIFICATION_PURPOSE,
+    verificationUrl,
+    expiresAt: issued.expiresAt,
+  };
+
+  let receipt: DeliveryReceipt;
+  try {
+    receipt = await deliver(message);
+  } catch (error) {
+    recordAuditEvent({
+      actor: user.userId,
+      action: "auth.verification_delivery_failed",
+      targetType: "verification_token",
+      safeTargetReference: issued.tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw error;
+  }
+
+  if (!receipt.accepted) {
+    recordAuditEvent({
+      actor: user.userId,
+      action: "auth.verification_delivery_failed",
+      targetType: "verification_token",
+      safeTargetReference: issued.tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    return {
+      outcome: "delivery_failed",
+      userId: user.userId,
+      retryAfterSeconds: Math.ceil(policy.resendCooldownMs / 1000),
+    };
+  }
+
+  recordAuditEvent({
+    actor: user.userId,
+    action: "auth.verification_token_issued",
+    targetType: "verification_token",
+    safeTargetReference: issued.tokenHash,
+    result: "success",
+    requestId: requestIdOf(context),
+  });
+
+  return {
+    outcome: "sent",
+    userId: user.userId,
+    retryAfterSeconds: Math.ceil(policy.resendCooldownMs / 1000),
+    expiresAt: issued.expiresAt,
+  };
+}
+
+/** Builds the clickable verification link carrying the plaintext token. */
+export function buildVerificationUrl(
+  appUrl: string,
+  email: string,
+  plaintextToken: string,
+): string {
+  const base = appUrl.endsWith("/") ? appUrl.slice(0, -1) : appUrl;
+  const params = new URLSearchParams({
+    email,
+    token: plaintextToken,
+  });
+  return `${base}/verify?${params.toString()}`;
+}
+
+async function activateUserIfPending(
+  repository: ApiRepository,
+  userId: string,
+  now: Date,
+): Promise<boolean> {
+  const user = await repository.getUserById(userId);
+  if (!user) return false;
+  if (user.status === "active") return true;
+  if (user.status !== "pending_verification") return false;
+
+  const first = await repository.updateUser({ ...user, status: "active" }, user.version);
+  if (first.updated) return true;
+
+  // Optimistic concurrency conflict: refresh and retry once.
+  const fresh = await repository.getUserById(userId);
+  if (!fresh) return false;
+  if (fresh.status === "active") return true;
+  if (fresh.status !== "pending_verification") return false;
+  const retry = await repository.updateUser({ ...fresh, status: "active" }, fresh.version);
+  return retry.updated;
+}

--- a/src/services/notifications/adapter.ts
+++ b/src/services/notifications/adapter.ts
@@ -1,0 +1,46 @@
+import type { NotificationTransport } from "@/config/schema";
+
+/**
+ * BETA-005: Pluggable verification-message delivery contract.
+ *
+ * The signup flow must deliver a verification message without depending on a
+ * third-party mail vendor. Every transport implements this single interface:
+ *
+ * - `sink` — local-development capture sink (messages buffered in memory).
+ * - `smtp` — self-hosted SMTP delivery.
+ *
+ * Security invariants:
+ * - Adapters receive the plaintext verification token (or a URL carrying it)
+ *   ONLY to deliver it to the account owner's inbox; they never persist or
+ *   log the token, and delivery receipts never echo it.
+ * - `safeTargetReference` on delivery receipts is a non-secret correlation
+ *   reference (e.g. a recipient hash), never the token.
+ */
+
+export interface VerificationEmailMessage {
+  /** Recipient address (normalized account email). */
+  to: string;
+  /** Verified account purpose — always "email_verification" in BETA-005. */
+  purpose: "email_verification";
+  /** Absolute URL the recipient opens to complete verification. */
+  verificationUrl: string;
+  /** Expiry instant of the token carried by the verification URL. */
+  expiresAt: Date;
+}
+
+export interface DeliveryReceipt {
+  transport: NotificationTransport;
+  /** Whether the transport accepted the message for delivery. */
+  accepted: boolean;
+  /** Non-secret provider reference (sink sequence id, SMTP message id). */
+  providerRef?: string;
+  /** Non-secret correlation reference; never the plaintext token. */
+  safeTargetReference: string;
+}
+
+export interface NotificationAdapter {
+  readonly transport: NotificationTransport;
+  deliverVerificationEmail(message: VerificationEmailMessage): Promise<DeliveryReceipt>;
+}
+
+export type { NotificationTransport };

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -1,0 +1,54 @@
+import type { ConfigProfile, NotificationsConfig } from "@/config/schema";
+import type { NotificationAdapter } from "./adapter";
+import { SinkNotificationAdapter } from "./sink";
+import { SmtpNotificationAdapter } from "./smtp";
+
+export * from "./adapter";
+export * from "./sink";
+export * from "./smtp";
+
+/**
+ * BETA-005: Creates the notification adapter selected by runtime config.
+ *
+ * - "sink" — local-development capture; hard-refused in the production path.
+ * - "smtp" — self-hosted SMTP delivery.
+ *
+ * Misconfiguration fails fast at construction time (never silently falls back
+ * to a demo transport), so a production deployment cannot accidentally send
+ * verification messages through the dev sink.
+ */
+export function createNotificationAdapter(
+  config: NotificationsConfig,
+  profile: ConfigProfile = "development",
+): NotificationAdapter {
+  if (config.transport === "sink") {
+    if (profile === "production") {
+      throw new Error(
+        "Configuration error: the 'sink' notification transport must never be selected in production.",
+      );
+    }
+    return new SinkNotificationAdapter();
+  }
+
+  if (config.smtp.host === "smtp.invalid" || config.smtp.host.trim().length === 0) {
+    throw new Error(
+      "Configuration error: STEALTH_SMTP_HOST must point at a self-hosted SMTP server.",
+    );
+  }
+
+  return new SmtpNotificationAdapter({
+    ...config.smtp,
+    fromAddress: config.fromAddress,
+  });
+}
+
+/**
+ * True when the selected transport is safe for the given profile. The dev
+ * capture sink is never allowed in production.
+ */
+export function isNotificationTransportAllowed(
+  transport: NotificationsConfig["transport"],
+  profile: ConfigProfile,
+): boolean {
+  return !(profile === "production" && transport === "sink");
+}

--- a/src/services/notifications/sink.ts
+++ b/src/services/notifications/sink.ts
@@ -1,0 +1,69 @@
+import type { DeliveryReceipt, NotificationAdapter, VerificationEmailMessage } from "./adapter";
+
+/**
+ * BETA-005: Local-development capture sink.
+ *
+ * Captures verification messages in memory instead of sending them over the
+ * network. This is the default transport for development/preview profiles and
+ * MUST NOT be selected in the production path — the production transport
+ * defaults to SMTP and the adapter factory refuses to construct a sink in
+ * production.
+ *
+ * The captured messages are visible to tests and local tooling only; the
+ * buffer is never persisted and is cleared on `clear()`.
+ */
+export class SinkNotificationAdapter implements NotificationAdapter {
+  readonly transport = "sink" as const;
+
+  private readonly messages: VerificationEmailMessage[] = [];
+
+  constructor(private readonly maxBuffered: number = 1000) {}
+
+  async deliverVerificationEmail(message: VerificationEmailMessage): Promise<DeliveryReceipt> {
+    if (this.messages.length >= this.maxBuffered) {
+      this.messages.shift();
+    }
+    this.messages.push({ ...message, expiresAt: new Date(message.expiresAt) });
+    return {
+      transport: "sink",
+      accepted: true,
+      providerRef: `sink-${this.messages.length}`,
+      safeTargetReference: await sha256Reference(message.to),
+    };
+  }
+
+  /** Messages captured so far, oldest first. Never persisted. */
+  get capturedMessages(): readonly VerificationEmailMessage[] {
+    return this.messages.map((message) => ({ ...message, expiresAt: new Date(message.expiresAt) }));
+  }
+
+  /** Most recently captured message, if any. */
+  get latestMessage(): VerificationEmailMessage | null {
+    const latest = this.messages.at(-1);
+    return latest ? { ...latest, expiresAt: new Date(latest.expiresAt) } : null;
+  }
+
+  get size(): number {
+    return this.messages.length;
+  }
+
+  clear(): void {
+    this.messages.length = 0;
+  }
+}
+
+async function sha256Reference(value: string): Promise<string> {
+  if (typeof crypto === "undefined" || !crypto.subtle) {
+    return `ref:${value}`;
+  }
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return toHex(new Uint8Array(digest));
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const byte of bytes) {
+    out += byte.toString(16).padStart(2, "0");
+  }
+  return out;
+}

--- a/src/services/notifications/smtp.ts
+++ b/src/services/notifications/smtp.ts
@@ -1,0 +1,363 @@
+import type { SmtpConfig } from "@/config/schema";
+import type { DeliveryReceipt, NotificationAdapter, VerificationEmailMessage } from "./adapter";
+
+/**
+ * BETA-005: Self-hosted SMTP delivery adapter.
+ *
+ * A minimal RFC 5321 client implemented directly over a socket transport, so
+ * account verification delivery never depends on a third-party mail vendor.
+ * The socket source is pluggable (Node `net`/`tls` in tests and local tooling,
+ * Cloudflare Workers `connect()` in production), which also makes the full
+ * protocol conversation testable with scripted sockets.
+ *
+ * Protocol flow: EHLO -> (AUTH PLAIN when credentials are configured) ->
+ * MAIL FROM -> RCPT TO -> DATA -> QUIT. STARTTLS is negotiated after EHLO when
+ * `startTls` is enabled and the transport supports it.
+ *
+ * Security invariants:
+ * - The plaintext token travels only inside the DATA payload destined for the
+ *   account owner's mailbox; it is never persisted, logged, or echoed in
+ *   error surface of this adapter (errors carry the SMTP reply *code* only).
+ * - Credentials are sent only when configured, only over an active TLS
+ *   session (secure connection or post-STARTTLS), never in the clear.
+ */
+export class SmtpError extends Error {
+  readonly code = "smtp_delivery_failed" as const;
+  readonly retryable = true;
+  /** The SMTP verb that failed, e.g. "MAIL FROM". */
+  readonly command?: string;
+  /** Numeric SMTP reply code (never the payload). */
+  readonly replyCode?: number;
+
+  constructor(message: string, options?: { command?: string; replyCode?: number }) {
+    super(message);
+    this.name = "SmtpError";
+    this.command = options?.command;
+    this.replyCode = options?.replyCode;
+  }
+}
+
+/** Minimal socket surface shared by Node net/tls sockets and Worker sockets. */
+export interface SmtpSocketLike {
+  write(data: string): void;
+  end(): void;
+  destroy(): void;
+  setTimeout(ms: number, callback?: () => void): unknown;
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  off?(event: string, listener: (...args: unknown[]) => void): unknown;
+  /** Workers-only: upgrades the connection to TLS in place. */
+  startTls?(): unknown;
+}
+
+export interface SmtpConnectionOptions {
+  host: string;
+  port: number;
+  secure: boolean;
+}
+
+export type SmtpSocketFactory = (
+  options: SmtpConnectionOptions,
+) => Promise<SmtpSocketLike> | SmtpSocketLike;
+
+export interface SmtpAdapterOptions extends SmtpConfig {
+  fromAddress: string;
+  /** Injectable for tests; defaults to the environment's native transport. */
+  socketFactory?: SmtpSocketFactory;
+  /** Socket inactivity timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+const CRLF = "\r\n";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+const isNodeRuntime = () => typeof process !== "undefined" && Boolean(process.versions?.node);
+
+/**
+ * Native socket factory: Node `net`/`tls` when running under Node (tests,
+ * local tooling), Cloudflare Workers `connect()` otherwise.
+ */
+export async function defaultSmtpSocketFactory(
+  options: SmtpConnectionOptions,
+): Promise<SmtpSocketLike> {
+  if (isNodeRuntime()) {
+    const { createConnection } = await import("node:net");
+    const { connect: tlsConnect } = await import("node:tls");
+    if (options.secure) {
+      return tlsConnect({
+        host: options.host,
+        port: options.port,
+        servername: options.host,
+        rejectUnauthorized: false,
+      }) as unknown as SmtpSocketLike;
+    }
+    return createConnection({
+      host: options.host,
+      port: options.port,
+    }) as unknown as SmtpSocketLike;
+  }
+
+  // Cloudflare Workers: TCP socket from cloudflare:sockets.
+  const { connect } = await import("cloudflare:sockets");
+  const socket = connect({
+    hostname: options.host,
+    port: options.port,
+    secureTransport: options.secure ? "on" : "starttls",
+  });
+  return {
+    write: (data: string) => socket.write(data),
+    end: () => socket.close(),
+    destroy: () => socket.close(),
+    setTimeout: () => undefined,
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      if (event === "timeout") return socket;
+      socket.addEventListener(event, (eventData: unknown) => {
+        const payload = (eventData as { data?: unknown })?.data ?? eventData;
+        listener(payload);
+      });
+      return socket;
+    },
+    startTls: () => socket.startTls(),
+  } satisfies SmtpSocketLike;
+}
+
+interface SmtpReply {
+  code: number;
+  text: string;
+}
+
+/**
+ * Reader that assembles SMTP replies from socket data, handling multi-line
+ * replies (continuation lines carry "NNN-", the final line "NNN ").
+ */
+class ReplyStream {
+  private buffer = "";
+  private readonly waiters: Array<{
+    resolve: (reply: SmtpReply) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  private error: Error | null = null;
+
+  constructor(socket: SmtpSocketLike) {
+    socket.on("data", (chunk: unknown) => {
+      this.buffer += chunkToString(chunk);
+      this.drain();
+    });
+    socket.on("error", (error: unknown) => {
+      this.fail(error instanceof Error ? error : new Error(String(error)));
+    });
+  }
+
+  private drain(): void {
+    while (this.waiters.length > 0) {
+      const reply = this.extractReply();
+      if (reply === null) return;
+      this.waiters.shift()!.resolve(reply);
+    }
+  }
+
+  private extractReply(): SmtpReply | null {
+    let code = 0;
+    let sawFinal = false;
+    const lines: string[] = [];
+
+    while (this.buffer.includes(CRLF)) {
+      const index = this.buffer.indexOf(CRLF);
+      const line = this.buffer.slice(0, index);
+      this.buffer = this.buffer.slice(index + CRLF.length);
+
+      const match = /^(\d{3})([ -])(.*)$/.exec(line);
+      if (!match) continue;
+      if (code === 0) {
+        code = Number(match[1]);
+      } else if (Number(match[1]) !== code) {
+        // Tolerate a stray line from another session; only the code we are
+        // waiting on completes the reply.
+        continue;
+      }
+      lines.push(match[3]);
+      if (match[2] === " ") {
+        sawFinal = true;
+        break;
+      }
+    }
+
+    if (!sawFinal) return null;
+    return { code, text: lines.join("\n") };
+  }
+
+  next(): Promise<SmtpReply> {
+    if (this.error) {
+      return Promise.reject(this.error);
+    }
+    const pending = this.extractReply();
+    if (pending) {
+      return Promise.resolve(pending);
+    }
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  fail(error: Error): void {
+    this.error = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
+  }
+}
+
+function chunkToString(chunk: unknown): string {
+  if (typeof chunk === "string") return chunk;
+  if (chunk instanceof Uint8Array) return new TextDecoder().decode(chunk);
+  if (chunk instanceof ArrayBuffer) return new TextDecoder().decode(chunk);
+  return String(chunk);
+}
+
+function base64(value: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf8").toString("base64");
+  }
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export class SmtpNotificationAdapter implements NotificationAdapter {
+  readonly transport = "smtp" as const;
+
+  private readonly config: SmtpAdapterOptions;
+  private readonly socketFactory: SmtpSocketFactory;
+  private readonly timeoutMs: number;
+
+  constructor(options: SmtpAdapterOptions) {
+    this.config = options;
+    this.socketFactory = options.socketFactory ?? defaultSmtpSocketFactory;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async deliverVerificationEmail(message: VerificationEmailMessage): Promise<DeliveryReceipt> {
+    const { host, port, secure } = this.config;
+    const socket = await this.socketFactory({ host, port, secure });
+    const replies = new ReplyStream(socket);
+    const messageId = `<${crypto.randomUUID()}@stealth.mail>`;
+
+    const withTimeout = <T>(work: Promise<T>, command: string): Promise<T> =>
+      new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          replies.fail(new SmtpError(`SMTP timed out during ${command}`, { command }));
+          socket.destroy();
+          reject(new SmtpError(`SMTP timed out during ${command}`, { command }));
+        }, this.timeoutMs);
+        work.then(
+          (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          (error: unknown) => {
+            clearTimeout(timer);
+            reject(error);
+          },
+        );
+      });
+
+    const expectReply = async (command: string, expected: number[]): Promise<SmtpReply> => {
+      const reply = await withTimeout(replies.next(), command);
+      if (!expected.includes(reply.code)) {
+        throw new SmtpError("SMTP delivery failed", { command, replyCode: reply.code });
+      }
+      return reply;
+    };
+
+    try {
+      await expectReply("connect", [220]);
+
+      // EHLO
+      await this.writeLine(socket, `EHLO stealth.mail${CRLF}`);
+      await expectReply("EHLO", [250]);
+
+      // STARTTLS upgrade when configured (never AUTH in the clear).
+      if (this.config.startTls && !secure && socket.startTls) {
+        await this.writeLine(socket, `STARTTLS${CRLF}`);
+        await expectReply("STARTTLS", [220]);
+        await socket.startTls();
+        await this.writeLine(socket, `EHLO stealth.mail${CRLF}`);
+        await expectReply("EHLO", [250]);
+      }
+
+      if (this.config.username && this.config.password) {
+        const credentials = base64(`\u0000${this.config.username}\u0000${this.config.password}`);
+        await this.writeLine(socket, `AUTH PLAIN ${credentials}${CRLF}`);
+        await expectReply("AUTH", [235]);
+      }
+
+      await this.writeLine(socket, `MAIL FROM:<${this.config.fromAddress}>${CRLF}`);
+      await expectReply("MAIL FROM", [250]);
+
+      await this.writeLine(socket, `RCPT TO:<${message.to}>${CRLF}`);
+      await expectReply("RCPT TO", [250, 251]);
+
+      await this.writeLine(socket, `DATA${CRLF}`);
+      await expectReply("DATA", [354]);
+
+      await this.writeLine(
+        socket,
+        [
+          `From: ${this.config.fromAddress}`,
+          `To: ${message.to}`,
+          `Subject: Verify your Stealth Mail account`,
+          `Date: ${new Date().toUTCString()}`,
+          `Message-ID: ${messageId}`,
+          `MIME-Version: 1.0`,
+          `Content-Type: text/plain; charset=utf-8`,
+          ``,
+          `Welcome to Stealth Mail.`,
+          ``,
+          `Open the link below to verify your account. The link expires on`,
+          `${message.expiresAt.toUTCString()}.`,
+          ``,
+          `${message.verificationUrl}`,
+          ``,
+          `If you did not request this message, you can safely ignore it.`,
+          ``,
+          `.`,
+        ].join(CRLF) + CRLF,
+      );
+      await expectReply("DATA", [250]);
+
+      await this.writeLine(socket, `QUIT${CRLF}`);
+      await withTimeout(
+        replies.next().then(() => undefined),
+        "QUIT",
+      ).catch(() => undefined);
+      socket.end();
+
+      return {
+        transport: "smtp",
+        accepted: true,
+        providerRef: messageId,
+        safeTargetReference: await this.sha256Reference(message.to),
+      };
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  private writeLine(socket: SmtpSocketLike, line: string): void {
+    socket.write(line);
+  }
+
+  private async sha256Reference(value: string): Promise<string> {
+    if (typeof crypto === "undefined" || !crypto.subtle) {
+      return `ref:${value}`;
+    }
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+    let out = "";
+    for (const byte of new Uint8Array(digest)) {
+      out += byte.toString(16).padStart(2, "0");
+    }
+    return out;
+  }
+}

--- a/src/types/cloudflare.d.ts
+++ b/src/types/cloudflare.d.ts
@@ -101,3 +101,17 @@ declare module "cloudflare:workers" {
     constructor(ctx: DurableObjectState, env: any);
   }
 }
+
+declare module "cloudflare:sockets" {
+  export interface Socket {
+    write(data: string): void;
+    close(): void;
+    startTls(): Socket;
+    addEventListener(type: string, listener: (event: unknown) => void): void;
+  }
+  export function connect(options: {
+    hostname: string;
+    port: number;
+    secureTransport: "on" | "off" | "starttls";
+  }): Socket;
+}

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -200,6 +200,29 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("insertEnvelope");
     return this.inner.insertEnvelope(envelope);
   }
+  async getVerificationToken(tokenHash: string) {
+    this.maybeFail("getVerificationToken");
+    return this.inner.getVerificationToken(tokenHash);
+  }
+  async getActiveVerificationToken(userId: string, purpose: "email_verification") {
+    this.maybeFail("getActiveVerificationToken");
+    return this.inner.getActiveVerificationToken(userId, purpose);
+  }
+  async issueVerificationToken(
+    token: import("../../../src/server/api/domain").VerificationToken,
+    now: Date,
+  ) {
+    this.maybeFail("issueVerificationToken");
+    return this.inner.issueVerificationToken(token, now);
+  }
+  async consumeVerificationToken(tokenHash: string, now: Date) {
+    this.maybeFail("consumeVerificationToken");
+    return this.inner.consumeVerificationToken(tokenHash, now);
+  }
+  async recordVerificationAttempt(tokenHash: string, now: Date) {
+    this.maybeFail("recordVerificationAttempt");
+    return this.inner.recordVerificationAttempt(tokenHash, now);
+  }
   reset(): void {
     this.inner.reset();
   }

--- a/tests/unit/api/verification-routes.test.ts
+++ b/tests/unit/api/verification-routes.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Route as ResendRoute } from "../../../src/routes/api/v1/auth/resend-verification";
+import { Route as VerifyRoute } from "../../../src/routes/api/v1/auth/verify";
+import { getApiContext } from "../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  getVerificationNotificationAdapter,
+  setVerificationAdapterForTesting,
+} from "../../../src/server/api/verification-delivery";
+import { SinkNotificationAdapter } from "../../../src/services/notifications/sink";
+
+const verifyHandler = (VerifyRoute.options as any).server?.handlers?.POST;
+const resendHandler = (ResendRoute.options as any).server?.handlers?.POST;
+
+const pendingUser = {
+  userId: "usr_route_1",
+  address: `G${"F".repeat(55)}`,
+  email: "carol@stealth.mail",
+  username: "carol_stealth",
+  status: "pending_verification" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  version: 1,
+};
+
+function postRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function parseJson(response: Response) {
+  return response.clone().json() as Promise<{
+    data?: Record<string, unknown>;
+    error?: { code: string; message: string; retryable: boolean; details?: unknown };
+  }>;
+}
+
+describe("BETA-005: verification endpoints (route-level tests)", () => {
+  let repo: MemoryApiRepository;
+  let sink: SinkNotificationAdapter;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+    sink = new SinkNotificationAdapter();
+    setVerificationAdapterForTesting(sink);
+    await repo.createUser(pendingUser);
+  });
+
+  afterEach(() => {
+    setVerificationAdapterForTesting(null);
+    repo.reset();
+  });
+
+  describe("POST /api/v1/auth/verify", () => {
+    it("verifies an account with a valid token", async () => {
+      const adapter = await getVerificationNotificationAdapter();
+      expect(adapter).toBe(sink);
+
+      const resend = await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: pendingUser.email,
+        }),
+      });
+      expect(resend.status).toBe(200);
+
+      const message = sink.latestMessage;
+      const token = message!.verificationUrl.split("token=")[1];
+      const response = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: pendingUser.email,
+          token,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ verified: true });
+      const user = await repo.getUserById(pendingUser.userId);
+      expect(user!.status).toBe("active");
+    });
+
+    it("reports token state without revealing account existence", async () => {
+      const response = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: pendingUser.email,
+          token: "not-a-real-token",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ verified: false, reason: "invalid_token" });
+    });
+
+    it("accepts a replayed token as verified (idempotent retries)", async () => {
+      await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: pendingUser.email,
+        }),
+      });
+      const token = sink.latestMessage!.verificationUrl.split("token=")[1];
+
+      const first = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: pendingUser.email,
+          token,
+        }),
+      });
+      const second = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: pendingUser.email,
+          token,
+        }),
+      });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect((await parseJson(second)).data).toEqual({ verified: true });
+    });
+
+    it("rejects an invalid email with 422", async () => {
+      const response = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: "not-an-email",
+          token: "abc",
+        }),
+      });
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+
+    it("rejects an empty token with 422", async () => {
+      const response = await verifyHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/verify", {
+          email: pendingUser.email,
+          token: "  ",
+        }),
+      });
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+  });
+
+  describe("POST /api/v1/auth/resend-verification", () => {
+    it("sends a verification message for a pending account", async () => {
+      const response = await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: pendingUser.email,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ status: "sent" });
+      expect(sink.size).toBe(1);
+      expect(sink.latestMessage!.to).toBe(pendingUser.email);
+    });
+
+    it("responds identically for unknown emails (no account enumeration)", async () => {
+      const response = await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: "ghost@stealth.mail",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect((await parseJson(response)).data).toEqual({ status: "sent" });
+      expect(sink.size).toBe(0);
+    });
+
+    it("returns 429 during the resend cooldown with a retry-after window", async () => {
+      await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: pendingUser.email,
+        }),
+      });
+
+      const response = await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: pendingUser.email,
+        }),
+      });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("retry-after")).not.toBeNull();
+      const body = await parseJson(response);
+      expect(body.error?.code).toBe("too_many_requests");
+      expect(
+        (body.error?.details as { retryAfterSeconds?: number }).retryAfterSeconds,
+      ).toBeGreaterThan(0);
+      expect(sink.size).toBe(1);
+    });
+
+    it("allows a resend after the cooldown has elapsed", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+      try {
+        await resendHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+            email: pendingUser.email,
+          }),
+        });
+
+        vi.setSystemTime(new Date("2026-02-01T00:01:01.000Z"));
+        const response = await resendHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+            email: pendingUser.email,
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(sink.size).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("rejects an invalid email with 422", async () => {
+      const response = await resendHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/resend-verification", {
+          email: "invalid",
+        }),
+      });
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+  });
+});

--- a/tests/unit/api/verification-service.test.ts
+++ b/tests/unit/api/verification-service.test.ts
@@ -1,0 +1,397 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getApiContext } from "../../../src/server/api/context";
+import type { ApiContext } from "../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  buildVerificationUrl,
+  DEFAULT_VERIFICATION_POLICY,
+  generateVerificationToken,
+  hashVerificationToken,
+  issueEmailVerificationToken,
+  resendEmailVerificationToken,
+  verifyEmailVerificationToken,
+  type VerificationPolicy,
+} from "../../../src/server/api/verification-service";
+import { VERIFICATION_PURPOSE } from "../../../src/server/api/verification-service";
+import type { VerificationEmailMessage } from "../../../src/services/notifications/adapter";
+
+const pendingUser = {
+  userId: "usr_verify_1",
+  address: `G${"D".repeat(55)}`,
+  email: "alice@stealth.mail",
+  username: "alice_stealth",
+  status: "pending_verification" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  version: 1,
+};
+
+const otherUser = {
+  userId: "usr_verify_2",
+  address: `G${"E".repeat(55)}`,
+  email: "bob@stealth.mail",
+  username: "bob_stealth",
+  status: "pending_verification" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  version: 1,
+};
+
+const policy: VerificationPolicy = {
+  tokenLifetimeMs: 60_000,
+  resendCooldownMs: 30_000,
+  maxAttempts: 5,
+};
+
+describe("BETA-005: verification-token service lifecycle", () => {
+  let context: ApiContext;
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    context = await getApiContext();
+    repo = context.repository as MemoryApiRepository;
+    repo.reset();
+    await repo.createUser(pendingUser);
+    await repo.createUser(otherUser);
+  });
+
+  afterEach(() => {
+    repo.reset();
+  });
+
+  describe("generateVerificationToken", () => {
+    it("produces 43-character base64url tokens (256 bits of entropy)", () => {
+      const token = generateVerificationToken();
+      expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    });
+
+    it("produces distinct tokens per call", () => {
+      const tokens = new Set(Array.from({ length: 32 }, () => generateVerificationToken()));
+      expect(tokens.size).toBe(32);
+    });
+  });
+
+  describe("hashVerificationToken", () => {
+    it("is deterministic and 64 lowercase hex characters", async () => {
+      const first = await hashVerificationToken("candidate-token");
+      const second = await hashVerificationToken("candidate-token");
+      expect(first).toBe(second);
+      expect(first).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it("differs for different inputs", async () => {
+      const first = await hashVerificationToken("token-a");
+      const second = await hashVerificationToken("token-b");
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe("issueEmailVerificationToken", () => {
+    it("persists only the hash, never the plaintext token", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+
+      const stored = await repo.getVerificationToken(issued.tokenHash);
+      expect(stored).not.toBeNull();
+      expect(stored!.tokenHash).toBe(issued.tokenHash);
+      expect(JSON.stringify(stored)).not.toContain(issued.plaintextToken);
+    });
+
+    it("respects the configured lifetime", async () => {
+      const now = new Date("2026-02-01T00:00:00.000Z");
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy, now);
+      expect(issued.expiresAt.getTime()).toBe(now.getTime() + policy.tokenLifetimeMs);
+    });
+
+    it("atomically replaces a still-redeemable previous token", async () => {
+      const first = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      const second = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+
+      expect(second.replaced).toBe(true);
+      const oldRecord = await repo.getVerificationToken(first.tokenHash);
+      expect(oldRecord!.replacedAt).not.toBeNull();
+      expect(oldRecord!.replacedByTokenHash).toBe(second.tokenHash);
+    });
+
+    it("does not replace a token that was already consumed", async () => {
+      const first = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      await repo.consumeVerificationToken(first.tokenHash, new Date("2026-02-01T00:00:00.000Z"));
+      const second = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      expect(second.replaced).toBe(false);
+    });
+  });
+
+  describe("verifyEmailVerificationToken", () => {
+    it("verifies a valid token and activates the pending account", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        issued.plaintextToken,
+      );
+
+      expect(outcome).toEqual({ outcome: "verified", userId: pendingUser.userId });
+      const user = await repo.getUserById(pendingUser.userId);
+      expect(user!.status).toBe("active");
+      const record = await repo.getVerificationToken(issued.tokenHash);
+      expect(record!.consumedAt).not.toBeNull();
+    });
+
+    it("rejects an unknown token without revealing account existence", async () => {
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        "some-random-token",
+      );
+
+      expect(outcome).toEqual({ outcome: "failed", reason: "invalid_token" });
+      const user = await repo.getUserById(pendingUser.userId);
+      expect(user!.status).toBe("pending_verification");
+    });
+
+    it("rejects an expired token and reports the reason", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      const afterExpiry = new Date(issued.expiresAt.getTime() + 1);
+
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        issued.plaintextToken,
+        afterExpiry,
+      );
+
+      expect(outcome).toEqual({
+        outcome: "failed",
+        reason: "expired",
+        userId: pendingUser.userId,
+      });
+    });
+
+    it("treats a replayed valid token against an active account as success", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      await verifyEmailVerificationToken(context, pendingUser.email, issued.plaintextToken);
+
+      const replay = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        issued.plaintextToken,
+      );
+
+      expect(replay).toEqual({ outcome: "verified", userId: pendingUser.userId });
+    });
+
+    it("reports reused when an already-consumed token is presented by a non-active account", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+
+      // Consume the token directly so the account stays pending (e.g. the
+      // activation step never ran); the service must then report "reused".
+      await repo.consumeVerificationToken(issued.tokenHash, new Date("2026-02-01T00:00:00.000Z"));
+
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        issued.plaintextToken,
+      );
+
+      expect(outcome).toEqual({
+        outcome: "failed",
+        reason: "reused",
+        userId: pendingUser.userId,
+      });
+      const user = await repo.getUserById(pendingUser.userId);
+      expect(user!.status).toBe("pending_verification");
+    });
+
+    it("does not leak the token owner when presented with a different email", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        otherUser.email,
+        issued.plaintextToken,
+      );
+
+      expect(outcome).toEqual({
+        outcome: "failed",
+        reason: "invalid_token",
+        userId: pendingUser.userId,
+      });
+      const bob = await repo.getUserById(otherUser.userId);
+      expect(bob!.status).toBe("pending_verification");
+    });
+
+    it("rejects a replaced token", async () => {
+      const first = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      await issueEmailVerificationToken(context, pendingUser.userId, policy);
+
+      const outcome = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        first.plaintextToken,
+      );
+
+      expect(outcome).toEqual({
+        outcome: "failed",
+        reason: "replaced",
+        userId: pendingUser.userId,
+      });
+    });
+
+    it("locks the token after the maximum number of failed attempts", async () => {
+      const issued = await issueEmailVerificationToken(context, pendingUser.userId, policy);
+      const afterExpiry = new Date(issued.expiresAt.getTime() + 1);
+
+      for (let attempt = 0; attempt < policy.maxAttempts; attempt += 1) {
+        const outcome = await verifyEmailVerificationToken(
+          context,
+          pendingUser.email,
+          issued.plaintextToken,
+          afterExpiry,
+        );
+        expect(outcome.outcome).toBe("failed");
+      }
+
+      const blocked = await verifyEmailVerificationToken(
+        context,
+        pendingUser.email,
+        issued.plaintextToken,
+        afterExpiry,
+      );
+      expect(blocked).toEqual({
+        outcome: "failed",
+        reason: "brute_force_blocked",
+        userId: pendingUser.userId,
+      });
+    });
+  });
+
+  describe("resendEmailVerificationToken", () => {
+    let delivered: VerificationEmailMessage[];
+    const deliver = async (message: VerificationEmailMessage) => {
+      delivered.push(message);
+      return { transport: "sink" as const, accepted: true, safeTargetReference: "ref" };
+    };
+    const appUrl = "https://stealth.mail";
+
+    beforeEach(() => {
+      delivered = [];
+    });
+
+    it("returns a generic noop for an unknown email", async () => {
+      const outcome = await resendEmailVerificationToken(
+        context,
+        "ghost@stealth.mail",
+        policy,
+        deliver,
+        appUrl,
+      );
+      expect(outcome).toEqual({ outcome: "noop" });
+      expect(delivered).toHaveLength(0);
+    });
+
+    it("returns a generic noop for a non-pending account", async () => {
+      await repo.updateUser({ ...pendingUser, status: "active" }, pendingUser.version);
+      const outcome = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        deliver,
+        appUrl,
+      );
+      expect(outcome).toEqual({ outcome: "noop" });
+      expect(delivered).toHaveLength(0);
+    });
+
+    it("sends a message carrying the plaintext verification URL", async () => {
+      const outcome = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        deliver,
+        appUrl,
+      );
+
+      expect(outcome.outcome).toBe("sent");
+      expect(delivered).toHaveLength(1);
+      const message = delivered[0];
+      expect(message.to).toBe(pendingUser.email);
+      expect(message.purpose).toBe(VERIFICATION_PURPOSE);
+      expect(message.verificationUrl).toContain("email=alice%40stealth.mail");
+      expect(message.verificationUrl).toContain("token=");
+
+      const issuedToken = message.verificationUrl.split("token=")[1];
+      const stored = await repo.getVerificationToken(await hashVerificationToken(issuedToken));
+      expect(stored).not.toBeNull();
+    });
+
+    it("enforces the resend cooldown with a retry-after window", async () => {
+      await resendEmailVerificationToken(context, pendingUser.email, policy, deliver, appUrl);
+      delivered.length = 0;
+
+      const second = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        deliver,
+        appUrl,
+      );
+
+      expect(second.outcome).toBe("cooldown");
+      if (second.outcome === "cooldown") {
+        expect(second.retryAfterSeconds).toBeGreaterThan(0);
+        expect(second.retryAfterSeconds).toBeLessThanOrEqual(
+          Math.ceil(policy.resendCooldownMs / 1000),
+        );
+      }
+      expect(delivered).toHaveLength(0);
+    });
+
+    it("allows a resend once the cooldown has elapsed and replaces the old token", async () => {
+      const first = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        deliver,
+        appUrl,
+      );
+      expect(first.outcome).toBe("sent");
+      if (first.outcome !== "sent") throw new Error("unreachable");
+
+      const now = new Date(Date.parse(first.expiresAt.toISOString()) - 1);
+      delivered.length = 0;
+      const second = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        deliver,
+        appUrl,
+        now,
+      );
+      expect(second.outcome).toBe("sent");
+      expect(delivered).toHaveLength(1);
+    });
+
+    it("reports delivery_failed when the transport rejects the message", async () => {
+      const failingDeliver = async () => ({
+        transport: "smtp" as const,
+        accepted: false,
+        safeTargetReference: "ref",
+      });
+      const outcome = await resendEmailVerificationToken(
+        context,
+        pendingUser.email,
+        policy,
+        failingDeliver,
+        appUrl,
+      );
+      expect(outcome.outcome).toBe("delivery_failed");
+    });
+  });
+
+  describe("buildVerificationUrl", () => {
+    it("builds a well-formed URL with email and token parameters", () => {
+      const url = buildVerificationUrl("https://stealth.mail/", "alice@stealth.mail", "tok_123");
+      expect(url).toBe("https://stealth.mail/verify?email=alice%40stealth.mail&token=tok_123");
+    });
+  });
+});

--- a/tests/unit/api/verification-token.test.ts
+++ b/tests/unit/api/verification-token.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  verificationPurposeSchema,
+  verificationTokenHashSchema,
+  verificationTokenSchema,
+} from "../../../src/server/api/domain";
+
+describe("BETA-005: Verification token domain schemas", () => {
+  const baseToken = {
+    tokenHash: "a".repeat(64),
+    userId: "usr_12345",
+    purpose: "email_verification",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-02T00:00:00.000Z",
+    consumedAt: null,
+    replacedAt: null,
+    replacedByTokenHash: null,
+    attemptCount: 0,
+    maxAttempts: 5,
+  };
+
+  describe("verificationPurposeSchema", () => {
+    it("accepts the supported purpose", () => {
+      expect(verificationPurposeSchema.parse("email_verification")).toBe("email_verification");
+    });
+
+    it("rejects unknown purposes", () => {
+      expect(() => verificationPurposeSchema.parse("phone_verification")).toThrow();
+    });
+  });
+
+  describe("verificationTokenHashSchema", () => {
+    it("normalizes to lowercase hex", () => {
+      expect(verificationTokenHashSchema.parse("A".repeat(64))).toBe("a".repeat(64));
+    });
+
+    it("rejects non-hex or wrong-length hashes", () => {
+      expect(() => verificationTokenHashSchema.parse("z".repeat(64))).toThrow();
+      expect(() => verificationTokenHashSchema.parse("a".repeat(63))).toThrow();
+      expect(() => verificationTokenHashSchema.parse("")).toThrow();
+    });
+  });
+
+  describe("verificationTokenSchema", () => {
+    it("parses a valid token record", () => {
+      const parsed = verificationTokenSchema.parse(baseToken);
+      expect(parsed).toEqual(baseToken);
+    });
+
+    it("accepts consumed and replaced timestamps", () => {
+      const parsed = verificationTokenSchema.parse({
+        ...baseToken,
+        consumedAt: "2026-01-01T01:00:00.000Z",
+        replacedAt: "2026-01-01T02:00:00.000Z",
+        replacedByTokenHash: "b".repeat(64),
+      });
+      expect(parsed.consumedAt).toBe("2026-01-01T01:00:00.000Z");
+      expect(parsed.replacedByTokenHash).toBe("b".repeat(64));
+    });
+
+    it("rejects negative attempt counts", () => {
+      expect(() => verificationTokenSchema.parse({ ...baseToken, attemptCount: -1 })).toThrow();
+    });
+
+    it("rejects non-positive max attempts", () => {
+      expect(() => verificationTokenSchema.parse({ ...baseToken, maxAttempts: 0 })).toThrow();
+    });
+
+    it("rejects invalid dates", () => {
+      expect(() =>
+        verificationTokenSchema.parse({ ...baseToken, expiresAt: "not-a-date" }),
+      ).toThrow();
+    });
+  });
+});

--- a/tests/unit/migrations/miniflare.test.ts
+++ b/tests/unit/migrations/miniflare.test.ts
@@ -3,6 +3,7 @@ import { Miniflare } from "miniflare";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 const NULL_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const MINIFLARE_TEST_TIMEOUT_MS = 30_000;
 
 let code: string;
 let mf: Miniflare;
@@ -86,82 +87,108 @@ function seedIdentityRecords(extra: Array<{ key: string; value: unknown }> = [])
 }
 
 describe("identity migration worker (local Cloudflare emulation)", () => {
-  it("rejects non-migration routes and missing commands", async () => {
-    const missing = await mf.dispatchFetch("http://localhost/other");
-    expect(missing.status).toBe(404);
+  it(
+    "rejects non-migration routes and missing commands",
+    async () => {
+      const missing = await mf.dispatchFetch("http://localhost/other");
+      expect(missing.status).toBe(404);
 
-    const bad = await mf.dispatchFetch("http://localhost/migrate", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "{}",
-    });
-    expect(bad.status).toBe(400);
-  });
+      const bad = await mf.dispatchFetch("http://localhost/migrate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      expect(bad.status).toBe(400);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 
-  it("runs dry-run against the emulated Durable Object storage", async () => {
-    await seedIdentityRecords();
-    const { status, body } = await run("dry-run");
+  it(
+    "runs dry-run against the emulated Durable Object storage",
+    async () => {
+      await seedIdentityRecords();
+      const { status, body } = await run("dry-run");
 
-    expect(status).toBe(200);
-    expect(body.command).toBe("dry-run");
-    const user = body.families.find((f: any) => f.family === "user");
-    const session = body.families.find((f: any) => f.family === "session");
-    expect(user.totalKeys).toBe(1);
-    expect(user.forwardPending).toBe(0);
-    expect(session.totalKeys).toBe(1);
-    expect(body.ok).toBe(true);
-  });
+      expect(status).toBe(200);
+      expect(body.command).toBe("dry-run");
+      const user = body.families.find((f: any) => f.family === "user");
+      const session = body.families.find((f: any) => f.family === "session");
+      expect(user.totalKeys).toBe(1);
+      expect(user.forwardPending).toBe(0);
+      expect(session.totalKeys).toBe(1);
+      expect(body.ok).toBe(true);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 
-  it("detects dangling and mismatched indexes during integrity-check", async () => {
-    await seedIdentityRecords([
-      { key: "user:username:ghost", value: "u_missing" },
-      { key: "user:email:alice@example.com", value: "someone-else" },
-    ]);
-    const { status, body } = await run("integrity-check");
+  it(
+    "detects dangling and mismatched indexes during integrity-check",
+    async () => {
+      await seedIdentityRecords([
+        { key: "user:username:ghost", value: "u_missing" },
+        { key: "user:email:alice@example.com", value: "someone-else" },
+      ]);
+      const { status, body } = await run("integrity-check");
 
-    expect(status).toBe(200);
-    expect(body.ok).toBe(false);
+      expect(status).toBe(200);
+      expect(body.ok).toBe(false);
 
-    const user = body.families.find((f: any) => f.family === "user");
-    const username = body.families.find((f: any) => f.family === "username");
+      const user = body.families.find((f: any) => f.family === "user");
+      const username = body.families.find((f: any) => f.family === "username");
 
-    expect(user.issues.map((i: any) => i.kind)).toContain("index_mismatch");
-    expect(username.issues.map((i: any) => i.kind)).toContain("dangling_index");
+      expect(user.issues.map((i: any) => i.kind)).toContain("index_mismatch");
+      expect(username.issues.map((i: any) => i.kind)).toContain("dangling_index");
 
-    // Redaction: full index values never appear in the report.
-    const serialized = JSON.stringify(body);
-    expect(serialized).not.toContain("ghost");
-    expect(serialized).not.toContain("alice@example.com");
-  });
+      // Redaction: full index values never appear in the report.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("ghost");
+      expect(serialized).not.toContain("alice@example.com");
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 
-  it("reports unsupported schema versions as failures without mutating data", async () => {
-    await seedIdentityRecords([{ key: "user:id:u_future", value: { $v: 99, userId: "u_future" } }]);
-    const { body } = await run("dry-run");
+  it(
+    "reports unsupported schema versions as failures without mutating data",
+    async () => {
+      await seedIdentityRecords([
+        { key: "user:id:u_future", value: { $v: 99, userId: "u_future" } },
+      ]);
+      const { body } = await run("dry-run");
 
-    const user = body.families.find((f: any) => f.family === "user");
-    expect(user.failed).toBe(1);
-    expect(user.errors[0]).toContain("unsupported schema version 99");
-    expect(body.ok).toBe(false);
-  });
+      const user = body.families.find((f: any) => f.family === "user");
+      expect(user.failed).toBe(1);
+      expect(user.errors[0]).toContain("unsupported schema version 99");
+      expect(body.ok).toBe(false);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 
-  it("forward is idempotent when every family is already current", async () => {
-    await seedIdentityRecords();
-    const { status, body } = await run("forward");
+  it(
+    "forward is idempotent when every family is already current",
+    async () => {
+      await seedIdentityRecords();
+      const { status, body } = await run("forward");
 
-    expect(status).toBe(200);
-    expect(body.ok).toBe(true);
-    const user = body.families.find((f: any) => f.family === "user");
-    const session = body.families.find((f: any) => f.family === "session");
-    expect(user.changed).toBe(0);
-    expect(session.changed).toBe(0);
-    expect(user.skipped).toBe(1);
-    expect(session.skipped).toBe(1);
-  });
+      expect(status).toBe(200);
+      expect(body.ok).toBe(true);
+      const user = body.families.find((f: any) => f.family === "user");
+      const session = body.families.find((f: any) => f.family === "session");
+      expect(user.changed).toBe(0);
+      expect(session.changed).toBe(0);
+      expect(user.skipped).toBe(1);
+      expect(session.skipped).toBe(1);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 
-  it("rollback without a target version is rejected by the runner", async () => {
-    await seedIdentityRecords();
-    const { body } = await run("rollback");
-    expect(body.ok).toBe(false);
-    expect(body.families[0].errors[0]).toContain("--target-version");
-  });
+  it(
+    "rollback without a target version is rejected by the runner",
+    async () => {
+      await seedIdentityRecords();
+      const { body } = await run("rollback");
+      expect(body.ok).toBe(false);
+      expect(body.families[0].errors[0]).toContain("--target-version");
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
 });

--- a/tests/unit/notifications/sink.test.ts
+++ b/tests/unit/notifications/sink.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { VerificationEmailMessage } from "../../../src/services/notifications/adapter";
+import { SinkNotificationAdapter } from "../../../src/services/notifications/sink";
+
+function sampleMessage(
+  overrides: Partial<VerificationEmailMessage> = {},
+): VerificationEmailMessage {
+  return {
+    to: "alice@stealth.mail",
+    purpose: "email_verification",
+    verificationUrl: "https://stealth.mail/verify?email=alice%40stealth.mail&token=abc",
+    expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("BETA-005: SinkNotificationAdapter (development capture sink)", () => {
+  it("accepts every message and records a receipt", async () => {
+    const sink = new SinkNotificationAdapter();
+    const receipt = await sink.deliverVerificationEmail(sampleMessage());
+
+    expect(receipt).toMatchObject({ transport: "sink", accepted: true });
+    expect(receipt.safeTargetReference).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("buffers captured messages in delivery order", async () => {
+    const sink = new SinkNotificationAdapter();
+    await sink.deliverVerificationEmail(sampleMessage({ to: "first@stealth.mail" }));
+    await sink.deliverVerificationEmail(sampleMessage({ to: "second@stealth.mail" }));
+
+    expect(sink.size).toBe(2);
+    expect(sink.capturedMessages.map((message) => message.to)).toEqual([
+      "first@stealth.mail",
+      "second@stealth.mail",
+    ]);
+    expect(sink.latestMessage?.to).toBe("second@stealth.mail");
+  });
+
+  it("preserves expiry as a Date in captured messages", async () => {
+    const sink = new SinkNotificationAdapter();
+    const expiresAt = new Date("2026-03-01T00:00:00.000Z");
+    await sink.deliverVerificationEmail(sampleMessage({ expiresAt }));
+
+    expect(sink.latestMessage?.expiresAt).toBeInstanceOf(Date);
+    expect(sink.latestMessage?.expiresAt).toEqual(expiresAt);
+  });
+
+  it("is bounded by the configured buffer size", async () => {
+    const sink = new SinkNotificationAdapter(2);
+    await sink.deliverVerificationEmail(sampleMessage({ to: "a@stealth.mail" }));
+    await sink.deliverVerificationEmail(sampleMessage({ to: "b@stealth.mail" }));
+    await sink.deliverVerificationEmail(sampleMessage({ to: "c@stealth.mail" }));
+
+    expect(sink.size).toBe(2);
+    expect(sink.capturedMessages.map((message) => message.to)).toEqual([
+      "b@stealth.mail",
+      "c@stealth.mail",
+    ]);
+  });
+
+  it("isolates returned messages from caller mutation", async () => {
+    const sink = new SinkNotificationAdapter();
+    await sink.deliverVerificationEmail(sampleMessage());
+
+    const captured = sink.latestMessage!;
+    captured.to = "mutated@stealth.mail";
+    expect(sink.latestMessage?.to).toBe("alice@stealth.mail");
+  });
+
+  it("clears the buffer on request", async () => {
+    const sink = new SinkNotificationAdapter();
+    await sink.deliverVerificationEmail(sampleMessage());
+    expect(sink.size).toBe(1);
+
+    sink.clear();
+    expect(sink.size).toBe(0);
+    expect(sink.latestMessage).toBeNull();
+  });
+});

--- a/tests/unit/notifications/smtp.test.ts
+++ b/tests/unit/notifications/smtp.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { VerificationEmailMessage } from "../../../src/services/notifications/adapter";
+import {
+  SmtpError,
+  SmtpNotificationAdapter,
+  type SmtpSocketLike,
+} from "../../../src/services/notifications/smtp";
+
+/**
+ * Scripted SMTP server: replies to each line the client writes. The greeting
+ * is delivered asynchronously so the client's data listener is always wired
+ * before the first reply arrives.
+ */
+class ScriptedSmtpServer implements SmtpSocketLike {
+  readonly written: string[] = [];
+  ended = false;
+  destroyed = false;
+
+  private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  constructor(
+    private readonly greetWith: string,
+    private readonly respond: (line: string) => string | null,
+  ) {
+    if (greetWith) {
+      setTimeout(() => this.emit("data", greetWith), 0);
+    }
+  }
+
+  on(event: string, listener: (...args: unknown[]) => void) {
+    const bucket = this.listeners.get(event) ?? [];
+    bucket.push(listener);
+    this.listeners.set(event, bucket);
+    return this;
+  }
+
+  off(event: string, listener: (...args: unknown[]) => void) {
+    const bucket = this.listeners.get(event) ?? [];
+    this.listeners.set(
+      event,
+      bucket.filter((candidate) => candidate !== listener),
+    );
+    return this;
+  }
+
+  write(data: string) {
+    this.written.push(data);
+    const rawLine = data.endsWith("\r\n") ? data.slice(0, -2) : data;
+    const reply = this.respond(rawLine);
+    if (reply !== null) {
+      queueMicrotask(() => this.emit("data", reply));
+    }
+  }
+
+  end() {
+    this.ended = true;
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+
+  setTimeout() {
+    return this;
+  }
+
+  startTls?: () => void = undefined;
+
+  private emit(event: string, ...args: unknown[]) {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+const smtpOptions = {
+  host: "smtp.test",
+  port: 2525,
+  secure: false,
+  startTls: false,
+  username: undefined,
+  password: undefined,
+  fromAddress: "no-reply@stealth.mail",
+  timeoutMs: 1000,
+};
+
+const message: VerificationEmailMessage = {
+  to: "alice@stealth.mail",
+  purpose: "email_verification",
+  verificationUrl: "https://stealth.mail/verify?email=alice%40stealth.mail&token=secret-token",
+  expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+};
+
+const fullConversation = (line: string): string | null => {
+  switch (line) {
+    case "EHLO stealth.mail":
+      return "250-stealth.test\r\n250 AUTH PLAIN\r\n";
+    case "MAIL FROM:<no-reply@stealth.mail>":
+      return "250 2.1.0 Ok\r\n";
+    case "RCPT TO:<alice@stealth.mail>":
+      return "250 2.1.5 Ok\r\n";
+    case "DATA":
+      return "354 End data with <CR><LF>.<CR><LF>\r\n";
+    case "QUIT":
+      return "221 2.0.0 Bye\r\n";
+    default:
+      // The DATA payload is one write terminating with a bare "." line.
+      return line.endsWith(".") ? "250 2.0.0 Ok: queued as 12345\r\n" : null;
+  }
+};
+
+describe("BETA-005: SmtpNotificationAdapter (scripted conversations)", () => {
+  it("delivers the verification email over a full SMTP session", async () => {
+    const server = new ScriptedSmtpServer("220 smtp.test ESMTP ready\r\n", fullConversation);
+    const adapter = new SmtpNotificationAdapter({
+      ...smtpOptions,
+      socketFactory: async () => server,
+    });
+
+    const receipt = await adapter.deliverVerificationEmail(message);
+
+    expect(receipt).toMatchObject({ transport: "smtp", accepted: true });
+    expect(receipt.providerRef).toMatch(/^<[0-9a-f-]+@stealth\.mail>$/);
+    expect(receipt.safeTargetReference).toMatch(/^[a-f0-9]{64}$/);
+
+    const conversation = server.written.join("").split("\r\n");
+    expect(conversation[0]).toBe("EHLO stealth.mail");
+    expect(conversation[1]).toBe("MAIL FROM:<no-reply@stealth.mail>");
+    expect(conversation[2]).toBe("RCPT TO:<alice@stealth.mail>");
+    expect(conversation[3]).toBe("DATA");
+    expect(server.written.join("")).toContain("https://stealth.mail/verify?");
+    expect(server.written.join("")).toContain("\r\n.\r\n");
+    expect(server.ended).toBe(true);
+  });
+
+  it("performs STARTTLS and re-EHLO before AUTH when configured", async () => {
+    const server = new ScriptedSmtpServer("220 smtp.test ESMTP ready\r\n", (line) => {
+      if (line === "EHLO stealth.mail") return "250-STARTTLS\r\n250 AUTH PLAIN\r\n";
+      if (line === "STARTTLS") return "220 2.0.0 Ready to start TLS\r\n";
+      if (line.startsWith("AUTH PLAIN ")) return "235 2.7.0 Authentication successful\r\n";
+      return fullConversation(line);
+    });
+    server.startTls = vi.fn(() => undefined) as never;
+
+    const adapter = new SmtpNotificationAdapter({
+      ...smtpOptions,
+      startTls: true,
+      username: "smtp-user",
+      password: "smtp-pass",
+      socketFactory: async () => server,
+    });
+
+    const receipt = await adapter.deliverVerificationEmail(message);
+    expect(receipt.accepted).toBe(true);
+
+    const expectedAuth = Buffer.from(`\u0000smtp-user\u0000smtp-pass`, "utf8").toString("base64");
+    const commands = server.written
+      .map((chunk) => chunk.split("\r\n")[0])
+      .filter((line) => /^(EHLO|STARTTLS|AUTH|MAIL FROM|RCPT TO|DATA|QUIT)/.test(line));
+    expect(commands).toEqual([
+      "EHLO stealth.mail",
+      "STARTTLS",
+      "EHLO stealth.mail",
+      `AUTH PLAIN ${expectedAuth}`,
+      "MAIL FROM:<no-reply@stealth.mail>",
+      "RCPT TO:<alice@stealth.mail>",
+      "DATA",
+      "QUIT",
+    ]);
+    expect(server.startTls).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an SMTP failure with the reply code and never the payload", async () => {
+    const server = new ScriptedSmtpServer("220 smtp.test ESMTP ready\r\n", (line) => {
+      if (line.startsWith("RCPT TO:")) return "550 5.1.1 <alice@stealth.mail> unknown mailbox\r\n";
+      return fullConversation(line);
+    });
+    const adapter = new SmtpNotificationAdapter({
+      ...smtpOptions,
+      socketFactory: async () => server,
+    });
+
+    await expect(adapter.deliverVerificationEmail(message)).rejects.toMatchObject({
+      name: "SmtpError",
+      code: "smtp_delivery_failed",
+      retryable: true,
+      command: "RCPT TO",
+      replyCode: 550,
+    });
+
+    // The failure surface carries the reply code only — never the payload.
+    const captured = (await adapter
+      .deliverVerificationEmail(message)
+      .then(() => null)
+      .catch((error: unknown) => error as SmtpError))!;
+    expect(JSON.stringify(captured)).not.toContain("secret-token");
+    expect(JSON.stringify(captured)).not.toContain("alice@stealth.mail");
+  });
+
+  it("fails when the server never greets (timeout)", async () => {
+    const server = new ScriptedSmtpServer("", () => null);
+    const adapter = new SmtpNotificationAdapter({
+      ...smtpOptions,
+      timeoutMs: 20,
+      socketFactory: async () => server,
+    });
+
+    await expect(adapter.deliverVerificationEmail(message)).rejects.toMatchObject({
+      name: "SmtpError",
+      command: "connect",
+    });
+  });
+});


### PR DESCRIPTION
## Overview
Implements BETA-005 for the auth flow: introduce a full verification-token lifecycle (expiry, single-use consumption, hash-only persistence, brute-force lockout, resend cooldown) and decouple token delivery behind a pluggable notification adapter so the transport (SMTP today, any transport later) is swappable and testable. Also adds the two public endpoints — `POST /auth/verify` and `POST /auth/resend-verification` — with strictly generic responses to prevent account probing.

## Related Issue
[Closes #1912 ](https://github.com/Stellar-Mail/stealth/issues/1912)

## Changes

- **[ADD]** Verification token domain: `email_verification` purpose, 43-char base64url tokens (256-bit entropy), expiry, security-token hash (HMAC-SHA256) persisted instead of the raw token, replace-on-issue semantics, attempt-count tracking for brute-force lockout.
- **[ADD]** `VerificationService` implementing the lifecycle: issue/consume (atomic), verify with replay-safe success and generic failure results, cross-user token isolation, resend cooldown and post-cooldown token replacement.
- **[ADD]** Pluggable delivery layer: `NotificationAdapter` interface with an in-memory sink (forcing explicit delivery in tests) and a real SMTP transport via Cloudflare `connect()` sockets (STARTTLS + AUTH PLAIN, scripted-conversation test seam).
- **[ADD]** Routes `src/routes/api/v1/auth/verify.ts` and `src/routes/api/v1/auth/resend-verification.ts` backed by zen validation, eager success for unknown accounts, 429 + `Retry-After` for cooldown, 503 on delivery failure, generic messages only.
- **[ADD]** KV repository methods (get/issue/consume/record-attempt) with `RETRY_SAFE_OPERATIONS` entries, `VerificationTokenRecord` schema registration in context, config schema/loader for SMTP + cooldown settings, OpenAPI paths for both endpoints, `cloudflare:sockets` ambient types.
- **[MODIFY]** `MemoryRepository`, `StealthCoordinator`, and the request body-limit registry to wire the new operations; repository interface extended with verification methods.

## Verification Results

- **[TEST]** 66 new unit tests (`verification-token`, `verification-service`, `verification-routes`, `notifications/sink`, `notifications/smtp`, extended `retryable-repository`) covering entropy, hash-only persistence, atomic replace, expired/reused tokens, replay safety, brute-force lockout, cross-user no-leak, cooldown/resend, SMTP scripted conversations, and timeouts. Full suite: 163 files — 1955 passed, 3 expected fail.
- **[CODE REVIEW]** Rebased onto the latest upstream (relay BETA-028, R2/storage BETA-030, encrypted-envelope) with both feature sets preserved; `openapi.json` re-generated from the merged spec — content verified identical to `origin/main` plus exactly the two new auth paths.
- **[CI/CD]** CI-equivalent checks pass locally: `prettier --check .`, `eslint .`, `tsc --noEmit`, `npm test`, `npm run build` (client + SSR worker). e2e runs in CI (needs bun + Playwright browsers not available locally).

## Acceptance Criteria

| Criterion | Status | Evidence |
|---|---|---|
| Tokens are single-use, expiring, and stored only as hashes | ✅ | `verification-service.test.ts` (hash-only persistence, consume/replace/expiry cases) |
| Verify endpoint never reveals account existence and is replay-safe | ✅ | `verification-routes.test.ts`, `verification-service.test.ts` |
| Resend enforces cooldown (429 + `Retry-After`) and replaces the token | ✅ | `verification-routes.test.ts`, `verification-service.test.ts` |
| Delivery is pluggable via `NotificationAdapter` | ✅ | `sink.test.ts`, `smtp.test.ts`, `verification-delivery.ts` |
| Brute-force attempts are locked out after a threshold | ✅ | `verification-service.test.ts` (brute-force lockout) |
| OpenAPI documents both endpoints and stays additive vs upstream | ✅ | `openapi.json` diff + optic diff in CI |