### PR TITLE
feat(auth): add session renewal, rotation, idle timeout, and absolute…

### DIFF
--- a/src/routes/api/v1/auth/session.ts
+++ b/src/routes/api/v1/auth/session.ts
@@ -1,6 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { parseSessionCookie, validateSession } from "@/server/api/auth/session-service";
+import {
+  buildSessionCookie,
+  parseSessionCookie,
+  renewSession,
+  validateSession,
+} from "@/server/api/auth/session-service";
 import { getApiContext } from "@/server/api/context";
 import { toPublicSession, toPublicUser } from "@/server/api/domain";
 import { ApiError } from "@/server/api/errors";
@@ -23,10 +28,41 @@ export const Route = createFileRoute("/api/v1/auth/session")({
             throw new ApiError(401, "unauthorized", "Session is invalid or expired");
           }
 
-          return apiSuccess(request, {
+          const nowMs = Date.now();
+          const expiresMs = new Date(activeSession.session.expiresAt).getTime();
+          const maxAgeSeconds = Math.max(0, Math.floor((expiresMs - nowMs) / 1000));
+          const isProd = import.meta.env?.PROD ?? false;
+          const cookieHeader = buildSessionCookie(
+            activeSession.session.sessionId,
+            maxAgeSeconds,
+            isProd,
+          );
+
+          const response = apiSuccess(request, {
             user: toPublicUser(activeSession.user),
             session: toPublicSession(activeSession.session),
           });
+          response.headers.append("Set-Cookie", cookieHeader);
+          return response;
+        }),
+
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const sessionId = parseSessionCookie(request.headers.get("cookie"));
+
+          if (!sessionId) {
+            throw new ApiError(401, "unauthorized", "No active session cookie found");
+          }
+
+          const renewed = await renewSession(apiContext, sessionId);
+
+          const response = apiSuccess(request, {
+            user: toPublicUser(renewed.user),
+            session: toPublicSession(renewed.session),
+          });
+          response.headers.append("Set-Cookie", renewed.cookieHeader);
+          return response;
         }),
     },
   },

--- a/src/server/api/auth/session-service.ts
+++ b/src/server/api/auth/session-service.ts
@@ -1,10 +1,13 @@
 import type { ApiContext } from "../context";
-import type { Session, User } from "../domain";
+import type { RetiredSession, Session, User } from "../domain";
 import { ApiError } from "../errors";
 import { dummyVerifyPassword, verifyPassword } from "./password";
 
 export const SESSION_COOKIE_NAME = "stealth_session";
 export const DEFAULT_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+export const DEFAULT_IDLE_TIMEOUT_SECONDS = 1800; // 30 minutes
+export const DEFAULT_ABSOLUTE_TIMEOUT_SECONDS = 7 * 24 * 60 * 60; // 7 days
+export const CONCURRENT_RENEWAL_GRACE_PERIOD_MS = 10 * 1000; // 10 seconds
 export const MAX_LOGIN_ATTEMPTS = 5;
 const RATE_LIMIT_WINDOW_SECONDS = 900; // 15 minutes
 
@@ -15,6 +18,12 @@ export interface AuthenticateInput {
   userAgent?: string;
   deviceFingerprint?: string;
   currentSessionId?: string;
+}
+
+export interface SessionOptions {
+  now?: () => Date;
+  idleTtlSeconds?: number;
+  absoluteTtlSeconds?: number;
 }
 
 export function parseSessionCookie(cookieHeader: string | null | undefined): string | null {
@@ -56,6 +65,7 @@ export function buildClearSessionCookie(isProd = false): string {
 export async function authenticateWithPassword(
   apiContext: ApiContext,
   input: AuthenticateInput,
+  options: SessionOptions = {},
 ): Promise<{ user: User; session: Session; cookieHeader: string }> {
   const repo = apiContext.repository;
   const normalizedId = input.identifier.trim().toLowerCase();
@@ -113,22 +123,37 @@ export async function authenticateWithPassword(
     throw new ApiError(403, "forbidden", "Account is not active");
   }
 
+  const now = options.now ? options.now() : new Date();
+  const nowMs = now.getTime();
+  const idleTtl = options.idleTtlSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+  const absoluteTtl = options.absoluteTtlSeconds ?? DEFAULT_ABSOLUTE_TIMEOUT_SECONDS;
+
+  const absoluteExpiresMs = nowMs + absoluteTtl * 1000;
+  const idleExpiresMs = nowMs + idleTtl * 1000;
+  const expiresMs = Math.min(idleExpiresMs, absoluteExpiresMs);
+
+  const newSessionId = `sess_${crypto.randomUUID().replace(/-/g, "")}`;
+
   // Session fixation prevention: rotate session if a previous session exists
   if (input.currentSessionId) {
+    const retiredSession: RetiredSession = {
+      sessionId: input.currentSessionId,
+      replacedBySessionId: newSessionId,
+      userId: user.userId,
+      retiredAt: now.toISOString(),
+      expiresAt: now.toISOString(),
+    };
+    await repo.createRetiredSession(retiredSession);
     await repo.deleteSession(input.currentSessionId);
   }
-
-  // Issue opaque server-side session
-  const newSessionId = `sess_${crypto.randomUUID().replace(/-/g, "")}`;
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + DEFAULT_SESSION_TTL_SECONDS * 1000);
 
   const session: Session = {
     sessionId: newSessionId,
     userId: user.userId,
     createdAt: now.toISOString(),
-    expiresAt: expiresAt.toISOString(),
+    expiresAt: new Date(expiresMs).toISOString(),
     lastActiveAt: now.toISOString(),
+    absoluteExpiresAt: new Date(absoluteExpiresMs).toISOString(),
     ipAddress: input.ip ?? null,
     userAgent: input.userAgent ?? null,
     deviceFingerprint: input.deviceFingerprint ?? null,
@@ -137,40 +162,169 @@ export async function authenticateWithPassword(
   await repo.createSession(session);
 
   const isProd = import.meta.env?.PROD ?? false;
-  const cookieHeader = buildSessionCookie(newSessionId, DEFAULT_SESSION_TTL_SECONDS, isProd);
+  const maxAgeSeconds = Math.max(0, Math.floor((expiresMs - nowMs) / 1000));
+  const cookieHeader = buildSessionCookie(newSessionId, maxAgeSeconds, isProd);
 
   return { user, session, cookieHeader };
 }
 
 /**
- * Validates a session by ID, enforcing expiration, account status, and activity tracking.
+ * Validates a session by ID, enforcing idle timeout, absolute lifetime expiry,
+ * account status, and retired session reuse protection.
  */
 export async function validateSession(
   apiContext: ApiContext,
   sessionId: string,
+  options: SessionOptions = {},
 ): Promise<{ user: User; session: Session } | null> {
   const repo = apiContext.repository;
+  const now = options.now ? options.now() : new Date();
+  const nowMs = now.getTime();
+
+  // 1. Look up active session
   const session = await repo.getSession(sessionId);
 
-  if (!session) return null;
+  if (session) {
+    const expiresAtMs = new Date(session.expiresAt).getTime();
+    const absoluteExpiresAtMs = session.absoluteExpiresAt
+      ? new Date(session.absoluteExpiresAt).getTime()
+      : Number.POSITIVE_INFINITY;
 
-  if (new Date(session.expiresAt) < new Date()) {
-    await repo.deleteSession(sessionId);
-    return null;
+    // Check idle expiration or absolute expiration
+    if (nowMs >= expiresAtMs || nowMs >= absoluteExpiresAtMs) {
+      await repo.deleteSession(sessionId);
+      return null;
+    }
+
+    const user = await repo.getUserById(session.userId);
+    if (!user || user.status !== "active") {
+      return null;
+    }
+
+    // Extend sliding window for idle timeout, bounded by absoluteExpiresAt
+    const idleTtl = options.idleTtlSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+    const nextIdleExpiresMs = nowMs + idleTtl * 1000;
+    const nextExpiresMs = Math.min(nextIdleExpiresMs, absoluteExpiresAtMs);
+
+    const updatedSession: Session = {
+      ...session,
+      lastActiveAt: now.toISOString(),
+      expiresAt: new Date(nextExpiresMs).toISOString(),
+    };
+
+    await repo.updateSession(updatedSession);
+    return { user, session: updatedSession };
   }
 
-  const user = await repo.getUserById(session.userId);
-  if (!user || user.status !== "active") {
-    return null;
+  // 2. Check retired sessions for rotation resolution or theft detection
+  const retired = await repo.getRetiredSession(sessionId);
+  if (retired) {
+    const retiredAtMs = new Date(retired.retiredAt).getTime();
+
+    // Concurrent renewal grace window: return replacement active session
+    if (nowMs - retiredAtMs <= CONCURRENT_RENEWAL_GRACE_PERIOD_MS) {
+      const replacement = await repo.getSession(retired.replacedBySessionId);
+      if (replacement) {
+        const user = await repo.getUserById(replacement.userId);
+        if (user && user.status === "active") {
+          return { user, session: replacement };
+        }
+      }
+      return null;
+    }
+
+    // Stolen retired session ID reuse attempt past grace window!
+    // Immediately revoke active replacement session and all user sessions for safety.
+    await repo.deleteSession(retired.replacedBySessionId);
+    await repo.deleteUserSessions(retired.userId);
+    throw new ApiError(
+      401,
+      "unauthorized",
+      "Retired session token reused. Session chain revoked for security.",
+    );
   }
 
-  const updatedSession: Session = {
-    ...session,
-    lastActiveAt: new Date().toISOString(),
+  return null;
+}
+
+/**
+ * Renews and rotates a session identifier, generating a new session record
+ * bound by the original absolute lifetime and creating a retired session marker.
+ */
+export async function renewSession(
+  apiContext: ApiContext,
+  sessionId: string,
+  options: SessionOptions = {},
+): Promise<{ user: User; session: Session; cookieHeader: string }> {
+  const repo = apiContext.repository;
+  const now = options.now ? options.now() : new Date();
+  const nowMs = now.getTime();
+
+  const validated = await validateSession(apiContext, sessionId, options);
+  if (!validated) {
+    throw new ApiError(401, "unauthorized", "Session invalid or expired");
+  }
+
+  const currentSession = validated.session;
+  const user = validated.user;
+
+  const absoluteExpiresAtMs = currentSession.absoluteExpiresAt
+    ? new Date(currentSession.absoluteExpiresAt).getTime()
+    : nowMs + (options.absoluteTtlSeconds ?? DEFAULT_ABSOLUTE_TIMEOUT_SECONDS) * 1000;
+
+  if (nowMs >= absoluteExpiresAtMs) {
+    await repo.deleteSession(currentSession.sessionId);
+    throw new ApiError(401, "unauthorized", "Session has reached maximum absolute lifetime");
+  }
+
+  const idleTtl = options.idleTtlSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+  const nextIdleExpiresMs = nowMs + idleTtl * 1000;
+  const nextExpiresMs = Math.min(nextIdleExpiresMs, absoluteExpiresAtMs);
+
+  const newSessionId = `sess_${crypto.randomUUID().replace(/-/g, "")}`;
+  const newSession: Session = {
+    sessionId: newSessionId,
+    userId: user.userId,
+    createdAt: currentSession.createdAt,
+    expiresAt: new Date(nextExpiresMs).toISOString(),
+    lastActiveAt: now.toISOString(),
+    absoluteExpiresAt: new Date(absoluteExpiresAtMs).toISOString(),
+    rotatedFromSessionId: currentSession.sessionId,
+    ipAddress: currentSession.ipAddress,
+    userAgent: currentSession.userAgent,
+    deviceFingerprint: currentSession.deviceFingerprint,
   };
 
-  await repo.updateSession(updatedSession);
-  return { user, session: updatedSession };
+  // 1. Record retired session marker
+  const retiredSession: RetiredSession = {
+    sessionId: currentSession.sessionId,
+    replacedBySessionId: newSessionId,
+    userId: user.userId,
+    retiredAt: now.toISOString(),
+    expiresAt: currentSession.expiresAt,
+  };
+  await repo.createRetiredSession(retiredSession);
+
+  // 2. Remove old session & save new session
+  await repo.deleteSession(currentSession.sessionId);
+  await repo.createSession(newSession);
+
+  const isProd = import.meta.env?.PROD ?? false;
+  const maxAgeSeconds = Math.max(0, Math.floor((nextExpiresMs - nowMs) / 1000));
+  const cookieHeader = buildSessionCookie(newSessionId, maxAgeSeconds, isProd);
+
+  return { user, session: newSession, cookieHeader };
+}
+
+/**
+ * Rotates session identifiers after privilege-sensitive events.
+ */
+export async function rotateSession(
+  apiContext: ApiContext,
+  sessionId: string,
+  options: SessionOptions = {},
+): Promise<{ user: User; session: Session; cookieHeader: string }> {
+  return renewSession(apiContext, sessionId, options);
 }
 
 /**

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,7 @@ import {
   profileSchema,
   credentialSchema,
   sessionSchema,
+  retiredSessionSchema,
   storedEnvelopeSchema,
 } from "./domain";
 import { ApiError } from "./errors";
@@ -197,6 +198,7 @@ registerRecordSchema("user", 1, userSchema);
 registerRecordSchema("profile", 1, profileSchema);
 registerRecordSchema("credential", 1, credentialSchema);
 registerRecordSchema("session", 1, sessionSchema);
+registerRecordSchema("retiredSession", 1, retiredSessionSchema);
 // v1 -> v2 (Issue #1498): records now carry a requestDigest binding the
 // lease/response to the exact request payload that created it. Legacy
 // records predate this and never bore a client-supplied payload we can

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -255,6 +255,8 @@ export const sessionSchema = z.object({
   createdAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
   lastActiveAt: z.string().datetime(),
+  absoluteExpiresAt: z.string().datetime().optional(),
+  rotatedFromSessionId: z.string().optional().nullable(),
   ipAddress: z.string().optional().nullable(),
   userAgent: z.string().optional().nullable(),
   deviceFingerprint: z.string().optional().nullable(),
@@ -266,10 +268,20 @@ export const publicSessionSchema = z.object({
   createdAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
   lastActiveAt: z.string().datetime(),
+  absoluteExpiresAt: z.string().datetime().optional(),
+});
+
+export const retiredSessionSchema = z.object({
+  sessionId: z.string().min(1, "Session ID cannot be empty"),
+  replacedBySessionId: z.string().min(1, "Replaced by Session ID cannot be empty"),
+  userId: z.string().min(1, "User ID cannot be empty"),
+  retiredAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
 });
 
 export type Session = z.infer<typeof sessionSchema>;
 export type PublicSession = z.infer<typeof publicSessionSchema>;
+export type RetiredSession = z.infer<typeof retiredSessionSchema>;
 
 export function toPublicSession(session: Session): PublicSession {
   return {
@@ -278,6 +290,7 @@ export function toPublicSession(session: Session): PublicSession {
     createdAt: session.createdAt,
     expiresAt: session.expiresAt,
     lastActiveAt: session.lastActiveAt,
+    absoluteExpiresAt: session.absoluteExpiresAt,
   };
 }
 

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -12,6 +12,7 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  RetiredSession,
   SenderRule,
   Session,
   StoredEnvelope,
@@ -197,6 +198,14 @@ export class HybridApiRepository implements ApiRepository {
 
   async deleteUserSessions(userId: string): Promise<void> {
     return this.getStub().deleteUserSessions(userId);
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    return this.getStub().getRetiredSession(sessionId);
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    return this.getStub().createRetiredSession(retiredSession);
   }
 
   // Consistent layer delegated to Durable Object via RPC

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -6,6 +6,7 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  RetiredSession,
   SenderRule,
   Session,
   StoredEnvelope,
@@ -45,6 +46,7 @@ export class MemoryApiRepository implements ApiRepository {
 
   // BETA-006: Session storage
   private readonly sessions = new Map<string, Session>();
+  private readonly retiredSessions = new Map<string, RetiredSession>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -338,6 +340,15 @@ export class MemoryApiRepository implements ApiRepository {
         this.sessions.delete(id);
       }
     }
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    return structuredClone(this.retiredSessions.get(sessionId) ?? null);
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    this.retiredSessions.set(retiredSession.sessionId, structuredClone(retiredSession));
+    return structuredClone(retiredSession);
   }
 
   async getRelayQueueDepth(_relayId: string) {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -7,6 +7,7 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  RetiredSession,
   SenderRule,
   Session,
   StoredEnvelope,
@@ -138,12 +139,14 @@ export interface ApiRepository {
   getCredential(userId: string): Promise<Credential | null>;
   setCredential(credential: Credential): Promise<Credential>;
 
-  // BETA-006: Server-Side Session Domain Methods
+  // BETA-006 & BETA-007: Server-Side Session Domain Methods
   getSession(sessionId: string): Promise<Session | null>;
   createSession(session: Session): Promise<Session>;
   updateSession(session: Session): Promise<Session>;
   deleteSession(sessionId: string): Promise<void>;
   deleteUserSessions(userId: string): Promise<void>;
+  getRetiredSession(sessionId: string): Promise<RetiredSession | null>;
+  createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession>;
 
   getRelayQueueDepth(relayId: string): Promise<number>;
   getRelayRetryCount(relayId: string): Promise<number>;
@@ -464,6 +467,18 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.deleteUserSessions(userId);
   }
 
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    const raw = await this.inner.getRetiredSession(sessionId);
+    return raw ? validateRecord<RetiredSession>("retiredSession", raw) : null;
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    const result = await this.inner.createRetiredSession(
+      versionRecord("retiredSession", retiredSession),
+    );
+    return validateRecord<RetiredSession>("retiredSession", result);
+  }
+
   getRelayQueueDepth(relayId: string): Promise<number> {
     return this.inner.getRelayQueueDepth(relayId);
   }
@@ -556,6 +571,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setCredential",
   "getSession",
   "updateSession",
+  "getRetiredSession",
   "getEnvelope",
 ]);
 
@@ -745,6 +761,14 @@ export class RetryableApiRepository implements ApiRepository {
 
   deleteUserSessions(userId: string): Promise<void> {
     return this.inner.deleteUserSessions(userId);
+  }
+
+  getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    return this.withRetry("getRetiredSession", () => this.inner.getRetiredSession(sessionId));
+  }
+
+  createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    return this.inner.createRetiredSession(retiredSession);
   }
 
   getRelayQueueDepth(relayId: string): Promise<number> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -5,6 +5,7 @@ import type {
   PostageStatus,
   Profile,
   Receipt,
+  RetiredSession,
   Session,
   StoredEnvelope,
   User,
@@ -356,6 +357,18 @@ export class StealthCoordinator extends DurableObjectBase {
         await this.ctx.storage.delete(key);
       }
     }
+  }
+
+  async getRetiredSession(sessionId: string): Promise<RetiredSession | null> {
+    const retired = (await this.ctx.storage.get(`retired_session:${sessionId}`)) as
+      | RetiredSession
+      | undefined;
+    return retired ?? null;
+  }
+
+  async createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession> {
+    await this.ctx.storage.put(`retired_session:${retiredSession.sessionId}`, retiredSession);
+    return retiredSession;
   }
 
   async getCounter(key: string): Promise<number> {

--- a/tests/unit/api/auth/auth-routes.test.ts
+++ b/tests/unit/api/auth/auth-routes.test.ts
@@ -147,4 +147,47 @@ describe("BETA-006: Auth API Routes (/api/v1/auth/*)", () => {
     const sessionResponse = await sessionHandler({ request: sessionRequest });
     expect(sessionResponse.status).toBe(401);
   });
+
+  it("POST /api/v1/auth/session renews session and rotates session ID", async () => {
+    // Login first
+    const loginHandler = (LoginRoute.options.server?.handlers as any).POST;
+    const loginRequest = new Request("https://stealth.mail/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier: "route_user",
+        password: testPassword,
+      }),
+    });
+    const loginResponse = await loginHandler({ request: loginRequest });
+    const oldCookieHeader = loginResponse.headers.get("Set-Cookie");
+    const oldCookieVal = oldCookieHeader?.split(";")[0];
+
+    // Renew session
+    const renewHandler = (SessionRoute.options.server?.handlers as any).POST;
+    const renewRequest = new Request("https://stealth.mail/api/v1/auth/session", {
+      method: "POST",
+      headers: { Cookie: oldCookieVal! },
+    });
+
+    const renewResponse = await renewHandler({ request: renewRequest });
+    expect(renewResponse.status).toBe(200);
+
+    const renewData = await renewResponse.json();
+    expect(renewData.data.session.sessionId).toBeDefined();
+
+    const newCookieHeader = renewResponse.headers.get("Set-Cookie");
+    expect(newCookieHeader).toContain("stealth_session=");
+    const newCookieVal = newCookieHeader?.split(";")[0];
+    expect(newCookieVal).not.toBe(oldCookieVal);
+
+    // Bootstrap GET with new session cookie should succeed
+    const getHandler = (SessionRoute.options.server?.handlers as any).GET;
+    const getRequest = new Request("https://stealth.mail/api/v1/auth/session", {
+      method: "GET",
+      headers: { Cookie: newCookieVal! },
+    });
+    const getResponse = await getHandler({ request: getRequest });
+    expect(getResponse.status).toBe(200);
+  });
 });

--- a/tests/unit/api/auth/session-service.test.ts
+++ b/tests/unit/api/auth/session-service.test.ts
@@ -5,7 +5,12 @@ import {
   buildSessionCookie,
   logoutSession,
   parseSessionCookie,
+  renewSession,
+  rotateSession,
   validateSession,
+  CONCURRENT_RENEWAL_GRACE_PERIOD_MS,
+  DEFAULT_ABSOLUTE_TIMEOUT_SECONDS,
+  DEFAULT_IDLE_TIMEOUT_SECONDS,
   MAX_LOGIN_ATTEMPTS,
 } from "../../../../src/server/api/auth/session-service";
 import { hashPassword } from "../../../../src/server/api/auth/password";
@@ -14,7 +19,7 @@ import type { AccountStatus, Credential, User } from "../../../../src/server/api
 import { ApiError } from "../../../../src/server/api/errors";
 import { MemoryApiRepository } from "../../../../src/server/api/memory-repository";
 
-describe("BETA-006: Password Login & Server-Side Sessions", () => {
+describe("BETA-006 & BETA-007: Password Login, Session Renewal, Rotation & Expiry", () => {
   let repo: MemoryApiRepository;
   let apiContext: ReturnType<typeof createApiContext>;
 
@@ -114,6 +119,7 @@ describe("BETA-006: Password Login & Server-Side Sessions", () => {
       expect(result.session.sessionId).toMatch(/^sess_/);
       expect(result.session.userId).toBe(result.user.userId);
       expect(result.session.ipAddress).toBe("127.0.0.1");
+      expect(result.session.absoluteExpiresAt).toBeDefined();
       expect(result.cookieHeader).toContain(`stealth_session=${result.session.sessionId}`);
     });
 
@@ -261,40 +267,186 @@ describe("BETA-006: Password Login & Server-Side Sessions", () => {
       expect(await repo.getSession(oldSessionId)).toBeNull();
       // New session must exist
       expect(await repo.getSession(newSessionId)).not.toBeNull();
+      // Retired session record must exist
+      expect(await repo.getRetiredSession(oldSessionId)).not.toBeNull();
     });
   });
 
-  describe("validateSession & logoutSession", () => {
-    it("validates an active session and updates lastActiveAt", async () => {
+  describe("validateSession & Expiry Boundaries", () => {
+    it("validates an active session and extends sliding idle expiration window", async () => {
+      let currentTime = new Date("2026-06-01T10:00:00.000Z");
       const { user } = await seedTestUser();
-      const authResult = await authenticateWithPassword(apiContext, {
-        identifier: user.email,
-        password: defaultPassword,
+
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => currentTime, idleTtlSeconds: 1800, absoluteTtlSeconds: 86400 },
+      );
+
+      const initialExpiresAt = authResult.session.expiresAt;
+      expect(initialExpiresAt).toBe(new Date("2026-06-01T10:30:00.000Z").toISOString());
+
+      // Advance time by 10 minutes (within 30-min idle window)
+      currentTime = new Date("2026-06-01T10:10:00.000Z");
+
+      const validated = await validateSession(apiContext, authResult.session.sessionId, {
+        now: () => currentTime,
+        idleTtlSeconds: 1800,
       });
 
-      const validated = await validateSession(apiContext, authResult.session.sessionId);
       expect(validated).not.toBeNull();
       expect(validated?.user.userId).toBe(user.userId);
-      expect(validated?.session.lastActiveAt).toBeDefined();
+      expect(validated?.session.lastActiveAt).toBe(currentTime.toISOString());
+      // Sliding window should push expiresAt 30 minutes from current time (10:40)
+      expect(validated?.session.expiresAt).toBe(new Date("2026-06-01T10:40:00.000Z").toISOString());
     });
 
-    it("rejects an expired session and deletes it", async () => {
+    it("rejects and deletes session when idle timeout duration is exceeded", async () => {
+      let currentTime = new Date("2026-06-01T10:00:00.000Z");
       const { user } = await seedTestUser();
-      const authResult = await authenticateWithPassword(apiContext, {
-        identifier: user.email,
-        password: defaultPassword,
+
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => currentTime, idleTtlSeconds: 1800 },
+      );
+
+      // Advance time by 31 minutes (exceeds 30-min idle timeout)
+      currentTime = new Date("2026-06-01T10:31:00.000Z");
+
+      const validated = await validateSession(apiContext, authResult.session.sessionId, {
+        now: () => currentTime,
+        idleTtlSeconds: 1800,
       });
 
-      // Manually set session expiry to the past
-      const expiredSession = {
-        ...authResult.session,
-        expiresAt: new Date(Date.now() - 10000).toISOString(),
-      };
-      await repo.updateSession(expiredSession);
-
-      const validated = await validateSession(apiContext, expiredSession.sessionId);
       expect(validated).toBeNull();
-      expect(await repo.getSession(expiredSession.sessionId)).toBeNull();
+      expect(await repo.getSession(authResult.session.sessionId)).toBeNull();
+    });
+
+    it("enforces absolute lifetime expiry ceiling even with continuous activity", async () => {
+      const startTime = new Date("2026-06-01T10:00:00.000Z");
+      const { user } = await seedTestUser();
+
+      // Set 1-hour absolute lifetime ceiling and 30-minute idle timeout
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => startTime, idleTtlSeconds: 1800, absoluteTtlSeconds: 3600 },
+      );
+
+      // Validate at +20 minutes (extends idle to 10:50:00)
+      const t1 = new Date("2026-06-01T10:20:00.000Z");
+      const v1 = await validateSession(apiContext, authResult.session.sessionId, {
+        now: () => t1,
+        idleTtlSeconds: 1800,
+      });
+
+      expect(v1).not.toBeNull();
+      expect(v1?.session.expiresAt).toBe(new Date("2026-06-01T10:50:00.000Z").toISOString());
+
+      // Validate at +45 minutes (extends idle to 10:45+30m=11:15, but capped at absolute lifetime 11:00:00)
+      const t2 = new Date("2026-06-01T10:45:00.000Z");
+      const v2 = await validateSession(apiContext, authResult.session.sessionId, {
+        now: () => t2,
+        idleTtlSeconds: 1800,
+      });
+
+      expect(v2).not.toBeNull();
+      expect(v2?.session.expiresAt).toBe(new Date("2026-06-01T11:00:00.000Z").toISOString());
+
+      // Attempt validation at +61 minutes (exceeds 1-hour absolute lifetime ceiling)
+      const t3 = new Date("2026-06-01T11:01:00.000Z");
+      const v3 = await validateSession(apiContext, authResult.session.sessionId, {
+        now: () => t3,
+        idleTtlSeconds: 1800,
+      });
+
+      expect(v3).toBeNull();
+      expect(await repo.getSession(authResult.session.sessionId)).toBeNull();
+    });
+  });
+
+  describe("Session Renewal, Rotation & Theft Prevention", () => {
+    it("renews session and rotates session identifier", async () => {
+      const startTime = new Date("2026-06-01T10:00:00.000Z");
+      const { user } = await seedTestUser();
+
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => startTime },
+      );
+
+      const oldSessionId = authResult.session.sessionId;
+
+      const renewTime = new Date("2026-06-01T10:15:00.000Z");
+      const renewed = await renewSession(apiContext, oldSessionId, { now: () => renewTime });
+
+      expect(renewed.session.sessionId).not.toBe(oldSessionId);
+      expect(renewed.session.rotatedFromSessionId).toBe(oldSessionId);
+      expect(renewed.session.createdAt).toBe(authResult.session.createdAt);
+      expect(renewed.cookieHeader).toContain(`stealth_session=${renewed.session.sessionId}`);
+
+      // Old session ID removed from active sessions
+      expect(await repo.getSession(oldSessionId)).toBeNull();
+      // Old session ID preserved in retired sessions
+      const retired = await repo.getRetiredSession(oldSessionId);
+      expect(retired).not.toBeNull();
+      expect(retired?.replacedBySessionId).toBe(renewed.session.sessionId);
+    });
+
+    it("resolves concurrent renewals deterministically within grace window", async () => {
+      const startTime = new Date("2026-06-01T10:00:00.000Z");
+      const { user } = await seedTestUser();
+
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => startTime },
+      );
+
+      const oldSessionId = authResult.session.sessionId;
+
+      // Request 1 rotates oldSessionId to newSessionId at 10:15:00
+      const renewTime = new Date("2026-06-01T10:15:00.000Z");
+      const renewed = await renewSession(apiContext, oldSessionId, { now: () => renewTime });
+
+      // Concurrent Request 2 arrives 2 seconds later (within 10s grace period) still using oldSessionId
+      const concurrentTime = new Date("2026-06-01T10:15:02.000Z");
+      const validatedConcurrent = await validateSession(apiContext, oldSessionId, {
+        now: () => concurrentTime,
+      });
+
+      expect(validatedConcurrent).not.toBeNull();
+      expect(validatedConcurrent?.session.sessionId).toBe(renewed.session.sessionId);
+    });
+
+    it("rejects stolen retired session reuse past grace window and revokes active session chain", async () => {
+      const startTime = new Date("2026-06-01T10:00:00.000Z");
+      const { user } = await seedTestUser();
+
+      const authResult = await authenticateWithPassword(
+        apiContext,
+        { identifier: user.email, password: defaultPassword },
+        { now: () => startTime },
+      );
+
+      const oldSessionId = authResult.session.sessionId;
+
+      // Legitimate user renews session at 10:15:00
+      const renewTime = new Date("2026-06-01T10:15:00.000Z");
+      const renewed = await renewSession(apiContext, oldSessionId, { now: () => renewTime });
+      const newSessionId = renewed.session.sessionId;
+
+      // Attacker attempts to reuse oldSessionId 30 seconds later (past 10s grace window)
+      const attackerTime = new Date("2026-06-01T10:15:30.000Z");
+
+      await expect(
+        validateSession(apiContext, oldSessionId, { now: () => attackerTime }),
+      ).rejects.toThrow("Retired session token reused");
+
+      // Active session chain must be revoked to protect the user
+      expect(await repo.getSession(newSessionId)).toBeNull();
     });
 
     it("revokes session on logout", async () => {

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -451,6 +451,28 @@ export function runRepositoryContractTests(
         await repo.deleteUserSessions("usr_test_1");
         expect(await repo.getSession("sess_contract_101")).toBeNull();
       });
+
+      it("creates and retrieves a retired session record", async () => {
+        const retiredRecord = {
+          sessionId: "sess_old_1",
+          replacedBySessionId: "sess_new_2",
+          userId: "usr_test_1",
+          retiredAt: "2026-01-01T00:00:00.000Z",
+          expiresAt: "2026-01-08T00:00:00.000Z",
+        };
+
+        expect(await repo.getRetiredSession("sess_old_1")).toBeNull();
+
+        const created = await repo.createRetiredSession(retiredRecord);
+        expect(created.sessionId).toBe("sess_old_1");
+
+        const fetched = await repo.getRetiredSession("sess_old_1");
+        expect(fetched).toMatchObject({
+          sessionId: "sess_old_1",
+          replacedBySessionId: "sess_new_2",
+          userId: "usr_test_1",
+        });
+      });
     });
   });
 }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -212,6 +212,16 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("deleteUserSessions");
     return this.inner.deleteUserSessions(userId);
   }
+  async getRetiredSession(sessionId: string) {
+    this.maybeFail("getRetiredSession");
+    return this.inner.getRetiredSession(sessionId);
+  }
+  async createRetiredSession(
+    retiredSession: import("../../../src/server/api/domain").RetiredSession,
+  ) {
+    this.maybeFail("createRetiredSession");
+    return this.inner.createRetiredSession(retiredSession);
+  }
   async getEnvelope(messageId: string) {
     this.maybeFail("getEnvelope");
     return this.inner.getEnvelope(messageId);


### PR DESCRIPTION
## Detailed Technical Note — BETA-007 Implementation

### Goal & User Story
**As a signed-in user, I want my session to remain active during normal use but expire safely after inactivity or the maximum allowed lifetime.**

This issue delivers controlled renewal and revocation of beta sessions beyond initial login, supporting sliding idle expiration, hard absolute lifetime boundaries, session identifier rotation on privilege-sensitive events, stolen token reuse detection/revocation, and deterministic concurrent renewal handling.

---

### Key Architectural & Implementation Components

#### 1. Domain Models & Schemas ([`domain.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/domain.ts))
- **`sessionSchema` & `publicSessionSchema`**: Added `absoluteExpiresAt: z.string().datetime()` to record the immutable upper-bound timestamp of session lifetime, and `rotatedFromSessionId` for tracking lineage.
- **`retiredSessionSchema` & `RetiredSession`**: Defined record structure to track retired/rotated session tokens:
  ```typescript
  export const retiredSessionSchema = z.object({
    sessionId: z.string().min(1),
    replacedBySessionId: z.string().min(1),
    userId: z.string().min(1),
    retiredAt: z.string().datetime(),
    expiresAt: z.string().datetime(),
  });
  ```
- **`toPublicSession`**: Updated public transformation helper to expose `absoluteExpiresAt`.

#### 2. Repository Layer Contracts ([`repository.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/repository.ts))
- Extended `ApiRepository` interface with retired session persistence methods:
  - `getRetiredSession(sessionId: string): Promise<RetiredSession | null>`
  - `createRetiredSession(retiredSession: RetiredSession): Promise<RetiredSession>`
- Implemented schema validation in `ValidatedApiRepository`, retry handling in `RetryableApiRepository`, and registered schema validation in [`context.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/context.ts).
- Implemented backing storage across:
  - [`memory-repository.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/memory-repository.ts): In-memory Map storage (`retiredSessions`).
  - [`stealth-coordinator.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/stealth-coordinator.ts): Cloudflare Durable Object storage (`retired_session:<sessionId>`).
  - [`kv-repository.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/kv-repository.ts): RPC forwarding stubs.

#### 3. Session Lifecycle & Security Core ([`session-service.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/auth/session-service.ts))
- **Sliding Idle Expiration**: On active request validation (`validateSession`), the session's `lastActiveAt` timestamp is updated and `expiresAt` is slid forward by `DEFAULT_IDLE_TIMEOUT_SECONDS` (30 minutes).
- **Absolute Lifetime Ceiling**: `expiresAt` is strictly capped by `absoluteExpiresAt` (`DEFAULT_ABSOLUTE_TIMEOUT_SECONDS` / 7 days from `createdAt`). Once `now >= absoluteExpiresAt`, session validation fails and purges the session.
- **Session Identifier Rotation**: `renewSession` and `rotateSession` issue a new opaque `sessionId` (`sess_<uuid>`), persist a `RetiredSession` tombstone pointing to the new ID, and issue a refreshed HttpOnly cookie.
- **Stolen Retired Token Reuse Protection**: If a request presents a retired `sessionId`:
  - If presented **past** the 10-second concurrency grace period (`CONCURRENT_RENEWAL_GRACE_PERIOD_MS = 10000`), a stolen token replay is flagged. The system immediately revokes the active replacement session and all user sessions (`deleteUserSessions`), throwing `ApiError(401, "unauthorized", "Retired session token reused. Session chain revoked for security.")`.
- **Deterministic Concurrent Renewal Resolution**: If a parallel request arrives using a recently rotated `sessionId` **within** the 10-second grace window, `validateSession` deterministically resolves to the newly rotated replacement session, preventing race condition errors for multi-tab users.
- **Injectable Clock Control**: Functions accept `options: SessionOptions = { now?: () => Date }` for deterministic, clock-controlled testing.

#### 4. API Endpoints ([`session.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/auth/session.ts))
- **`GET /api/v1/auth/session`**: Safe app bootstrap endpoint. Parses `stealth_session` cookie, validates session activity (triggering sliding idle renewal), and appends updated `Set-Cookie` header.
- **`POST /api/v1/auth/session`**: Explicit session renewal & rotation endpoint. Rotates session identifier and returns fresh session details with updated `Set-Cookie` header.

---

### Verification & Automated Test Evidence

| Test Command / Check | Result | Highlights |
| :--- | :--- | :--- |
| `npx vitest run tests/unit/api/auth/session-service.test.ts` | **Passed (17/17)** | Sliding idle timeout, absolute lifetime ceiling, session rotation, stolen token reuse revocation, concurrent grace window resolution. |
| `npx vitest run tests/unit/api/auth/auth-routes.test.ts` | **Passed (5/5)** | `GET` bootstrap and `POST` session renewal route handlers. |
| `npx vitest run tests/unit/api/repository-contract.test.ts` | **Passed (29/29)** | Conformance tests for `getRetiredSession` and `createRetiredSession` across repositories. |
| `npm test` | **Passed (162 files, 1929 tests)** | Full repository unit test suite regression pass. |
| `npx tsc --noEmit` | **Clean (0 errors)** | Full TypeScript typecheck. |
| `npm run lint` | **Clean (0 errors)** | ESLint code style and syntax check. |

Closes #1914
