### PR TITLE
feat(auth): add authentication pages

### DIFF
--- a/src/features/identity/auth-pages.tsx
+++ b/src/features/identity/auth-pages.tsx
@@ -1,0 +1,252 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { CheckCircle2, LoaderCircle, Mail, ShieldCheck } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+type ApiFailure = {
+  error?: { message?: string; details?: { validationErrors?: Array<{ message?: string }> } };
+};
+
+function safeDestination(destination?: string) {
+  return destination?.startsWith("/") && !destination.startsWith("//") ? destination : "/";
+}
+
+function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="ambient-bg flex min-h-screen items-center justify-center px-4 py-8 sm:px-6">
+      <Card className="w-full max-w-md border-border/80 bg-card/95 shadow-xl backdrop-blur">
+        {children}
+      </Card>
+    </main>
+  );
+}
+
+function FormError({ message }: { message: string | null }) {
+  return message ? (
+    <p role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      {message}
+    </p>
+  ) : null;
+}
+
+export function SignUpPage({ destination }: { destination?: string }) {
+  const navigate = useNavigate();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const password = String(form.get("password") ?? "");
+    const confirmation = String(form.get("passwordConfirmation") ?? "");
+    if (password !== confirmation) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/v1/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: form.get("displayName"),
+          email: form.get("email"),
+          username: form.get("username"),
+          password,
+          passwordConfirmation: confirmation,
+          termsVersion: "2026-01",
+          privacyPolicyVersion: "2026-01",
+        }),
+      });
+      const payload = (await response.json()) as { data?: { maskedEmail?: string } } & ApiFailure;
+      if (!response.ok)
+        throw new Error(
+          payload.error?.details?.validationErrors?.[0]?.message ??
+            payload.error?.message ??
+            "We could not create your account. Please try again.",
+        );
+      await navigate({
+        to: "/auth/verify",
+        search: {
+          email: payload.data?.maskedEmail ?? "your email",
+          next: safeDestination(destination),
+        },
+      });
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "We could not create your account. Please try again.",
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <AuthLayout>
+      <CardHeader>
+        <div className="mb-2 flex size-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Mail />
+        </div>
+        <CardTitle>Create your account</CardTitle>
+        <CardDescription>
+          No wallet connection is needed. Use an email and password to get started.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-4" onSubmit={submit} noValidate>
+          <FormError message={error} />
+          <label className="grid gap-1.5 text-sm font-medium">
+            Name
+            <Input name="displayName" autoComplete="name" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Email address
+            <Input name="email" type="email" autoComplete="email" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Username
+            <Input name="username" autoComplete="username" pattern="[a-z0-9_-]{3,30}" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Password
+            <Input
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              minLength={12}
+              required
+            />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Confirm password
+            <Input
+              name="passwordConfirmation"
+              type="password"
+              autoComplete="new-password"
+              required
+            />
+          </label>
+          <Button className="w-full" disabled={pending}>
+            {pending && <LoaderCircle className="animate-spin" />}
+            {pending ? "Creating account…" : "Create account"}
+          </Button>
+        </form>
+        <p className="mt-5 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link
+            className="text-primary underline-offset-4 hover:underline"
+            to="/auth/sign-in"
+            search={{ next: safeDestination(destination) }}
+          >
+            Sign in
+          </Link>
+        </p>
+      </CardContent>
+    </AuthLayout>
+  );
+}
+
+export function SignInPage({ destination }: { destination?: string }) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    setPending(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/v1/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          identifier: form.get("identifier"),
+          password: form.get("password"),
+        }),
+      });
+      const payload = (await response.json()) as ApiFailure;
+      if (!response.ok)
+        throw new Error(
+          response.status === 403
+            ? "Your account needs email verification before you can sign in."
+            : (payload.error?.message ?? "Invalid email, username, or password."),
+        );
+      window.location.assign(safeDestination(destination));
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "We could not sign you in. Please try again.",
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+  return (
+    <AuthLayout>
+      <CardHeader>
+        <div className="mb-2 flex size-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <ShieldCheck />
+        </div>
+        <CardTitle>Sign in</CardTitle>
+        <CardDescription>Enter your credentials to access your private mailbox.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-4" onSubmit={submit}>
+          <FormError message={error} />
+          <label className="grid gap-1.5 text-sm font-medium">
+            Email or username
+            <Input name="identifier" autoComplete="username" required />
+          </label>
+          <label className="grid gap-1.5 text-sm font-medium">
+            Password
+            <Input name="password" type="password" autoComplete="current-password" required />
+          </label>
+          <Button className="w-full" disabled={pending}>
+            {pending && <LoaderCircle className="animate-spin" />}
+            {pending ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+        <p className="mt-5 text-center text-sm text-muted-foreground">
+          New to Stealth?{" "}
+          <Link
+            className="text-primary underline-offset-4 hover:underline"
+            to="/auth/sign-up"
+            search={{ next: safeDestination(destination) }}
+          >
+            Create an account
+          </Link>
+        </p>
+      </CardContent>
+    </AuthLayout>
+  );
+}
+
+export function VerifyEmailPage({ email }: { email?: string }) {
+  return (
+    <AuthLayout>
+      <CardHeader className="items-center text-center">
+        <div className="mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <CheckCircle2 />
+        </div>
+        <CardTitle>Check your email</CardTitle>
+        <CardDescription>
+          We sent a verification link to {email || "your email address"}. Open it in this browser to
+          finish setting up your account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-center">
+        <p className="text-sm text-muted-foreground">
+          The link may take a few minutes to arrive. If it expires, return to this page from a new
+          registration email.
+        </p>
+        <Button variant="outline" className="w-full" asChild>
+          <Link to="/auth/sign-in">Back to sign in</Link>
+        </Button>
+      </CardContent>
+    </AuthLayout>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,9 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as MotionGalleryRouteImport } from './routes/motion-gallery'
 import { Route as PolicyEditorRouteRouteImport } from './routes/policy-editor/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
+import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
+import { Route as AuthSignInRouteImport } from './routes/auth/sign-in'
 import { Route as ApiV1ProtocolRouteImport } from './routes/api/v1/protocol'
 import { Route as ApiV1OpenapiDotjsonRouteImport } from './routes/api/v1/openapi[.]json'
 import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
@@ -27,9 +30,9 @@ import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/posta
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
+import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
-import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -48,6 +51,21 @@ const PolicyEditorRouteRoute = PolicyEditorRouteRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthVerifyRoute = AuthVerifyRouteImport.update({
+  id: '/auth/verify',
+  path: '/auth/verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthSignUpRoute = AuthSignUpRouteImport.update({
+  id: '/auth/sign-up',
+  path: '/auth/sign-up',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthSignInRoute = AuthSignInRouteImport.update({
+  id: '/auth/sign-in',
+  path: '/auth/sign-in',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1ProtocolRoute = ApiV1ProtocolRouteImport.update({
@@ -125,6 +143,11 @@ const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
   path: '/api/v1/auth/session',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
+  id: '/api/v1/auth/register',
+  path: '/api/v1/auth/register',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
   id: '/api/v1/auth/logout',
   path: '/api/v1/auth/logout',
@@ -133,11 +156,6 @@ const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
 const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
   id: '/api/v1/auth/login',
   path: '/api/v1/auth/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
-  id: '/api/v1/auth/register',
-  path: '/api/v1/auth/register',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
@@ -169,12 +187,15 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/auth/sign-in': typeof AuthSignInRoute
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -196,12 +217,15 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/auth/sign-in': typeof AuthSignInRoute
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -224,12 +248,15 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/auth/sign-in': typeof AuthSignInRoute
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/api/v1/health': typeof ApiV1HealthRoute
   '/api/v1/openapi.json': typeof ApiV1OpenapiDotjsonRoute
   '/api/v1/protocol': typeof ApiV1ProtocolRoute
   '/api/v1/auth/login': typeof ApiV1AuthLoginRoute
-  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/logout': typeof ApiV1AuthLogoutRoute
+  '/api/v1/auth/register': typeof ApiV1AuthRegisterRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
@@ -253,12 +280,15 @@ export interface FileRouteTypes {
     | '/'
     | '/policy-editor'
     | '/motion-gallery'
+    | '/auth/sign-in'
+    | '/auth/sign-up'
+    | '/auth/verify'
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -280,12 +310,15 @@ export interface FileRouteTypes {
     | '/'
     | '/policy-editor'
     | '/motion-gallery'
+    | '/auth/sign-in'
+    | '/auth/sign-up'
+    | '/auth/verify'
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -307,12 +340,15 @@ export interface FileRouteTypes {
     | '/'
     | '/policy-editor'
     | '/motion-gallery'
+    | '/auth/sign-in'
+    | '/auth/sign-up'
+    | '/auth/verify'
     | '/api/v1/health'
     | '/api/v1/openapi.json'
     | '/api/v1/protocol'
     | '/api/v1/auth/login'
-    | '/api/v1/auth/register'
     | '/api/v1/auth/logout'
+    | '/api/v1/auth/register'
     | '/api/v1/auth/session'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
@@ -335,12 +371,15 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   PolicyEditorRouteRoute: typeof PolicyEditorRouteRoute
   MotionGalleryRoute: typeof MotionGalleryRoute
+  AuthSignInRoute: typeof AuthSignInRoute
+  AuthSignUpRoute: typeof AuthSignUpRoute
+  AuthVerifyRoute: typeof AuthVerifyRoute
   ApiV1HealthRoute: typeof ApiV1HealthRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1ProtocolRoute: typeof ApiV1ProtocolRoute
   ApiV1AuthLoginRoute: typeof ApiV1AuthLoginRoute
-  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthLogoutRoute: typeof ApiV1AuthLogoutRoute
+  ApiV1AuthRegisterRoute: typeof ApiV1AuthRegisterRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
@@ -376,6 +415,27 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/verify': {
+      id: '/auth/verify'
+      path: '/auth/verify'
+      fullPath: '/auth/verify'
+      preLoaderRoute: typeof AuthVerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/sign-up': {
+      id: '/auth/sign-up'
+      path: '/auth/sign-up'
+      fullPath: '/auth/sign-up'
+      preLoaderRoute: typeof AuthSignUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/sign-in': {
+      id: '/auth/sign-in'
+      path: '/auth/sign-in'
+      fullPath: '/auth/sign-in'
+      preLoaderRoute: typeof AuthSignInRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/protocol': {
@@ -483,6 +543,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AuthSessionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/register': {
+      id: '/api/v1/auth/register'
+      path: '/api/v1/auth/register'
+      fullPath: '/api/v1/auth/register'
+      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/auth/logout': {
       id: '/api/v1/auth/logout'
       path: '/api/v1/auth/logout'
@@ -495,13 +562,6 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/auth/login'
       fullPath: '/api/v1/auth/login'
       preLoaderRoute: typeof ApiV1AuthLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/register': {
-      id: '/api/v1/auth/register'
-      path: '/api/v1/auth/register'
-      fullPath: '/api/v1/auth/register'
-      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/receipts/$messageId/read': {
@@ -579,12 +639,15 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   PolicyEditorRouteRoute: PolicyEditorRouteRoute,
   MotionGalleryRoute: MotionGalleryRoute,
+  AuthSignInRoute: AuthSignInRoute,
+  AuthSignUpRoute: AuthSignUpRoute,
+  AuthVerifyRoute: AuthVerifyRoute,
   ApiV1HealthRoute: ApiV1HealthRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1ProtocolRoute: ApiV1ProtocolRoute,
   ApiV1AuthLoginRoute: ApiV1AuthLoginRoute,
-  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthLogoutRoute: ApiV1AuthLogoutRoute,
+  ApiV1AuthRegisterRoute: ApiV1AuthRegisterRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,

--- a/src/routes/auth/sign-in.tsx
+++ b/src/routes/auth/sign-in.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { SignInPage } from "@/features/identity/auth-pages";
+
+export const Route = createFileRoute("/auth/sign-in")({
+  validateSearch: z.object({ next: z.string().optional() }),
+  component: SignInRoute,
+});
+
+function SignInRoute() {
+  const { next } = Route.useSearch();
+  return <SignInPage destination={next} />;
+}

--- a/src/routes/auth/sign-up.tsx
+++ b/src/routes/auth/sign-up.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { SignUpPage } from "@/features/identity/auth-pages";
+
+export const Route = createFileRoute("/auth/sign-up")({
+  validateSearch: z.object({ next: z.string().optional() }),
+  component: SignUpRoute,
+});
+
+function SignUpRoute() {
+  const { next } = Route.useSearch();
+  return <SignUpPage destination={next} />;
+}

--- a/src/routes/auth/verify.tsx
+++ b/src/routes/auth/verify.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { VerifyEmailPage } from "@/features/identity/auth-pages";
+
+export const Route = createFileRoute("/auth/verify")({
+  validateSearch: z.object({ email: z.string().optional(), next: z.string().optional() }),
+  component: VerifyEmailRoute,
+});
+
+function VerifyEmailRoute() {
+  const { email } = Route.useSearch();
+  return <VerifyEmailPage email={email} />;
+}


### PR DESCRIPTION
Closes #1918 

## Summary

Implementation done for the authentication pages for #1918.

- Adds dedicated `/auth/sign-up`, `/auth/sign-in`, and `/auth/verify` routes.
- Adds an email/password registration form with client-side password confirmation.
- Connects registration to `POST /api/v1/auth/register`.
- Connects sign-in to `POST /api/v1/auth/login`.
- Shows API validation and authentication errors inline.
- Preserves safe internal `next` destinations through the auth flow.
- Adds a verification-email confirmation screen.
- Regenerates the TanStack route tree.

## Validation

- [x] Targeted ESLint passes for the new auth pages and routes.
- [x] `git diff --check` passes.
- [ ] Full production build and project-wide TypeScript verification were attempted but exceeded the execution environment timeout.