### PR TITLE
feat(auth): add email password registration

### DIFF
--- a/src/components/mail/AuthModal.tsx
+++ b/src/components/mail/AuthModal.tsx
@@ -25,7 +25,13 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (registering) {
-      if (!displayName.trim() || !email.trim() || !username.trim() || !password || !passwordConfirmation) {
+      if (
+        !displayName.trim() ||
+        !email.trim() ||
+        !username.trim() ||
+        !password ||
+        !passwordConfirmation
+      ) {
         setError("Complete every required field.");
         return;
       }
@@ -52,7 +58,11 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
         const data = await res.json();
         if (!res.ok) {
           const fieldError = data.error?.details?.validationErrors?.[0]?.message;
-          setError(fieldError || data.error?.message || "We could not create your account. Please try again.");
+          setError(
+            fieldError ||
+              data.error?.message ||
+              "We could not create your account. Please try again.",
+          );
           setLoading(false);
           return;
         }
@@ -145,9 +155,13 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               <KeyRound className="h-6 w-6" />
             </div>
             <div>
-              <h2 className="text-xl font-bold tracking-tight">{registering ? "Create your Stealth account" : "Sign in to Stealth"}</h2>
+              <h2 className="text-xl font-bold tracking-tight">
+                {registering ? "Create your Stealth account" : "Sign in to Stealth"}
+              </h2>
               <p className="text-xs text-muted-foreground">
-                {registering ? "No wallet connection is required." : "Enter your credentials to access your mailbox securely."}
+                {registering
+                  ? "No wallet connection is required."
+                  : "Enter your credentials to access your mailbox securely."}
               </p>
             </div>
           </div>
@@ -159,109 +173,179 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
                 <span>Check your email</span>
               </div>
               <p className="text-sm text-muted-foreground">
-                We sent verification instructions to {registeredEmail}. You can correct your email by creating the account again with the right address.
+                We sent verification instructions to {registeredEmail}. You can correct your email
+                by creating the account again with the right address.
               </p>
             </div>
-          ) : <form onSubmit={handleSubmit} className="space-y-4">
-            {error && (
-              <motion.div
-                initial={{ opacity: 0, y: -6 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive"
-              >
-                <AlertCircle className="h-4 w-4 shrink-0" />
-                <span>{error}</span>
-              </motion.div>
-            )}
-
-            {success && !registering && (
-              <motion.div
-                initial={{ opacity: 0, y: -6 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="flex items-center gap-2.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-400"
-              >
-                <CheckCircle2 className="h-4 w-4 shrink-0" />
-                <span>Authentication successful! Accessing mailbox...</span>
-              </motion.div>
-            )}
-
-            {registering && <>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Full name</label>
-              <input value={displayName} onChange={(e) => setDisplayName(e.target.value)} autoComplete="name" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
-            </div>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Email address</label>
-              <div className="relative flex items-center"><Mail className="absolute left-3 h-4 w-4 text-muted-foreground" /><input type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground" /></div>
-            </div>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Stealth username</label>
-              <input value={username} onChange={(e) => setUsername(e.target.value.toLowerCase())} autoComplete="username" required pattern="[a-z0-9_-]{3,30}" className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
-              <p className="mt-1 text-xs text-muted-foreground">{username || "username"}@stealth.me</p>
-            </div>
-            </>}
-            {!registering && <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Email or Username
-              </label>
-              <div className="relative flex items-center">
-                <User className="absolute left-3 h-4 w-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  value={identifier}
-                  onChange={(e) => setIdentifier(e.target.value)}
-                  placeholder="alice@stealth.mail or alice_99"
-                  className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
-                  autoComplete="username"
-                  required
-                />
-              </div>
-            </div>}
-
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Password
-              </label>
-              <div className="relative flex items-center">
-                <Lock className="absolute left-3 h-4 w-4 text-muted-foreground" />
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••••••"
-                  className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
-                  autoComplete="current-password"
-                  required
-                />
-              </div>
-            </div>
-
-            {registering && <>
-            <div>
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Confirm password</label>
-              <input type="password" value={passwordConfirmation} onChange={(e) => setPasswordConfirmation(e.target.value)} autoComplete="new-password" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
-            </div>
-            <label className="flex items-start gap-2 text-xs text-muted-foreground"><input type="checkbox" checked={acceptedLegal} onChange={(e) => setAcceptedLegal(e.target.checked)} required className="mt-0.5" />I agree to the Terms and Privacy Policy.</label>
-            </>}
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="glow-ring flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
-            >
-              {loading ? (
-                <span className="inline-flex items-center gap-2">
-                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
-                  {registering ? "Creating account..." : "Authenticating..."}
-                </span>
-              ) : (
-                registering ? "Create account" : "Sign In"
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                <motion.div
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="flex items-center gap-2.5 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive"
+                >
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  <span>{error}</span>
+                </motion.div>
               )}
-            </button>
-            <button type="button" onClick={() => { setRegistering(!registering); setError(null); setSuccess(false); }} className="w-full text-center text-xs text-primary hover:underline">
-              {registering ? "Already have an account? Sign in" : "New to Stealth? Create an account"}
-            </button>
-          </form>}
+
+              {success && !registering && (
+                <motion.div
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="flex items-center gap-2.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-400"
+                >
+                  <CheckCircle2 className="h-4 w-4 shrink-0" />
+                  <span>Authentication successful! Accessing mailbox...</span>
+                </motion.div>
+              )}
+
+              {registering && (
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Full name
+                    </label>
+                    <input
+                      value={displayName}
+                      onChange={(e) => setDisplayName(e.target.value)}
+                      autoComplete="name"
+                      required
+                      className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground"
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Email address
+                    </label>
+                    <div className="relative flex items-center">
+                      <Mail className="absolute left-3 h-4 w-4 text-muted-foreground" />
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        autoComplete="email"
+                        required
+                        className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Stealth username
+                    </label>
+                    <input
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value.toLowerCase())}
+                      autoComplete="username"
+                      required
+                      pattern="[a-z0-9_-]{3,30}"
+                      className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground"
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {username || "username"}@stealth.me
+                    </p>
+                  </div>
+                </>
+              )}
+              {!registering && (
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                    Email or Username
+                  </label>
+                  <div className="relative flex items-center">
+                    <User className="absolute left-3 h-4 w-4 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={identifier}
+                      onChange={(e) => setIdentifier(e.target.value)}
+                      placeholder="alice@stealth.mail or alice_99"
+                      className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
+                      autoComplete="username"
+                      required
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                  Password
+                </label>
+                <div className="relative flex items-center">
+                  <Lock className="absolute left-3 h-4 w-4 text-muted-foreground" />
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••••••"
+                    className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition focus:bg-white/[0.08]"
+                    autoComplete="current-password"
+                    required
+                  />
+                </div>
+              </div>
+
+              {registering && (
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Confirm password
+                    </label>
+                    <input
+                      type="password"
+                      value={passwordConfirmation}
+                      onChange={(e) => setPasswordConfirmation(e.target.value)}
+                      autoComplete="new-password"
+                      required
+                      className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground"
+                    />
+                  </div>
+                  <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={acceptedLegal}
+                      onChange={(e) => setAcceptedLegal(e.target.checked)}
+                      required
+                      className="mt-0.5"
+                    />
+                    I agree to the Terms and Privacy Policy.
+                  </label>
+                </>
+              )}
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="glow-ring flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+              >
+                {loading ? (
+                  <span className="inline-flex items-center gap-2">
+                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+                    {registering ? "Creating account..." : "Authenticating..."}
+                  </span>
+                ) : registering ? (
+                  "Create account"
+                ) : (
+                  "Sign In"
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setRegistering(!registering);
+                  setError(null);
+                  setSuccess(false);
+                }}
+                className="w-full text-center text-xs text-primary hover:underline"
+              >
+                {registering
+                  ? "Already have an account? Sign in"
+                  : "New to Stealth? Create an account"}
+              </button>
+            </form>
+          )}
         </motion.div>
       </div>
     </AnimatePresence>

--- a/src/components/mail/AuthModal.tsx
+++ b/src/components/mail/AuthModal.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { KeyRound, Lock, User, AlertCircle, CheckCircle2, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { KeyRound, Lock, User, AlertCircle, CheckCircle2, X, Mail } from "lucide-react";
 
 export interface AuthModalProps {
   open: boolean;
@@ -11,13 +10,61 @@ export interface AuthModalProps {
 
 export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
   const [identifier, setIdentifier] = useState("");
+  const [registering, setRegistering] = useState(false);
+  const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [acceptedLegal, setAcceptedLegal] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (registering) {
+      if (!displayName.trim() || !email.trim() || !username.trim() || !password || !passwordConfirmation) {
+        setError("Complete every required field.");
+        return;
+      }
+      if (!acceptedLegal) {
+        setError("Please accept the Terms and Privacy Policy.");
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/v1/auth/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            displayName,
+            email,
+            username,
+            password,
+            passwordConfirmation,
+            termsVersion: "2026-01",
+            privacyPolicyVersion: "2026-01",
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          const fieldError = data.error?.details?.validationErrors?.[0]?.message;
+          setError(fieldError || data.error?.message || "We could not create your account. Please try again.");
+          setLoading(false);
+          return;
+        }
+        setRegisteredEmail(data.data.maskedEmail);
+        setSuccess(true);
+        setLoading(false);
+      } catch {
+        setError("Unable to connect to the registration server. Please try again.");
+        setLoading(false);
+      }
+      return;
+    }
     if (!identifier.trim() || !password) {
       setError("Please enter your email/username and password.");
       return;
@@ -98,14 +145,24 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               <KeyRound className="h-6 w-6" />
             </div>
             <div>
-              <h2 className="text-xl font-bold tracking-tight">Sign in to Stealth</h2>
+              <h2 className="text-xl font-bold tracking-tight">{registering ? "Create your Stealth account" : "Sign in to Stealth"}</h2>
               <p className="text-xs text-muted-foreground">
-                Enter your credentials to access your mailbox securely.
+                {registering ? "No wallet connection is required." : "Enter your credentials to access your mailbox securely."}
               </p>
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          {registeredEmail ? (
+            <div className="space-y-4" role="status">
+              <div className="flex items-center gap-2.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-400">
+                <CheckCircle2 className="h-4 w-4 shrink-0" />
+                <span>Check your email</span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                We sent verification instructions to {registeredEmail}. You can correct your email by creating the account again with the right address.
+              </p>
+            </div>
+          ) : <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
               <motion.div
                 initial={{ opacity: 0, y: -6 }}
@@ -117,7 +174,7 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               </motion.div>
             )}
 
-            {success && (
+            {success && !registering && (
               <motion.div
                 initial={{ opacity: 0, y: -6 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -128,7 +185,22 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               </motion.div>
             )}
 
+            {registering && <>
             <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Full name</label>
+              <input value={displayName} onChange={(e) => setDisplayName(e.target.value)} autoComplete="name" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Email address</label>
+              <div className="relative flex items-center"><Mail className="absolute left-3 h-4 w-4 text-muted-foreground" /><input type="email" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="email" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] py-2.5 pl-9 pr-3 text-sm text-foreground" /></div>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Stealth username</label>
+              <input value={username} onChange={(e) => setUsername(e.target.value.toLowerCase())} autoComplete="username" required pattern="[a-z0-9_-]{3,30}" className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
+              <p className="mt-1 text-xs text-muted-foreground">{username || "username"}@stealth.me</p>
+            </div>
+            </>}
+            {!registering && <div>
               <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                 Email or Username
               </label>
@@ -144,7 +216,7 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
                   required
                 />
               </div>
-            </div>
+            </div>}
 
             <div>
               <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
@@ -164,6 +236,14 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               </div>
             </div>
 
+            {registering && <>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Confirm password</label>
+              <input type="password" value={passwordConfirmation} onChange={(e) => setPasswordConfirmation(e.target.value)} autoComplete="new-password" required className="glow-ring w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-foreground" />
+            </div>
+            <label className="flex items-start gap-2 text-xs text-muted-foreground"><input type="checkbox" checked={acceptedLegal} onChange={(e) => setAcceptedLegal(e.target.checked)} required className="mt-0.5" />I agree to the Terms and Privacy Policy.</label>
+            </>}
+
             <button
               type="submit"
               disabled={loading}
@@ -172,13 +252,16 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
               {loading ? (
                 <span className="inline-flex items-center gap-2">
                   <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
-                  Authenticating...
+                  {registering ? "Creating account..." : "Authenticating..."}
                 </span>
               ) : (
-                "Sign In"
+                registering ? "Create account" : "Sign In"
               )}
             </button>
-          </form>
+            <button type="button" onClick={() => { setRegistering(!registering); setError(null); setSuccess(false); }} className="w-full text-center text-xs text-primary hover:underline">
+              {registering ? "Already have an account? Sign in" : "New to Stealth? Create an account"}
+            </button>
+          </form>}
         </motion.div>
       </div>
     </AnimatePresence>

--- a/src/features/identity/registration.ts
+++ b/src/features/identity/registration.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+import { emailSchema, usernameSchema } from "@/server/api/domain";
+
+export const CURRENT_TERMS_VERSION = "2026-01";
+export const CURRENT_PRIVACY_POLICY_VERSION = "2026-01";
+
+export const registrationRequestSchema = z
+  .object({
+    displayName: z.string().trim().min(1, "Name is required").max(120, "Name is too long"),
+    email: emailSchema,
+    username: usernameSchema,
+    password: z
+      .string()
+      .min(12, "Password must be at least 12 characters")
+      .max(256, "Password is too long")
+      .refine((value) => /[a-z]/.test(value), "Password must include a lowercase letter")
+      .refine((value) => /[A-Z]/.test(value), "Password must include an uppercase letter")
+      .refine((value) => /\d/.test(value), "Password must include a number"),
+    passwordConfirmation: z.string(),
+    termsVersion: z.literal(CURRENT_TERMS_VERSION),
+    privacyPolicyVersion: z.literal(CURRENT_PRIVACY_POLICY_VERSION),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.password !== value.passwordConfirmation) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["passwordConfirmation"],
+        message: "Passwords do not match",
+      });
+    }
+  });
+
+export const registrationResponseSchema = z.object({
+  accountStatus: z.literal("pending_verification"),
+  email: emailSchema,
+  maskedEmail: z.string(),
+  username: usernameSchema,
+});
+
+export type RegistrationRequest = z.infer<typeof registrationRequestSchema>;
+export type RegistrationResponse = z.infer<typeof registrationResponseSchema>;
+
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split("@");
+  const visible = local.length <= 2 ? local.slice(0, 1) : local.slice(0, 2);
+  return `${visible}${"•".repeat(Math.max(1, local.length - visible.length))}@${domain}`;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
+import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -134,6 +135,11 @@ const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
   path: '/api/v1/auth/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
+  id: '/api/v1/auth/register',
+  path: '/api/v1/auth/register',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -167,6 +173,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
@@ -193,6 +200,7 @@ export interface FileRoutesByTo {
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
@@ -220,6 +228,7 @@ export interface FileRoutesById {
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
@@ -248,6 +257,7 @@ export interface FileRouteTypes {
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
@@ -274,6 +284,7 @@ export interface FileRouteTypes {
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
@@ -300,6 +311,7 @@ export interface FileRouteTypes {
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
@@ -327,6 +339,7 @@ export interface RootRouteChildren {
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
   ApiV1AuthLoginRoute: typeof ApiV1AuthLoginRoute
+  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthLogoutRoute: typeof ApiV1AuthLogoutRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
@@ -484,6 +497,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AuthLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/register': {
+      id: '/api/v1/auth/register'
+      path: '/api/v1/auth/register'
+      fullPath: '/api/v1/auth/register'
+      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -563,6 +583,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
   ApiV1AuthLoginRoute: ApiV1AuthLoginRoute,
+  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthLogoutRoute: ApiV1AuthLogoutRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,

--- a/src/routes/api/v1/auth/register.ts
+++ b/src/routes/api/v1/auth/register.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { registrationRequestSchema } from "@/features/identity/registration";
+import { registerWithPassword } from "@/server/api/auth/registration-service";
+import { getApiContext } from "@/server/api/context";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/auth/register")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const body = await parseJsonBody(request, registrationRequestSchema, "compact");
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+          const result = await registerWithPassword(await getApiContext(request), body, ip);
+          return apiSuccess(request, result, { status: 201 });
+        }),
+    },
+  },
+});

--- a/src/server/api/auth/registration-service.ts
+++ b/src/server/api/auth/registration-service.ts
@@ -1,0 +1,75 @@
+import type { RegistrationRequest, RegistrationResponse } from "@/features/identity/registration";
+import { maskEmail } from "@/features/identity/registration";
+import type { ApiContext } from "../context";
+import type { Credential, Profile, User } from "../domain";
+import { ApiError } from "../errors";
+import { hashPassword } from "./password";
+
+const SIGNUP_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
+const MAX_SIGNUPS_PER_IP = 10;
+const BASE32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function generatedAccountAddress(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(55));
+  return `G${Array.from(bytes, (byte) => BASE32[byte % BASE32.length]).join("")}`;
+}
+
+export async function registerWithPassword(
+  apiContext: ApiContext,
+  input: RegistrationRequest,
+  ip = "unknown",
+): Promise<RegistrationResponse> {
+  const rateLimitKey = `signup:${ip}`;
+  if ((await apiContext.repository.getCounter(rateLimitKey)) >= MAX_SIGNUPS_PER_IP) {
+    throw new ApiError("too_many_requests", { retryAfterSeconds: SIGNUP_RATE_LIMIT_WINDOW_SECONDS });
+  }
+
+  const now = new Date().toISOString();
+  const userId = `usr_${crypto.randomUUID().replace(/-/g, "")}`;
+  const { hash, salt } = await hashPassword(input.password);
+  const user: User = {
+    userId,
+    // This is an internal unique placeholder, not an external wallet connection.
+    address: generatedAccountAddress(),
+    email: input.email,
+    username: input.username,
+    status: "pending_verification",
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+  };
+  const credential: Credential = {
+    credentialId: `cred_${crypto.randomUUID().replace(/-/g, "")}`,
+    userId,
+    authMethod: "password_hash",
+    secretHash: `${hash}:${salt}`,
+    walletKeyRef: `pending_${userId}`,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const profile: Profile = {
+    userId,
+    username: input.username,
+    displayName: input.displayName,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  try {
+    await apiContext.repository.createUser(user, credential, profile);
+  } catch (error) {
+    if (error instanceof ApiError && error.code === "conflict") {
+      // Keep email and username ownership private.
+      throw new ApiError("conflict");
+    }
+    throw error;
+  }
+
+  await apiContext.repository.incrementCounter(rateLimitKey, SIGNUP_RATE_LIMIT_WINDOW_SECONDS, 1);
+  return {
+    accountStatus: "pending_verification",
+    email: user.email,
+    maskedEmail: maskEmail(user.email),
+    username: user.username,
+  };
+}

--- a/src/server/api/auth/registration-service.ts
+++ b/src/server/api/auth/registration-service.ts
@@ -21,7 +21,9 @@ export async function registerWithPassword(
 ): Promise<RegistrationResponse> {
   const rateLimitKey = `signup:${ip}`;
   if ((await apiContext.repository.getCounter(rateLimitKey)) >= MAX_SIGNUPS_PER_IP) {
-    throw new ApiError("too_many_requests", { retryAfterSeconds: SIGNUP_RATE_LIMIT_WINDOW_SECONDS });
+    throw new ApiError("too_many_requests", {
+      retryAfterSeconds: SIGNUP_RATE_LIMIT_WINDOW_SECONDS,
+    });
   }
 
   const now = new Date().toISOString();


### PR DESCRIPTION
Closes #1911 

## Summary
Implements BETA-004 email-and-password registration without requiring a wallet connection.

- Adds `POST /api/v1/auth/register` with typed request/response contracts.
- Validates and normalizes name, email, username, password confirmation, and current legal-document versions.
- Hashes passwords before persistence and creates the pending-verification user, profile, and password credential together through the existing atomic repository operation.
- Enforces persistence-layer email/username uniqueness, rate limits signup attempts, and returns safe public conflict errors.
- Returns a pending-verification response with a masked email address.
- Extends the existing auth modal with an accessible Create account flow, loading protection, legal acceptance, username address preview, error handling, and a check-your-email success state.

## Verification

- `git diff --check` passed.
- Type-check could not run because dependencies are not installed and `npx` could not access the npm registry in this environment.