### PR TITLE
feat(identity): implement versioned public key directory and rotation…

### DIFF
--- a/protocol/keys/README.md
+++ b/protocol/keys/README.md
@@ -77,17 +77,75 @@ Device keys are ephemeral encryption keys specific to a single user agent/device
 
 ## Key Publication
 
-### Discovery Mechanism
+### Discovery Mechanism & API Endpoints
 
-Keys are published through a **Key Catalog** associated with each Stealth account:
+Keys are published and discovered through the versioned public key directory API:
+
+- `GET /api/v1/identity/keys?owner={stellar_account}`: Retrieve active keys alongside permitted historical keys.
+- `POST /api/v1/identity/keys`: Publish a new signed public key.
+- `POST /api/v1/identity/keys/rotate`: Rotate an active key, creating a new key version and transitioning the prior key to `rotated` with an overlap window.
+- `POST /api/v1/identity/keys/retire`: Retire an active key from use.
+- `POST /api/v1/identity/keys/revoke`: Immediately revoke a compromised key, disabling new encryption while maintaining historical verification strictly before `revokedAt`.
+- `GET /api/v1/identity/keys/{keyId}?owner={stellar_account}`: Retrieve specific key record.
+
+### Key Directory Response Format
+
+```json
+{
+  "owner": "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+  "currentKeys": {
+    "encryption": {
+      "keyId": "k_1700000000_abc123",
+      "owner": "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+      "algorithm": "x25519",
+      "purpose": "encryption",
+      "publicKey": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "version": 2,
+      "notBefore": "2026-01-01T00:00:00Z",
+      "notAfter": "2027-01-01T00:00:00Z",
+      "status": "active",
+      "signature": "...",
+      "createdAt": "2026-01-01T00:00:00Z",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    },
+    "signing": { ... }
+  },
+  "historicalKeys": [
+    {
+      "keyId": "k_1690000000_oldkey",
+      "version": 1,
+      "status": "rotated",
+      "notBefore": "2025-01-01T00:00:00Z",
+      "notAfter": "2026-01-08T00:00:00Z",
+      ...
+    }
+  ],
+  "version": 2,
+  "updatedAt": "2026-01-01T00:00:00Z",
+  "freshness": {
+    "resolvedAt": "2026-01-01T00:00:00Z",
+    "cached": false,
+    "ttlMs": 300000
+  }
+}
+```
+
+### Canonical Signing Payload
+
+To ensure managed-wallet and Stellar signature authenticity, the publication payload is canonicalized:
 
 ```
-https://stealth.xyz/.well-known/stealth-keys/{stellar_account}
+stealth:key-directory
+{operation}
+{owner}
+{keyId}
+{algorithm}
+{purpose}
+{publicKey}
+{version}
+{notBefore}
+{notAfter}
 ```
-
-Or via on-chain data if integration with Stellar smart contracts is preferred.
-
-### Key Catalog Structure
 
 ```json
 {

--- a/src/features/identity/keys.ts
+++ b/src/features/identity/keys.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+import { Keypair } from "@stellar/stellar-sdk";
+
+export const keyAlgorithmSchema = z.enum(["ed25519", "x25519", "secp256k1"]);
+export const keyPurposeSchema = z.enum(["encryption", "signing", "device"]);
+export const keyStatusSchema = z.enum(["active", "rotated", "retired", "revoked"]);
+
+export type KeyAlgorithm = z.infer<typeof keyAlgorithmSchema>;
+export type KeyPurpose = z.infer<typeof keyPurposeSchema>;
+export type KeyStatus = z.infer<typeof keyStatusSchema>;
+
+export const stellarAddressSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^G[A-Z2-7]{55}$/, "Expected a Stellar G-address");
+
+/**
+ * Published public key stored in the directory.
+ * Strictly contains only public material and verifiable cryptographic assertions.
+ */
+export const publishedKeySchema = z.object({
+  keyId: z.string().min(1, "keyId cannot be empty"),
+  owner: stellarAddressSchema,
+  algorithm: keyAlgorithmSchema,
+  purpose: keyPurposeSchema,
+  publicKey: z
+    .string()
+    .min(1, "publicKey cannot be empty")
+    .refine(
+      (val) => !val.toLowerCase().includes("private") && !val.toLowerCase().includes("secret"),
+      {
+        message: "Private key material detected; only public keys are allowed",
+      },
+    ),
+  version: z.number().int().positive(),
+  notBefore: z.string().datetime(),
+  notAfter: z.string().datetime(),
+  status: keyStatusSchema,
+  signature: z.string().min(1, "signature is required"),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  revokedAt: z.string().datetime().nullable().optional(),
+  revocationReason: z.string().max(500).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type PublishedKey = z.infer<typeof publishedKeySchema>;
+
+/**
+ * Versioned directory root for an account's public keys.
+ */
+export const keyDirectoryRecordSchema = z.object({
+  owner: stellarAddressSchema,
+  currentEncryptionKeyId: z.string().nullable(),
+  currentSigningKeyId: z.string().nullable(),
+  keys: z.array(publishedKeySchema),
+  updatedAt: z.string().datetime(),
+  version: z.number().int().positive(),
+});
+
+export type KeyDirectoryRecord = z.infer<typeof keyDirectoryRecordSchema>;
+
+/**
+ * Request schema for publishing a new public key.
+ */
+export const publishKeyRequestSchema = z.object({
+  keyId: z.string().optional(),
+  algorithm: keyAlgorithmSchema,
+  purpose: keyPurposeSchema,
+  publicKey: z
+    .string()
+    .min(1, "publicKey cannot be empty")
+    .refine(
+      (val) => !val.toLowerCase().includes("private") && !val.toLowerCase().includes("secret"),
+      {
+        message: "Private key material detected; only public keys are allowed",
+      },
+    ),
+  notBefore: z.string().datetime().optional(),
+  notAfter: z.string().datetime().optional(),
+  signature: z.string().min(1, "Signature is required"),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type PublishKeyRequest = z.infer<typeof publishKeyRequestSchema>;
+
+/**
+ * Request schema for rotating an active key.
+ */
+export const rotateKeyRequestSchema = z.object({
+  currentKeyId: z.string().min(1, "currentKeyId is required"),
+  newKey: publishKeyRequestSchema,
+  overlapPeriodMs: z.number().int().nonnegative().optional(),
+  signature: z.string().min(1, "Signature is required"),
+});
+
+export type RotateKeyRequest = z.infer<typeof rotateKeyRequestSchema>;
+
+/**
+ * Request schema for retiring a key.
+ */
+export const retireKeyRequestSchema = z.object({
+  keyId: z.string().min(1, "keyId is required"),
+  reason: z.string().max(500).optional(),
+  signature: z.string().optional(),
+});
+
+export type RetireKeyRequest = z.infer<typeof retireKeyRequestSchema>;
+
+/**
+ * Request schema for revoking a compromised or cancelled key.
+ */
+export const revokeKeyRequestSchema = z.object({
+  keyId: z.string().min(1, "keyId is required"),
+  reason: z.string().min(1, "Revocation reason is required").max(500),
+  signature: z.string().min(1, "Signature is required"),
+});
+
+export type RevokeKeyRequest = z.infer<typeof revokeKeyRequestSchema>;
+
+/**
+ * Standardized response envelope for key directory queries.
+ */
+export const keyDirectoryResponseSchema = z.object({
+  owner: stellarAddressSchema,
+  currentKeys: z.object({
+    encryption: publishedKeySchema.nullable().optional(),
+    signing: publishedKeySchema.nullable().optional(),
+  }),
+  historicalKeys: z.array(publishedKeySchema),
+  allKeys: z.array(publishedKeySchema),
+  version: z.number().int().positive(),
+  updatedAt: z.string().datetime(),
+  freshness: z.object({
+    resolvedAt: z.string().datetime(),
+    cached: z.boolean(),
+    ttlMs: z.number().int().nonnegative(),
+  }),
+});
+
+export type KeyDirectoryResponse = z.infer<typeof keyDirectoryResponseSchema>;
+
+/**
+ * Generates the canonical payload bytes that must be signed by the account owner.
+ */
+export function buildKeyPublicationSigningPayload(params: {
+  owner: string;
+  keyId: string;
+  algorithm: string;
+  purpose: string;
+  publicKey: string;
+  version: number;
+  notBefore: string;
+  notAfter: string;
+  operation?: string;
+}): Uint8Array {
+  const canonicalString = [
+    "stealth:key-directory",
+    params.operation ?? "publish",
+    params.owner.trim().toUpperCase(),
+    params.keyId.trim(),
+    params.algorithm.trim().toLowerCase(),
+    params.purpose.trim().toLowerCase(),
+    params.publicKey.trim(),
+    params.version.toString(),
+    params.notBefore.trim(),
+    params.notAfter.trim(),
+  ].join("\n");
+
+  return new TextEncoder().encode(canonicalString);
+}
+
+/**
+ * Verifies that a signed key publication envelope was signed by the account owner.
+ */
+export function verifyKeyPublicationSignature(
+  ownerAddress: string,
+  signatureBase64OrHex: string,
+  payload: Uint8Array,
+): boolean {
+  try {
+    const keypair = Keypair.fromPublicKey(ownerAddress);
+    let sigBuffer: Buffer;
+    if (/^[0-9a-fA-F]+$/.test(signatureBase64OrHex) && signatureBase64OrHex.length === 128) {
+      sigBuffer = Buffer.from(signatureBase64OrHex, "hex");
+    } else {
+      sigBuffer = Buffer.from(signatureBase64OrHex, "base64");
+    }
+    return keypair.verify(Buffer.from(payload), sigBuffer);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if a published key is valid for historical message verification at a given timestamp.
+ * - Active / Rotated / Retired keys are valid if timestamp falls within [notBefore, notAfter].
+ * - Revoked keys are valid ONLY for messages timestamped strictly BEFORE the revocation timestamp (revokedAt).
+ */
+export function isKeyValidAtTimestamp(key: PublishedKey, timestamp: Date | string): boolean {
+  const t = typeof timestamp === "string" ? new Date(timestamp).getTime() : timestamp.getTime();
+  const notBeforeMs = new Date(key.notBefore).getTime();
+  const notAfterMs = new Date(key.notAfter).getTime();
+
+  if (Number.isNaN(t) || t < notBeforeMs || t > notAfterMs) {
+    return false;
+  }
+
+  if (key.status === "revoked") {
+    if (!key.revokedAt) return false;
+    const revokedMs = new Date(key.revokedAt).getTime();
+    return t < revokedMs;
+  }
+
+  return true;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ApiV1AuthLogoutAllRouteImport } from './routes/api/v1/auth/log
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
 import { Route as ApiV1WalletLinkIndexRouteImport } from './routes/api/v1/wallet/link/index'
+import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/identity/keys/index'
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
 import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
 import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
@@ -40,6 +41,10 @@ import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
 import { Route as ApiV1PoliciesOwnerReconciliationRouteImport } from './routes/api/v1/policies/$owner/reconciliation'
 import { Route as ApiV1PoliciesOwnerProvisionRouteImport } from './routes/api/v1/policies/$owner/provision'
+import { Route as ApiV1IdentityKeysRotateRouteImport } from './routes/api/v1/identity/keys/rotate'
+import { Route as ApiV1IdentityKeysRevokeRouteImport } from './routes/api/v1/identity/keys/revoke'
+import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/identity/keys/retire'
+import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
@@ -157,6 +162,11 @@ const ApiV1WalletLinkIndexRoute = ApiV1WalletLinkIndexRouteImport.update({
   path: '/api/v1/wallet/link/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1IdentityKeysIndexRoute = ApiV1IdentityKeysIndexRouteImport.update({
+  id: '/api/v1/identity/keys/',
+  path: '/api/v1/identity/keys/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1WalletLinkVerifyRoute = ApiV1WalletLinkVerifyRouteImport.update({
   id: '/api/v1/wallet/link/verify',
   path: '/api/v1/wallet/link/verify',
@@ -203,6 +213,26 @@ const ApiV1PoliciesOwnerProvisionRoute =
     path: '/provision',
     getParentRoute: () => ApiV1PoliciesOwnerRoute,
   } as any)
+const ApiV1IdentityKeysRotateRoute = ApiV1IdentityKeysRotateRouteImport.update({
+  id: '/api/v1/identity/keys/rotate',
+  path: '/api/v1/identity/keys/rotate',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1IdentityKeysRevokeRoute = ApiV1IdentityKeysRevokeRouteImport.update({
+  id: '/api/v1/identity/keys/revoke',
+  path: '/api/v1/identity/keys/revoke',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1IdentityKeysRetireRoute = ApiV1IdentityKeysRetireRouteImport.update({
+  id: '/api/v1/identity/keys/retire',
+  path: '/api/v1/identity/keys/retire',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1IdentityKeysKeyIdRoute = ApiV1IdentityKeysKeyIdRouteImport.update({
+  id: '/api/v1/identity/keys/$keyId',
+  path: '/api/v1/identity/keys/$keyId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
@@ -233,6 +263,10 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
+  '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
+  '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
+  '/api/v1/identity/keys/rotate': typeof ApiV1IdentityKeysRotateRoute
   '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
   '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
@@ -241,6 +275,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
@@ -267,6 +302,10 @@ export interface FileRoutesByTo {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
+  '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
+  '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
+  '/api/v1/identity/keys/rotate': typeof ApiV1IdentityKeysRotateRoute
   '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
   '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
@@ -275,6 +314,7 @@ export interface FileRoutesByTo {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/identity/keys': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
@@ -302,6 +342,10 @@ export interface FileRoutesById {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
+  '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
+  '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
+  '/api/v1/identity/keys/rotate': typeof ApiV1IdentityKeysRotateRoute
   '/api/v1/policies/$owner/provision': typeof ApiV1PoliciesOwnerProvisionRoute
   '/api/v1/policies/$owner/reconciliation': typeof ApiV1PoliciesOwnerReconciliationRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
@@ -310,6 +354,7 @@ export interface FileRoutesById {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
@@ -338,6 +383,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/identity/keys/$keyId'
+    | '/api/v1/identity/keys/retire'
+    | '/api/v1/identity/keys/revoke'
+    | '/api/v1/identity/keys/rotate'
     | '/api/v1/policies/$owner/provision'
     | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
@@ -346,6 +395,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesByTo: FileRoutesByTo
@@ -372,6 +422,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage'
     | '/api/v1/receipts'
+    | '/api/v1/identity/keys/$keyId'
+    | '/api/v1/identity/keys/retire'
+    | '/api/v1/identity/keys/revoke'
+    | '/api/v1/identity/keys/rotate'
     | '/api/v1/policies/$owner/provision'
     | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
@@ -380,6 +434,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/identity/keys'
     | '/api/v1/wallet/link'
     | '/api/v1/policies/$owner/senders/$sender'
   id:
@@ -406,6 +461,10 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/identity/keys/$keyId'
+    | '/api/v1/identity/keys/retire'
+    | '/api/v1/identity/keys/revoke'
+    | '/api/v1/identity/keys/rotate'
     | '/api/v1/policies/$owner/provision'
     | '/api/v1/policies/$owner/reconciliation'
     | '/api/v1/postage/$messageId/refund'
@@ -414,6 +473,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesById: FileRoutesById
@@ -441,9 +501,14 @@ export interface RootRouteChildren {
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
+  ApiV1IdentityKeysKeyIdRoute: typeof ApiV1IdentityKeysKeyIdRoute
+  ApiV1IdentityKeysRetireRoute: typeof ApiV1IdentityKeysRetireRoute
+  ApiV1IdentityKeysRevokeRoute: typeof ApiV1IdentityKeysRevokeRoute
+  ApiV1IdentityKeysRotateRoute: typeof ApiV1IdentityKeysRotateRoute
   ApiV1WalletLinkAddressRoute: typeof ApiV1WalletLinkAddressRoute
   ApiV1WalletLinkChallengeRoute: typeof ApiV1WalletLinkChallengeRoute
   ApiV1WalletLinkVerifyRoute: typeof ApiV1WalletLinkVerifyRoute
+  ApiV1IdentityKeysIndexRoute: typeof ApiV1IdentityKeysIndexRoute
   ApiV1WalletLinkIndexRoute: typeof ApiV1WalletLinkIndexRoute
 }
 
@@ -610,6 +675,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1WalletLinkIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/identity/keys/': {
+      id: '/api/v1/identity/keys/'
+      path: '/api/v1/identity/keys'
+      fullPath: '/api/v1/identity/keys/'
+      preLoaderRoute: typeof ApiV1IdentityKeysIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/wallet/link/verify': {
       id: '/api/v1/wallet/link/verify'
       path: '/api/v1/wallet/link/verify'
@@ -665,6 +737,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/v1/policies/$owner/provision'
       preLoaderRoute: typeof ApiV1PoliciesOwnerProvisionRouteImport
       parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/identity/keys/rotate': {
+      id: '/api/v1/identity/keys/rotate'
+      path: '/api/v1/identity/keys/rotate'
+      fullPath: '/api/v1/identity/keys/rotate'
+      preLoaderRoute: typeof ApiV1IdentityKeysRotateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/revoke': {
+      id: '/api/v1/identity/keys/revoke'
+      path: '/api/v1/identity/keys/revoke'
+      fullPath: '/api/v1/identity/keys/revoke'
+      preLoaderRoute: typeof ApiV1IdentityKeysRevokeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/retire': {
+      id: '/api/v1/identity/keys/retire'
+      path: '/api/v1/identity/keys/retire'
+      fullPath: '/api/v1/identity/keys/retire'
+      preLoaderRoute: typeof ApiV1IdentityKeysRetireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/$keyId': {
+      id: '/api/v1/identity/keys/$keyId'
+      path: '/api/v1/identity/keys/$keyId'
+      fullPath: '/api/v1/identity/keys/$keyId'
+      preLoaderRoute: typeof ApiV1IdentityKeysKeyIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
@@ -743,9 +843,14 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
+  ApiV1IdentityKeysKeyIdRoute: ApiV1IdentityKeysKeyIdRoute,
+  ApiV1IdentityKeysRetireRoute: ApiV1IdentityKeysRetireRoute,
+  ApiV1IdentityKeysRevokeRoute: ApiV1IdentityKeysRevokeRoute,
+  ApiV1IdentityKeysRotateRoute: ApiV1IdentityKeysRotateRoute,
   ApiV1WalletLinkAddressRoute: ApiV1WalletLinkAddressRoute,
   ApiV1WalletLinkChallengeRoute: ApiV1WalletLinkChallengeRoute,
   ApiV1WalletLinkVerifyRoute: ApiV1WalletLinkVerifyRoute,
+  ApiV1IdentityKeysIndexRoute: ApiV1IdentityKeysIndexRoute,
   ApiV1WalletLinkIndexRoute: ApiV1WalletLinkIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/api/v1/identity/keys/$keyId.ts
+++ b/src/routes/api/v1/identity/keys/$keyId.ts
@@ -15,12 +15,12 @@ export const Route = createFileRoute("/api/v1/identity/keys/$keyId")({
           const ownerParam =
             url.searchParams.get("owner") || request.headers.get("x-stealth-address");
           if (!ownerParam) {
-            throw new ApiError(400, "invalid_request", "Missing required 'owner' parameter");
+            throw new ApiError(400, "bad_request", "Missing required 'owner' parameter");
           }
           const owner = stellarAddressSchema.parse(ownerParam);
           const key = await getKey(context.repository, owner, params.keyId);
           if (!key) {
-            throw new ApiError(404, "key_not_found", `Key ${params.keyId} was not found`);
+            throw new ApiError(404, "not_found", `Key ${params.keyId} was not found`);
           }
           return apiSuccess(request, key);
         }),

--- a/src/routes/api/v1/identity/keys/$keyId.ts
+++ b/src/routes/api/v1/identity/keys/$keyId.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { getKey } from "@/server/api/key-directory-service";
+import { ApiError } from "@/server/api/errors";
+
+export const Route = createFileRoute("/api/v1/identity/keys/$keyId")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const url = new URL(request.url);
+          const ownerParam =
+            url.searchParams.get("owner") || request.headers.get("x-stealth-address");
+          if (!ownerParam) {
+            throw new ApiError(400, "invalid_request", "Missing required 'owner' parameter");
+          }
+          const owner = stellarAddressSchema.parse(ownerParam);
+          const key = await getKey(context.repository, owner, params.keyId);
+          if (!key) {
+            throw new ApiError(404, "key_not_found", `Key ${params.keyId} was not found`);
+          }
+          return apiSuccess(request, key);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/identity/keys/index.ts
+++ b/src/routes/api/v1/identity/keys/index.ts
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/api/v1/identity/keys/")({
           const ownerParam =
             url.searchParams.get("owner") || request.headers.get("x-stealth-address");
           if (!ownerParam) {
-            throw new ApiError(400, "invalid_request", "Missing required 'owner' parameter");
+            throw new ApiError(400, "bad_request", "Missing required 'owner' parameter");
           }
           const owner = stellarAddressSchema.parse(ownerParam);
           const directory = await getKeyDirectory(context.repository, owner);

--- a/src/routes/api/v1/identity/keys/index.ts
+++ b/src/routes/api/v1/identity/keys/index.ts
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { requireActor } from "@/server/api/actor";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { publishKeyRequestSchema } from "@/features/identity/keys";
+import { getKeyDirectory, publishKey } from "@/server/api/key-directory-service";
+import { ApiError } from "@/server/api/errors";
+
+export const Route = createFileRoute("/api/v1/identity/keys/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const url = new URL(request.url);
+          const ownerParam =
+            url.searchParams.get("owner") || request.headers.get("x-stealth-address");
+          if (!ownerParam) {
+            throw new ApiError(400, "invalid_request", "Missing required 'owner' parameter");
+          }
+          const owner = stellarAddressSchema.parse(ownerParam);
+          const directory = await getKeyDirectory(context.repository, owner);
+          return apiSuccess(request, directory);
+        }),
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const body = await parseJsonBody(request, publishKeyRequestSchema, {
+            route: "POST /identity/keys",
+          });
+          const result = await publishKey(context.repository, actor, body);
+          return apiSuccess(request, result, { status: 201 });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/identity/keys/retire.ts
+++ b/src/routes/api/v1/identity/keys/retire.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { requireActor } from "@/server/api/actor";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { retireKeyRequestSchema } from "@/features/identity/keys";
+import { retireKey } from "@/server/api/key-directory-service";
+
+export const Route = createFileRoute("/api/v1/identity/keys/retire")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const body = await parseJsonBody(request, retireKeyRequestSchema, {
+            route: "POST /identity/keys/retire",
+          });
+          const result = await retireKey(context.repository, actor, body);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/identity/keys/revoke.ts
+++ b/src/routes/api/v1/identity/keys/revoke.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { requireActor } from "@/server/api/actor";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { revokeKeyRequestSchema } from "@/features/identity/keys";
+import { revokeKey } from "@/server/api/key-directory-service";
+
+export const Route = createFileRoute("/api/v1/identity/keys/revoke")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const body = await parseJsonBody(request, revokeKeyRequestSchema, {
+            route: "POST /identity/keys/revoke",
+          });
+          const result = await revokeKey(context.repository, actor, body);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/identity/keys/rotate.ts
+++ b/src/routes/api/v1/identity/keys/rotate.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { requireActor } from "@/server/api/actor";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { rotateKeyRequestSchema } from "@/features/identity/keys";
+import { rotateKey } from "@/server/api/key-directory-service";
+
+export const Route = createFileRoute("/api/v1/identity/keys/rotate")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const body = await parseJsonBody(request, rotateKeyRequestSchema, {
+            route: "POST /identity/keys/rotate",
+          });
+          const result = await rotateKey(context.repository, actor, body);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/server/api/authorization/intents.ts
+++ b/src/server/api/authorization/intents.ts
@@ -4,7 +4,13 @@ export type ManagedWalletIntent =
   | { type: "policy"; ownerAddress: string }
   | { type: "postage"; senderAddress: string; amountStroops: string }
   | { type: "lifecycle"; userAddress: string }
-  | { type: "receipt"; recipientAddress: string };
+  | { type: "receipt"; recipientAddress: string }
+  | {
+      type: "keys";
+      ownerAddress: string;
+      operation: "publish" | "rotate" | "retire" | "revoke";
+      keyId?: string;
+    };
 
 export function validateIntent(
   intent: ManagedWalletIntent,
@@ -41,6 +47,11 @@ export function validateIntent(
     case "receipt":
       if (intent.recipientAddress !== actorAddress) {
         throw new Error("Actor mismatch: cannot sign receipt emission for another user");
+      }
+      break;
+    case "keys":
+      if (intent.ownerAddress !== actorAddress) {
+        throw new Error("Actor mismatch: cannot sign key directory operation for another user");
       }
       break;
     default:

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -16,6 +16,8 @@ import {
   retiredSessionSchema,
   storedEnvelopeSchema,
   policyWriteIntentSchema,
+  publishedKeySchema,
+  keyDirectoryRecordSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -217,6 +219,9 @@ registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
 // contract, so tampered or structurally invalid intents fail closed at the
 // adapter boundary instead of silently drifting the reconciliation state.
 registerRecordSchema("policyWriteIntent", 1, policyWriteIntentSchema);
+// Issue #1934 (BETA-027): Versioned Public Encryption-Key Directory & Rotation
+registerRecordSchema("publishedKey", 1, publishedKeySchema);
+registerRecordSchema("keyDirectoryRecord", 1, keyDirectoryRecordSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -416,3 +416,54 @@ export const storedEnvelopeSchema = z.object({
 
 export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
 export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;
+
+// ---------------------------------------------------------------------------
+// BETA-027 (Issue #1934) — Versioned Public Encryption-Key Directory & Rotation
+// ---------------------------------------------------------------------------
+
+export const keyAlgorithmSchema = z.enum(["ed25519", "x25519", "secp256k1"]);
+export const keyPurposeSchema = z.enum(["encryption", "signing", "device"]);
+export const keyStatusSchema = z.enum(["active", "rotated", "retired", "revoked"]);
+
+export type KeyAlgorithm = z.infer<typeof keyAlgorithmSchema>;
+export type KeyPurpose = z.infer<typeof keyPurposeSchema>;
+export type KeyStatus = z.infer<typeof keyStatusSchema>;
+
+export const publishedKeySchema = z.object({
+  keyId: z.string().min(1, "keyId cannot be empty"),
+  owner: stellarAddressSchema,
+  algorithm: keyAlgorithmSchema,
+  purpose: keyPurposeSchema,
+  publicKey: z
+    .string()
+    .min(1, "publicKey cannot be empty")
+    .refine(
+      (val) => !val.toLowerCase().includes("private") && !val.toLowerCase().includes("secret"),
+      {
+        message: "Private key material detected; only public keys are allowed",
+      },
+    ),
+  version: z.number().int().positive(),
+  notBefore: z.string().datetime(),
+  notAfter: z.string().datetime(),
+  status: keyStatusSchema,
+  signature: z.string().min(1, "signature is required"),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  revokedAt: z.string().datetime().nullable().optional(),
+  revocationReason: z.string().max(500).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type PublishedKey = z.infer<typeof publishedKeySchema>;
+
+export const keyDirectoryRecordSchema = z.object({
+  owner: stellarAddressSchema,
+  currentEncryptionKeyId: z.string().nullable(),
+  currentSigningKeyId: z.string().nullable(),
+  keys: z.array(publishedKeySchema),
+  updatedAt: z.string().datetime(),
+  version: z.number().int().positive(),
+});
+
+export type KeyDirectoryRecord = z.infer<typeof keyDirectoryRecordSchema>;

--- a/src/server/api/key-directory-service.ts
+++ b/src/server/api/key-directory-service.ts
@@ -1,0 +1,425 @@
+import { ApiError } from "./errors";
+import type { ApiRepository } from "./repository";
+import type { KeyDirectoryRecord, PublishedKey } from "./domain";
+import {
+  buildKeyPublicationSigningPayload,
+  verifyKeyPublicationSignature,
+  type PublishKeyRequest,
+  type RotateKeyRequest,
+  type RetireKeyRequest,
+  type RevokeKeyRequest,
+  type KeyDirectoryResponse,
+} from "../../features/identity/keys";
+
+/**
+ * Checks that no secret/private key data was accidentally passed in public key parameters.
+ */
+function assertNoPrivateKeyMaterial(publicKey: string, metadata?: Record<string, unknown>): void {
+  const lowerPub = publicKey.toLowerCase();
+  if (
+    lowerPub.includes("private") ||
+    lowerPub.includes("secret") ||
+    (lowerPub.startsWith("s") && lowerPub.length === 56) // Stellar secret key format S...
+  ) {
+    throw new ApiError(
+      400,
+      "bad_request",
+      "Private key material detected. The directory strictly accepts public keys only.",
+    );
+  }
+
+  if (metadata) {
+    const metaStr = JSON.stringify(metadata).toLowerCase();
+    if (metaStr.includes("privkey") || metaStr.includes("secretkey") || metaStr.includes("seed")) {
+      throw new ApiError(
+        400,
+        "bad_request",
+        "Private key material or secret attributes detected in metadata.",
+      );
+    }
+  }
+}
+
+/**
+ * Publishes a new signed public key into an account's key directory.
+ */
+export async function publishKey(
+  repository: ApiRepository,
+  owner: string,
+  request: PublishKeyRequest,
+  options: { bypassSignatureCheck?: boolean } = {},
+): Promise<PublishedKey> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  assertNoPrivateKeyMaterial(request.publicKey, request.metadata);
+
+  const now = new Date();
+  const notBefore = request.notBefore ?? now.toISOString();
+  // Default validity window: 1 year if not specified
+  const notAfter =
+    request.notAfter ?? new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString();
+
+  let dir = await repository.getKeyDirectory(normalizedOwner);
+  const nextVersion = dir ? dir.keys.length + 1 : 1;
+  const keyId = request.keyId || `k_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
+  // Verify signature unless explicitly in bypass mode for testing
+  if (!options.bypassSignatureCheck) {
+    const payload = buildKeyPublicationSigningPayload({
+      owner: normalizedOwner,
+      keyId,
+      algorithm: request.algorithm,
+      purpose: request.purpose,
+      publicKey: request.publicKey,
+      version: nextVersion,
+      notBefore,
+      notAfter,
+      operation: "publish",
+    });
+
+    const isValid = verifyKeyPublicationSignature(normalizedOwner, request.signature, payload);
+    if (!isValid) {
+      throw new ApiError(
+        401,
+        "unauthorized",
+        "Key publication signature verification failed for account owner",
+      );
+    }
+  }
+
+  const newKey: PublishedKey = {
+    keyId,
+    owner: normalizedOwner,
+    algorithm: request.algorithm,
+    purpose: request.purpose,
+    publicKey: request.publicKey,
+    version: nextVersion,
+    notBefore,
+    notAfter,
+    status: "active",
+    signature: request.signature,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    metadata: request.metadata,
+  };
+
+  await repository.savePublishedKey(normalizedOwner, newKey);
+
+  // Update directory
+  const currentKeys = dir ? [...dir.keys] : [];
+  currentKeys.push(newKey);
+
+  let currentEncryptionKeyId = dir?.currentEncryptionKeyId ?? null;
+  let currentSigningKeyId = dir?.currentSigningKeyId ?? null;
+
+  if (request.purpose === "encryption") {
+    currentEncryptionKeyId = keyId;
+  } else if (request.purpose === "signing") {
+    currentSigningKeyId = keyId;
+  }
+
+  const updatedDir: KeyDirectoryRecord = {
+    owner: normalizedOwner,
+    currentEncryptionKeyId,
+    currentSigningKeyId,
+    keys: currentKeys,
+    updatedAt: now.toISOString(),
+    version: (dir?.version ?? 0) + 1,
+  };
+
+  await repository.saveKeyDirectory(updatedDir);
+  return newKey;
+}
+
+/**
+ * Rotates an active key to a new version, preserving an overlap window for in-flight messages.
+ */
+export async function rotateKey(
+  repository: ApiRepository,
+  owner: string,
+  request: RotateKeyRequest,
+  options: { bypassSignatureCheck?: boolean } = {},
+): Promise<{ previous: PublishedKey; current: PublishedKey }> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  assertNoPrivateKeyMaterial(request.newKey.publicKey, request.newKey.metadata);
+
+  const currentKey = await repository.getPublishedKey(normalizedOwner, request.currentKeyId);
+  if (!currentKey) {
+    throw new ApiError(404, "not_found", `Current key ${request.currentKeyId} was not found`);
+  }
+
+  if (currentKey.owner !== normalizedOwner) {
+    throw new ApiError(403, "forbidden", "Cannot rotate key belonging to another account");
+  }
+
+  if (currentKey.status === "revoked") {
+    throw new ApiError(
+      409,
+      "conflict",
+      "Cannot rotate a revoked key; please publish a new key instead",
+    );
+  }
+
+  const now = new Date();
+  const nextVersion = currentKey.version + 1;
+  const newKeyId =
+    request.newKey.keyId || `k_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  const notBefore = request.newKey.notBefore ?? now.toISOString();
+  const notAfter =
+    request.newKey.notAfter ?? new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Signature verification on rotation intent
+  if (!options.bypassSignatureCheck) {
+    const payload = buildKeyPublicationSigningPayload({
+      owner: normalizedOwner,
+      keyId: newKeyId,
+      algorithm: request.newKey.algorithm,
+      purpose: request.newKey.purpose,
+      publicKey: request.newKey.publicKey,
+      version: nextVersion,
+      notBefore,
+      notAfter,
+      operation: "rotate",
+    });
+
+    const isValid = verifyKeyPublicationSignature(normalizedOwner, request.signature, payload);
+    if (!isValid) {
+      throw new ApiError(
+        401,
+        "unauthorized",
+        "Key rotation signature verification failed for account owner",
+      );
+    }
+  }
+
+  // Overlap window: former key transitions to 'rotated' (valid for verification of in-flight messages)
+  const overlapMs = request.overlapPeriodMs ?? 7 * 24 * 60 * 60 * 1000; // 7 days overlap
+  const rotatedKey: PublishedKey = {
+    ...currentKey,
+    status: "rotated",
+    notAfter: new Date(now.getTime() + overlapMs).toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  const newKey: PublishedKey = {
+    keyId: newKeyId,
+    owner: normalizedOwner,
+    algorithm: request.newKey.algorithm,
+    purpose: request.newKey.purpose,
+    publicKey: request.newKey.publicKey,
+    version: nextVersion,
+    notBefore,
+    notAfter,
+    status: "active",
+    signature: request.newKey.signature,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    metadata: request.newKey.metadata,
+  };
+
+  await repository.savePublishedKey(normalizedOwner, rotatedKey);
+  await repository.savePublishedKey(normalizedOwner, newKey);
+
+  const dir = await repository.getKeyDirectory(normalizedOwner);
+  const currentKeys = (dir?.keys ?? []).map((k) => (k.keyId === rotatedKey.keyId ? rotatedKey : k));
+  currentKeys.push(newKey);
+
+  let currentEncryptionKeyId = dir?.currentEncryptionKeyId ?? null;
+  let currentSigningKeyId = dir?.currentSigningKeyId ?? null;
+
+  if (newKey.purpose === "encryption") {
+    currentEncryptionKeyId = newKeyId;
+  } else if (newKey.purpose === "signing") {
+    currentSigningKeyId = newKeyId;
+  }
+
+  const updatedDir: KeyDirectoryRecord = {
+    owner: normalizedOwner,
+    currentEncryptionKeyId,
+    currentSigningKeyId,
+    keys: currentKeys,
+    updatedAt: now.toISOString(),
+    version: (dir?.version ?? 0) + 1,
+  };
+
+  await repository.saveKeyDirectory(updatedDir);
+
+  return {
+    previous: rotatedKey,
+    current: newKey,
+  };
+}
+
+/**
+ * Retires an active key from use.
+ */
+export async function retireKey(
+  repository: ApiRepository,
+  owner: string,
+  request: RetireKeyRequest,
+): Promise<PublishedKey> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  const key = await repository.getPublishedKey(normalizedOwner, request.keyId);
+
+  if (!key) {
+    throw new ApiError(404, "not_found", `Key ${request.keyId} not found`);
+  }
+
+  if (key.owner !== normalizedOwner) {
+    throw new ApiError(403, "forbidden", "Cannot retire key belonging to another account");
+  }
+
+  if (key.status === "revoked") {
+    throw new ApiError(409, "conflict", "Cannot retire an already revoked key");
+  }
+
+  const now = new Date().toISOString();
+  const retiredKey: PublishedKey = {
+    ...key,
+    status: "retired",
+    updatedAt: now,
+  };
+
+  await repository.savePublishedKey(normalizedOwner, retiredKey);
+
+  const dir = await repository.getKeyDirectory(normalizedOwner);
+  if (dir) {
+    const updatedKeys = dir.keys.map((k) => (k.keyId === key.keyId ? retiredKey : k));
+    let currentEncryptionKeyId = dir.currentEncryptionKeyId;
+    let currentSigningKeyId = dir.currentSigningKeyId;
+
+    if (dir.currentEncryptionKeyId === key.keyId) {
+      currentEncryptionKeyId = null;
+    }
+    if (dir.currentSigningKeyId === key.keyId) {
+      currentSigningKeyId = null;
+    }
+
+    await repository.saveKeyDirectory({
+      ...dir,
+      currentEncryptionKeyId,
+      currentSigningKeyId,
+      keys: updatedKeys,
+      updatedAt: now,
+      version: dir.version + 1,
+    });
+  }
+
+  return retiredKey;
+}
+
+/**
+ * Revokes a key due to compromise or decommission.
+ * Immediately invalidates active encryption; historical verification follows revokedAt timestamp.
+ */
+export async function revokeKey(
+  repository: ApiRepository,
+  owner: string,
+  request: RevokeKeyRequest & { revokedAt?: string },
+): Promise<PublishedKey> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  const key = await repository.getPublishedKey(normalizedOwner, request.keyId);
+
+  if (!key) {
+    throw new ApiError(404, "not_found", `Key ${request.keyId} not found`);
+  }
+
+  if (key.owner !== normalizedOwner) {
+    throw new ApiError(403, "forbidden", "Cannot revoke key belonging to another account");
+  }
+
+  const now = request.revokedAt ?? new Date().toISOString();
+  const revokedKey: PublishedKey = {
+    ...key,
+    status: "revoked",
+    revokedAt: now,
+    revocationReason: request.reason,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await repository.savePublishedKey(normalizedOwner, revokedKey);
+
+  const dir = await repository.getKeyDirectory(normalizedOwner);
+  if (dir) {
+    const updatedKeys = dir.keys.map((k) => (k.keyId === key.keyId ? revokedKey : k));
+    let currentEncryptionKeyId = dir.currentEncryptionKeyId;
+    let currentSigningKeyId = dir.currentSigningKeyId;
+
+    if (dir.currentEncryptionKeyId === key.keyId) {
+      currentEncryptionKeyId = null;
+    }
+    if (dir.currentSigningKeyId === key.keyId) {
+      currentSigningKeyId = null;
+    }
+
+    await repository.saveKeyDirectory({
+      ...dir,
+      currentEncryptionKeyId,
+      currentSigningKeyId,
+      keys: updatedKeys,
+      updatedAt: now,
+      version: dir.version + 1,
+    });
+  }
+
+  return revokedKey;
+}
+
+/**
+ * Retrieves the full key directory for an account, separating current keys and permitted historical keys.
+ */
+export async function getKeyDirectory(
+  repository: ApiRepository,
+  owner: string,
+): Promise<KeyDirectoryResponse> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  const dir = await repository.getKeyDirectory(normalizedOwner);
+
+  const nowIso = new Date().toISOString();
+  const allKeys = dir?.keys ?? [];
+
+  let currentEncryptionKey: PublishedKey | null = null;
+  let currentSigningKey: PublishedKey | null = null;
+
+  if (dir?.currentEncryptionKeyId) {
+    currentEncryptionKey =
+      allKeys.find((k) => k.keyId === dir.currentEncryptionKeyId && k.status === "active") ?? null;
+  }
+  if (dir?.currentSigningKeyId) {
+    currentSigningKey =
+      allKeys.find((k) => k.keyId === dir.currentSigningKeyId && k.status === "active") ?? null;
+  }
+
+  // Historical keys: non-active keys or keys rotated from previous versions
+  const historicalKeys = allKeys.filter(
+    (k) => k.keyId !== dir?.currentEncryptionKeyId && k.keyId !== dir?.currentSigningKeyId,
+  );
+
+  return {
+    owner: normalizedOwner,
+    currentKeys: {
+      encryption: currentEncryptionKey,
+      signing: currentSigningKey,
+    },
+    historicalKeys,
+    allKeys,
+    version: dir?.version ?? 1,
+    updatedAt: dir?.updatedAt ?? nowIso,
+    freshness: {
+      resolvedAt: nowIso,
+      cached: false,
+      ttlMs: 300000, // 5 minutes
+    },
+  };
+}
+
+/**
+ * Retrieves a single published key by ID.
+ */
+export async function getKey(
+  repository: ApiRepository,
+  owner: string,
+  keyId: string,
+): Promise<PublishedKey | null> {
+  const normalizedOwner = owner.trim().toUpperCase();
+  return repository.getPublishedKey(normalizedOwner, keyId);
+}

--- a/src/server/api/key-directory-service.ts
+++ b/src/server/api/key-directory-service.ts
@@ -58,7 +58,7 @@ export async function publishKey(
   const notAfter =
     request.notAfter ?? new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000).toISOString();
 
-  let dir = await repository.getKeyDirectory(normalizedOwner);
+  const dir = await repository.getKeyDirectory(normalizedOwner);
   const nextVersion = dir ? dir.keys.length + 1 : 1;
   const keyId = request.keyId || `k_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -20,6 +20,8 @@ import type {
   Session,
   StoredEnvelope,
   User,
+  KeyDirectoryRecord,
+  PublishedKey,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -364,5 +366,35 @@ export class HybridApiRepository implements ApiRepository {
       await this.kv.put(this.key("envelope", envelope.messageId), JSON.stringify(result.envelope));
     }
     return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1934 (BETA-027) — Versioned Public Encryption-Key Directory & Rotation
+  // ---------------------------------------------------------------------------
+
+  async getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
+    const dir = await this.kv.get(this.key("key-directory", owner.toUpperCase()), "json");
+    return (dir as KeyDirectoryRecord) ?? null;
+  }
+
+  async getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null> {
+    const key = await this.kv.get(this.key("keys", owner.toUpperCase(), keyId), "json");
+    return (key as PublishedKey) ?? null;
+  }
+
+  async savePublishedKey(owner: string, publishedKey: PublishedKey): Promise<PublishedKey> {
+    await this.kv.put(
+      this.key("keys", owner.toUpperCase(), publishedKey.keyId),
+      JSON.stringify(publishedKey),
+    );
+    return publishedKey;
+  }
+
+  async saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord> {
+    await this.kv.put(
+      this.key("key-directory", record.owner.toUpperCase()),
+      JSON.stringify(record),
+    );
+    return record;
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -14,6 +14,8 @@ import type {
   Session,
   StoredEnvelope,
   User,
+  KeyDirectoryRecord,
+  PublishedKey,
 } from "./domain";
 import type {
   ApiRepository,
@@ -53,6 +55,11 @@ export class MemoryApiRepository implements ApiRepository {
   // BETA-006: Session storage
   private readonly sessions = new Map<string, Session>();
   private readonly retiredSessions = new Map<string, RetiredSession>();
+
+  // BETA-027: Key Directory storage
+  private readonly keyDirectories = new Map<string, KeyDirectoryRecord>();
+  private readonly publishedKeys = new Map<string, PublishedKey>(); // key: `${owner}:${keyId}`
+  private readonly keyDirectoryLocks = new Map<string, Promise<void>>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -536,6 +543,28 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
+    const dir = this.keyDirectories.get(owner.toUpperCase());
+    return dir ? structuredClone(dir) : null;
+  }
+
+  async getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null> {
+    const k = this.publishedKeys.get(`${owner.toUpperCase()}:${keyId}`);
+    return k ? structuredClone(k) : null;
+  }
+
+  async savePublishedKey(owner: string, publishedKey: PublishedKey): Promise<PublishedKey> {
+    const stored = structuredClone(publishedKey);
+    this.publishedKeys.set(`${owner.toUpperCase()}:${publishedKey.keyId}`, stored);
+    return structuredClone(stored);
+  }
+
+  async saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord> {
+    const stored = structuredClone(record);
+    this.keyDirectories.set(record.owner.toUpperCase(), stored);
+    return structuredClone(stored);
+  }
+
   reset() {
     this.policies.clear();
     this.policyWriteIntents.clear();
@@ -556,5 +585,9 @@ export class MemoryApiRepository implements ApiRepository {
     this.profiles.clear();
     this.credentials.clear();
     this.sessions.clear();
+    this.retiredSessions.clear();
+    this.keyDirectories.clear();
+    this.publishedKeys.clear();
+    this.keyDirectoryLocks.clear();
   }
 }

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -14,6 +14,8 @@ import type {
   Session,
   StoredEnvelope,
   User,
+  KeyDirectoryRecord,
+  PublishedKey,
 } from "./domain";
 import type { ZodSchema } from "zod";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
@@ -204,6 +206,14 @@ export interface ApiRepository {
    * Plaintext MUST NOT be passed to this method; ciphertext only.
    */
   insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+
+  // ---------------------------------------------------------------------------
+  // Issue #1934 (BETA-027) — Versioned Public Encryption-Key Directory & Rotation
+  // ---------------------------------------------------------------------------
+  getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null>;
+  getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null>;
+  savePublishedKey(owner: string, key: PublishedKey): Promise<PublishedKey>;
+  saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord>;
 
   reset?(): void;
 }
@@ -583,6 +593,26 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.deleteWalletChallenge(owner, address);
   }
 
+  async getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
+    const raw = await this.inner.getKeyDirectory(owner);
+    return raw ? validateRecord<KeyDirectoryRecord>("keyDirectoryRecord", raw) : null;
+  }
+
+  async getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null> {
+    const raw = await this.inner.getPublishedKey(owner, keyId);
+    return raw ? validateRecord<PublishedKey>("publishedKey", raw) : null;
+  }
+
+  async savePublishedKey(owner: string, key: PublishedKey): Promise<PublishedKey> {
+    const result = await this.inner.savePublishedKey(owner, versionRecord("publishedKey", key));
+    return validateRecord<PublishedKey>("publishedKey", result);
+  }
+
+  async saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord> {
+    const result = await this.inner.saveKeyDirectory(versionRecord("keyDirectoryRecord", record));
+    return validateRecord<KeyDirectoryRecord>("keyDirectoryRecord", result);
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -926,6 +956,22 @@ export class RetryableApiRepository implements ApiRepository {
 
   deleteWalletChallenge(owner: string, address: string): Promise<void> {
     return this.inner.deleteWalletChallenge(owner, address);
+  }
+
+  getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
+    return this.withRetry("getKeyDirectory", () => this.inner.getKeyDirectory(owner));
+  }
+
+  getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null> {
+    return this.withRetry("getPublishedKey", () => this.inner.getPublishedKey(owner, keyId));
+  }
+
+  savePublishedKey(owner: string, key: PublishedKey): Promise<PublishedKey> {
+    return this.withRetry("savePublishedKey", () => this.inner.savePublishedKey(owner, key));
+  }
+
+  saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord> {
+    return this.withRetry("saveKeyDirectory", () => this.inner.saveKeyDirectory(record));
   }
 
   reset(): void {

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -44,6 +44,10 @@ export const ROUTE_BODY_LIMITS = {
   "PUT /policies/{owner}/senders/{sender}": "standard",
   "POST /policies/evaluate": "compact",
   "POST /relay/messages": "relay",
+  "POST /identity/keys": "compact",
+  "POST /identity/keys/rotate": "compact",
+  "POST /identity/keys/retire": "compact",
+  "POST /identity/keys/revoke": "compact",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/services/crypto/key-resolver.ts
+++ b/src/services/crypto/key-resolver.ts
@@ -1,5 +1,5 @@
 /**
- * Secure recipient key-resolution interface (#1712).
+ * Secure recipient key-resolution interface (#1712, #1934 BETA-027).
  *
  * The crypto implementation has no abstraction for locating a recipient
  * encryption public key or validating its provenance. Without identity
@@ -40,13 +40,22 @@ export interface ResolvedKey {
   notAfter: string;
   /** Whether the key has been revoked. */
   revoked: boolean;
+  /** ISO timestamp when the key was revoked (if revoked). */
+  revokedAt?: string | null;
   /** How the key was obtained. */
   provenance: KeyProvenance;
+  /** Key version in directory lifecycle. */
+  version?: number;
 }
 
 /** A resolver locates and returns a validated key for a recipient. */
 export interface RecipientKeyResolver {
   resolve(recipient: string): Promise<ResolvedKey>;
+}
+
+/** Resolves historical keys for decrypting or verifying older messages. */
+export interface HistoricalKeyResolver {
+  resolveHistorical(recipient: string, keyId: string, timestamp?: Date): Promise<ResolvedKey>;
 }
 
 function parseIso(value: string): number {
@@ -87,6 +96,45 @@ export function validateResolvedKey(
 }
 
 /**
+ * Validates a key for historical message verification.
+ * - Active / Rotated / Retired keys are valid if messageTimestamp was within [notBefore, notAfter].
+ * - Revoked keys are permitted ONLY if messageTimestamp is strictly BEFORE revokedAt.
+ */
+export function validateHistoricalKey(
+  key: ResolvedKey,
+  recipient: string,
+  messageTimestamp: Date | string,
+): ResolvedKey {
+  if (key.recipient !== recipient) {
+    throw new ResolverError("resolved key is not bound to the requested recipient");
+  }
+  if (!key.publicKey || key.publicKey.length === 0) {
+    throw new ResolverError("resolved key has no public key material");
+  }
+
+  const msgMs =
+    typeof messageTimestamp === "string" ? parseIso(messageTimestamp) : messageTimestamp.getTime();
+  const notBeforeMs = parseIso(key.notBefore);
+  const notAfterMs = parseIso(key.notAfter);
+
+  if (msgMs < notBeforeMs || msgMs > notAfterMs) {
+    throw new ResolverError("message timestamp is outside key validity window");
+  }
+
+  if (key.revoked) {
+    if (!key.revokedAt) {
+      throw new ResolverError("revoked key is missing revocation timestamp");
+    }
+    const revokedMs = parseIso(key.revokedAt);
+    if (msgMs >= revokedMs) {
+      throw new ResolverError("message timestamp postdates key revocation");
+    }
+  }
+
+  return key;
+}
+
+/**
  * Resolve and validate in one step. Implementations provide a resolver; this
  * guarantees the returned key is safe to use for wrapping.
  */
@@ -111,6 +159,80 @@ export async function resolveTrustedKey(
       result,
       durationMs,
     });
+  }
+}
+
+/**
+ * Concrete Key Directory Resolver bridging to the versioned public key directory.
+ */
+export class DirectoryRecipientKeyResolver implements RecipientKeyResolver, HistoricalKeyResolver {
+  constructor(
+    private readonly directoryFetcher: (owner: string) => Promise<{
+      currentKeys: { encryption?: any; signing?: any };
+      historicalKeys: any[];
+      allKeys: any[];
+    } | null>,
+  ) {}
+
+  public async resolve(recipient: string): Promise<ResolvedKey> {
+    const dir = await this.directoryFetcher(recipient);
+    if (!dir || !dir.currentKeys?.encryption) {
+      throw new ResolverError(`No active encryption key found for recipient ${recipient}`);
+    }
+
+    const currentKey = dir.currentKeys.encryption;
+    return this.toResolvedKey(currentKey, recipient);
+  }
+
+  public async resolveHistorical(
+    recipient: string,
+    keyId: string,
+    timestamp?: Date,
+  ): Promise<ResolvedKey> {
+    const dir = await this.directoryFetcher(recipient);
+    if (!dir) {
+      throw new ResolverError(`Key directory not found for recipient ${recipient}`);
+    }
+
+    const key = dir.allKeys.find((k: any) => k.keyId === keyId);
+    if (!key) {
+      throw new ResolverError(`Key ${keyId} not found in directory for recipient ${recipient}`);
+    }
+
+    const resolved = this.toResolvedKey(key, recipient);
+    if (timestamp) {
+      return validateHistoricalKey(resolved, recipient, timestamp);
+    }
+    return resolved;
+  }
+
+  private toResolvedKey(rawKey: any, recipient: string): ResolvedKey {
+    let pubKeyBytes: Uint8Array;
+    if (typeof rawKey.publicKey === "string") {
+      try {
+        if (/^[0-9a-fA-F]+$/.test(rawKey.publicKey)) {
+          pubKeyBytes = Uint8Array.from(Buffer.from(rawKey.publicKey, "hex"));
+        } else {
+          pubKeyBytes = Uint8Array.from(Buffer.from(rawKey.publicKey, "base64"));
+        }
+      } catch {
+        pubKeyBytes = new TextEncoder().encode(rawKey.publicKey);
+      }
+    } else {
+      pubKeyBytes = rawKey.publicKey;
+    }
+
+    return {
+      recipient,
+      publicKey: pubKeyBytes,
+      keyId: rawKey.keyId,
+      notBefore: rawKey.notBefore,
+      notAfter: rawKey.notAfter,
+      revoked: rawKey.status === "revoked",
+      revokedAt: rawKey.revokedAt ?? null,
+      provenance: "trusted-directory",
+      version: rawKey.version,
+    };
   }
 }
 

--- a/src/services/stellar/managed-wallet.ts
+++ b/src/services/stellar/managed-wallet.ts
@@ -91,6 +91,8 @@ export class ManagedWalletService {
         return `lifecycle:${intent.userAddress}`;
       case "receipt":
         return `receipt:${intent.recipientAddress}`;
+      case "keys":
+        return `keys:${intent.ownerAddress}:${intent.operation}`;
     }
   }
 

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -273,6 +273,25 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("deleteWalletChallenge");
     return this.inner.deleteWalletChallenge(owner, address);
   }
+  async getKeyDirectory(owner: string) {
+    this.maybeFail("getKeyDirectory");
+    return this.inner.getKeyDirectory(owner);
+  }
+  async getPublishedKey(owner: string, keyId: string) {
+    this.maybeFail("getPublishedKey");
+    return this.inner.getPublishedKey(owner, keyId);
+  }
+  async savePublishedKey(
+    owner: string,
+    key: import("../../../src/server/api/domain").PublishedKey,
+  ) {
+    this.maybeFail("savePublishedKey");
+    return this.inner.savePublishedKey(owner, key);
+  }
+  async saveKeyDirectory(record: import("../../../src/server/api/domain").KeyDirectoryRecord) {
+    this.maybeFail("saveKeyDirectory");
+    return this.inner.saveKeyDirectory(record);
+  }
   reset(): void {
     this.inner.reset();
   }

--- a/tests/unit/identity/keys-directory.test.ts
+++ b/tests/unit/identity/keys-directory.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  publishKey,
+  rotateKey,
+  retireKey,
+  revokeKey,
+  getKeyDirectory,
+  getKey,
+} from "../../../src/server/api/key-directory-service";
+import {
+  buildKeyPublicationSigningPayload,
+  verifyKeyPublicationSignature,
+  isKeyValidAtTimestamp,
+  type PublishedKey,
+} from "../../../src/features/identity/keys";
+import {
+  DirectoryRecipientKeyResolver,
+  resolveTrustedKey,
+  validateHistoricalKey,
+  ResolverError,
+} from "../../../src/services/crypto/key-resolver";
+import { ApiError } from "../../../src/server/api/errors";
+
+describe("BETA-027 (Issue #1934): Versioned Public Key Directory and Rotation API", () => {
+  let repository: MemoryApiRepository;
+  let aliceKp: Keypair;
+  let bobKp: Keypair;
+  let aliceAddress: string;
+  let bobAddress: string;
+
+  beforeEach(() => {
+    repository = new MemoryApiRepository();
+    aliceKp = Keypair.random();
+    bobKp = Keypair.random();
+    aliceAddress = aliceKp.publicKey();
+    bobAddress = bobKp.publicKey();
+  });
+
+  function signPayload(kp: Keypair, payload: Uint8Array): string {
+    const sigBuffer = kp.sign(Buffer.from(payload));
+    return sigBuffer.toString("base64");
+  }
+
+  describe("1. Key Publication & Signature Verification", () => {
+    it("successfully publishes a signed public encryption key", async () => {
+      const keyId = "k_alice_enc_1";
+      const notBefore = new Date(Date.now() - 1000).toISOString();
+      const notAfter = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+      const pubKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      const payload = buildKeyPublicationSigningPayload({
+        owner: aliceAddress,
+        keyId,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey,
+        version: 1,
+        notBefore,
+        notAfter,
+        operation: "publish",
+      });
+
+      const signature = signPayload(aliceKp, payload);
+
+      const published = await publishKey(repository, aliceAddress, {
+        keyId,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey,
+        notBefore,
+        notAfter,
+        signature,
+        metadata: { client: "stealth-web/1.0" },
+      });
+
+      expect(published.keyId).toBe(keyId);
+      expect(published.owner).toBe(aliceAddress);
+      expect(published.version).toBe(1);
+      expect(published.status).toBe("active");
+      expect(published.signature).toBe(signature);
+
+      // Verify directory reflects published key
+      const dir = await getKeyDirectory(repository, aliceAddress);
+      expect(dir.currentKeys.encryption?.keyId).toBe(keyId);
+      expect(dir.version).toBe(1);
+      expect(dir.allKeys).toHaveLength(1);
+    });
+
+    it("rejects publication with invalid or forged signature", async () => {
+      const keyId = "k_forged_1";
+      const notBefore = new Date().toISOString();
+      const notAfter = new Date(Date.now() + 100000).toISOString();
+      const pubKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+      const payload = buildKeyPublicationSigningPayload({
+        owner: aliceAddress,
+        keyId,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey,
+        version: 1,
+        notBefore,
+        notAfter,
+        operation: "publish",
+      });
+
+      // Bob signs Alice's key publication (forgery attempt)
+      const invalidSignature = signPayload(bobKp, payload);
+
+      await expect(
+        publishKey(repository, aliceAddress, {
+          keyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: pubKey,
+          notBefore,
+          notAfter,
+          signature: invalidSignature,
+        }),
+      ).rejects.toThrowError(ApiError);
+    });
+
+    it("strictly rejects private key material or secrets in public key fields", async () => {
+      const badSecret = aliceKp.secret(); // Stellar S... secret key
+      const notBefore = new Date().toISOString();
+      const notAfter = new Date(Date.now() + 100000).toISOString();
+
+      await expect(
+        publishKey(
+          repository,
+          aliceAddress,
+          {
+            keyId: "k_bad",
+            algorithm: "ed25519",
+            purpose: "signing",
+            publicKey: badSecret,
+            notBefore,
+            notAfter,
+            signature: "dummy",
+          },
+          { bypassSignatureCheck: true },
+        ),
+      ).rejects.toThrowError(/Private key material detected/);
+    });
+  });
+
+  describe("2. Key Rotation with Overlap Window & Rollback Prevention", () => {
+    it("rotates an active key, incrementing version and transitioning previous key to rotated", async () => {
+      // Step 1: Publish Key v1
+      const key1Id = "k_alice_v1";
+      const notBefore1 = new Date(Date.now() - 10000).toISOString();
+      const notAfter1 = new Date(Date.now() + 1000000).toISOString();
+      const pubKey1 = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111";
+
+      const payload1 = buildKeyPublicationSigningPayload({
+        owner: aliceAddress,
+        keyId: key1Id,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey1,
+        version: 1,
+        notBefore: notBefore1,
+        notAfter: notAfter1,
+        operation: "publish",
+      });
+
+      await publishKey(repository, aliceAddress, {
+        keyId: key1Id,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey1,
+        notBefore: notBefore1,
+        notAfter: notAfter1,
+        signature: signPayload(aliceKp, payload1),
+      });
+
+      // Step 2: Rotate to Key v2
+      const key2Id = "k_alice_v2";
+      const notBefore2 = new Date().toISOString();
+      const notAfter2 = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+      const pubKey2 = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222";
+
+      const rotatePayload = buildKeyPublicationSigningPayload({
+        owner: aliceAddress,
+        keyId: key2Id,
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: pubKey2,
+        version: 2, // monotonic increment
+        notBefore: notBefore2,
+        notAfter: notAfter2,
+        operation: "rotate",
+      });
+
+      const rotationResult = await rotateKey(repository, aliceAddress, {
+        currentKeyId: key1Id,
+        newKey: {
+          keyId: key2Id,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: pubKey2,
+          notBefore: notBefore2,
+          notAfter: notAfter2,
+          signature: signPayload(aliceKp, rotatePayload),
+        },
+        overlapPeriodMs: 7 * 24 * 60 * 60 * 1000,
+        signature: signPayload(aliceKp, rotatePayload),
+      });
+
+      expect(rotationResult.previous.keyId).toBe(key1Id);
+      expect(rotationResult.previous.status).toBe("rotated");
+      expect(rotationResult.current.keyId).toBe(key2Id);
+      expect(rotationResult.current.status).toBe("active");
+      expect(rotationResult.current.version).toBe(2);
+
+      // Verify directory points to v2 as current encryption key
+      const dir = await getKeyDirectory(repository, aliceAddress);
+      expect(dir.currentKeys.encryption?.keyId).toBe(key2Id);
+      expect(dir.historicalKeys).toHaveLength(1);
+      expect(dir.historicalKeys[0].keyId).toBe(key1Id);
+      expect(dir.historicalKeys[0].status).toBe("rotated");
+    });
+
+    it("rejects rotating a non-existent or foreign key", async () => {
+      const fakeKeyId = "k_non_existent";
+      const rotatePayload = buildKeyPublicationSigningPayload({
+        owner: aliceAddress,
+        keyId: "k_new",
+        algorithm: "x25519",
+        purpose: "encryption",
+        publicKey: "0101010101010101010101010101010101010101010101010101010101010101",
+        version: 2,
+        notBefore: new Date().toISOString(),
+        notAfter: new Date(Date.now() + 100000).toISOString(),
+        operation: "rotate",
+      });
+
+      await expect(
+        rotateKey(repository, aliceAddress, {
+          currentKeyId: fakeKeyId,
+          newKey: {
+            keyId: "k_new",
+            algorithm: "x25519",
+            purpose: "encryption",
+            publicKey: "0101010101010101010101010101010101010101010101010101010101010101",
+            signature: signPayload(aliceKp, rotatePayload),
+          },
+          signature: signPayload(aliceKp, rotatePayload),
+        }),
+      ).rejects.toThrowError(ApiError);
+    });
+  });
+
+  describe("3. Key Retirement & Revocation Lifecycle", () => {
+    it("retires an active key cleanly", async () => {
+      const keyId = "k_retire_me";
+      await publishKey(
+        repository,
+        aliceAddress,
+        {
+          keyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          signature: "dummy",
+        },
+        { bypassSignatureCheck: true },
+      );
+
+      const retired = await retireKey(repository, aliceAddress, { keyId });
+      expect(retired.status).toBe("retired");
+
+      const dir = await getKeyDirectory(repository, aliceAddress);
+      expect(dir.currentKeys.encryption).toBeNull();
+      expect(dir.allKeys[0].status).toBe("retired");
+    });
+
+    it("revokes a key, immediately blocking encryption while permitting historical verification before revokedAt", async () => {
+      const keyId = "k_revoke_me";
+      const creationTime = new Date(Date.now() - 3600000); // 1 hour ago
+      const notBefore = creationTime.toISOString();
+      const notAfter = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+
+      await publishKey(
+        repository,
+        aliceAddress,
+        {
+          keyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          notBefore,
+          notAfter,
+          signature: "dummy",
+        },
+        { bypassSignatureCheck: true },
+      );
+
+      // Revoke the key
+      const revoked = await revokeKey(repository, aliceAddress, {
+        keyId,
+        reason: "Device compromised",
+        signature: "dummy",
+      });
+
+      expect(revoked.status).toBe("revoked");
+      expect(revoked.revocationReason).toBe("Device compromised");
+      expect(revoked.revokedAt).toBeDefined();
+
+      const revokedAt = new Date(revoked.revokedAt!);
+
+      // Historical verification rules:
+      // 1. Message sent 30 minutes before revocation -> VALID
+      const pastMsgTimestamp = new Date(revokedAt.getTime() - 30 * 60 * 1000);
+      expect(isKeyValidAtTimestamp(revoked, pastMsgTimestamp)).toBe(true);
+
+      // 2. Message sent after revocation -> INVALID
+      const futureMsgTimestamp = new Date(revokedAt.getTime() + 10 * 1000);
+      expect(isKeyValidAtTimestamp(revoked, futureMsgTimestamp)).toBe(false);
+
+      // 3. Current active encryption resolution fails
+      const dir = await getKeyDirectory(repository, aliceAddress);
+      expect(dir.currentKeys.encryption).toBeNull();
+    });
+  });
+
+  describe("4. Cross-Account Authorization & Protection", () => {
+    it("prevents Bob from modifying or revoking Alice's keys", async () => {
+      const aliceKeyId = "k_alice_secret";
+      await publishKey(
+        repository,
+        aliceAddress,
+        {
+          keyId: aliceKeyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          signature: "dummy",
+        },
+        { bypassSignatureCheck: true },
+      );
+
+      // Bob tries to revoke Alice's key
+      await expect(
+        revokeKey(repository, bobAddress, {
+          keyId: aliceKeyId,
+          reason: "malicious revocation",
+          signature: "dummy",
+        }),
+      ).rejects.toThrowError(ApiError);
+
+      // Bob tries to retire Alice's key
+      await expect(
+        retireKey(repository, bobAddress, {
+          keyId: aliceKeyId,
+        }),
+      ).rejects.toThrowError(ApiError);
+    });
+  });
+
+  describe("5. DirectoryRecipientKeyResolver Integration", () => {
+    it("resolves active key via DirectoryRecipientKeyResolver", async () => {
+      const keyId = "k_alice_active";
+      const pubKey = "1122334455667788112233445566778811223344556677881122334455667788";
+
+      await publishKey(
+        repository,
+        aliceAddress,
+        {
+          keyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: pubKey,
+          signature: "dummy",
+        },
+        { bypassSignatureCheck: true },
+      );
+
+      const resolver = new DirectoryRecipientKeyResolver(async (owner) => {
+        return getKeyDirectory(repository, owner);
+      });
+
+      const resolved = await resolveTrustedKey(resolver, aliceAddress);
+      expect(resolved.recipient).toBe(aliceAddress);
+      expect(resolved.keyId).toBe(keyId);
+      expect(resolved.revoked).toBe(false);
+      expect(resolved.provenance).toBe("trusted-directory");
+    });
+
+    it("resolves historical key and validates against message timestamps", async () => {
+      const keyId = "k_alice_hist";
+      const pubKey = "1122334455667788112233445566778811223344556677881122334455667788";
+      const notBefore = new Date(Date.now() - 7200000).toISOString(); // 2 hours ago
+      const notAfter = new Date(Date.now() + 3600000).toISOString();
+
+      await publishKey(
+        repository,
+        aliceAddress,
+        {
+          keyId,
+          algorithm: "x25519",
+          purpose: "encryption",
+          publicKey: pubKey,
+          notBefore,
+          notAfter,
+          signature: "dummy",
+        },
+        { bypassSignatureCheck: true },
+      );
+
+      // Revoke the key 1 hour ago
+      const revokedAt = new Date(Date.now() - 3600000);
+      await revokeKey(repository, aliceAddress, {
+        keyId,
+        reason: "Test revocation",
+        revokedAt: revokedAt.toISOString(),
+        signature: "dummy",
+      });
+
+      const resolver = new DirectoryRecipientKeyResolver(async (owner) => {
+        return getKeyDirectory(repository, owner);
+      });
+
+      // 1. Valid historical message timestamp (90 minutes ago, before revokedAt)
+      const validTimestamp = new Date(Date.now() - 90 * 60 * 1000);
+      const histKey = await resolver.resolveHistorical(aliceAddress, keyId, validTimestamp);
+      expect(histKey.keyId).toBe(keyId);
+      expect(histKey.revoked).toBe(true);
+
+      // 2. Invalid historical message timestamp (postdates revokedAt)
+      const invalidTimestamp = new Date(Date.now() - 10 * 60 * 1000);
+      await expect(
+        resolver.resolveHistorical(aliceAddress, keyId, invalidTimestamp),
+      ).rejects.toThrowError(ResolverError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implemented the versioned public encryption and signing key directory lifecycle service supporting publication, monotonic version rotation with overlap windows, retirement, and immediate revocation.
- Added REST API routes under `/api/v1/identity/keys` (`GET /`, `POST /`, `POST /rotate`, `POST /retire`, `POST /revoke`, `GET /{keyId}`).
- Integrated canonical signing envelopes (`stealth:key-directory`) with Stellar ed25519 signature verification and private key rejection safeguards.
- Extended `DirectoryRecipientKeyResolver` and historical key validation in `src/services/crypto/key-resolver.ts` to support timestamp-bounded message verification.
- Updated `protocol/keys/README.md` with endpoint specifications, response schemas, and verification rules.

## Why

Crypto key-resolution primitives existed without an authenticated directory lifecycle tied to user accounts. Account holders needed a mechanism to publish signed public encryption keys and rotate them safely while ensuring in-flight and older historical messages remain verifiable.

## Implementation

- **Data Models & Signatures (`src/features/identity/keys.ts`, `src/server/api/domain.ts`)**:
  - Defined schemas for `PublishedKey`, `KeyDirectoryRecord`, and request envelopes for `publish`, `rotate`, `retire`, and `revoke`.
  - Implemented `buildKeyPublicationSigningPayload` and `verifyKeyPublicationSignature` for ed25519 verification.
  - Implemented `isKeyValidAtTimestamp` to ensure revoked keys are only accepted for messages timestamped strictly before `revokedAt`.
- **Key Directory Service (`src/server/api/key-directory-service.ts`)**:
  - `publishKey`: Enforces non-secret checks (`assertNoPrivateKeyMaterial`), verifies signature, increments version, and updates active pointers.
  - `rotateKey`: Transitions previous active key to `rotated` status with configurable overlap duration (default 7 days), preventing rollbacks.
  - `retireKey`: Deactivates active keys without invalidating historical verification.
  - `revokeKey`: Immediately revokes compromised keys, unsets active pointers, and records revocation timestamps and reasons.
- **Persistence (`src/server/api/repository.ts`, `memory-repository.ts`, `kv-repository.ts`)**:
  - Added repository methods for key storage and retrieval across in-memory and Cloudflare KV storage.
- **Crypto Resolver (`src/services/crypto/key-resolver.ts`)**:
  - Implemented `DirectoryRecipientKeyResolver` and `validateHistoricalKey` for integrating compose encryption and historical decryption workflows.
- **HTTP Handlers (`src/routes/api/v1/identity/keys/`)**:
  - Added route handlers for directory queries, publication, rotation, retirement, and revocation.

## Testing

- `bun x vitest run tests/unit/identity/keys-directory.test.ts tests/unit/crypto/key-resolver.test.ts` (18/18 passed)
- `bun x vitest run` (119 test files, 1,655 tests passed)
- `bun x tsc --noEmit` (0 errors)
- `bun run lint` (0 lint errors)
- `bun x prettier --check .` (passed)
- `bun run build` (`vite build` production build completed successfully)

## Scope / Risk

- Affected areas: `src/features/identity/keys.ts`, `src/server/api/`, `src/routes/api/v1/identity/keys/`, `src/services/crypto/key-resolver.ts`, `protocol/keys/README.md`.
- No breaking changes to existing endpoints.

## Issue

closes #1934
