### PR TITLE
fix(compose): prevent schedule-send readiness race

### DIFF
--- a/src/components/mail/Compose.tsx
+++ b/src/components/mail/Compose.tsx
@@ -519,8 +519,18 @@ export function Compose({
               <motion.button
                 whileTap={{ scale: 0.97 }}
                 onClick={() => handleSend(true)}
-                disabled={isSending}
-                className="ml-auto inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-muted-foreground transition hover:bg-white/6 hover:text-foreground"
+                disabled={
+                  isSending ||
+                  isPolicyBlocking(quoteState) ||
+                  resolvedRecipients.length === 0 ||
+                  resolvedRecipients.some(
+                    (recipient) =>
+                      recipient.state === "blocked" ||
+                      recipient.state === "invalid" ||
+                      recipient.state === "resolving",
+                  )
+                }
+                className="ml-auto inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-1.5 text-xs text-muted-foreground transition hover:bg-white/6 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <CalendarClock className="h-3.5 w-3.5" />
                 Schedule


### PR DESCRIPTION
## Summary
- disable the Schedule action until recipient resolution has completed
- apply the same blocked/invalid/policy readiness guard used by immediate Send
- keep the compose panel open only for genuine validation failures

## Root cause
The Schedule button remained clickable while the debounced recipient lookup was still in the `resolving` state. The click reached validation too early, was rejected, and left “New message” visible. This made the scheduled-send E2E test race-dependent.

## Validation
- Existing scheduled-send E2E test covers the regression
- Full GitHub Actions CI requested on this branch