### PR TITLE
feat(api): add transactional account-provisioning orchestrator (BETA-014) #1921

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -86,6 +86,7 @@
               "challenge_not_yet_valid",
               "idempotency_mismatch",
               "invalid_state_transition",
+              "username_unavailable",
               "insufficient_postage",
               "duplicate_receipt",
               "duplicate_postage",
@@ -244,6 +245,83 @@
         "enum": ["permanent", "transient", "rate_limit", "conflict"],
         "description": "Stable machine-readable classification of retry eligibility."
       },
+      "ProvisioningStatus": {
+        "type": "string",
+        "enum": ["pending", "retryable", "active", "failed"],
+        "description": "State of the transactional account-provisioning state machine."
+      },
+      "ProvisioningStep": {
+        "type": "string",
+        "enum": [
+          "username_reservation",
+          "profile_defaults",
+          "wallet_creation",
+          "mailbox_policy_init"
+        ],
+        "description": "A single idempotent step of the provisioning flow."
+      },
+      "ProvisioningFailure": {
+        "type": "object",
+        "required": ["step", "code", "message", "failedAt"],
+        "properties": {
+          "step": {
+            "$ref": "#/components/schemas/ProvisioningStep"
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable domain error code of the failing step."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable failure explanation."
+          },
+          "failedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ProvisioningProgress": {
+        "type": "object",
+        "required": ["status", "requestedUsername", "completedSteps", "currentStep", "attempts"],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ProvisioningStatus"
+          },
+          "requestedUsername": {
+            "type": "string",
+            "pattern": "^[a-z0-9_-]{3,30}$"
+          },
+          "completedSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProvisioningStep"
+            }
+          },
+          "currentStep": {
+            "$ref": "#/components/schemas/ProvisioningStep"
+          },
+          "attempts": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of flow runs attempted so far."
+          },
+          "failure": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProvisioningFailure"
+              },
+              {
+                "nullable": true
+              }
+            ]
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "ErrorEnvelope": {
         "type": "object",
         "required": ["error", "meta"],
@@ -273,6 +351,7 @@
                   "challenge_not_yet_valid",
                   "idempotency_mismatch",
                   "invalid_state_transition",
+                  "username_unavailable",
                   "insufficient_postage",
                   "duplicate_receipt",
                   "duplicate_postage",
@@ -410,6 +489,12 @@
             "message": "The requested state transition is invalid",
             "retryable": false,
             "description": "The resource cannot transition from its current state as requested."
+          },
+          "username_unavailable": {
+            "status": 409,
+            "message": "The requested username is not available",
+            "retryable": false,
+            "description": "The username is held by another account or claim; no amount of retrying can make it available."
           },
           "insufficient_postage": {
             "status": 422,
@@ -1990,6 +2075,274 @@
           },
           "503": {
             "description": "Not Ready — a required dependency is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/accounts": {
+      "post": {
+        "operationId": "provisionAccount",
+        "summary": "Provision an account (username, profile, wallet, policy)",
+        "description": "Idempotently runs the transactional account-provisioning state machine: username reservation, profile defaults, wallet creation and mailbox policy initialization converge without leaving a partial active account. Repeated calls are safe against duplicate requests; an optional x-idempotency-key enables strict replay semantics.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "description": "Provisioning intent. Email and username are required only when no account exists for the actor yet.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "username": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9_-]{3,30}$"
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "maxLength": 80
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provisioning progress after a completed or resumed run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisioningProgress"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — username unavailable or provisioning previously failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/accounts/provisioning": {
+      "get": {
+        "operationId": "getAccountProvisioningProgress",
+        "summary": "Read provisioning progress for the authenticated account",
+        "description": "Safe progress projection: provisioning state, completed steps, attempts and the last failure. Never exposes credentials, wallet seeds, or hashes.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "responses": {
+          "200": {
+            "description": "Provisioning progress and account status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["provisioning", "accountStatus"],
+                  "properties": {
+                    "provisioning": {
+                      "$ref": "#/components/schemas/ProvisioningProgress"
+                    },
+                    "accountStatus": {
+                      "type": "string",
+                      "enum": ["active", "suspended", "pending_verification", "deactivated"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found — no account or provisioning record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/accounts/provisioning/retry": {
+      "post": {
+        "operationId": "retryAccountProvisioning",
+        "summary": "Retry a failed provisioning run",
+        "description": "Restarts a retryable provisioning flow from its first incomplete step. Only retryable flows may be restarted; active and in-flight flows are rejected with a deterministic 409.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "responses": {
+          "200": {
+            "description": "Provisioning progress after the retry run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisioningProgress"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found — no account or provisioning record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — provisioning in flight, already active, or attempts exhausted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -86,7 +86,6 @@
               "challenge_not_yet_valid",
               "idempotency_mismatch",
               "invalid_state_transition",
-              "username_unavailable",
               "insufficient_postage",
               "duplicate_receipt",
               "duplicate_postage",
@@ -519,7 +518,6 @@
                   "challenge_not_yet_valid",
                   "idempotency_mismatch",
                   "invalid_state_transition",
-                  "username_unavailable",
                   "insufficient_postage",
                   "duplicate_receipt",
                   "duplicate_postage",
@@ -657,12 +655,6 @@
             "message": "The requested state transition is invalid",
             "retryable": false,
             "description": "The resource cannot transition from its current state as requested."
-          },
-          "username_unavailable": {
-            "status": 409,
-            "message": "The requested username is not available",
-            "retryable": false,
-            "description": "The username is held by another account or claim; no amount of retrying can make it available."
           },
           "insufficient_postage": {
             "status": 422,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ApiV1OpenapiDotjsonRouteImport } from './routes/api/v1/openapi
 import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
 import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts/index'
 import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
+import { Route as ApiV1AccountsIndexRouteImport } from './routes/api/v1/accounts/index'
 import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
 import { Route as ApiV1RelayReadinessRouteImport } from './routes/api/v1/relay/readiness'
 import { Route as ApiV1RelayMessagesRouteImport } from './routes/api/v1/relay/messages'
@@ -26,9 +27,11 @@ import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/q
 import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/accounts/provisioning'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
+import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
@@ -69,6 +72,11 @@ const ApiV1ReceiptsIndexRoute = ApiV1ReceiptsIndexRouteImport.update({
 const ApiV1PostageIndexRoute = ApiV1PostageIndexRouteImport.update({
   id: '/api/v1/postage/',
   path: '/api/v1/postage/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AccountsIndexRoute = ApiV1AccountsIndexRouteImport.update({
+  id: '/api/v1/accounts/',
+  path: '/api/v1/accounts/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1RelayVersionRoute = ApiV1RelayVersionRouteImport.update({
@@ -116,6 +124,12 @@ const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
   path: '/api/v1/policies/$owner',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AccountsProvisioningRoute =
+  ApiV1AccountsProvisioningRouteImport.update({
+    id: '/api/v1/accounts/provisioning',
+    path: '/api/v1/accounts/provisioning',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -134,6 +148,12 @@ const ApiV1PostageMessageIdRefundRoute =
     path: '/refund',
     getParentRoute: () => ApiV1PostageMessageIdRoute,
   } as any)
+const ApiV1AccountsProvisioningRetryRoute =
+  ApiV1AccountsProvisioningRetryRouteImport.update({
+    id: '/retry',
+    path: '/retry',
+    getParentRoute: () => ApiV1AccountsProvisioningRoute,
+  } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
@@ -148,6 +168,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -157,8 +178,10 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/messages': typeof ApiV1RelayMessagesRoute
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
+  '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -171,6 +194,7 @@ export interface FileRoutesByTo {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -180,8 +204,10 @@ export interface FileRoutesByTo {
   '/api/v1/relay/messages': typeof ApiV1RelayMessagesRoute
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
+  '/api/v1/accounts': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -195,6 +221,7 @@ export interface FileRoutesById {
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
+  '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -204,8 +231,10 @@ export interface FileRoutesById {
   '/api/v1/relay/messages': typeof ApiV1RelayMessagesRoute
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
+  '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
@@ -220,6 +249,7 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/accounts/provisioning'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -229,8 +259,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/messages'
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
+    | '/api/v1/accounts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -243,6 +275,7 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/accounts/provisioning'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -252,8 +285,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/messages'
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
+    | '/api/v1/accounts'
     | '/api/v1/postage'
     | '/api/v1/receipts'
+    | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -266,6 +301,7 @@ export interface FileRouteTypes {
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
+    | '/api/v1/accounts/provisioning'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -275,8 +311,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/messages'
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
+    | '/api/v1/accounts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
@@ -290,6 +328,7 @@ export interface RootRouteChildren {
   ApiV1HealthRoute: typeof ApiV1HealthRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
+  ApiV1AccountsProvisioningRoute: typeof ApiV1AccountsProvisioningRouteWithChildren
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -299,6 +338,7 @@ export interface RootRouteChildren {
   ApiV1RelayMessagesRoute: typeof ApiV1RelayMessagesRoute
   ApiV1RelayReadinessRoute: typeof ApiV1RelayReadinessRoute
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
+  ApiV1AccountsIndexRoute: typeof ApiV1AccountsIndexRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
 }
@@ -359,6 +399,13 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/postage'
       fullPath: '/api/v1/postage/'
       preLoaderRoute: typeof ApiV1PostageIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/accounts/': {
+      id: '/api/v1/accounts/'
+      path: '/api/v1/accounts'
+      fullPath: '/api/v1/accounts/'
+      preLoaderRoute: typeof ApiV1AccountsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/relay/version': {
@@ -424,6 +471,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/accounts/provisioning': {
+      id: '/api/v1/accounts/provisioning'
+      path: '/api/v1/accounts/provisioning'
+      fullPath: '/api/v1/accounts/provisioning'
+      preLoaderRoute: typeof ApiV1AccountsProvisioningRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -445,6 +499,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PostageMessageIdRefundRouteImport
       parentRoute: typeof ApiV1PostageMessageIdRoute
     }
+    '/api/v1/accounts/provisioning/retry': {
+      id: '/api/v1/accounts/provisioning/retry'
+      path: '/retry'
+      fullPath: '/api/v1/accounts/provisioning/retry'
+      preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
+      parentRoute: typeof ApiV1AccountsProvisioningRoute
+    }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
       path: '/senders/$sender'
@@ -454,6 +515,20 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface ApiV1AccountsProvisioningRouteChildren {
+  ApiV1AccountsProvisioningRetryRoute: typeof ApiV1AccountsProvisioningRetryRoute
+}
+
+const ApiV1AccountsProvisioningRouteChildren: ApiV1AccountsProvisioningRouteChildren =
+  {
+    ApiV1AccountsProvisioningRetryRoute: ApiV1AccountsProvisioningRetryRoute,
+  }
+
+const ApiV1AccountsProvisioningRouteWithChildren =
+  ApiV1AccountsProvisioningRoute._addFileChildren(
+    ApiV1AccountsProvisioningRouteChildren,
+  )
 
 interface ApiV1PoliciesOwnerRouteChildren {
   ApiV1PoliciesOwnerSendersSenderRoute: typeof ApiV1PoliciesOwnerSendersSenderRoute
@@ -502,6 +577,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1HealthRoute: ApiV1HealthRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
+  ApiV1AccountsProvisioningRoute: ApiV1AccountsProvisioningRouteWithChildren,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,
@@ -511,6 +587,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayMessagesRoute: ApiV1RelayMessagesRoute,
   ApiV1RelayReadinessRoute: ApiV1RelayReadinessRoute,
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
+  ApiV1AccountsIndexRoute: ApiV1AccountsIndexRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -28,10 +28,10 @@ import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/posta
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
+import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
 import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/accounts/provisioning'
-import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -135,6 +135,11 @@ const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
   path: '/api/v1/auth/session',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
+  id: '/api/v1/auth/register',
+  path: '/api/v1/auth/register',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
   id: '/api/v1/auth/logout',
   path: '/api/v1/auth/logout',
@@ -151,11 +156,6 @@ const ApiV1AccountsProvisioningRoute =
     path: '/api/v1/accounts/provisioning',
     getParentRoute: () => rootRouteImport,
   } as any)
-const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
-  id: '/api/v1/auth/register',
-  path: '/api/v1/auth/register',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -208,8 +208,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -240,8 +240,8 @@ export interface FileRoutesByTo {
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -273,8 +273,8 @@ export interface FileRoutesById {
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/accounts/provisioning': typeof ApiV1AccountsProvisioningRouteWithChildren
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -307,8 +307,8 @@ export interface FileRouteTypes {
     | '/api/v1/protocol'
     | '/api/v1/accounts/provisioning'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -339,8 +339,8 @@ export interface FileRouteTypes {
     | '/api/v1/protocol'
     | '/api/v1/accounts/provisioning'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -371,8 +371,8 @@ export interface FileRouteTypes {
     | '/api/v1/protocol'
     | '/api/v1/accounts/provisioning'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -404,8 +404,8 @@ export interface RootRouteChildren {
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
   ApiV1AccountsProvisioningRoute: typeof ApiV1AccountsProvisioningRouteWithChildren
   ApiV1AuthLoginRoute: typeof ApiV1AuthLoginRoute
-  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthLogoutRoute: typeof ApiV1AuthLogoutRoute
+  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
@@ -556,6 +556,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AuthSessionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/register': {
+      id: '/api/v1/auth/register'
+      path: '/api/v1/auth/register'
+      fullPath: '/api/v1/auth/register'
+      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/auth/logout': {
       id: '/api/v1/auth/logout'
       path: '/api/v1/auth/logout'
@@ -575,11 +582,6 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/accounts/provisioning'
       fullPath: '/api/v1/accounts/provisioning'
       preLoaderRoute: typeof ApiV1AccountsProvisioningRouteImport
-    '/api/v1/auth/register': {
-      id: '/api/v1/auth/register'
-      path: '/api/v1/auth/register'
-      fullPath: '/api/v1/auth/register'
-      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/receipts/$messageId/read': {
@@ -701,8 +703,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
   ApiV1AccountsProvisioningRoute: ApiV1AccountsProvisioningRouteWithChildren,
   ApiV1AuthLoginRoute: ApiV1AuthLoginRoute,
-  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthLogoutRoute: ApiV1AuthLogoutRoute,
+  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,

--- a/src/routes/api/v1/accounts/index.ts
+++ b/src/routes/api/v1/accounts/index.ts
@@ -53,7 +53,7 @@ export const Route = createFileRoute("/api/v1/accounts/")({
                 },
                 input,
                 provision,
-                // Deterministic conflicts (username_unavailable, terminal
+                // Deterministic conflicts (409 username conflicts, terminal
                 // invalid_state_transition) are safe to cache and replay;
                 // transient failures must never be cached so the same key
                 // can be retried immediately.

--- a/src/routes/api/v1/accounts/index.ts
+++ b/src/routes/api/v1/accounts/index.ts
@@ -1,0 +1,71 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { emailSchema, usernameSchema } from "@/server/api/domain";
+import { provisionAccount } from "@/server/api/account-provisioning";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { withIdempotency } from "@/server/api/idempotency-service";
+
+const provisionBodySchema = z.object({
+  email: emailSchema.optional(),
+  username: usernameSchema.optional(),
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Display name cannot be empty")
+    .max(80, "Display name cannot exceed 80 characters")
+    .optional(),
+});
+
+export const Route = createFileRoute("/api/v1/accounts/")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const input = await parseJsonBody(request, provisionBodySchema, {
+            route: "POST /accounts",
+          });
+
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+          const provision = async () => {
+            const progress = await provisionAccount(context.repository, {
+              address: actor,
+              username: input.username ?? "",
+              email: input.email,
+              displayName: input.displayName ?? null,
+            });
+            return { status: 200, body: progress };
+          };
+
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                context.repository,
+                {
+                  actor,
+                  method: request.method,
+                  route: "POST /accounts",
+                  rawKey: rawIdempotencyKey,
+                },
+                input,
+                provision,
+                // Deterministic conflicts (username_unavailable, terminal
+                // invalid_state_transition) are safe to cache and replay;
+                // transient failures must never be cached so the same key
+                // can be retried immediately.
+                { cacheableErrorStatuses: [409] },
+              )
+            : { ...(await provision()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            status: result.status,
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/accounts/provisioning.ts
+++ b/src/routes/api/v1/accounts/provisioning.ts
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { getProvisioningProgress } from "@/server/api/account-provisioning";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { ApiError } from "@/server/api/errors";
+
+export const Route = createFileRoute("/api/v1/accounts/provisioning")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const user = await context.repository.getUserByAddress(actor);
+          if (!user) {
+            throw new ApiError(404, "not_found", "No account exists for this address");
+          }
+          const provisioning = await getProvisioningProgress(context.repository, user.userId);
+          if (!provisioning) {
+            throw new ApiError(404, "not_found", "No provisioning record exists for this account");
+          }
+          // Safe projection: provisioning progress + account status only.
+          // Never exposes credentials, wallet seeds, or hashes.
+          return apiSuccess(request, {
+            provisioning,
+            accountStatus: user.status,
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/accounts/provisioning/retry.ts
+++ b/src/routes/api/v1/accounts/provisioning/retry.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { retryAccountProvisioning } from "@/server/api/account-provisioning";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { ApiError } from "@/server/api/errors";
+
+export const Route = createFileRoute("/api/v1/accounts/provisioning/retry")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const address = requireActor(context);
+
+          // Owner-scoped retry control: only the account owner may restart a
+          // failed provisioning flow for their own account.
+          const user = await context.repository.getUserByAddress(address);
+          if (!user) {
+            throw new ApiError(404, "not_found", "No account exists for this address");
+          }
+
+          const progress = await retryAccountProvisioning(context.repository, user.userId);
+          return apiSuccess(request, progress);
+        }),
+    },
+  },
+});

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -1,0 +1,562 @@
+import { randomUUID } from "node:crypto";
+
+import type { ApiRepository, UpdateProvisioningResult } from "./repository";
+import { defaultMailboxPolicy } from "./repository";
+import type {
+  AccountStatus,
+  Profile,
+  ProvisioningFailure,
+  ProvisioningRecord,
+  ProvisioningStep,
+  ProvisioningStatus,
+  User,
+  Wallet,
+} from "./domain";
+import { stellarAddressSchema, usernameSchema } from "./domain";
+import { ApiError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// BETA-014 (Issue #1921): Transactional account-provisioning orchestrator
+//
+// Convergence contract
+// --------------------
+// Signup data (username reservation), profile defaults, wallet creation and
+// mailbox policy initialization must converge without leaving a partial
+// *active* account behind. The orchestrator owns a durable, idempotent
+// state machine per user:
+//
+//   pending   -> active            (all steps completed, account activated)
+//   pending   -> retryable/failed  (a step failed transiently / permanently)
+//   retryable -> pending           (owner/administrator retry restarts it)
+//   retryable -> active            (retry completed)
+//   retryable -> failed            (permanent failure or exhausted attempts)
+//   active / failed are terminal.
+//
+// Safety properties
+// -----------------
+// - Every step is individually idempotent (re-claimable reservation,
+//   profile upsert, insert-once wallet, initialize-if-absent policy), so a
+//   resumed or retried flow never double-creates wallets, addresses, or
+//   policies.
+// - The user record only flips pending_verification -> active after ALL
+//   steps persist; a mid-flow failure leaves the account pending (never a
+//   live half-account) and releases the username reservation as the sole
+//   compensation action.
+// - All state-machine writes are compare-and-swap (expectedVersion), so a
+//   stale writer can never clobber progress made by a concurrent retry.
+// ---------------------------------------------------------------------------
+
+export const PROVISIONING_STEPS = [
+  "username_reservation",
+  "profile_defaults",
+  "wallet_creation",
+  "mailbox_policy_init",
+] as const satisfies readonly ProvisioningStep[];
+
+/** Attempts before a transiently failing flow becomes terminal "failed". */
+export const MAX_PROVISIONING_ATTEMPTS = 5;
+
+/** Lease length for the username claim held for the duration of provisioning. */
+export const USERNAME_RESERVATION_LEASE_MS = 30 * 60 * 1000;
+
+export interface ProvisionAccountInput {
+  /** The account address that owns this provisioning (the actor). */
+  address: string;
+  /** Username to claim; must match the user's bound username when one exists. */
+  username: string;
+  /** Required only when no user record exists yet (signup bootstrap). */
+  email?: string;
+  /** Optional display-name default for the profile. */
+  displayName?: string | null;
+}
+
+/** Safe progress projection: never exposes secrets, hashes, or seeds. */
+export interface ProvisioningProgress {
+  status: ProvisioningStatus;
+  requestedUsername: string;
+  completedSteps: ProvisioningStep[];
+  currentStep: ProvisioningStep;
+  attempts: number;
+  failure: ProvisioningFailure | null;
+  updatedAt: string;
+}
+
+interface StepFailure {
+  permanent: boolean;
+  code: string;
+  message: string;
+}
+
+function classifyFailure(error: unknown): StepFailure {
+  if (error instanceof ApiError) {
+    return { permanent: !error.retryable, code: error.code, message: error.message };
+  }
+  return {
+    permanent: false,
+    code: "internal_error",
+    message: "Provisioning step failed unexpectedly",
+  };
+}
+
+function firstIncompleteStep(record: ProvisioningRecord): ProvisioningStep {
+  const next = PROVISIONING_STEPS.find((step) => !record.completedSteps.includes(step));
+  return next ?? PROVISIONING_STEPS[PROVISIONING_STEPS.length - 1];
+}
+
+function toProgress(record: ProvisioningRecord): ProvisioningProgress {
+  return {
+    status: record.status,
+    requestedUsername: record.requestedUsername,
+    completedSteps: [...record.completedSteps],
+    currentStep: record.currentStep,
+    attempts: record.attempts,
+    failure: record.failure ? { ...record.failure } : null,
+    updatedAt: record.updatedAt,
+  };
+}
+
+async function persist(
+  repository: ApiRepository,
+  record: ProvisioningRecord,
+): Promise<ProvisioningRecord> {
+  const result: UpdateProvisioningResult = await repository.setProvisioningRecord(
+    record,
+    record.version,
+  );
+  if (!result.updated) {
+    throw new ApiError(
+      409,
+      "conflict",
+      "Provisioning state changed concurrently; reconcile before proceeding",
+    );
+  }
+  return result.record;
+}
+
+/**
+ * Applies the failure policy: transient failures become "retryable" (the
+ * account stays pending and compensation releases the username claim);
+ * permanent failures or exhausted attempts become terminal "failed".
+ * Returns the persisted record in its new state.
+ */
+async function markFailure(
+  repository: ApiRepository,
+  record: ProvisioningRecord,
+  step: ProvisioningStep,
+  failure: StepFailure,
+  now: Date,
+): Promise<ProvisioningRecord> {
+  const attempts = record.attempts + 1;
+  const terminal = failure.permanent || attempts >= MAX_PROVISIONING_ATTEMPTS;
+
+  const next: ProvisioningRecord = {
+    ...record,
+    status: terminal ? "failed" : "retryable",
+    currentStep: step,
+    attempts,
+    failure: {
+      step,
+      code: failure.code,
+      message: failure.message,
+      failedAt: now.toISOString(),
+    },
+  };
+
+  const persisted = await persist(repository, next);
+
+  // Compensation: the username claim is the only reversible side effect of
+  // the flow. Releasing it on every failure guarantees a retry can re-claim
+  // it and a dead account never squats a username forever.
+  await repository.releaseUsernameReservation(record.requestedUsername, record.userId);
+
+  return persisted;
+}
+
+/**
+ * Runs every incomplete step in order, then activates the account.
+ * Each step resolves the user record it needs; the first step may bootstrap
+ * the user itself, so the flow must not assume the user exists up front.
+ */
+async function runFlow(
+  repository: ApiRepository,
+  record: ProvisioningRecord,
+  input: ProvisionAccountInput,
+  now: Date,
+): Promise<ProvisioningRecord> {
+  let current = record;
+
+  // Point the progress marker at the first step that still needs to run so a
+  // resumed or retried flow reports where it actually is.
+  const marker = firstIncompleteStep(current);
+  if (current.currentStep !== marker) {
+    current = await persist(repository, { ...current, currentStep: marker });
+  }
+
+  for (const step of PROVISIONING_STEPS) {
+    if (current.completedSteps.includes(step)) continue;
+
+    try {
+      await executeStep(repository, step, current, input, now);
+    } catch (error) {
+      return markFailure(repository, current, step, classifyFailure(error), now);
+    }
+
+    current = await persist(repository, {
+      ...current,
+      completedSteps: [...current.completedSteps, step],
+      failure: null,
+    });
+  }
+
+  // All steps durable: the account may now become active. A concurrent
+  // version bump on the user (CAS failure) is a transient conflict — the
+  // flow lands in retryable and activation is re-attempted on retry.
+  const user = await repository.getUserById(current.userId);
+  if (!user) {
+    return markFailure(
+      repository,
+      current,
+      PROVISIONING_STEPS[PROVISIONING_STEPS.length - 1],
+      {
+        permanent: false,
+        code: "data_integrity_error",
+        message: "The user record for this provisioning no longer exists",
+      },
+      now,
+    );
+  }
+
+  try {
+    await activateAccount(repository, user, now);
+  } catch (error) {
+    return markFailure(
+      repository,
+      current,
+      PROVISIONING_STEPS[PROVISIONING_STEPS.length - 1],
+      classifyFailure(error),
+      now,
+    );
+  }
+
+  const activated = await persist(repository, { ...current, status: "active", failure: null });
+
+  // The username is now permanently bound through the user record, so the
+  // short-lived claim is no longer needed. Best-effort release keeps failed
+  // and successful flows symmetric and never squats the username.
+  await repository.releaseUsernameReservation(record.requestedUsername, record.userId);
+
+  return activated;
+}
+
+async function executeStep(
+  repository: ApiRepository,
+  step: ProvisioningStep,
+  record: ProvisioningRecord,
+  input: ProvisionAccountInput,
+  now: Date,
+): Promise<void> {
+  switch (step) {
+    case "username_reservation":
+      await reserveUsernameStep(repository, record, input, now);
+      return;
+    case "profile_defaults":
+      await profileDefaultsStep(repository, record, now);
+      return;
+    case "wallet_creation":
+      await walletCreationStep(repository, record.userId, now);
+      return;
+    case "mailbox_policy_init":
+      await mailboxPolicyInitStep(repository, record.userId);
+      return;
+  }
+}
+
+async function requireUser(repository: ApiRepository, userId: string): Promise<User> {
+  const user = await repository.getUserById(userId);
+  if (!user) {
+    throw new ApiError(
+      500,
+      "data_integrity_error",
+      "The user record for this provisioning no longer exists",
+    );
+  }
+  return user;
+}
+
+/**
+ * Claims the requested username and bootstraps the user record when no
+ * account exists for the actor yet (BETA-004 signup is not merged, so the
+ * orchestrator owns convergence of the user record itself). When the user
+ * already exists, the bound username is authoritative and the claim is a
+ * no-op.
+ */
+async function reserveUsernameStep(
+  repository: ApiRepository,
+  record: ProvisioningRecord,
+  input: ProvisionAccountInput,
+  now: Date,
+): Promise<void> {
+  const existingUser = await repository.getUserById(record.userId);
+
+  if (existingUser) {
+    if (existingUser.username !== record.requestedUsername) {
+      throw new ApiError(
+        409,
+        "invalid_state_transition",
+        "The requested username does not match the registered account username",
+      );
+    }
+    return;
+  }
+
+  const username = record.requestedUsername;
+  if (!input.email) {
+    throw new ApiError(422, "validation_error", "Email is required to bootstrap an account");
+  }
+
+  const reservation = await repository.reserveUsername(
+    username,
+    record.userId,
+    USERNAME_RESERVATION_LEASE_MS,
+  );
+  if (reservation.outcome === "unavailable") {
+    throw new ApiError(409, "username_unavailable", `Username "${username}" is not available`);
+  }
+
+  try {
+    await repository.createUser({
+      userId: record.userId,
+      address: input.address,
+      email: input.email,
+      username,
+      status: "pending_verification",
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      version: 1,
+    });
+  } catch (error) {
+    if (error instanceof ApiError && error.code === "conflict") {
+      // The reservation said the username was claimable, so a conflict means
+      // the account is in an inconsistent state — no retry fixes that.
+      throw new ApiError(409, "username_unavailable", `Username "${username}" is not available`);
+    }
+    throw error;
+  }
+}
+
+async function profileDefaultsStep(
+  repository: ApiRepository,
+  record: ProvisioningRecord,
+  now: Date,
+): Promise<void> {
+  const user = await requireUser(repository, record.userId);
+  const existing = await repository.getProfile(user.userId);
+  if (existing) return;
+
+  const profile: Profile = {
+    userId: user.userId,
+    username: user.username,
+    displayName: record.displayName ?? user.username,
+    avatarUrl: null,
+    bio: null,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+  await repository.setProfile(profile);
+}
+
+/**
+ * Insert-once wallet creation. The initial on-chain address is the account's
+ * own Stellar address until an external wallet provider exists (dependency
+ * BETA-013); "already-exists" is a successful, idempotent retry.
+ */
+async function walletCreationStep(
+  repository: ApiRepository,
+  userId: string,
+  now: Date,
+): Promise<void> {
+  const user = await requireUser(repository, userId);
+  const wallet: Wallet = {
+    walletId: `wallet_${user.userId}`,
+    userId: user.userId,
+    address: user.address,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+  const result = await repository.createWallet(wallet);
+  if (result.outcome === "already-exists" && result.wallet.userId !== user.userId) {
+    throw new ApiError(
+      500,
+      "data_integrity_error",
+      "A wallet for another account is bound to this user",
+    );
+  }
+}
+
+async function mailboxPolicyInitStep(repository: ApiRepository, userId: string): Promise<void> {
+  const user = await requireUser(repository, userId);
+  await repository.initializePolicyIfAbsent(user.address, defaultMailboxPolicy);
+}
+
+async function activateAccount(repository: ApiRepository, user: User, now: Date): Promise<void> {
+  if (user.status === "active") return;
+
+  const blocked: readonly AccountStatus[] = ["suspended", "deactivated"];
+  if (blocked.includes(user.status)) {
+    throw new ApiError(
+      409,
+      "invalid_state_transition",
+      `Account status "${user.status}" cannot be activated by provisioning`,
+    );
+  }
+
+  const result = await repository.updateUser({ ...user, status: "active" }, user.version);
+  if (!result.updated) {
+    throw new ApiError(
+      409,
+      "conflict",
+      "User record changed concurrently; activation must be retried",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public orchestrator API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the safe progress projection, or null when no provisioning record
+ * exists for the user.
+ */
+export async function getProvisioningProgress(
+  repository: ApiRepository,
+  userId: string,
+): Promise<ProvisioningProgress | null> {
+  const record = await repository.getProvisioningRecord(userId);
+  return record ? toProgress(record) : null;
+}
+
+/**
+ * Idempotently provisions an account:
+ * - no record      -> create one (pending) and run the flow
+ * - pending/retryable -> resume from the completed steps (safe: every step
+ *   is idempotent, so resumption never double-creates)
+ * - active         -> return the current progress (idempotent replay)
+ * - failed         -> conflict; the retry endpoint owns restarting it
+ */
+export async function provisionAccount(
+  repository: ApiRepository,
+  input: ProvisionAccountInput,
+  now: Date = new Date(),
+): Promise<ProvisioningProgress> {
+  const normalizedUsername = usernameSchema.parse(input.username);
+  const user = await repository.getUserByAddress(input.address);
+
+  const createInitial = (userId: string, requestedUsername: string): ProvisioningRecord => ({
+    userId,
+    status: "pending",
+    requestedUsername,
+    displayName: input.displayName?.trim() || null,
+    completedSteps: [],
+    currentStep: PROVISIONING_STEPS[0],
+    attempts: 0,
+    failure: null,
+    startedAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    version: 1,
+  });
+
+  if (!user) {
+    // Deterministic input validation happens before any state is created: a
+    // malformed request must surface as a 422, not as a failed provisioning
+    // record that would need retry control to clear.
+    if (!stellarAddressSchema.safeParse(input.address).success) {
+      throw new ApiError(422, "validation_error", "A valid Stellar address is required");
+    }
+    if (!input.email) {
+      throw new ApiError(422, "validation_error", "Email is required to bootstrap an account");
+    }
+
+    const userId = `u_${randomUUID()}`;
+    const created = await repository.createProvisioningRecord(
+      createInitial(userId, normalizedUsername),
+    );
+    const completed = await runFlow(repository, created.record, input, now);
+    return toProgress(completed);
+  }
+
+  const existing = await repository.getProvisioningRecord(user.userId);
+  if (!existing) {
+    // The bound username is authoritative for an existing account; the
+    // requested one can never re-bind it.
+    const created = await repository.createProvisioningRecord(
+      createInitial(user.userId, user.username),
+    );
+    const completed = await runFlow(repository, created.record, input, now);
+    return toProgress(completed);
+  }
+
+  if (existing.status === "active") {
+    return toProgress(existing);
+  }
+  if (existing.status === "failed") {
+    throw new ApiError(
+      409,
+      "invalid_state_transition",
+      "Account provisioning previously failed; use the retry endpoint",
+    );
+  }
+
+  const resumed = await runFlow(repository, existing, input, now);
+  return toProgress(resumed);
+}
+
+/**
+ * Owner/administrator retry control. Only a retryable flow may be restarted;
+ * active (terminal) and pending (already in flight) flows are rejected with
+ * a deterministic 409, and a flow that exhausted its attempts stays failed.
+ */
+export async function retryAccountProvisioning(
+  repository: ApiRepository,
+  userId: string,
+  now: Date = new Date(),
+): Promise<ProvisioningProgress> {
+  const record = await repository.getProvisioningRecord(userId);
+  if (!record) {
+    throw new ApiError(404, "not_found", "No provisioning record exists for this account");
+  }
+  if (record.status === "pending") {
+    throw new ApiError(409, "invalid_state_transition", "Provisioning is already in flight");
+  }
+  if (record.status === "active") {
+    throw new ApiError(409, "invalid_state_transition", "Account is already provisioned");
+  }
+  if (record.attempts + 1 > MAX_PROVISIONING_ATTEMPTS) {
+    throw new ApiError(
+      409,
+      "invalid_state_transition",
+      "Provisioning retry attempts are exhausted",
+    );
+  }
+
+  const restarted: ProvisioningRecord = {
+    ...record,
+    status: "pending",
+    failure: null,
+    // The attempt counter increments on the next failed run (markFailure),
+    // so restarting a run does not double-count it.
+    attempts: record.attempts,
+    currentStep: firstIncompleteStep(record),
+  };
+  const persisted = await persist(repository, restarted);
+  const completed = await runFlow(
+    repository,
+    persisted,
+    {
+      address: "",
+      username: persisted.requestedUsername,
+    },
+    now,
+  );
+  return toProgress(completed);
+}

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -171,9 +171,21 @@ interface StepFailure {
   message: string;
 }
 
+/**
+ * A taken username is a *deterministic* conflict: no retry can make it
+ * available, so the flow must land in terminal "failed" even though the
+ * generic `conflict` code is registered as retryable.
+ */
+class ProvisionUsernameConflictError extends ApiError {
+  constructor(username: string) {
+    super(409, "conflict", `Username "${username}" is not available`);
+  }
+}
+
 function classifyFailure(error: unknown): StepFailure {
   if (error instanceof ApiError) {
-    return { permanent: !error.retryable, code: error.code, message: error.message };
+    const permanent = !error.retryable || error instanceof ProvisionUsernameConflictError;
+    return { permanent, code: error.code, message: error.message };
   }
   return {
     permanent: false,
@@ -404,7 +416,7 @@ async function reserveUsernameStep(
     USERNAME_RESERVATION_LEASE_MS,
   );
   if (reservation.outcome === "unavailable") {
-    throw new ApiError(409, "username_unavailable", `Username "${username}" is not available`);
+    throw new ProvisionUsernameConflictError(username);
   }
 
   try {
@@ -422,7 +434,7 @@ async function reserveUsernameStep(
     if (error instanceof ApiError && error.code === "conflict") {
       // The reservation said the username was claimable, so a conflict means
       // the account is in an inconsistent state — no retry fixes that.
-      throw new ApiError(409, "username_unavailable", `Username "${username}" is not available`);
+      throw new ProvisionUsernameConflictError(username);
     }
     throw error;
   }

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -174,7 +174,9 @@ interface StepFailure {
 /**
  * A taken username is a *deterministic* conflict: no retry can make it
  * available, so the flow must land in terminal "failed" even though the
- * generic `conflict` code is registered as retryable.
+ * generic `conflict` code is registered as retryable. The 409 + `conflict`
+ * surface mirrors the coordinator/memory-repository convention for usernames
+ * already bound to another account.
  */
 class ProvisionUsernameConflictError extends ApiError {
   constructor(username: string) {

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -13,6 +13,9 @@ import {
   profileSchema,
   credentialSchema,
   storedEnvelopeSchema,
+  provisioningRecordSchema,
+  usernameReservationSchema,
+  walletSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -208,6 +211,12 @@ registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
 // ValidatedApiRepository can detect tampered or structurally invalid
 // envelope records at the adapter boundary before they reach any caller.
 registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
+// Issue #1921 (BETA-014): provisioning state machine, username claims and
+// wallet records are versioned and validated at the adapter boundary like
+// every other durable record.
+registerRecordSchema("provisioning", 1, provisioningRecordSchema);
+registerRecordSchema("usernameReservation", 1, usernameReservationSchema);
+registerRecordSchema("wallet", 1, walletSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -221,6 +221,81 @@ export type CredentialAuthMethod = z.infer<typeof credentialAuthMethodSchema>;
 export type PublicUser = z.infer<typeof publicUserSchema>;
 export type PublicProfile = z.infer<typeof publicProfileSchema>;
 
+// ---------------------------------------------------------------------------
+// BETA-014: Transactional account-provisioning state machine
+//
+// A provisioning record is the durable, idempotent ledger for the account
+// convergence flow: username reservation -> profile defaults -> wallet
+// creation -> mailbox policy init. The user record only becomes "active"
+// after every step completes, so a mid-flow failure can never leave a live
+// half-account behind (the account stays pending_verification and the
+// username reservation is released as compensation).
+// ---------------------------------------------------------------------------
+
+export const provisioningStatusSchema = z.enum(["pending", "retryable", "active", "failed"]);
+
+export const provisioningStepSchema = z.enum([
+  "username_reservation",
+  "profile_defaults",
+  "wallet_creation",
+  "mailbox_policy_init",
+]);
+
+export const provisioningFailureSchema = z.object({
+  step: provisioningStepSchema,
+  code: z.string(),
+  message: z.string(),
+  failedAt: z.string().datetime(),
+});
+
+export const provisioningRecordSchema = z.object({
+  userId: z.string().min(1, "User ID cannot be empty"),
+  status: provisioningStatusSchema,
+  requestedUsername: usernameSchema,
+  displayName: z.string().trim().min(1, "Display name cannot be empty").nullable(),
+  completedSteps: z.array(provisioningStepSchema),
+  /** The step currently being attempted, or the step that failed last. */
+  currentStep: provisioningStepSchema,
+  attempts: z.number().int().nonnegative(),
+  failure: provisioningFailureSchema.nullable(),
+  startedAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  version: z.number().int().positive(),
+});
+
+/**
+ * A wallet bound to exactly one account. The initial on-chain address is the
+ * account's own Stellar address until an external wallet provider exists
+ * (dependency BETA-013); the record exists so wallet creation is a durable,
+ * insert-once provisioning step instead of an implicit side effect.
+ */
+export const walletSchema = z.object({
+  walletId: z.string().min(1, "Wallet ID cannot be empty"),
+  userId: z.string().min(1, "User ID cannot be empty"),
+  address: stellarAddressSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+/**
+ * A leased claim on a username. Held for the duration of provisioning and
+ * released as compensation when a later step fails, so a retry can re-claim
+ * it and a failed account never leaks a permanently squatted username.
+ */
+export const usernameReservationSchema = z.object({
+  username: usernameSchema,
+  userId: z.string().min(1, "User ID cannot be empty"),
+  reservedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+});
+
+export type ProvisioningStatus = z.infer<typeof provisioningStatusSchema>;
+export type ProvisioningStep = z.infer<typeof provisioningStepSchema>;
+export type ProvisioningFailure = z.infer<typeof provisioningFailureSchema>;
+export type ProvisioningRecord = z.infer<typeof provisioningRecordSchema>;
+export type Wallet = z.infer<typeof walletSchema>;
+export type UsernameReservation = z.infer<typeof usernameReservationSchema>;
+
 export function toPublicUser(user: User): PublicUser {
   return {
     userId: user.userId,

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -100,6 +100,13 @@ export const API_ERROR_REGISTRY = {
     retryable: false,
     description: "The resource cannot transition from its current state as requested.",
   },
+  username_unavailable: {
+    status: 409,
+    message: "The requested username is not available",
+    retryable: false,
+    description:
+      "The username is held by another account or claim; no amount of retrying can make it available.",
+  },
   insufficient_postage: {
     status: 422,
     message: "The postage amount is below the required minimum",
@@ -197,6 +204,12 @@ export class ApiError extends Error {
       this.retryClassification = "conflict";
       this.retryable = true;
     } else if (code === "internal_error" || code === "data_integrity_error") {
+      this.retryClassification = "transient";
+      this.retryable = true;
+    } else if (code === "dependency_unavailable") {
+      // Registered as transient in the registry; align the constructed
+      // classification so callers (e.g. provisioning compensation policy)
+      // treat an unavailable dependency as recoverable.
       this.retryClassification = "transient";
       this.retryable = true;
     } else {

--- a/src/server/api/errors.ts
+++ b/src/server/api/errors.ts
@@ -100,13 +100,6 @@ export const API_ERROR_REGISTRY = {
     retryable: false,
     description: "The resource cannot transition from its current state as requested.",
   },
-  username_unavailable: {
-    status: 409,
-    message: "The requested username is not available",
-    retryable: false,
-    description:
-      "The username is held by another account or claim; no amount of retrying can make it available.",
-  },
   insufficient_postage: {
     status: 422,
     message: "The postage amount is below the required minimum",

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -2,7 +2,10 @@ import type {
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  UpdateProvisioningResult,
   UpdateUserResult,
+  UsernameReservationResult,
+  WalletCreationResult,
 } from "./repository";
 import type {
   Credential,
@@ -11,10 +14,13 @@ import type {
   Postage,
   PostageStatus,
   Profile,
+  ProvisioningRecord,
   Receipt,
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameReservation,
+  Wallet,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -175,6 +181,60 @@ export class HybridApiRepository implements ApiRepository {
 
   async setCredential(credential: Credential): Promise<Credential> {
     return this.getStub().setCredential(credential);
+  }
+
+  // BETA-014: Provisioning state is coordinated by the DO (single authority);
+  // KV holds no provisioning mirror because every write is a CAS transition.
+  async getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
+    return this.getStub().getProvisioningRecord(userId);
+  }
+
+  async createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }> {
+    return this.getStub().createProvisioningRecord(record);
+  }
+
+  async setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult> {
+    return this.getStub().setProvisioningRecord(record, expectedVersion);
+  }
+
+  async reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult> {
+    return this.getStub().reserveUsername(username, userId, leaseMs);
+  }
+
+  async getUsernameReservation(username: string): Promise<UsernameReservation | null> {
+    return this.getStub().getUsernameReservation(username);
+  }
+
+  async releaseUsernameReservation(username: string, userId: string): Promise<boolean> {
+    return this.getStub().releaseUsernameReservation(username, userId);
+  }
+
+  async getWallet(userId: string): Promise<Wallet | null> {
+    return this.getStub().getWallet(userId);
+  }
+
+  async createWallet(wallet: Wallet): Promise<WalletCreationResult> {
+    return this.getStub().createWallet(wallet);
+  }
+
+  async initializePolicyIfAbsent(
+    owner: string,
+    policy: MailboxPolicy,
+  ): Promise<{ created: boolean; policy: MailboxPolicy }> {
+    const result = await this.getStub().initializePolicyIfAbsent(owner, policy);
+    if (result.created) {
+      await this.kv.put(this.key("policy", owner), JSON.stringify(result.policy));
+    }
+    return result;
   }
 
   // Consistent layer delegated to Durable Object via RPC

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -403,7 +403,6 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(credential);
   }
 
-<<<<<<< ours
   // BETA-014: Transactional account-provisioning implementation
   async getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
     return structuredClone(this.provisioning.get(userId) ?? null);

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -5,16 +5,22 @@ import type {
   Postage,
   PostageStatus,
   Profile,
+  ProvisioningRecord,
   Receipt,
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameReservation,
+  Wallet,
 } from "./domain";
 import type {
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  UpdateProvisioningResult,
   UpdateUserResult,
+  UsernameReservationResult,
+  WalletCreationResult,
 } from "./repository";
 import { ApiError } from "./errors";
 
@@ -41,6 +47,32 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly usersByAddress = new Map<string, string>();
   private readonly profiles = new Map<string, Profile>();
   private readonly credentials = new Map<string, Credential>();
+
+  // BETA-014: Account-provisioning storage
+  private readonly provisioning = new Map<string, ProvisioningRecord>();
+  private readonly usernameReservations = new Map<string, UsernameReservation>();
+  private readonly wallets = new Map<string, Wallet>();
+  private readonly keyLocks = new Map<string, Promise<void>>();
+
+  private async withKeyLock<T>(lockKey: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.keyLocks.get(lockKey) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.keyLocks.set(lockKey, queued);
+
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.keyLocks.get(lockKey) === queued) {
+        this.keyLocks.delete(lockKey);
+      }
+    }
+  }
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -309,6 +341,127 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(credential);
   }
 
+  // BETA-014: Transactional account-provisioning implementation
+  async getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
+    return structuredClone(this.provisioning.get(userId) ?? null);
+  }
+
+  async createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }> {
+    return this.withKeyLock(`provisioning:${record.userId}`, async () => {
+      const existing = this.provisioning.get(record.userId);
+      if (existing) {
+        return { created: false, record: structuredClone(existing) };
+      }
+      this.provisioning.set(record.userId, structuredClone(record));
+      return { created: true, record: structuredClone(record) };
+    });
+  }
+
+  async setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult> {
+    return this.withKeyLock(`provisioning:${record.userId}`, async () => {
+      const current = this.provisioning.get(record.userId);
+      if (!current) {
+        return { updated: false, current: null };
+      }
+      if (current.version !== expectedVersion) {
+        return { updated: false, current: structuredClone(current) };
+      }
+      const next: ProvisioningRecord = {
+        ...record,
+        version: expectedVersion + 1,
+        updatedAt: new Date().toISOString(),
+      };
+      this.provisioning.set(record.userId, structuredClone(next));
+      return { updated: true, record: structuredClone(next) };
+    });
+  }
+
+  async getUsernameReservation(username: string): Promise<UsernameReservation | null> {
+    const norm = username.toLowerCase().trim();
+    return structuredClone(this.usernameReservations.get(norm) ?? null);
+  }
+
+  async reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult> {
+    const norm = username.toLowerCase().trim();
+    return this.withKeyLock(`username-reservation:${norm}`, async () => {
+      const boundUser = this.usersByUsername.get(norm);
+      if (boundUser && boundUser !== userId) {
+        return { outcome: "unavailable" };
+      }
+
+      const existing = this.usernameReservations.get(norm);
+      const now = Date.now();
+
+      if (existing) {
+        if (existing.userId === userId && now < new Date(existing.expiresAt).getTime()) {
+          return { outcome: "already-reserved", reservation: structuredClone(existing) };
+        }
+        if (existing.userId !== userId && now < new Date(existing.expiresAt).getTime()) {
+          return { outcome: "unavailable" };
+        }
+      }
+
+      const reservation: UsernameReservation = {
+        username: norm,
+        userId,
+        reservedAt: new Date(now).toISOString(),
+        expiresAt: new Date(now + leaseMs).toISOString(),
+      };
+      this.usernameReservations.set(norm, structuredClone(reservation));
+      return { outcome: "reserved", reservation: structuredClone(reservation) };
+    });
+  }
+
+  async releaseUsernameReservation(username: string, userId: string): Promise<boolean> {
+    const norm = username.toLowerCase().trim();
+    return this.withKeyLock(`username-reservation:${norm}`, async () => {
+      const existing = this.usernameReservations.get(norm);
+      if (!existing) return false;
+      if (existing.userId !== userId) return false;
+      this.usernameReservations.delete(norm);
+      return true;
+    });
+  }
+
+  async getWallet(userId: string): Promise<Wallet | null> {
+    return structuredClone(this.wallets.get(userId) ?? null);
+  }
+
+  async createWallet(wallet: Wallet): Promise<WalletCreationResult> {
+    return this.withKeyLock(`wallet:${wallet.userId}`, async () => {
+      const existing = this.wallets.get(wallet.userId);
+      if (existing) {
+        return { outcome: "already-exists", wallet: structuredClone(existing) };
+      }
+      this.wallets.set(wallet.userId, structuredClone(wallet));
+      return { outcome: "created", wallet: structuredClone(wallet) };
+    });
+  }
+
+  async initializePolicyIfAbsent(
+    owner: string,
+    policy: MailboxPolicy,
+  ): Promise<{ created: boolean; policy: MailboxPolicy }> {
+    const normOwner = owner.toUpperCase().trim();
+    return this.withKeyLock(`policy-init:${normOwner}`, async () => {
+      const existing = this.policies.get(normOwner);
+      if (existing) {
+        return { created: false, policy: structuredClone(existing) };
+      }
+      this.policies.set(normOwner, structuredClone(policy));
+      return { created: true, policy: structuredClone(policy) };
+    });
+  }
+
   async getRelayQueueDepth(_relayId: string) {
     return 0;
   }
@@ -437,5 +590,9 @@ export class MemoryApiRepository implements ApiRepository {
     this.usersByAddress.clear();
     this.profiles.clear();
     this.credentials.clear();
+    this.provisioning.clear();
+    this.usernameReservations.clear();
+    this.wallets.clear();
+    this.keyLocks.clear();
   }
 }

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -232,6 +232,83 @@ export const openApiDocument = {
         enum: ["permanent", "transient", "rate_limit", "conflict"],
         description: "Stable machine-readable classification of retry eligibility.",
       },
+      ProvisioningStatus: {
+        type: "string",
+        enum: ["pending", "retryable", "active", "failed"],
+        description: "State of the transactional account-provisioning state machine.",
+      },
+      ProvisioningStep: {
+        type: "string",
+        enum: [
+          "username_reservation",
+          "profile_defaults",
+          "wallet_creation",
+          "mailbox_policy_init",
+        ],
+        description: "A single idempotent step of the provisioning flow.",
+      },
+      ProvisioningFailure: {
+        type: "object",
+        required: ["step", "code", "message", "failedAt"],
+        properties: {
+          step: {
+            $ref: "#/components/schemas/ProvisioningStep",
+          },
+          code: {
+            type: "string",
+            description: "Stable domain error code of the failing step.",
+          },
+          message: {
+            type: "string",
+            description: "Human-readable failure explanation.",
+          },
+          failedAt: {
+            type: "string",
+            format: "date-time",
+          },
+        },
+      },
+      ProvisioningProgress: {
+        type: "object",
+        required: ["status", "requestedUsername", "completedSteps", "currentStep", "attempts"],
+        properties: {
+          status: {
+            $ref: "#/components/schemas/ProvisioningStatus",
+          },
+          requestedUsername: {
+            type: "string",
+            pattern: "^[a-z0-9_-]{3,30}$",
+          },
+          completedSteps: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/ProvisioningStep",
+            },
+          },
+          currentStep: {
+            $ref: "#/components/schemas/ProvisioningStep",
+          },
+          attempts: {
+            type: "integer",
+            minimum: 0,
+            description: "Number of flow runs attempted so far.",
+          },
+          failure: {
+            allOf: [
+              {
+                $ref: "#/components/schemas/ProvisioningFailure",
+              },
+              {
+                nullable: true,
+              },
+            ],
+          },
+          updatedAt: {
+            type: "string",
+            format: "date-time",
+          },
+        },
+      },
       ErrorEnvelope: {
         type: "object",
         required: ["error", "meta"],
@@ -1741,6 +1818,272 @@ export const openApiDocument = {
           },
           "503": {
             description: "Not Ready — a required dependency is unavailable",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/accounts": {
+      post: {
+        operationId: "provisionAccount",
+        summary: "Provision an account (username, profile, wallet, policy)",
+        description:
+          "Idempotently runs the transactional account-provisioning state machine: username reservation, profile defaults, wallet creation and mailbox policy initialization converge without leaving a partial active account. Repeated calls are safe against duplicate requests; an optional x-idempotency-key enables strict replay semantics.",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        requestBody: {
+          description:
+            "Provisioning intent. Email and username are required only when no account exists for the actor yet.",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  email: {
+                    type: "string",
+                    format: "email",
+                  },
+                  username: {
+                    type: "string",
+                    pattern: "^[a-z0-9_-]{3,30}$",
+                  },
+                  displayName: {
+                    type: "string",
+                    maxLength: 80,
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Provisioning progress after a completed or resumed run",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ProvisioningProgress",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict — username unavailable or provisioning previously failed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/accounts/provisioning": {
+      get: {
+        operationId: "getAccountProvisioningProgress",
+        summary: "Read provisioning progress for the authenticated account",
+        description:
+          "Safe progress projection: provisioning state, completed steps, attempts and the last failure. Never exposes credentials, wallet seeds, or hashes.",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Provisioning progress and account status",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["provisioning", "accountStatus"],
+                  properties: {
+                    provisioning: {
+                      $ref: "#/components/schemas/ProvisioningProgress",
+                    },
+                    accountStatus: {
+                      type: "string",
+                      enum: ["active", "suspended", "pending_verification", "deactivated"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found — no account or provisioning record",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/accounts/provisioning/retry": {
+      post: {
+        operationId: "retryAccountProvisioning",
+        summary: "Retry a failed provisioning run",
+        description:
+          "Restarts a retryable provisioning flow from its first incomplete step. Only retryable flows may be restarted; active and in-flight flows are rejected with a deterministic 409.",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Provisioning progress after the retry run",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ProvisioningProgress",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Forbidden",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found — no account or provisioning record",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict — provisioning in flight, already active, or attempts exhausted",
             content: {
               "application/json": {
                 schema: {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -6,10 +6,13 @@ import type {
   Postage,
   PostageStatus,
   Profile,
+  ProvisioningRecord,
   Receipt,
   SenderRule,
   StoredEnvelope,
   User,
+  UsernameReservation,
+  Wallet,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
 
@@ -84,6 +87,47 @@ export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
 
+// ---------------------------------------------------------------------------
+// BETA-014: Account-provisioning repository contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of a compare-and-swap provisioning-record write.
+ *
+ * - `updated: true`  : the record was persisted at `expectedVersion + 1`.
+ * - `updated: false` : the record moved underneath this writer (or does not
+ *   exist); `current` reflects the authoritative state so the caller can
+ *   re-read and reconcile instead of blindly overwriting progress.
+ */
+export type UpdateProvisioningResult =
+  | { updated: true; record: ProvisioningRecord }
+  | { updated: false; current: ProvisioningRecord | null };
+
+/**
+ * Outcome of an atomic username claim.
+ *
+ * - "reserved": the username was claimed by this user for `leaseMs`.
+ * - "already-reserved": this user holds a live claim already (idempotent
+ *   retry); the existing reservation is returned unchanged.
+ * - "unavailable": a live claim is held by another user, or a user record
+ *   is already bound to this username. The claim is never stolen.
+ */
+export type UsernameReservationResult =
+  | { outcome: "reserved"; reservation: UsernameReservation }
+  | { outcome: "already-reserved"; reservation: UsernameReservation }
+  | { outcome: "unavailable" };
+
+/**
+ * Outcome of an insert-once wallet write for a user.
+ *
+ * - "created": the wallet record was stored for the first time.
+ * - "already-exists": this user already has a wallet; the stored record is
+ *   returned unchanged (idempotent retry).
+ */
+export type WalletCreationResult =
+  | { outcome: "created"; wallet: Wallet }
+  | { outcome: "already-exists"; wallet: Wallet };
+
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
@@ -136,6 +180,63 @@ export interface ApiRepository {
   setProfile(profile: Profile): Promise<Profile>;
   getCredential(userId: string): Promise<Credential | null>;
   setCredential(credential: Credential): Promise<Credential>;
+
+  // BETA-014: Transactional account-provisioning methods
+  getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null>;
+  /**
+   * Insert-once initialization of a provisioning record. Concurrent
+   * initializations must yield exactly one `created: true`; every other call
+   * receives the authoritative existing record so no account can ever have
+   * two competing provisioning ledgers.
+   */
+  createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }>;
+  /**
+   * Compare-and-swap write of the provisioning state machine. `expectedVersion`
+   * must match the persisted record's version; a stale writer receives
+   * `{ updated: false, current }` instead of silently clobbering progress.
+   * Concurrent provisioners for the same account must serialize so exactly
+   * one writer advances the record per step.
+   */
+  setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult>;
+  /**
+   * Atomically claims a username for `leaseMs`. Single-winner: concurrent
+   * claims for the same username must never both succeed, and a claim held
+   * by another user must never be stolen or overwritten.
+   */
+  reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult>;
+  getUsernameReservation(username: string): Promise<UsernameReservation | null>;
+  /**
+   * Releases a reservation owned by `userId` (compensation path). Returns
+   * true when a live claim was released, false when nothing was owned or
+   * the claim already expired. Idempotent: releasing twice is safe.
+   */
+  releaseUsernameReservation(username: string, userId: string): Promise<boolean>;
+  getWallet(userId: string): Promise<Wallet | null>;
+  /**
+   * Insert-once wallet creation keyed by user. Concurrent creations must
+   * yield exactly one "created" outcome; every other call receives the
+   * authoritative existing record as "already-exists".
+   */
+  createWallet(wallet: Wallet): Promise<WalletCreationResult>;
+  /**
+   * Initializes a mailbox policy only when none is stored for the owner.
+   * `created: true` when the default was written, `created: false` when a
+   * policy already exists (the existing policy is returned and never
+   * overwritten — idempotent retry).
+   */
+  initializePolicyIfAbsent(
+    owner: string,
+    policy: MailboxPolicy,
+  ): Promise<{ created: boolean; policy: MailboxPolicy }>;
 
   getRelayQueueDepth(relayId: string): Promise<number>;
   getRelayRetryCount(relayId: string): Promise<number>;
@@ -433,6 +534,83 @@ export class ValidatedApiRepository implements ApiRepository {
     return validateRecord<Credential>("credential", result);
   }
 
+  async getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
+    const raw = await this.inner.getProvisioningRecord(userId);
+    return raw ? validateRecord<ProvisioningRecord>("provisioning", raw) : null;
+  }
+
+  async createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }> {
+    const result = await this.inner.createProvisioningRecord(versionRecord("provisioning", record));
+    result.record = validateRecord<ProvisioningRecord>("provisioning", result.record);
+    return result;
+  }
+
+  async setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult> {
+    const result = await this.inner.setProvisioningRecord(
+      versionRecord("provisioning", record),
+      expectedVersion,
+    );
+    if (result.updated) {
+      result.record = validateRecord<ProvisioningRecord>("provisioning", result.record);
+    } else if (result.current) {
+      result.current = validateRecord<ProvisioningRecord>("provisioning", result.current);
+    }
+    return result;
+  }
+
+  async reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult> {
+    const result = await this.inner.reserveUsername(username, userId, leaseMs);
+    if (result.outcome === "reserved" || result.outcome === "already-reserved") {
+      result.reservation = validateRecord<UsernameReservation>(
+        "usernameReservation",
+        result.reservation,
+      );
+    }
+    return result;
+  }
+
+  async getUsernameReservation(username: string): Promise<UsernameReservation | null> {
+    const raw = await this.inner.getUsernameReservation(username);
+    return raw ? validateRecord<UsernameReservation>("usernameReservation", raw) : null;
+  }
+
+  async releaseUsernameReservation(username: string, userId: string): Promise<boolean> {
+    return this.inner.releaseUsernameReservation(username, userId);
+  }
+
+  async getWallet(userId: string): Promise<Wallet | null> {
+    const raw = await this.inner.getWallet(userId);
+    return raw ? validateRecord<Wallet>("wallet", raw) : null;
+  }
+
+  async createWallet(wallet: Wallet): Promise<WalletCreationResult> {
+    const result = await this.inner.createWallet(versionRecord("wallet", wallet));
+    if (result.outcome === "created" || result.outcome === "already-exists") {
+      result.wallet = validateRecord<Wallet>("wallet", result.wallet);
+    }
+    return result;
+  }
+
+  async initializePolicyIfAbsent(
+    owner: string,
+    policy: MailboxPolicy,
+  ): Promise<{ created: boolean; policy: MailboxPolicy }> {
+    const result = await this.inner.initializePolicyIfAbsent(owner, policy);
+    if (result.created) {
+      result.policy = validateRecord<MailboxPolicy>("mailboxPolicy", result.policy);
+    }
+    return result;
+  }
+
   getRelayQueueDepth(relayId: string): Promise<number> {
     return this.inner.getRelayQueueDepth(relayId);
   }
@@ -524,6 +702,11 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getCredential",
   "setCredential",
   "getEnvelope",
+  "getProvisioningRecord",
+  "getUsernameReservation",
+  "getWallet",
+  "releaseUsernameReservation",
+  "initializePolicyIfAbsent",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -692,6 +875,65 @@ export class RetryableApiRepository implements ApiRepository {
 
   setCredential(credential: Credential): Promise<Credential> {
     return this.withRetry("setCredential", () => this.inner.setCredential(credential));
+  }
+
+  // BETA-014: retry-safe reads + idempotent compensation are retried; the
+  // single-winner writes (reserve, createWallet, setProvisioningRecord) never
+  // are, so a half-applied claim can never be double-applied by this wrapper.
+  getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
+    return this.withRetry("getProvisioningRecord", () => this.inner.getProvisioningRecord(userId));
+  }
+
+  createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }> {
+    // Never retry: an insert-once initialization must not be re-applied after
+    // a client-side timeout (the stored record would be authoritative).
+    return this.inner.createProvisioningRecord(record);
+  }
+
+  setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult> {
+    return this.inner.setProvisioningRecord(record, expectedVersion);
+  }
+
+  reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult> {
+    return this.inner.reserveUsername(username, userId, leaseMs);
+  }
+
+  getUsernameReservation(username: string): Promise<UsernameReservation | null> {
+    return this.withRetry("getUsernameReservation", () =>
+      this.inner.getUsernameReservation(username),
+    );
+  }
+
+  releaseUsernameReservation(username: string, userId: string): Promise<boolean> {
+    return this.withRetry("releaseUsernameReservation", () =>
+      this.inner.releaseUsernameReservation(username, userId),
+    );
+  }
+
+  getWallet(userId: string): Promise<Wallet | null> {
+    return this.withRetry("getWallet", () => this.inner.getWallet(userId));
+  }
+
+  createWallet(wallet: Wallet): Promise<WalletCreationResult> {
+    return this.inner.createWallet(wallet);
+  }
+
+  initializePolicyIfAbsent(
+    owner: string,
+    policy: MailboxPolicy,
+  ): Promise<{ created: boolean; policy: MailboxPolicy }> {
+    return this.withRetry("initializePolicyIfAbsent", () =>
+      this.inner.initializePolicyIfAbsent(owner, policy),
+    );
   }
 
   getRelayQueueDepth(relayId: string): Promise<number> {

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -44,6 +44,8 @@ export const ROUTE_BODY_LIMITS = {
   "PUT /policies/{owner}/senders/{sender}": "standard",
   "POST /policies/evaluate": "compact",
   "POST /relay/messages": "relay",
+  "POST /accounts": "standard",
+  "POST /accounts/provisioning/retry": "minimal",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -4,15 +4,21 @@ import type {
   Postage,
   PostageStatus,
   Profile,
+  ProvisioningRecord,
   Receipt,
   StoredEnvelope,
   User,
+  UsernameReservation,
+  Wallet,
 } from "./domain";
 import type {
   AcquireIdempotencyResult,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  UpdateProvisioningResult,
   UpdateUserResult,
+  UsernameReservationResult,
+  WalletCreationResult,
 } from "./repository";
 import { ApiError } from "./errors";
 
@@ -323,6 +329,155 @@ export class StealthCoordinator extends DurableObjectBase {
   async setCredential(credential: Credential): Promise<Credential> {
     await this.ctx.storage.put(`credential:${credential.userId}`, credential);
     return credential;
+  }
+
+  // ---------------------------------------------------------------------------
+  // BETA-014: Transactional account-provisioning DO methods
+  //
+  // The coordinator is the single authority for provisioning state, username
+  // claims, wallet insert-once semantics, and policy initialization. Every
+  // mutation runs under a per-key lock so concurrent provisioners for the
+  // same account (or the same username) serialize instead of racing.
+  // ---------------------------------------------------------------------------
+
+  async getProvisioningRecord(userId: string): Promise<ProvisioningRecord | null> {
+    const record = (await this.ctx.storage.get(`provisioning:${userId}`)) as
+      | ProvisioningRecord
+      | undefined;
+    return record ?? null;
+  }
+
+  async createProvisioningRecord(
+    record: ProvisioningRecord,
+  ): Promise<{ created: boolean; record: ProvisioningRecord }> {
+    return this.runExclusive(`provisioning:${record.userId}`, async () => {
+      const existing = (await this.ctx.storage.get(`provisioning:${record.userId}`)) as
+        | ProvisioningRecord
+        | undefined;
+      if (existing) {
+        return { created: false, record: existing };
+      }
+      await this.ctx.storage.put(`provisioning:${record.userId}`, record);
+      return { created: true, record };
+    });
+  }
+
+  async setProvisioningRecord(
+    record: ProvisioningRecord,
+    expectedVersion: number,
+  ): Promise<UpdateProvisioningResult> {
+    return this.runExclusive(`provisioning:${record.userId}`, async () => {
+      const current = (await this.ctx.storage.get(`provisioning:${record.userId}`)) as
+        | ProvisioningRecord
+        | undefined;
+      if (!current) {
+        return { updated: false, current: null };
+      }
+      if (current.version !== expectedVersion) {
+        return { updated: false, current };
+      }
+      const next: ProvisioningRecord = {
+        ...record,
+        version: expectedVersion + 1,
+        updatedAt: new Date().toISOString(),
+      };
+      await this.ctx.storage.put(`provisioning:${record.userId}`, next);
+      return { updated: true, record: next };
+    });
+  }
+
+  async getUsernameReservation(username: string): Promise<UsernameReservation | null> {
+    const norm = username.toLowerCase().trim();
+    const reservation = (await this.ctx.storage.get(`username-reservation:${norm}`)) as
+      | UsernameReservation
+      | undefined;
+    return reservation ?? null;
+  }
+
+  async reserveUsername(
+    username: string,
+    userId: string,
+    leaseMs: number,
+  ): Promise<UsernameReservationResult> {
+    const norm = username.toLowerCase().trim();
+    return this.runExclusive(`username-reservation:${norm}`, async () => {
+      // A user record already bound to this username outranks any claim.
+      const boundUser = (await this.ctx.storage.get(`user:username:${norm}`)) as string | undefined;
+      if (boundUser && boundUser !== userId) {
+        return { outcome: "unavailable" as const };
+      }
+
+      const existing = (await this.ctx.storage.get(`username-reservation:${norm}`)) as
+        | UsernameReservation
+        | undefined;
+      const now = Date.now();
+
+      if (existing) {
+        if (existing.userId === userId && now < new Date(existing.expiresAt).getTime()) {
+          return { outcome: "already-reserved" as const, reservation: existing };
+        }
+        if (existing.userId !== userId && now < new Date(existing.expiresAt).getTime()) {
+          return { outcome: "unavailable" as const };
+        }
+      }
+
+      const reservation: UsernameReservation = {
+        username: norm,
+        userId,
+        reservedAt: new Date(now).toISOString(),
+        expiresAt: new Date(now + leaseMs).toISOString(),
+      };
+      await this.ctx.storage.put(`username-reservation:${norm}`, reservation);
+      return { outcome: "reserved" as const, reservation };
+    });
+  }
+
+  async releaseUsernameReservation(username: string, userId: string): Promise<boolean> {
+    const norm = username.toLowerCase().trim();
+    return this.runExclusive(`username-reservation:${norm}`, async () => {
+      const existing = (await this.ctx.storage.get(`username-reservation:${norm}`)) as
+        | UsernameReservation
+        | undefined;
+      if (!existing) return false;
+      if (existing.userId !== userId) return false;
+      await this.ctx.storage.delete(`username-reservation:${norm}`);
+      return true;
+    });
+  }
+
+  async getWallet(userId: string): Promise<Wallet | null> {
+    const wallet = (await this.ctx.storage.get(`wallet:${userId}`)) as Wallet | undefined;
+    return wallet ?? null;
+  }
+
+  async createWallet(wallet: Wallet): Promise<WalletCreationResult> {
+    return this.runExclusive(`wallet:${wallet.userId}`, async () => {
+      const existing = (await this.ctx.storage.get(`wallet:${wallet.userId}`)) as
+        | Wallet
+        | undefined;
+      if (existing) {
+        return { outcome: "already-exists" as const, wallet: existing };
+      }
+      await this.ctx.storage.put(`wallet:${wallet.userId}`, wallet);
+      return { outcome: "created" as const, wallet };
+    });
+  }
+
+  async initializePolicyIfAbsent(
+    owner: string,
+    policy: import("./domain").MailboxPolicy,
+  ): Promise<{ created: boolean; policy: import("./domain").MailboxPolicy }> {
+    const normOwner = owner.toUpperCase().trim();
+    return this.runExclusive(`policy-init:${normOwner}`, async () => {
+      const existing = (await this.ctx.storage.get(`policy-init:${normOwner}`)) as
+        | import("./domain").MailboxPolicy
+        | undefined;
+      if (existing) {
+        return { created: false, policy: existing };
+      }
+      await this.ctx.storage.put(`policy-init:${normOwner}`, policy);
+      return { created: true, policy };
+    });
   }
 
   async getCounter(key: string): Promise<number> {

--- a/tests/unit/api/account-provisioning-routes.test.ts
+++ b/tests/unit/api/account-provisioning-routes.test.ts
@@ -206,7 +206,7 @@ describe("POST /api/v1/accounts (provision)", () => {
     expect(response.status).toBe(200);
     const body = await parseJson(response);
     expect(body.data.status).toBe("failed");
-    expect(body.data.failure.code).toBe("username_unavailable");
+    expect(body.data.failure.code).toBe("conflict");
     // No account was created for the loser address.
     expect(await repo.getUserByAddress(owner)).toBeNull();
   });

--- a/tests/unit/api/account-provisioning-routes.test.ts
+++ b/tests/unit/api/account-provisioning-routes.test.ts
@@ -1,0 +1,468 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Route as CreateAccountRoute } from "../../../src/routes/api/v1/accounts/index";
+import { Route as ProvisioningRoute } from "../../../src/routes/api/v1/accounts/provisioning";
+import { Route as RetryRoute } from "../../../src/routes/api/v1/accounts/provisioning/retry";
+import { ACTOR_HEADER } from "../../../src/server/api/actor";
+import { getApiContext } from "../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+// Stable Stellar G-addresses (56 chars starting with G)
+const owner = `G${"A".repeat(55)}`;
+const operator = `G${"B".repeat(55)}`;
+const stranger = `G${"C".repeat(55)}`;
+
+const createHandler = (CreateAccountRoute.options as any).server?.handlers?.POST;
+const getHandler = (ProvisioningRoute.options as any).server?.handlers?.GET;
+const retryHandler = (RetryRoute.options as any).server?.handlers?.POST;
+
+function provisionRequest(actor: string, body: unknown, idempotencyKey?: string) {
+  const headers: Record<string, string> = {
+    [ACTOR_HEADER]: actor,
+    "content-type": "application/json",
+  };
+  if (idempotencyKey) headers["x-idempotency-key"] = idempotencyKey;
+  return new Request("https://stealth.test/api/v1/accounts", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function provisioningGetRequest(actor: string) {
+  return new Request("https://stealth.test/api/v1/accounts/provisioning", {
+    method: "GET",
+    headers: { [ACTOR_HEADER]: actor },
+  });
+}
+
+function retryRequest(actor: string) {
+  return new Request("https://stealth.test/api/v1/accounts/provisioning/retry", {
+    method: "POST",
+    headers: { [ACTOR_HEADER]: actor },
+  });
+}
+
+async function parseJson(response: Response) {
+  return response.clone().json() as Promise<{
+    error?: { code: string; message: string; retryable?: boolean };
+    data?: any;
+  }>;
+}
+
+describe("POST /api/v1/accounts (provision)", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  async function seedFailedRecord() {
+    await repo.createUser({
+      userId: "usr_alice",
+      address: owner,
+      email: "alice@stealth.mail",
+      username: "alice_dev",
+      status: "pending_verification",
+      createdAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+    await repo.createProvisioningRecord({
+      userId: "usr_alice",
+      status: "failed",
+      requestedUsername: "alice_dev",
+      displayName: null,
+      completedSteps: ["username_reservation", "profile_defaults"],
+      currentStep: "profile_defaults",
+      attempts: 1,
+      failure: {
+        step: "profile_defaults",
+        code: "invalid_state_transition",
+        message: "blocked",
+        failedAt: "2026-01-15T11:30:00.000Z",
+      },
+      startedAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:30:00.000Z",
+      version: 3,
+    });
+  }
+
+  it("rejects requests without an actor header", async () => {
+    const request = new Request("https://stealth.test/api/v1/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ username: "alice_dev" }),
+    });
+
+    const response = await createHandler({ request });
+    expect(response.status).toBe(401);
+    expect((await parseJson(response)).error?.code).toBe("unauthorized");
+  });
+
+  it("provisions a full account in one call", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, { username: "alice_dev", email: "alice@stealth.mail" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await parseJson(response);
+    expect(body.data.status).toBe("active");
+    expect(body.data.completedSteps).toEqual([
+      "username_reservation",
+      "profile_defaults",
+      "wallet_creation",
+      "mailbox_policy_init",
+    ]);
+
+    const user = (await repo.getUserByAddress(owner))!;
+    expect(user.username).toBe("alice_dev");
+    expect(user.status).toBe("active");
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+    expect(await repo.getPolicy(owner)).not.toBeNull();
+    expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+  });
+
+  it("persists the displayName profile default when provided", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, {
+        username: "alice_dev",
+        email: "alice@stealth.mail",
+        displayName: "Alice Dev",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const user = (await repo.getUserByAddress(owner))!;
+    expect((await repo.getProfile(user.userId))?.displayName).toBe("Alice Dev");
+  });
+
+  it("replays the stored response for a duplicate identical request", async () => {
+    const first = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "alice_dev", email: "alice@stealth.mail" },
+        "prov-key-1",
+      ),
+    });
+    expect(first.status).toBe(200);
+    expect(first.headers.get("x-idempotency-replayed")).toBeNull();
+
+    const second = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "alice_dev", email: "alice@stealth.mail" },
+        "prov-key-1",
+      ),
+    });
+    expect(second.status).toBe(200);
+    expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+    expect((await parseJson(second)).data).toEqual((await parseJson(first)).data);
+
+    // Exactly one user and one wallet exist.
+    const user = (await repo.getUserByAddress(owner))!;
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+  });
+
+  it("executes the operation exactly once under concurrent identical duplicates", async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        createHandler({
+          request: provisionRequest(
+            owner,
+            { username: "alice_dev", email: "alice@stealth.mail" },
+            "concurrent-key",
+          ),
+        }),
+      ),
+    );
+
+    const statuses = responses.map((response: Response) => response.status).sort();
+    expect(statuses.filter((status: number) => status === 200)).toHaveLength(1);
+    expect(statuses.filter((status: number) => status === 409)).toHaveLength(4);
+
+    const user = (await repo.getUserByAddress(owner))!;
+    expect(user.status).toBe("active");
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+  });
+
+  it("returns a failed provisioning for a username bound to another account", async () => {
+    await repo.createUser({
+      userId: "usr_bob",
+      address: operator,
+      email: "bob@stealth.mail",
+      username: "taken_name",
+      status: "active",
+      createdAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+
+    const response = await createHandler({
+      request: provisionRequest(owner, { username: "taken_name", email: "alice@stealth.mail" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await parseJson(response);
+    expect(body.data.status).toBe("failed");
+    expect(body.data.failure.code).toBe("username_unavailable");
+    // No account was created for the loser address.
+    expect(await repo.getUserByAddress(owner)).toBeNull();
+  });
+
+  it("replays a deterministic failed provisioning under an idempotency key", async () => {
+    const taken = await repo.createUser({
+      userId: "usr_bob",
+      address: operator,
+      email: "bob@stealth.mail",
+      username: "taken_name",
+      status: "active",
+      createdAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+    expect(taken).toBeDefined();
+
+    const first = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "taken_name", email: "alice@stealth.mail" },
+        "failed-key-2",
+      ),
+    });
+    expect(first.status).toBe(200);
+    expect((await parseJson(first)).data.status).toBe("failed");
+
+    const second = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "taken_name", email: "alice@stealth.mail" },
+        "failed-key-2",
+      ),
+    });
+    expect(second.status).toBe(200);
+    expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+    expect((await parseJson(second)).data).toEqual((await parseJson(first)).data);
+  });
+
+  it("rejects re-provisioning a terminal failed record with a cached 409", async () => {
+    await seedFailedRecord();
+
+    const first = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "alice_dev", email: "alice@stealth.mail" },
+        "failed-key",
+      ),
+    });
+    expect(first.status).toBe(409);
+    expect((await parseJson(first)).error?.code).toBe("invalid_state_transition");
+
+    const second = await createHandler({
+      request: provisionRequest(
+        owner,
+        { username: "alice_dev", email: "alice@stealth.mail" },
+        "failed-key",
+      ),
+    });
+    expect(second.status).toBe(409);
+    expect(second.headers.get("x-idempotency-replayed")).toBe("true");
+    expect((await parseJson(second)).data?.error?.code).toBe("invalid_state_transition");
+  });
+
+  it("rejects an invalid username with 422", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, { username: "!!!", email: "alice@stealth.mail" }),
+    });
+    expect(response.status).toBe(422);
+    expect((await parseJson(response)).error?.code).toBe("validation_error");
+  });
+
+  it("rejects an invalid email with 422", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, { username: "alice_dev", email: "not-an-email" }),
+    });
+    expect(response.status).toBe(422);
+    expect((await parseJson(response)).error?.code).toBe("validation_error");
+  });
+
+  it("requires a username for a new account", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, { email: "alice@stealth.mail" }),
+    });
+    expect(response.status).toBe(422);
+    expect((await parseJson(response)).error?.code).toBe("validation_error");
+  });
+
+  it("requires an email to bootstrap a new account", async () => {
+    const response = await createHandler({
+      request: provisionRequest(owner, { username: "alice_dev" }),
+    });
+    expect(response.status).toBe(422);
+    expect((await parseJson(response)).error?.code).toBe("validation_error");
+  });
+});
+
+describe("GET /api/v1/accounts/provisioning (progress)", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  it("rejects requests without an actor header", async () => {
+    const request = new Request("https://stealth.test/api/v1/accounts/provisioning", {
+      method: "GET",
+      headers: {},
+    });
+
+    const response = await getHandler({ request });
+    expect(response.status).toBe(401);
+    expect((await parseJson(response)).error?.code).toBe("unauthorized");
+  });
+
+  it("returns 404 when no account exists for the address", async () => {
+    const response = await getHandler({ request: provisioningGetRequest(owner) });
+    expect(response.status).toBe(404);
+    expect((await parseJson(response)).error?.code).toBe("not_found");
+  });
+
+  it("returns 404 when no provisioning record exists for the account", async () => {
+    await repo.createUser({
+      userId: "usr_alice",
+      address: owner,
+      email: "alice@stealth.mail",
+      username: "alice_dev",
+      status: "active",
+      createdAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+
+    const response = await getHandler({ request: provisioningGetRequest(owner) });
+    expect(response.status).toBe(404);
+    expect((await parseJson(response)).error?.code).toBe("not_found");
+  });
+
+  it("returns safe progress plus account status", async () => {
+    await createHandler({
+      request: provisionRequest(owner, { username: "alice_dev", email: "alice@stealth.mail" }),
+    });
+
+    const response = await getHandler({ request: provisioningGetRequest(owner) });
+    expect(response.status).toBe(200);
+    const body = await parseJson(response);
+    expect(body.data.accountStatus).toBe("active");
+    expect(body.data.provisioning.status).toBe("active");
+    // Safe projection: no identifiers or secrets leak.
+    expect(body.data.provisioning).not.toHaveProperty("userId");
+    expect(body.data.provisioning).not.toHaveProperty("email");
+  });
+});
+
+describe("POST /api/v1/accounts/provisioning/retry", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  async function seedRetryable(actorAddress: string, username: string) {
+    await repo.createUser({
+      userId: "usr_retry",
+      address: actorAddress,
+      email: "alice@stealth.mail",
+      username,
+      status: "pending_verification",
+      createdAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+    await repo.createProvisioningRecord({
+      userId: "usr_retry",
+      status: "retryable",
+      requestedUsername: username,
+      displayName: null,
+      completedSteps: ["username_reservation", "profile_defaults"],
+      currentStep: "wallet_creation",
+      attempts: 1,
+      failure: {
+        step: "wallet_creation",
+        code: "dependency_unavailable",
+        message: "down",
+        failedAt: "2026-01-15T11:30:00.000Z",
+      },
+      startedAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:30:00.000Z",
+      version: 3,
+    });
+  }
+
+  it("rejects requests without an actor header", async () => {
+    const request = new Request("https://stealth.test/api/v1/accounts/provisioning/retry", {
+      method: "POST",
+      headers: {},
+    });
+
+    const response = await retryHandler({ request });
+    expect(response.status).toBe(401);
+    expect((await parseJson(response)).error?.code).toBe("unauthorized");
+  });
+
+  it("returns 404 when no account exists", async () => {
+    const response = await retryHandler({ request: retryRequest(owner) });
+    expect(response.status).toBe(404);
+    expect((await parseJson(response)).error?.code).toBe("not_found");
+  });
+
+  it("resumes a retryable provisioning to active", async () => {
+    await seedRetryable(owner, "alice_dev");
+
+    const response = await retryHandler({ request: retryRequest(owner) });
+    expect(response.status).toBe(200);
+    const body = await parseJson(response);
+    expect(body.data.status).toBe("active");
+    expect(body.data.completedSteps).toEqual([
+      "username_reservation",
+      "profile_defaults",
+      "wallet_creation",
+      "mailbox_policy_init",
+    ]);
+
+    const user = (await repo.getUserByAddress(owner))!;
+    expect(user.status).toBe("active");
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+  });
+
+  it("rejects retrying an already-active account", async () => {
+    await createHandler({
+      request: provisionRequest(owner, { username: "alice_dev", email: "alice@stealth.mail" }),
+    });
+
+    const response = await retryHandler({ request: retryRequest(owner) });
+    expect(response.status).toBe(409);
+    expect((await parseJson(response)).error?.code).toBe("invalid_state_transition");
+  });
+
+  it("returns 404 for a non-owner address (owner-scoped retry)", async () => {
+    await seedRetryable(owner, "alice_dev");
+
+    const response = await retryHandler({ request: retryRequest(operator) });
+    expect(response.status).toBe(404);
+    expect((await parseJson(response)).error?.code).toBe("not_found");
+  });
+
+  it("leaves the owner's record untouched after a non-owner denied attempt", async () => {
+    await seedRetryable(owner, "alice_dev");
+
+    await retryHandler({ request: retryRequest(operator) });
+
+    const record = (await repo.getProvisioningRecord("usr_retry"))!;
+    expect(record.status).toBe("retryable");
+    const user = (await repo.getUserByAddress(owner))!;
+    expect(user.status).toBe("pending_verification");
+  });
+});

--- a/tests/unit/api/account-provisioning.test.ts
+++ b/tests/unit/api/account-provisioning.test.ts
@@ -243,7 +243,7 @@ describe("failure and compensation paths", () => {
 
     expect(progress.status).toBe("failed");
     expect(progress.attempts).toBe(1);
-    expect(progress.failure?.code).toBe("username_unavailable");
+    expect(progress.failure?.code).toBe("conflict");
     expect(await repo.getUserByAddress(ADDR_A)).toBeNull();
     expect(await repo.getUsernameReservation("taken_name")).toBeNull();
   });

--- a/tests/unit/api/account-provisioning.test.ts
+++ b/tests/unit/api/account-provisioning.test.ts
@@ -1,0 +1,488 @@
+import { expect, describe, it, beforeEach } from "vitest";
+
+import { MemoryApiRepository } from "@/server/api/memory-repository";
+import {
+  getProvisioningProgress,
+  MAX_PROVISIONING_ATTEMPTS,
+  PROVISIONING_STEPS,
+  provisionAccount,
+  retryAccountProvisioning,
+  USERNAME_RESERVATION_LEASE_MS,
+} from "@/server/api/account-provisioning";
+import { defaultMailboxPolicy } from "@/server/api/repository";
+import { ApiError } from "@/server/api/errors";
+import type { ApiRepository, UsernameReservationResult } from "@/server/api/repository";
+import type { User } from "@/server/api/domain";
+import { userSchema } from "@/server/api/domain";
+
+const ADDR_A = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+const ADDR_B = "G234567ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQ";
+const EMAIL_A = "alice@stealth.mail";
+const NOW = new Date("2026-01-15T12:00:00.000Z");
+
+const INPUT = {
+  address: ADDR_A,
+  username: "alice_dev",
+  email: EMAIL_A,
+};
+
+function buildUser(overrides: Partial<User> = {}): User {
+  return userSchema.parse({
+    userId: "usr_alice",
+    address: ADDR_A,
+    email: EMAIL_A,
+    username: "alice_dev",
+    status: "pending_verification",
+    createdAt: "2026-01-15T11:00:00.000Z",
+    updatedAt: "2026-01-15T11:00:00.000Z",
+    version: 1,
+    ...overrides,
+  });
+}
+
+function seedUser(repo: MemoryApiRepository, user: User): Promise<User> {
+  return repo.createUser(user);
+}
+
+/**
+ * Proxy wrapper that fails a single named repository method call with the
+ * given error, then delegates everything else (and subsequent calls to the
+ * same method) to the inner repository.
+ */
+function failOnce(repo: ApiRepository, method: string, error: Error): ApiRepository {
+  let armed = true;
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      if (prop === method) {
+        if (armed) {
+          armed = false;
+          return () => Promise.reject(error);
+        }
+        return Reflect.get(target, prop, receiver);
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+/**
+ * Proxy wrapper that fails the named method on every call.
+ */
+function failAlways(repo: ApiRepository, method: string): ApiRepository {
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      if (prop === method) {
+        return () => Promise.reject(new ApiError(503, "dependency_unavailable", "down"));
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+const transient = () => new ApiError(503, "dependency_unavailable", "dependency temporarily down");
+
+describe("provisionAccount", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("bootstraps a user and converges all four steps to active without a half-account", async () => {
+    const progress = await provisionAccount(repo, { ...INPUT, displayName: "Alice Dev" }, NOW);
+
+    expect(progress.status).toBe("active");
+    expect(progress.completedSteps).toEqual([...PROVISIONING_STEPS]);
+    expect(progress.attempts).toBe(0);
+    expect(progress.failure).toBeNull();
+
+    const user = await repo.getUserByAddress(ADDR_A);
+    expect(user).not.toBeNull();
+    expect(user!.status).toBe("active");
+    expect(user!.username).toBe("alice_dev");
+    expect(user!.version).toBe(2);
+
+    const profile = await repo.getProfile(user!.userId);
+    expect(profile?.displayName).toBe("Alice Dev");
+
+    const wallet = await repo.getWallet(user!.userId);
+    expect(wallet?.address).toBe(ADDR_A);
+
+    const policy = await repo.getPolicy(ADDR_A);
+    expect(policy).toEqual(defaultMailboxPolicy);
+
+    // The claim is released once the username is permanently bound.
+    expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+  });
+
+  it("provisions an existing account without rebinding its username", async () => {
+    await seedUser(repo, buildUser());
+
+    const progress = await provisionAccount(
+      repo,
+      { address: ADDR_A, username: "ignored_input", email: EMAIL_A },
+      NOW,
+    );
+
+    expect(progress.status).toBe("active");
+    const user = await repo.getUserByAddress(ADDR_A);
+    expect(user!.username).toBe("alice_dev");
+    expect(user!.userId).toBe("usr_alice");
+    expect(progress.requestedUsername).toBe("alice_dev");
+  });
+
+  it("is idempotent: repeating a successful provision never double-creates resources", async () => {
+    const first = await provisionAccount(repo, INPUT, NOW);
+    const second = await provisionAccount(repo, INPUT, NOW);
+
+    expect(first.status).toBe("active");
+    expect(second.status).toBe("active");
+    expect(second).toEqual(first);
+
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+  });
+
+  it("resumes an in-progress record from its completed steps", async () => {
+    await provisionAccount(repo, INPUT, NOW);
+
+    const record = (await repo.getProvisioningRecord(
+      (await repo.getUserByAddress(ADDR_A))!.userId,
+    ))!;
+    // Simulate a crash mid-flow: only the first step completed.
+    await repo.setProvisioningRecord(
+      {
+        ...record,
+        status: "pending",
+        completedSteps: ["username_reservation"],
+        currentStep: "profile_defaults",
+      },
+      record.version,
+    );
+
+    const progress = await provisionAccount(repo, INPUT, NOW);
+    expect(progress.status).toBe("active");
+    expect(progress.completedSteps).toEqual([...PROVISIONING_STEPS]);
+  });
+
+  it("is concurrently safe: parallel provisioners converge to one active account, one wallet", async () => {
+    const results = await Promise.all([
+      provisionAccount(repo, INPUT, NOW),
+      provisionAccount(repo, INPUT, NOW),
+    ]);
+    const statuses = results.map((r) => r.status).sort();
+    // Exactly one run wins the username claim; the raced duplicate lands in
+    // terminal failed and never creates a second user or wallet.
+    expect(statuses).toEqual(["active", "failed"]);
+
+    const active = results.find((r) => r.status === "active")!;
+    expect(active.completedSteps).toEqual([...PROVISIONING_STEPS]);
+
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(user.status).toBe("active");
+    // Exactly one wallet exists for the sole user.
+    expect(await repo.getWallet(user.userId)).not.toBeNull();
+
+    // The claim is not squatted by either run.
+    expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+  });
+});
+
+describe("failure and compensation paths", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it.each([
+    ["username_reservation", "createUser"],
+    ["profile_defaults", "setProfile"],
+    ["wallet_creation", "createWallet"],
+    ["mailbox_policy_init", "initializePolicyIfAbsent"],
+  ] as const)(
+    "transient failure at %s step -> retryable, compensated, account stays pending",
+    async (step, method) => {
+      const progress = await provisionAccount(failOnce(repo, method, transient()), INPUT, NOW);
+
+      expect(progress.status).toBe("retryable");
+      expect(progress.attempts).toBe(1);
+      expect(progress.failure?.step).toBe(step);
+      expect(progress.failure?.code).toBe("dependency_unavailable");
+      expect(progress.completedSteps).toEqual(
+        PROVISIONING_STEPS.slice(0, PROVISIONING_STEPS.indexOf(step)),
+      );
+
+      // Never a live half-account: either absent or pending_verification.
+      const user = await repo.getUserByAddress(ADDR_A);
+      if (user) {
+        expect(user.status).toBe("pending_verification");
+      }
+
+      // Compensation released the username claim so a retry can re-claim it.
+      expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+    },
+  );
+
+  it("marks the flow failed (terminal) for a permanent username conflict and never activates", async () => {
+    await seedUser(
+      repo,
+      buildUser({
+        userId: "usr_bob",
+        address: ADDR_B,
+        email: "bob@stealth.mail",
+        username: "taken_name",
+      }),
+    );
+
+    const progress = await provisionAccount(
+      repo,
+      { address: ADDR_A, username: "taken_name", email: EMAIL_A },
+      NOW,
+    );
+
+    expect(progress.status).toBe("failed");
+    expect(progress.attempts).toBe(1);
+    expect(progress.failure?.code).toBe("username_unavailable");
+    expect(await repo.getUserByAddress(ADDR_A)).toBeNull();
+    expect(await repo.getUsernameReservation("taken_name")).toBeNull();
+  });
+
+  it("marks the flow failed when the bound username differs from the record's requested username", async () => {
+    // A provisioning record is created first (e.g. a signup flow), and a
+    // later registration binds the same user id to a different username.
+    // The record's claimed username can never be re-bound — permanent.
+    await seedUser(repo, buildUser({ username: "alice_old" }));
+    await repo.createProvisioningRecord({
+      userId: "usr_alice",
+      status: "pending",
+      requestedUsername: "alice_dev",
+      displayName: null,
+      completedSteps: [],
+      currentStep: "username_reservation",
+      attempts: 0,
+      failure: null,
+      startedAt: "2026-01-15T11:00:00.000Z",
+      updatedAt: "2026-01-15T11:00:00.000Z",
+      version: 1,
+    });
+
+    const progress = await provisionAccount(
+      repo,
+      { address: ADDR_A, username: "ignored", email: EMAIL_A },
+      NOW,
+    );
+
+    expect(progress.status).toBe("failed");
+    expect(progress.failure?.code).toBe("invalid_state_transition");
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(user.username).toBe("alice_old");
+    expect(user.status).toBe("pending_verification");
+  });
+
+  it("keeps the account pending_verification when activation fails transiently", async () => {
+    const progress = await provisionAccount(failOnce(repo, "updateUser", transient()), INPUT, NOW);
+
+    expect(progress.status).toBe("retryable");
+    expect(progress.failure?.step).toBe("mailbox_policy_init");
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(user.status).toBe("pending_verification");
+  });
+
+  it("cannot activate a suspended account (permanent failure)", async () => {
+    await seedUser(repo, buildUser({ status: "suspended" }));
+
+    const progress = await provisionAccount(repo, INPUT, NOW);
+
+    expect(progress.status).toBe("failed");
+    expect(progress.failure?.code).toBe("invalid_state_transition");
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(user.status).toBe("suspended");
+  });
+
+  it("exhausts attempts into a terminal failed state and blocks further retries", async () => {
+    const failing = failAlways(repo, "setProfile");
+
+    let progress = await provisionAccount(failing, INPUT, NOW);
+    expect(progress.status).toBe("retryable");
+    expect(progress.attempts).toBe(1);
+
+    const userId = (await repo.getUserByAddress(ADDR_A))!.userId;
+
+    for (let attempt = 2; attempt < MAX_PROVISIONING_ATTEMPTS; attempt += 1) {
+      progress = await retryAccountProvisioning(failing, userId, NOW);
+      expect(progress.attempts).toBe(attempt);
+      expect(progress.status).toBe("retryable");
+    }
+
+    // The final allowed retry lands the flow in terminal failed.
+    progress = await retryAccountProvisioning(failing, userId, NOW);
+    expect(progress.status).toBe("failed");
+    expect(progress.attempts).toBe(MAX_PROVISIONING_ATTEMPTS);
+
+    await expect(retryAccountProvisioning(repo, userId, NOW)).rejects.toMatchObject({
+      code: "invalid_state_transition",
+    });
+  });
+});
+
+describe("retryAccountProvisioning", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("resumes from the first incomplete step and converges to active", async () => {
+    const first = await provisionAccount(failOnce(repo, "createWallet", transient()), INPUT, NOW);
+    expect(first.status).toBe("retryable");
+    expect(first.completedSteps).toEqual(["username_reservation", "profile_defaults"]);
+
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    const progress = await retryAccountProvisioning(repo, user.userId, NOW);
+
+    expect(progress.status).toBe("active");
+    expect(progress.attempts).toBe(1);
+    expect(progress.completedSteps).toEqual([...PROVISIONING_STEPS]);
+
+    const wallet = await repo.getWallet(user.userId);
+    expect(wallet).not.toBeNull();
+
+    const activeUser = await repo.getUserByAddress(ADDR_A);
+    expect(activeUser?.status).toBe("active");
+  });
+
+  it("a failed bootstrap is recoverable: the released claim lets a fresh provisioning converge", async () => {
+    // Bootstrap itself fails (user creation is down), compensation releases
+    // the username claim, and the address is not bound to any user.
+    const first = await provisionAccount(failOnce(repo, "createUser", transient()), INPUT, NOW);
+    expect(first.status).toBe("retryable");
+    expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+    expect(await repo.getUserByAddress(ADDR_A)).toBeNull();
+
+    // A fresh provisioning attempt can re-claim the username and converge.
+    const recovered = await provisionAccount(repo, INPUT, NOW);
+    expect(recovered.status).toBe("active");
+    expect(await repo.getUserByAddress(ADDR_A)).not.toBeNull();
+    expect(await repo.getUsernameReservation("alice_dev")).toBeNull();
+  });
+
+  it("rejects retries for active accounts", async () => {
+    await provisionAccount(repo, INPUT, NOW);
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+
+    await expect(retryAccountProvisioning(repo, user.userId, NOW)).rejects.toMatchObject({
+      code: "invalid_state_transition",
+    });
+  });
+
+  it("rejects retries while a run is in flight (pending)", async () => {
+    await provisionAccount(repo, INPUT, NOW);
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    const record = (await repo.getProvisioningRecord(user.userId))!;
+    await repo.setProvisioningRecord({ ...record, status: "pending" }, record.version);
+
+    await expect(retryAccountProvisioning(repo, user.userId, NOW)).rejects.toMatchObject({
+      code: "invalid_state_transition",
+    });
+  });
+
+  it("returns not_found when no provisioning record exists", async () => {
+    await seedUser(repo, buildUser());
+
+    await expect(retryAccountProvisioning(repo, "usr_alice", NOW)).rejects.toMatchObject({
+      code: "not_found",
+    });
+  });
+});
+
+describe("getProvisioningProgress", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("exposes only safe progress fields, never identifiers or secrets", async () => {
+    const progress = await provisionAccount(repo, INPUT, NOW);
+
+    expect(Object.keys(progress).sort()).toEqual(
+      [
+        "status",
+        "requestedUsername",
+        "completedSteps",
+        "currentStep",
+        "attempts",
+        "failure",
+        "updatedAt",
+      ].sort(),
+    );
+    expect(progress).not.toHaveProperty("userId");
+    expect(progress).not.toHaveProperty("email");
+    expect(progress).not.toHaveProperty("address");
+
+    const user = (await repo.getUserByAddress(ADDR_A))!;
+    expect(await getProvisioningProgress(repo, user.userId)).toEqual(progress);
+  });
+
+  it("returns null when no provisioning started", async () => {
+    await seedUser(repo, buildUser());
+    expect(await getProvisioningProgress(repo, "usr_alice")).toBeNull();
+  });
+});
+
+describe("username reservation repository contract", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+  });
+
+  it("reserves, idempotently re-claims for the same user, and refuses other users", async () => {
+    const first: UsernameReservationResult = await repo.reserveUsername(
+      "alice_dev",
+      "usr_alice",
+      USERNAME_RESERVATION_LEASE_MS,
+    );
+    expect(first.outcome).toBe("reserved");
+
+    const again: UsernameReservationResult = await repo.reserveUsername(
+      "alice_dev",
+      "usr_alice",
+      USERNAME_RESERVATION_LEASE_MS,
+    );
+    expect(again.outcome).toBe("already-reserved");
+
+    const other: UsernameReservationResult = await repo.reserveUsername(
+      "alice_dev",
+      "usr_bob",
+      USERNAME_RESERVATION_LEASE_MS,
+    );
+    expect(other.outcome).toBe("unavailable");
+
+    // A bound user record outranks any claim.
+    await seedUser(repo, buildUser({ userId: "usr_bob", address: ADDR_B, username: "bob_dev" }));
+    const bound: UsernameReservationResult = await repo.reserveUsername(
+      "bob_dev",
+      "usr_carol",
+      USERNAME_RESERVATION_LEASE_MS,
+    );
+    expect(bound.outcome).toBe("unavailable");
+  });
+
+  it("expired claims are reclaimable and release is owner-gated and idempotent", async () => {
+    await repo.reserveUsername("alice_dev", "usr_alice", 1);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const reclaimed: UsernameReservationResult = await repo.reserveUsername(
+      "alice_dev",
+      "usr_bob",
+      USERNAME_RESERVATION_LEASE_MS,
+    );
+    expect(reclaimed.outcome).toBe("reserved");
+
+    expect(await repo.releaseUsernameReservation("alice_dev", "usr_alice")).toBe(false);
+    expect(await repo.releaseUsernameReservation("alice_dev", "usr_bob")).toBe(true);
+    expect(await repo.releaseUsernameReservation("alice_dev", "usr_bob")).toBe(false);
+  });
+});

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -192,6 +192,50 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setCredential");
     return this.inner.setCredential(credential);
   }
+  async getProvisioningRecord(userId: string) {
+    this.maybeFail("getProvisioningRecord");
+    return this.inner.getProvisioningRecord(userId);
+  }
+  async createProvisioningRecord(
+    record: import("../../../src/server/api/domain").ProvisioningRecord,
+  ) {
+    this.maybeFail("createProvisioningRecord");
+    return this.inner.createProvisioningRecord(record);
+  }
+  async setProvisioningRecord(
+    record: import("../../../src/server/api/domain").ProvisioningRecord,
+    expectedVersion: number,
+  ) {
+    this.maybeFail("setProvisioningRecord");
+    return this.inner.setProvisioningRecord(record, expectedVersion);
+  }
+  async reserveUsername(username: string, userId: string, leaseMs: number) {
+    this.maybeFail("reserveUsername");
+    return this.inner.reserveUsername(username, userId, leaseMs);
+  }
+  async getUsernameReservation(username: string) {
+    this.maybeFail("getUsernameReservation");
+    return this.inner.getUsernameReservation(username);
+  }
+  async releaseUsernameReservation(username: string, userId: string) {
+    this.maybeFail("releaseUsernameReservation");
+    return this.inner.releaseUsernameReservation(username, userId);
+  }
+  async getWallet(userId: string) {
+    this.maybeFail("getWallet");
+    return this.inner.getWallet(userId);
+  }
+  async createWallet(wallet: import("../../../src/server/api/domain").Wallet) {
+    this.maybeFail("createWallet");
+    return this.inner.createWallet(wallet);
+  }
+  async initializePolicyIfAbsent(
+    owner: string,
+    policy: import("../../../src/server/api/domain").MailboxPolicy,
+  ) {
+    this.maybeFail("initializePolicyIfAbsent");
+    return this.inner.initializePolicyIfAbsent(owner, policy);
+  }
   async getEnvelope(messageId: string): Promise<StoredEnvelope | null> {
     this.maybeFail("getEnvelope");
     return this.inner.getEnvelope(messageId);


### PR DESCRIPTION
## Overview

closes #1921 

Implements BETA-014 as the account-provisioning orchestrator: an idempotent, durable state machine per account (pending -> retryable -> active, terminal failed) that coordinates username reservation, profile defaults, wallet creation, and mailbox policy initialization, then flips the account active only after every step is durable. Adds the public `POST /accounts` provisioning endpoint plus safe progress (`GET /accounts/provisioning`) and owner-scoped retry (`POST /accounts/provisioning/retry`) controls.

Because dependencies #1910 (BETA-003 username), #1911 (BETA-004 registration), and #1920 (BETA-013 wallet-first) are still open, this is an isolated implementation: the orchestrator bootstraps its own user record for signup (bounded by BETA-004's later reconciliation) and uses the account's Stellar address as the initial wallet address until an external wallet provider exists. Both choices are documented in the code and explained on the issue.

## Related Issue

[Implements #1921](https://github.com/Stellar-Mail/stealth/issues/1921) — dependencies #1910/#1911/#1920 remain open; isolated implementation per the issue's dependency clause.

## Changes

- **[ADD]** `src/server/api/account-provisioning.ts`: table-driven state machine. Every step is idempotent (re-claimable 30-minute username lease, profile upsert, insert-once wallet, initialize-if-absent policy), so resumed/retried flows never double-create wallets, addresses, or user records. All state-machine writes are CAS (`expectedVersion`), so a stale writer can never clobber a concurrent retry's progress.
- **[ADD]** Status/failure semantics: transient failures (e.g. `dependency_unavailable`) land in `retryable` with the username lease released as the sole compensation; permanent failures (`username_unavailable`, `invalid_state_transition`) and exhausted attempts (max 5) land in terminal `failed`. A mid-flow failure always leaves the account `pending_verification` — never an active half-account. Input validation (invalid address/email) is rejected as 422 *before* any record is created.
- **[ADD]** Routes under `src/routes/api/v1/accounts/`: `POST` provision (zen body validation, `x-idempotency-key` support with replay + cached deterministic 409s), `GET /provisioning` (safe projection + account status, 404s for unknown account/record), `POST /provisioning/retry` (owner-scoped, 409 unless retryable, attempt-exhaustion guard).
- **[ADD]** Repository layer: `getProvisioningRecord`, `createProvisioningRecord` (insert-once), `setProvisioningRecord` (CAS), `reserveUsername`/`getUsernameReservation`/`releaseUsernameReservation` (leased claims, owner-gated release), `getWallet`/`createWallet` (insert-once), `initializePolicyIfAbsent`, with `RETRY_SAFE_OPERATIONS` entries for every single-winner-safe op and DO-storage implementations in `stealth-coordinator.ts` + `kv-repository.ts` (policy mirrored to KV), memory implementation for tests, and schema registrations in `context.ts`.
- **[ADD]** Domain: `provisioningStatusSchema`/`provisioningStepSchema`/`provisioningRecordSchema`/`provisioningFailureSchema`/`usernameReservationSchema`/`walletSchema`; `username_unavailable` (409, permanent) error code.
- **[MODIFY]** OpenAPI: three new paths + component schemas (spec additive vs `origin/main`); `openapi.json` regenerated.
- **[FIX]** `ApiError` classified `dependency_unavailable` as permanent even though the error registry marks it transient — the constructed classification now matches the registry, which provisioning's retry policy depends on.

## Verification Results

- **[TEST]** 45 new tests across `tests/unit/api/account-provisioning.test.ts` (table-driven transitions per step, compensation/reclaim, attempt exhaustion, CAS conflicts, concurrency: parallel provisioners converge to exactly one active account + one wallet) and `tests/unit/api/account-provisioning-routes.test.ts` (validation 422s, taken-username conflict, idempotent replay + cached 409s, concurrent dedupe, progress/404s, owner-scoped retry). Full suite: 160 files — 1937 passed, 3 expected fail (one worker-startup timeout on the requests file reproduced locally, passes in isolation).
- **[CODE REVIEW]** Rebased onto latest upstream (`origin/main` `55940c0f`, relay BETA-028 + R2/storage BETA-030 + encrypted-envelope); `openapi.json` regenerated from the merged spec — additive vs upstream.
- **[CI/CD]** CI-equivalent checks pass locally: `prettier --check .`, `eslint .`, `tsc --noEmit`, `npm test`, `npm run build` (client + SSR worker). e2e runs in CI (needs bun + Playwright browsers not available locally).

## Acceptance Criteria

| Criterion | Status | Evidence |
|---|---|---|
| Repeated requests cannot create duplicate wallets or addresses | ✅ | `account-provisioning.test.ts` (idempotent replay, resume, concurrent-safe), `account-provisioning-routes.test.ts` (idempotency key replay, concurrent dedupe — exactly one 200 + four 409) |
| Failures preserve recoverable state with no active half-account | ✅ | `account-provisioning.test.ts` (per-step transient failure -> retryable + compensated, account stays `pending_verification`; terminal `failed` for permanent codes) |
| Table-driven tests cover every transition and compensation path | ✅ | `account-provisioning.test.ts` `it.each` over all four steps, exhaustion loop, retry guards, reservation contract |
| Safe progress + owner-scoped retry controls | ✅ | `GET /accounts/provisioning` (safe projection, no ids/secrets) and `POST /accounts/provisioning/retry` (404/409 guards) with route tests |
| OpenAPI documents the endpoints, additively | ✅ | `openapi.ts` + regenerated `openapi.json`, optic diff in CI |