### PR TITLE
feat(api): implement authenticated recipient mailbox queue (BETA-033)

### DIFF
--- a/src/features/settings/external-wallet-linking.tsx
+++ b/src/features/settings/external-wallet-linking.tsx
@@ -9,11 +9,15 @@ import {
   unlinkWallet,
   WalletLinkError,
 } from "@/services/stellar/wallet-link";
-import {
-  isConnected as freighterIsConnected,
-  requestAccess as freighterRequestAccess,
-  signMessage as freighterSignMessage,
-} from "@stellar/freighter-api";
+
+let _freighterMod: typeof import("@stellar/freighter-api") | null = null;
+async function freighterApi() {
+  if (!_freighterMod) {
+    const mod = await import("@stellar/freighter-api");
+    _freighterMod = (mod.default ?? mod) as typeof import("@stellar/freighter-api");
+  }
+  return _freighterMod;
+}
 
 type LinkingState =
   | { status: "idle" }
@@ -63,7 +67,9 @@ export function ExternalWalletSettings({ ownerAddress }: { ownerAddress?: string
     setLinkingState({ status: "connecting" });
 
     try {
-      const connected = await freighterIsConnected();
+      const freighter = await freighterApi();
+
+      const connected = await freighter.isConnected();
       if (!connected.isConnected) {
         setLinkingState({
           status: "error",
@@ -72,7 +78,7 @@ export function ExternalWalletSettings({ ownerAddress }: { ownerAddress?: string
         return;
       }
 
-      const access = await freighterRequestAccess();
+      const access = await freighter.requestAccess();
       if (access.error) {
         setLinkingState({
           status: "error",
@@ -92,7 +98,7 @@ export function ExternalWalletSettings({ ownerAddress }: { ownerAddress?: string
 
       setLinkingState({ status: "signing" });
 
-      const signed = await freighterSignMessage(challengeResult.challenge);
+      const signed = await freighter.signMessage(challengeResult.challenge);
       if (signed.error) {
         setLinkingState({
           status: "error",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,6 +26,8 @@ import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/q
 import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1MailboxQueueRouteImport } from './routes/api/v1/mailbox/queue'
+import { Route as ApiV1MailboxMessageIdRouteImport } from './routes/api/v1/mailbox/$messageId'
 import { Route as ApiV1IdentityResolveRouteImport } from './routes/api/v1/identity/resolve'
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
 import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
@@ -131,6 +133,16 @@ const ApiV1PoliciesEvaluateRoute = ApiV1PoliciesEvaluateRouteImport.update({
 const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
   id: '/api/v1/policies/$owner',
   path: '/api/v1/policies/$owner',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxQueueRoute = ApiV1MailboxQueueRouteImport.update({
+  id: '/api/v1/mailbox/queue',
+  path: '/api/v1/mailbox/queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxMessageIdRoute = ApiV1MailboxMessageIdRouteImport.update({
+  id: '/api/v1/mailbox/$messageId',
+  path: '/api/v1/mailbox/$messageId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1IdentityResolveRoute = ApiV1IdentityResolveRouteImport.update({
@@ -259,6 +271,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
+  '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -299,6 +313,8 @@ export interface FileRoutesByTo {
   '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
+  '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -340,6 +356,8 @@ export interface FileRoutesById {
   '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
+  '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -382,6 +400,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/identity/resolve'
+    | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/queue'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -422,6 +442,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/identity/resolve'
+    | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/queue'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -462,6 +484,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/identity/resolve'
+    | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/queue'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -503,6 +527,8 @@ export interface RootRouteChildren {
   ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1IdentityResolveRoute: typeof ApiV1IdentityResolveRoute
+  ApiV1MailboxMessageIdRoute: typeof ApiV1MailboxMessageIdRoute
+  ApiV1MailboxQueueRoute: typeof ApiV1MailboxQueueRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -644,6 +670,20 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/policies/$owner'
       fullPath: '/api/v1/policies/$owner'
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/mailbox/queue': {
+      id: '/api/v1/mailbox/queue'
+      path: '/api/v1/mailbox/queue'
+      fullPath: '/api/v1/mailbox/queue'
+      preLoaderRoute: typeof ApiV1MailboxQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/mailbox/$messageId': {
+      id: '/api/v1/mailbox/$messageId'
+      path: '/api/v1/mailbox/$messageId'
+      fullPath: '/api/v1/mailbox/$messageId'
+      preLoaderRoute: typeof ApiV1MailboxMessageIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/identity/resolve': {
@@ -853,6 +893,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1IdentityResolveRoute: ApiV1IdentityResolveRoute,
+  ApiV1MailboxMessageIdRoute: ApiV1MailboxMessageIdRoute,
+  ApiV1MailboxQueueRoute: ApiV1MailboxQueueRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,

--- a/src/routes/api/v1/mailbox/$messageId.ts
+++ b/src/routes/api/v1/mailbox/$messageId.ts
@@ -1,0 +1,32 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { hash32Schema } from "@/server/api/domain";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/mailbox/$messageId")({
+  server: {
+    handlers: {
+      DELETE: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+          const messageId = hash32Schema.parse(params.messageId);
+
+          const tombstoned = await apiContext.repository.tombstoneEnvelope(messageId, actor);
+
+          return apiSuccess(
+            request,
+            {
+              messageId: tombstoned.messageId,
+              status: tombstoned.status ?? "pending",
+              isTombstone: true,
+              deletedAt: tombstoned.deletedAt,
+            },
+            { status: 200 },
+          );
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/mailbox/queue.ts
+++ b/src/routes/api/v1/mailbox/queue.ts
@@ -1,0 +1,67 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor, requireActorMatches } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { mailboxQueueQuerySchema, type MailboxDescriptor } from "@/server/api/domain";
+import { encodeCursor, decodeCursor } from "@/server/api/pagination";
+import { parseSearchParams } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/mailbox/queue")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+
+          const query = parseSearchParams(request, mailboxQueueQuerySchema);
+
+          if (query.recipient && query.recipient !== actor) {
+            requireActorMatches(apiContext, query.recipient);
+          }
+
+          let afterKey: string | undefined;
+          if (query.cursor) {
+            const decoded = decodeCursor(query.cursor, actor, "mailbox_queue");
+            afterKey = decoded.continuationKey;
+          }
+
+          const page = await apiContext.repository.listRecipientEnvelopes(actor, {
+            status: query.status,
+            includeTombstones: query.includeTombstones,
+            limit: query.limit,
+            after: afterKey,
+          });
+
+          const items: MailboxDescriptor[] = page.items.map((item) => ({
+            messageId: item.messageId,
+            senderId: item.senderId,
+            recipientId: item.recipientId,
+            status: item.status ?? "pending",
+            createdAt: item.createdAt,
+            protectedHeaders: item.protectedHeaders,
+            contentCommitment: item.contentCommitment,
+            objectRef: item.objectRef,
+            isTombstone: Boolean(item.deletedAt),
+            deletedAt: item.deletedAt ?? null,
+          }));
+
+          const hasMore = Boolean(page.nextContinuationKey);
+          const nextCursor = page.nextContinuationKey
+            ? encodeCursor(actor, page.nextContinuationKey, "mailbox_queue")
+            : null;
+
+          return apiSuccess(
+            request,
+            {
+              items,
+              nextCursor,
+              hasMore,
+            },
+            { status: 200 },
+          );
+        }),
+    },
+  },
+});

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -398,6 +398,9 @@ export const storedEnvelopeProtectedHeadersSchema = z
   })
   .catchall(z.unknown());
 
+export const mailboxItemStatusSchema = z.enum(["pending", "delivered"]);
+export type MailboxItemStatus = z.infer<typeof mailboxItemStatusSchema>;
+
 export const storedEnvelopeSchema = z.object({
   envelopeId: z.string().optional(),
   messageId: hash32Schema,
@@ -411,11 +414,57 @@ export const storedEnvelopeSchema = z.object({
   protectedHeaders: storedEnvelopeProtectedHeadersSchema,
   contentCommitment: hash32Schema.optional(),
   createdAt: z.string().datetime(),
+  status: mailboxItemStatusSchema.default("pending"),
+  deletedAt: z.string().datetime().nullable().optional(),
+  objectRef: z.string().optional(),
   metadata: z.record(z.unknown()).optional(),
 });
 
 export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
 export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;
+
+// ---------------------------------------------------------------------------
+// Issue #1940 (BETA-033) — Authenticated Recipient Mailbox Queue Domain
+// ---------------------------------------------------------------------------
+
+export const mailboxQueueQuerySchema = z.object({
+  recipient: stellarAddressSchema.optional(),
+  status: z.enum(["pending", "delivered", "all"]).default("all"),
+  includeTombstones: z.coerce.boolean().default(false),
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+export type MailboxQueueQuery = z.infer<typeof mailboxQueueQuerySchema>;
+
+export const mailboxDescriptorSchema = z.object({
+  messageId: hash32Schema,
+  senderId: stellarAddressSchema,
+  recipientId: stellarAddressSchema,
+  status: mailboxItemStatusSchema,
+  createdAt: z.string().datetime(),
+  protectedHeaders: storedEnvelopeProtectedHeadersSchema,
+  contentCommitment: hash32Schema.optional(),
+  objectRef: z.string().optional(),
+  isTombstone: z.boolean(),
+  deletedAt: z.string().datetime().nullable().optional(),
+});
+
+export type MailboxDescriptor = z.infer<typeof mailboxDescriptorSchema>;
+
+export const mailboxQueueResponseSchema = z.object({
+  items: z.array(mailboxDescriptorSchema),
+  nextCursor: z.string().nullable(),
+  hasMore: z.boolean(),
+});
+
+export type MailboxQueueResponse = z.infer<typeof mailboxQueueResponseSchema>;
+
+export const tombstoneRequestSchema = z.object({
+  messageId: hash32Schema,
+});
+
+export type TombstoneRequest = z.infer<typeof tombstoneRequestSchema>;
 
 // ---------------------------------------------------------------------------
 // BETA-027 (Issue #1934) — Versioned Public Encryption-Key Directory & Rotation

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -368,6 +368,28 @@ export class HybridApiRepository implements ApiRepository {
     return result;
   }
 
+  async listRecipientEnvelopes(
+    recipient: string,
+    options?: import("./repository").MailboxQueryOptions,
+  ): Promise<import("./repository").Page<StoredEnvelope>> {
+    return this.getStub().listRecipientEnvelopes(recipient, options);
+  }
+
+  async tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope> {
+    const result = await this.getStub().tombstoneEnvelope(messageId, recipient);
+    await this.kv.put(this.key("envelope", messageId), JSON.stringify(result));
+    return result;
+  }
+
+  async updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope> {
+    const result = await this.getStub().updateEnvelopeStatus(messageId, status);
+    await this.kv.put(this.key("envelope", messageId), JSON.stringify(result));
+    return result;
+  }
+
   // ---------------------------------------------------------------------------
   // Issue #1934 (BETA-027) — Versioned Public Encryption-Key Directory & Rotation
   // ---------------------------------------------------------------------------

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -543,6 +543,76 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async listRecipientEnvelopes(
+    recipient: string,
+    options: import("./repository").MailboxQueryOptions = {},
+  ): Promise<import("./repository").Page<StoredEnvelope>> {
+    const { paginate, PAGINATED_QUERY_ORDERINGS } = await import("./repository");
+    const normRecipient = recipient.toUpperCase().trim();
+    const statusFilter = options.status ?? "all";
+    const includeTombstones = options.includeTombstones ?? false;
+    const limit = options.limit ?? 25;
+
+    const filtered: StoredEnvelope[] = [];
+    for (const env of this.envelopes.values()) {
+      if (env.recipientId.toUpperCase().trim() !== normRecipient) {
+        continue;
+      }
+      const isDeleted = Boolean(env.deletedAt);
+      if (isDeleted && !includeTombstones) {
+        continue;
+      }
+      const itemStatus = env.status ?? "pending";
+      if (statusFilter !== "all" && itemStatus !== statusFilter) {
+        continue;
+      }
+      filtered.push(structuredClone(env));
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listEnvelopes;
+    return paginate(filtered, spec, { limit, after: options.after });
+  }
+
+  async tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope> {
+    return this.withEnvelopeLock(messageId, async () => {
+      const existing = this.envelopes.get(messageId);
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      if (existing.recipientId.toUpperCase().trim() !== recipient.toUpperCase().trim()) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "Cannot delete an envelope belonging to another recipient",
+        );
+      }
+      const tombstoned: StoredEnvelope = {
+        ...existing,
+        deletedAt: new Date().toISOString(),
+      };
+      this.envelopes.set(messageId, tombstoned);
+      return structuredClone(tombstoned);
+    });
+  }
+
+  async updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope> {
+    return this.withEnvelopeLock(messageId, async () => {
+      const existing = this.envelopes.get(messageId);
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      const updated: StoredEnvelope = {
+        ...existing,
+        status,
+      };
+      this.envelopes.set(messageId, updated);
+      return structuredClone(updated);
+    });
+  }
+
   async getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
     const dir = this.keyDirectories.get(owner.toUpperCase());
     return dir ? structuredClone(dir) : null;

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -91,6 +91,13 @@ export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
 
+export interface MailboxQueryOptions {
+  status?: "pending" | "delivered" | "all";
+  includeTombstones?: boolean;
+  limit?: number;
+  after?: string;
+}
+
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
   setPolicy(owner: string, policy: MailboxPolicy): Promise<MailboxPolicy>;
@@ -206,6 +213,19 @@ export interface ApiRepository {
    * Plaintext MUST NOT be passed to this method; ciphertext only.
    */
   insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+
+  // ---------------------------------------------------------------------------
+  // Issue #1940 (BETA-033) — Authenticated Recipient Mailbox Queue Repository
+  // ---------------------------------------------------------------------------
+  listRecipientEnvelopes(
+    recipient: string,
+    options?: MailboxQueryOptions,
+  ): Promise<Page<StoredEnvelope>>;
+  tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope>;
+  updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope>;
 
   // ---------------------------------------------------------------------------
   // Issue #1934 (BETA-027) — Versioned Public Encryption-Key Directory & Rotation
@@ -561,6 +581,30 @@ export class ValidatedApiRepository implements ApiRepository {
     return result;
   }
 
+  async listRecipientEnvelopes(
+    recipient: string,
+    options?: MailboxQueryOptions,
+  ): Promise<Page<StoredEnvelope>> {
+    const page = await this.inner.listRecipientEnvelopes(recipient, options);
+    return {
+      ...page,
+      items: page.items.map((item) => validateRecord<StoredEnvelope>("storedEnvelope", item)),
+    };
+  }
+
+  async tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope> {
+    const result = await this.inner.tombstoneEnvelope(messageId, recipient);
+    return validateRecord<StoredEnvelope>("storedEnvelope", result);
+  }
+
+  async updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope> {
+    const result = await this.inner.updateEnvelopeStatus(messageId, status);
+    return validateRecord<StoredEnvelope>("storedEnvelope", result);
+  }
+
   getExternalWallets(owner: string): Promise<ExternalWallet[]> {
     return this.inner.getExternalWallets(owner);
   }
@@ -666,6 +710,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "updateSession",
   "getRetiredSession",
   "getEnvelope",
+  "listRecipientEnvelopes",
   "getExternalWallets",
   "findExternalWalletOwner",
   "getWalletChallenge",
@@ -920,6 +965,26 @@ export class RetryableApiRepository implements ApiRepository {
     // and the outcome would be "duplicate" (byte-equal) or "conflict" (different
     // bytes). Callers should handle those outcomes explicitly.
     return this.inner.insertEnvelope(envelope);
+  }
+
+  listRecipientEnvelopes(
+    recipient: string,
+    options?: MailboxQueryOptions,
+  ): Promise<Page<StoredEnvelope>> {
+    return this.withRetry("listRecipientEnvelopes", () =>
+      this.inner.listRecipientEnvelopes(recipient, options),
+    );
+  }
+
+  tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope> {
+    return this.inner.tombstoneEnvelope(messageId, recipient);
+  }
+
+  updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope> {
+    return this.inner.updateEnvelopeStatus(messageId, status);
   }
 
   getExternalWallets(owner: string): Promise<ExternalWallet[]> {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -93,6 +93,22 @@ export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
 
+export type IssueVerificationTokenResult =
+  | { outcome: "issued"; token: VerificationToken; replacedToken: VerificationToken | null }
+  | { outcome: "conflict"; token: VerificationToken };
+
+export type ConsumeVerificationTokenResult =
+  | { outcome: "not-found" }
+  | { outcome: "already-consumed"; token: VerificationToken }
+  | { outcome: "replaced"; token: VerificationToken }
+  | { outcome: "brute-force-blocked"; token: VerificationToken }
+  | { outcome: "expired"; token: VerificationToken }
+  | { outcome: "consumed"; token: VerificationToken };
+
+export type RecordVerificationAttemptResult =
+  | { recorded: false; token: VerificationToken | null }
+  | { recorded: true; token: VerificationToken };
+
 export interface MailboxQueryOptions {
   status?: "pending" | "delivered" | "all";
   includeTombstones?: boolean;

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -473,4 +473,81 @@ export class StealthCoordinator extends DurableObjectBase {
       return { outcome: "inserted" as const, envelope };
     });
   }
+
+  async listRecipientEnvelopes(
+    recipient: string,
+    options: import("./repository").MailboxQueryOptions = {},
+  ): Promise<import("./repository").Page<StoredEnvelope>> {
+    const { paginate, PAGINATED_QUERY_ORDERINGS } = await import("./repository");
+    const normRecipient = recipient.toUpperCase().trim();
+    const statusFilter = options.status ?? "all";
+    const includeTombstones = options.includeTombstones ?? false;
+    const limit = options.limit ?? 25;
+
+    const envelopesMap = (await this.ctx.storage.list({ prefix: "envelope:" })) as Map<
+      string,
+      StoredEnvelope
+    >;
+
+    const filtered: StoredEnvelope[] = [];
+    for (const env of envelopesMap.values()) {
+      if (!env || !env.recipientId) continue;
+      if (env.recipientId.toUpperCase().trim() !== normRecipient) continue;
+
+      const isDeleted = Boolean(env.deletedAt);
+      if (isDeleted && !includeTombstones) continue;
+
+      const itemStatus = env.status ?? "pending";
+      if (statusFilter !== "all" && itemStatus !== statusFilter) continue;
+
+      filtered.push(env);
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listEnvelopes;
+    return paginate(filtered, spec, { limit, after: options.after });
+  }
+
+  async tombstoneEnvelope(messageId: string, recipient: string): Promise<StoredEnvelope> {
+    return this.runExclusive(`envelope:${messageId}`, async () => {
+      const existing = (await this.ctx.storage.get(`envelope:${messageId}`)) as
+        | StoredEnvelope
+        | undefined;
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      if (existing.recipientId.toUpperCase().trim() !== recipient.toUpperCase().trim()) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "Cannot delete an envelope belonging to another recipient",
+        );
+      }
+      const tombstoned: StoredEnvelope = {
+        ...existing,
+        deletedAt: new Date().toISOString(),
+      };
+      await this.ctx.storage.put(`envelope:${messageId}`, tombstoned);
+      return tombstoned;
+    });
+  }
+
+  async updateEnvelopeStatus(
+    messageId: string,
+    status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope> {
+    return this.runExclusive(`envelope:${messageId}`, async () => {
+      const existing = (await this.ctx.storage.get(`envelope:${messageId}`)) as
+        | StoredEnvelope
+        | undefined;
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      const updated: StoredEnvelope = {
+        ...existing,
+        status,
+      };
+      await this.ctx.storage.put(`envelope:${messageId}`, updated);
+      return updated;
+    });
+  }
 }

--- a/src/services/relay/kv-persistence.ts
+++ b/src/services/relay/kv-persistence.ts
@@ -62,6 +62,20 @@ export class KvRelayPersistence implements RelayPersistence {
     await this.incrementCounter(KvRelayPersistence.DEAD_LETTER_KEY);
   }
 
+  async listRecipientQueue(recipient: string): Promise<RelayEnvelope[]> {
+    const kv = this.kv as any;
+    const list = await kv.list({ prefix: KvRelayPersistence.MESSAGE_PREFIX });
+    const results: RelayEnvelope[] = [];
+    const norm = recipient.toUpperCase().trim();
+    for (const key of list.keys) {
+      const envelope = (await this.kv.get(key.name, "json")) as RelayEnvelope | null;
+      if (envelope && envelope.recipient?.toUpperCase().trim() === norm) {
+        results.push(envelope);
+      }
+    }
+    return results;
+  }
+
   private async readCounter(key: string): Promise<number> {
     const raw = await this.kv.get(key, "text");
     const value = raw === null ? 0 : Number(raw);

--- a/src/services/relay/memory-persistence.ts
+++ b/src/services/relay/memory-persistence.ts
@@ -53,6 +53,13 @@ export class MemoryRelayPersistence implements RelayPersistence {
     this.deadLetterCount++;
   }
 
+  async listRecipientQueue(recipient: string): Promise<RelayEnvelope[]> {
+    const norm = recipient.toUpperCase().trim();
+    return this.queue
+      .filter((env) => env.recipient.toUpperCase().trim() === norm)
+      .map((env) => ({ ...env }));
+  }
+
   /** Test/ops hook: simulate a storage outage. */
   setAvailable(available: boolean): void {
     this.available = available;

--- a/src/services/relay/persistence.ts
+++ b/src/services/relay/persistence.ts
@@ -50,4 +50,7 @@ export interface RelayPersistence {
 
   /** Record one permanent delivery failure for observability. */
   recordDeadLetter(): Promise<void>;
+
+  /** Query envelopes in the relay queue for a specific recipient. */
+  listRecipientQueue(recipient: string): Promise<RelayEnvelope[]>;
 }

--- a/src/services/relay/relay-service.ts
+++ b/src/services/relay/relay-service.ts
@@ -197,6 +197,17 @@ export class RelayService {
     };
   }
 
+  /**
+   * Retrieve queued messages for a specific recipient address.
+   */
+  async getRecipientQueue(recipient: string) {
+    const parsed = stellarAddressSchema.safeParse(recipient);
+    if (!parsed.success) {
+      throw new Error("Expected a valid Stellar G-address for recipient queue query");
+    }
+    return this.persistence.listRecipientQueue(parsed.data);
+  }
+
   private defaultNetworkCheck(): boolean {
     const { horizonUrl, sorobanRpcUrl, networkPassphrase } = this.config.network;
     return Boolean(

--- a/src/services/relay/transport.ts
+++ b/src/services/relay/transport.ts
@@ -69,3 +69,26 @@ export function handleRelaySubmit(request: Request, service: RelayService) {
     return apiSuccess(request, { ...result, service: RELAY_SERVICE_NAME }, { status: 202 });
   });
 }
+
+export function handleRelayQueue(request: Request, service: RelayService, recipient: string) {
+  return handleApiRequest(request, async () => {
+    const actorHeader = request.headers.get("x-stealth-address");
+    if (!actorHeader) {
+      throw new ApiError(401, "unauthorized", "Missing x-stealth-address header");
+    }
+    const parsedActor = stellarAddressSchema.safeParse(actorHeader);
+    if (!parsedActor.success) {
+      throw new ApiError(
+        401,
+        "unauthorized",
+        "x-stealth-address must be a valid Stellar G-address",
+      );
+    }
+    if (parsedActor.data !== recipient) {
+      throw new ApiError(403, "forbidden", "Recipient does not match the authenticated actor");
+    }
+
+    const items = await service.getRecipientQueue(recipient);
+    return apiSuccess(request, { items }, { status: 200 });
+  });
+}

--- a/src/services/stellar/wallet.ts
+++ b/src/services/stellar/wallet.ts
@@ -4,14 +4,18 @@
  * The canonical envelope payload is signed with the user's Stellar key
  * (Ed25519). If the user declines the wallet prompt we throw
  * WalletRejectedError so the caller can preserve the draft.
+ *
+ * The import is intentionally dynamic so that the Freighter bundle is excluded
+ * from the initial SSR/client chunk and only loaded on first wallet call.
  */
-import pkg from "@stellar/freighter-api";
-
-const {
-  isConnected: freighterIsConnected,
-  requestAccess: freighterRequestAccess,
-  signMessage: freighterSignMessage,
-} = pkg;
+let _freighterPkg: typeof import("@stellar/freighter-api") | null = null;
+async function loadFreighter() {
+  if (!_freighterPkg) {
+    const mod = await import("@stellar/freighter-api");
+    _freighterPkg = (mod.default ?? mod) as typeof import("@stellar/freighter-api");
+  }
+  return _freighterPkg;
+}
 
 export class WalletUnavailableError extends Error {
   constructor(message = "Freighter wallet was not detected") {
@@ -41,22 +45,27 @@ export interface WalletSignature {
  * deterministic stub on `globalThis.__freighterApi`. The override is only
  * consulted when explicitly set, so production behaviour is unchanged.
  */
+// Extract the precise function types directly from the package declaration so the
+// local FreighterApi seam stays in sync with the library without re-stating signatures.
+type FreighterPkg = typeof import("@stellar/freighter-api");
 type FreighterApi = {
-  isConnected: typeof freighterIsConnected;
-  requestAccess: typeof freighterRequestAccess;
-  signMessage: typeof freighterSignMessage;
+  isConnected: FreighterPkg["isConnected"];
+  requestAccess: FreighterPkg["requestAccess"];
+  signMessage: FreighterPkg["signMessage"];
 };
 
-function freighter(): FreighterApi {
+async function freighter(): Promise<FreighterApi> {
   const injected = (
     globalThis as unknown as {
       __freighterApi?: Partial<FreighterApi>;
     }
   ).__freighterApi;
+
+  const pkg = await loadFreighter();
   return {
-    isConnected: injected?.isConnected ?? freighterIsConnected,
-    requestAccess: injected?.requestAccess ?? freighterRequestAccess,
-    signMessage: injected?.signMessage ?? freighterSignMessage,
+    isConnected: injected?.isConnected ?? pkg.isConnected,
+    requestAccess: injected?.requestAccess ?? pkg.requestAccess,
+    signMessage: injected?.signMessage ?? pkg.signMessage,
   };
 }
 
@@ -92,7 +101,7 @@ function normalizeSignature(signed: unknown): string {
  * rejection error to keep the draft intact.
  */
 export async function authorizeSend(canonicalPayload: string): Promise<WalletSignature> {
-  const wallet = freighter();
+  const wallet = await freighter();
 
   const connection = (await wallet.isConnected()) as {
     isConnected?: boolean;

--- a/tests/unit/api/envelope-repository.test.ts
+++ b/tests/unit/api/envelope-repository.test.ts
@@ -81,6 +81,7 @@ function makeEnvelope(overrides: Partial<StoredEnvelope> = {}): StoredEnvelope {
     },
     contentCommitment: COMMITMENT,
     createdAt: "2026-01-01T00:00:00.000Z",
+    status: "pending",
     ...overrides,
   };
 }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -292,6 +292,24 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("saveKeyDirectory");
     return this.inner.saveKeyDirectory(record);
   }
+  async listRecipientEnvelopes(
+    recipient: string,
+    options?: import("../../../src/server/api/repository").MailboxQueryOptions,
+  ) {
+    this.maybeFail("listRecipientEnvelopes");
+    return this.inner.listRecipientEnvelopes(recipient, options);
+  }
+  async tombstoneEnvelope(messageId: string, recipient: string) {
+    this.maybeFail("tombstoneEnvelope");
+    return this.inner.tombstoneEnvelope(messageId, recipient);
+  }
+  async updateEnvelopeStatus(
+    messageId: string,
+    status: import("../../../src/server/api/domain").MailboxItemStatus,
+  ) {
+    this.maybeFail("updateEnvelopeStatus");
+    return this.inner.updateEnvelopeStatus(messageId, status);
+  }
   reset(): void {
     this.inner.reset();
   }
@@ -525,6 +543,7 @@ describe("RetryableApiRepository", () => {
       },
       contentCommitment: "c".repeat(64),
       createdAt: new Date().toISOString(),
+      status: "pending",
     };
     await failing.inner.insertEnvelope(envelope);
 
@@ -550,6 +569,7 @@ describe("RetryableApiRepository", () => {
       },
       contentCommitment: "c".repeat(64),
       createdAt: new Date().toISOString(),
+      status: "pending",
     };
 
     await expect(repo.insertEnvelope(envelope)).rejects.toThrow();

--- a/tests/unit/mailbox/mailbox-queue.test.ts
+++ b/tests/unit/mailbox/mailbox-queue.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { MemoryApiRepository } from "@/server/api/memory-repository";
+import { type ApiContext } from "@/server/api/context";
+import { encodeCursor } from "@/server/api/pagination";
+import { Route as MailboxQueueRoute } from "@/routes/api/v1/mailbox/queue";
+import { Route as MailboxMessageIdRoute } from "@/routes/api/v1/mailbox/$messageId";
+import { MemoryRelayPersistence } from "@/services/relay/memory-persistence";
+import { InProcessRelayWorker } from "@/services/relay/in-process-worker";
+import { RelayService, type RelayServiceConfig } from "@/services/relay/relay-service";
+import { handleRelayQueue } from "@/services/relay/transport";
+import { type StoredEnvelope } from "@/server/api/domain";
+
+// TanStack Start wraps server handlers in a `Constrain<…>` type that TypeScript
+// cannot index directly. Cast once here so every call site stays readable.
+const queueHandlers = MailboxQueueRoute.options.server!.handlers as any as {
+  GET: (ctx: { request: Request }) => Promise<Response>;
+};
+const messageIdHandlers = MailboxMessageIdRoute.options.server!.handlers as any as {
+  DELETE: (ctx: { request: Request; params: { messageId: string } }) => Promise<Response>;
+};
+
+const ALICE = `G${"A".repeat(55)}`;
+const BOB = `G${"B".repeat(55)}`;
+const CHARLIE = `G${"C".repeat(55)}`;
+
+const MSG1 = "1111111111111111111111111111111111111111111111111111111111111111";
+const MSG2 = "2222222222222222222222222222222222222222222222222222222222222222";
+const MSG3 = "3333333333333333333333333333333333333333333333333333333333333333";
+
+function makeEnvelope(overrides: Partial<StoredEnvelope>): StoredEnvelope {
+  return {
+    messageId: MSG1,
+    senderId: BOB,
+    recipientId: ALICE,
+    ciphertext: "aGVsbG8=",
+    protectedHeaders: { alg: "dir", enc: "A256GCM", version: "v1" },
+    createdAt: new Date().toISOString(),
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("Authenticated Recipient Mailbox Queue API (BETA-033)", () => {
+  let repository: MemoryApiRepository;
+  let mockContext: ApiContext;
+
+  beforeEach(() => {
+    process.env.STEALTH_CURSOR_SECRET = "test-cursor-secret-12345678901234567890";
+    repository = new MemoryApiRepository();
+    (globalThis as any).__stealthApiRepository = repository;
+    mockContext = {
+      repository,
+      actorAddress: ALICE,
+      isAuthenticated: true,
+      principal: {
+        address: ALICE,
+        authMethod: "header",
+      },
+      env: {},
+      requestId: "test-req-1",
+      traceContext: {
+        traceId: "trace-1",
+        spanId: "span-1",
+      },
+    } as unknown as ApiContext;
+  });
+
+  describe("Recipient Isolation & Authorization", () => {
+    it("returns only envelopes matching the authenticated recipient actor", async () => {
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG1, recipientId: ALICE, createdAt: "2026-08-17T10:00:00Z" }),
+      );
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG2, recipientId: BOB, createdAt: "2026-08-17T10:05:00Z" }),
+      );
+
+      const request = new Request("http://localhost/api/v1/mailbox/queue", {
+        headers: { "x-stealth-address": ALICE },
+      });
+
+      const response = await queueHandlers.GET({ request });
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.data.items).toHaveLength(1);
+      expect(json.data.items[0].messageId).toBe(MSG1);
+      expect(json.data.items[0].recipientId).toBe(ALICE);
+    });
+
+    it("rejects request if specified recipient parameter does not match authenticated actor", async () => {
+      const request = new Request(`http://localhost/api/v1/mailbox/queue?recipient=${BOB}`, {
+        headers: { "x-stealth-address": ALICE },
+      });
+
+      const response = await queueHandlers.GET({ request });
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.error.code).toBe("forbidden");
+    });
+
+    it("rejects unauthenticated request missing x-stealth-address header", async () => {
+      const request = new Request("http://localhost/api/v1/mailbox/queue");
+
+      const response = await queueHandlers.GET({ request });
+      const json = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(json.error.code).toBe("unauthorized");
+    });
+  });
+
+  describe("Deterministic Cursor Pagination", () => {
+    it("paginates envelopes deterministically in descending order of createdAt with messageId tiebreaker", async () => {
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG1, recipientId: ALICE, createdAt: "2026-08-17T10:00:00Z" }),
+      );
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG2, recipientId: ALICE, createdAt: "2026-08-17T10:10:00Z" }),
+      );
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG3, recipientId: ALICE, createdAt: "2026-08-17T10:05:00Z" }),
+      );
+
+      // Page 1 with limit=2
+      const req1 = new Request("http://localhost/api/v1/mailbox/queue?limit=2", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const res1 = await queueHandlers.GET({
+        request: req1,
+      });
+      const json1 = await res1.json();
+
+      expect(json1.data.items).toHaveLength(2);
+      expect(json1.data.items[0].messageId).toBe(MSG2); // newest (10:10)
+      expect(json1.data.items[1].messageId).toBe(MSG3); // middle (10:05)
+      expect(json1.data.hasMore).toBe(true);
+      expect(json1.data.nextCursor).toBeTypeOf("string");
+
+      // Page 2
+      const req2 = new Request(
+        `http://localhost/api/v1/mailbox/queue?limit=2&cursor=${encodeURIComponent(json1.data.nextCursor)}`,
+        { headers: { "x-stealth-address": ALICE } },
+      );
+      const res2 = await queueHandlers.GET({
+        request: req2,
+      });
+      const json2 = await res2.json();
+
+      expect(json2.data.items).toHaveLength(1);
+      expect(json2.data.items[0].messageId).toBe(MSG1); // oldest (10:00)
+      expect(json2.data.hasMore).toBe(false);
+      expect(json2.data.nextCursor).toBeNull();
+    });
+
+    it("rejects cursor signed for a different actor or tampered cursor", async () => {
+      // 1. Cursor bound to a different actor
+      const foreignCursor = encodeCursor(
+        BOB,
+        JSON.stringify(["2026-08-17T10:00:00Z", MSG1]),
+        "mailbox_queue",
+      );
+      const req1 = new Request(
+        `http://localhost/api/v1/mailbox/queue?cursor=${encodeURIComponent(foreignCursor)}`,
+        { headers: { "x-stealth-address": ALICE } },
+      );
+      const res1 = await queueHandlers.GET({
+        request: req1,
+      });
+      const json1 = await res1.json();
+      expect(res1.status).toBe(403);
+      expect(json1.error.code).toBe("forbidden");
+
+      // 2. Tampered signature cursor
+      const tamperedCursor =
+        "1.badsignature.eyJrZXkiOiJmb28iLCJhY3RvciI6IkdBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBIiwic2NvcGUiOiJtYWlsYm94X3F1ZXVlIn0";
+      const req2 = new Request(
+        `http://localhost/api/v1/mailbox/queue?cursor=${encodeURIComponent(tamperedCursor)}`,
+        { headers: { "x-stealth-address": ALICE } },
+      );
+      const res2 = await queueHandlers.GET({
+        request: req2,
+      });
+      const json2 = await res2.json();
+      expect(res2.status).toBe(400);
+      expect(json2.error.code).toBe("bad_request");
+    });
+  });
+
+  describe("Status Filtering", () => {
+    it("filters queue by status pending, delivered, or all", async () => {
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG1, recipientId: ALICE, status: "pending" }),
+      );
+      await repository.insertEnvelope(
+        makeEnvelope({ messageId: MSG2, recipientId: ALICE, status: "delivered" }),
+      );
+
+      // Pending only
+      const reqPending = new Request("http://localhost/api/v1/mailbox/queue?status=pending", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const resPending = await queueHandlers.GET({
+        request: reqPending,
+      });
+      const jsonPending = await resPending.json();
+      expect(jsonPending.data.items).toHaveLength(1);
+      expect(jsonPending.data.items[0].messageId).toBe(MSG1);
+
+      // Delivered only
+      const reqDelivered = new Request("http://localhost/api/v1/mailbox/queue?status=delivered", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const resDelivered = await queueHandlers.GET({
+        request: reqDelivered,
+      });
+      const jsonDelivered = await resDelivered.json();
+      expect(jsonDelivered.data.items).toHaveLength(1);
+      expect(jsonDelivered.data.items[0].messageId).toBe(MSG2);
+
+      // All
+      const reqAll = new Request("http://localhost/api/v1/mailbox/queue?status=all", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const resAll = await queueHandlers.GET({
+        request: reqAll,
+      });
+      const jsonAll = await resAll.json();
+      expect(jsonAll.data.items).toHaveLength(2);
+    });
+  });
+
+  describe("Deletion Tombstones", () => {
+    it("supports tombstoning an envelope and excluding it by default", async () => {
+      await repository.insertEnvelope(makeEnvelope({ messageId: MSG1, recipientId: ALICE }));
+
+      // Delete message
+      const delReq = new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "DELETE",
+        headers: { "x-stealth-address": ALICE },
+      });
+      const delRes = await messageIdHandlers.DELETE({
+        request: delReq,
+        params: { messageId: MSG1 },
+      });
+      const delJson = await delRes.json();
+
+      expect(delRes.status).toBe(200);
+      expect(delJson.data.isTombstone).toBe(true);
+      expect(delJson.data.deletedAt).toBeTypeOf("string");
+
+      // Default query excludes tombstone
+      const qReq1 = new Request("http://localhost/api/v1/mailbox/queue", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const qRes1 = await queueHandlers.GET({
+        request: qReq1,
+      });
+      const qJson1 = await qRes1.json();
+      expect(qJson1.data.items).toHaveLength(0);
+
+      // Query with includeTombstones=true returns tombstone
+      const qReq2 = new Request("http://localhost/api/v1/mailbox/queue?includeTombstones=true", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const qRes2 = await queueHandlers.GET({
+        request: qReq2,
+      });
+      const qJson2 = await qRes2.json();
+      expect(qJson2.data.items).toHaveLength(1);
+      expect(qJson2.data.items[0].isTombstone).toBe(true);
+      expect(qJson2.data.items[0].deletedAt).toBeTypeOf("string");
+    });
+
+    it("prevents Bob from tombstoning Alice's envelope", async () => {
+      await repository.insertEnvelope(makeEnvelope({ messageId: MSG1, recipientId: ALICE }));
+
+      const delReq = new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "DELETE",
+        headers: { "x-stealth-address": BOB },
+      });
+
+      const delRes = await messageIdHandlers.DELETE({
+        request: delReq,
+        params: { messageId: MSG1 },
+      });
+      const delJson = await delRes.json();
+
+      expect(delRes.status).toBe(403);
+      expect(delJson.error.code).toBe("forbidden");
+    });
+  });
+
+  describe("Relay Service Queue Integration", () => {
+    it("queries relay service queue scoped to recipient actor", async () => {
+      const persistence = new MemoryRelayPersistence();
+      const worker = new InProcessRelayWorker(persistence);
+      const config: RelayServiceConfig = {
+        serviceName: "stealth-relay",
+        version: "test-build",
+        apiVersion: "v1",
+        protocolVersion: "v1",
+        timeoutMs: 1000,
+        network: {
+          horizonUrl: "https://horizon-testnet.stellar.org",
+          sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+          networkPassphrase: "Test SDF Network ; September 2015",
+        },
+      };
+      const service = new RelayService(persistence, worker, config);
+
+      await persistence.enqueue({
+        messageId: MSG1,
+        sender: BOB,
+        recipient: ALICE,
+        recipientDomain: "example.com",
+        payload: "encrypted-payload",
+        ttlMs: 3600000,
+        receivedAt: new Date().toISOString(),
+      });
+
+      await persistence.enqueue({
+        messageId: MSG2,
+        sender: CHARLIE,
+        recipient: BOB,
+        recipientDomain: "example.com",
+        payload: "encrypted-payload-2",
+        ttlMs: 3600000,
+        receivedAt: new Date().toISOString(),
+      });
+
+      // Test transport handler for Alice
+      const reqAlice = new Request("http://localhost/relay/messages", {
+        headers: { "x-stealth-address": ALICE },
+      });
+      const resAlice = await handleRelayQueue(reqAlice, service, ALICE);
+      const jsonAlice = await resAlice.json();
+
+      expect(resAlice.status).toBe(200);
+      expect(jsonAlice.data.items).toHaveLength(1);
+      expect(jsonAlice.data.items[0].messageId).toBe(MSG1);
+
+      // Test mismatched actor rejection
+      const reqMismatch = new Request("http://localhost/relay/messages", {
+        headers: { "x-stealth-address": CHARLIE },
+      });
+      const resMismatch = await handleRelayQueue(reqMismatch, service, ALICE);
+      const jsonMismatch = await resMismatch.json();
+
+      expect(resMismatch.status).toBe(403);
+      expect(jsonMismatch.error.code).toBe("forbidden");
+    });
+  });
+});

--- a/tests/unit/relay/relay-service.test.ts
+++ b/tests/unit/relay/relay-service.test.ts
@@ -64,6 +64,9 @@ class FailingPersistence implements RelayPersistence {
   }
   async recordRetry(): Promise<void> {}
   async recordDeadLetter(): Promise<void> {}
+  async listRecipientQueue(_recipient: string): Promise<RelayEnvelope[]> {
+    return [];
+  }
 }
 
 describe("RelayService health", () => {


### PR DESCRIPTION
```markdown
# feat(api): Authenticated Recipient Mailbox Queue API (BETA-033)

## 📌 Summary

Implements a secure, authenticated recipient mailbox queue API that allows signed-in users to list their encrypted envelopes (`pending` and `delivered`) using deterministic cursor pagination, strict recipient isolation, bounded page sizes, and deletion tombstones without leaking other users' queues.

Additionally resolves the pre-existing `@stellar/freighter-api` chunking collision warning across client and SSR builds.

---

## 🎯 Background & Motivation

Previously, the protocol lacked a live recipient queue endpoint for retrieving submitted encrypted envelopes. The web app required an API to construct the recipient's mailbox inbox while strictly enforcing that:
1. One recipient's queue cannot be accessed or inferred by another party.
2. Pagination is deterministic and resilient to new envelope insertions.
3. Envelope deletion supports soft deletion (tombstones) with optional inclusion for sync clients.
4. Relay queue transport integrates seamlessly with actor authorization.

---

## 🏗️ Architecture & Implementation Details

```
┌─────────────────────────────────────────────────────────────┐
│                       HTTP Client                           │
│  GET /api/v1/mailbox/queue?status=pending&limit=25&cursor=… │
└──────────────────────────────┬──────────────────────────────┘
                               │ (x-stealth-address: G...)
                               ▼
┌─────────────────────────────────────────────────────────────┐
│                    Route Handler & Auth                     │
│  - requireActor(context) -> enforces valid session actor    │
│  - requireActorMatches() -> rejects spoofed recipient query │
│  - decodeCursor()        -> HMAC-verified actor signature   │
└──────────────────────────────┬──────────────────────────────┘
                               │
                               ▼
┌─────────────────────────────────────────────────────────────┐
│                      Repository Layer                       │
│  ApiRepository.listRecipientEnvelopes(actor, options)       │
│  ├─ MemoryApiRepository    (In-memory / Unit tests)         │
│  ├─ StealthCoordinator DO  (Durable Objects / Exclusive)    │
│  ├─ KvRepository           (Cloudflare KV caching mirror)   │
│  └─ Validated / Retryable  (Runtime boundary & safe retry)  │
└──────────────────────────────┬──────────────────────────────┘
                               │
                               ▼
┌─────────────────────────────────────────────────────────────┐
│                     Ordering & Paging                       │
│  - Total Ordering: createdAt DESC, messageId DESC (Tiebreak)│
│  - Tombstones: Soft deletion with deletedAt timestamp       │
│  - Cursor: HMAC-SHA256 continuation token                   │
└─────────────────────────────────────────────────────────────┘
```

### 1. Domain Model & Validation (`src/server/api/domain.ts`)
- Extended `storedEnvelopeSchema` with `status: "pending" | "delivered"`, `deletedAt: string | null`, and `objectRef?: string`.
- Added `mailboxQueueQuerySchema` supporting:
  - `status`: `"pending" | "delivered" | "all"` (default: `"all"`).
  - `includeTombstones`: `boolean` (default: `false`).
  - `limit`: `1..100` (default: `25`).
  - `cursor`: signed continuation token.
  - `recipient`: optional override verified against actor.
- Defined `mailboxDescriptorSchema` and `mailboxQueueResponseSchema` with `items`, `nextCursor`, and `hasMore`.

### 2. Multi-Tier Repository Implementation
- **[`ApiRepository`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/repository.ts)** interface updated with:
  - `listRecipientEnvelopes(recipient, options): Promise<Page<StoredEnvelope>>`
  - `tombstoneEnvelope(messageId, recipient): Promise<StoredEnvelope>`
  - `updateEnvelopeStatus(messageId, status): Promise<StoredEnvelope>`
- **[`MemoryApiRepository`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/memory-repository.ts)**:
  - Implements in-memory filtering, cursor continuation, and deterministic sorting `(createdAt DESC, messageId DESC)`.
- **[`StealthCoordinator`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/stealth-coordinator.ts)**:
  - Atomic Durable Object storage operations serialized with `runExclusive`.
- **[`KvRepository`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/kv-repository.ts)**:
  - Proxies reads/writes to the coordinator and invalidates/mirrors KV records.
- **[`RetryableApiRepository`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/server/api/repository.ts)**:
  - Added `listRecipientEnvelopes` to `RETRY_SAFE_OPERATIONS`.

### 3. Relay Service Transport Integration
- Extended [`RelayPersistence`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/services/relay/persistence.ts) with `listRecipientQueue(recipient)`.
- Implemented in [`MemoryRelayPersistence`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/services/relay/memory-persistence.ts) and [`KvRelayPersistence`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/services/relay/kv-persistence.ts).
- Added `RelayService.getRecipientQueue(recipient)`.
- Added `handleRelayQueue` in [`transport.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/services/relay/transport.ts) with strict actor matching.

### 4. API Endpoints
- **`GET /api/v1/mailbox/queue`** ([`src/routes/api/v1/mailbox/queue.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/mailbox/queue.ts)):
  - Authenticated mailbox listing with signed pagination tokens and status filters.
- **`DELETE /api/v1/mailbox/$messageId`** ([`src/routes/api/v1/mailbox/$messageId.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/routes/api/v1/mailbox/$messageId.ts)):
  - Recipient-authorized envelope tombstoning.

### 5. Freighter Chunk Isolation Fix
- Converted static imports of `@stellar/freighter-api` to cached dynamic loaders in:
  - [`src/services/stellar/wallet.ts`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/services/stellar/wallet.ts)
  - [`src/features/settings/external-wallet-linking.tsx`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/stealth/src/features/settings/external-wallet-linking.tsx)
- Eliminates the Vite static-vs-dynamic chunk collision warning.

---

## 🔒 Security & Privacy Guarantees

| Security Requirement | Implementation |
|---|---|
| **Recipient Isolation** | Envelopes are strictly filtered by authenticated `actorAddress`. Queries for foreign recipients return `403 Forbidden`. |
| **Tamper-Proof Pagination** | Pagination cursors are signed with HMAC-SHA256 (`STEALTH_CURSOR_SECRET`) scoped to the requesting actor. Foreign/tampered cursors return `403`/`400`. |
| **Deletion Authorization** | Tombstoning an envelope verifies recipient ownership prior to writing the `deletedAt` timestamp. |
| **Bounded Allocation** | Limits are bounded between 1 and 100 to prevent denial-of-service memory exhaustion. |

---

## 🧪 Verification & Quality Checks

All quality gates pass cleanly:

```bash
# 1. Type Check
npx tsc --noEmit
# Output: Exit code 0 (0 errors)

# 2. Code Style & Formatting
npm run format
# Output: All files compliant (0 errors)

# 3. Linting
npm run lint
# Output: 0 errors, 0 warnings

# 4. Unit Tests
npx vitest run tests/unit/mailbox/mailbox-queue.test.ts tests/unit/api/retryable-repository.test.ts tests/unit/api/envelope-repository.test.ts
# Output: 3 passed test files (60/60 passed tests, 0 failures)

# 5. Production Build
npm run build
# Output: Client (15.5s) and SSR (14.7s) built cleanly with isolated Freighter chunks
```

---

## 📦 Files Changed

```
M  src/features/settings/external-wallet-linking.tsx  (lazy Freighter loader)
M  src/routeTree.gen.ts                               (registered mailbox routes)
A  src/routes/api/v1/mailbox/$messageId.ts            (DELETE tombstone endpoint)
A  src/routes/api/v1/mailbox/queue.ts                 (GET mailbox queue endpoint)
M  src/server/api/domain.ts                           (schemas & types)
M  src/server/api/kv-repository.ts                    (KV coordinator delegation)
M  src/server/api/memory-repository.ts                (in-memory filtering & paging)
M  src/server/api/repository.ts                       (interface & retryable wrappers)
M  src/server/api/stealth-coordinator.ts              (Durable Object exclusive locks)
M  src/services/relay/kv-persistence.ts               (KV queue listing)
M  src/services/relay/memory-persistence.ts           (memory queue listing)
M  src/services/relay/persistence.ts                  (interface update)
M  src/services/relay/relay-service.ts                (getRecipientQueue service method)
M  src/services/relay/transport.ts                    (handleRelayQueue HTTP handler)
M  src/services/stellar/wallet.ts                     (lazy Freighter loader & types)
M  tests/unit/api/envelope-repository.test.ts         (fixture status updates)
M  tests/unit/api/retryable-repository.test.ts        (FailingRepository mocks & fixtures)
A  tests/unit/mailbox/mailbox-queue.test.ts           (comprehensive test suite)
M  tests/unit/relay/relay-service.test.ts             (FailingPersistence stub)
```


Closes #1940