### PR TITLE
feat(migrations): add versioned Cloudflare persistence bindings and identity migrations (BETA-024 / #1931)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# BETA-024 (Issue #1931) — environment variables for generating a deployable
+# wrangler config.
+#
+# Copy this file to a private location (never commit real values). The
+# committed wrangler.jsonc only ships placeholder tokens; run
+#   bun run config:generate
+# to substitute these values into the gitignored .wrangler/generated/wrangler.jsonc
+# and deploy with `wrangler deploy --env <env> --config .wrangler/generated/wrangler.jsonc`.
+#
+# The guard (tests/unit/config/wrangler-config.test.ts + `bun run config:check`)
+# refuses real IDs or placeholder leakage in production.
+
+# KV namespace ids (created via `wrangler kv namespace create <name>`).
+# Local is the value used by plain `wrangler dev`; any non-empty value works for
+# the local-emulated namespace.
+STEALTH_KV_LOCAL_ID=
+STEALTH_KV_PREVIEW_ID=
+STEALTH_KV_PRODUCTION_ID=

--- a/docs/deployment/MIGRATIONS.md
+++ b/docs/deployment/MIGRATIONS.md
@@ -62,3 +62,109 @@ If you need to roll back a deployment that introduced a schema migration, the fo
   1. Re-deploy the older codebase.
   2. Any records written in the newer schema will be inaccessible until they are either manually downgraded in the storage layer or the newer code is successfully rolled forward again.
   3. Avoid writing breaking schema changes unless necessary. For additive changes, consider keeping them backward-compatible (e.g., using `z.optional()`) rather than bumping the schema version, as this minimizes the risk of `DataIntegrityError` upon rollback.
+
+---
+
+## Versioned Cloudflare Persistence Bindings & Identity Migrations (BETA-024 / Issue #1931)
+
+BETA-024 adds deployable schema governance for the durable identity records
+persisted by the `StealthCoordinator` Durable Object. It introduces:
+
+1. **Environment-scoped Cloudflare bindings** (`preview`, `production`) with
+   **no real resource IDs committed** — the committed `wrangler.jsonc` ships
+   `{VAR_NAME}` placeholder tokens that a generator injects at deploy time.
+2. **A versioned migration engine** over the identity record families
+   (users, sessions, usernames, verification, wallet metadata) with `dry-run`,
+   `forward`, `rollback`, and `integrity-check` commands.
+3. **Local Cloudflare emulation tests** so every command is verified against
+   Miniflare before it is ever run against real storage.
+
+### Persistence Bindings & Config Generation
+
+The committed `wrangler.jsonc` defines top-level (local dev) plus `env.preview`
+and `env.production` sections. Every KV namespace ID is a placeholder such as
+`{STEALTH_KV_PRODUCTION_ID}`; real IDs and secret values are **never** committed.
+
+```bash
+# Provide the real KV namespace IDs (see .env.example) and generate:
+bun run config:generate        # writes .wrangler/generated/wrangler.jsonc
+bun run config:check           # CI-safe: validates the committed config only
+
+# Deploy with the generated config:
+wrangler deploy --env production --config .wrangler/generated/wrangler.jsonc
+```
+
+Guards enforced by `validateCommittedConfig` / `validateResolvedConfig`
+(`src/server/migrations/wrangler-config-guard.ts`):
+
+- No 32-hex-char real resource IDs and no secret values may appear in the
+  committed config.
+- `preview` and `production` must resolve to **distinct** KV namespaces, so the
+  two environments can never share storage accidentally.
+- Both named environments must declare their Durable Object binding and their
+  `secrets.required` list (currently `STEALTH_CURSOR_SECRET`).
+
+### Identity Record Families
+
+| Family            | Key prefix         | Schema source                                |
+| :---------------- | :----------------- | :------------------------------------------- |
+| `user`            | `user:id:`         | `userSchema` (`src/server/api/domain.ts`)    |
+| `session`         | `session:`         | `sessionSchema` (`src/server/api/domain.ts`) |
+| `username`        | `user:username:`   | username index (userId string)               |
+| `verification`    | `verification:`    | `verificationSchema` (BETA-024)              |
+| `wallet-metadata` | `wallet:metadata:` | `walletMetadataSchema` (BETA-024)            |
+
+All five families are governed at `$v: 1` today. Records follow the same
+`{ $v, ...payload }` envelope convention as the repository layer; legacy
+unversioned records are implicitly `$v: 1`.
+
+The `user` family declares its email/address secondary indexes; integrity
+checks verify each index exists (`missing_index`), points back
+(`index_mismatch`), and that every `user:username:` entry still targets a live
+user (`dangling_index`).
+
+### Migration Commands (CLI)
+
+The commands run the engine against a **local Miniflare emulation** of the
+Durable Object storage. State persists under `.wrangler/state/migrations`, so
+`forward`/`rollback` are restartable across invocations and operate on the same
+emulated store.
+
+```bash
+bun run migrations:dry-run            # report forward-pending counts, no writes
+bun run migrations:forward            # apply pending forward migrations
+bun run migrations:rollback -- --target-version 1 [--family session]
+bun run migrations:integrity-check    # schema/index integrity report
+```
+
+Optional flags: `--family <user|session|username|verification|wallet-metadata>`
+restricts a run to a single family; `rollback` requires `--target-version`.
+
+Engine contract (`src/server/migrations/runner.ts`):
+
+- **Restartable**: a successful run leaves every record at the target version;
+  re-running it reports `0 changed`, `0 failed`.
+- **Exact counts**: each family report carries `totalKeys`, `forwardPending`,
+  `changed`, `skipped`, and `failed`.
+- **No sensitive payloads**: record values and full index keys (which can
+  contain emails/usernames) are never echoed — reports reference only a
+  namespace prefix plus a digest fingerprint.
+
+### Production Invocation
+
+A separate migration worker **cannot** share Durable Object storage with the
+app worker, so the engine also runs in-process on the real coordinator via
+`StealthCoordinator.runIdentityMigrations(command, options)`
+(`src/server/api/stealth-coordinator.ts`). Operators invoke it on the
+production DO instance; wiring an authenticated admin route is a follow-up.
+
+### Adding a New Record Version
+
+1. Bump `currentVersion` for the family in
+   `src/server/migrations/adapters.ts`.
+2. Add the forward transform keyed by the **source** version (e.g. `2:` maps
+   `v1 -> v2`) and, for rollback support, the backward transform keyed by the
+   version being reverted from.
+3. Add deterministic tests in `tests/unit/migrations/runner.test.ts` covering
+   forward, restartability, and rollback; extend the Miniflare test
+   (`tests/unit/migrations/miniflare.test.ts`) with a migrated fixture.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -83,3 +83,24 @@ STEALTH_APP_URL=http://localhost:3000
 STEALTH_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 STEALTH_CORS_ALLOW_CREDENTIALS=true
 ```
+
+---
+
+### Cloudflare Persistence Bindings (BETA-024 / Issue #1931)
+
+The committed `wrangler.jsonc` defines `preview` and `production` environments
+with distinct KV namespaces, Durable Object bindings, and `secrets.required`
+(`STEALTH_CURSOR_SECRET`). **No real resource IDs are committed** — KV ids are
+`{VAR_NAME}` placeholders injected at deploy time:
+
+```bash
+# Variables (see .env.example):
+#   STEALTH_KV_LOCAL_ID / STEALTH_KV_PREVIEW_ID / STEALTH_KV_PRODUCTION_ID
+bun run config:generate        # writes .wrangler/generated/wrangler.jsonc
+bun run config:check           # CI guard: no real IDs/secrets committed, envs isolated
+
+wrangler deploy --env production --config .wrangler/generated/wrangler.jsonc
+```
+
+Identity record migrations (dry-run / forward / rollback / integrity-check)
+are documented in [Schema Migrations](MIGRATIONS.md).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     "local:setup:unix": "bash scripts/setup-local-env/setup.sh",
     "local:teardown:unix": "bash scripts/setup-local-env/teardown.sh",
     "generate:bindings": "node scripts/generate-contract-bindings.mjs",
-    "generate:openapi": "bun scripts/generate-openapi.ts"
+    "generate:openapi": "bun scripts/generate-openapi.ts",
+    "config:generate": "bun scripts/generate-wrangler-config.ts",
+    "config:check": "bun scripts/generate-wrangler-config.ts --check",
+    "migrations:dry-run": "node scripts/identity-migrate.mjs dry-run",
+    "migrations:forward": "node scripts/identity-migrate.mjs forward",
+    "migrations:rollback": "node scripts/identity-migrate.mjs rollback",
+    "migrations:integrity-check": "node scripts/identity-migrate.mjs integrity-check"
   },
   "overrides": {
     "ws": "8.21.0"

--- a/scripts/generate-wrangler-config.ts
+++ b/scripts/generate-wrangler-config.ts
@@ -1,0 +1,95 @@
+/**
+ * BETA-024 (Issue #1931) — generate a deployable wrangler config by injecting
+ * real Cloudflare resource IDs from environment variables.
+ *
+ * The committed `wrangler.jsonc` ships placeholder tokens (`{STEALTH_KV_...}`)
+ * and never contains real IDs. This script substitutes the values provided via
+ * environment variables and writes the resolved config to the gitignored
+ * `.wrangler/generated/wrangler.jsonc`, which is what `wrangler deploy --env
+ * preview|production` should be pointed at.
+ *
+ * Usage:
+ *   bun run config:generate
+ *   bun run config:check        # CI-safe: validate the committed config only
+ *
+ * Required env vars (see `.env.example`):
+ *   STEALTH_KV_LOCAL_ID        # local `wrangler dev` KV namespace (any local value)
+ *   STEALTH_KV_PREVIEW_ID      # preview KV namespace id
+ *   STEALTH_KV_PRODUCTION_ID   # production KV namespace id (must differ from preview)
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  findPlaceholders,
+  parseJsonc,
+  resolvePlaceholders,
+  validateCommittedConfig,
+  validateResolvedConfig,
+} from "../src/server/migrations/wrangler-config-guard";
+
+const ROOT = dirname(fileURLToPath(import.meta.url)) + "/..";
+const SOURCE = join(ROOT, "wrangler.jsonc");
+const OUTPUT_DIR = join(ROOT, ".wrangler", "generated");
+const OUTPUT = join(OUTPUT_DIR, "wrangler.jsonc");
+
+const args = new Set(process.argv.slice(2));
+const checkOnly = args.has("--check");
+
+function fail(message: string): never {
+  console.error(`✖ ${message}`);
+  process.exit(1);
+}
+
+const source = readFileSync(SOURCE, "utf8");
+
+const committed = validateCommittedConfig(source);
+if (!committed.ok) {
+  fail(
+    `Committed wrangler.jsonc violates the bindings policy:\n  ${committed.errors.join("\n  ")}`,
+  );
+}
+console.log("✓ Committed wrangler.jsonc uses only placeholder tokens (no real IDs committed).");
+
+if (checkOnly) {
+  console.log("✓ Config check passed. No real resource IDs or secrets in committed config.");
+  process.exit(0);
+}
+
+const config = parseJsonc<Record<string, unknown>>(source);
+const tokens = findPlaceholders(config);
+const required = [...new Set(tokens.map((t) => t.token.slice(1, -1)))].sort();
+const missing = required.filter((name) => {
+  const value = process.env[name];
+  return value === undefined || value.trim() === "";
+});
+if (missing.length > 0) {
+  fail(
+    `Missing required environment variables for config generation:\n  ${missing.join(
+      ", ",
+    )}\nSee .env.example for the variables to provide.`,
+  );
+}
+
+const resolved = resolvePlaceholders(
+  config,
+  Object.fromEntries(required.map((name) => [name, process.env[name]!.trim()])),
+) as Record<string, unknown>;
+
+const resolvedCheck = validateResolvedConfig(resolved);
+if (!resolvedCheck.ok) {
+  fail(`Generated config failed validation:\n  ${resolvedCheck.errors.join("\n  ")}`);
+}
+
+mkdirSync(OUTPUT_DIR, { recursive: true });
+writeFileSync(OUTPUT, JSON.stringify(resolved, null, 2) + "\n", "utf8");
+
+console.log(
+  `✓ Generated ${OUTPUT.replace(ROOT, ".")} from ${required.length} environment variable(s): ${required
+    .map((name) => name.replace(/^STEALTH_/, ""))
+    .join(", ")}.`,
+);
+console.log(
+  "  Deploy with: wrangler deploy --env preview|production --config .wrangler/generated/wrangler.jsonc",
+);

--- a/scripts/identity-migrate.mjs
+++ b/scripts/identity-migrate.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * BETA-024 (Issue #1931) — identity migration CLI.
+ *
+ * Runs the schema-governance commands (dry-run / forward / rollback /
+ * integrity-check) against a local Cloudflare emulation of the durable
+ * identity records (users, sessions, usernames, verification, wallet
+ * metadata) using the repository's own migration worker. Records persist
+ * under `.wrangler/state/migrations`, so commands are restartable and
+ * forward/rollback operate on the same emulated store across invocations.
+ *
+ * Usage:
+ *   node scripts/identity-migrate.mjs dry-run [--family <name>]
+ *   node scripts/identity-migrate.mjs forward [--family <name>]
+ *   node scripts/identity-migrate.mjs rollback --target-version <n> [--family <name>]
+ *   node scripts/identity-migrate.mjs integrity-check [--family <name>]
+ */
+import { build } from "esbuild";
+import { Miniflare } from "miniflare";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+const WORKER = join(ROOT, "src", "server", "migrations", "worker.ts");
+const DEFAULT_PERSIST = join(ROOT, ".wrangler", "state", "migrations");
+
+const args = process.argv.slice(2);
+const command = args.shift();
+if (!["dry-run", "forward", "rollback", "integrity-check"].includes(command ?? "")) {
+  console.error(
+    "Usage: identity-migrate.mjs <dry-run|forward|rollback|integrity-check> [--family <name>] [--target-version <n>]",
+  );
+  process.exit(1);
+}
+
+const options = {};
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--family") options.family = args[++i];
+  else if (args[i] === "--target-version") options.targetVersion = Number(args[++i]);
+}
+
+if (
+  command === "rollback" &&
+  (!Number.isInteger(options.targetVersion) || options.targetVersion < 1)
+) {
+  console.error("rollback requires --target-version <positive integer>");
+  process.exit(1);
+}
+
+console.log(`✦ Identity migrations — command: ${command}`);
+if (options.family) console.log(`  family:            ${options.family}`);
+if (options.targetVersion) console.log(`  target version:    ${options.targetVersion}`);
+
+const result = await build({
+  entryPoints: [WORKER],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  external: ["cloudflare:workers"],
+  write: false,
+  logLevel: "silent",
+});
+const code = result.outputFiles[0].text;
+
+const mf = new Miniflare({
+  // A stable `name` is required so separate CLI invocations (and any seeding
+  // harness using the same name) share the persisted emulated store.
+  name: "stealth-migrations",
+  modules: true,
+  script: code,
+  compatibilityDate: "2025-09-24",
+  compatibilityFlags: ["nodejs_compat"],
+  durableObjects: { STEALTH_COORDINATOR: "StealthCoordinator" },
+  kvNamespaces: { STEALTH_KV: "local-emulation-kv" },
+  durableObjectsPersist: DEFAULT_PERSIST,
+});
+
+try {
+  const res = await mf.dispatchFetch("http://localhost/migrate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ command, options }),
+  });
+  const report = await res.json();
+
+  console.log(`  generated at:      ${report.generatedAt}`);
+  console.log("");
+  for (const family of report.families) {
+    const line = [
+      `[${family.family}]`,
+      `total=${family.totalKeys}`,
+      `forwardPending=${family.forwardPending}`,
+      `changed=${family.changed}`,
+      `skipped=${family.skipped}`,
+      `failed=${family.failed}`,
+    ].join("  ");
+    console.log(`  ${line}`);
+    for (const error of family.errors) console.log(`      ✖ ${error}`);
+    for (const issue of family.issues) console.log(`      ⚠ ${issue.kind} @ ${issue.key}`);
+  }
+
+  console.log("");
+  console.log(
+    report.ok ? "✓ Migration command completed." : "✖ Migration command reported problems.",
+  );
+  process.exit(report.ok ? 0 : 1);
+} finally {
+  await mf.dispose();
+}

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -16,6 +16,10 @@ import type {
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
+import { identityRecordFamilies, selectFamilies } from "../migrations/adapters";
+import { createDurableObjectMigrationStorage } from "../migrations/durable-object-storage";
+import { dryRun, forward, integrityCheck, rollback } from "../migrations/runner";
+import type { MigrationCommand, MigrationReport, MigrationRunOptions } from "../migrations/types";
 
 const DurableObjectBase: any = import.meta.env.PROD
   ? (await import("cloudflare:workers")).DurableObject
@@ -355,6 +359,35 @@ export class StealthCoordinator extends DurableObjectBase {
       if (sess && sess.userId === userId) {
         await this.ctx.storage.delete(key);
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // BETA-024 (Issue #1931) — identity schema-governance commands.
+  //
+  // Operators invoke these commands on the production DO instance so the
+  // migrations run in-process against the exact records the API persists
+  // (a separate migration worker cannot share Durable Object storage). The
+  // engine is the same code exercised by the Miniflare emulation tests.
+  // ---------------------------------------------------------------------------
+
+  async runIdentityMigrations(
+    command: MigrationCommand,
+    options: MigrationRunOptions = {},
+  ): Promise<MigrationReport> {
+    const storage = createDurableObjectMigrationStorage(this.ctx);
+    const families = selectFamilies(identityRecordFamilies, options);
+    switch (command) {
+      case "dry-run":
+        return dryRun(storage, families, options);
+      case "forward":
+        return forward(storage, families, options);
+      case "rollback":
+        return rollback(storage, families, options);
+      case "integrity-check":
+        return integrityCheck(storage, families, options);
+      default:
+        throw new Error(`Unknown migration command: ${String(command)}`);
     }
   }
 

--- a/src/server/migrations/adapters.ts
+++ b/src/server/migrations/adapters.ts
@@ -1,0 +1,115 @@
+import { userSchema, sessionSchema } from "../api/domain";
+import { usernameIndexSchema, verificationSchema, walletMetadataSchema } from "./identity-schemas";
+import { fingerprintKey } from "./envelope";
+import type { IdentityRecordFamily, MigrationRunOptions } from "./types";
+
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — identity record families.
+//
+// Five families cover the identity/session schema surface named in the issue:
+// users, sessions, usernames (the username secondary index), verification, and
+// wallet metadata. All five are governed at version 1 today; forward/backward
+// maps are wired per-family so later betas (BETA-007 sessions, BETA-014
+// provisioning) can bump a version and ship its transform + reversion here.
+//
+// The `username` family owns the `user:username:` namespace as versioned
+// records; its integrity hook confirms each username still points at a live
+// user (dangling-index detection). The `user` family verifies its email and
+// address indexes exist and point back, and the `username` family is the
+// single owner of username dangling detection.
+// ---------------------------------------------------------------------------
+
+export const identityRecordFamilies: readonly IdentityRecordFamily[] = [
+  {
+    name: "user",
+    keyPrefix: "user:id:",
+    indexPrefixes: ["user:email:", "user:address:"] as const,
+    indexResolvers: [
+      {
+        prefix: "user:email:",
+        resolve: (payload) => {
+          const email = payload.email;
+          return typeof email === "string" ? email.toLowerCase().trim() : null;
+        },
+      },
+      {
+        prefix: "user:username:",
+        resolve: (payload) => {
+          const username = payload.username;
+          return typeof username === "string" ? username.toLowerCase().trim() : null;
+        },
+      },
+      {
+        prefix: "user:address:",
+        resolve: (payload) => {
+          const address = payload.address;
+          return typeof address === "string" ? address.toUpperCase().trim() : null;
+        },
+      },
+    ] as const,
+    currentVersion: 1,
+    schema: userSchema,
+    forward: {},
+    backward: {},
+  },
+  {
+    name: "session",
+    keyPrefix: "session:",
+    indexPrefixes: [] as const,
+    currentVersion: 1,
+    schema: sessionSchema,
+    forward: {},
+    backward: {},
+  },
+  {
+    name: "username",
+    keyPrefix: "user:username:",
+    indexPrefixes: [] as const,
+    currentVersion: 1,
+    schema: usernameIndexSchema,
+    forward: {},
+    backward: {},
+    checkRecord: async (payload, key, storage) => {
+      if (typeof payload !== "string") return null;
+      const target = await storage.get(`user:id:${payload}`);
+      if (target === null || target === undefined) {
+        return { kind: "dangling_index", key: fingerprintKey(key) };
+      }
+      return null;
+    },
+  },
+  {
+    name: "verification",
+    keyPrefix: "verification:",
+    indexPrefixes: [] as const,
+    currentVersion: 1,
+    schema: verificationSchema,
+    forward: {},
+    backward: {},
+  },
+  {
+    name: "wallet-metadata",
+    keyPrefix: "wallet:metadata:",
+    indexPrefixes: [] as const,
+    currentVersion: 1,
+    schema: walletMetadataSchema,
+    forward: {},
+    backward: {},
+  },
+];
+
+export function selectFamilies(
+  families: readonly IdentityRecordFamily[],
+  options: MigrationRunOptions = {},
+): readonly IdentityRecordFamily[] {
+  if (!options.family) return families;
+  const selected = families.filter((family) => family.name === options.family);
+  return selected;
+}
+
+export function getFamily(
+  families: readonly IdentityRecordFamily[],
+  name: string,
+): IdentityRecordFamily | undefined {
+  return families.find((family) => family.name === name);
+}

--- a/src/server/migrations/durable-object-storage.ts
+++ b/src/server/migrations/durable-object-storage.ts
@@ -1,0 +1,63 @@
+import type { MigrationStorage } from "./types";
+
+/**
+ * Adapts a Durable Object's transactional storage to the `MigrationStorage`
+ * surface so the identity migration engine can run against the same keys the
+ * `StealthCoordinator` DO persists (users, sessions, usernames, …). `listKeys`
+ * paginates through `ctx.storage.list` to stay complete past the 1000-key
+ * per-call limit.
+ */
+export function createDurableObjectMigrationStorage(
+  state: Pick<DurableObjectState, "storage">,
+): MigrationStorage {
+  const storage = state.storage;
+
+  return {
+    async listKeys(prefix: string): Promise<string[]> {
+      const keys: string[] = [];
+      let cursor: string | undefined;
+      do {
+        // NOTE: in real workerd `list()` returns `{ keys, list_complete, cursor }`,
+        // while Miniflare 4 emulation returns a `Map<storageKey, value>` whose
+        // `keys` property is `Map.prototype.keys` (a function). Handle both.
+        const page = (await storage.list({
+          prefix,
+          limit: 1000,
+          ...(cursor ? { cursor } : {}),
+        })) as
+          | { keys: Array<{ name: string }>; list_complete: boolean; cursor?: string }
+          | Map<string, unknown>;
+
+        if (typeof page.keys === "function") {
+          for (const key of page.keys()) keys.push(key);
+          // Miniflare's Map carries no pagination metadata; it returns every
+          // matching key for the prefix, so a single pass is complete.
+          break;
+        }
+
+        const recordPage = page as {
+          keys: Array<{ name: string }>;
+          list_complete: boolean;
+          cursor?: string;
+        };
+        for (const key of recordPage.keys) keys.push(key.name);
+        cursor = recordPage.cursor;
+        if (!recordPage.list_complete && !cursor) break;
+      } while (cursor);
+      return keys;
+    },
+
+    async get(key: string): Promise<unknown | null> {
+      const value = await storage.get<unknown>(key);
+      return value ?? null;
+    },
+
+    async put(key: string, value: unknown): Promise<void> {
+      await storage.put(key, value);
+    },
+
+    async delete(key: string): Promise<void> {
+      await storage.delete(key);
+    },
+  };
+}

--- a/src/server/migrations/envelope.ts
+++ b/src/server/migrations/envelope.ts
@@ -1,0 +1,113 @@
+import type { IdentityRecordFamily } from "./types";
+
+// ---------------------------------------------------------------------------
+// Versioned-record envelope helpers (BETA-024 / Issue #1931).
+//
+// Persisted records carry a `$v` marker alongside their payload — the same
+// envelope convention the API repository layer uses (see
+// `registerRecordSchema` / `validateRecord` in `src/server/api/repository.ts`).
+// Records that predate versioning are treated as `$v: 1`, matching the
+// repository's "legacy records are implicitly version 1" rule.
+// ---------------------------------------------------------------------------
+
+export function readEnvelope(raw: unknown): { version: number; payload: Record<string, unknown> } {
+  if (typeof raw === "object" && raw !== null) {
+    const record = raw as Record<string, unknown>;
+    if (typeof record.$v === "number" && Number.isInteger(record.$v) && record.$v >= 1) {
+      const { $v, ...payload } = record;
+      return { version: $v, payload };
+    }
+  }
+  // Legacy / unversioned record: implicit version 1.
+  return { version: 1, payload: (raw as Record<string, unknown>) ?? {} };
+}
+
+export function wrapEnvelope(payload: Record<string, unknown>, version: number): unknown {
+  return { ...payload, $v: version };
+}
+
+/**
+ * Applies forward migrations from a record's stored version up to the family's
+ * current version. Returns the migrated envelope (with the new `$v`) or `null`
+ * when a required forward step is missing (caller treats this as a failure and
+ * leaves the record untouched).
+ */
+export function applyForward(
+  family: IdentityRecordFamily,
+  raw: unknown,
+): { record: unknown; fromVersion: number; toVersion: number } | null {
+  const { version, payload } = readEnvelope(raw);
+  let current = payload;
+  for (let v = version; v < family.currentVersion; v++) {
+    const step = family.forward[v];
+    if (!step) return null;
+    current = step(current);
+    if (typeof current !== "object" || current === null) return null;
+  }
+  return {
+    record: wrapEnvelope(current, family.currentVersion),
+    fromVersion: version,
+    toVersion: family.currentVersion,
+  };
+}
+
+/**
+ * Applies backward migrations from a record's stored version down to
+ * `targetVersion` (which must be >= 1 and < the stored version). Returns the
+ * reverted envelope or `null` when a required backward step is missing.
+ */
+export function applyBackward(
+  family: IdentityRecordFamily,
+  raw: unknown,
+  targetVersion: number,
+): { record: unknown; fromVersion: number; toVersion: number } | null {
+  if (!Number.isInteger(targetVersion) || targetVersion < 1) return null;
+  const { version, payload } = readEnvelope(raw);
+  if (version <= targetVersion) return null;
+  let current = payload;
+  for (let v = version; v > targetVersion; v--) {
+    const step = family.backward[v];
+    if (!step) return null;
+    current = step(current);
+    if (typeof current !== "object" || current === null) return null;
+  }
+  return {
+    record: wrapEnvelope(current, targetVersion),
+    fromVersion: version,
+    toVersion: targetVersion,
+  };
+}
+
+/**
+ * Returns a redacted, traceable representation of a storage key for reports:
+ * the namespace prefix plus a short digest of the full key. The full key can
+ * contain usernames or email addresses (secondary indexes), so it is never
+ * echoed verbatim.
+ */
+/**
+ * Returns a redacted, traceable representation of a storage key for reports:
+ * only the namespace prefix (up to the last `:`) plus a short digest of the
+ * full key. The value portion — which can contain usernames or email
+ * addresses in secondary indexes — is never echoed.
+ */
+export function fingerprintKey(key: string): string {
+  const lastColon = key.lastIndexOf(":");
+  const prefix = lastColon >= 0 ? key.slice(0, lastColon + 1) : key.slice(0, 8);
+  return `${prefix}…(${digestKey(key)})`;
+}
+
+/**
+ * Deterministic, dependency-free key fingerprint used only for redaction in
+ * reports. This is a FNV-1a + linear hash, NOT a cryptographic hash — it
+ * merely keeps email/usernames embedded in index keys out of operator logs.
+ */
+export function digestKey(value: string): string {
+  let fnv = 0x811c9dc5;
+  let lin = 0x01000193;
+  for (let i = 0; i < value.length; i++) {
+    fnv ^= value.charCodeAt(i);
+    fnv = Math.imul(fnv, 0x01000193);
+    lin = (lin * 31 + value.charCodeAt(i)) | 0;
+  }
+  return (fnv >>> 0).toString(16).padStart(8, "0") + (lin >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/server/migrations/identity-schemas.ts
+++ b/src/server/migrations/identity-schemas.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+import { stellarAddressSchema } from "../api/domain";
+
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — identity record schemas.
+//
+// The `user`, `session` and `username` families reuse the schemas already
+// registered by BETA-002/BETA-006 in `src/server/api/domain.ts`. The
+// `verification` and `wallet-metadata` families are the schema-governance
+// contracts for identity records that later betas persist (BETA-007 session
+// verification, BETA-014 wallet metadata); they are declared here so migration
+// adapters and integrity checks have a versioned contract to validate against
+// from the day the records land.
+//
+// No secrets are ever stored in these records: verification codes are hashed
+// (never the raw code), and wallet metadata carries no private key material.
+// ---------------------------------------------------------------------------
+
+/** Index record: a secondary lookup key (`user:username:<name>`) points at a userId. */
+export const usernameIndexSchema = z.string().min(1, "Username index value must be a userId");
+
+export const verificationMethodSchema = z.enum(["otp", "passkey", "email", "wallet"]);
+export type VerificationMethod = z.infer<typeof verificationMethodSchema>;
+
+export const verificationStatusSchema = z.enum(["pending", "verified", "expired", "revoked"]);
+export type VerificationStatus = z.infer<typeof verificationStatusSchema>;
+
+/**
+ * A verification attempt / outcome for a subject (a user, a relay, or a wallet
+ * address). Only a digest of any code is stored — the plaintext code never
+ * reaches durable storage.
+ */
+export const verificationSchema = z.object({
+  verificationId: z.string().min(1, "Verification ID cannot be empty"),
+  subject: z.string().min(1, "Verification subject cannot be empty"),
+  method: verificationMethodSchema,
+  status: verificationStatusSchema,
+  /** Digest (e.g. SHA-256 hex) of the code/credential — never the raw value. */
+  codeDigest: z
+    .string()
+    .regex(/^[a-f0-9]{16,64}$/i, "codeDigest must be a hex digest")
+    .optional(),
+  attempts: z.number().int().nonnegative().default(0),
+  expiresAt: z.string().datetime(),
+  createdAt: z.string().datetime(),
+  verifiedAt: z.string().datetime().optional().nullable(),
+});
+
+export const walletMetadataSchema = z.object({
+  address: stellarAddressSchema,
+  userId: z.string().optional().nullable(),
+  displayName: z
+    .string()
+    .max(120, "Display name cannot exceed 120 characters")
+    .optional()
+    .nullable(),
+  publicKeyRef: z
+    .string()
+    .max(256, "Public key reference cannot exceed 256 characters")
+    .optional()
+    .nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});

--- a/src/server/migrations/in-memory-storage.ts
+++ b/src/server/migrations/in-memory-storage.ts
@@ -1,0 +1,30 @@
+import type { MigrationStorage } from "./types";
+
+/**
+ * In-memory `MigrationStorage` used by unit tests (and useful for a local
+ * dry-run against disposable data). Maps are keyed by storage key.
+ */
+export class InMemoryMigrationStorage implements MigrationStorage {
+  private readonly store = new Map<string, unknown>();
+
+  async listKeys(prefix: string): Promise<string[]> {
+    return [...this.store.keys()].filter((key) => key.startsWith(prefix)).sort();
+  }
+
+  async get(key: string): Promise<unknown | null> {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  /** Test helper: seed a record directly. */
+  seed(key: string, value: unknown): void {
+    this.store.set(key, value);
+  }
+}

--- a/src/server/migrations/runner.ts
+++ b/src/server/migrations/runner.ts
@@ -1,0 +1,263 @@
+import { applyBackward, applyForward, fingerprintKey, readEnvelope } from "./envelope";
+import type {
+  FamilyReport,
+  IdentityRecordFamily,
+  IntegrityIssue,
+  MigrationCommand,
+  MigrationReport,
+  MigrationRunOptions,
+  MigrationStorage,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — identity migration engine.
+//
+// The engine is a pure module over a `MigrationStorage` surface, so the exact
+// same code runs:
+//   1. as unit tests against `InMemoryMigrationStorage`,
+//   2. against local Cloudflare emulation (Miniflare / workerd) via the
+//      migration worker, and
+//   3. inside a Durable Object when an operator runs the CLI commands.
+//
+// Contract:
+//   - Restartable: a successful command leaves every record at the target
+//     version, so re-running it reports 0 changed and 0 failures.
+//   - Exact counts: reports `changed`/`skipped`/`failed` per family.
+//   - No sensitive payloads: records and full index keys are never echoed;
+//     failures reference the family and a redacted key fingerprint only.
+// ---------------------------------------------------------------------------
+
+function baseReport(command: MigrationCommand, families: readonly IdentityRecordFamily[]) {
+  return {
+    command,
+    generatedAt: new Date().toISOString(),
+    families: families.map<FamilyReport>((family) => ({
+      family: family.name,
+      keyPrefix: family.keyPrefix,
+      totalKeys: 0,
+      forwardPending: 0,
+      changed: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [],
+      issues: [],
+    })),
+    ok: true,
+  };
+}
+
+export async function dryRun(
+  storage: MigrationStorage,
+  families: readonly IdentityRecordFamily[],
+  options: MigrationRunOptions = {},
+): Promise<MigrationReport> {
+  const report = baseReport("dry-run", families);
+  for (const family of families) {
+    const familyReport = report.families.find((f) => f.family === family.name)!;
+    const keys = await storage.listKeys(family.keyPrefix);
+    familyReport.totalKeys = keys.length;
+    for (const key of keys) {
+      const raw = await storage.get(key);
+      if (raw === null || raw === undefined) {
+        familyReport.failed += 1;
+        familyReport.errors.push(`missing value for ${fingerprintKey(key)}`);
+        report.ok = false;
+        continue;
+      }
+      const { version } = readEnvelope(raw);
+      if (version > family.currentVersion) {
+        familyReport.failed += 1;
+        familyReport.errors.push(
+          `unsupported schema version ${version} for ${fingerprintKey(key)}`,
+        );
+        report.ok = false;
+        continue;
+      }
+      if (version < family.currentVersion) familyReport.forwardPending += 1;
+    }
+  }
+  return report;
+}
+
+export async function forward(
+  storage: MigrationStorage,
+  families: readonly IdentityRecordFamily[],
+  options: MigrationRunOptions = {},
+): Promise<MigrationReport> {
+  const report = baseReport("forward", families);
+  for (const family of families) {
+    const familyReport = report.families.find((f) => f.family === family.name)!;
+    const keys = await storage.listKeys(family.keyPrefix);
+    familyReport.totalKeys = keys.length;
+    for (const key of keys) {
+      const raw = await storage.get(key);
+      if (raw === null || raw === undefined) {
+        familyReport.failed += 1;
+        familyReport.errors.push(`missing value for ${fingerprintKey(key)}`);
+        report.ok = false;
+        continue;
+      }
+      const { version } = readEnvelope(raw);
+      if (version > family.currentVersion) {
+        familyReport.failed += 1;
+        familyReport.errors.push(
+          `unsupported schema version ${version} for ${fingerprintKey(key)}`,
+        );
+        report.ok = false;
+        continue;
+      }
+      if (version === family.currentVersion) {
+        familyReport.skipped += 1;
+        continue;
+      }
+      const migrated = applyForward(family, raw);
+      if (!migrated) {
+        familyReport.failed += 1;
+        familyReport.errors.push(`missing forward migration step for ${fingerprintKey(key)}`);
+        report.ok = false;
+        continue;
+      }
+      await storage.put(key, migrated.record);
+      familyReport.changed += 1;
+    }
+  }
+  return report;
+}
+
+export async function rollback(
+  storage: MigrationStorage,
+  families: readonly IdentityRecordFamily[],
+  options: MigrationRunOptions = {},
+): Promise<MigrationReport> {
+  const targetVersion = options.targetVersion;
+  if (!targetVersion || targetVersion < 1) {
+    const report = baseReport("rollback", families);
+    report.ok = false;
+    for (const family of report.families) {
+      family.errors.push("rollback requires a positive --target-version");
+    }
+    return report;
+  }
+
+  const report = baseReport("rollback", families);
+  for (const family of families) {
+    const familyReport = report.families.find((f) => f.family === family.name)!;
+    const keys = await storage.listKeys(family.keyPrefix);
+    familyReport.totalKeys = keys.length;
+    for (const key of keys) {
+      const raw = await storage.get(key);
+      if (raw === null || raw === undefined) {
+        familyReport.failed += 1;
+        familyReport.errors.push(`missing value for ${fingerprintKey(key)}`);
+        report.ok = false;
+        continue;
+      }
+      const { version } = readEnvelope(raw);
+      if (version <= targetVersion) {
+        familyReport.skipped += 1;
+        continue;
+      }
+      const reverted = applyBackward(family, raw, targetVersion);
+      if (!reverted) {
+        familyReport.failed += 1;
+        familyReport.errors.push(
+          `missing backward migration step to v${targetVersion} for ${fingerprintKey(key)}`,
+        );
+        report.ok = false;
+        continue;
+      }
+      await storage.put(key, reverted.record);
+      familyReport.changed += 1;
+    }
+  }
+  return report;
+}
+
+export async function integrityCheck(
+  storage: MigrationStorage,
+  families: readonly IdentityRecordFamily[],
+  options: MigrationRunOptions = {},
+): Promise<MigrationReport> {
+  const report = baseReport("integrity-check", families);
+  for (const family of families) {
+    const familyReport = report.families.find((f) => f.family === family.name)!;
+    const keys = await storage.listKeys(family.keyPrefix);
+    familyReport.totalKeys = keys.length;
+
+    const issues = await checkFamilyIntegrity(storage, family, keys);
+    familyReport.issues = issues;
+    familyReport.failed = issues.length;
+    if (issues.length > 0) report.ok = false;
+  }
+  return report;
+}
+
+async function checkFamilyIntegrity(
+  storage: MigrationStorage,
+  family: IdentityRecordFamily,
+  keys: string[],
+): Promise<IntegrityIssue[]> {
+  const issues: IntegrityIssue[] = [];
+
+  for (const key of keys) {
+    const raw = await storage.get(key);
+    if (raw === null || raw === undefined) {
+      issues.push({ kind: "corrupt_envelope", key: fingerprintKey(key) });
+      continue;
+    }
+    const { version, payload } = readEnvelope(raw);
+    if (version > family.currentVersion) {
+      issues.push({ kind: "unsupported_version", key: fingerprintKey(key) });
+      continue;
+    }
+    if (version < family.currentVersion) {
+      // Not a corruption — a forward migration is pending. Reported by dry-run.
+      continue;
+    }
+    const parsed = family.schema.safeParse(payload);
+    if (!parsed.success) {
+      issues.push({ kind: "invalid_record", key: fingerprintKey(key) });
+      continue;
+    }
+
+    // Forward index verification: every canonical record must have its
+    // secondary indexes present and pointing back at it.
+    const canonicalId = key.slice(family.keyPrefix.length);
+    for (const resolver of family.indexResolvers ?? []) {
+      const indexValue = resolver.resolve(payload);
+      if (indexValue === null) continue;
+      const indexKey = `${resolver.prefix}${indexValue}`;
+      const owner = await storage.get(indexKey);
+      if (owner === null || owner === undefined) {
+        issues.push({ kind: "missing_index", key: fingerprintKey(indexKey) });
+      } else if (owner !== canonicalId) {
+        issues.push({ kind: "index_mismatch", key: fingerprintKey(indexKey) });
+      }
+    }
+
+    // Family-specific integrity hooks (e.g. username -> user back-reference).
+    if (family.checkRecord) {
+      const issue = await family.checkRecord(payload, key, storage);
+      if (issue) issues.push(issue);
+    }
+  }
+
+  // Index back-references: every secondary index must point at a live record.
+  for (const indexPrefix of family.indexPrefixes) {
+    const indexKeys = await storage.listKeys(indexPrefix);
+    for (const indexKey of indexKeys) {
+      const target = await storage.get(indexKey);
+      if (typeof target !== "string") {
+        issues.push({ kind: "dangling_index", key: fingerprintKey(indexKey) });
+        continue;
+      }
+      const canonicalKey = `${family.keyPrefix}${target}`;
+      const canonical = await storage.get(canonicalKey);
+      if (canonical === null || canonical === undefined) {
+        issues.push({ kind: "dangling_index", key: fingerprintKey(indexKey) });
+      }
+    }
+  }
+
+  return issues;
+}

--- a/src/server/migrations/types.ts
+++ b/src/server/migrations/types.ts
@@ -1,0 +1,113 @@
+import type { ZodType } from "zod";
+
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — deployable schema governance for identity records.
+//
+// The migration tooling in this module gives release operators dry-run,
+// forward, rollback and integrity-check commands over the versioned identity
+// records (users, sessions, usernames, verification, wallet metadata) stored
+// in Cloudflare Durable Object / KV storage. All reporting is count-based and
+// deliberately redacted: record payloads (and email/usernames used as index
+// keys) are never echoed to logs or reports.
+// ---------------------------------------------------------------------------
+
+/**
+ * A narrow, storage-agnostic key/value surface the migration engine needs.
+ * `listKeys` returns every key under `prefix`; `get`/`put`/`delete` are the
+ * usual CRUD primitives. Both the Durable Object storage and the in-memory
+ * test backend implement it, so the engine is fully unit-testable and also
+ * runs against local Cloudflare emulation.
+ */
+export interface MigrationStorage {
+  listKeys(prefix: string): Promise<string[]>;
+  get(key: string): Promise<unknown | null>;
+  put(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * A single record family's schema-governance contract.
+ *
+ * - `keyPrefix` is the canonical record namespace (e.g. `user:id:`).
+ * - `indexPrefixes` are the secondary-index namespaces that point at this
+ *   family's canonical records (e.g. `user:email:`), used by integrity checks.
+ * - `indexResolvers` derive the secondary-index value stored under each
+ *   `indexPrefix` from a canonical record's payload, so integrity checks can
+ *   confirm every canonical record has its indexes present and pointing back.
+ * - `currentVersion` is the newest schema version this build understands.
+ * - `forward` maps `v(n) -> v(n+1)` transform functions keyed by the source
+ *   version; `backward` maps `v(n) -> v(n-1)` reversion functions keyed by the
+ *   version being reverted from.
+ * - `schema` validates a record payload after envelope stripping.
+ * - `checkRecord` is an optional family-specific integrity hook (e.g. the
+ *   username family verifies its target user still exists).
+ */
+export interface IdentityRecordFamily {
+  name: "user" | "session" | "username" | "verification" | "wallet-metadata";
+  keyPrefix: string;
+  indexPrefixes: readonly string[];
+  indexResolvers?: readonly IndexResolver[];
+  currentVersion: number;
+  schema: ZodType;
+  forward: Record<number, (data: Record<string, unknown>) => Record<string, unknown>>;
+  backward: Record<number, (data: Record<string, unknown>) => Record<string, unknown>>;
+  checkRecord?: (
+    payload: unknown,
+    key: string,
+    storage: MigrationStorage,
+  ) => Promise<IntegrityIssue | null>;
+}
+
+export interface IndexResolver {
+  prefix: string;
+  /** Derives the index value (e.g. the user's email) from a record payload. */
+  resolve: (payload: Record<string, unknown>) => string | null;
+}
+
+export type MigrationCommand = "dry-run" | "forward" | "rollback" | "integrity-check";
+
+export interface MigrationRunOptions {
+  /** Restrict the run to a single record family by name. */
+  family?: string;
+  /** Rollback target version (rollback command only). */
+  targetVersion?: number;
+}
+
+export type IntegrityIssueKind =
+  | "invalid_record"
+  | "unsupported_version"
+  | "missing_index"
+  | "index_mismatch"
+  | "dangling_index"
+  | "corrupt_envelope";
+
+export interface IntegrityIssue {
+  kind: IntegrityIssueKind;
+  /** Truncated, redacted key — never the full value or record payload. */
+  key: string;
+}
+
+export interface FamilyReport {
+  family: string;
+  keyPrefix: string;
+  totalKeys: number;
+  /** Counted by dry-run: records that would be migrated forward. */
+  forwardPending: number;
+  /** Records successfully migrated forward / rolled back by the run. */
+  changed: number;
+  /** Records already at the target version (idempotent restarts). */
+  skipped: number;
+  /** Records that failed to migrate and are left untouched. */
+  failed: number;
+  /** Redacted failure reasons — never payloads. */
+  errors: string[];
+  /** Integrity findings (integrity-check command only). */
+  issues: IntegrityIssue[];
+}
+
+export interface MigrationReport {
+  command: MigrationCommand;
+  generatedAt: string;
+  families: FamilyReport[];
+  ok: boolean;
+}

--- a/src/server/migrations/worker.ts
+++ b/src/server/migrations/worker.ts
@@ -1,0 +1,80 @@
+import { DurableObject } from "cloudflare:workers";
+
+import { createDurableObjectMigrationStorage } from "./durable-object-storage";
+import { identityRecordFamilies, selectFamilies } from "./adapters";
+import { dryRun, forward, integrityCheck, rollback } from "./runner";
+import { MigrationCommand, MigrationReport, MigrationRunOptions } from "./types";
+
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — identity migration worker.
+//
+// This worker is NOT part of the public API surface. It is the deployable
+// entrypoint for the schema-governance commands and is run either:
+//   - locally via `bun run migrations:dry-run|forward|rollback|integrity-check`
+//     (the CLI drives it with a Miniflare emulation of Cloudflare storage), or
+//   - by pointing a tool at an equivalent route in a deployed environment.
+//
+// The DO instance it binds to shares its storage with the `StealthCoordinator`
+// (same instance name `global-stealth-coordinator`), so migrations operate on
+// exactly the records the API persists — never on a shadow copy.
+// ---------------------------------------------------------------------------
+
+const MIGRATION_INSTANCE = "global-stealth-coordinator";
+
+export class StealthMigrationCoordinator extends DurableObject {
+  async run(
+    command: MigrationCommand,
+    options: MigrationRunOptions = {},
+  ): Promise<MigrationReport> {
+    const storage = createDurableObjectMigrationStorage(this.ctx);
+    const families = selectFamilies(identityRecordFamilies, options);
+    switch (command) {
+      case "dry-run":
+        return dryRun(storage, families, options);
+      case "forward":
+        return forward(storage, families, options);
+      case "rollback":
+        return rollback(storage, families, options);
+      case "integrity-check":
+        return integrityCheck(storage, families, options);
+      default:
+        throw new Error(`Unknown migration command: ${String(command)}`);
+    }
+  }
+
+  /**
+   * Test-only record seeding for the local Cloudflare emulation tests. This is
+   * a direct RPC on the DO stub and is NOT reachable through the fetch handler,
+   * so it cannot be triggered over HTTP in any deployed environment.
+   */
+  async _debugSeed(records: Array<{ key: string; value: unknown }>): Promise<number> {
+    for (const { key, value } of records) {
+      await this.ctx.storage.put(key, value);
+    }
+    return records.length;
+  }
+}
+
+export default {
+  async fetch(request: Request, env: { STEALTH_COORDINATOR: DurableObjectNamespace }) {
+    const url = new URL(request.url);
+    if (url.pathname !== "/migrate" || request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+
+    const body = (await request.json()) as {
+      command?: MigrationCommand;
+      options?: MigrationRunOptions;
+    };
+    if (!body.command) {
+      return new Response("missing command", { status: 400 });
+    }
+
+    const id = env.STEALTH_COORDINATOR.idFromName(MIGRATION_INSTANCE);
+    const stub = env.STEALTH_COORDINATOR.get(id);
+    const report = await stub.run(body.command, body.options ?? {});
+    return Response.json(report);
+  },
+};
+
+export { StealthMigrationCoordinator as StealthCoordinator };

--- a/src/server/migrations/wrangler-config-guard.ts
+++ b/src/server/migrations/wrangler-config-guard.ts
@@ -1,0 +1,260 @@
+// ---------------------------------------------------------------------------
+// BETA-024 (Issue #1931) — wrangler config guard.
+//
+// Pure, dependency-free helpers that enforce the persistence-bindings policy:
+//   1. The committed `wrangler.jsonc` must never contain real Cloudflare
+//      resource IDs or secret values — only `{VAR_NAME}` placeholder tokens.
+//   2. `preview` and `production` environments must resolve to distinct KV
+//      namespaces, so the two environments can never share storage by accident.
+//   3. Both named environments must declare their Durable Object binding and
+//      `secrets.required` list.
+//   4. After the generator injects real values, no `{VAR_NAME}` tokens may
+//      remain, and the resolved IDs must still be distinct per environment.
+//
+// Used by `scripts/generate-wrangler-config.ts` at generate/check time and by
+// the unit tests (tests/unit/config/wrangler-config.test.ts).
+// ---------------------------------------------------------------------------
+
+export interface GuardResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Real Cloudflare resource IDs are lowercase 32-char hex strings. */
+const REAL_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+/** Placeholder tokens look like `{UPPER_SNAKE_VAR_NAME}`. */
+export const PLACEHOLDER_PATTERN = /^\{[A-Z][A-Z0-9_]{2,}\}$/;
+
+export function isPlaceholderToken(value: unknown): value is string {
+  return typeof value === "string" && PLACEHOLDER_PATTERN.test(value.trim());
+}
+
+export function isRealResourceId(value: unknown): boolean {
+  return typeof value === "string" && REAL_ID_PATTERN.test(value.trim().toLowerCase());
+}
+
+/**
+ * Strips line and block comments plus trailing commas so JSONC parses as
+ * JSON. Respects quoted strings so comment markers inside values are left
+ * intact, and a comma outside a string is dropped when it is the last element
+ * of an object/array (JSONC trailing-comma style).
+ */
+export function stripJsoncComments(text: string): string {
+  const out: string[] = [];
+  let i = 0;
+  let inString = false;
+  let quote = "";
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (inString) {
+      out.push(ch);
+      if (ch === "\\") {
+        out.push(next ?? "");
+        i += 2;
+        continue;
+      }
+      if (ch === quote) inString = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      quote = ch;
+      out.push(ch);
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 2;
+      continue;
+    }
+    if (ch === ",") {
+      // Drop trailing commas: if only whitespace separates this comma from a
+      // closing brace/bracket, JSON would reject it.
+      let j = i + 1;
+      while (j < text.length && /[\s]/.test(text[j])) j += 1;
+      if (text[j] === "}" || text[j] === "]") {
+        i += 1;
+        continue;
+      }
+    }
+    out.push(ch);
+    i += 1;
+  }
+  return out.join("");
+}
+
+export function parseJsonc<T>(text: string): T {
+  return JSON.parse(stripJsoncComments(text)) as T;
+}
+
+/** Collects every `{VAR_NAME}` placeholder token in a config object (with paths). */
+export function findPlaceholders(
+  value: unknown,
+  path = "$",
+  found: Array<{ token: string; path: string }> = [],
+): Array<{ token: string; path: string }> {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findPlaceholders(item, `${path}[${index}]`, found));
+  } else if (typeof value === "object" && value !== null) {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      findPlaceholders(child, `${path}.${key}`, found);
+    }
+  } else if (isPlaceholderToken(value)) {
+    found.push({ token: value, path });
+  }
+  return found;
+}
+
+/** Recursively replaces placeholder tokens using the supplied env mapping. */
+export function resolvePlaceholders(
+  value: unknown,
+  env: Record<string, string | undefined>,
+  missing: string[] = [],
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => resolvePlaceholders(item, env, missing));
+  }
+  if (typeof value === "object" && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = resolvePlaceholders(child, env, missing);
+    }
+    return result;
+  }
+  if (isPlaceholderToken(value)) {
+    const name = value.slice(1, -1);
+    const replacement = env[name];
+    if (replacement === undefined || replacement === "") {
+      missing.push(name);
+      return value;
+    }
+    return replacement;
+  }
+  return value;
+}
+
+function kvIdsForEnv(config: Record<string, any>, envName: string): string[] {
+  const envConfig = config.env?.[envName];
+  const namespaces = envConfig?.kv_namespaces ?? [];
+  return namespaces
+    .map((ns: { id?: string }) => ns.id)
+    .filter((id: unknown): id is string => typeof id === "string");
+}
+
+/**
+ * Validates the committed `wrangler.jsonc` source (placeholders must be used,
+ * real IDs must not be present, environments must be isolated and complete).
+ */
+export function validateCommittedConfig(text: string): GuardResult {
+  const errors: string[] = [];
+  let config: Record<string, any>;
+  try {
+    config = parseJsonc<Record<string, any>>(text);
+  } catch (error) {
+    return { ok: false, errors: [`wrangler.jsonc is not valid JSONC: ${String(error)}`] };
+  }
+
+  // 1. No real resource IDs anywhere in the committed config.
+  const realIds: string[] = [];
+  const walk = (value: unknown, path: string): void => {
+    if (Array.isArray(value)) value.forEach((item, index) => walk(item, `${path}[${index}]`));
+    else if (typeof value === "object" && value !== null) {
+      for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        walk(child, `${path}.${key}`);
+      }
+    } else if (isRealResourceId(value)) {
+      realIds.push(path);
+    }
+  };
+  walk(config, "$");
+  if (realIds.length > 0) {
+    errors.push(
+      `Real Cloudflare resource IDs must never be committed; found at: ${realIds.join(", ")}`,
+    );
+  }
+
+  // 2. Every KV namespace id must be a placeholder token.
+  const allNs = [
+    ...(config.kv_namespaces ?? []),
+    ...(config.env?.preview?.kv_namespaces ?? []),
+    ...(config.env?.production?.kv_namespaces ?? []),
+  ];
+  for (const ns of allNs) {
+    if (!isPlaceholderToken(ns?.id)) {
+      errors.push(
+        `KV namespace binding "${ns?.binding}" id must be a {VAR_NAME} placeholder (found "${ns?.id}")`,
+      );
+    }
+  }
+
+  // 3. Placeholder tokens must actually be present so generation is possible.
+  const placeholders = findPlaceholders(config);
+  if (placeholders.length === 0) {
+    errors.push("No {VAR_NAME} placeholder tokens found; generator has nothing to substitute");
+  }
+
+  // 4. Named environments must exist and be complete.
+  for (const envName of ["preview", "production"]) {
+    const envConfig = config.env?.[envName];
+    if (!envConfig) {
+      errors.push(`Missing "env.${envName}" section`);
+      continue;
+    }
+    if (!envConfig.durable_objects?.bindings?.length) {
+      errors.push(`env.${envName} must declare durable_objects.bindings`);
+    }
+    if (!envConfig.secrets?.required?.length) {
+      errors.push(`env.${envName} must declare secrets.required`);
+    }
+    const kvIds = kvIdsForEnv(config, envName);
+    if (kvIds.length === 0) {
+      errors.push(`env.${envName} must declare at least one kv_namespaces id`);
+    }
+  }
+
+  // 5. Preview and production must use distinct KV namespace placeholders.
+  const previewIds = kvIdsForEnv(config, "preview");
+  const productionIds = kvIdsForEnv(config, "production");
+  const shared = previewIds.filter((id) => productionIds.includes(id));
+  if (shared.length > 0) {
+    errors.push(
+      `Preview and production share KV namespace id(s) ${shared.join(", ")}; environments must not share storage`,
+    );
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Validates the generated (resolved) config: no placeholder tokens may remain,
+ * and the resolved preview/production KV ids must still be distinct.
+ */
+export function validateResolvedConfig(config: Record<string, any>): GuardResult {
+  const errors: string[] = [];
+  const remaining = findPlaceholders(config);
+  if (remaining.length > 0) {
+    errors.push(
+      `Placeholder tokens remain after generation (missing env vars?): ${remaining
+        .map((r) => r.token)
+        .join(", ")}`,
+    );
+  }
+  const previewIds = kvIdsForEnv(config, "preview");
+  const productionIds = kvIdsForEnv(config, "production");
+  const shared = previewIds.filter((id) => productionIds.includes(id));
+  if (shared.length > 0) {
+    errors.push(
+      `Preview and production resolve to the same KV namespace id ${shared.join(", ")}; environments must not share storage`,
+    );
+  }
+  return { ok: errors.length === 0, errors };
+}

--- a/src/types/cloudflare.d.ts
+++ b/src/types/cloudflare.d.ts
@@ -20,6 +20,11 @@ interface DurableObjectState {
     get<T>(key: string): Promise<T | undefined>;
     put(key: string, value: any): Promise<void>;
     delete(key: string): Promise<boolean>;
+    list(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+      keys: Array<{ name: string }>;
+      list_complete: boolean;
+      cursor?: string;
+    }>;
   };
 }
 

--- a/tests/unit/config/wrangler-config.test.ts
+++ b/tests/unit/config/wrangler-config.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  findPlaceholders,
+  isPlaceholderToken,
+  isRealResourceId,
+  parseJsonc,
+  resolvePlaceholders,
+  stripJsoncComments,
+  validateCommittedConfig,
+  validateResolvedConfig,
+} from "../../../src/server/migrations/wrangler-config-guard";
+
+const WRANGLER_JSONC = fileURLToPath(new URL("../../../wrangler.jsonc", import.meta.url));
+
+describe("wrangler config guard (BETA-024)", () => {
+  it("recognizes placeholder tokens and real resource IDs", () => {
+    expect(isPlaceholderToken("{STEALTH_KV_PREVIEW_ID}")).toBe(true);
+    expect(isPlaceholderToken("stealth-kv-beta-prod-id")).toBe(false);
+    expect(isPlaceholderToken("abc")).toBe(false);
+    expect(isRealResourceId("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")).toBe(true);
+    expect(isRealResourceId("{STEALTH_KV_LOCAL_ID}")).toBe(false);
+  });
+
+  it("strips JSONC comments and parses the committed config", () => {
+    const config = parseJsonc<Record<string, any>>(readFileSync(WRANGLER_JSONC, "utf8"));
+    expect(config.main).toBe("src/server.ts");
+    expect(config.env?.preview).toBeDefined();
+    expect(config.env?.production).toBeDefined();
+  });
+
+  it("committed wrangler.jsonc never contains real resource IDs and isolates environments", () => {
+    const source = readFileSync(WRANGLER_JSONC, "utf8");
+    const result = validateCommittedConfig(source);
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+
+    const config = parseJsonc<Record<string, any>>(source);
+    const serialized = JSON.stringify(config);
+
+    // No real IDs may ever be committed.
+    expect(isRealResourceId(config.kv_namespaces?.[0]?.id)).toBe(false);
+    expect(config.env.preview.kv_namespaces[0].id).not.toBe(
+      config.env.production.kv_namespaces[0].id,
+    );
+    expect(serialized).not.toMatch(/[0-9a-f]{32}/);
+
+    // Placeholder tokens are present so the generator can substitute them.
+    const tokens = findPlaceholders(config).map((t) => t.token);
+    expect(tokens).toContain("{STEALTH_KV_PREVIEW_ID}");
+    expect(tokens).toContain("{STEALTH_KV_PRODUCTION_ID}");
+
+    // Both named environments declare bindings and secret references.
+    for (const envName of ["preview", "production"]) {
+      expect(config.env[envName].durable_objects.bindings.length).toBeGreaterThan(0);
+      expect(config.env[envName].secrets.required).toContain("STEALTH_CURSOR_SECRET");
+    }
+  });
+
+  it("resolvePlaceholders substitutes tokens and records missing variables", () => {
+    const config = parseJsonc<Record<string, any>>(readFileSync(WRANGLER_JSONC, "utf8"));
+    const missing: string[] = [];
+    const resolved = resolvePlaceholders(
+      config,
+      {
+        STEALTH_KV_LOCAL_ID: "local",
+        STEALTH_KV_PREVIEW_ID: "preview",
+        STEALTH_KV_PRODUCTION_ID: "prod",
+      },
+      missing,
+    ) as Record<string, any>;
+
+    expect(missing).toEqual([]);
+    expect(resolved.kv_namespaces[0].id).toBe("local");
+    expect(resolved.env.preview.kv_namespaces[0].id).toBe("preview");
+    expect(resolved.env.production.kv_namespaces[0].id).toBe("prod");
+  });
+
+  it("generation fails when required variables are missing", () => {
+    const config = parseJsonc<Record<string, any>>(readFileSync(WRANGLER_JSONC, "utf8"));
+    const missing: string[] = [];
+    resolvePlaceholders(config, {}, missing);
+    expect(missing).toContain("STEALTH_KV_PREVIEW_ID");
+    expect(missing).toContain("STEALTH_KV_PRODUCTION_ID");
+  });
+
+  it("resolved config validation rejects leftover placeholders or shared storage", () => {
+    const bad = {
+      env: {
+        preview: { kv_namespaces: [{ id: "{STEALTH_KV_PREVIEW_ID}" }] },
+        production: { kv_namespaces: [{ id: "{STEALTH_KV_PREVIEW_ID}" }] },
+      },
+    };
+    const result = validateResolvedConfig(bad);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toContain("Placeholder tokens remain");
+    expect(result.errors.join("\n")).toContain("same KV namespace");
+
+    const good = {
+      env: {
+        preview: { kv_namespaces: [{ id: "preview-ns" }] },
+        production: { kv_namespaces: [{ id: "prod-ns" }] },
+      },
+    };
+    expect(validateResolvedConfig(good).ok).toBe(true);
+  });
+});

--- a/tests/unit/migrations/identity-schemas.test.ts
+++ b/tests/unit/migrations/identity-schemas.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyBackward,
+  applyForward,
+  readEnvelope,
+  wrapEnvelope,
+} from "../../../src/server/migrations/envelope";
+import {
+  verificationSchema,
+  walletMetadataSchema,
+} from "../../../src/server/migrations/identity-schemas";
+import { identityRecordFamilies } from "../../../src/server/migrations/adapters";
+
+describe("identity record schemas (BETA-024)", () => {
+  describe("verificationSchema", () => {
+    it("accepts a pending verification with a code digest", () => {
+      const result = verificationSchema.safeParse({
+        verificationId: "v_1",
+        subject: "relay-testnet.stealth.mail",
+        method: "otp",
+        status: "pending",
+        codeDigest: "a".repeat(64),
+        attempts: 2,
+        expiresAt: "2026-01-02T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a raw (unhashed) code as the digest", () => {
+      const result = verificationSchema.safeParse({
+        verificationId: "v_1",
+        subject: "alice",
+        method: "otp",
+        status: "pending",
+        codeDigest: "123456",
+        attempts: 0,
+        expiresAt: "2026-01-02T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects records that omit required fields or use an unknown method", () => {
+      const missing = verificationSchema.safeParse({
+        subject: "alice",
+        method: "otp",
+        status: "pending",
+      });
+      expect(missing.success).toBe(false);
+
+      const unknownMethod = verificationSchema.safeParse({
+        verificationId: "v_1",
+        subject: "alice",
+        method: "sms",
+        status: "pending",
+        expiresAt: "2026-01-02T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(unknownMethod.success).toBe(false);
+    });
+  });
+
+  describe("walletMetadataSchema", () => {
+    it("accepts a valid wallet metadata record", () => {
+      const result = walletMetadataSchema.safeParse({
+        address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        userId: "u_1",
+        displayName: "Alice",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects non-Stellar addresses", () => {
+      const result = walletMetadataSchema.safeParse({
+        address: "0xabc",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("envelope helpers", () => {
+    it("treats unversioned legacy records as version 1", () => {
+      expect(readEnvelope({ userId: "u_1" })).toEqual({
+        version: 1,
+        payload: { userId: "u_1" },
+      });
+    });
+
+    it("reads and writes the $v marker", () => {
+      const wrapped = wrapEnvelope({ a: 1 }, 2);
+      expect(readEnvelope(wrapped)).toEqual({ version: 2, payload: { a: 1 } });
+    });
+
+    it("returns null when a required forward step is missing", () => {
+      const family = { ...identityRecordFamilies[0], currentVersion: 3 };
+      const result = applyForward(family, wrapEnvelope({ userId: "u_1" }, 1));
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the rollback target is invalid", () => {
+      const family = { ...identityRecordFamilies[0], currentVersion: 2 };
+      const result = applyBackward(family, wrapEnvelope({ userId: "u_1" }, 2), 0);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/migrations/miniflare.test.ts
+++ b/tests/unit/migrations/miniflare.test.ts
@@ -1,0 +1,167 @@
+import { build } from "esbuild";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const NULL_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+let code: string;
+let mf: Miniflare;
+
+beforeAll(async () => {
+  const result = await build({
+    entryPoints: ["src/server/migrations/worker.ts"],
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    external: ["cloudflare:workers"],
+    write: false,
+    logLevel: "silent",
+  });
+  code = result.outputFiles[0].text;
+});
+
+beforeEach(() => {
+  mf = new Miniflare({
+    modules: true,
+    script: code,
+    compatibilityDate: "2025-09-24",
+    compatibilityFlags: ["nodejs_compat"],
+    durableObjects: { STEALTH_COORDINATOR: "StealthCoordinator" },
+    kvNamespaces: { STEALTH_KV: "local-emulation-kv" },
+  });
+});
+
+afterEach(async () => {
+  await mf.dispose();
+});
+
+async function seed(records: Array<{ key: string; value: unknown }>) {
+  const ns: any = await mf.getDurableObjectNamespace("STEALTH_COORDINATOR");
+  const stub = ns.get(ns.idFromName("global-stealth-coordinator"));
+  await stub._debugSeed(records);
+}
+
+async function run(command: string, options: Record<string, unknown> = {}) {
+  const res = await mf.dispatchFetch("http://localhost/migrate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ command, options }),
+  });
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+function seedIdentityRecords(extra: Array<{ key: string; value: unknown }> = []) {
+  return seed([
+    {
+      key: "user:id:u_1",
+      value: {
+        $v: 1,
+        userId: "u_1",
+        address: NULL_ADDRESS,
+        email: "alice@example.com",
+        username: "alice",
+        status: "active",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: 1,
+      },
+    },
+    { key: "user:email:alice@example.com", value: "u_1" },
+    { key: "user:username:alice", value: "u_1" },
+    { key: `user:address:${NULL_ADDRESS}`, value: "u_1" },
+    {
+      key: "session:s_1",
+      value: {
+        $v: 1,
+        sessionId: "s_1",
+        userId: "u_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      },
+    },
+    ...extra,
+  ]);
+}
+
+describe("identity migration worker (local Cloudflare emulation)", () => {
+  it("rejects non-migration routes and missing commands", async () => {
+    const missing = await mf.dispatchFetch("http://localhost/other");
+    expect(missing.status).toBe(404);
+
+    const bad = await mf.dispatchFetch("http://localhost/migrate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(bad.status).toBe(400);
+  });
+
+  it("runs dry-run against the emulated Durable Object storage", async () => {
+    await seedIdentityRecords();
+    const { status, body } = await run("dry-run");
+
+    expect(status).toBe(200);
+    expect(body.command).toBe("dry-run");
+    const user = body.families.find((f: any) => f.family === "user");
+    const session = body.families.find((f: any) => f.family === "session");
+    expect(user.totalKeys).toBe(1);
+    expect(user.forwardPending).toBe(0);
+    expect(session.totalKeys).toBe(1);
+    expect(body.ok).toBe(true);
+  });
+
+  it("detects dangling and mismatched indexes during integrity-check", async () => {
+    await seedIdentityRecords([
+      { key: "user:username:ghost", value: "u_missing" },
+      { key: "user:email:alice@example.com", value: "someone-else" },
+    ]);
+    const { status, body } = await run("integrity-check");
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(false);
+
+    const user = body.families.find((f: any) => f.family === "user");
+    const username = body.families.find((f: any) => f.family === "username");
+
+    expect(user.issues.map((i: any) => i.kind)).toContain("index_mismatch");
+    expect(username.issues.map((i: any) => i.kind)).toContain("dangling_index");
+
+    // Redaction: full index values never appear in the report.
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("ghost");
+    expect(serialized).not.toContain("alice@example.com");
+  });
+
+  it("reports unsupported schema versions as failures without mutating data", async () => {
+    await seedIdentityRecords([{ key: "user:id:u_future", value: { $v: 99, userId: "u_future" } }]);
+    const { body } = await run("dry-run");
+
+    const user = body.families.find((f: any) => f.family === "user");
+    expect(user.failed).toBe(1);
+    expect(user.errors[0]).toContain("unsupported schema version 99");
+    expect(body.ok).toBe(false);
+  });
+
+  it("forward is idempotent when every family is already current", async () => {
+    await seedIdentityRecords();
+    const { status, body } = await run("forward");
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    const user = body.families.find((f: any) => f.family === "user");
+    const session = body.families.find((f: any) => f.family === "session");
+    expect(user.changed).toBe(0);
+    expect(session.changed).toBe(0);
+    expect(user.skipped).toBe(1);
+    expect(session.skipped).toBe(1);
+  });
+
+  it("rollback without a target version is rejected by the runner", async () => {
+    await seedIdentityRecords();
+    const { body } = await run("rollback");
+    expect(body.ok).toBe(false);
+    expect(body.families[0].errors[0]).toContain("--target-version");
+  });
+});

--- a/tests/unit/migrations/runner.test.ts
+++ b/tests/unit/migrations/runner.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import { identityRecordFamilies } from "../../../src/server/migrations/adapters";
+import { wrapEnvelope } from "../../../src/server/migrations/envelope";
+import { InMemoryMigrationStorage } from "../../../src/server/migrations/in-memory-storage";
+import { dryRun, forward, integrityCheck, rollback } from "../../../src/server/migrations/runner";
+import type { IdentityRecordFamily } from "../../../src/server/migrations/types";
+
+const NULL_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function validUser(userId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    userId,
+    address: NULL_ADDRESS,
+    email: `${userId}@example.com`,
+    username: userId,
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    version: 1,
+    ...overrides,
+  };
+}
+
+function validSession(sessionId: string) {
+  return {
+    sessionId,
+    userId: "u_1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-02-01T00:00:00.000Z",
+    lastActiveAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** A v2 user family with a forward + backward transform, for migration tests. */
+function v2UserFamily(): IdentityRecordFamily {
+  const base = identityRecordFamilies[0];
+  return {
+    ...base,
+    currentVersion: 2,
+    schema: (base.schema as any).passthrough(),
+    forward: {
+      1: (data) => ({ ...data, displayName: "" }),
+    },
+    backward: {
+      2: (data) => {
+        const { displayName, ...rest } = data;
+        return rest;
+      },
+    },
+  };
+}
+
+describe("identity migration runner", () => {
+  describe("dry-run", () => {
+    it("reports per-family totals and forward-pending counts without mutating storage", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_1", wrapEnvelope(validUser("u_1"), 1));
+      storage.seed("session:s_1", wrapEnvelope(validSession("s_1"), 1));
+
+      const report = await dryRun(storage, [v2UserFamily()]);
+      const user = report.families.find((f) => f.family === "user")!;
+      expect(user.totalKeys).toBe(1);
+      expect(user.forwardPending).toBe(1);
+      expect(user.changed).toBe(0);
+
+      const stored = await storage.get("user:id:u_1");
+      expect(stored).toEqual(wrapEnvelope(validUser("u_1"), 1));
+      expect(report.ok).toBe(true);
+    });
+
+    it("flags records newer than the current schema version", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_9", wrapEnvelope(validUser("u_9"), 3));
+
+      const report = await dryRun(storage, [v2UserFamily()]);
+      const user = report.families.find((f) => f.family === "user")!;
+      expect(user.failed).toBe(1);
+      expect(user.errors[0]).toContain("unsupported schema version 3");
+      expect(report.ok).toBe(false);
+    });
+  });
+
+  describe("forward", () => {
+    it("migrates v1 -> v2 and is restartable with exact counts", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_1", wrapEnvelope(validUser("u_1"), 1));
+
+      const first = await forward(storage, [v2UserFamily()]);
+      const user = first.families.find((f) => f.family === "user")!;
+      expect(user.changed).toBe(1);
+      expect(user.skipped).toBe(0);
+      expect(first.ok).toBe(true);
+
+      const stored = await storage.get("user:id:u_1");
+      expect(stored).toMatchObject({ $v: 2, displayName: "" });
+
+      const second = await forward(storage, [v2UserFamily()]);
+      const user2 = second.families.find((f) => f.family === "user")!;
+      expect(user2.changed).toBe(0);
+      expect(user2.skipped).toBe(1);
+      expect(user2.failed).toBe(0);
+      expect(second.ok).toBe(true);
+    });
+
+    it("leaves records untouched and reports failure when a forward step is missing", async () => {
+      const family = v2UserFamily();
+      family.currentVersion = 3;
+      const storage = new InMemoryMigrationStorage();
+      const seeded = wrapEnvelope(validUser("u_1"), 1);
+      storage.seed("user:id:u_1", seeded);
+
+      const report = await forward(storage, [family]);
+      const user = report.families.find((f) => f.family === "user")!;
+      expect(user.failed).toBe(1);
+      expect(user.errors[0]).toContain("missing forward migration step");
+      expect(report.ok).toBe(false);
+      expect(await storage.get("user:id:u_1")).toEqual(seeded);
+    });
+  });
+
+  describe("rollback", () => {
+    it("rejects a run without a target version", async () => {
+      const report = await rollback(new InMemoryMigrationStorage(), identityRecordFamilies, {});
+      expect(report.ok).toBe(false);
+      expect(report.families[0].errors[0]).toContain("--target-version");
+    });
+
+    it("reverts v2 -> v1 with a backward transform and is restartable", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_1", wrapEnvelope({ ...validUser("u_1"), displayName: "Al" }, 2));
+
+      const first = await rollback(storage, [v2UserFamily()], { targetVersion: 1 });
+      const user = first.families.find((f) => f.family === "user")!;
+      expect(user.changed).toBe(1);
+      expect(first.ok).toBe(true);
+
+      const stored = await storage.get("user:id:u_1");
+      expect(stored).toMatchObject({ $v: 1 });
+      expect(stored).not.toHaveProperty("displayName");
+
+      const second = await rollback(storage, [v2UserFamily()], { targetVersion: 1 });
+      const user2 = second.families.find((f) => f.family === "user")!;
+      expect(user2.changed).toBe(0);
+      expect(user2.skipped).toBe(1);
+    });
+
+    it("reports failure without mutating when a backward step is missing", async () => {
+      const family = v2UserFamily();
+      family.currentVersion = 3;
+      family.forward = { 1: (d) => ({ ...d, a: 1 }), 2: (d) => ({ ...d, b: 2 }) };
+      family.backward = {
+        2: (d) => {
+          const { a, ...rest } = d;
+          return rest;
+        },
+      };
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_1", wrapEnvelope(validUser("u_1"), 3));
+
+      const report = await rollback(storage, [family], { targetVersion: 1 });
+      const user = report.families.find((f) => f.family === "user")!;
+      expect(user.failed).toBe(1);
+      expect(user.errors[0]).toContain("missing backward migration step");
+      expect(report.ok).toBe(false);
+    });
+  });
+
+  describe("integrity-check", () => {
+    it("reports a clean bill of health for consistent identity records", async () => {
+      const storage = new InMemoryMigrationStorage();
+      const user = validUser("u_1");
+      storage.seed("user:id:u_1", wrapEnvelope(user, 1));
+      storage.seed("user:email:u_1@example.com", user.userId);
+      storage.seed("user:username:u_1", user.userId);
+      storage.seed(
+        "user:address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        user.userId,
+      );
+      storage.seed("session:s_1", wrapEnvelope(validSession("s_1"), 1));
+
+      const report = await integrityCheck(storage, identityRecordFamilies);
+      const userReport = report.families.find((f) => f.family === "user")!;
+      const sessionReport = report.families.find((f) => f.family === "session")!;
+      expect(userReport.issues).toEqual([]);
+      expect(sessionReport.issues).toEqual([]);
+      expect(report.ok).toBe(true);
+    });
+
+    it("detects invalid, missing, mismatched and dangling index records", async () => {
+      const storage = new InMemoryMigrationStorage();
+
+      const badUser = validUser("u_bad", { address: "not-a-stellar-address" });
+      storage.seed("user:id:u_bad", wrapEnvelope(badUser, 1));
+      storage.seed("user:email:u_bad@example.com", "u_bad");
+      storage.seed("user:username:u_bad", "u_bad");
+
+      const orphan = validUser("u_missing_index");
+      storage.seed("user:id:u_missing_index", wrapEnvelope(orphan, 1));
+      // no email/username/address indexes written
+
+      const wrongOwner = validUser("u_wrong");
+      storage.seed("user:id:u_wrong", wrapEnvelope(wrongOwner, 1));
+      storage.seed("user:email:u_wrong@example.com", "someone-else");
+      storage.seed("user:username:u_wrong", "u_wrong");
+      storage.seed(
+        "user:address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        "u_wrong",
+      );
+
+      storage.seed("user:username:ghost", "u_does_not_exist");
+
+      const report = await integrityCheck(storage, identityRecordFamilies);
+      const user = report.families.find((f) => f.family === "user")!;
+      const kinds = user.issues.map((i) => i.kind).sort();
+
+      expect(kinds).toContain("invalid_record");
+      expect(kinds).toContain("missing_index");
+      expect(kinds).toContain("index_mismatch");
+      expect(report.ok).toBe(false);
+
+      const username = report.families.find((f) => f.family === "username")!;
+      expect(username.issues.some((i) => i.kind === "dangling_index")).toBe(true);
+    });
+
+    it("detects records at an unsupported schema version", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:u_9", wrapEnvelope(validUser("u_9"), 9));
+
+      const report = await integrityCheck(storage, identityRecordFamilies);
+      const user = report.families.find((f) => f.family === "user")!;
+      expect(user.issues.some((i) => i.kind === "unsupported_version")).toBe(true);
+    });
+
+    it("never echoes record payloads or full index values in the report", async () => {
+      const storage = new InMemoryMigrationStorage();
+      storage.seed("user:id:secret-user", wrapEnvelope(validUser("secret-user"), 1));
+      storage.seed("user:email:topsecret@example.com", "someone-else");
+      storage.seed("user:username:secret-user", "secret-user");
+      storage.seed(
+        "user:address:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        "secret-user",
+      );
+
+      const report = await integrityCheck(storage, identityRecordFamilies);
+      const serialized = JSON.stringify(report);
+
+      expect(serialized).not.toContain("topsecret@example.com");
+      expect(serialized).not.toContain("secret-user");
+      expect(serialized).not.toContain("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+      expect(serialized).toContain("user:email:");
+    });
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,11 +4,16 @@
   "compatibility_date": "2025-09-24",
   "compatibility_flags": ["nodejs_compat"],
   "main": "src/server.ts",
+  // BETA-024 (#1931): no real Cloudflare resource IDs are ever committed.
+  // The values below are {VAR_NAME} placeholder tokens that
+  // scripts/generate-wrangler-config.ts replaces from environment variables
+  // into .wrangler/generated/wrangler.jsonc at deploy time. The top-level
+  // section is the local `wrangler dev` default and stays emulated/local.
   "kv_namespaces": [
     {
       "binding": "STEALTH_KV",
-      "id": "stealth-kv-beta-prod-id",
-      "preview_id": "stealth-kv-beta-preview-id",
+      "id": "{STEALTH_KV_LOCAL_ID}",
+      "preview_id": "{STEALTH_KV_LOCAL_ID}",
     },
   ],
   "r2_buckets": [
@@ -33,12 +38,100 @@
     },
   ],
   "vars": {
-    "STEALTH_ENV": "production",
+    "STEALTH_ENV": "development",
     "STEALTH_STELLAR_NETWORK": "testnet",
     "STEALTH_HORIZON_URL": "https://horizon-testnet.stellar.org",
     "STEALTH_SOROBAN_RPC_URL": "https://soroban-testnet.stellar.org",
     "STEALTH_RELAY_URL": "https://relay-testnet.stealth.mail",
-    "STEALTH_APP_URL": "https://app.stealth.mail",
-    "STEALTH_CORS_ALLOWED_ORIGINS": "https://app.stealth.mail",
+    "STEALTH_APP_URL": "http://localhost:3000",
+    "STEALTH_CORS_ALLOWED_ORIGINS": "http://localhost:3000,http://localhost:5173",
+  },
+  "env": {
+    "preview": {
+      "name": "stealth-mail-preview",
+      "kv_namespaces": [
+        {
+          "binding": "STEALTH_KV",
+          "id": "{STEALTH_KV_PREVIEW_ID}",
+          "preview_id": "{STEALTH_KV_LOCAL_ID}",
+        },
+      ],
+      "r2_buckets": [
+        {
+          "binding": "STEALTH_OBJECT_STORE",
+          "bucket_name": "stealth-mail-object-store-preview",
+        },
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "STEALTH_COORDINATOR",
+            "class_name": "StealthCoordinator",
+          },
+        ],
+      },
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": ["StealthCoordinator"],
+        },
+      ],
+      "secrets": {
+        "required": ["STEALTH_CURSOR_SECRET"],
+      },
+      "vars": {
+        "STEALTH_ENV": "preview",
+        "STEALTH_STELLAR_NETWORK": "testnet",
+        "STEALTH_HORIZON_URL": "https://horizon-testnet.stellar.org",
+        "STEALTH_SOROBAN_RPC_URL": "https://soroban-testnet.stellar.org",
+        "STEALTH_RELAY_URL": "https://relay-testnet.stealth.mail",
+        "STEALTH_APP_URL": "https://app-preview.stealth.mail",
+        "STEALTH_CORS_ALLOWED_ORIGINS": "https://app-preview.stealth.mail",
+      },
+    },
+    "production": {
+      "name": "stealth-mail",
+      "kv_namespaces": [
+        {
+          "binding": "STEALTH_KV",
+          "id": "{STEALTH_KV_PRODUCTION_ID}",
+          // `wrangler dev` for the production env should hit the preview
+          // namespace, never the production one.
+          "preview_id": "{STEALTH_KV_PREVIEW_ID}",
+        },
+      ],
+      "r2_buckets": [
+        {
+          "binding": "STEALTH_OBJECT_STORE",
+          "bucket_name": "stealth-mail-object-store",
+        },
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "STEALTH_COORDINATOR",
+            "class_name": "StealthCoordinator",
+          },
+        ],
+      },
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": ["StealthCoordinator"],
+        },
+      ],
+      "secrets": {
+        "required": ["STEALTH_CURSOR_SECRET"],
+      },
+      "vars": {
+        "STEALTH_ENV": "production",
+        "STEALTH_STELLAR_NETWORK": "testnet",
+        "STEALTH_HORIZON_URL": "https://horizon-testnet.stellar.org",
+        "STEALTH_SOROBAN_RPC_URL": "https://soroban-testnet.stellar.org",
+        "STEALTH_RELAY_URL": "https://relay-testnet.stealth.mail",
+        "STEALTH_APP_URL": "https://app.stealth.mail",
+        "STEALTH_CORS_ALLOWED_ORIGINS": "https://app.stealth.mail",
+      },
+    },
   },
 }


### PR DESCRIPTION
## Overview

BETA-024 adds **versioned Cloudflare persistence bindings** and **identity
migrations** to the durable identity layer. The committed `wrangler.jsonc`
now defines `preview` and `production` environments whose KV namespaces are
`{VAR_NAME}` placeholder tokens (never real IDs), a deploy-time generator
injects real IDs from environment variables into a gitignored config, and a
versioned migration engine (dry-run / forward / rollback / integrity-check)
governs the identity record families: users, sessions, usernames,
verification, and wallet metadata.

## Related Issue

Closes #1931

## Changes

- [ADD] `src/server/migrations/` — schema-governance engine: `types.ts`
  (MigrationStorage + IdentityRecordFamily), `envelope.ts` (`$v` read/write +
  forward/backward transforms + redacted key fingerprinting), `adapters.ts`
  (five identity families), `runner.ts` (dry-run/forward/rollback/
  integrity-check with restartable + exact-count semantics), and
  `durable-object-storage.ts` / `in-memory-storage.ts` storage backends.
- [ADD] `src/server/migrations/identity-schemas.ts` — versioned
  `verificationSchema` (code digests only, never raw codes) and
  `walletMetadataSchema` contracts.
- [ADD] `src/server/migrations/worker.ts` — deployable/Miniflare-runnable
  migration worker (own Durable Object; does not import the app coordinator),
  with a test-only `_debugSeed` RPC that is unreachable over HTTP.
- [ADD] `src/server/migrations/wrangler-config-guard.ts` — pure JSONC guard:
  rejects committed real resource IDs / secrets, enforces distinct preview vs
  production KV namespaces, and validates resolved configs.
- [ADD] `scripts/generate-wrangler-config.ts` + `.env.example` +
  `scripts/identity-migrate.mjs` CLI — `config:generate`, `config:check`, and
  `migrations:dry-run|forward|rollback|integrity-check` npm scripts.
- [MODIFY] `wrangler.jsonc` — top-level local-dev config plus
  `env.preview`/`env.production` with distinct KV placeholders, R2 buckets,
  Durable Object bindings, `secrets.required` (`STEALTH_CURSOR_SECRET`), and
  per-environment vars.
- [MODIFY] `src/server/api/stealth-coordinator.ts` — `runIdentityMigrations`
  RPC so migrations can run in-process on the production Durable Object
  (a separate worker cannot share DO storage).
- [MODIFY] `src/types/cloudflare.d.ts` — add `storage.list()` (with cursor
  pagination) to the ambient Durable Object state type.
- [MODIFY] `docs/deployment/MIGRATIONS.md` + `docs/deployment/README.md` —
  binding/config-generation runbook and migration command documentation.
- [ADD] Tests: `tests/unit/migrations/runner.test.ts`,
  `tests/unit/migrations/identity-schemas.test.ts`,
  `tests/unit/migrations/miniflare.test.ts` (local Cloudflare emulation), and
  `tests/unit/config/wrangler-config.test.ts` (bindings guard).

## Verification Results

- `prettier --check .` — pass
- `eslint .` — pass (0 problems)
- `tsc --noEmit` — pass (exit 0)
- `vitest run tests/unit` — 166 files, **1955 passed | 3 expected fail**
- `vite build` — pass (dist/server built)
- `wrangler deploy --dry-run --env production --config .wrangler/generated/wrangler.jsonc`
  — config structure validates (no binding/env warnings; framework entry-point
  resolution is handled by the Cloudflare Vite plugin)
- Migration CLI verified end-to-end against local emulation: dry-run,
  integrity-check (dangling-index + redaction confirmed), restartable
  forward/rollback via unit tests.

### Acceptance Criteria

| Criterion | Status |
| :--- | :--- |
| Preview and production bindings defined for KV, Durable Objects, and secret references without committing IDs | ✅ placeholder tokens + `secrets.required`; generator injects IDs at deploy time |
| Preview and production cannot share storage accidentally | ✅ distinct KV placeholders per env, enforced by `validateCommittedConfig`/`validateResolvedConfig` + guard test |
| Migration adapters for users, sessions, usernames, verification, wallet-metadata | ✅ five families in `adapters.ts` at `$v: 1` |
| dry-run / forward / rollback / integrity-check commands | ✅ engine + CLI + npm scripts |
| Restartable migrations with exact counts and no sensitive payloads | ✅ runner contract + redaction via key fingerprinting; Miniflare emulation tests |

## Dependencies

- BETA-007 #1914 (session renewal/rotation) and BETA-014 #1921 (provisioning)
  are open upstream. The `verification` and `wallet-metadata` families ship
  version-1 schema contracts now so those betas can version their records
  without touching this surface; the engine is exercised through local
  Cloudflare emulation (Miniflare) per the issue's acceptance criteria, so
  this change is an isolated slice that does not depend on those betas
  merging first.