### PR TITLE
feat(requests): persist unknown sender decisions

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AuthSignInRouteImport } from './routes/auth/sign-in'
 import { Route as ApiV1ProtocolRouteImport } from './routes/api/v1/protocol'
 import { Route as ApiV1OpenapiDotjsonRouteImport } from './routes/api/v1/openapi[.]json'
 import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
+import { Route as ApiV1RequestsIndexRouteImport } from './routes/api/v1/requests/index'
 import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts/index'
 import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
 import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
@@ -33,6 +34,7 @@ import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/sessi
 import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
 import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
 import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
+import { Route as ApiV1RequestsRequestIdDecisionsRouteImport } from './routes/api/v1/requests/$requestId/decisions'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -81,6 +83,11 @@ const ApiV1OpenapiDotjsonRoute = ApiV1OpenapiDotjsonRouteImport.update({
 const ApiV1HealthRoute = ApiV1HealthRouteImport.update({
   id: '/api/v1/health',
   path: '/api/v1/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1RequestsIndexRoute = ApiV1RequestsIndexRouteImport.update({
+  id: '/api/v1/requests/',
+  path: '/api/v1/requests/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1ReceiptsIndexRoute = ApiV1ReceiptsIndexRouteImport.update({
@@ -158,6 +165,12 @@ const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
   path: '/api/v1/auth/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1RequestsRequestIdDecisionsRoute =
+  ApiV1RequestsRequestIdDecisionsRouteImport.update({
+    id: '/api/v1/requests/$requestId/decisions',
+    path: '/api/v1/requests/$requestId/decisions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -208,9 +221,11 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesByTo {
@@ -238,9 +253,11 @@ export interface FileRoutesByTo {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesById {
@@ -269,9 +286,11 @@ export interface FileRoutesById {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRouteTypes {
@@ -301,9 +320,11 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/requests/'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -331,9 +352,11 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage'
     | '/api/v1/receipts'
+    | '/api/v1/requests'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/policies/$owner/senders/$sender'
   id:
     | '__root__'
@@ -361,9 +384,11 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/requests/'
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesById: FileRoutesById
 }
@@ -392,6 +417,8 @@ export interface RootRouteChildren {
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
+  ApiV1RequestsIndexRoute: typeof ApiV1RequestsIndexRoute
+  ApiV1RequestsRequestIdDecisionsRoute: typeof ApiV1RequestsRequestIdDecisionsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -457,6 +484,13 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/health'
       fullPath: '/api/v1/health'
       preLoaderRoute: typeof ApiV1HealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/requests/': {
+      id: '/api/v1/requests/'
+      path: '/api/v1/requests'
+      fullPath: '/api/v1/requests/'
+      preLoaderRoute: typeof ApiV1RequestsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/receipts/': {
@@ -564,6 +598,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AuthLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/requests/$requestId/decisions': {
+      id: '/api/v1/requests/$requestId/decisions'
+      path: '/api/v1/requests/$requestId/decisions'
+      fullPath: '/api/v1/requests/$requestId/decisions'
+      preLoaderRoute: typeof ApiV1RequestsRequestIdDecisionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -660,6 +701,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
+  ApiV1RequestsIndexRoute: ApiV1RequestsIndexRoute,
+  ApiV1RequestsRequestIdDecisionsRoute: ApiV1RequestsRequestIdDecisionsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/iden
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
 import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
 import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
+import { Route as ApiV1RequestsRequestIdDecisionsRouteImport } from './routes/api/v1/requests/$requestId/decisions'
 import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
 import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
 import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
@@ -252,6 +253,12 @@ const ApiV1WalletLinkAddressRoute = ApiV1WalletLinkAddressRouteImport.update({
   path: '/api/v1/wallet/link/$address',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1RequestsRequestIdDecisionsRoute =
+  ApiV1RequestsRequestIdDecisionsRouteImport.update({
+    id: '/api/v1/requests/$requestId/decisions',
+    path: '/api/v1/requests/$requestId/decisions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1ReceiptsMessageIdReadRoute =
   ApiV1ReceiptsMessageIdReadRouteImport.update({
     id: '/read',
@@ -348,6 +355,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
@@ -358,6 +366,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
@@ -398,6 +407,7 @@ export interface FileRoutesByTo {
   '/api/v1/accounts': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
@@ -408,6 +418,7 @@ export interface FileRoutesByTo {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
@@ -449,6 +460,7 @@ export interface FileRoutesById {
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
+  '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
@@ -459,6 +471,7 @@ export interface FileRoutesById {
   '/api/v1/postage/$messageId/refund': typeof ApiV1PostageMessageIdRefundRoute
   '/api/v1/postage/$messageId/settle': typeof ApiV1PostageMessageIdSettleRoute
   '/api/v1/receipts/$messageId/read': typeof ApiV1ReceiptsMessageIdReadRoute
+  '/api/v1/requests/$requestId/decisions': typeof ApiV1RequestsRequestIdDecisionsRoute
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
@@ -501,6 +514,7 @@ export interface FileRouteTypes {
     | '/api/v1/accounts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
@@ -511,6 +525,7 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
@@ -551,6 +566,7 @@ export interface FileRouteTypes {
     | '/api/v1/accounts'
     | '/api/v1/postage'
     | '/api/v1/receipts'
+    | '/api/v1/requests'
     | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
@@ -561,6 +577,7 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
@@ -601,6 +618,7 @@ export interface FileRouteTypes {
     | '/api/v1/accounts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
+    | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
@@ -611,6 +629,7 @@ export interface FileRouteTypes {
     | '/api/v1/postage/$messageId/refund'
     | '/api/v1/postage/$messageId/settle'
     | '/api/v1/receipts/$messageId/read'
+    | '/api/v1/requests/$requestId/decisions'
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
@@ -652,10 +671,12 @@ export interface RootRouteChildren {
   ApiV1AccountsIndexRoute: typeof ApiV1AccountsIndexRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
+  ApiV1RequestsIndexRoute: typeof ApiV1RequestsIndexRoute
   ApiV1IdentityKeysKeyIdRoute: typeof ApiV1IdentityKeysKeyIdRoute
   ApiV1IdentityKeysRetireRoute: typeof ApiV1IdentityKeysRetireRoute
   ApiV1IdentityKeysRevokeRoute: typeof ApiV1IdentityKeysRevokeRoute
   ApiV1IdentityKeysRotateRoute: typeof ApiV1IdentityKeysRotateRoute
+  ApiV1RequestsRequestIdDecisionsRoute: typeof ApiV1RequestsRequestIdDecisionsRoute
   ApiV1WalletLinkAddressRoute: typeof ApiV1WalletLinkAddressRoute
   ApiV1WalletLinkChallengeRoute: typeof ApiV1WalletLinkChallengeRoute
   ApiV1WalletLinkVerifyRoute: typeof ApiV1WalletLinkVerifyRoute
@@ -931,6 +952,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1WalletLinkAddressRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/requests/$requestId/decisions': {
+      id: '/api/v1/requests/$requestId/decisions'
+      path: '/api/v1/requests/$requestId/decisions'
+      fullPath: '/api/v1/requests/$requestId/decisions'
+      preLoaderRoute: typeof ApiV1RequestsRequestIdDecisionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/receipts/$messageId/read': {
       id: '/api/v1/receipts/$messageId/read'
       path: '/read'
@@ -1102,10 +1130,12 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1AccountsIndexRoute: ApiV1AccountsIndexRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
+  ApiV1RequestsIndexRoute: ApiV1RequestsIndexRoute,
   ApiV1IdentityKeysKeyIdRoute: ApiV1IdentityKeysKeyIdRoute,
   ApiV1IdentityKeysRetireRoute: ApiV1IdentityKeysRetireRoute,
   ApiV1IdentityKeysRevokeRoute: ApiV1IdentityKeysRevokeRoute,
   ApiV1IdentityKeysRotateRoute: ApiV1IdentityKeysRotateRoute,
+  ApiV1RequestsRequestIdDecisionsRoute: ApiV1RequestsRequestIdDecisionsRoute,
   ApiV1WalletLinkAddressRoute: ApiV1WalletLinkAddressRoute,
   ApiV1WalletLinkChallengeRoute: ApiV1WalletLinkChallengeRoute,
   ApiV1WalletLinkVerifyRoute: ApiV1WalletLinkVerifyRoute,

--- a/src/routes/api/v1/requests/$requestId/decisions.ts
+++ b/src/routes/api/v1/requests/$requestId/decisions.ts
@@ -10,7 +10,7 @@ import { decideSenderRequest } from "@/server/api/sender-request-service";
 
 const decisionBodySchema = z.object({ decision: unknownSenderDecisionSchema });
 
-export const Route = createFileRoute("/api/v1/requests/$requestId/decisions")({
+export const Route = createFileRoute("/api/v1/requests/$requestId/decisions" as never)({
   server: {
     handlers: {
       POST: ({ request, params }) =>
@@ -22,7 +22,12 @@ export const Route = createFileRoute("/api/v1/requests/$requestId/decisions")({
           });
           return apiSuccess(
             request,
-            await decideSenderRequest(context.repository, params.requestId, actor, decision),
+            await decideSenderRequest(
+              context.repository,
+              (params as { requestId: string }).requestId,
+              actor,
+              decision,
+            ),
           );
         }),
     },

--- a/src/routes/api/v1/requests/$requestId/decisions.ts
+++ b/src/routes/api/v1/requests/$requestId/decisions.ts
@@ -22,12 +22,7 @@ export const Route = createFileRoute(`/api/v1/requests/$requestId/decisions`)({
           });
           return apiSuccess(
             request,
-            await decideSenderRequest(
-              context.repository,
-              params.requestId,
-              actor,
-              decision,
-            ),
+            await decideSenderRequest(context.repository, params.requestId, actor, decision),
           );
         }),
     },

--- a/src/routes/api/v1/requests/$requestId/decisions.ts
+++ b/src/routes/api/v1/requests/$requestId/decisions.ts
@@ -10,7 +10,7 @@ import { decideSenderRequest } from "@/server/api/sender-request-service";
 
 const decisionBodySchema = z.object({ decision: unknownSenderDecisionSchema });
 
-export const Route = createFileRoute("/api/v1/requests/$requestId/decisions" as never)({
+export const Route = createFileRoute(`/api/v1/requests/$requestId/decisions`)({
   server: {
     handlers: {
       POST: ({ request, params }) =>
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/api/v1/requests/$requestId/decisions" as 
             request,
             await decideSenderRequest(
               context.repository,
-              (params as { requestId: string }).requestId,
+              params.requestId,
               actor,
               decision,
             ),

--- a/src/routes/api/v1/requests/$requestId/decisions.ts
+++ b/src/routes/api/v1/requests/$requestId/decisions.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { unknownSenderDecisionSchema } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { decideSenderRequest } from "@/server/api/sender-request-service";
+
+const decisionBodySchema = z.object({ decision: unknownSenderDecisionSchema });
+
+export const Route = createFileRoute("/api/v1/requests/$requestId/decisions")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const { decision } = await parseJsonBody(request, decisionBodySchema, {
+            route: "POST /requests/{requestId}/decisions",
+          });
+          return apiSuccess(
+            request,
+            await decideSenderRequest(context.repository, params.requestId, actor, decision),
+          );
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/requests/index.ts
+++ b/src/routes/api/v1/requests/index.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import {
+  encryptedMessageReferenceSchema,
+  stellarAddressSchema,
+  unknownSenderRequestSchema,
+} from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { createSenderRequest } from "@/server/api/sender-request-service";
+import { ApiError } from "@/server/api/errors";
+
+const createRequestBodySchema = z.object({
+  requestId: z.string().uuid(),
+  recipient: stellarAddressSchema,
+  sender: stellarAddressSchema,
+  message: encryptedMessageReferenceSchema,
+  expiresAt: z.string().datetime(),
+});
+
+export const Route = createFileRoute("/api/v1/requests/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          return apiSuccess(request, await context.repository.listSenderRequests(actor, "pending"));
+        }),
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const actor = requireActor(context);
+          const input = await parseJsonBody(request, createRequestBodySchema, {
+            route: "POST /requests",
+          });
+          if (input.sender !== actor) {
+            throw new ApiError(
+              403,
+              "forbidden",
+              "Authenticated sender does not match request sender",
+            );
+          }
+          const result = await createSenderRequest(
+            context.repository,
+            unknownSenderRequestSchema.parse({
+              ...input,
+              createdAt: new Date().toISOString(),
+              status: "pending",
+            }),
+          );
+          return apiSuccess(request, result, { status: result.created ? 201 : 200 });
+        }),
+    },
+  },
+});

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -14,6 +14,7 @@ import {
   credentialSchema,
   sessionSchema,
   storedEnvelopeSchema,
+  unknownSenderRequestSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -210,6 +211,7 @@ registerRecordSchema("idempotencyRecord", 2, idempotencyRecordSchema, {
 // ValidatedApiRepository can detect tampered or structurally invalid
 // envelope records at the adapter boundary before they reach any caller.
 registerRecordSchema("storedEnvelope", 1, storedEnvelopeSchema);
+registerRecordSchema("unknownSenderRequest", 1, unknownSenderRequestSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -583,6 +583,39 @@ export const tombstoneRequestSchema = z.object({
 
 export type TombstoneRequest = z.infer<typeof tombstoneRequestSchema>;
 
+export const unknownSenderRequestStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+  "blocked",
+  "expired",
+]);
+export const unknownSenderDecisionSchema = z.enum([
+  "approve_once",
+  "always_allow",
+  "reject",
+  "block",
+  "expire",
+]);
+export const encryptedMessageReferenceSchema = z.object({
+  messageId: hash32Schema,
+  envelopeId: z.string().min(1).max(256).optional(),
+  ciphertextHash: hash32Schema,
+});
+export const unknownSenderRequestSchema = z.object({
+  requestId: z.string().uuid(),
+  recipient: stellarAddressSchema,
+  sender: stellarAddressSchema,
+  message: encryptedMessageReferenceSchema,
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  status: unknownSenderRequestStatusSchema,
+  decidedAt: z.string().datetime().optional(),
+  decision: unknownSenderDecisionSchema.optional(),
+});
+export type UnknownSenderRequest = z.infer<typeof unknownSenderRequestSchema>;
+export type UnknownSenderDecision = z.infer<typeof unknownSenderDecisionSchema>;
+
 // ---------------------------------------------------------------------------
 // BETA-027 (Issue #1934) — Versioned Public Encryption-Key Directory & Rotation
 // ---------------------------------------------------------------------------

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -323,3 +323,45 @@ export const storedEnvelopeSchema = z.object({
 
 export type StoredEnvelopeProtectedHeaders = z.infer<typeof storedEnvelopeProtectedHeadersSchema>;
 export type StoredEnvelope = z.infer<typeof storedEnvelopeSchema>;
+
+// ---------------------------------------------------------------------------
+// Unknown sender requests (Issue #1945 / BETA-038)
+// ---------------------------------------------------------------------------
+// Only encrypted-message identifiers and commitments are retained here. The
+// request queue must never become an alternate plaintext mailbox store.
+
+export const unknownSenderRequestStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+  "blocked",
+  "expired",
+]);
+export const unknownSenderDecisionSchema = z.enum([
+  "approve_once",
+  "always_allow",
+  "reject",
+  "block",
+  "expire",
+]);
+
+export const encryptedMessageReferenceSchema = z.object({
+  messageId: hash32Schema,
+  envelopeId: z.string().min(1).max(256).optional(),
+  ciphertextHash: hash32Schema,
+});
+
+export const unknownSenderRequestSchema = z.object({
+  requestId: z.string().uuid(),
+  recipient: stellarAddressSchema,
+  sender: stellarAddressSchema,
+  message: encryptedMessageReferenceSchema,
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  status: unknownSenderRequestStatusSchema,
+  decidedAt: z.string().datetime().optional(),
+  decision: unknownSenderDecisionSchema.optional(),
+});
+
+export type UnknownSenderRequest = z.infer<typeof unknownSenderRequestSchema>;
+export type UnknownSenderDecision = z.infer<typeof unknownSenderDecisionSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -464,6 +464,23 @@ export class HybridApiRepository implements ApiRepository {
     }
     return result;
   }
+  getSenderRequest(requestId: string) {
+    return this.getStub().getSenderRequest(requestId);
+  }
+  listSenderRequests(recipient: string, status?: "pending") {
+    return this.getStub().listSenderRequests(recipient, status);
+  }
+  createSenderRequestIfAbsent(request: import("./domain").UnknownSenderRequest) {
+    return this.getStub().createSenderRequestIfAbsent(request);
+  }
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: import("./domain").UnknownSenderDecision,
+    now?: Date,
+  ) {
+    return this.getStub().transitionSenderRequest(requestId, recipient, decision, now);
+  }
 
   async listRecipientEnvelopes(
     recipient: string,

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -3,6 +3,8 @@ import type {
   InsertEnvelopeResult,
   PostageTransitionResult,
   UpdateUserResult,
+  CreateSenderRequestResult,
+  SenderRequestTransitionResult,
 } from "./repository";
 import type {
   Credential,
@@ -16,6 +18,8 @@ import type {
   Session,
   StoredEnvelope,
   User,
+  UnknownSenderDecision,
+  UnknownSenderRequest,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -282,6 +286,40 @@ export class HybridApiRepository implements ApiRepository {
     if (result.outcome === "inserted" || result.outcome === "duplicate") {
       // Mirror to KV so getEnvelope hits the fast path on subsequent reads.
       await this.kv.put(this.key("envelope", envelope.messageId), JSON.stringify(result.envelope));
+    }
+    return result;
+  }
+
+  async getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    const request = await this.getStub().getSenderRequest(requestId);
+    return request ?? null;
+  }
+
+  async listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    return this.getStub().listSenderRequests(recipient, status);
+  }
+
+  async createSenderRequestIfAbsent(
+    request: UnknownSenderRequest,
+  ): Promise<CreateSenderRequestResult> {
+    return this.getStub().createSenderRequestIfAbsent(request);
+  }
+
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ): Promise<SenderRequestTransitionResult> {
+    const result = await this.getStub().transitionSenderRequest(
+      requestId,
+      recipient,
+      decision,
+      now,
+    );
+    if (result.outcome === "applied") {
+      const rule = decision === "always_allow" ? "allow" : decision === "block" ? "block" : null;
+      if (rule) await this.setSenderRule(recipient, result.request.sender, rule);
     }
     return result;
   }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -9,12 +9,16 @@ import type {
   SenderRule,
   Session,
   StoredEnvelope,
+  UnknownSenderDecision,
+  UnknownSenderRequest,
   User,
 } from "./domain";
 import type {
   ApiRepository,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  CreateSenderRequestResult,
+  SenderRequestTransitionResult,
   UpdateUserResult,
 } from "./repository";
 import { ApiError } from "./errors";
@@ -34,6 +38,8 @@ export class MemoryApiRepository implements ApiRepository {
   // Issue #1936: envelope store and per-key insert locks.
   private readonly envelopes = new Map<string, StoredEnvelope>();
   private readonly envelopeLocks = new Map<string, Promise<void>>();
+  private readonly senderRequests = new Map<string, UnknownSenderRequest>();
+  private readonly senderRequestLocks = new Map<string, Promise<void>>();
 
   // BETA-002: User Account, Profile, Credential storage & unique index maps
   private readonly usersById = new Map<string, User>();
@@ -83,6 +89,24 @@ export class MemoryApiRepository implements ApiRepository {
       if (this.envelopeLocks.get(messageId) === queued) {
         this.envelopeLocks.delete(messageId);
       }
+    }
+  }
+
+  private async withSenderRequestLock<T>(requestId: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.senderRequestLocks.get(requestId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.senderRequestLocks.set(requestId, queued);
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.senderRequestLocks.get(requestId) === queued)
+        this.senderRequestLocks.delete(requestId);
     }
   }
 
@@ -452,6 +476,68 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    return structuredClone(this.senderRequests.get(requestId) ?? null);
+  }
+
+  async listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    return [...this.senderRequests.values()]
+      .filter(
+        (request) => request.recipient === recipient && (!status || request.status === status),
+      )
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .map((request) => structuredClone(request));
+  }
+
+  async createSenderRequestIfAbsent(
+    request: UnknownSenderRequest,
+  ): Promise<CreateSenderRequestResult> {
+    return this.withSenderRequestLock(request.requestId, async () => {
+      const existing = this.senderRequests.get(request.requestId);
+      if (existing) return { created: false, request: structuredClone(existing) };
+      this.senderRequests.set(request.requestId, structuredClone(request));
+      return { created: true, request: structuredClone(request) };
+    });
+  }
+
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now = new Date(),
+  ): Promise<SenderRequestTransitionResult> {
+    return this.withSenderRequestLock(requestId, async () => {
+      const current = this.senderRequests.get(requestId);
+      if (!current || current.recipient !== recipient) return { outcome: "not_found" };
+      if (current.status !== "pending")
+        return { outcome: "conflict", request: structuredClone(current) };
+      const expired = new Date(current.expiresAt).getTime() <= now.getTime();
+      if (expired && decision !== "expire")
+        return { outcome: "conflict", request: structuredClone(current) };
+      const status =
+        decision === "approve_once" || decision === "always_allow"
+          ? "approved"
+          : decision === "block"
+            ? "blocked"
+            : decision === "expire"
+              ? "expired"
+              : "rejected";
+      const updated: UnknownSenderRequest = {
+        ...current,
+        status,
+        decision,
+        decidedAt: now.toISOString(),
+      };
+      if (decision === "always_allow") {
+        this.senderRules.set(key(recipient, current.sender), "allow");
+      } else if (decision === "block") {
+        this.senderRules.set(key(recipient, current.sender), "block");
+      }
+      this.senderRequests.set(requestId, updated);
+      return { outcome: "applied", request: structuredClone(updated) };
+    });
+  }
+
   reset() {
     this.policies.clear();
     this.postage.clear();
@@ -462,6 +548,8 @@ export class MemoryApiRepository implements ApiRepository {
     this.receiptLocks.clear();
     this.envelopes.clear();
     this.envelopeLocks.clear();
+    this.senderRequests.clear();
+    this.senderRequestLocks.clear();
     this.usersById.clear();
     this.usersByEmail.clear();
     this.usersByUsername.clear();

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -860,6 +860,58 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    return structuredClone(this.senderRequests.get(requestId) ?? null);
+  }
+  async listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    return [...this.senderRequests.values()]
+      .filter((r) => r.recipient === recipient && (!status || r.status === status))
+      .map((r) => structuredClone(r));
+  }
+  async createSenderRequestIfAbsent(request: UnknownSenderRequest) {
+    return this.withEnvelopeLock(`request:${request.requestId}`, async () => {
+      const existing = this.senderRequests.get(request.requestId);
+      if (existing) return { created: false, request: structuredClone(existing) };
+      this.senderRequests.set(request.requestId, structuredClone(request));
+      return { created: true, request: structuredClone(request) };
+    });
+  }
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now = new Date(),
+  ) {
+    return this.withEnvelopeLock(`request:${requestId}`, async () => {
+      const current = this.senderRequests.get(requestId);
+      if (!current || current.recipient !== recipient) return { outcome: "not_found" as const };
+      if (
+        current.status !== "pending" ||
+        (new Date(current.expiresAt) <= now && decision !== "expire")
+      )
+        return { outcome: "conflict" as const, request: structuredClone(current) };
+      const status =
+        decision === "approve_once" || decision === "always_allow"
+          ? "approved"
+          : decision === "block"
+            ? "blocked"
+            : decision === "expire"
+              ? "expired"
+              : "rejected";
+      const request = {
+        ...current,
+        status,
+        decision,
+        decidedAt: now.toISOString(),
+      } as UnknownSenderRequest;
+      if (decision === "always_allow")
+        this.senderRules.set(key(recipient, current.sender), "allow");
+      if (decision === "block") this.senderRules.set(key(recipient, current.sender), "block");
+      this.senderRequests.set(requestId, request);
+      return { outcome: "applied" as const, request: structuredClone(request) };
+    });
+  }
+
   async listRecipientEnvelopes(
     recipient: string,
     options: import("./repository").MailboxQueryOptions = {},

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -10,6 +10,8 @@ import type {
   SenderRule,
   Session,
   StoredEnvelope,
+  UnknownSenderDecision,
+  UnknownSenderRequest,
   User,
 } from "./domain";
 import { ApiError, DataIntegrityError, RetryExhaustedError } from "./errors";
@@ -84,6 +86,12 @@ export type MarkReceiptReadResult =
 export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
+
+export type CreateSenderRequestResult = { created: boolean; request: UnknownSenderRequest };
+export type SenderRequestTransitionResult =
+  | { outcome: "not_found" }
+  | { outcome: "conflict"; request: UnknownSenderRequest }
+  | { outcome: "applied"; request: UnknownSenderRequest };
 
 export interface ApiRepository {
   getPolicy(owner: string): Promise<MailboxPolicy | null>;
@@ -181,6 +189,16 @@ export interface ApiRepository {
    * Plaintext MUST NOT be passed to this method; ciphertext only.
    */
   insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+
+  getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null>;
+  listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]>;
+  createSenderRequestIfAbsent(request: UnknownSenderRequest): Promise<CreateSenderRequestResult>;
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ): Promise<SenderRequestTransitionResult>;
 
   reset?(): void;
 }
@@ -507,6 +525,42 @@ export class ValidatedApiRepository implements ApiRepository {
     return result;
   }
 
+  async getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    const raw = await this.inner.getSenderRequest(requestId);
+    return raw ? validateRecord<UnknownSenderRequest>("unknownSenderRequest", raw) : null;
+  }
+
+  async listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    return (await this.inner.listSenderRequests(recipient, status)).map((request) =>
+      validateRecord<UnknownSenderRequest>("unknownSenderRequest", request),
+    );
+  }
+
+  async createSenderRequestIfAbsent(
+    request: UnknownSenderRequest,
+  ): Promise<CreateSenderRequestResult> {
+    const result = await this.inner.createSenderRequestIfAbsent(
+      versionRecord("unknownSenderRequest", request),
+    );
+    return {
+      ...result,
+      request: validateRecord<UnknownSenderRequest>("unknownSenderRequest", result.request),
+    };
+  }
+
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ): Promise<SenderRequestTransitionResult> {
+    const result = await this.inner.transitionSenderRequest(requestId, recipient, decision, now);
+    if (result.outcome !== "not_found") {
+      result.request = validateRecord<UnknownSenderRequest>("unknownSenderRequest", result.request);
+    }
+    return result;
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -557,6 +611,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getSession",
   "updateSession",
   "getEnvelope",
+  "getSenderRequest",
+  "listSenderRequests",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -792,6 +848,29 @@ export class RetryableApiRepository implements ApiRepository {
     // and the outcome would be "duplicate" (byte-equal) or "conflict" (different
     // bytes). Callers should handle those outcomes explicitly.
     return this.inner.insertEnvelope(envelope);
+  }
+
+  getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    return this.withRetry("getSenderRequest", () => this.inner.getSenderRequest(requestId));
+  }
+
+  listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    return this.withRetry("listSenderRequests", () =>
+      this.inner.listSenderRequests(recipient, status),
+    );
+  }
+
+  createSenderRequestIfAbsent(request: UnknownSenderRequest): Promise<CreateSenderRequestResult> {
+    return this.inner.createSenderRequestIfAbsent(request);
+  }
+
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ): Promise<SenderRequestTransitionResult> {
+    return this.inner.transitionSenderRequest(requestId, recipient, decision, now);
   }
 
   reset(): void {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -97,6 +97,11 @@ export type MarkReceiptReadResult =
 export type UpdateUserResult =
   | { updated: true; user: User }
   | { updated: false; current: User | null };
+export type CreateSenderRequestResult = { created: boolean; request: UnknownSenderRequest };
+export type SenderRequestTransitionResult =
+  | { outcome: "not_found" }
+  | { outcome: "conflict"; request: UnknownSenderRequest }
+  | { outcome: "applied"; request: UnknownSenderRequest };
 
 // ---------------------------------------------------------------------------
 // BETA-014: Account-provisioning repository contracts
@@ -349,6 +354,15 @@ export interface ApiRepository {
    * Plaintext MUST NOT be passed to this method; ciphertext only.
    */
   insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+  getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null>;
+  listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]>;
+  createSenderRequestIfAbsent(request: UnknownSenderRequest): Promise<CreateSenderRequestResult>;
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ): Promise<SenderRequestTransitionResult>;
 
   // ---------------------------------------------------------------------------
   // Issue #1940 (BETA-033) — Authenticated Recipient Mailbox Queue Repository
@@ -848,6 +862,23 @@ export class ValidatedApiRepository implements ApiRepository {
     }
     return result;
   }
+  getSenderRequest(requestId: string) {
+    return this.inner.getSenderRequest(requestId);
+  }
+  listSenderRequests(recipient: string, status?: "pending") {
+    return this.inner.listSenderRequests(recipient, status);
+  }
+  createSenderRequestIfAbsent(request: UnknownSenderRequest) {
+    return this.inner.createSenderRequestIfAbsent(request);
+  }
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ) {
+    return this.inner.transitionSenderRequest(requestId, recipient, decision, now);
+  }
 
   async listRecipientEnvelopes(
     recipient: string,
@@ -1330,6 +1361,25 @@ export class RetryableApiRepository implements ApiRepository {
     // and the outcome would be "duplicate" (byte-equal) or "conflict" (different
     // bytes). Callers should handle those outcomes explicitly.
     return this.inner.insertEnvelope(envelope);
+  }
+  getSenderRequest(requestId: string) {
+    return this.withRetry("getSenderRequest", () => this.inner.getSenderRequest(requestId));
+  }
+  listSenderRequests(recipient: string, status?: "pending") {
+    return this.withRetry("listSenderRequests", () =>
+      this.inner.listSenderRequests(recipient, status),
+    );
+  }
+  createSenderRequestIfAbsent(request: UnknownSenderRequest) {
+    return this.inner.createSenderRequestIfAbsent(request);
+  }
+  transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now?: Date,
+  ) {
+    return this.inner.transitionSenderRequest(requestId, recipient, decision, now);
   }
 
   listRecipientEnvelopes(

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -44,6 +44,8 @@ export const ROUTE_BODY_LIMITS = {
   "PUT /policies/{owner}/senders/{sender}": "standard",
   "POST /policies/evaluate": "compact",
   "POST /relay/messages": "relay",
+  "POST /requests": "standard",
+  "POST /requests/{requestId}/decisions": "compact",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -52,6 +52,8 @@ export const ROUTE_BODY_LIMITS = {
   "POST /identity/keys/rotate": "compact",
   "POST /identity/keys/retire": "compact",
   "POST /identity/keys/revoke": "compact",
+  "POST /requests": "standard",
+  "POST /requests/{requestId}/decisions": "compact",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/server/api/sender-request-service.ts
+++ b/src/server/api/sender-request-service.ts
@@ -1,0 +1,34 @@
+import { ApiError } from "./errors";
+import type { UnknownSenderDecision, UnknownSenderRequest } from "./domain";
+import type { ApiRepository } from "./repository";
+
+export async function createSenderRequest(
+  repository: ApiRepository,
+  request: UnknownSenderRequest,
+): Promise<{ created: boolean; request: UnknownSenderRequest }> {
+  return repository.createSenderRequestIfAbsent(request);
+}
+
+/**
+ * Makes exactly one durable terminal decision. Approved requests represent a
+ * released inbox message; always_allow/block additionally change the sender
+ * rule in the same repository decision path.
+ */
+export async function decideSenderRequest(
+  repository: ApiRepository,
+  requestId: string,
+  recipient: string,
+  decision: UnknownSenderDecision,
+): Promise<UnknownSenderRequest> {
+  const result = await repository.transitionSenderRequest(requestId, recipient, decision);
+  if (result.outcome === "not_found") {
+    throw new ApiError(404, "not_found", "Sender request was not found");
+  }
+  if (result.outcome === "conflict") {
+    throw new ApiError(409, "conflict", "Sender request has already been decided or expired", {
+      status: result.request.status,
+      decision: result.request.decision,
+    });
+  }
+  return result.request;
+}

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -733,6 +733,63 @@ export class StealthCoordinator extends DurableObjectBase {
       return { outcome: "inserted" as const, envelope };
     });
   }
+  async getSenderRequest(requestId: string) {
+    return (
+      ((await this.ctx.storage.get(`sender-request:${requestId}`)) as
+        | import("./domain").UnknownSenderRequest
+        | undefined) ?? null
+    );
+  }
+  async listSenderRequests(recipient: string, status?: "pending") {
+    const all = (await this.ctx.storage.list({ prefix: "sender-request:" })) as Map<
+      string,
+      import("./domain").UnknownSenderRequest
+    >;
+    return [...all.values()].filter(
+      (r) => r.recipient === recipient && (!status || r.status === status),
+    );
+  }
+  async createSenderRequestIfAbsent(request: import("./domain").UnknownSenderRequest) {
+    return this.runExclusive(`sender-request:${request.requestId}`, async () => {
+      const key = `sender-request:${request.requestId}`;
+      const existing = await this.getSenderRequest(request.requestId);
+      if (existing) return { created: false, request: existing };
+      await this.ctx.storage.put(key, request);
+      return { created: true, request };
+    });
+  }
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: import("./domain").UnknownSenderDecision,
+    now = new Date(),
+  ) {
+    return this.runExclusive(`sender-request:${requestId}`, async () => {
+      const current = await this.getSenderRequest(requestId);
+      if (!current || current.recipient !== recipient) return { outcome: "not_found" as const };
+      if (
+        current.status !== "pending" ||
+        (new Date(current.expiresAt) <= now && decision !== "expire")
+      )
+        return { outcome: "conflict" as const, request: current };
+      const status =
+        decision === "approve_once" || decision === "always_allow"
+          ? "approved"
+          : decision === "block"
+            ? "blocked"
+            : decision === "expire"
+              ? "expired"
+              : "rejected";
+      const request = {
+        ...current,
+        status,
+        decision,
+        decidedAt: now.toISOString(),
+      } as import("./domain").UnknownSenderRequest;
+      await this.ctx.storage.put(`sender-request:${requestId}`, request);
+      return { outcome: "applied" as const, request };
+    });
+  }
 
   async listRecipientEnvelopes(
     recipient: string,

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -7,6 +7,8 @@ import type {
   Receipt,
   Session,
   StoredEnvelope,
+  UnknownSenderDecision,
+  UnknownSenderRequest,
   User,
 } from "./domain";
 import type {
@@ -14,6 +16,8 @@ import type {
   InsertEnvelopeResult,
   PostageTransitionResult,
   UpdateUserResult,
+  CreateSenderRequestResult,
+  SenderRequestTransitionResult,
 } from "./repository";
 import { ApiError } from "./errors";
 
@@ -425,6 +429,78 @@ export class StealthCoordinator extends DurableObjectBase {
 
       await this.ctx.storage.put(`envelope:${envelope.messageId}`, envelope);
       return { outcome: "inserted" as const, envelope };
+    });
+  }
+
+  async getSenderRequest(requestId: string): Promise<UnknownSenderRequest | null> {
+    return (
+      ((await this.ctx.storage.get(`sender-request:${requestId}`)) as
+        | UnknownSenderRequest
+        | undefined) ?? null
+    );
+  }
+
+  async listSenderRequests(recipient: string, status?: "pending"): Promise<UnknownSenderRequest[]> {
+    const listed = (await this.ctx.storage.list({ prefix: "sender-request:" })) as Map<
+      string,
+      UnknownSenderRequest
+    >;
+    return [...listed.values()]
+      .filter(
+        (request) => request.recipient === recipient && (!status || request.status === status),
+      )
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async createSenderRequestIfAbsent(
+    request: UnknownSenderRequest,
+  ): Promise<CreateSenderRequestResult> {
+    return this.runExclusive(`sender-request:${request.requestId}`, async () => {
+      const key = `sender-request:${request.requestId}`;
+      const existing = (await this.ctx.storage.get(key)) as UnknownSenderRequest | undefined;
+      if (existing) return { created: false, request: existing };
+      await this.ctx.storage.put(key, request);
+      return { created: true, request };
+    });
+  }
+
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: UnknownSenderDecision,
+    now = new Date(),
+  ): Promise<SenderRequestTransitionResult> {
+    return this.runExclusive(`sender-request:${requestId}`, async () => {
+      const key = `sender-request:${requestId}`;
+      const current = (await this.ctx.storage.get(key)) as UnknownSenderRequest | undefined;
+      if (!current || current.recipient !== recipient) return { outcome: "not_found" };
+      if (
+        current.status !== "pending" ||
+        (new Date(current.expiresAt) <= now && decision !== "expire")
+      ) {
+        return { outcome: "conflict", request: current };
+      }
+      const status =
+        decision === "approve_once" || decision === "always_allow"
+          ? "approved"
+          : decision === "block"
+            ? "blocked"
+            : decision === "expire"
+              ? "expired"
+              : "rejected";
+      const request = {
+        ...current,
+        status,
+        decision,
+        decidedAt: now.toISOString(),
+      } as UnknownSenderRequest;
+      if (decision === "always_allow") {
+        await this.ctx.storage.put(`sender-rule:${recipient}:${current.sender}`, "allow");
+      } else if (decision === "block") {
+        await this.ctx.storage.put(`sender-rule:${recipient}:${current.sender}`, "block");
+      }
+      await this.ctx.storage.put(key, request);
+      return { outcome: "applied", request };
     });
   }
 }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -220,6 +220,29 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("insertEnvelope");
     return this.inner.insertEnvelope(envelope);
   }
+  async getSenderRequest(requestId: string) {
+    this.maybeFail("getSenderRequest");
+    return this.inner.getSenderRequest(requestId);
+  }
+  async listSenderRequests(recipient: string, status?: "pending") {
+    this.maybeFail("listSenderRequests");
+    return this.inner.listSenderRequests(recipient, status);
+  }
+  async createSenderRequestIfAbsent(
+    request: import("../../../src/server/api/domain").UnknownSenderRequest,
+  ) {
+    this.maybeFail("createSenderRequestIfAbsent");
+    return this.inner.createSenderRequestIfAbsent(request);
+  }
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: import("../../../src/server/api/domain").UnknownSenderDecision,
+    now?: Date,
+  ) {
+    this.maybeFail("transitionSenderRequest");
+    return this.inner.transitionSenderRequest(requestId, recipient, decision, now);
+  }
   reset(): void {
     this.inner.reset();
   }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -282,6 +282,25 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("insertEnvelope");
     return this.inner.insertEnvelope(envelope);
   }
+  async getSenderRequest(requestId: string) {
+    return this.inner.getSenderRequest(requestId);
+  }
+  async listSenderRequests(recipient: string, status?: "pending") {
+    return this.inner.listSenderRequests(recipient, status);
+  }
+  async createSenderRequestIfAbsent(
+    request: import("../../../src/server/api/domain").UnknownSenderRequest,
+  ) {
+    return this.inner.createSenderRequestIfAbsent(request);
+  }
+  async transitionSenderRequest(
+    requestId: string,
+    recipient: string,
+    decision: import("../../../src/server/api/domain").UnknownSenderDecision,
+    now?: Date,
+  ) {
+    return this.inner.transitionSenderRequest(requestId, recipient, decision, now);
+  }
   async getVerificationToken(tokenHash: string) {
     this.maybeFail("getVerificationToken");
     return this.inner.getVerificationToken(tokenHash);

--- a/tests/unit/api/sender-request-service.test.ts
+++ b/tests/unit/api/sender-request-service.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  createSenderRequest,
+  decideSenderRequest,
+} from "../../../src/server/api/sender-request-service";
+
+const recipient = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+const otherRecipient = `G${"C".repeat(55)}`;
+
+function pendingRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    requestId: "00000000-0000-4000-8000-000000000001",
+    recipient,
+    sender,
+    message: {
+      messageId: "a".repeat(64),
+      ciphertextHash: "b".repeat(64),
+    },
+    createdAt: "2026-08-18T00:00:00.000Z",
+    expiresAt: "2026-08-19T00:00:00.000Z",
+    status: "pending" as const,
+    ...overrides,
+  };
+}
+
+describe("sender request service", () => {
+  it("creates idempotently and applies an approve-once decision exactly once", async () => {
+    const repository = new MemoryApiRepository();
+    const request = pendingRequest();
+
+    expect(await createSenderRequest(repository, request)).toMatchObject({
+      created: true,
+      request,
+    });
+    expect(await createSenderRequest(repository, request)).toMatchObject({
+      created: false,
+      request,
+    });
+
+    const approved = await decideSenderRequest(
+      repository,
+      request.requestId,
+      recipient,
+      "approve_once",
+    );
+    expect(approved).toMatchObject({ status: "approved", decision: "approve_once" });
+    await expect(
+      decideSenderRequest(repository, request.requestId, recipient, "reject"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "conflict",
+    });
+  });
+
+  it("persists sender rules for always-allow and block decisions", async () => {
+    const repository = new MemoryApiRepository();
+    const allowed = pendingRequest();
+    const blocked = pendingRequest({ requestId: "00000000-0000-4000-8000-000000000002" });
+    await createSenderRequest(repository, allowed);
+    await createSenderRequest(repository, blocked);
+
+    await decideSenderRequest(repository, allowed.requestId, recipient, "always_allow");
+    expect(await repository.getSenderRule(recipient, sender)).toBe("allow");
+
+    await decideSenderRequest(repository, blocked.requestId, recipient, "block");
+    expect(await repository.getSenderRule(recipient, sender)).toBe("block");
+  });
+
+  it("does not disclose requests to another recipient", async () => {
+    const repository = new MemoryApiRepository();
+    const request = pendingRequest();
+    await createSenderRequest(repository, request);
+
+    await expect(
+      decideSenderRequest(repository, request.requestId, otherRecipient, "reject"),
+    ).rejects.toEqual(expect.objectContaining({ status: 404, code: "not_found" }));
+  });
+});


### PR DESCRIPTION
Closes #1945 

## Summary

Implements durable unknown-sender request handling for BETA-038.

- Adds encrypted-metadata-only sender request records and lifecycle states.
- Adds request creation, listing, and decision APIs.
- Supports approve once, always allow, reject, block, and expire decisions.
- Enforces atomic terminal decisions to prevent concurrent approve/reject outcomes.
- Persists allow/block sender rules with the applicable decision.
- Adds memory, KV, Durable Object, validation, retry, and route-tree support.

## Verification
- `npx tsc --noEmit`
- `npx eslint src/server/api/domain.ts src/server/api/repository.ts src/server/api/memory-repository.ts src/server/api/kv-repository.ts src/server/api/stealth-coordinator.ts src/server/api/sender-request-service.ts src/routes/api/v1/requests tests/unit/api/sender-request-service.test.ts`
- `npx vitest run tests/unit/api/sender-request-service.test.ts`