### PR TITLE
feat(policy): initialize privacy-safe mailbox policy defaults during provisioning (BETA-023 / #1930)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -130,6 +130,174 @@
           }
         }
       },
+      "ChainMailboxPolicy": {
+        "type": "object",
+        "required": ["allowUnknown", "minimumPostage", "requireReceipt", "requireVerified"],
+        "properties": {
+          "allowUnknown": {
+            "type": "boolean"
+          },
+          "minimumPostage": {
+            "$ref": "#/components/schemas/StroopAmount"
+          },
+          "requireReceipt": {
+            "type": "boolean",
+            "description": "Delivery-receipt preference, mapped to on-chain require_receipt."
+          },
+          "requireVerified": {
+            "type": "boolean"
+          }
+        }
+      },
+      "MailboxPolicyWriteRequest": {
+        "type": "object",
+        "required": ["allowUnknown", "minimumPostage", "requireVerified"],
+        "properties": {
+          "allowUnknown": {
+            "type": "boolean"
+          },
+          "minimumPostage": {
+            "$ref": "#/components/schemas/StroopAmount"
+          },
+          "requireReceipt": {
+            "type": "boolean",
+            "description": "Optional delivery-receipt preference; defaults to false and is carried into the scheduled on-chain write."
+          },
+          "requireVerified": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PolicyWriteIntent": {
+        "type": "object",
+        "required": ["owner", "policy", "offchainVersion", "status", "scheduledAt", "updatedAt"],
+        "properties": {
+          "owner": {
+            "$ref": "#/components/schemas/StellarAddress"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/ChainMailboxPolicy"
+          },
+          "offchainVersion": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Off-chain policy version; bumped only on an effective policy change, never on retries."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "submitted", "confirmed", "failed"]
+          },
+          "scheduledAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "failureCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "lastError": {
+            "type": "string",
+            "nullable": true,
+            "description": "Redacted failure reason; never contains secrets."
+          }
+        }
+      },
+      "InitializePolicyDefaultsResult": {
+        "type": "object",
+        "required": ["provisioned", "policy", "source", "offchainVersion", "scheduled"],
+        "properties": {
+          "provisioned": {
+            "type": "boolean",
+            "description": "False when the owner already had a policy; no version bump occurs."
+          },
+          "policy": {
+            "$ref": "#/components/schemas/ChainMailboxPolicy"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["default", "configured"]
+          },
+          "offchainVersion": {
+            "type": "integer",
+            "minimum": 0,
+            "nullable": true
+          },
+          "scheduled": {
+            "type": "boolean",
+            "description": "Whether a testnet contract write was scheduled."
+          }
+        }
+      },
+      "PolicyReconciliationState": {
+        "type": "string",
+        "enum": ["not_provisioned", "pending_write", "synced", "chain_ahead", "diverged"]
+      },
+      "PolicyReconciliation": {
+        "type": "object",
+        "required": ["owner", "state", "offchain", "chain", "writeIntent"],
+        "properties": {
+          "owner": {
+            "$ref": "#/components/schemas/StellarAddress"
+          },
+          "state": {
+            "$ref": "#/components/schemas/PolicyReconciliationState"
+          },
+          "offchain": {
+            "type": "object",
+            "required": ["policy", "source", "version"],
+            "properties": {
+              "policy": {
+                "$ref": "#/components/schemas/MailboxPolicy"
+              },
+              "source": {
+                "type": "string",
+                "enum": ["default", "configured"],
+                "nullable": true
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 0,
+                "nullable": true
+              }
+            }
+          },
+          "chain": {
+            "type": "object",
+            "required": ["policy", "version"],
+            "properties": {
+              "policy": {
+                "$ref": "#/components/schemas/MailboxPolicy"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 0,
+                "nullable": true
+              }
+            }
+          },
+          "writeIntent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PolicyWriteIntent"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
       "ValidationErrorItem": {
         "type": "object",
         "required": ["path", "rule", "message"],
@@ -816,6 +984,154 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/policies/{owner}/provision": {
+      "post": {
+        "operationId": "initializeMailboxPolicyDefaults",
+        "x-max-body-bytes": 4096,
+        "summary": "Initialize privacy-safe mailbox policy defaults (BETA-023)",
+        "description": "Idempotently initializes the beta mailbox policy defaults for the owner, persisting the off-chain policy and scheduling the matching testnet contract write. A retry never re-submits an identical write and never bumps the on-chain policy version.",
+        "security": [
+          {
+            "StellarSignedRequest": []
+          }
+        ],
+        "x-stability": "beta",
+        "responses": {
+          "200": {
+            "description": "Provisioning result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/InitializePolicyDefaultsResult"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (idempotency)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/policies/{owner}/reconciliation": {
+      "get": {
+        "operationId": "getPolicyReconciliation",
+        "summary": "Read mailbox policy reconciliation state (BETA-023)",
+        "description": "Exposes the reconciliation state between the durable off-chain policy and the on-chain Policies contract. When the chain client is unavailable, reconciliation is derived from the durable write intent alone (pending write surfaced as testnet synchronization pending).",
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "chainVersion",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "On-chain policy version reported by the Policies contract; supplied by the chain client wired by BETA-017."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reconciliation state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PolicyReconciliation"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -1,5 +1,5 @@
 import type { UnknownSenderPolicy } from "@/features/preferences";
-import type { MailboxPolicy } from "@/server/api/domain";
+import type { ChainMailboxPolicy, MailboxPolicy } from "@/server/api/domain";
 
 export type OnboardingStep =
   | "identity"
@@ -72,5 +72,20 @@ export function draftToMailboxPolicy(draft: OnboardingDraft): MailboxPolicy {
   return {
     ...SENDER_RULE_TO_POLICY[draft.unknownSenderRule],
     minimumPostage: xlmToStroops(draft.minimumPostage),
+  };
+}
+
+/**
+ * Build the full on-chain mailbox policy for the completed onboarding draft,
+ * including the delivery-receipt preference. This is the privacy-safe beta
+ * default that provisioning schedules for the testnet contract write, and it
+ * matches the beta default's "request unknown senders, zero minimum postage,
+ * no forced receipts" starting point when the user accepts every default.
+ */
+export function draftToBetaDefaults(draft: OnboardingDraft): ChainMailboxPolicy {
+  return {
+    ...SENDER_RULE_TO_POLICY[draft.unknownSenderRule],
+    minimumPostage: xlmToStroops(draft.minimumPostage),
+    requireReceipt: draft.receiptOnDelivery,
   };
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,8 @@ import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
+import { Route as ApiV1PoliciesOwnerReconciliationRouteImport } from './routes/api/v1/policies/$owner/reconciliation'
+import { Route as ApiV1PoliciesOwnerProvisionRouteImport } from './routes/api/v1/policies/$owner/provision'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
@@ -134,6 +136,18 @@ const ApiV1PostageMessageIdRefundRoute =
     path: '/refund',
     getParentRoute: () => ApiV1PostageMessageIdRoute,
   } as any)
+const ApiV1PoliciesOwnerReconciliationRoute =
+  ApiV1PoliciesOwnerReconciliationRouteImport.update({
+    id: '/reconciliation',
+    path: '/reconciliation',
+    getParentRoute: () => ApiV1PoliciesOwnerRoute,
+  } as any)
+const ApiV1PoliciesOwnerProvisionRoute =
+  ApiV1PoliciesOwnerProvisionRouteImport.update({
+    id: '/provision',
+    path: '/provision',
+    getParentRoute: () => ApiV1PoliciesOwnerRoute,
+  } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
@@ -159,6 +173,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
+  '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -182,6 +198,8 @@ export interface FileRoutesByTo {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
+  '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -206,6 +224,8 @@ export interface FileRoutesById {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
+  '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -231,6 +251,8 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/policies/$owner/provision'
+    | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -254,6 +276,8 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage'
     | '/api/v1/receipts'
+    | '/api/v1/policies/$owner/provision'
+    | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -277,6 +301,8 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/policies/$owner/provision'
+    | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -445,6 +471,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PostageMessageIdRefundRouteImport
       parentRoute: typeof ApiV1PostageMessageIdRoute
     }
+    '/api/v1/policies/$owner/reconciliation': {
+      id: '/api/v1/policies/$owner/reconciliation'
+      path: '/reconciliation'
+      fullPath: '/api/v1/policies/$owner/reconciliation'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerReconciliationRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/policies/$owner/provision': {
+      id: '/api/v1/policies/$owner/provision'
+      path: '/provision'
+      fullPath: '/api/v1/policies/$owner/provision'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerProvisionRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
       path: '/senders/$sender'
@@ -456,10 +496,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface ApiV1PoliciesOwnerRouteChildren {
+  ApiV1PoliciesOwnerProvisionRoute: typeof ApiV1PoliciesOwnerProvisionRoute
+  ApiV1PoliciesOwnerReconciliationRoute: typeof ApiV1PoliciesOwnerReconciliationRoute
   ApiV1PoliciesOwnerSendersSenderRoute: typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 
 const ApiV1PoliciesOwnerRouteChildren: ApiV1PoliciesOwnerRouteChildren = {
+  ApiV1PoliciesOwnerProvisionRoute: ApiV1PoliciesOwnerProvisionRoute,
+  ApiV1PoliciesOwnerReconciliationRoute: ApiV1PoliciesOwnerReconciliationRoute,
   ApiV1PoliciesOwnerSendersSenderRoute: ApiV1PoliciesOwnerSendersSenderRoute,
 }
 

--- a/src/routes/api/v1/policies/$owner.ts
+++ b/src/routes/api/v1/policies/$owner.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { parseDelegationHeader, requireActorMatches } from "@/server/api/actor";
-import { mailboxPolicySchema, stellarAddressSchema } from "@/server/api/domain";
+import { mailboxPolicyWriteSchema, stellarAddressSchema } from "@/server/api/domain";
 import { getApiContext } from "@/server/api/context";
 import { getMailboxPolicy, setMailboxPolicy } from "@/server/api/policy-service";
 import { parseJsonBody } from "@/server/api/request";
@@ -26,10 +26,13 @@ export const Route = createFileRoute("/api/v1/policies/$owner")({
             owner,
             parseDelegationHeader(request, "policy:update", `mailbox:${owner}:policy`),
           );
-          const policy = await parseJsonBody(request, mailboxPolicySchema, {
+          const body = await parseJsonBody(request, mailboxPolicyWriteSchema, {
             route: "PUT /policies/{owner}",
           });
-          const result = await setMailboxPolicy(context.repository, owner, policy);
+          const { requireReceipt, ...policy } = body;
+          const result = await setMailboxPolicy(context.repository, owner, policy, {
+            requireReceipt,
+          });
           return apiSuccess(request, result);
         }),
     },

--- a/src/routes/api/v1/policies/$owner/provision.ts
+++ b/src/routes/api/v1/policies/$owner/provision.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActorMatches } from "@/server/api/actor";
+import { initializeMailboxPolicyDefaults } from "@/server/api/account-provisioning";
+import { getApiContext } from "@/server/api/context";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { withIdempotency } from "@/server/api/idempotency-service";
+
+export const Route = createFileRoute("/api/v1/policies/$owner/provision")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const owner = stellarAddressSchema.parse(params.owner);
+          requireActorMatches(apiContext, owner);
+
+          const repo = apiContext.repository;
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+
+          const provision = async () => {
+            const result = await initializeMailboxPolicyDefaults(repo, owner);
+            return { status: 200, body: result };
+          };
+
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                repo,
+                {
+                  actor: owner,
+                  method: request.method,
+                  route: "POST /policies/{owner}/provision",
+                  rawKey: rawIdempotencyKey,
+                },
+                { owner },
+                provision,
+              )
+            : { ...(await provision()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/policies/$owner/reconciliation.ts
+++ b/src/routes/api/v1/policies/$owner/reconciliation.ts
@@ -1,0 +1,34 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { getPolicyReconciliation } from "@/server/api/policy-service";
+import { parseSearchParams } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const reconciliationQuerySchema = z.object({
+  /**
+   * On-chain policy version reported by the Policies contract. When absent,
+   * reconciliation is derived from the durable write intent alone (the chain
+   * client that supplies this is wired by BETA-017 / Issue #1924).
+   */
+  chainVersion: z.coerce.number().int().min(0).optional(),
+});
+
+export const Route = createFileRoute("/api/v1/policies/$owner/reconciliation")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = stellarAddressSchema.parse(params.owner);
+          const query = parseSearchParams(request, reconciliationQuerySchema);
+          const result = await getPolicyReconciliation(context.repository, owner, {
+            ...(query.chainVersion === undefined ? {} : { version: query.chainVersion }),
+          });
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -1,0 +1,81 @@
+import type { ChainMailboxPolicy } from "./domain";
+import {
+  betaDefaultMailboxPolicy,
+  getMailboxPolicy,
+  getPolicyWriteIntent,
+  setMailboxPolicy,
+  toChainMailboxPolicy,
+} from "./policy-service";
+import type { ApiRepository } from "./repository";
+
+// ---------------------------------------------------------------------------
+// BETA-023 (Issue #1930) — privacy-safe mailbox policy defaults during
+// provisioning.
+//
+// This module is the isolated policy-initialization slice of the transactional
+// account-provisioning orchestrator (BETA-014 / Issue #1921). It guarantees
+// that provisioning leaves every account with an evaluable, privacy-safe
+// default policy and a durable intent for the matching testnet contract write.
+//
+// The orchestrator (once BETA-014 merges) calls `initializeMailboxPolicyDefaults`
+// inside its transactional flow; the POST /policies/{owner}/provision route
+// exposes the same entrypoint for the beta walkthrough and retries.
+// ---------------------------------------------------------------------------
+
+export interface InitializePolicyDefaultsResult {
+  /** False when the owner already had a (possibly customized) policy. */
+  provisioned: boolean;
+  policy: ChainMailboxPolicy;
+  source: "default" | "configured";
+  offchainVersion: number | null;
+  scheduled: boolean;
+}
+
+/**
+ * Idempotently initializes the privacy-safe beta mailbox policy defaults for
+ * `owner`.
+ *
+ * - No policy exists: persists the beta default off-chain and schedules the
+ *   matching testnet contract write at off-chain version 1.
+ * - A policy already exists (including a user-customized one): no write and no
+ *   version bump. Provisioning retries therefore never re-submit an identical
+ *   write and never inflate the on-chain policy version.
+ */
+export async function initializeMailboxPolicyDefaults(
+  repository: ApiRepository,
+  owner: string,
+  now = new Date(),
+): Promise<InitializePolicyDefaultsResult> {
+  const existing = await getMailboxPolicy(repository, owner);
+  const intent = await getPolicyWriteIntent(repository, owner);
+
+  if (existing.source === "configured") {
+    return {
+      provisioned: false,
+      policy: toChainMailboxPolicy(existing.policy, intent?.policy.requireReceipt),
+      source: "configured",
+      offchainVersion: intent?.offchainVersion ?? null,
+      scheduled: false,
+    };
+  }
+
+  const result = await setMailboxPolicy(
+    repository,
+    owner,
+    {
+      allowUnknown: betaDefaultMailboxPolicy.allowUnknown,
+      requireVerified: betaDefaultMailboxPolicy.requireVerified,
+      minimumPostage: betaDefaultMailboxPolicy.minimumPostage,
+    },
+    { requireReceipt: betaDefaultMailboxPolicy.requireReceipt },
+  );
+
+  const scheduled = await getPolicyWriteIntent(repository, owner);
+  return {
+    provisioned: true,
+    policy: scheduled?.policy ?? betaDefaultMailboxPolicy,
+    source: "default",
+    offchainVersion: scheduled?.offchainVersion ?? null,
+    scheduled: scheduled !== null,
+  };
+}

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,7 @@ import {
   profileSchema,
   credentialSchema,
   storedEnvelopeSchema,
+  policyWriteIntentSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -208,6 +209,10 @@ registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
 // ValidatedApiRepository can detect tampered or structurally invalid
 // envelope records at the adapter boundary before they reach any caller.
 registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
+// Issue #1930 (BETA-023): durable scheduled-write intent for the Policies
+// contract, so tampered or structurally invalid intents fail closed at the
+// adapter boundary instead of silently drifting the reconciliation state.
+registerRecordSchema("policyWriteIntent", 1, policyWriteIntentSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -38,6 +38,61 @@ export const mailboxPolicySchema = z.object({
   requireVerified: z.boolean(),
 });
 
+/**
+ * Request body accepted when replacing a mailbox policy. `requireReceipt` is
+ * optional: when absent it defaults to false and is carried into the scheduled
+ * on-chain write as `require_receipt = false`.
+ */
+export const mailboxPolicyWriteSchema = z.object({
+  allowUnknown: z.boolean(),
+  minimumPostage: stroopAmountSchema,
+  requireVerified: z.boolean(),
+  requireReceipt: z.boolean().default(false),
+});
+
+// ---------------------------------------------------------------------------
+// BETA-023 (Issue #1930) — privacy-safe mailbox policy provisioning
+//
+// The on-chain Policies contract persists a four-field policy (including the
+// delivery-receipt preference). The off-chain `MailboxPolicy` deliberately
+// stays at three fields for backward compatibility with stored records and
+// existing callers; the delivery-receipt preference and the off-chain policy
+// version travel with the durable write intent that is scheduled for the
+// matching testnet contract write.
+// ---------------------------------------------------------------------------
+
+export const chainMailboxPolicySchema = z.object({
+  allowUnknown: z.boolean(),
+  minimumPostage: stroopAmountSchema,
+  requireReceipt: z.boolean(),
+  requireVerified: z.boolean(),
+});
+
+export const policyWriteStatusSchema = z.enum(["pending", "submitted", "confirmed", "failed"]);
+
+/**
+ * Durable intent to write a mailbox policy to the Policies contract on
+ * testnet. `offchainVersion` is the off-chain policy version: it is bumped
+ * only when the effective policy actually changes, never on a retry of the
+ * same policy — mirroring the contract's version-as-change-marker contract
+ * without re-submitting an identical write (which the contract would still
+ * count as a version bump).
+ *
+ * `lastError` is a redacted, bounded failure reason; wallet seeds, tokens and
+ * transaction payloads never appear in it.
+ */
+export const policyWriteIntentSchema = z.object({
+  owner: stellarAddressSchema,
+  policy: chainMailboxPolicySchema,
+  offchainVersion: z.number().int().nonnegative(),
+  status: policyWriteStatusSchema,
+  scheduledAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  failureCount: z.number().int().nonnegative().default(0),
+  lastError: z.string().max(300).nullable().default(null),
+  txHash: z.string().nullable().default(null),
+});
+
 export const postageSchema = z.object({
   amount: stroopAmountSchema,
   createdAt: z.string().datetime(),
@@ -106,6 +161,9 @@ export function createReceiptSchema(options: ReceiptSchemaOptions = {}) {
 export const receiptSchema = createReceiptSchema();
 
 export type MailboxPolicy = z.infer<typeof mailboxPolicySchema>;
+export type ChainMailboxPolicy = z.infer<typeof chainMailboxPolicySchema>;
+export type PolicyWriteIntent = z.infer<typeof policyWriteIntentSchema>;
+export type PolicyWriteStatus = z.infer<typeof policyWriteStatusSchema>;
 export type Postage = z.infer<typeof postageSchema>;
 export type PostageStatus = z.infer<typeof postageStatusSchema>;
 export type Receipt = z.infer<typeof receiptSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -8,6 +8,7 @@ import type {
   Credential,
   IdempotencyRecord,
   MailboxPolicy,
+  PolicyWriteIntent,
   Postage,
   PostageStatus,
   Profile,
@@ -36,6 +37,16 @@ export class HybridApiRepository implements ApiRepository {
   async setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
     await this.kv.put(this.key("policy", owner), JSON.stringify(policy));
     return policy;
+  }
+
+  async getPolicyWriteIntent(owner: string): Promise<PolicyWriteIntent | null> {
+    const intent = await this.kv.get(this.key("policy-write", owner), "json");
+    return (intent as PolicyWriteIntent) ?? null;
+  }
+
+  async setPolicyWriteIntent(intent: PolicyWriteIntent): Promise<PolicyWriteIntent> {
+    await this.kv.put(this.key("policy-write", intent.owner), JSON.stringify(intent));
+    return intent;
   }
 
   async getSenderRule(owner: string, sender: string): Promise<SenderRule> {

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -2,6 +2,7 @@ import type {
   Credential,
   IdempotencyRecord,
   MailboxPolicy,
+  PolicyWriteIntent,
   Postage,
   PostageStatus,
   Profile,
@@ -24,6 +25,7 @@ function key(owner: string, sender: string) {
 
 export class MemoryApiRepository implements ApiRepository {
   private readonly policies = new Map<string, MailboxPolicy>();
+  private readonly policyWriteIntents = new Map<string, PolicyWriteIntent>();
   private readonly postage = new Map<string, Postage>();
   private readonly receipts = new Map<string, Receipt>();
   private readonly senderRules = new Map<string, SenderRule>();
@@ -89,6 +91,15 @@ export class MemoryApiRepository implements ApiRepository {
   async setPolicy(owner: string, policy: MailboxPolicy) {
     this.policies.set(owner, structuredClone(policy));
     return structuredClone(policy);
+  }
+
+  async getPolicyWriteIntent(owner: string) {
+    return structuredClone(this.policyWriteIntents.get(owner) ?? null);
+  }
+
+  async setPolicyWriteIntent(intent: PolicyWriteIntent) {
+    this.policyWriteIntents.set(intent.owner, structuredClone(intent));
+    return structuredClone(intent);
   }
 
   async getSenderRule(owner: string, sender: string) {
@@ -423,6 +434,7 @@ export class MemoryApiRepository implements ApiRepository {
 
   reset() {
     this.policies.clear();
+    this.policyWriteIntents.clear();
     this.postage.clear();
     this.receipts.clear();
     this.senderRules.clear();

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -115,6 +115,176 @@ export const openApiDocument = {
           },
         },
       },
+      ChainMailboxPolicy: {
+        type: "object",
+        required: ["allowUnknown", "minimumPostage", "requireReceipt", "requireVerified"],
+        properties: {
+          allowUnknown: {
+            type: "boolean",
+          },
+          minimumPostage: {
+            $ref: "#/components/schemas/StroopAmount",
+          },
+          requireReceipt: {
+            type: "boolean",
+            description: "Delivery-receipt preference, mapped to on-chain require_receipt.",
+          },
+          requireVerified: {
+            type: "boolean",
+          },
+        },
+      },
+      MailboxPolicyWriteRequest: {
+        type: "object",
+        required: ["allowUnknown", "minimumPostage", "requireVerified"],
+        properties: {
+          allowUnknown: {
+            type: "boolean",
+          },
+          minimumPostage: {
+            $ref: "#/components/schemas/StroopAmount",
+          },
+          requireReceipt: {
+            type: "boolean",
+            description:
+              "Optional delivery-receipt preference; defaults to false and is carried into the scheduled on-chain write.",
+          },
+          requireVerified: {
+            type: "boolean",
+          },
+        },
+      },
+      PolicyWriteIntent: {
+        type: "object",
+        required: ["owner", "policy", "offchainVersion", "status", "scheduledAt", "updatedAt"],
+        properties: {
+          owner: {
+            $ref: "#/components/schemas/StellarAddress",
+          },
+          policy: {
+            $ref: "#/components/schemas/ChainMailboxPolicy",
+          },
+          offchainVersion: {
+            type: "integer",
+            minimum: 0,
+            description:
+              "Off-chain policy version; bumped only on an effective policy change, never on retries.",
+          },
+          status: {
+            type: "string",
+            enum: ["pending", "submitted", "confirmed", "failed"],
+          },
+          scheduledAt: {
+            type: "string",
+            format: "date-time",
+          },
+          updatedAt: {
+            type: "string",
+            format: "date-time",
+          },
+          failureCount: {
+            type: "integer",
+            minimum: 0,
+          },
+          lastError: {
+            type: "string",
+            nullable: true,
+            description: "Redacted failure reason; never contains secrets.",
+          },
+        },
+      },
+      InitializePolicyDefaultsResult: {
+        type: "object",
+        required: ["provisioned", "policy", "source", "offchainVersion", "scheduled"],
+        properties: {
+          provisioned: {
+            type: "boolean",
+            description: "False when the owner already had a policy; no version bump occurs.",
+          },
+          policy: {
+            $ref: "#/components/schemas/ChainMailboxPolicy",
+          },
+          source: {
+            type: "string",
+            enum: ["default", "configured"],
+          },
+          offchainVersion: {
+            type: "integer",
+            minimum: 0,
+            nullable: true,
+          },
+          scheduled: {
+            type: "boolean",
+            description: "Whether a testnet contract write was scheduled.",
+          },
+        },
+      },
+      PolicyReconciliationState: {
+        type: "string",
+        enum: ["not_provisioned", "pending_write", "synced", "chain_ahead", "diverged"],
+      },
+      PolicyReconciliation: {
+        type: "object",
+        required: ["owner", "state", "offchain", "chain", "writeIntent"],
+        properties: {
+          owner: {
+            $ref: "#/components/schemas/StellarAddress",
+          },
+          state: {
+            $ref: "#/components/schemas/PolicyReconciliationState",
+          },
+          offchain: {
+            type: "object",
+            required: ["policy", "source", "version"],
+            properties: {
+              policy: {
+                $ref: "#/components/schemas/MailboxPolicy",
+              },
+              source: {
+                type: "string",
+                enum: ["default", "configured"],
+                nullable: true,
+              },
+              version: {
+                type: "integer",
+                minimum: 0,
+                nullable: true,
+              },
+            },
+          },
+          chain: {
+            type: "object",
+            required: ["policy", "version"],
+            properties: {
+              policy: {
+                $ref: "#/components/schemas/MailboxPolicy",
+              },
+              version: {
+                type: "integer",
+                minimum: 0,
+                nullable: true,
+              },
+            },
+          },
+          writeIntent: {
+            allOf: [
+              {
+                $ref: "#/components/schemas/PolicyWriteIntent",
+              },
+              {
+                type: "object",
+                properties: {
+                  version: {
+                    type: "integer",
+                    minimum: 0,
+                  },
+                },
+              },
+            ],
+            nullable: true,
+          },
+        },
+      },
       ValidationErrorItem: {
         type: "object",
         required: ["path", "rule", "message"],
@@ -607,6 +777,153 @@ export const openApiDocument = {
           },
           "401": {
             description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/policies/{owner}/provision": {
+      post: {
+        operationId: "initializeMailboxPolicyDefaults",
+        "x-max-body-bytes": 4 * 1024,
+        summary: "Initialize privacy-safe mailbox policy defaults (BETA-023)",
+        description:
+          "Idempotently initializes the beta mailbox policy defaults for the owner, persisting the off-chain policy and scheduling the matching testnet contract write. A retry never re-submits an identical write and never bumps the on-chain policy version.",
+        security: [
+          {
+            StellarSignedRequest: [],
+          },
+        ],
+        "x-stability": "beta",
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Provisioning result",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    {
+                      $ref: "#/components/schemas/SuccessEnvelope",
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          $ref: "#/components/schemas/InitializePolicyDefaultsResult",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict (idempotency)",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/policies/{owner}/reconciliation": {
+      get: {
+        operationId: "getPolicyReconciliation",
+        summary: "Read mailbox policy reconciliation state (BETA-023)",
+        description:
+          "Exposes the reconciliation state between the durable off-chain policy and the on-chain Policies contract. When the chain client is unavailable, reconciliation is derived from the durable write intent alone (pending write surfaced as testnet synchronization pending).",
+        "x-stability": "beta",
+        parameters: [
+          {
+            name: "chainVersion",
+            in: "query",
+            required: false,
+            schema: {
+              type: "integer",
+              minimum: 0,
+            },
+            description:
+              "On-chain policy version reported by the Policies contract; supplied by the chain client wired by BETA-017.",
+          },
+        ],
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Reconciliation state",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    {
+                      $ref: "#/components/schemas/SuccessEnvelope",
+                    },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          $ref: "#/components/schemas/PolicyReconciliation",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
             content: {
               "application/json": {
                 schema: {

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -1,6 +1,65 @@
-import type { MailboxPolicy, SenderRule } from "./domain";
+import type {
+  ChainMailboxPolicy,
+  MailboxPolicy,
+  PolicyWriteIntent,
+  PolicyWriteStatus,
+  SenderRule,
+} from "./domain";
 import type { ApiRepository } from "./repository";
 import { defaultMailboxPolicy } from "./repository";
+
+// ---------------------------------------------------------------------------
+// BETA-023 (Issue #1930) — privacy-safe mailbox policy defaults
+//
+// The beta default routes unknown senders to a review request, charges no
+// (or the configured) minimum postage, and does not force delivery receipts.
+// It is the provisioning default, distinct from the generic `defaultMailboxPolicy`
+// fallback that applies to owners who have never been provisioned.
+// ---------------------------------------------------------------------------
+
+export const betaDefaultMailboxPolicy: ChainMailboxPolicy = {
+  allowUnknown: true,
+  requireVerified: false,
+  requireReceipt: false,
+  minimumPostage: "0",
+};
+
+/** The evaluable three-field off-chain policy carried by the beta default. */
+export function toMailboxPolicy(chain: ChainMailboxPolicy): MailboxPolicy {
+  return {
+    allowUnknown: chain.allowUnknown,
+    requireVerified: chain.requireVerified,
+    minimumPostage: chain.minimumPostage,
+  };
+}
+
+/** Rebuilds the full on-chain policy, defaulting an unknown receipt preference to off. */
+export function toChainMailboxPolicy(
+  policy: MailboxPolicy,
+  requireReceipt: boolean | undefined,
+): ChainMailboxPolicy {
+  return {
+    ...policy,
+    requireReceipt: requireReceipt ?? false,
+  };
+}
+
+function chainPoliciesEqual(left: ChainMailboxPolicy, right: ChainMailboxPolicy): boolean {
+  return (
+    left.allowUnknown === right.allowUnknown &&
+    left.requireVerified === right.requireVerified &&
+    left.requireReceipt === right.requireReceipt &&
+    left.minimumPostage === right.minimumPostage
+  );
+}
+
+function apiPoliciesEqual(left: MailboxPolicy, right: MailboxPolicy): boolean {
+  return (
+    left.allowUnknown === right.allowUnknown &&
+    left.requireVerified === right.requireVerified &&
+    left.minimumPostage === right.minimumPostage
+  );
+}
 
 export async function getMailboxPolicy(repository: ApiRepository, owner: string) {
   const stored = await repository.getPolicy(owner);
@@ -15,10 +74,17 @@ export async function setMailboxPolicy(
   repository: ApiRepository,
   owner: string,
   policy: MailboxPolicy,
+  options: { requireReceipt?: boolean } = {},
 ) {
+  const stored = await repository.setPolicy(owner, policy);
+  await schedulePolicyWrite(
+    repository,
+    owner,
+    toChainMailboxPolicy(policy, options.requireReceipt),
+  );
   return {
     owner,
-    policy: await repository.setPolicy(owner, policy),
+    policy: stored,
     source: "configured" as const,
   };
 }
@@ -71,4 +137,242 @@ export async function evaluateMailboxPolicy(
   }
 
   return { allowed: true, policy, source, reason: "policy_satisfied" as const, rule };
+}
+
+// ---------------------------------------------------------------------------
+// Durable scheduled-write intent (the "schedule the matching testnet contract
+// write" half of provisioning). BETA-017's managed-wallet signer consumes and
+// advances these records; this slice owns their creation and idempotency.
+// ---------------------------------------------------------------------------
+
+export async function getPolicyWriteIntent(
+  repository: ApiRepository,
+  owner: string,
+): Promise<PolicyWriteIntent | null> {
+  return repository.getPolicyWriteIntent(owner);
+}
+
+/**
+ * Records the durable intent to write `policy` to the Policies contract.
+ *
+ * Idempotency contract (mirrors the contract's version-as-change-marker rule):
+ * - Re-scheduling the SAME policy is a no-op and NEVER bumps the off-chain
+ *   version, so provisioning retries cannot inflate the on-chain version.
+ * - A previously failed intent for the same policy is re-armed as `pending`
+ *   with the SAME version (a retry, not a new change).
+ * - A genuinely different policy bumps the version by exactly one.
+ */
+export async function schedulePolicyWrite(
+  repository: ApiRepository,
+  owner: string,
+  policy: ChainMailboxPolicy,
+  now = new Date(),
+): Promise<PolicyWriteIntent> {
+  const iso = now.toISOString();
+  const existing = await repository.getPolicyWriteIntent(owner);
+
+  if (existing && chainPoliciesEqual(existing.policy, policy)) {
+    if (existing.status === "failed") {
+      return repository.setPolicyWriteIntent({
+        ...existing,
+        status: "pending",
+        updatedAt: iso,
+        lastError: null,
+      });
+    }
+    return existing;
+  }
+
+  const offchainVersion = existing ? existing.offchainVersion + 1 : 1;
+  const intent: PolicyWriteIntent = {
+    owner,
+    policy,
+    offchainVersion,
+    status: "pending",
+    scheduledAt: iso,
+    updatedAt: iso,
+    failureCount: existing?.failureCount ?? 0,
+    lastError: null,
+    txHash: null,
+  };
+  return repository.setPolicyWriteIntent(intent);
+}
+
+/** Marks the contract write as submitted (signed, not yet confirmed). */
+export async function submitPolicyWrite(
+  repository: ApiRepository,
+  owner: string,
+  now = new Date(),
+): Promise<PolicyWriteIntent | null> {
+  const existing = await repository.getPolicyWriteIntent(owner);
+  if (!existing || existing.status !== "pending") return existing;
+  return repository.setPolicyWriteIntent({
+    ...existing,
+    status: "submitted",
+    updatedAt: now.toISOString(),
+  });
+}
+
+/** Records a confirmed contract write. `txHash` is a redacted on-chain reference. */
+export async function confirmPolicyWrite(
+  repository: ApiRepository,
+  owner: string,
+  txHash?: string,
+  now = new Date(),
+): Promise<PolicyWriteIntent | null> {
+  const existing = await repository.getPolicyWriteIntent(owner);
+  if (!existing) return null;
+  return repository.setPolicyWriteIntent({
+    ...existing,
+    status: "confirmed",
+    updatedAt: now.toISOString(),
+    txHash: txHash ?? existing.txHash,
+    lastError: null,
+  });
+}
+
+/**
+ * Records a contract-write failure. The version is NEVER bumped here; a retry
+ * of the same policy re-arms the intent at the same version (see
+ * {@link schedulePolicyWrite}). `message` is sanitized and bounded so wallet
+ * seeds, tokens and transaction payloads can never leak into logs or clients.
+ */
+export async function failPolicyWrite(
+  repository: ApiRepository,
+  owner: string,
+  message: string,
+  now = new Date(),
+): Promise<PolicyWriteIntent | null> {
+  const existing = await repository.getPolicyWriteIntent(owner);
+  if (!existing) return null;
+  return repository.setPolicyWriteIntent({
+    ...existing,
+    status: "failed",
+    updatedAt: now.toISOString(),
+    failureCount: existing.failureCount + 1,
+    lastError: sanitizeFailureReason(message),
+  });
+}
+
+function sanitizeFailureReason(message: string): string {
+  // Strip control characters and newlines (log-injection guard), then bound
+  // the length. Callers must never pass secrets; this is defense in depth.
+  let cleaned = "";
+  for (const char of message) {
+    const code = char.charCodeAt(0);
+    cleaned += code > 31 && code !== 127 ? char : " ";
+  }
+  return cleaned.trim().slice(0, 300);
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation state: API policy version vs chain policy version.
+// ---------------------------------------------------------------------------
+
+export type PolicyReconciliationState =
+  | "not_provisioned"
+  | "pending_write"
+  | "synced"
+  | "chain_ahead"
+  | "diverged";
+
+export interface PolicyReconciliationChainState {
+  policy?: MailboxPolicy;
+  version?: number;
+}
+
+export interface PolicyReconciliation {
+  owner: string;
+  state: PolicyReconciliationState;
+  offchain: {
+    policy: MailboxPolicy | null;
+    source: "default" | "configured" | null;
+    version: number | null;
+  };
+  chain: {
+    policy: MailboxPolicy | null;
+    version: number | null;
+  };
+  writeIntent: {
+    status: PolicyWriteStatus;
+    version: number;
+    policy: ChainMailboxPolicy;
+    scheduledAt: string;
+    updatedAt: string;
+    failureCount: number;
+    lastError: string | null;
+  } | null;
+}
+
+/**
+ * Computes the reconciliation state between the durable off-chain policy and
+ * the on-chain Policies contract state. `chain` is the versioned policy read
+ * from the contract; while BETA-017's chain client is not yet wired, callers
+ * may omit it and reconciliation reports from the durable write intent alone.
+ */
+export async function getPolicyReconciliation(
+  repository: ApiRepository,
+  owner: string,
+  chain: PolicyReconciliationChainState = {},
+): Promise<PolicyReconciliation> {
+  const stored = await repository.getPolicy(owner);
+  const intent = await repository.getPolicyWriteIntent(owner);
+  const { policy, source } = await getMailboxPolicy(repository, owner);
+
+  const chainPolicy = chain.policy ?? null;
+  const chainVersion = chain.version ?? null;
+  const offchainVersion = intent?.offchainVersion ?? null;
+
+  const writeIntent = intent
+    ? {
+        status: intent.status,
+        version: intent.offchainVersion,
+        policy: intent.policy,
+        scheduledAt: intent.scheduledAt,
+        updatedAt: intent.updatedAt,
+        failureCount: intent.failureCount,
+        lastError: intent.lastError,
+      }
+    : null;
+
+  const base = {
+    owner,
+    offchain: { policy, source, version: offchainVersion },
+    chain: { policy: chainPolicy, version: chainVersion },
+    writeIntent,
+  };
+
+  if (!stored) {
+    // An active account must never be without an evaluable policy; provisioning
+    // guarantees this. Reaching here means provisioning never ran for the owner.
+    return { ...base, state: "not_provisioned" as const };
+  }
+
+  // A write is outstanding or retryable: the durable intent exists but the
+  // chain has not confirmed it. This is the "testnet synchronization pending"
+  // signal the story requires.
+  if (intent && (intent.status === "pending" || intent.status === "submitted")) {
+    return { ...base, state: "pending_write" as const };
+  }
+  if (intent && intent.status === "failed") {
+    return { ...base, state: "pending_write" as const };
+  }
+
+  if (chainVersion === null) {
+    // No chain state supplied: a confirmed (or absent) intent is treated as
+    // in sync. The signer wires live chain reads once BETA-017 lands.
+    return { ...base, state: "synced" as const };
+  }
+
+  if (chainVersion > (offchainVersion ?? 0)) {
+    return { ...base, state: "chain_ahead" as const };
+  }
+  if (chainVersion < (offchainVersion ?? 0)) {
+    return { ...base, state: "pending_write" as const };
+  }
+
+  if (chainPolicy && !apiPoliciesEqual(chainPolicy, policy)) {
+    return { ...base, state: "diverged" as const };
+  }
+  return { ...base, state: "synced" as const };
 }

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -3,6 +3,7 @@ import type {
   Credential,
   IdempotencyRecord,
   MailboxPolicy,
+  PolicyWriteIntent,
   Postage,
   PostageStatus,
   Profile,
@@ -87,6 +88,12 @@ export type UpdateUserResult =
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
+  // BETA-023 (Issue #1930): durable scheduled-write intent for the Policies
+  // contract. The off-chain policy and the intent are written together during
+  // provisioning so a retry never re-submits (and never re-bumps the on-chain
+  // version) for an already-scheduled policy.
+  getPolicyWriteIntent(owner: string): Promise<PolicyWriteIntent | null>;
+  setPolicyWriteIntent(intent: PolicyWriteIntent): Promise<PolicyWriteIntent>;
   getSenderRule(owner: string, sender: string): Promise<SenderRule>;
   setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule>;
   getPostage(messageId: string): Promise<Postage | null>;
@@ -278,6 +285,15 @@ export class ValidatedApiRepository implements ApiRepository {
 
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
     return this.inner.setPolicy(owner, versionRecord("mailboxPolicy", policy));
+  }
+
+  async getPolicyWriteIntent(owner: string): Promise<PolicyWriteIntent | null> {
+    const raw = await this.inner.getPolicyWriteIntent(owner);
+    return raw ? validateRecord<PolicyWriteIntent>("policyWriteIntent", raw) : null;
+  }
+
+  setPolicyWriteIntent(intent: PolicyWriteIntent): Promise<PolicyWriteIntent> {
+    return this.inner.setPolicyWriteIntent(versionRecord("policyWriteIntent", intent));
   }
 
   async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
@@ -497,6 +513,7 @@ export const DEFAULT_RETRY_POLICY: RetryPolicy = {
 
 const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getPolicy",
+  "getPolicyWriteIntent",
   "getSenderRule",
   "getPostage",
   "getReceipt",
@@ -508,6 +525,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getRelayDeadLetterCount",
   "getCounter",
   "setPolicy",
+  "setPolicyWriteIntent",
   "setSenderRule",
   "setPostage",
   "setReceipt",
@@ -586,6 +604,14 @@ export class RetryableApiRepository implements ApiRepository {
 
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy> {
     return this.withRetry("setPolicy", () => this.inner.setPolicy(owner, policy));
+  }
+
+  getPolicyWriteIntent(owner: string): Promise<PolicyWriteIntent | null> {
+    return this.withRetry("getPolicyWriteIntent", () => this.inner.getPolicyWriteIntent(owner));
+  }
+
+  setPolicyWriteIntent(intent: PolicyWriteIntent): Promise<PolicyWriteIntent> {
+    return this.withRetry("setPolicyWriteIntent", () => this.inner.setPolicyWriteIntent(intent));
   }
 
   getSenderRule(owner: string, sender: string): Promise<SenderRule> {

--- a/tests/unit/api/account-provisioning.test.ts
+++ b/tests/unit/api/account-provisioning.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { initializeMailboxPolicyDefaults } from "../../../src/server/api/account-provisioning";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  betaDefaultMailboxPolicy,
+  getMailboxPolicy,
+  getPolicyWriteIntent,
+} from "../../../src/server/api/policy-service";
+
+const owner = `G${"A".repeat(55)}`;
+
+describe("initializeMailboxPolicyDefaults (BETA-023 / Issue #1930)", () => {
+  it("provisions the privacy-safe beta default on first run", async () => {
+    const repository = new MemoryApiRepository();
+
+    const result = await initializeMailboxPolicyDefaults(repository, owner);
+
+    expect(result).toMatchObject({
+      provisioned: true,
+      source: "default",
+      offchainVersion: 1,
+      scheduled: true,
+      policy: betaDefaultMailboxPolicy,
+    });
+
+    await expect(getMailboxPolicy(repository, owner)).resolves.toMatchObject({
+      policy: {
+        allowUnknown: true,
+        requireVerified: false,
+        minimumPostage: "0",
+      },
+      source: "configured",
+    });
+  });
+
+  it("schedules a matching testnet contract write at version 1", async () => {
+    const repository = new MemoryApiRepository();
+
+    await initializeMailboxPolicyDefaults(repository, owner);
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent).toMatchObject({
+      status: "pending",
+      offchainVersion: 1,
+      policy: betaDefaultMailboxPolicy,
+    });
+  });
+
+  it("is idempotent: a retry never bumps the version or re-schedules", async () => {
+    const repository = new MemoryApiRepository();
+
+    await initializeMailboxPolicyDefaults(repository, owner);
+    const second = await initializeMailboxPolicyDefaults(repository, owner);
+    const third = await initializeMailboxPolicyDefaults(repository, owner);
+
+    expect(second).toMatchObject({ provisioned: false, scheduled: false });
+    expect(third).toMatchObject({ provisioned: false, scheduled: false });
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent?.offchainVersion).toBe(1);
+  });
+
+  it("never overwrites a user-customized policy", async () => {
+    const repository = new MemoryApiRepository();
+
+    const { setMailboxPolicy } = await import("../../../src/server/api/policy-service");
+    await setMailboxPolicy(repository, owner, {
+      allowUnknown: false,
+      requireVerified: true,
+      minimumPostage: "250",
+    });
+
+    const result = await initializeMailboxPolicyDefaults(repository, owner);
+
+    expect(result).toMatchObject({
+      provisioned: false,
+      source: "configured",
+      scheduled: false,
+      offchainVersion: 1,
+    });
+
+    await expect(getMailboxPolicy(repository, owner)).resolves.toMatchObject({
+      policy: {
+        allowUnknown: false,
+        requireVerified: true,
+        minimumPostage: "250",
+      },
+    });
+  });
+
+  it("reports the beta default as the scheduled policy", async () => {
+    const repository = new MemoryApiRepository();
+
+    const result = await initializeMailboxPolicyDefaults(repository, owner);
+
+    expect(result.policy).toEqual(betaDefaultMailboxPolicy);
+  });
+});

--- a/tests/unit/api/policy-reconciliation.test.ts
+++ b/tests/unit/api/policy-reconciliation.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { initializeMailboxPolicyDefaults } from "../../../src/server/api/account-provisioning";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  confirmPolicyWrite,
+  failPolicyWrite,
+  getPolicyReconciliation,
+} from "../../../src/server/api/policy-service";
+
+const owner = `G${"A".repeat(55)}`;
+
+const BETA_POLICY_OFFCHAIN = {
+  allowUnknown: true,
+  requireVerified: false,
+  minimumPostage: "0",
+};
+
+describe("getPolicyReconciliation (BETA-023 / Issue #1930)", () => {
+  it("reports not_provisioned when the owner has no stored policy", async () => {
+    const repository = new MemoryApiRepository();
+
+    const result = await getPolicyReconciliation(repository, owner);
+
+    expect(result.state).toBe("not_provisioned");
+    expect(result.offchain.source).toBe("default");
+    expect(result.writeIntent).toBeNull();
+  });
+
+  it("reports pending_write while the provisioning write is outstanding", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+
+    const result = await getPolicyReconciliation(repository, owner);
+
+    expect(result.state).toBe("pending_write");
+    expect(result.writeIntent).toMatchObject({
+      status: "pending",
+      version: 1,
+    });
+  });
+
+  it("reports pending_write for a failed (retryable) write", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await failPolicyWrite(repository, owner, "rpc down");
+
+    const result = await getPolicyReconciliation(repository, owner);
+
+    expect(result.state).toBe("pending_write");
+    expect(result.writeIntent?.status).toBe("failed");
+    expect(result.writeIntent?.failureCount).toBe(1);
+  });
+
+  it("treats a confirmed intent without chain state as synced", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await confirmPolicyWrite(repository, owner, "tx-1");
+
+    const result = await getPolicyReconciliation(repository, owner);
+
+    expect(result.state).toBe("synced");
+    expect(result.writeIntent?.status).toBe("confirmed");
+  });
+
+  it("reports chain_ahead when the contract is newer than the off-chain policy", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await confirmPolicyWrite(repository, owner, "tx-1");
+
+    const result = await getPolicyReconciliation(repository, owner, {
+      policy: {
+        ...BETA_POLICY_OFFCHAIN,
+        minimumPostage: "500",
+      },
+      version: 4,
+    });
+
+    expect(result.state).toBe("chain_ahead");
+    expect(result.chain.version).toBe(4);
+  });
+
+  it("reports diverged when versions match but policies differ", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await confirmPolicyWrite(repository, owner, "tx-1");
+
+    const result = await getPolicyReconciliation(repository, owner, {
+      policy: {
+        ...BETA_POLICY_OFFCHAIN,
+        requireVerified: true,
+      },
+      version: 1,
+    });
+
+    expect(result.state).toBe("diverged");
+  });
+
+  it("reports pending_write when the contract lags the off-chain version", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await confirmPolicyWrite(repository, owner, "tx-1");
+
+    const result = await getPolicyReconciliation(repository, owner, {
+      policy: BETA_POLICY_OFFCHAIN,
+      version: 0,
+    });
+
+    expect(result.state).toBe("pending_write");
+  });
+
+  it("reports synced when versions and policies align", async () => {
+    const repository = new MemoryApiRepository();
+    await initializeMailboxPolicyDefaults(repository, owner);
+    await confirmPolicyWrite(repository, owner, "tx-1");
+
+    const result = await getPolicyReconciliation(repository, owner, {
+      policy: BETA_POLICY_OFFCHAIN,
+      version: 1,
+    });
+
+    expect(result.state).toBe("synced");
+  });
+});

--- a/tests/unit/api/policy-write-intent.test.ts
+++ b/tests/unit/api/policy-write-intent.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  betaDefaultMailboxPolicy,
+  confirmPolicyWrite,
+  failPolicyWrite,
+  getPolicyWriteIntent,
+  schedulePolicyWrite,
+  submitPolicyWrite,
+} from "../../../src/server/api/policy-service";
+
+const owner = `G${"A".repeat(55)}`;
+
+describe("policy write intents (BETA-023 / Issue #1930)", () => {
+  it("schedules a fresh pending intent at off-chain version 1", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent).toMatchObject({
+      owner,
+      policy: betaDefaultMailboxPolicy,
+      offchainVersion: 1,
+      status: "pending",
+      failureCount: 0,
+    });
+  });
+
+  it("re-scheduling the identical policy never bumps the version", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent?.offchainVersion).toBe(1);
+  });
+
+  it("a genuinely different policy bumps the version by exactly one", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await schedulePolicyWrite(repository, owner, {
+      ...betaDefaultMailboxPolicy,
+      minimumPostage: "100",
+    });
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent?.offchainVersion).toBe(2);
+    expect(intent?.policy.minimumPostage).toBe("100");
+  });
+
+  it("re-arms a failed intent at the same version (retry, not a new change)", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await failPolicyWrite(repository, owner, "soroban rpc unavailable");
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent).toMatchObject({
+      status: "pending",
+      offchainVersion: 1,
+      lastError: null,
+    });
+  });
+
+  it("advances an intent through pending -> submitted -> confirmed", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await submitPolicyWrite(repository, owner);
+
+    let intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent?.status).toBe("submitted");
+
+    await confirmPolicyWrite(repository, owner, "tx-abc");
+    intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent).toMatchObject({
+      status: "confirmed",
+      txHash: "tx-abc",
+    });
+  });
+
+  it("records sanitized, bounded failure reasons", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await failPolicyWrite(repository, owner, "seed=super-secret\nline2");
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent).toMatchObject({
+      status: "failed",
+      failureCount: 1,
+    });
+    expect(intent?.lastError).toBe("seed=super-secret line2");
+  });
+
+  it("a failed intent reports its version as-is (never bumped on failure)", async () => {
+    const repository = new MemoryApiRepository();
+
+    await schedulePolicyWrite(repository, owner, betaDefaultMailboxPolicy);
+    await failPolicyWrite(repository, owner, "boom");
+
+    const intent = await getPolicyWriteIntent(repository, owner);
+    expect(intent?.offchainVersion).toBe(1);
+  });
+});

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -61,6 +61,54 @@ export function runRepositoryContractTests(
       });
     });
 
+    describe("policy write intents (BETA-023 / Issue #1930)", () => {
+      const intent = {
+        owner,
+        policy: {
+          allowUnknown: true,
+          requireVerified: false,
+          requireReceipt: false,
+          minimumPostage: "0",
+        },
+        offchainVersion: 1,
+        status: "pending" as const,
+        scheduledAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        failureCount: 0,
+        lastError: null,
+        txHash: null,
+      };
+
+      it("returns null for a missing write intent", async () => {
+        await expect(repo.getPolicyWriteIntent(owner)).resolves.toBeNull();
+      });
+
+      it("round-trips a policy write intent keyed by owner", async () => {
+        await repo.setPolicyWriteIntent(intent);
+        await expect(repo.getPolicyWriteIntent(owner)).resolves.toMatchObject({
+          owner,
+          offchainVersion: 1,
+          status: "pending",
+        });
+      });
+
+      it("overwrites an existing write intent and isolates per owner", async () => {
+        const otherOwner = `G${"C".repeat(55)}`;
+        await repo.setPolicyWriteIntent(intent);
+        await repo.setPolicyWriteIntent({
+          ...intent,
+          owner: otherOwner,
+          offchainVersion: 2,
+        });
+        await expect(repo.getPolicyWriteIntent(owner)).resolves.toMatchObject({
+          offchainVersion: 1,
+        });
+        await expect(repo.getPolicyWriteIntent(otherOwner)).resolves.toMatchObject({
+          offchainVersion: 2,
+        });
+      });
+    });
+
     describe("sender rules", () => {
       it("defaults to 'default' when no rule exists", async () => {
         await expect(repo.getSenderRule(owner, sender)).resolves.toBe("default");

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -60,6 +60,14 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setPolicy");
     return this.inner.setPolicy(owner, policy);
   }
+  async getPolicyWriteIntent(owner: string) {
+    this.maybeFail("getPolicyWriteIntent");
+    return this.inner.getPolicyWriteIntent(owner);
+  }
+  async setPolicyWriteIntent(intent: import("../../../src/server/api/domain").PolicyWriteIntent) {
+    this.maybeFail("setPolicyWriteIntent");
+    return this.inner.setPolicyWriteIntent(intent);
+  }
   async getSenderRule(owner: string, sender: string): Promise<SenderRule> {
     this.maybeFail("getSenderRule");
     return this.inner.getSenderRule(owner, sender);

--- a/tests/unit/onboarding/onboarding.test.ts
+++ b/tests/unit/onboarding/onboarding.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DRAFT,
   ONBOARDING_STEPS,
   SENDER_RULE_TO_POLICY,
+  draftToBetaDefaults,
   draftToMailboxPolicy,
   xlmToStroops,
   type OnboardingDraft,
@@ -105,6 +106,41 @@ describe("draftToMailboxPolicy", () => {
       allowUnknown: false,
       requireVerified: false,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// draftToBetaDefaults (BETA-023 / Issue #1930): full on-chain policy including
+// the delivery-receipt preference, used to schedule the testnet contract write.
+// ---------------------------------------------------------------------------
+describe("draftToBetaDefaults", () => {
+  const base: OnboardingDraft = {
+    ...DEFAULT_DRAFT,
+    walletAddress: `G${"A".repeat(55)}`,
+  };
+
+  it("matches the privacy-safe beta default when all onboarding defaults are accepted", () => {
+    expect(draftToBetaDefaults(base)).toEqual({
+      allowUnknown: true,
+      requireVerified: false,
+      requireReceipt: false,
+      minimumPostage: "0",
+    });
+  });
+
+  it("carries the delivery-receipt preference through", () => {
+    const draft: OnboardingDraft = { ...base, receiptOnDelivery: true };
+    expect(draftToBetaDefaults(draft).requireReceipt).toBe(true);
+  });
+
+  it("carries a configured minimum postage through as stroops", () => {
+    const draft: OnboardingDraft = { ...base, minimumPostage: "0.01" };
+    expect(draftToBetaDefaults(draft).minimumPostage).toBe("100000");
+  });
+
+  it("matches the beta default definition used by provisioning", async () => {
+    const { betaDefaultMailboxPolicy } = await import("../../../src/server/api/policy-service");
+    expect(draftToBetaDefaults(base)).toEqual(betaDefaultMailboxPolicy);
   });
 });
 


### PR DESCRIPTION
## Overview

This PR implements **BETA-023** by initializing a privacy-safe mailbox policy default during provisioning: unknown senders are routed to review requests, no minimum postage is forced (configured postage honored), and delivery receipts are off by default. It persists the off-chain policy, schedules the matching testnet contract write as a durable write intent, and exposes reconciliation state when the API and chain policy versions differ.

## Related Issue

Closes [#1930](https://github.com/Stellar-Mail/stealth/issues/1930)

## Changes

### Policy defaults & provisioning

- **\[ADD\]** `src/server/api/account-provisioning.ts` — idempotent `initializeMailboxPolicyDefaults`: every account gets an evaluable privacy-safe policy; provisioning retries never re-submit an identical write and never bump the policy version; a user-customized policy is never overwritten.
- **\[MODIFY\]** `src/server/api/policy-service.ts` — `betaDefaultMailboxPolicy`, `toChainMailboxPolicy`, `schedulePolicyWrite` / `submitPolicyWrite` / `confirmPolicyWrite` / `failPolicyWrite`, and `getPolicyReconciliation` (states: `not_provisioned`, `pending_write`, `synced`, `chain_ahead`, `diverged`). Sanitized, bounded failure reasons so secrets can never leak into logs.

### Durable write intent (schedule the matching testnet contract write)

- **\[ADD\]** `ChainMailboxPolicy` and `PolicyWriteIntent` records in `src/server/api/domain.ts`, persisted through `ValidatedApiRepository`, `RetryableApiRepository`, and the memory + KV repositories.
- **\[ADD\]** `requireReceipt` carried into the on-chain policy shape. Re-scheduling the identical policy is a no-op and never inflates the on-chain version — mirroring the Policies contract's version-as-change-marker rule (`contracts/soroban/policies/src/lib.rs`).

### API surface

- **\[ADD\]** `POST /api/v1/policies/{owner}/provision` (`src/routes/api/v1/policies/$owner/provision.ts`) with `x-idempotency-key` support.
- **\[ADD\]** `GET /api/v1/policies/{owner}/reconciliation` (`src/routes/api/v1/policies/$owner/reconciliation.ts`) — surfaces "testnet synchronization pending" when the durable write is outstanding.
- **\[MODIFY\]** `PUT /api/v1/policies/{owner}` (`$owner.ts`) accepts the optional `requireReceipt` field.
- **\[MODIFY\]** `src/server/api/openapi.ts` + `openapi.json` — new schemas and paths, regenerated.

### Onboarding

- **\[ADD\]** `draftToBetaDefaults` in `src/features/onboarding/types.ts` maps the onboarding draft (sender rule, minimum postage, receipt preference) to the full on-chain beta policy.

## Verification Results

```
npx prettier --check .
✅ All matched files use Prettier code style!

npm run lint
✅ eslint . — 0 problems

npx tsc --noEmit
✅ exit 0

npm run test
✅ Test Files 162 passed (162) — 1930 passed | 3 expected fail
   (one pre-existing flaky fork-worker timeout in
    tests/unit/requests/requests.test.ts; passes in isolation)

npm run build
✅ vite build — client + SSR environments built successfully
```

Acceptance Criteria | Status
--- | ---
No active account exists without an evaluable policy | ✅ `initializeMailboxPolicyDefaults` guarantees a stored policy; reconciliation reports `not_provisioned` when absent
Provisioning retries do not increment policy versions unnecessarily | ✅ identical re-schedule / re-provision is a no-op at the same version; only genuine policy changes bump by exactly one
Tests cover defaults, user customization, contract failure, and reconciliation | ✅ `account-provisioning.test.ts`, `policy-write-intent.test.ts`, `policy-reconciliation.test.ts`, `onboarding.test.ts`, `repository-contract.ts`
Secrets absent from logs and fixtures | ✅ `failPolicyWrite` sanitizes control characters and bounds error text; no seeds or tokens logged

## Dependencies

- **#1921** — `BETA-014` (transactional account-provisioning orchestrator): this PR delivers the isolated policy-initialization slice (`account-provisioning.ts`) that the orchestrator will call; the provisioning route already exercises the same entrypoint.
- **#1924** — `BETA-017` (managed-wallet signer + chain client): the durable write-intent pipeline (`schedule` → `submit` → `confirm` / `fail`) is fully implemented and unit-tested; the signer consumes and advances these records, and `getPolicyReconciliation` already accepts live chain state.
