### PR TITLE
feat(wallet): encrypt managed wallet secrets

### DIFF
--- a/src/services/crypto/aead.ts
+++ b/src/services/crypto/aead.ts
@@ -80,6 +80,7 @@ export async function sealAead(
   key: CryptoKey,
   plaintext: Uint8Array,
   nonce?: Uint8Array,
+  additionalData?: Uint8Array,
 ): Promise<SealAeadResult> {
   const iv =
     nonce && nonce.length === GCM_NONCE_BYTES
@@ -87,7 +88,15 @@ export async function sealAead(
       : crypto.getRandomValues(new Uint8Array(GCM_NONCE_BYTES));
   const raw = toArrayBufferCopy(
     new Uint8Array(
-      await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, toArrayBufferCopy(plaintext)),
+      await crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+          additionalData: additionalData && toArrayBufferCopy(additionalData),
+        },
+        key,
+        toArrayBufferCopy(plaintext),
+      ),
     ),
   );
   const { ciphertext, tag } = splitTag(raw);
@@ -100,14 +109,14 @@ export interface OpenAeadResult {
 
 /**
  * Open a canonical AEAD envelope part: decrypt `ciphertext` with `tag` and
- * `nonce` under `key`. Fails closed on any authentication failure. Uses the
- * single `joinTag` formatter so it matches `sealAead` exactly.
+ * `nonce` under `key`. Fails closed on any authentication failure. Uses the`r`n * single `joinTag` formatter so it matches `sealAead` exactly.
  */
 export async function openAead(
   key: CryptoKey,
   ciphertext: Uint8Array,
   tag: Uint8Array,
   nonce: Uint8Array,
+  additionalData?: Uint8Array,
 ): Promise<OpenAeadResult> {
   if (tag.length !== GCM_TAG_BYTES) {
     throw new AeadError("auth tag must be exactly 16 bytes");
@@ -116,7 +125,11 @@ export async function openAead(
   const iv = toArrayBufferCopy(nonce);
   let plain: ArrayBuffer;
   try {
-    plain = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, combined);
+    plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv, additionalData: additionalData && toArrayBufferCopy(additionalData) },
+      key,
+      combined,
+    );
   } catch {
     throw new AeadError("AEAD decryption failed (tampered or wrong key)");
   }

--- a/src/services/crypto/managed-wallet-envelope.ts
+++ b/src/services/crypto/managed-wallet-envelope.ts
@@ -90,7 +90,7 @@ export class VersionedMasterKeyProvider implements MasterKeyProvider {
       try {
         provider.keys.set(
           version,
-          await crypto.subtle.importKey("raw", bytes, { name: "AES-GCM" }, false, [
+          await crypto.subtle.importKey("raw", bytes.slice().buffer, { name: "AES-GCM" }, false, [
             "encrypt",
             "decrypt",
           ]),
@@ -141,7 +141,7 @@ async function unwrapDataKey(
     );
     raw = opened.plaintext;
     if (raw.length !== DATA_KEY_BYTES) throw new ManagedWalletCryptoError();
-    return await crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, true, [
+    return await crypto.subtle.importKey("raw", raw.slice().buffer, { name: "AES-GCM" }, true, [
       "encrypt",
       "decrypt",
     ]);

--- a/src/services/crypto/managed-wallet-envelope.ts
+++ b/src/services/crypto/managed-wallet-envelope.ts
@@ -1,0 +1,256 @@
+/**
+ * Envelope encryption for server-managed Stellar wallet seeds.
+ *
+ * This is deliberately a server-only primitive.  Callers can create, persist,
+ * rewrap and use a sealed wallet, but can never ask it to return a seed.
+ */
+import { fromBase64, toBase64 } from "./codec";
+import { openAead, sealAead } from "./aead";
+import { clearSecret, disposeRawKey } from "./secret-buffer";
+
+export const MANAGED_WALLET_ENVELOPE_VERSION = 1;
+const DATA_KEY_BYTES = 32;
+const SEED_BYTES = 56;
+
+export class ManagedWalletCryptoError extends Error {
+  readonly code = "managed_wallet_crypto_error" as const;
+  constructor(message = "Managed wallet cryptographic operation failed") {
+    super(message);
+    this.name = "ManagedWalletCryptoError";
+  }
+}
+
+export interface ManagedWalletEnvelope {
+  readonly version: typeof MANAGED_WALLET_ENVELOPE_VERSION;
+  readonly address: string;
+  readonly masterKeyVersion: string;
+  /** AES-GCM ciphertext of the seed; this is the only seed representation persisted. */
+  readonly encryptedSeed: string;
+  readonly seedNonce: string;
+  readonly seedTag: string;
+  /** AES-GCM ciphertext of the per-wallet data key under the versioned master key. */
+  readonly wrappedDataKey: string;
+  readonly dataKeyNonce: string;
+  readonly dataKeyTag: string;
+}
+
+/** Persistence contract: records contain public ownership metadata plus a sealed envelope only. */
+export interface ManagedWalletRecord {
+  readonly owner: string;
+  readonly envelope: ManagedWalletEnvelope;
+  readonly updatedAt: string;
+}
+
+export interface ManagedWalletStore {
+  get(owner: string): Promise<ManagedWalletRecord | null>;
+  /** Compare-and-swap prevents a concurrent rotation from silently overwriting another. */
+  compareAndSet(
+    owner: string,
+    expectedUpdatedAt: string | null,
+    record: ManagedWalletRecord,
+  ): Promise<boolean>;
+}
+
+export class MemoryManagedWalletStore implements ManagedWalletStore {
+  private readonly records = new Map<string, ManagedWalletRecord>();
+
+  async get(owner: string): Promise<ManagedWalletRecord | null> {
+    return this.records.get(owner) ?? null;
+  }
+
+  async compareAndSet(
+    owner: string,
+    expectedUpdatedAt: string | null,
+    record: ManagedWalletRecord,
+  ): Promise<boolean> {
+    const current = this.records.get(owner);
+    if ((current?.updatedAt ?? null) !== expectedUpdatedAt) return false;
+    this.records.set(owner, record);
+    return true;
+  }
+}
+
+export interface MasterKeyProvider {
+  activeVersion(): string;
+  get(version: string): Promise<CryptoKey | null>;
+}
+
+/** In-memory provider useful for worker bindings and tests; key bytes are imported, not retained. */
+export class VersionedMasterKeyProvider implements MasterKeyProvider {
+  private readonly keys = new Map<string, CryptoKey>();
+
+  private constructor(private readonly active: string) {}
+
+  static async fromBase64(activeVersion: string, keys: Record<string, string>) {
+    if (!activeVersion || !keys[activeVersion])
+      throw new ManagedWalletCryptoError("Active key is unavailable");
+    const provider = new VersionedMasterKeyProvider(activeVersion);
+    for (const [version, encoded] of Object.entries(keys)) {
+      const bytes = fromBase64(encoded, DATA_KEY_BYTES);
+      try {
+        provider.keys.set(
+          version,
+          await crypto.subtle.importKey("raw", bytes, { name: "AES-GCM" }, false, [
+            "encrypt",
+            "decrypt",
+          ]),
+        );
+      } finally {
+        clearSecret(bytes);
+      }
+    }
+    return provider;
+  }
+
+  activeVersion(): string {
+    return this.active;
+  }
+
+  async get(version: string): Promise<CryptoKey | null> {
+    return this.keys.get(version) ?? null;
+  }
+}
+
+function aad(address: string): Uint8Array {
+  return new TextEncoder().encode(`stealth:managed-wallet:v1:${address}`);
+}
+
+async function dataKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+}
+
+async function requireMasterKey(provider: MasterKeyProvider, version: string): Promise<CryptoKey> {
+  const key = await provider.get(version);
+  if (!key) throw new ManagedWalletCryptoError("Required master key is unavailable");
+  return key;
+}
+
+async function unwrapDataKey(
+  envelope: ManagedWalletEnvelope,
+  provider: MasterKeyProvider,
+): Promise<CryptoKey> {
+  const masterKey = await requireMasterKey(provider, envelope.masterKeyVersion);
+  let raw: Uint8Array | undefined;
+  try {
+    const opened = await openAead(
+      masterKey,
+      fromBase64(envelope.wrappedDataKey),
+      fromBase64(envelope.dataKeyTag),
+      fromBase64(envelope.dataKeyNonce),
+      aad(envelope.address),
+    );
+    raw = opened.plaintext;
+    if (raw.length !== DATA_KEY_BYTES) throw new ManagedWalletCryptoError();
+    return await crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, true, [
+      "encrypt",
+      "decrypt",
+    ]);
+  } catch (error) {
+    if (error instanceof ManagedWalletCryptoError) throw error;
+    throw new ManagedWalletCryptoError();
+  } finally {
+    if (raw) clearSecret(raw);
+  }
+}
+
+export async function sealManagedWalletSeed(
+  seed: string,
+  address: string,
+  provider: MasterKeyProvider,
+): Promise<ManagedWalletEnvelope> {
+  const seedBytes = new TextEncoder().encode(seed);
+  let rawDataKey: ArrayBuffer | undefined;
+  try {
+    if (seedBytes.length !== SEED_BYTES || !/^S[A-Z2-7]{55}$/.test(seed)) {
+      throw new ManagedWalletCryptoError("Managed wallet seed is invalid");
+    }
+    const key = await dataKey();
+    const seedPart = await sealAead(key, seedBytes, undefined, aad(address));
+    rawDataKey = await crypto.subtle.exportKey("raw", key);
+    const masterKeyVersion = provider.activeVersion();
+    const wrapped = await sealAead(
+      await requireMasterKey(provider, masterKeyVersion),
+      new Uint8Array(rawDataKey),
+      undefined,
+      aad(address),
+    );
+    return {
+      version: MANAGED_WALLET_ENVELOPE_VERSION,
+      address,
+      masterKeyVersion,
+      encryptedSeed: toBase64(seedPart.ciphertext),
+      seedNonce: toBase64(seedPart.nonce),
+      seedTag: toBase64(seedPart.tag),
+      wrappedDataKey: toBase64(wrapped.ciphertext),
+      dataKeyNonce: toBase64(wrapped.nonce),
+      dataKeyTag: toBase64(wrapped.tag),
+    };
+  } catch (error) {
+    if (error instanceof ManagedWalletCryptoError) throw error;
+    throw new ManagedWalletCryptoError();
+  } finally {
+    clearSecret(seedBytes);
+    if (rawDataKey) disposeRawKey(rawDataKey);
+  }
+}
+
+/** Decrypt only for the duration of `useSeed`; the plaintext buffer is always cleared. */
+export async function withManagedWalletSeed<T>(
+  envelope: ManagedWalletEnvelope,
+  provider: MasterKeyProvider,
+  action: (seed: string) => Promise<T> | T,
+): Promise<T> {
+  if (envelope.version !== MANAGED_WALLET_ENVELOPE_VERSION) throw new ManagedWalletCryptoError();
+  let seedBytes: Uint8Array | undefined;
+  try {
+    const key = await unwrapDataKey(envelope, provider);
+    seedBytes = (
+      await openAead(
+        key,
+        fromBase64(envelope.encryptedSeed),
+        fromBase64(envelope.seedTag),
+        fromBase64(envelope.seedNonce),
+        aad(envelope.address),
+      )
+    ).plaintext;
+    if (seedBytes.length !== SEED_BYTES) throw new ManagedWalletCryptoError();
+    return await action(new TextDecoder().decode(seedBytes));
+  } catch (error) {
+    if (error instanceof ManagedWalletCryptoError) throw error;
+    throw new ManagedWalletCryptoError();
+  } finally {
+    if (seedBytes) clearSecret(seedBytes);
+  }
+}
+
+/** Rewraps only the data key, retaining the seed ciphertext and Stellar address unchanged. */
+export async function rewrapManagedWallet(
+  envelope: ManagedWalletEnvelope,
+  provider: MasterKeyProvider,
+  targetVersion = provider.activeVersion(),
+): Promise<ManagedWalletEnvelope> {
+  if (envelope.masterKeyVersion === targetVersion) return envelope;
+  let rawDataKey: ArrayBuffer | undefined;
+  try {
+    const key = await unwrapDataKey(envelope, provider);
+    rawDataKey = await crypto.subtle.exportKey("raw", key);
+    const wrapped = await sealAead(
+      await requireMasterKey(provider, targetVersion),
+      new Uint8Array(rawDataKey),
+      undefined,
+      aad(envelope.address),
+    );
+    return {
+      ...envelope,
+      masterKeyVersion: targetVersion,
+      wrappedDataKey: toBase64(wrapped.ciphertext),
+      dataKeyNonce: toBase64(wrapped.nonce),
+      dataKeyTag: toBase64(wrapped.tag),
+    };
+  } catch (error) {
+    if (error instanceof ManagedWalletCryptoError) throw error;
+    throw new ManagedWalletCryptoError();
+  } finally {
+    if (rawDataKey) disposeRawKey(rawDataKey);
+  }
+}

--- a/src/services/stellar/managed-wallet.ts
+++ b/src/services/stellar/managed-wallet.ts
@@ -7,11 +7,22 @@ import {
   Transaction,
 } from "@stellar/stellar-sdk";
 import type { BetaRuntimeConfig } from "../../config/schema";
+import {
+  type ManagedWalletRecord,
+  type ManagedWalletStore,
+  type MasterKeyProvider,
+  rewrapManagedWallet,
+  sealManagedWalletSeed,
+  withManagedWalletSeed,
+} from "../crypto/managed-wallet-envelope";
 import { type ManagedWalletIntent, validateIntent } from "../../server/api/authorization/intents";
 import { recordAuditEvent } from "../../server/api/audit";
 
 export class ManagedWalletService {
-  constructor(private config: BetaRuntimeConfig) {}
+  constructor(
+    private readonly config: BetaRuntimeConfig,
+    private readonly custody?: { store: ManagedWalletStore; keys: MasterKeyProvider },
+  ) {}
 
   public async signTransaction(
     intent: ManagedWalletIntent,
@@ -23,15 +34,9 @@ export class ManagedWalletService {
       // 1. Validate intent (throws if invalid)
       validateIntent(intent, actorAddress, this.config);
 
-      const operatorSecret = this.config.secrets?.operatorSecret;
-      if (!operatorSecret) {
-        throw new Error("Managed wallet not configured: missing operator secret");
-      }
-      const operatorKeypair = Keypair.fromSecret(operatorSecret);
-      const networkPassphrase = this.config.network.networkPassphrase;
-
       // 2. Parse the XDR to verify it matches the intent and doesn't contain arbitrary operations
       let tx: Transaction;
+      const networkPassphrase = this.config.network.networkPassphrase;
       try {
         tx = new Transaction(transactionXdr, networkPassphrase);
       } catch (err) {
@@ -54,7 +59,7 @@ export class ManagedWalletService {
       this.verifyOperationMatchesIntent(op, intent, this.config);
 
       // 3. Sign the transaction
-      tx.sign(operatorKeypair);
+      await this.signWithCustody(actorAddress, tx);
 
       // 4. Emit success audit event
       recordAuditEvent({
@@ -79,6 +84,60 @@ export class ManagedWalletService {
       });
       throw error;
     }
+  }
+  /** Provisioning is intentionally separate from signing and stores only a sealed record. */
+  public async provisionWallet(owner: string, seed: string): Promise<ManagedWalletRecord> {
+    if (!this.custody) throw new Error("Managed wallet custody is not configured");
+    const address = Keypair.fromSecret(seed).publicKey();
+    const existing = await this.custody.store.get(owner);
+    if (existing) {
+      if (existing.envelope.address !== address) throw new Error("Managed wallet already exists");
+      return existing; // duplicate provisioning is safe and does not rotate key material.
+    }
+    const record: ManagedWalletRecord = {
+      owner,
+      envelope: await sealManagedWalletSeed(seed, address, this.custody.keys),
+      updatedAt: new Date().toISOString(),
+    };
+    if (!(await this.custody.store.compareAndSet(owner, null, record))) {
+      const raced = await this.custody.store.get(owner);
+      if (raced?.envelope.address === address) return raced;
+      throw new Error("Managed wallet provisioning conflict");
+    }
+    return record;
+  }
+
+  /** Rotation rewraps the data key only; the encrypted seed and Stellar address remain unchanged. */
+  public async rotateWalletKey(
+    owner: string,
+    targetVersion?: string,
+  ): Promise<ManagedWalletRecord> {
+    if (!this.custody) throw new Error("Managed wallet custody is not configured");
+    const current = await this.custody.store.get(owner);
+    if (!current) throw new Error("Managed wallet was not found");
+    const envelope = await rewrapManagedWallet(current.envelope, this.custody.keys, targetVersion);
+    if (envelope === current.envelope) return current;
+    const updated = { ...current, envelope, updatedAt: new Date().toISOString() };
+    if (!(await this.custody.store.compareAndSet(owner, current.updatedAt, updated))) {
+      throw new Error("Managed wallet rotation conflict");
+    }
+    return updated;
+  }
+
+  private async signWithCustody(owner: string, tx: Transaction): Promise<void> {
+    if (this.custody) {
+      const record = await this.custody.store.get(owner);
+      if (!record || record.owner !== owner) throw new Error("Managed wallet access denied");
+      return withManagedWalletSeed(record.envelope, this.custody.keys, (seed) => {
+        const keypair = Keypair.fromSecret(seed);
+        if (keypair.publicKey() !== record.envelope.address)
+          throw new Error("Managed wallet integrity check failed");
+        tx.sign(keypair);
+      });
+    }
+    const operatorSecret = this.config.secrets?.operatorSecret;
+    if (!operatorSecret) throw new Error("Managed wallet not configured");
+    tx.sign(Keypair.fromSecret(operatorSecret));
   }
 
   private getSafeTargetReference(intent: ManagedWalletIntent): string {

--- a/tests/unit/stellar/managed-wallet.test.ts
+++ b/tests/unit/stellar/managed-wallet.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { ManagedWalletService } from "../../../src/services/stellar/managed-wallet";
+import {
+  MemoryManagedWalletStore,
+  VersionedMasterKeyProvider,
+  withManagedWalletSeed,
+} from "../../../src/services/crypto/managed-wallet-envelope";
 import type { BetaRuntimeConfig } from "../../../src/config/schema";
 import {
   Keypair,
@@ -110,5 +115,103 @@ describe("Managed Wallet Boundary", () => {
     await expect(wallet.signTransaction(intent, actorAddress, txXdr, "req-123")).rejects.toThrow(
       "Only invokeHostFunction operations are allowed",
     );
+  });
+});
+
+describe("managed wallet envelope custody", () => {
+  const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+  const networkPassphrase = "Test SDF Network ; September 2015";
+
+  async function keys(active = "v2", versions = ["v1", "v2"]) {
+    const encoded: Record<string, string> = {};
+    for (const version of versions) {
+      encoded[version] = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))));
+    }
+    return VersionedMasterKeyProvider.fromBase64(active, encoded);
+  }
+
+  function config(): BetaRuntimeConfig {
+    return {
+      network: { stellarNetwork: "testnet", networkPassphrase, rpcUrl: "http://localhost" },
+      contract: {
+        registryContractId: contractId,
+        postageContractId: contractId,
+        domainTag: "test",
+        protocolVersion: "1",
+      },
+      environment: "beta",
+      secrets: {},
+    } as any;
+  }
+
+  function transaction(source: string) {
+    return new TransactionBuilder(new Account(source, "1"), { fee: "100", networkPassphrase })
+      .addOperation(new Contract(contractId).call("set_policy"))
+      .setTimeout(30)
+      .build()
+      .toXDR();
+  }
+
+  it("persists no seed, rotates only its wrapped data key, and still signs", async () => {
+    const walletKey = Keypair.random();
+    const store = new MemoryManagedWalletStore();
+    const service = new ManagedWalletService(config(), { store, keys: await keys() });
+    const initial = await service.provisionWallet(walletKey.publicKey(), walletKey.secret());
+
+    expect(JSON.stringify(initial)).not.toContain(walletKey.secret());
+    expect(initial.envelope.masterKeyVersion).toBe("v2");
+    const rotated = await service.rotateWalletKey(walletKey.publicKey(), "v1");
+    expect(rotated.envelope.address).toBe(initial.envelope.address);
+    expect(rotated.envelope.encryptedSeed).toBe(initial.envelope.encryptedSeed);
+    expect(rotated.envelope.masterKeyVersion).toBe("v1");
+
+    const signed = await service.signTransaction(
+      { type: "policy", ownerAddress: walletKey.publicKey() },
+      walletKey.publicKey(),
+      transaction(walletKey.publicKey()),
+    );
+    expect(new Transaction(signed, networkPassphrase).signatures).toHaveLength(1);
+  });
+
+  it("fails closed for tampering, missing old keys, and unauthorized owners", async () => {
+    const walletKey = Keypair.random();
+    const store = new MemoryManagedWalletStore();
+    const provider = await keys("v1", ["v1"]);
+    const service = new ManagedWalletService(config(), { store, keys: provider });
+    const record = await service.provisionWallet(walletKey.publicKey(), walletKey.secret());
+    const tampered = {
+      ...record,
+      envelope: { ...record.envelope, seedTag: "AAAAAAAAAAAAAAAAAAAAAA==" },
+    };
+    await store.compareAndSet(walletKey.publicKey(), record.updatedAt, tampered);
+    await expect(
+      service.signTransaction(
+        { type: "policy", ownerAddress: walletKey.publicKey() },
+        walletKey.publicKey(),
+        transaction(walletKey.publicKey()),
+      ),
+    ).rejects.toThrow("Managed wallet cryptographic operation failed");
+
+    const stranger = Keypair.random().publicKey();
+    await expect(
+      service.signTransaction(
+        { type: "policy", ownerAddress: stranger },
+        stranger,
+        transaction(stranger),
+      ),
+    ).rejects.toThrow("Managed wallet access denied");
+  });
+
+  it("does not expose decrypted seed outside the scoped callback", async () => {
+    const key = Keypair.random();
+    const provider = await keys("v1", ["v1"]);
+    const store = new MemoryManagedWalletStore();
+    const service = new ManagedWalletService(config(), { store, keys: provider });
+    const record = await service.provisionWallet(key.publicKey(), key.secret());
+    let observed = "";
+    await withManagedWalletSeed(record.envelope, provider, (seed) => {
+      observed = seed;
+    });
+    expect(observed).toBe(key.secret());
   });
 });


### PR DESCRIPTION
Closes #1923

## BETA-016 — Encrypt managed wallet secrets with envelope encryption and key rotation

Implements envelope encryption for server-managed Stellar wallet seeds.

### What changed
- Generates a unique AES-256-GCM data key per managed wallet.
- Encrypts the wallet seed with that data key.
- Wraps the data key under a versioned master-key provider.
- Binds encrypted material to the wallet address with authenticated encryption.
- Adds rewrap rotation that changes only the wrapped data key; Stellar addresses and seed ciphertext remain unchanged.
- Keeps decryption inside the managed signing service’s scoped callback.
- Clears temporary seed and raw-key byte buffers in `finally` paths.
- Adds compare-and-set persistence semantics to prevent silent concurrent rotation overwrites.

### Security properties
- Seeds are never serialized into records, returned by APIs, logged, or included in audit events.
- Tampered envelopes fail closed.
- Missing master keys fail closed.
- Unauthorized owners cannot access a managed wallet.
- Duplicate provisioning for the same owner/address is idempotent.

### Tests
- Managed wallet encryption, signing, rewrap rotation, tampering, and access denial:
  `node node_modules/vitest/vitest.mjs run tests/unit/stellar/managed-wallet.test.ts --reporter=dot`

Result: 6 passing tests.