### PR TITLE
feat(beta-066): add live contacts CRUD, trust state, and safe import #1973

### DIFF
--- a/scripts/generate-route-tree.ts
+++ b/scripts/generate-route-tree.ts
@@ -1,0 +1,41 @@
+import { configSchema, Generator } from "@tanstack/router-generator";
+import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+const config = configSchema.parse({
+  target: "react",
+  routesDirectory: path.join(root, "src", "routes"),
+  generatedRouteTree: path.join(root, "src", "routeTree.gen.ts"),
+  tmpDir: path.join(root, ".tanstack", "tmp"),
+});
+
+const generator = new Generator({ config, root });
+
+await generator.run();
+
+// The @tanstack/react-start plugin appends a typed router registration so the
+// `server` handler option is accepted by createFileRoute. The standalone
+// generator does not emit it, so re-append it to match a plugin build.
+const routeTreePath = path.join(root, "src", "routeTree.gen.ts");
+const content = readFileSync(routeTreePath, "utf8");
+const marker = "\nimport type { getRouter } from './router.tsx'";
+if (!content.trimEnd().endsWith("_addFileTypes<FileRouteTypes>()")) {
+  console.error("Unexpected routeTree.gen.ts tail; skipping react-start registration.");
+  process.exit(1);
+}
+const appended =
+  content.trimEnd() +
+  "\n\n" +
+  "import type { getRouter } from './router.tsx'\n" +
+  "import type { createStart } from '@tanstack/react-start'\n" +
+  "declare module '@tanstack/react-start' {\n" +
+  "  interface Register {\n" +
+  "    ssr: true\n" +
+  "    router: Awaited<ReturnType<typeof getRouter>>\n" +
+  "  }\n" +
+  "}\n";
+writeFileSync(routeTreePath, appended);
+console.log("routeTree.gen.ts regenerated");

--- a/src/features/contacts/api.ts
+++ b/src/features/contacts/api.ts
@@ -1,0 +1,183 @@
+import type { SenderRule } from "@/server/api/domain";
+
+// Live client for the /api/v1/contacts endpoints (BETA-066 / Issue #1973).
+// The server routes derive the owner from the x-stealth-address actor header,
+// so every call forwards the authenticated actor address.
+
+export class ContactsApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ContactsApiError";
+  }
+}
+
+function isGAddress(value: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(value.trim().toUpperCase());
+}
+
+async function contactsFetch<T>(path: string, actor: string, init: RequestInit = {}): Promise<T> {
+  const headers: Record<string, string> = {
+    "x-stealth-address": actor,
+    ...((init.headers as Record<string, string>) ?? {}),
+  };
+  const response = await fetch(`/api/v1/contacts${path}`, { ...init, headers });
+  const body = (await response.json().catch(() => null)) as {
+    data?: T;
+    error?: { message?: string; code?: string };
+  } | null;
+  if (!response.ok) {
+    throw new ContactsApiError(
+      body?.error?.message ?? `Request failed with status ${response.status}`,
+      response.status,
+      body?.error?.code,
+    );
+  }
+  return body?.data as T;
+}
+
+export type ContactResolutionIdentity = {
+  identifier?: string;
+  canonicalAddress?: string;
+  resolved?: boolean;
+  status?: string;
+} | null;
+
+export type ContactWithResolution = {
+  contact: {
+    contactId: string;
+    name: string;
+    address: string;
+    canonicalAddress: string | null;
+    trust: SenderRule;
+    source: string;
+    createdAt: string;
+    updatedAt: string;
+    version: number;
+  };
+  resolution: {
+    identity: ContactResolutionIdentity;
+    senderRule: SenderRule;
+    senderRuleConfigured: boolean;
+  };
+};
+
+export type ContactListResult = {
+  items: ContactWithResolution[];
+  nextContinuationKey: string | null;
+};
+
+export type ImportPreviewResult = {
+  format: "csv" | "vcard";
+  totalRows: number;
+  validRows: number;
+  duplicateRows: number;
+  errorRows: number;
+  truncated: boolean;
+  limit: { maxRows: number };
+  rows: Array<{
+    rowNumber: number;
+    name: string;
+    address: string;
+    status: "valid" | "duplicate" | "error";
+    error: string | null;
+    canonicalAddress: string | null;
+    existing: { contactId: string; trust: SenderRule } | null;
+  }>;
+};
+
+export type ImportCommitResult = {
+  created: number;
+  updated: number;
+  unchanged: number;
+  rejected: number;
+  total: number;
+  appliedRules: number;
+  contacts: ContactWithResolution["contact"][];
+};
+
+export async function listContacts(
+  actor: string,
+  options: { query?: string; cursor?: string; limit?: number } = {},
+): Promise<ContactListResult> {
+  const params = new URLSearchParams();
+  if (options.query) params.set("query", options.query);
+  if (options.cursor) params.set("cursor", options.cursor);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  return contactsFetch<ContactListResult>(`?${qs}`, actor);
+}
+
+export async function createContact(
+  actor: string,
+  input: { name: string; address: string; trust?: SenderRule },
+): Promise<ContactWithResolution> {
+  return contactsFetch<ContactWithResolution>("/", actor, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function getContact(actor: string, contactId: string): Promise<ContactWithResolution> {
+  return contactsFetch<ContactWithResolution>(`/${encodeURIComponent(contactId)}`, actor);
+}
+
+export async function updateContact(
+  actor: string,
+  contactId: string,
+  input: { name?: string; address?: string; trust?: SenderRule; expectedVersion?: number },
+): Promise<ContactWithResolution> {
+  return contactsFetch<ContactWithResolution>(`/${encodeURIComponent(contactId)}`, actor, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteContact(actor: string, contactId: string): Promise<void> {
+  await contactsFetch<unknown>(`/${encodeURIComponent(contactId)}`, actor, {
+    method: "DELETE",
+  });
+}
+
+export async function mergeContacts(
+  actor: string,
+  input: { keepContactId: string; mergeContactIds: string[] },
+): Promise<ContactWithResolution> {
+  return contactsFetch<ContactWithResolution>("/merge", actor, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function previewContactImport(
+  actor: string,
+  input: { format: "csv" | "vcard"; content: string },
+): Promise<ImportPreviewResult> {
+  return contactsFetch<ImportPreviewResult>("/import/preview", actor, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export async function commitContactImport(
+  actor: string,
+  input: {
+    rows: Array<{ name: string; address: string; trust?: SenderRule; source?: "csv" | "vcard" }>;
+    applyTrust?: boolean;
+  },
+): Promise<ImportCommitResult> {
+  return contactsFetch<ImportCommitResult>("/import/commit", actor, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+export { isGAddress };

--- a/src/features/contacts/import/ContactMigrationDialog.tsx
+++ b/src/features/contacts/import/ContactMigrationDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { AlertCircle, Users, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isGAddress } from "../api";
 import { ImportSourcePicker } from "./ImportSourcePicker";
 import { IdentityReviewTable } from "./IdentityReviewTable";
 import { BulkWriteProgressPanel } from "./BulkWriteProgressPanel";
@@ -14,6 +15,7 @@ import {
   pauseWrite,
   resumeWrite,
   createMemoryPolicyApi,
+  createLivePolicyApi,
   type PolicyApi,
 } from "./bulkPolicyWriter";
 import { saveSession, defaultRetentionForSource, cleanExpiredSessions } from "./dataRetention";
@@ -73,7 +75,12 @@ export function ContactMigrationDialog({
   const [fallbackTrust, setFallbackTrust] = useState<"allow" | "block" | "default">("default");
   const [retention, setRetention] = useState<DataRetentionPolicy>("session");
   const [source, setSource] = useState<ImportSource>("csv");
-  const apiRef = useRef<PolicyApi>(externalApi ?? createMemoryPolicyApi());
+  // Default to the live contacts API when the owner is a valid Stellar
+  // G-address (BETA-066); otherwise fall back to the in-memory demo API so the
+  // wizard still works in preview environments.
+  const apiRef = useRef<PolicyApi>(
+    externalApi ?? (isGAddress(owner) ? createLivePolicyApi(owner) : createMemoryPolicyApi()),
+  );
   const runningRef = useRef(false);
 
   // Clean expired sessions on mount

--- a/src/features/contacts/import/bulkPolicyWriter.ts
+++ b/src/features/contacts/import/bulkPolicyWriter.ts
@@ -1,3 +1,4 @@
+import { commitContactImport } from "../api";
 import type {
   BulkWriteProgress,
   BulkWriteStatus,
@@ -35,6 +36,31 @@ export function createMemoryPolicyApi(): PolicyApi & { dump(): Record<string, "a
     },
     dump() {
       return Object.fromEntries(rules);
+    },
+  };
+}
+
+/**
+ * Live policy API backed by the BETA-066 contacts import/commit endpoint.
+ *
+ * Each rule write commits a single contact row through
+ * `POST /api/v1/contacts/import/commit` with `applyTrust: true`, so the
+ * resulting contact row is stored and the allow/block sender rule is applied
+ * atomically. Unlike the memory API this persists to the actor's mailbox.
+ */
+export function createLivePolicyApi(owner: string): PolicyApi {
+  return {
+    async setSenderRule(_owner: string, sender: string, rule: "allow" | "block") {
+      await commitContactImport(owner, {
+        rows: [{ name: sender, address: sender, trust: rule, source: "csv" }],
+        applyTrust: true,
+      });
+    },
+    async removeSenderRule(_owner: string, sender: string) {
+      await commitContactImport(owner, {
+        rows: [{ name: sender, address: sender, trust: "default", source: "csv" }],
+        applyTrust: false,
+      });
     },
   };
 }

--- a/src/features/contacts/index.ts
+++ b/src/features/contacts/index.ts
@@ -1,5 +1,23 @@
 export { ContactMigrationDialog } from "./import/ContactMigrationDialog";
 export type { ImportedContact } from "./types";
+export {
+  listContacts,
+  createContact,
+  getContact,
+  updateContact,
+  deleteContact,
+  mergeContacts,
+  previewContactImport,
+  commitContactImport,
+  isGAddress,
+  ContactsApiError,
+} from "./api";
+export type {
+  ContactWithResolution,
+  ContactListResult,
+  ImportPreviewResult,
+  ImportCommitResult,
+} from "./api";
 export type {
   ImportedContactRow,
   IdentityMatch,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
 import { Route as ApiV1RequestsIndexRouteImport } from './routes/api/v1/requests/index'
 import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts/index'
 import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
+import { Route as ApiV1ContactsIndexRouteImport } from './routes/api/v1/contacts/index'
 import { Route as ApiV1AccountsIndexRouteImport } from './routes/api/v1/accounts/index'
 import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
 import { Route as ApiV1RelayReadinessRouteImport } from './routes/api/v1/relay/readiness'
@@ -34,6 +35,8 @@ import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies
 import { Route as ApiV1MailboxQueueRouteImport } from './routes/api/v1/mailbox/queue'
 import { Route as ApiV1MailboxMessageIdRouteImport } from './routes/api/v1/mailbox/$messageId'
 import { Route as ApiV1IdentityResolveRouteImport } from './routes/api/v1/identity/resolve'
+import { Route as ApiV1ContactsMergeRouteImport } from './routes/api/v1/contacts/merge'
+import { Route as ApiV1ContactsContactIdRouteImport } from './routes/api/v1/contacts/$contactId'
 import { Route as ApiV1AuthVerifyRouteImport } from './routes/api/v1/auth/verify'
 import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
 import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
@@ -57,6 +60,8 @@ import { Route as ApiV1IdentityKeysRotateRouteImport } from './routes/api/v1/ide
 import { Route as ApiV1IdentityKeysRevokeRouteImport } from './routes/api/v1/identity/keys/revoke'
 import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/identity/keys/retire'
 import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
+import { Route as ApiV1ContactsImportPreviewRouteImport } from './routes/api/v1/contacts/import/preview'
+import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/contacts/import/commit'
 import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 
@@ -118,6 +123,11 @@ const ApiV1ReceiptsIndexRoute = ApiV1ReceiptsIndexRouteImport.update({
 const ApiV1PostageIndexRoute = ApiV1PostageIndexRouteImport.update({
   id: '/api/v1/postage/',
   path: '/api/v1/postage/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsIndexRoute = ApiV1ContactsIndexRouteImport.update({
+  id: '/api/v1/contacts/',
+  path: '/api/v1/contacts/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1AccountsIndexRoute = ApiV1AccountsIndexRouteImport.update({
@@ -183,6 +193,16 @@ const ApiV1MailboxMessageIdRoute = ApiV1MailboxMessageIdRouteImport.update({
 const ApiV1IdentityResolveRoute = ApiV1IdentityResolveRouteImport.update({
   id: '/api/v1/identity/resolve',
   path: '/api/v1/identity/resolve',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsMergeRoute = ApiV1ContactsMergeRouteImport.update({
+  id: '/api/v1/contacts/merge',
+  path: '/api/v1/contacts/merge',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsContactIdRoute = ApiV1ContactsContactIdRouteImport.update({
+  id: '/api/v1/contacts/$contactId',
+  path: '/api/v1/contacts/$contactId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1AuthVerifyRoute = ApiV1AuthVerifyRouteImport.update({
@@ -309,6 +329,18 @@ const ApiV1IdentityKeysKeyIdRoute = ApiV1IdentityKeysKeyIdRouteImport.update({
   path: '/api/v1/identity/keys/$keyId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1ContactsImportPreviewRoute =
+  ApiV1ContactsImportPreviewRouteImport.update({
+    id: '/api/v1/contacts/import/preview',
+    path: '/api/v1/contacts/import/preview',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1ContactsImportCommitRoute =
+  ApiV1ContactsImportCommitRouteImport.update({
+    id: '/api/v1/contacts/import/commit',
+    path: '/api/v1/contacts/import/commit',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1AccountsProvisioningRetryRoute =
   ApiV1AccountsProvisioningRetryRouteImport.update({
     id: '/retry',
@@ -340,6 +372,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
+  '/api/v1/contacts/$contactId': typeof ApiV1ContactsContactIdRoute
+  '/api/v1/contacts/merge': typeof ApiV1ContactsMergeRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
@@ -353,10 +387,13 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
+  '/api/v1/contacts/': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
+  '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
   '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
@@ -392,6 +429,8 @@ export interface FileRoutesByTo {
   '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
+  '/api/v1/contacts/$contactId': typeof ApiV1ContactsContactIdRoute
+  '/api/v1/contacts/merge': typeof ApiV1ContactsMergeRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
@@ -405,10 +444,13 @@ export interface FileRoutesByTo {
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/accounts': typeof ApiV1AccountsIndexRoute
+  '/api/v1/contacts': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
+  '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
   '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
@@ -445,6 +487,8 @@ export interface FileRoutesById {
   '/api/v1/auth/resend-verification': typeof ApiV1AuthResendVerificationRoute
   '/api/v1/auth/session': typeof ApiV1AuthSessionRoute
   '/api/v1/auth/verify': typeof ApiV1AuthVerifyRoute
+  '/api/v1/contacts/$contactId': typeof ApiV1ContactsContactIdRoute
+  '/api/v1/contacts/merge': typeof ApiV1ContactsMergeRoute
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
@@ -458,10 +502,13 @@ export interface FileRoutesById {
   '/api/v1/relay/readiness': typeof ApiV1RelayReadinessRoute
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
+  '/api/v1/contacts/': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
+  '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
   '/api/v1/identity/keys/retire': typeof ApiV1IdentityKeysRetireRoute
   '/api/v1/identity/keys/revoke': typeof ApiV1IdentityKeysRevokeRoute
@@ -499,6 +546,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
     | '/api/v1/auth/verify'
+    | '/api/v1/contacts/$contactId'
+    | '/api/v1/contacts/merge'
     | '/api/v1/identity/resolve'
     | '/api/v1/mailbox/$messageId'
     | '/api/v1/mailbox/queue'
@@ -512,10 +561,13 @@ export interface FileRouteTypes {
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
     | '/api/v1/accounts/'
+    | '/api/v1/contacts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/contacts/import/commit'
+    | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
     | '/api/v1/identity/keys/revoke'
@@ -551,6 +603,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
     | '/api/v1/auth/verify'
+    | '/api/v1/contacts/$contactId'
+    | '/api/v1/contacts/merge'
     | '/api/v1/identity/resolve'
     | '/api/v1/mailbox/$messageId'
     | '/api/v1/mailbox/queue'
@@ -564,10 +618,13 @@ export interface FileRouteTypes {
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
     | '/api/v1/accounts'
+    | '/api/v1/contacts'
     | '/api/v1/postage'
     | '/api/v1/receipts'
     | '/api/v1/requests'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/contacts/import/commit'
+    | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
     | '/api/v1/identity/keys/revoke'
@@ -603,6 +660,8 @@ export interface FileRouteTypes {
     | '/api/v1/auth/resend-verification'
     | '/api/v1/auth/session'
     | '/api/v1/auth/verify'
+    | '/api/v1/contacts/$contactId'
+    | '/api/v1/contacts/merge'
     | '/api/v1/identity/resolve'
     | '/api/v1/mailbox/$messageId'
     | '/api/v1/mailbox/queue'
@@ -616,10 +675,13 @@ export interface FileRouteTypes {
     | '/api/v1/relay/readiness'
     | '/api/v1/relay/version'
     | '/api/v1/accounts/'
+    | '/api/v1/contacts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/contacts/import/commit'
+    | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
     | '/api/v1/identity/keys/retire'
     | '/api/v1/identity/keys/revoke'
@@ -656,6 +718,8 @@ export interface RootRouteChildren {
   ApiV1AuthResendVerificationRoute: typeof ApiV1AuthResendVerificationRoute
   ApiV1AuthSessionRoute: typeof ApiV1AuthSessionRoute
   ApiV1AuthVerifyRoute: typeof ApiV1AuthVerifyRoute
+  ApiV1ContactsContactIdRoute: typeof ApiV1ContactsContactIdRoute
+  ApiV1ContactsMergeRoute: typeof ApiV1ContactsMergeRoute
   ApiV1IdentityResolveRoute: typeof ApiV1IdentityResolveRoute
   ApiV1MailboxMessageIdRoute: typeof ApiV1MailboxMessageIdRoute
   ApiV1MailboxQueueRoute: typeof ApiV1MailboxQueueRoute
@@ -669,9 +733,12 @@ export interface RootRouteChildren {
   ApiV1RelayReadinessRoute: typeof ApiV1RelayReadinessRoute
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
   ApiV1AccountsIndexRoute: typeof ApiV1AccountsIndexRoute
+  ApiV1ContactsIndexRoute: typeof ApiV1ContactsIndexRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
   ApiV1RequestsIndexRoute: typeof ApiV1RequestsIndexRoute
+  ApiV1ContactsImportCommitRoute: typeof ApiV1ContactsImportCommitRoute
+  ApiV1ContactsImportPreviewRoute: typeof ApiV1ContactsImportPreviewRoute
   ApiV1IdentityKeysKeyIdRoute: typeof ApiV1IdentityKeysKeyIdRoute
   ApiV1IdentityKeysRetireRoute: typeof ApiV1IdentityKeysRetireRoute
   ApiV1IdentityKeysRevokeRoute: typeof ApiV1IdentityKeysRevokeRoute
@@ -770,6 +837,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PostageIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/contacts/': {
+      id: '/api/v1/contacts/'
+      path: '/api/v1/contacts'
+      fullPath: '/api/v1/contacts/'
+      preLoaderRoute: typeof ApiV1ContactsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/accounts/': {
       id: '/api/v1/accounts/'
       path: '/api/v1/accounts'
@@ -859,6 +933,20 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/identity/resolve'
       fullPath: '/api/v1/identity/resolve'
       preLoaderRoute: typeof ApiV1IdentityResolveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/merge': {
+      id: '/api/v1/contacts/merge'
+      path: '/api/v1/contacts/merge'
+      fullPath: '/api/v1/contacts/merge'
+      preLoaderRoute: typeof ApiV1ContactsMergeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/$contactId': {
+      id: '/api/v1/contacts/$contactId'
+      path: '/api/v1/contacts/$contactId'
+      fullPath: '/api/v1/contacts/$contactId'
+      preLoaderRoute: typeof ApiV1ContactsContactIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/auth/verify': {
@@ -1022,6 +1110,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1IdentityKeysKeyIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/contacts/import/preview': {
+      id: '/api/v1/contacts/import/preview'
+      path: '/api/v1/contacts/import/preview'
+      fullPath: '/api/v1/contacts/import/preview'
+      preLoaderRoute: typeof ApiV1ContactsImportPreviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/import/commit': {
+      id: '/api/v1/contacts/import/commit'
+      path: '/api/v1/contacts/import/commit'
+      fullPath: '/api/v1/contacts/import/commit'
+      preLoaderRoute: typeof ApiV1ContactsImportCommitRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/accounts/provisioning/retry': {
       id: '/api/v1/accounts/provisioning/retry'
       path: '/retry'
@@ -1115,6 +1217,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1AuthResendVerificationRoute: ApiV1AuthResendVerificationRoute,
   ApiV1AuthSessionRoute: ApiV1AuthSessionRoute,
   ApiV1AuthVerifyRoute: ApiV1AuthVerifyRoute,
+  ApiV1ContactsContactIdRoute: ApiV1ContactsContactIdRoute,
+  ApiV1ContactsMergeRoute: ApiV1ContactsMergeRoute,
   ApiV1IdentityResolveRoute: ApiV1IdentityResolveRoute,
   ApiV1MailboxMessageIdRoute: ApiV1MailboxMessageIdRoute,
   ApiV1MailboxQueueRoute: ApiV1MailboxQueueRoute,
@@ -1128,9 +1232,12 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayReadinessRoute: ApiV1RelayReadinessRoute,
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
   ApiV1AccountsIndexRoute: ApiV1AccountsIndexRoute,
+  ApiV1ContactsIndexRoute: ApiV1ContactsIndexRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
   ApiV1RequestsIndexRoute: ApiV1RequestsIndexRoute,
+  ApiV1ContactsImportCommitRoute: ApiV1ContactsImportCommitRoute,
+  ApiV1ContactsImportPreviewRoute: ApiV1ContactsImportPreviewRoute,
   ApiV1IdentityKeysKeyIdRoute: ApiV1IdentityKeysKeyIdRoute,
   ApiV1IdentityKeysRetireRoute: ApiV1IdentityKeysRetireRoute,
   ApiV1IdentityKeysRevokeRoute: ApiV1IdentityKeysRevokeRoute,

--- a/src/routes/api/v1/contacts/$contactId.ts
+++ b/src/routes/api/v1/contacts/$contactId.ts
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { deleteContact, getContact, updateContact } from "@/server/api/contact-service";
+import { getApiContext } from "@/server/api/context";
+import { contactUpdateSchema } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/contacts/$contactId")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const result = await getContact(context.repository, owner, params.contactId);
+          return apiSuccess(request, result);
+        }),
+      PUT: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const body = await parseJsonBody(request, contactUpdateSchema, {
+            route: "PUT /contacts/{contactId}",
+          });
+          const result = await updateContact(context.repository, owner, params.contactId, body);
+          return apiSuccess(request, result);
+        }),
+      DELETE: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const result = await deleteContact(context.repository, owner, params.contactId);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/contacts/-_schemas.ts
+++ b/src/routes/api/v1/contacts/-_schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+import { senderRuleSchema } from "@/server/api/domain";
+
+export const contactListQuerySchema = z.object({
+  query: z.string().trim().max(200).optional(),
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+export const contactMergeSchema = z.object({
+  keepContactId: z.string().trim().min(1),
+  mergeContactIds: z.array(z.string().trim().min(1)).min(1),
+});
+
+export const importCommitRowSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  address: z.string().trim().min(1).max(300),
+  trust: senderRuleSchema.optional(),
+  source: z.enum(["csv", "vcard"]).optional(),
+});
+
+export const importCommitSchema = z.object({
+  rows: z.array(importCommitRowSchema).min(1).max(1000),
+  applyTrust: z.boolean().default(false),
+});
+
+export const importPreviewSchema = z.object({
+  format: z.enum(["csv", "vcard"]),
+  content: z
+    .string()
+    .min(1)
+    .max(512 * 1024),
+});

--- a/src/routes/api/v1/contacts/import/commit.ts
+++ b/src/routes/api/v1/contacts/import/commit.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { commitContactImport } from "@/server/api/contact-service";
+import { getApiContext } from "@/server/api/context";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+import { importCommitSchema } from "../-_schemas";
+
+export const Route = createFileRoute("/api/v1/contacts/import/commit")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const body = await parseJsonBody(request, importCommitSchema, {
+            route: "POST /contacts/import/commit",
+          });
+          const result = await commitContactImport(context.repository, owner, body);
+          return apiSuccess(request, result, { status: 201 });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/contacts/import/preview.ts
+++ b/src/routes/api/v1/contacts/import/preview.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { previewContactImport } from "@/server/api/contact-service";
+import { getApiContext } from "@/server/api/context";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+import { importPreviewSchema } from "../-_schemas";
+
+export const Route = createFileRoute("/api/v1/contacts/import/preview")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const body = await parseJsonBody(request, importPreviewSchema, {
+            route: "POST /contacts/import/preview",
+          });
+          const result = await previewContactImport(context.repository, owner, body);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/contacts/index.ts
+++ b/src/routes/api/v1/contacts/index.ts
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { createContact, listContacts } from "@/server/api/contact-service";
+import { getApiContext } from "@/server/api/context";
+import { contactCreateSchema } from "@/server/api/domain";
+import { parseJsonBody, parseSearchParams } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+import { contactListQuerySchema } from "./-_schemas";
+
+export const Route = createFileRoute("/api/v1/contacts/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const query = parseSearchParams(request, contactListQuerySchema);
+          const result = await listContacts(context.repository, owner, {
+            query: query.query,
+            limit: query.limit,
+            after: query.cursor,
+          });
+          return apiSuccess(request, result);
+        }),
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const body = await parseJsonBody(request, contactCreateSchema, {
+            route: "POST /contacts",
+          });
+          const result = await createContact(context.repository, owner, body);
+          return apiSuccess(request, result, { status: 201 });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/contacts/merge.ts
+++ b/src/routes/api/v1/contacts/merge.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { mergeContacts } from "@/server/api/contact-service";
+import { getApiContext } from "@/server/api/context";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+import { contactMergeSchema } from "./-_schemas";
+
+export const Route = createFileRoute("/api/v1/contacts/merge")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = requireActor(context);
+          const body = await parseJsonBody(request, contactMergeSchema, {
+            route: "POST /contacts/merge",
+          });
+          const result = await mergeContacts(context.repository, owner, body);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/server/api/contact-import.ts
+++ b/src/server/api/contact-import.ts
@@ -1,0 +1,236 @@
+import { contactSchema } from "./domain";
+
+// ---------------------------------------------------------------------------
+// Issue #1973 (BETA-066) — Safe CSV / vCard contact import parsing
+//
+// Pure parsing utilities shared by the import preview/commit routes. No I/O,
+// no policy mutation: these functions only turn raw text into validated rows
+// with per-row errors, so a malformed file degrades gracefully instead of
+// aborting the whole import.
+// ---------------------------------------------------------------------------
+
+export type ImportFormat = "csv" | "vcard";
+
+export type ParsedImportRow = {
+  rowNumber: number;
+  name: string;
+  address: string;
+  /** "csv" | "vcard" — recorded on the durable contact when committed. */
+  source: "csv" | "vcard";
+  error: string | null;
+};
+
+const MAX_NAME_LENGTH = 200;
+const MAX_ADDRESS_LENGTH = 300;
+
+function validateAddress(address: string): string | null {
+  const trimmed = address.trim();
+  if (!trimmed) return "Address is required.";
+  if (trimmed.length > MAX_ADDRESS_LENGTH) {
+    return `Address exceeds ${MAX_ADDRESS_LENGTH} characters.`;
+  }
+  if (/^[GS][A-Z2-7]{55}$/.test(trimmed)) return null;
+  if (trimmed.includes("*")) return null;
+  if (contactSchema.shape.address.safeParse(trimmed).success) return null;
+  return "Not a valid Stealth/Stellar address or federation address (name*domain).";
+}
+
+function validateName(name: string): string {
+  const trimmed = name.trim();
+  return trimmed.length > MAX_NAME_LENGTH ? trimmed.slice(0, MAX_NAME_LENGTH) : trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// CSV / TSV parsing
+// ---------------------------------------------------------------------------
+
+const CSV_HEADER_PATTERNS = [
+  /^name[,;\t]address$/i,
+  /^address[,;\t]name$/i,
+  /^full.?name[,;\t]email[,;\t]address$/i,
+  /^email[,;\t]address$/i,
+  /^address$/i,
+];
+
+function detectDelimiter(line: string): string {
+  const comma = (line.match(/,/g) || []).length;
+  const tab = (line.match(/\t/g) || []).length;
+  const semi = (line.match(/;/g) || []).length;
+  if (tab > comma && tab > semi) return "\t";
+  if (semi > comma && semi > tab) return ";";
+  return ",";
+}
+
+function isCsvHeaderLine(line: string): boolean {
+  const normalised = line.toLowerCase().replace(/ /g, "").replace(/["']/g, "");
+  return CSV_HEADER_PATTERNS.some((pattern) => pattern.test(normalised));
+}
+
+function splitCsvLine(line: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === delimiter && !inQuotes) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts.map((part) => part.replace(/^"|"$/g, "").trim());
+}
+
+export function parseCsv(raw: string): ParsedImportRow[] {
+  const cleaned = raw.replace(/^\uFEFF/, "").trim();
+  if (!cleaned) return [];
+
+  const lines = cleaned
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return [];
+
+  const delimiter = detectDelimiter(lines[0]);
+  const hasHeader = isCsvHeaderLine(lines[0]);
+  const dataLines = hasHeader ? lines.slice(1) : lines;
+  const header = hasHeader
+    ? lines[0].split(delimiter).map((h) => h.trim().toLowerCase().replace(/["']/g, ""))
+    : [];
+
+  const nameIdx = header.findIndex(
+    (h) => h === "name" || h === "full name" || h === "full_name" || h === "fullname",
+  );
+  const addressIdx = header.findIndex(
+    (h) => h === "address" || h === "stellar address" || h === "stellar_address" || h === "wallet",
+  );
+  const emailIdx = header.findIndex((h) => h === "email");
+
+  const results: ParsedImportRow[] = [];
+  for (let i = 0; i < dataLines.length; i += 1) {
+    const parts = splitCsvLine(dataLines[i], delimiter);
+    if (parts.length === 0) continue;
+
+    let name = "";
+    let address = "";
+
+    if (hasHeader && nameIdx >= 0 && addressIdx >= 0) {
+      name = parts[nameIdx]?.trim() ?? "";
+      address = parts[addressIdx]?.trim() ?? "";
+    } else if (hasHeader && emailIdx >= 0 && addressIdx >= 0) {
+      name = parts[emailIdx]?.trim() ?? "";
+      address = parts[addressIdx]?.trim() ?? "";
+    } else if (hasHeader && addressIdx >= 0) {
+      name = parts.length > 1 ? (parts[0]?.trim() ?? "") : "";
+      address = parts[addressIdx]?.trim() ?? "";
+    } else if (parts.length === 1) {
+      address = parts[0].trim();
+    } else {
+      name = parts[0].trim();
+      address = parts[1]?.trim() ?? "";
+    }
+
+    const error = validateAddress(address);
+    if (error && !address && !name) continue;
+
+    results.push({
+      rowNumber: i + 1 + (hasHeader ? 1 : 0),
+      name: validateName(name),
+      address,
+      source: "csv",
+      error,
+    });
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// vCard (v3/v4) parsing
+// ---------------------------------------------------------------------------
+
+export function parseVCard(raw: string): ParsedImportRow[] {
+  const cleaned = raw.replace(/^\uFEFF/, "").trim();
+  if (!cleaned) return [];
+
+  const normalized = cleaned.replace(/\r\n?/g, "\n");
+  const blocks = normalized
+    .split(/^END:VCARD$/gim)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const results: ParsedImportRow[] = [];
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (!block || !/^BEGIN:VCARD/i.test(block)) {
+      continue;
+    }
+
+    const lines = block
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    let name = "";
+    let address = "";
+    const emailAddresses: string[] = [];
+
+    for (const line of lines) {
+      const colonIndex = line.indexOf(":");
+      if (colonIndex < 0) continue;
+      const keyRaw = line.slice(0, colonIndex);
+      const value = line.slice(colonIndex + 1).trim();
+      const key = keyRaw.toUpperCase();
+
+      if (key.startsWith("FN")) {
+        name = value;
+      } else if (key.startsWith("EMAIL")) {
+        emailAddresses.push(value);
+      } else if (key.startsWith("TEL")) {
+        // Ignore phone numbers as addresses.
+      }
+    }
+
+    if (!name) {
+      // Fall back to N (structured name) when FN is missing.
+      const nLine = lines.find((line) => line.toUpperCase().startsWith("N:"));
+      if (nLine) {
+        const [, value] = nLine.split(":");
+        const [family, given] = value.split(";");
+        name = [given, family].filter(Boolean).join(" ").trim();
+      }
+    }
+
+    // Prefer a Stealth/Stellar-shaped field, then any email.
+    const stellarish = emailAddresses.find((email) => /^[GS][A-Z2-7]{55}$/.test(email.trim()));
+    address = (stellarish ?? emailAddresses[0] ?? "").trim();
+
+    const error = validateAddress(address);
+    results.push({
+      rowNumber: i + 1,
+      name: validateName(name),
+      address,
+      source: "vcard",
+      error,
+    });
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Shared preview builder
+// ---------------------------------------------------------------------------
+
+export function buildImportPreview(
+  format: ImportFormat,
+  content: string,
+  maxRows: number,
+): { rows: ParsedImportRow[]; truncated: boolean } {
+  const parsed = format === "vcard" ? parseVCard(content) : parseCsv(content);
+  const truncated = parsed.length > maxRows;
+  const rows = truncated ? parsed.slice(0, maxRows) : parsed;
+  return { rows, truncated };
+}

--- a/src/server/api/contact-service.ts
+++ b/src/server/api/contact-service.ts
@@ -1,0 +1,523 @@
+import { defaultIdentityResolver } from "@/features/identity/resolver";
+import type { ResolvedIdentity } from "@/features/identity/types";
+import type { Contact, ContactUpdateInput, SenderRule } from "./domain";
+import { contactSchema } from "./domain";
+import { ApiError } from "./errors";
+import { getKeyDirectory } from "./key-directory-service";
+import { setSenderRule } from "./policy-service";
+import type { ApiRepository, ContactQueryOptions, Page } from "./repository";
+import { buildImportPreview, type ParsedImportRow } from "./contact-import";
+
+// ---------------------------------------------------------------------------
+// Issue #1973 (BETA-066) — Live contacts service
+//
+// Resolves every contact to a Stealth identity, key-freshness, and sender
+// trust state. Contact rows never mutate mailbox policy implicitly: the
+// "trust" field only records the *intent*; policy writes happen through the
+// explicit sender-rule endpoints (or the user's confirmed import).
+// ---------------------------------------------------------------------------
+
+export interface ContactResolution {
+  identity: ResolvedIdentity | null;
+  keyDirectory: Awaited<ReturnType<typeof getKeyDirectory>> | null;
+  senderRule: SenderRule;
+  senderRuleConfigured: boolean;
+}
+
+export interface ContactWithResolution {
+  contact: Contact;
+  resolution: ContactResolution;
+}
+
+export interface ContactListResult {
+  items: ContactWithResolution[];
+  nextContinuationKey: string | null;
+}
+
+const IDENTITY_RESOLUTION_TIMEOUT_MS = 2000;
+
+function contactId(): string {
+  return `c_${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function normalizeOwner(owner: string): string {
+  return owner.trim().toUpperCase();
+}
+
+async function resolveContact(
+  repository: ApiRepository,
+  owner: string,
+  contact: Contact,
+): Promise<ContactWithResolution> {
+  const normOwner = normalizeOwner(owner);
+  const resolution = await resolveContactState(repository, normOwner, contact);
+  return { contact, resolution };
+}
+
+/**
+ * Resolve the live identity, key-freshness, and trust state for a single
+ * contact. Resolution failures degrade to `identity: null` (plus a non-fatal
+ * error under `resolutionError`) rather than throwing, so a stale or
+ * unreachable directory never breaks listing.
+ */
+export async function resolveContactState(
+  repository: ApiRepository,
+  owner: string,
+  contact: Contact,
+): Promise<ContactResolution> {
+  const normOwner = normalizeOwner(owner);
+  let identity: ResolvedIdentity | null = null;
+  try {
+    const result = await defaultIdentityResolver.resolve(contact.address, {
+      repository,
+      timeoutMs: IDENTITY_RESOLUTION_TIMEOUT_MS,
+    });
+    if (result.resolved) {
+      identity = result;
+    }
+  } catch {
+    identity = null;
+  }
+
+  let keyDirectory: ContactResolution["keyDirectory"] = null;
+  const targetAddress = identity?.canonicalAddress ?? contact.canonicalAddress;
+  if (targetAddress) {
+    try {
+      keyDirectory = await getKeyDirectory(repository, targetAddress);
+    } catch {
+      keyDirectory = null;
+    }
+  }
+
+  const senderAddress = identity?.canonicalAddress ?? contact.address;
+  let senderRule: SenderRule = "default";
+  let senderRuleConfigured = false;
+  try {
+    const stored = await repository.getSenderRule(normOwner, senderAddress);
+    senderRule = stored;
+    senderRuleConfigured = stored !== "default";
+  } catch {
+    // A missing rule is indistinguishable from "default" by contract.
+  }
+
+  return { identity, keyDirectory, senderRule, senderRuleConfigured };
+}
+
+export async function listContacts(
+  repository: ApiRepository,
+  owner: string,
+  options: ContactQueryOptions = {},
+): Promise<ContactListResult> {
+  const normOwner = normalizeOwner(owner);
+  const page: Page<Contact> = await repository.listContacts(normOwner, options);
+  const items = await Promise.all(
+    page.items.map((contact) => resolveContact(repository, normOwner, contact)),
+  );
+  return { items, nextContinuationKey: page.nextContinuationKey };
+}
+
+export async function getContact(
+  repository: ApiRepository,
+  owner: string,
+  contactId: string,
+): Promise<ContactWithResolution> {
+  const normOwner = normalizeOwner(owner);
+  const contact = await repository.getContact(normOwner, contactId);
+  if (!contact) {
+    throw new ApiError(404, "not_found", `No contact found for ${contactId}`);
+  }
+  return resolveContact(repository, normOwner, contact);
+}
+
+export async function createContact(
+  repository: ApiRepository,
+  owner: string,
+  input: { name: string; address: string; trust?: SenderRule },
+): Promise<ContactWithResolution> {
+  const normOwner = normalizeOwner(owner);
+  const now = new Date().toISOString();
+  const contact: Contact = {
+    contactId: contactId(),
+    owner: normOwner,
+    name: input.name,
+    address: input.address,
+    canonicalAddress: null,
+    trust: input.trust ?? "default",
+    source: "manual",
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+  };
+  const stored = await repository.createContact(contact);
+  return resolveContact(repository, normOwner, stored);
+}
+
+export async function updateContact(
+  repository: ApiRepository,
+  owner: string,
+  contactId: string,
+  input: ContactUpdateInput,
+): Promise<ContactWithResolution> {
+  const normOwner = normalizeOwner(owner);
+  const existing = await repository.getContact(normOwner, contactId);
+  if (!existing) {
+    throw new ApiError(404, "not_found", `No contact found for ${contactId}`);
+  }
+
+  const next: Contact = {
+    ...existing,
+    name: input.name ?? existing.name,
+    address: input.address ?? existing.address,
+    trust: input.trust ?? existing.trust,
+    updatedAt: new Date().toISOString(),
+  };
+
+  // If the address changed, the previously resolved canonical address is stale.
+  if (input.address !== undefined && input.address !== existing.address) {
+    next.canonicalAddress = null;
+  }
+
+  const expectedVersion = input.expectedVersion ?? existing.version;
+  const result = await repository.updateContact(next, expectedVersion);
+  if (!result.updated) {
+    if (result.current) {
+      throw new ApiError(409, "conflict", "Contact was modified concurrently; re-read and retry");
+    }
+    throw new ApiError(404, "not_found", `No contact found for ${contactId}`);
+  }
+  return resolveContact(repository, normOwner, result.contact);
+}
+
+export async function deleteContact(
+  repository: ApiRepository,
+  owner: string,
+  contactId: string,
+): Promise<{ deleted: boolean; contactId: string }> {
+  const normOwner = normalizeOwner(owner);
+  await repository.deleteContact(normOwner, contactId);
+  return { deleted: true, contactId };
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+export interface MergeContactsInput {
+  keepContactId: string;
+  mergeContactIds: string[];
+}
+
+/**
+ * Merges `mergeContactIds` into `keepContactId` (both scoped to `owner`).
+ * The kept contact wins; every merged contact is deleted. Returns the
+ * surviving contact re-resolved against live identity/trust state.
+ */
+export async function mergeContacts(
+  repository: ApiRepository,
+  owner: string,
+  input: MergeContactsInput,
+): Promise<ContactWithResolution> {
+  const normOwner = normalizeOwner(owner);
+  const { keepContactId, mergeContactIds } = input;
+  if (mergeContactIds.includes(keepContactId)) {
+    throw new ApiError(400, "bad_request", "Cannot merge a contact into itself");
+  }
+  if (new Set(mergeContactIds).size !== mergeContactIds.length) {
+    throw new ApiError(400, "bad_request", "Duplicate contact IDs in merge list");
+  }
+
+  const keep = await repository.getContact(normOwner, keepContactId);
+  if (!keep) {
+    throw new ApiError(404, "not_found", `No contact found for ${keepContactId}`);
+  }
+
+  for (const mergeId of mergeContactIds) {
+    const merged = await repository.getContact(normOwner, mergeId);
+    if (!merged) {
+      throw new ApiError(404, "not_found", `No contact found for ${mergeId}`);
+    }
+    if (merged.owner.toUpperCase() !== normOwner) {
+      throw new ApiError(403, "forbidden", "Cannot merge a contact owned by another actor");
+    }
+  }
+
+  for (const mergeId of mergeContactIds) {
+    await repository.deleteContact(normOwner, mergeId);
+  }
+
+  // The kept record wins with a bumped version so concurrent writers cannot
+  // resurrect a merged-away contact.
+  const result = await repository.updateContact(keep, keep.version);
+  if (!result.updated) {
+    throw new ApiError(409, "conflict", "Contact was modified concurrently; re-read and retry");
+  }
+  return resolveContact(repository, normOwner, result.contact);
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+export const IMPORT_MAX_ROWS = 1000;
+
+export interface ContactImportPreviewResult {
+  format: "csv" | "vcard";
+  totalRows: number;
+  validRows: number;
+  duplicateRows: number;
+  errorRows: number;
+  truncated: boolean;
+  limit: { maxRows: number };
+  rows: Array<{
+    rowNumber: number;
+    name: string;
+    address: string;
+    status: "valid" | "duplicate" | "error";
+    error: string | null;
+    canonicalAddress: string | null;
+    identityStatus: string | null;
+    keyFreshness: string | null;
+    existing: { contactId: string; trust: SenderRule } | null;
+  }>;
+}
+
+export interface ContactImportCommitInput {
+  rows: Array<{ name: string; address: string; trust?: SenderRule; source?: "csv" | "vcard" }>;
+  /** When true, apply each row's trust as a sender rule for the owner. */
+  applyTrust?: boolean;
+}
+
+export interface ContactImportCommitResult {
+  created: number;
+  updated: number;
+  unchanged: number;
+  rejected: number;
+  total: number;
+  appliedRules: number;
+  contacts: Contact[];
+}
+
+function dedupeRows(rows: ParsedImportRow[]): ParsedImportRow[] {
+  const seen = new Map<string, ParsedImportRow>();
+  for (const row of rows) {
+    const key = row.address.trim().toLowerCase();
+    const prior = seen.get(key);
+    if (prior) {
+      // Keep the row with a name when one row lacks a name.
+      if (!prior.name.trim() && row.name.trim()) {
+        seen.set(key, row);
+      }
+    } else {
+      seen.set(key, row);
+    }
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Parses raw CSV/vCard content into a preview. Safe by construction: the
+ * parser never writes, never mutates policy, and rejects malformed rows with
+ * per-row errors instead of failing the whole file.
+ */
+export async function previewContactImport(
+  repository: ApiRepository,
+  owner: string,
+  input: { format: "csv" | "vcard"; content: string },
+): Promise<ContactImportPreviewResult> {
+  const normOwner = normalizeOwner(owner);
+  const { rows, truncated } = buildImportPreview(input.format, input.content, IMPORT_MAX_ROWS);
+  const deduplicated = dedupeRows(rows);
+
+  const resolved = await Promise.all(
+    deduplicated.map(async (row) => {
+      let canonicalAddress: string | null = null;
+      let identityStatus: string | null = null;
+      let keyFreshness: string | null = null;
+      let existing: ContactImportPreviewResult["rows"][number]["existing"] = null;
+
+      if (row.error === null) {
+        try {
+          const identity = await defaultIdentityResolver.resolve(row.address, {
+            repository,
+            timeoutMs: IDENTITY_RESOLUTION_TIMEOUT_MS,
+          });
+          if (identity.resolved) {
+            canonicalAddress = identity.canonicalAddress;
+            identityStatus = identity.status;
+          }
+        } catch {
+          identityStatus = "unknown";
+        }
+      }
+
+      if (canonicalAddress) {
+        try {
+          const dir = await getKeyDirectory(repository, canonicalAddress);
+          const currentEnc = dir?.currentKeys.encryption;
+          keyFreshness =
+            currentEnc && currentEnc.status === "active"
+              ? "active"
+              : currentEnc
+                ? currentEnc.status
+                : "none";
+        } catch {
+          keyFreshness = "unknown";
+        }
+
+        const storedContact = await findExistingContact(repository, normOwner, canonicalAddress);
+        if (storedContact) {
+          existing = { contactId: storedContact.contactId, trust: storedContact.trust };
+        }
+      }
+
+      return {
+        rowNumber: row.rowNumber,
+        name: row.name,
+        address: row.address,
+        status: row.error === null ? ("valid" as const) : ("error" as const),
+        error: row.error,
+        canonicalAddress,
+        identityStatus,
+        keyFreshness,
+        existing,
+      };
+    }),
+  );
+
+  const statusCounts = resolved.reduce(
+    (acc, row) => {
+      if (row.status === "error") acc.errorRows += 1;
+      else acc.validRows += 1;
+      if (row.status !== "error" && row.existing) acc.duplicateRows += 1;
+      return acc;
+    },
+    { validRows: 0, duplicateRows: 0, errorRows: 0 },
+  );
+
+  return {
+    format: input.format,
+    totalRows: rows.length,
+    validRows: statusCounts.validRows,
+    duplicateRows: statusCounts.duplicateRows,
+    errorRows: statusCounts.errorRows,
+    truncated,
+    limit: { maxRows: IMPORT_MAX_ROWS },
+    rows: resolved,
+  };
+}
+
+async function findExistingContact(
+  repository: ApiRepository,
+  owner: string,
+  address: string,
+): Promise<Contact | null> {
+  const normOwner = normalizeOwner(owner);
+  const target = address.trim().toUpperCase();
+  let after: string | undefined;
+  for (;;) {
+    const page = await repository.listContacts(normOwner, { limit: 100, after });
+    const match = page.items.find(
+      (contact) =>
+        (contact.canonicalAddress ?? "").toUpperCase() === target ||
+        contact.address.toUpperCase() === target,
+    );
+    if (match) return match;
+    after = page.nextContinuationKey ?? undefined;
+    if (after === undefined) return null;
+  }
+}
+
+/**
+ * Idempotently commits a validated import. Duplicate addresses are upserted
+ * (create when absent, update when present) so re-running the same import
+ * never creates duplicate contacts. Policy mutation is opt-in: `applyTrust`
+ * must be explicitly confirmed by the user (defaults to false in the routes)
+ * and even then only `allow`/`block` rows touch the sender-rule store.
+ */
+export async function commitContactImport(
+  repository: ApiRepository,
+  owner: string,
+  input: ContactImportCommitInput,
+): Promise<ContactImportCommitResult> {
+  const normOwner = normalizeOwner(owner);
+  const applyTrust = input.applyTrust ?? false;
+  if (input.rows.length > IMPORT_MAX_ROWS) {
+    throw new ApiError(400, "bad_request", `Import exceeds the ${IMPORT_MAX_ROWS} row limit`);
+  }
+
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let rejected = 0;
+  let appliedRules = 0;
+  const contacts: Contact[] = [];
+
+  for (const rawRow of input.rows) {
+    const parsed = contactSchema
+      .pick({ name: true, address: true })
+      .safeParse({ name: rawRow.name, address: rawRow.address });
+    if (!parsed.success) {
+      rejected += 1;
+      continue;
+    }
+
+    const existing = await findExistingContact(repository, normOwner, rawRow.address);
+    const now = new Date().toISOString();
+    let stored: Contact;
+
+    if (existing) {
+      const changed =
+        existing.name !== parsed.data.name || existing.address !== parsed.data.address;
+      if (!changed) {
+        unchanged += 1;
+        stored = existing;
+      } else {
+        const result = await repository.updateContact(
+          { ...existing, name: parsed.data.name, updatedAt: now },
+          existing.version,
+        );
+        if (!result.updated) {
+          unchanged += 1;
+          stored = existing;
+        } else {
+          updated += 1;
+          stored = result.contact;
+        }
+      }
+    } else {
+      stored = await repository.createContact({
+        contactId: contactId(),
+        owner: normOwner,
+        name: parsed.data.name,
+        address: parsed.data.address,
+        canonicalAddress: null,
+        trust: "default",
+        source: rawRow.source ?? "csv",
+        createdAt: now,
+        updatedAt: now,
+        version: 1,
+      });
+      created += 1;
+    }
+
+    contacts.push(stored);
+
+    const resolved = await resolveContactState(repository, normOwner, stored);
+    const senderAddress = resolved.identity?.canonicalAddress ?? stored.address;
+    const rule = rawRow.trust ?? "default";
+    if (applyTrust && rule !== "default") {
+      await setSenderRule(repository, normOwner, senderAddress, rule);
+      appliedRules += 1;
+    }
+  }
+
+  return {
+    created,
+    updated,
+    unchanged,
+    rejected,
+    total: input.rows.length,
+    appliedRules,
+    contacts,
+  };
+}

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -22,6 +22,7 @@ import {
   policyWriteIntentSchema,
   publishedKeySchema,
   keyDirectoryRecordSchema,
+  contactSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -233,6 +234,9 @@ registerRecordSchema("policyWriteIntent", 1, policyWriteIntentSchema);
 // Issue #1934 (BETA-027): Versioned Public Encryption-Key Directory & Rotation
 registerRecordSchema("publishedKey", 1, publishedKeySchema);
 registerRecordSchema("keyDirectoryRecord", 1, keyDirectoryRecordSchema);
+// Issue #1973 (BETA-066): durable user-owned contacts are versioned and
+// validated at the adapter boundary like every other durable record.
+registerRecordSchema("contact", 1, contactSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -666,3 +666,57 @@ export const keyDirectoryRecordSchema = z.object({
 });
 
 export type KeyDirectoryRecord = z.infer<typeof keyDirectoryRecordSchema>;
+
+// ---------------------------------------------------------------------------
+// Issue #1973 (BETA-066) — Live contacts CRUD, trust state, and safe import
+//
+// A contact is a durable, user-owned address-book entry. `address` holds the
+// raw identifier the user supplied (Stealth/Stellar G-address, local handle,
+// or federation address); `canonicalAddress` is the resolved Stealth identity
+// once identity resolution succeeds (null while unresolved or invalid).
+// `trust` reuses the mailbox sender-rule vocabulary so contacts and policy
+// stay consistent, but a contact row is NEVER an implicit policy mutation.
+// ---------------------------------------------------------------------------
+
+export const contactSourceSchema = z.enum(["manual", "csv", "vcard", "api"]);
+
+export const contactSchema = z.object({
+  contactId: z.string().trim().min(1),
+  owner: stellarAddressSchema,
+  name: z.string().trim().min(1).max(200),
+  address: z.string().trim().min(1).max(300),
+  canonicalAddress: stellarAddressSchema.nullable().default(null),
+  trust: senderRuleSchema.default("default"),
+  source: contactSourceSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  version: z.number().int().positive(),
+});
+
+export const contactCreateSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  address: z.string().trim().min(1).max(300),
+  trust: senderRuleSchema.default("default"),
+});
+
+export const contactUpdateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+    address: z.string().trim().min(1).max(300).optional(),
+    trust: senderRuleSchema.optional(),
+    expectedVersion: z.number().int().positive().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.name === undefined && data.address === undefined && data.trust === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one of name, address, or trust must be provided",
+        path: [],
+      });
+    }
+  });
+
+export type Contact = z.infer<typeof contactSchema>;
+export type ContactSource = z.infer<typeof contactSourceSchema>;
+export type ContactCreateInput = z.infer<typeof contactCreateSchema>;
+export type ContactUpdateInput = z.infer<typeof contactUpdateSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -1,13 +1,16 @@
 import type {
   ApiRepository,
+  ContactQueryOptions,
   InsertEnvelopeResult,
   PostageTransitionResult,
+  UpdateContactResult,
   UpdateProvisioningResult,
   UpdateUserResult,
   UsernameReservationResult,
   WalletCreationResult,
 } from "./repository";
 import type {
+  Contact,
   Credential,
   ExternalWallet,
   ExternalWalletChallenge,
@@ -532,5 +535,95 @@ export class HybridApiRepository implements ApiRepository {
       JSON.stringify(record),
     );
     return record;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1973 (BETA-066) — Live contacts CRUD
+  //
+  // Each owner stores a JSON array of contacts under a single key (the same
+  // shape as the external-wallet collection) so list/get/update/delete and
+  // search all resolve in one KV read without coordinator round-trips.
+  // ---------------------------------------------------------------------------
+
+  private contactKey(owner: string): string {
+    return this.key("contacts", owner.toUpperCase().trim());
+  }
+
+  private async readContacts(owner: string): Promise<Contact[]> {
+    const stored = await this.kv.get(this.contactKey(owner), "json");
+    return (stored as Contact[]) ?? [];
+  }
+
+  async listContacts(
+    owner: string,
+    options: ContactQueryOptions = {},
+  ): Promise<import("./repository").Page<Contact>> {
+    const { paginate, PAGINATED_QUERY_ORDERINGS } = await import("./repository");
+    const normOwner = owner.toUpperCase().trim();
+    const limit = options.limit ?? 25;
+    const query = options.query?.trim().toLowerCase();
+
+    const stored = await this.readContacts(normOwner);
+    const filtered: Contact[] = [];
+    for (const contact of stored) {
+      if (contact.owner.toUpperCase().trim() !== normOwner) {
+        continue;
+      }
+      if (query) {
+        const haystack =
+          `${contact.name} ${contact.address} ${contact.canonicalAddress ?? ""}`.toLowerCase();
+        if (!haystack.includes(query)) {
+          continue;
+        }
+      }
+      filtered.push(contact);
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listContacts;
+    return paginate(filtered, spec, { limit, after: options.after });
+  }
+
+  async getContact(owner: string, contactId: string): Promise<Contact | null> {
+    const contacts = await this.readContacts(owner);
+    return contacts.find((c) => c.contactId === contactId) ?? null;
+  }
+
+  async createContact(contact: Contact): Promise<Contact> {
+    const normOwner = contact.owner.toUpperCase().trim();
+    const contacts = await this.readContacts(normOwner);
+    if (contacts.some((c) => c.contactId === contact.contactId)) {
+      throw new ApiError(409, "conflict", `A contact already exists for ${contact.contactId}`);
+    }
+    contacts.push(contact);
+    await this.kv.put(this.contactKey(normOwner), JSON.stringify(contacts));
+    return contact;
+  }
+
+  async updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult> {
+    const normOwner = contact.owner.toUpperCase().trim();
+    const contacts = await this.readContacts(normOwner);
+    const index = contacts.findIndex((c) => c.contactId === contact.contactId);
+    if (index < 0) {
+      return { updated: false, current: null };
+    }
+    const existing = contacts[index];
+    if (existing.version !== expectedVersion) {
+      return { updated: false, current: existing };
+    }
+    const updated = { ...contact, version: expectedVersion + 1 };
+    contacts[index] = updated;
+    await this.kv.put(this.contactKey(normOwner), JSON.stringify(contacts));
+    return { updated: true, contact: updated };
+  }
+
+  async deleteContact(owner: string, contactId: string): Promise<void> {
+    const normOwner = owner.toUpperCase().trim();
+    const contacts = await this.readContacts(normOwner);
+    const index = contacts.findIndex((c) => c.contactId === contactId);
+    if (index < 0) {
+      throw new ApiError(404, "not_found", `No contact found for ${contactId}`);
+    }
+    contacts.splice(index, 1);
+    await this.kv.put(this.contactKey(normOwner), JSON.stringify(contacts));
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -1,4 +1,5 @@
 import type {
+  Contact,
   Credential,
   ExternalWallet,
   ExternalWalletChallenge,
@@ -26,11 +27,13 @@ import type {
 } from "./domain";
 import type {
   ApiRepository,
+  ContactQueryOptions,
   ConsumeVerificationTokenResult,
   InsertEnvelopeResult,
   IssueVerificationTokenResult,
   PostageTransitionResult,
   RecordVerificationAttemptResult,
+  UpdateContactResult,
   UpdateProvisioningResult,
   UpdateUserResult,
   UsernameReservationResult,
@@ -62,6 +65,8 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly envelopeLocks = new Map<string, Promise<void>>();
   private readonly senderRequests = new Map<string, UnknownSenderRequest>();
   private readonly senderRequestLocks = new Map<string, Promise<void>>();
+  // Issue #1973: owner-scoped contact store keyed by `${owner}:${contactId}`.
+  private readonly contacts = new Map<string, Contact>();
 
   // BETA-002: User Account, Profile, Credential storage & unique index maps
   private readonly usersById = new Map<string, User>();
@@ -1004,6 +1009,75 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(stored);
   }
 
+  async listContacts(
+    owner: string,
+    options: ContactQueryOptions = {},
+  ): Promise<import("./repository").Page<Contact>> {
+    const { paginate, PAGINATED_QUERY_ORDERINGS } = await import("./repository");
+    const normOwner = owner.toUpperCase().trim();
+    const limit = options.limit ?? 25;
+    const query = options.query?.trim().toLowerCase();
+
+    const filtered: Contact[] = [];
+    for (const contact of this.contacts.values()) {
+      if (contact.owner.toUpperCase().trim() !== normOwner) {
+        continue;
+      }
+      if (query) {
+        const haystack =
+          `${contact.name} ${contact.address} ${contact.canonicalAddress ?? ""}`.toLowerCase();
+        if (!haystack.includes(query)) {
+          continue;
+        }
+      }
+      filtered.push(structuredClone(contact));
+    }
+
+    const spec = PAGINATED_QUERY_ORDERINGS.listContacts;
+    return paginate(filtered, spec, { limit, after: options.after });
+  }
+
+  async getContact(owner: string, contactId: string): Promise<Contact | null> {
+    const contact = this.contacts.get(this.contactKey(owner, contactId));
+    return contact ? structuredClone(contact) : null;
+  }
+
+  async createContact(contact: Contact): Promise<Contact> {
+    const key = this.contactKey(contact.owner, contact.contactId);
+    if (this.contacts.has(key)) {
+      throw new ApiError(409, "conflict", `A contact already exists for ${contact.contactId}`);
+    }
+    const stored = structuredClone(contact);
+    this.contacts.set(key, stored);
+    return structuredClone(stored);
+  }
+
+  async updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult> {
+    const key = this.contactKey(contact.owner, contact.contactId);
+    const existing = this.contacts.get(key);
+    if (!existing) {
+      return { updated: false, current: null };
+    }
+    if (existing.version !== expectedVersion) {
+      return { updated: false, current: structuredClone(existing) };
+    }
+    const updated = { ...contact, version: expectedVersion + 1 };
+    this.contacts.set(key, updated);
+    return { updated: true, contact: structuredClone(updated) };
+  }
+
+  async deleteContact(owner: string, contactId: string): Promise<void> {
+    const key = this.contactKey(owner, contactId);
+    if (!this.contacts.has(key)) {
+      throw new ApiError(404, "not_found", `No contact found for ${contactId}`);
+    }
+    this.contacts.delete(key);
+  }
+
+  private contactKey(owner: string, contactId: string): string {
+    return `${owner.toUpperCase().trim()}:${contactId}`;
+  }
+
   reset() {
     this.policies.clear();
     this.policyWriteIntents.clear();
@@ -1037,5 +1111,6 @@ export class MemoryApiRepository implements ApiRepository {
     this.keyDirectories.clear();
     this.publishedKeys.clear();
     this.keyDirectoryLocks.clear();
+    this.contacts.clear();
   }
 }

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -618,6 +618,236 @@ export const openApiDocument = {
           service: { type: "string", description: "Service name." },
         },
       },
+      Contact: {
+        type: "object",
+        required: [
+          "contactId",
+          "owner",
+          "name",
+          "address",
+          "canonicalAddress",
+          "trust",
+          "source",
+          "createdAt",
+          "updatedAt",
+          "version",
+        ],
+        additionalProperties: false,
+        properties: {
+          contactId: { type: "string", description: "Unique contact identifier." },
+          owner: {
+            type: "string",
+            description: "Stellar account that owns this contact.",
+            pattern: "^G[A-Z2-7]{55}$",
+          },
+          name: { type: "string", maxLength: 200, description: "Display name." },
+          address: {
+            type: "string",
+            maxLength: 300,
+            description: "Raw address identifier (G-address, email, or handle).",
+          },
+          canonicalAddress: {
+            anyOf: [{ type: "string", pattern: "^G[A-Z2-7]{55}$" }, { type: "null" }],
+            description: "Resolved canonical G-address, or null until resolved.",
+          },
+          trust: {
+            type: "string",
+            enum: ["default", "allow", "block"],
+            description: "Sender rule. Never applied to policy unless the owner opts in.",
+          },
+          source: {
+            type: "string",
+            enum: ["manual", "csv", "vcard", "api"],
+            description: "Origin of this contact row.",
+          },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+          version: {
+            type: "integer",
+            minimum: 1,
+            description: "Optimistic concurrency version.",
+          },
+        },
+      },
+      ContactResolution: {
+        type: "object",
+        required: ["senderRule", "senderRuleConfigured"],
+        additionalProperties: false,
+        properties: {
+          identity: {
+            anyOf: [
+              {
+                type: "object",
+                required: [
+                  "identifier",
+                  "canonicalAddress",
+                  "account",
+                  "resolved",
+                  "status",
+                  "publicKey",
+                  "encryptionKeyVersion",
+                  "policyEndpoint",
+                  "freshness",
+                ],
+                additionalProperties: true,
+                properties: {
+                  identifier: { type: "string" },
+                  canonicalAddress: { type: "string" },
+                  account: { anyOf: [{ type: "string" }, { type: "null" }] },
+                  resolved: { type: "boolean" },
+                  status: { type: "string" },
+                  publicKey: { anyOf: [{ type: "string" }, { type: "null" }] },
+                  encryptionKeyVersion: { anyOf: [{ type: "integer" }, { type: "null" }] },
+                  policyEndpoint: { anyOf: [{ type: "string" }, { type: "null" }] },
+                  freshness: { type: "string", enum: ["fresh", "stale", "unknown"] },
+                  memo: { type: "string" },
+                  memoType: { type: "string", enum: ["text", "id", "hash"] },
+                },
+              },
+              { type: "null" },
+            ],
+            description: "Resolved identity, or null when resolution failed or is pending.",
+          },
+          keyDirectory: {
+            anyOf: [
+              {
+                type: "object",
+                description: "Live key directory entry for the canonical address.",
+                additionalProperties: true,
+              },
+              { type: "null" },
+            ],
+          },
+          senderRule: { type: "string", enum: ["default", "allow", "block"] },
+          senderRuleConfigured: {
+            type: "boolean",
+            description: "True when the owner has an explicit policy rule for this address.",
+          },
+        },
+      },
+      ContactWithResolution: {
+        type: "object",
+        required: ["contact", "resolution"],
+        additionalProperties: false,
+        properties: {
+          contact: { $ref: "#/components/schemas/Contact" },
+          resolution: { $ref: "#/components/schemas/ContactResolution" },
+        },
+      },
+      ContactListResult: {
+        type: "object",
+        required: ["items", "nextContinuationKey"],
+        additionalProperties: false,
+        properties: {
+          items: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ContactWithResolution" },
+          },
+          nextContinuationKey: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            description: "Cursor for the next page, or null at the end.",
+          },
+        },
+      },
+      ContactMergeResult: {
+        type: "object",
+        required: ["contact", "resolution"],
+        additionalProperties: false,
+        description: "The surviving contact after merging, re-resolved against live state.",
+        properties: {
+          contact: { $ref: "#/components/schemas/Contact" },
+          resolution: { $ref: "#/components/schemas/ContactResolution" },
+        },
+      },
+      ContactImportPreviewResult: {
+        type: "object",
+        required: [
+          "format",
+          "totalRows",
+          "validRows",
+          "duplicateRows",
+          "errorRows",
+          "truncated",
+          "limit",
+          "rows",
+        ],
+        additionalProperties: false,
+        properties: {
+          format: { type: "string", enum: ["csv", "vcard"] },
+          totalRows: { type: "integer", minimum: 0 },
+          validRows: { type: "integer", minimum: 0 },
+          duplicateRows: { type: "integer", minimum: 0 },
+          errorRows: { type: "integer", minimum: 0 },
+          truncated: {
+            type: "boolean",
+            description: "True when parsing stopped at the row limit.",
+          },
+          limit: {
+            type: "object",
+            required: ["maxRows"],
+            properties: { maxRows: { type: "integer", minimum: 1 } },
+          },
+          rows: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["rowNumber", "name", "address", "status"],
+              additionalProperties: false,
+              properties: {
+                rowNumber: { type: "integer", minimum: 1 },
+                name: { type: "string" },
+                address: { type: "string" },
+                status: { type: "string", enum: ["valid", "duplicate", "error"] },
+                error: { anyOf: [{ type: "string" }, { type: "null" }] },
+                canonicalAddress: {
+                  anyOf: [{ type: "string", pattern: "^G[A-Z2-7]{55}$" }, { type: "null" }],
+                },
+                identityStatus: { anyOf: [{ type: "string" }, { type: "null" }] },
+                keyFreshness: { anyOf: [{ type: "string" }, { type: "null" }] },
+                existing: {
+                  anyOf: [
+                    {
+                      type: "object",
+                      required: ["contactId", "trust"],
+                      properties: {
+                        contactId: { type: "string" },
+                        trust: { type: "string", enum: ["default", "allow", "block"] },
+                      },
+                    },
+                    { type: "null" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      ContactImportCommitResult: {
+        type: "object",
+        required: [
+          "created",
+          "updated",
+          "unchanged",
+          "rejected",
+          "total",
+          "appliedRules",
+          "contacts",
+        ],
+        additionalProperties: false,
+        properties: {
+          created: { type: "integer", minimum: 0 },
+          updated: { type: "integer", minimum: 0 },
+          unchanged: { type: "integer", minimum: 0 },
+          rejected: { type: "integer", minimum: 0 },
+          total: { type: "integer", minimum: 0 },
+          appliedRules: {
+            type: "integer",
+            minimum: 0,
+            description: "Sender rules applied to policy; only when applyTrust was requested.",
+          },
+          contacts: { type: "array", items: { $ref: "#/components/schemas/Contact" } },
+        },
+      },
     },
   },
   paths: {
@@ -2567,6 +2797,722 @@ export const openApiDocument = {
           },
           "503": {
             description: "The verification message could not be delivered",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/contacts": {
+      get: {
+        operationId: "listContacts",
+        summary: "List contacts for the authenticated account",
+        description:
+          "Returns the owner's contacts with live identity, key-freshness, and trust state. Resolution failures degrade to null rather than failing the page.",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        parameters: [
+          {
+            name: "query",
+            in: "query",
+            schema: { type: "string", maxLength: 200 },
+            description: "Optional substring filter on name or address.",
+          },
+          {
+            name: "cursor",
+            in: "query",
+            schema: { type: "string" },
+            description: "Pagination continuation key.",
+          },
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 25 },
+          },
+        ],
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Listed contacts",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactListResult",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        operationId: "createContact",
+        summary: "Create a contact",
+        description:
+          "Stores a new owner-scoped contact. The trust field is advisory and never mutates mailbox policy.",
+        "x-max-body-bytes": 8 * 1024,
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["name", "address"],
+                additionalProperties: false,
+                properties: {
+                  name: { type: "string", maxLength: 200 },
+                  address: { type: "string", maxLength: 300 },
+                  trust: { type: "string", enum: ["default", "allow", "block"] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "201": {
+            description: "Created contact with live resolution",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactWithResolution",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/contacts/{contactId}": {
+      get: {
+        operationId: "getContact",
+        summary: "Read a single contact",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        parameters: [
+          {
+            name: "contactId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Contact with live resolution",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactWithResolution",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+      put: {
+        operationId: "updateContact",
+        summary: "Update a contact",
+        "x-max-body-bytes": 8 * 1024,
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        parameters: [
+          {
+            name: "contactId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                description: "At least one of name, address, or trust is required.",
+                additionalProperties: false,
+                properties: {
+                  name: { type: "string", maxLength: 200 },
+                  address: { type: "string", maxLength: 300 },
+                  trust: { type: "string", enum: ["default", "allow", "block"] },
+                  expectedVersion: { type: "integer", minimum: 1 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Updated contact with live resolution",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactWithResolution",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict — concurrent modification detected",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        operationId: "deleteContact",
+        summary: "Delete a contact",
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        parameters: [
+          {
+            name: "contactId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Contact deleted",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/contacts/merge": {
+      post: {
+        operationId: "mergeContacts",
+        summary: "Merge duplicate contacts",
+        description:
+          "Deletes the merge targets and bumps the version of the kept contact so concurrent writers cannot resurrect merged-away rows. All IDs are scoped to the authenticated owner.",
+        "x-max-body-bytes": 8 * 1024,
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["keepContactId", "mergeContactIds"],
+                additionalProperties: false,
+                properties: {
+                  keepContactId: { type: "string" },
+                  mergeContactIds: {
+                    type: "array",
+                    minItems: 1,
+                    items: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Surviving contact re-resolved after merge",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactMergeResult",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Forbidden — cannot merge a contact owned by another actor",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Not Found",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Conflict — kept contact modified concurrently",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/contacts/import/preview": {
+      post: {
+        operationId: "previewContactImport",
+        summary: "Parse and preview a CSV or vCard contact import",
+        description:
+          "Parses the uploaded content into rows with per-row validity, duplicate detection, and live identity resolution. Never writes contact rows.",
+        "x-max-body-bytes": 1024 * 1024,
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["format", "content"],
+                additionalProperties: false,
+                properties: {
+                  format: { type: "string", enum: ["csv", "vcard"] },
+                  content: {
+                    type: "string",
+                    description: "Raw import file content, UTF-8.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Parsed import preview",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactImportPreviewResult",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/contacts/import/commit": {
+      post: {
+        operationId: "commitContactImport",
+        summary: "Commit a contact import",
+        description:
+          "Idempotently upserts the reviewed rows by address. Policy is never mutated unless applyTrust is explicitly true, and even then only allow/block rows touch sender rules.",
+        "x-max-body-bytes": 1024 * 1024,
+        security: [
+          {
+            ActorHeader: [],
+          },
+        ],
+        "x-stability": "beta",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["rows"],
+                additionalProperties: false,
+                properties: {
+                  rows: {
+                    type: "array",
+                    minItems: 1,
+                    maxItems: 1000,
+                    items: {
+                      type: "object",
+                      required: ["name", "address"],
+                      additionalProperties: false,
+                      properties: {
+                        name: { type: "string", maxLength: 200 },
+                        address: { type: "string", maxLength: 300 },
+                        trust: { type: "string", enum: ["default", "allow", "block"] },
+                        source: { type: "string", enum: ["csv", "vcard"] },
+                      },
+                    },
+                  },
+                  applyTrust: {
+                    type: "boolean",
+                    default: false,
+                    description: "Opt-in application of trust rows to mailbox policy.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "201": {
+            description: "Import committed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ContactImportCommitResult",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Unprocessable Entity — Request payload validation failure",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
             content: {
               "application/json": {
                 schema: {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -1,4 +1,5 @@
 import type {
+  Contact,
   Credential,
   ExternalWallet,
   ExternalWalletChallenge,
@@ -103,6 +104,18 @@ export type SenderRequestTransitionResult =
   | { outcome: "conflict"; request: UnknownSenderRequest }
   | { outcome: "applied"; request: UnknownSenderRequest };
 
+/**
+ * Outcome of a compare-and-swap contact write (Issue #1973 BETA-066).
+ *
+ * - `updated: true`  : the contact was persisted at `expectedVersion + 1`.
+ * - `updated: false` : the contact moved underneath this writer (or does not
+ *   exist); `current` reflects the authoritative state so the caller can
+ *   re-read and reconcile instead of blindly overwriting.
+ */
+export type UpdateContactResult =
+  | { updated: true; contact: Contact }
+  | { updated: false; current: Contact | null };
+
 // ---------------------------------------------------------------------------
 // BETA-014: Account-provisioning repository contracts
 // ---------------------------------------------------------------------------
@@ -163,6 +176,21 @@ export type RecordVerificationAttemptResult =
 export interface MailboxQueryOptions {
   status?: "pending" | "delivered" | "all";
   includeTombstones?: boolean;
+  limit?: number;
+  after?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1973 (BETA-066) — Live contacts repository
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for listing a user's contacts. `query` filters case-insensitively
+ * against the contact name and raw address; `limit`/`after` walk the declared
+ * total order ({@link PAGINATED_QUERY_ORDERINGS}.listContacts).
+ */
+export interface ContactQueryOptions {
+  query?: string;
   limit?: number;
   after?: string;
 }
@@ -384,6 +412,21 @@ export interface ApiRepository {
   getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null>;
   savePublishedKey(owner: string, key: PublishedKey): Promise<PublishedKey>;
   saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord>;
+
+  // ---------------------------------------------------------------------------
+  // Issue #1973 (BETA-066) — Live contacts CRUD
+  // ---------------------------------------------------------------------------
+  listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>>;
+  getContact(owner: string, contactId: string): Promise<Contact | null>;
+  /**
+   * Insert-once contact creation keyed by contactId (scoped to `owner`).
+   * A duplicate contactId for the same owner must reject with a deterministic
+   * conflict (ApiError 409 "conflict") so imports can never create ambiguous
+   * address-book state.
+   */
+  createContact(contact: Contact): Promise<Contact>;
+  updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult>;
+  deleteContact(owner: string, contactId: string): Promise<void>;
 
   reset?(): void;
 }
@@ -956,6 +999,42 @@ export class ValidatedApiRepository implements ApiRepository {
     return validateRecord<KeyDirectoryRecord>("keyDirectoryRecord", result);
   }
 
+  async listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {
+    const page = await this.inner.listContacts(owner, options);
+    return {
+      ...page,
+      items: page.items.map((item) => validateRecord<Contact>("contact", item)),
+    };
+  }
+
+  async getContact(owner: string, contactId: string): Promise<Contact | null> {
+    const raw = await this.inner.getContact(owner, contactId);
+    return raw ? validateRecord<Contact>("contact", raw) : null;
+  }
+
+  async createContact(contact: Contact): Promise<Contact> {
+    const result = await this.inner.createContact(versionRecord("contact", contact));
+    return validateRecord<Contact>("contact", result);
+  }
+
+  async updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult> {
+    const result = await this.inner.updateContact(
+      versionRecord("contact", contact),
+      expectedVersion,
+    );
+    if (result.updated) {
+      return { updated: true, contact: validateRecord<Contact>("contact", result.contact) };
+    }
+    return {
+      updated: false,
+      current: result.current ? validateRecord<Contact>("contact", result.current) : null,
+    };
+  }
+
+  async deleteContact(owner: string, contactId: string): Promise<void> {
+    return this.inner.deleteContact(owner, contactId);
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -1020,6 +1099,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "findExternalWalletOwner",
   "getVerificationToken",
   "getWalletChallenge",
+  "listContacts",
+  "getContact",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -1454,6 +1535,28 @@ export class RetryableApiRepository implements ApiRepository {
     return this.withRetry("saveKeyDirectory", () => this.inner.saveKeyDirectory(record));
   }
 
+  listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {
+    return this.withRetry("listContacts", () => this.inner.listContacts(owner, options));
+  }
+
+  getContact(owner: string, contactId: string): Promise<Contact | null> {
+    return this.withRetry("getContact", () => this.inner.getContact(owner, contactId));
+  }
+
+  createContact(contact: Contact): Promise<Contact> {
+    return this.inner.createContact(contact);
+  }
+
+  updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult> {
+    return this.withRetry("updateContact", () =>
+      this.inner.updateContact(contact, expectedVersion),
+    );
+  }
+
+  deleteContact(owner: string, contactId: string): Promise<void> {
+    return this.withRetry("deleteContact", () => this.inner.deleteContact(owner, contactId));
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -1691,6 +1794,13 @@ export const PAGINATED_QUERY_ORDERINGS = {
     [{ field: "createdAt", direction: "desc" }],
     "messageId",
   ),
+  /**
+   * Issue #1973 (BETA-066): Owner-scoped contact listing.
+   * Ordered by creation time descending (newest first); contactId is the
+   * unique tie-breaker so the walk is stable. Callers filter by owner and the
+   * optional search query before passing the collection to `paginate`.
+   */
+  listContacts: declareOrdering<Contact>([{ field: "createdAt", direction: "desc" }], "contactId"),
 } as const;
 
 export type PaginatedQueryName = keyof typeof PAGINATED_QUERY_ORDERINGS;

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -52,6 +52,11 @@ export const ROUTE_BODY_LIMITS = {
   "POST /identity/keys/rotate": "compact",
   "POST /identity/keys/retire": "compact",
   "POST /identity/keys/revoke": "compact",
+  "POST /contacts": "compact",
+  "PUT /contacts/{contactId}": "compact",
+  "POST /contacts/merge": "compact",
+  "POST /contacts/import/preview": "bulk",
+  "POST /contacts/import/commit": "bulk",
   "POST /requests": "standard",
   "POST /requests/{requestId}/decisions": "compact",
 } as const satisfies Record<string, BodyLimitCategory>;

--- a/tests/unit/api/contact-routes.test.ts
+++ b/tests/unit/api/contact-routes.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Route as ContactsIndexRoute } from "../../../src/routes/api/v1/contacts/index";
+import { Route as ContactRoute } from "../../../src/routes/api/v1/contacts/$contactId";
+import { Route as MergeRoute } from "../../../src/routes/api/v1/contacts/merge";
+import { Route as ImportPreviewRoute } from "../../../src/routes/api/v1/contacts/import/preview";
+import { Route as ImportCommitRoute } from "../../../src/routes/api/v1/contacts/import/commit";
+import { ACTOR_HEADER } from "../../../src/server/api/actor";
+import { listContacts } from "../../../src/server/api/contact-service";
+import { getApiContext } from "../../../src/server/api/context";
+import type { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+
+const owner = `G${"A".repeat(55)}`;
+const otherOwner = `G${"B".repeat(55)}`;
+
+const VALID_G = `G${"C".repeat(55)}`;
+
+const listHandler = (ContactsIndexRoute.options as any).server?.handlers?.GET;
+const createHandler = (ContactsIndexRoute.options as any).server?.handlers?.POST;
+const getHandler = (ContactRoute.options as any).server?.handlers?.GET;
+const putHandler = (ContactRoute.options as any).server?.handlers?.PUT;
+const deleteHandler = (ContactRoute.options as any).server?.handlers?.DELETE;
+const mergeHandler = (MergeRoute.options as any).server?.handlers?.POST;
+const previewHandler = (ImportPreviewRoute.options as any).server?.handlers?.POST;
+const commitHandler = (ImportCommitRoute.options as any).server?.handlers?.POST;
+
+function request(path: string, method: string, actor?: string, body?: unknown) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (actor !== undefined) headers[ACTOR_HEADER] = actor;
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(`https://stealth.test${path}`, init);
+}
+
+describe("contacts route actor authorization (BETA-066 / Issue #1973)", () => {
+  let repo: MemoryApiRepository;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+  });
+
+  it("rejects anonymous and invalid principals on every mutating route", async () => {
+    const cases: Array<{ label: string; handler: (arg: any) => Promise<Response>; args: any }> = [
+      {
+        label: "POST /contacts",
+        handler: createHandler,
+        args: {
+          request: request("/api/v1/contacts", "POST", undefined, { name: "A", address: VALID_G }),
+        },
+      },
+      {
+        label: "PUT /contacts/:id",
+        handler: putHandler,
+        args: {
+          request: request("/api/v1/contacts/c_1", "PUT", undefined, { name: "B" }),
+          params: { contactId: "c_1" },
+        },
+      },
+      {
+        label: "DELETE /contacts/:id",
+        handler: deleteHandler,
+        args: { request: request("/api/v1/contacts/c_1", "DELETE"), params: { contactId: "c_1" } },
+      },
+      {
+        label: "POST /contacts/merge",
+        handler: mergeHandler,
+        args: {
+          request: request("/api/v1/contacts/merge", "POST", undefined, {
+            keepContactId: "c_1",
+            mergeContactIds: ["c_2"],
+          }),
+        },
+      },
+      {
+        label: "POST /contacts/import/preview",
+        handler: previewHandler,
+        args: {
+          request: request("/api/v1/contacts/import/preview", "POST", undefined, {
+            format: "csv",
+            content: "A,a",
+          }),
+        },
+      },
+      {
+        label: "POST /contacts/import/commit",
+        handler: commitHandler,
+        args: {
+          request: request("/api/v1/contacts/import/commit", "POST", undefined, {
+            rows: [{ name: "A", address: VALID_G }],
+          }),
+        },
+      },
+    ];
+
+    for (const { label, handler, args } of cases) {
+      const response = await handler(args);
+      expect(response.status, label).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({ error: { code: "unauthorized" } });
+    }
+  });
+
+  it("scopes all routes to the authenticated actor's own contact set", async () => {
+    const createA = await createHandler({
+      request: request("/api/v1/contacts", "POST", owner, { name: "Mine", address: VALID_G }),
+    });
+    expect(createA.status).toBe(201);
+
+    const listOther = await listHandler({
+      request: request("/api/v1/contacts", "GET", otherOwner),
+    });
+    expect(listOther.status).toBe(200);
+    const otherData = await listOther.json();
+    expect(otherData.data.items).toHaveLength(0);
+
+    const listMine = await listHandler({ request: request("/api/v1/contacts", "GET", owner) });
+    expect(listMine.status).toBe(200);
+    const mineData = await listMine.json();
+    expect(mineData.data.items).toHaveLength(1);
+    expect(mineData.data.items[0].contact.address).toBe(VALID_G);
+  });
+
+  it("cannot read or delete another actor's contact", async () => {
+    const created = await createHandler({
+      request: request("/api/v1/contacts", "POST", owner, { name: "Mine", address: VALID_G }),
+    });
+    const { contact } = (await created.json()).data;
+
+    const forbiddenGet = await getHandler({
+      request: request(`/api/v1/contacts/${contact.contactId}`, "GET", otherOwner),
+      params: { contactId: contact.contactId },
+    });
+    expect(forbiddenGet.status).toBe(404);
+
+    const forbiddenDelete = await deleteHandler({
+      request: request(`/api/v1/contacts/${contact.contactId}`, "DELETE", otherOwner),
+      params: { contactId: contact.contactId },
+    });
+    expect(forbiddenDelete.status).toBe(404);
+
+    const stillThere = await listHandler({ request: request("/api/v1/contacts", "GET", owner) });
+    expect((await stillThere.json()).data.items).toHaveLength(1);
+  });
+
+  it("performs full CRUD round-trip for the owner", async () => {
+    const created = await createHandler({
+      request: request("/api/v1/contacts", "POST", owner, { name: "Alice", address: VALID_G }),
+    });
+    expect(created.status).toBe(201);
+    const { contact } = (await created.json()).data;
+    expect(contact.contactId).toMatch(/^c_/);
+
+    const fetched = await getHandler({
+      request: request(`/api/v1/contacts/${contact.contactId}`, "GET", owner),
+      params: { contactId: contact.contactId },
+    });
+    expect(fetched.status).toBe(200);
+    expect((await fetched.json()).data.contact.name).toBe("Alice");
+
+    const updated = await putHandler({
+      request: request(`/api/v1/contacts/${contact.contactId}`, "PUT", owner, {
+        name: "Alice Updated",
+        trust: "allow",
+      }),
+      params: { contactId: contact.contactId },
+    });
+    expect(updated.status).toBe(200);
+    const updatedData = await updated.json();
+    expect(updatedData.data.contact.name).toBe("Alice Updated");
+    expect(updatedData.data.contact.version).toBe(2);
+
+    const deleted = await deleteHandler({
+      request: request(`/api/v1/contacts/${contact.contactId}`, "DELETE", owner),
+      params: { contactId: contact.contactId },
+    });
+    expect(deleted.status).toBe(200);
+  });
+
+  it("merge validates ownership of both sides", async () => {
+    const keep = await createHandler({
+      request: request("/api/v1/contacts", "POST", owner, { name: "Keep", address: VALID_G }),
+    });
+    const dup = await createHandler({
+      request: request("/api/v1/contacts", "POST", owner, {
+        name: "Dup",
+        address: `S${"D".repeat(55)}`,
+      }),
+    });
+    const keepData = (await keep.json()).data.contact;
+    const dupData = (await dup.json()).data.contact;
+
+    const merged = await mergeHandler({
+      request: request("/api/v1/contacts/merge", "POST", owner, {
+        keepContactId: keepData.contactId,
+        mergeContactIds: [dupData.contactId],
+      }),
+    });
+    expect(merged.status).toBe(200);
+    expect((await merged.json()).data.contact.contactId).toBe(keepData.contactId);
+
+    const page = await listContacts(repo, owner);
+    expect(page.items).toHaveLength(1);
+  });
+
+  it("import preview and commit round-trip for the owner", async () => {
+    const preview = await previewHandler({
+      request: request("/api/v1/contacts/import/preview", "POST", owner, {
+        format: "csv",
+        content: `Alice,${VALID_G}\nBob,g*bob`,
+      }),
+    });
+    expect(preview.status).toBe(200);
+    const previewData = (await preview.json()).data;
+    expect(previewData.totalRows).toBe(2);
+    expect(previewData.validRows).toBeGreaterThanOrEqual(1);
+
+    const commit = await commitHandler({
+      request: request("/api/v1/contacts/import/commit", "POST", owner, {
+        rows: [{ name: "Alice", address: VALID_G, source: "csv" }],
+      }),
+    });
+    expect(commit.status).toBe(201);
+    const commitData = (await commit.json()).data;
+    expect(commitData.created).toBe(1);
+    expect(commitData.appliedRules).toBe(0);
+  });
+
+  it("commit without applyTrust never touches sender rules", async () => {
+    const commit = await commitHandler({
+      request: request("/api/v1/contacts/import/commit", "POST", owner, {
+        rows: [{ name: "Blocked", address: VALID_G, trust: "block" }],
+      }),
+    });
+    expect(commit.status).toBe(201);
+    expect((await commit.json()).data.appliedRules).toBe(0);
+  });
+});

--- a/tests/unit/api/contact-service.test.ts
+++ b/tests/unit/api/contact-service.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commitContactImport,
+  createContact,
+  deleteContact,
+  getContact,
+  listContacts,
+  mergeContacts,
+  previewContactImport,
+  resolveContactState,
+  updateContact,
+  type ContactImportCommitInput,
+} from "../../../src/server/api/contact-service";
+import { buildImportPreview, parseCsv, parseVCard } from "../../../src/server/api/contact-import";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { getSenderRule } from "../../../src/server/api/policy-service";
+
+const owner = `G${"A".repeat(55)}`;
+const otherOwner = `G${"B".repeat(55)}`;
+
+const VALID_G = `G${"C".repeat(55)}`;
+const VALID_S = `S${"D".repeat(55)}`;
+
+describe("contact import parsing (BETA-066 / Issue #1973)", () => {
+  it("parses headerless CSV with name,address columns", () => {
+    const rows = parseCsv("Alice,galice\nBob,gbob");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ name: "Alice", address: "galice", source: "csv", error: null });
+  });
+
+  it("parses CSV with a header row and skips it", () => {
+    const rows = parseCsv("name,address\nAlice,GALICE-ADDR\nBob,GBOB-ADDR");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].rowNumber).toBe(2);
+    expect(rows[1].name).toBe("Bob");
+  });
+
+  it("accepts TSV and semicolon-delimited files", () => {
+    expect(parseCsv("name\taddress\nAlice\tga")).toHaveLength(1);
+    expect(parseCsv("name;address\nBob;gb")).toHaveLength(1);
+  });
+
+  it("handles quoted CSV fields containing delimiters", () => {
+    const rows = parseCsv(`"Smith, John","g*smith"`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("Smith, John");
+    expect(rows[0].address).toBe("g*smith");
+  });
+
+  it("flags malformed addresses with per-row errors instead of failing", () => {
+    const rows = parseCsv("Alice,\nBob,g*bob");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].error).not.toBeNull();
+    expect(rows[1].error).toBeNull();
+  });
+
+  it("truncates overlong names", () => {
+    const rows = parseCsv(`${"x".repeat(300)},g*a`);
+    expect(rows[0].name).toHaveLength(200);
+  });
+
+  it("parses vCard blocks with FN and EMAIL", () => {
+    const vcard = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "FN:Alice Example",
+      `EMAIL:${VALID_G}`,
+      "END:VCARD",
+    ].join("\n");
+    const rows = parseVCard(vcard);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      name: "Alice Example",
+      address: VALID_G,
+      source: "vcard",
+      error: null,
+    });
+  });
+
+  it("prefers a Stellar-shaped email over a plain email in vCards", () => {
+    const vcard = [
+      "BEGIN:VCARD",
+      "VERSION:4.0",
+      "FN:Bob",
+      "EMAIL:bob@example.com",
+      `EMAIL:${VALID_S}`,
+      "END:VCARD",
+    ].join("\n");
+    const rows = parseVCard(vcard);
+    expect(rows[0].address).toBe(VALID_S);
+  });
+
+  it("falls back to the N line when FN is missing", () => {
+    const vcard = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "N:Example;Alice;;;",
+      `EMAIL:${VALID_G}`,
+      "END:VCARD",
+    ].join("\n");
+    const rows = parseVCard(vcard);
+    expect(rows[0].name).toBe("Alice Example");
+  });
+
+  it("handles multiple vCards and ignores garbage blocks", () => {
+    const vcard = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "FN:One",
+      `EMAIL:${VALID_G}`,
+      "END:VCARD",
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "FN:Two",
+      `EMAIL:${VALID_S}`,
+      "END:VCARD",
+      "not-a-card",
+    ].join("\n");
+    const rows = parseVCard(vcard);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("buildImportPreview truncates at the row limit and reports it", () => {
+    const csv = Array.from({ length: 5 }, (_, i) => `Name${i},g*addr${i}`).join("\n");
+    const { rows, truncated } = buildImportPreview("csv", csv, 3);
+    expect(rows).toHaveLength(3);
+    expect(truncated).toBe(true);
+  });
+
+  it("preview deduplicates repeated addresses keeping the row that has a name", async () => {
+    const repository = new MemoryApiRepository();
+    const preview = await previewContactImport(repository, owner, {
+      format: "csv",
+      content: `,${VALID_G}\nNamed,${VALID_G}`,
+    });
+    expect(preview.totalRows).toBe(2);
+    expect(preview.rows).toHaveLength(1);
+    expect(preview.rows[0].name).toBe("Named");
+  });
+});
+
+describe("contact service CRUD (BETA-066 / Issue #1973)", () => {
+  it("creates a contact and resolves its state", async () => {
+    const repository = new MemoryApiRepository();
+    const created = await createContact(repository, owner, { name: "Alice", address: "galice" });
+
+    expect(created.contact).toMatchObject({
+      owner,
+      name: "Alice",
+      address: "galice",
+      canonicalAddress: null,
+      trust: "default",
+      source: "manual",
+      version: 1,
+    });
+    expect(created.contact.contactId).toMatch(/^c_/);
+    expect(created.resolution.senderRule).toBe("default");
+    expect(created.resolution.senderRuleConfigured).toBe(false);
+  });
+
+  it("throws not-found when reading a missing contact", async () => {
+    const repository = new MemoryApiRepository();
+    await expect(getContact(repository, owner, "c_missing")).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("lists contacts and respects the owner scope", async () => {
+    const repository = new MemoryApiRepository();
+    await createContact(repository, owner, { name: "A", address: "ga" });
+    await createContact(repository, owner, { name: "B", address: "gb" });
+    await createContact(repository, otherOwner, { name: "C", address: "gc" });
+
+    const page = await listContacts(repository, owner, { query: "g" });
+    expect(page.items).toHaveLength(2);
+    expect(page.items.every((item) => item.contact.owner === owner)).toBe(true);
+  });
+
+  it("updates a contact and bumps the version", async () => {
+    const repository = new MemoryApiRepository();
+    const created = await createContact(repository, owner, { name: "Old", address: VALID_G });
+
+    const updated = await updateContact(repository, owner, created.contact.contactId, {
+      name: "New",
+      trust: "allow",
+    });
+    expect(updated.contact.name).toBe("New");
+    expect(updated.contact.trust).toBe("allow");
+    expect(updated.contact.version).toBe(2);
+  });
+
+  it("update never mutates policy, even when trust is changed", async () => {
+    const repository = new MemoryApiRepository();
+    const created = await createContact(repository, owner, { name: "A", address: VALID_G });
+    await updateContact(repository, owner, created.contact.contactId, { trust: "block" });
+
+    const rule = await getSenderRule(repository, owner, VALID_G);
+    expect(rule.rule).toBe("default");
+  });
+
+  it("deletes a contact", async () => {
+    const repository = new MemoryApiRepository();
+    const created = await createContact(repository, owner, { name: "A", address: VALID_G });
+    await deleteContact(repository, owner, created.contact.contactId);
+    await expect(getContact(repository, owner, created.contact.contactId)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("merges contacts keeping the survivor and deleting the merged rows", async () => {
+    const repository = new MemoryApiRepository();
+    const keep = await createContact(repository, owner, { name: "Keep", address: VALID_G });
+    const dup = await createContact(repository, owner, { name: "Dup", address: VALID_S });
+
+    const merged = await mergeContacts(repository, owner, {
+      keepContactId: keep.contact.contactId,
+      mergeContactIds: [dup.contact.contactId],
+    });
+    expect(merged.contact.contactId).toBe(keep.contact.contactId);
+
+    await expect(getContact(repository, owner, dup.contact.contactId)).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("merge rejects a self-merge", async () => {
+    const repository = new MemoryApiRepository();
+    const c = await createContact(repository, owner, { name: "A", address: VALID_G });
+    await expect(
+      mergeContacts(repository, owner, {
+        keepContactId: c.contact.contactId,
+        mergeContactIds: [c.contact.contactId],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("resolveContactState returns default trust when no rule is configured", async () => {
+    const repository = new MemoryApiRepository();
+    const created = await createContact(repository, owner, { name: "A", address: VALID_G });
+    const state = await resolveContactState(repository, owner, created.contact);
+    expect(state).toMatchObject({ senderRule: "default", senderRuleConfigured: false });
+  });
+});
+
+describe("contact import commit (BETA-066 / Issue #1973)", () => {
+  it("creates contacts idempotently on repeated commits", async () => {
+    const repository = new MemoryApiRepository();
+    const input: ContactImportCommitInput = {
+      rows: [
+        { name: "Alice", address: VALID_G, source: "csv" },
+        { name: "Bob", address: VALID_S, source: "vcard" },
+      ],
+    };
+
+    const first = await commitContactImport(repository, owner, input);
+    expect(first.created).toBe(2);
+    expect(first.total).toBe(2);
+    expect(first.contacts).toHaveLength(2);
+    expect(first.contacts[0].source).toBe("csv");
+    expect(first.contacts[1].source).toBe("vcard");
+
+    const second = await commitContactImport(repository, owner, input);
+    expect(second.created).toBe(0);
+    expect(second.unchanged).toBe(2);
+
+    const page = await listContacts(repository, owner);
+    expect(page.items).toHaveLength(2);
+  });
+
+  it("updates existing contacts when the address matches", async () => {
+    const repository = new MemoryApiRepository();
+    await createContact(repository, owner, { name: "Old", address: VALID_G });
+
+    const result = await commitContactImport(repository, owner, {
+      rows: [{ name: "New", address: VALID_G, source: "csv" }],
+    });
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+  });
+
+  it("rejects invalid rows without aborting valid ones", async () => {
+    const repository = new MemoryApiRepository();
+    const result = await commitContactImport(repository, owner, {
+      rows: [
+        { name: "Good", address: VALID_G },
+        { name: "Bad", address: "" },
+      ],
+    });
+    expect(result.rejected).toBe(1);
+    expect(result.created).toBe(1);
+  });
+
+  it("does not touch sender rules unless applyTrust is explicitly set", async () => {
+    const repository = new MemoryApiRepository();
+    await commitContactImport(repository, owner, {
+      rows: [{ name: "A", address: VALID_G, trust: "block" }],
+    });
+    const rule = await getSenderRule(repository, owner, VALID_G);
+    expect(rule.rule).toBe("default");
+  });
+
+  it("applies allow/block trust rules when applyTrust is true", async () => {
+    const repository = new MemoryApiRepository();
+    const result = await commitContactImport(repository, owner, {
+      rows: [
+        { name: "Blocked", address: VALID_G, trust: "block" },
+        { name: "Default", address: VALID_S },
+      ],
+      applyTrust: true,
+    });
+    expect(result.appliedRules).toBe(1);
+    const blocked = await getSenderRule(repository, owner, VALID_G);
+    expect(blocked.rule).toBe("block");
+    const unset = await getSenderRule(repository, owner, VALID_S);
+    expect(unset.rule).toBe("default");
+  });
+
+  it("rejects a commit that exceeds the row limit", async () => {
+    const repository = new MemoryApiRepository();
+    const rows = Array.from({ length: 1001 }, (_, i) => ({
+      name: `N${i}`,
+      address: `g*n${i}`,
+    }));
+    await expect(commitContactImport(repository, owner, { rows })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("preview detects existing contacts and reports them as duplicates", async () => {
+    const repository = new MemoryApiRepository();
+    await createContact(repository, owner, { name: "Existing", address: VALID_G });
+
+    const preview = await previewContactImport(repository, owner, {
+      format: "csv",
+      content: `Existing,${VALID_G}\nFresh,${VALID_S}`,
+    });
+    expect(preview.format).toBe("csv");
+    expect(preview.validRows).toBe(2);
+    expect(preview.duplicateRows).toBe(1);
+    const existingRow = preview.rows.find((row) => row.address === VALID_G);
+    expect(existingRow?.existing).toMatchObject({ trust: "default" });
+  });
+});

--- a/tests/unit/api/openapi.coverage.test.ts
+++ b/tests/unit/api/openapi.coverage.test.ts
@@ -41,6 +41,11 @@ describe("OpenAPI route coverage", () => {
         "/relay/readiness",
         "/relay/version",
         "/relay/messages",
+        "/contacts",
+        "/contacts/{contactId}",
+        "/contacts/merge",
+        "/contacts/import/preview",
+        "/contacts/import/commit",
       ]),
     );
   });

--- a/tests/unit/api/repository-contract.ts
+++ b/tests/unit/api/repository-contract.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { StoredEnvelope } from "../../../src/server/api/domain";
+import type { Contact, StoredEnvelope } from "../../../src/server/api/domain";
 import type { ApiRepository } from "../../../src/server/api/repository";
 
 // Issue #1494: one reusable repository conformance suite that every adapter must
@@ -520,6 +520,127 @@ export function runRepositoryContractTests(
           replacedBySessionId: "sess_new_2",
           userId: "usr_test_1",
         });
+      });
+    });
+
+    describe("contacts (BETA-066 / Issue #1973)", () => {
+      const otherOwner = `G${"C".repeat(55)}`;
+
+      function sampleContact(id: string, overrides: Partial<Contact> = {}): Contact {
+        return {
+          contactId: id,
+          owner,
+          name: `Contact ${id}`,
+          address: `g-address-${id}`,
+          canonicalAddress: null,
+          trust: "default",
+          source: "manual",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          version: 1,
+          ...overrides,
+        };
+      }
+
+      it("returns null for a missing contact", async () => {
+        await expect(repo.getContact(owner, "c_missing")).resolves.toBeNull();
+      });
+
+      it("round-trips a created contact and isolates it per owner", async () => {
+        const stored = await repo.createContact(sampleContact("c_1"));
+        expect(stored).toMatchObject({ contactId: "c_1", owner, name: "Contact c_1" });
+
+        const fetched = await repo.getContact(owner, "c_1");
+        expect(fetched).toMatchObject({ contactId: "c_1", owner, version: 1 });
+
+        await expect(repo.getContact(otherOwner, "c_1")).resolves.toBeNull();
+      });
+
+      it("rejects duplicate contactId creation for the same owner", async () => {
+        await repo.createContact(sampleContact("c_dup"));
+        await expect(repo.createContact(sampleContact("c_dup"))).rejects.toThrow();
+      });
+
+      it("allows the same contactId under a different owner", async () => {
+        await repo.createContact(sampleContact("c_shared"));
+        await expect(
+          repo.createContact(sampleContact("c_shared", { owner: otherOwner })),
+        ).resolves.toMatchObject({ owner: otherOwner });
+      });
+
+      it("applies compare-and-swap updates keyed by expectedVersion", async () => {
+        await repo.createContact(sampleContact("c_cas"));
+
+        const moved = await repo.updateContact(
+          sampleContact("c_cas", { version: 2, name: "Moved" }),
+          1,
+        );
+        expect(moved.updated).toBe(true);
+        if (moved.updated) {
+          expect(moved.contact).toMatchObject({ name: "Moved", version: 2 });
+        }
+
+        const stale = await repo.updateContact(sampleContact("c_cas"), 1);
+        expect(stale.updated).toBe(false);
+      });
+
+      it("reports not-found CAS when the contact never existed", async () => {
+        const result = await repo.updateContact(sampleContact("c_ghost"), 1);
+        expect(result).toEqual({ updated: false, current: null });
+      });
+
+      it("deletes a contact and leaves other owners untouched", async () => {
+        await repo.createContact(sampleContact("c_del", { owner: otherOwner }));
+        await repo.createContact(sampleContact("c_keep"));
+
+        await repo.deleteContact(owner, "c_keep");
+        await expect(repo.getContact(owner, "c_keep")).resolves.toBeNull();
+        await expect(repo.getContact(otherOwner, "c_del")).resolves.not.toBeNull();
+      });
+
+      it("lists contacts scoped to the owner with the declared ordering", async () => {
+        await repo.createContact(sampleContact("c_a", { name: "Alpha" }));
+        await repo.createContact(sampleContact("c_b", { name: "Beta" }));
+        await repo.createContact(sampleContact("c_z", { owner: otherOwner, name: "Zulu" }));
+
+        const page = await repo.listContacts(owner);
+        expect(page.items.map((c) => c.contactId).sort()).toEqual(["c_a", "c_b"]);
+        expect(page.items.every((c) => c.owner === owner)).toBe(true);
+      });
+
+      it("filters by query against name and raw address case-insensitively", async () => {
+        await repo.createContact(sampleContact("c_alpha", { name: "Alice" }));
+        await repo.createContact(sampleContact("c_bravo", { address: "GALICE-ADDRESS" }));
+
+        const byName = await repo.listContacts(owner, { query: "alice" });
+        expect(byName.items.map((c) => c.contactId).sort()).toEqual(["c_alpha", "c_bravo"]);
+
+        const onlyAddress = await repo.listContacts(owner, { query: "galice" });
+        expect(onlyAddress.items.map((c) => c.contactId)).toEqual(["c_bravo"]);
+      });
+
+      it("paginates contacts with limit and continuation key", async () => {
+        for (let i = 0; i < 5; i += 1) {
+          await repo.createContact(sampleContact(`c_page_${i}`));
+        }
+
+        const first = await repo.listContacts(owner, { limit: 2 });
+        expect(first.items).toHaveLength(2);
+        expect(first.nextContinuationKey).not.toBeNull();
+
+        const second = await repo.listContacts(owner, {
+          limit: 2,
+          after: first.nextContinuationKey ?? undefined,
+        });
+        expect(second.items).toHaveLength(2);
+        expect(second.items[0].contactId).not.toBe(first.items[0].contactId);
+
+        const last = await repo.listContacts(owner, {
+          limit: 5,
+          after: second.nextContinuationKey ?? undefined,
+        });
+        expect(last.items).toHaveLength(1);
+        expect(last.nextContinuationKey).toBeNull();
       });
     });
   });

--- a/tests/unit/api/request.body-limits.test.ts
+++ b/tests/unit/api/request.body-limits.test.ts
@@ -99,6 +99,11 @@ describe("body-limit registry (#1487)", () => {
       "quotePostage",
       "recordDelivery",
       "submitRelayMessage",
+      "createContact",
+      "updateContact",
+      "mergeContacts",
+      "previewContactImport",
+      "commitContactImport",
     ]) {
       expect(documented.get(opId), `${opId} documents x-max-body-bytes`).toBeGreaterThan(0);
     }

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -396,6 +396,32 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("updateEnvelopeStatus");
     return this.inner.updateEnvelopeStatus(messageId, status);
   }
+  async listContacts(
+    owner: string,
+    options?: import("../../../src/server/api/repository").ContactQueryOptions,
+  ) {
+    this.maybeFail("listContacts");
+    return this.inner.listContacts(owner, options);
+  }
+  async getContact(owner: string, contactId: string) {
+    this.maybeFail("getContact");
+    return this.inner.getContact(owner, contactId);
+  }
+  async createContact(contact: import("../../../src/server/api/domain").Contact) {
+    this.maybeFail("createContact");
+    return this.inner.createContact(contact);
+  }
+  async updateContact(
+    contact: import("../../../src/server/api/domain").Contact,
+    expectedVersion: number,
+  ) {
+    this.maybeFail("updateContact");
+    return this.inner.updateContact(contact, expectedVersion);
+  }
+  async deleteContact(owner: string, contactId: string) {
+    this.maybeFail("deleteContact");
+    return this.inner.deleteContact(owner, contactId);
+  }
   reset(): void {
     this.inner.reset();
   }


### PR DESCRIPTION
## Overview

This PR delivers the BETA-066 vertical slice for **live contacts CRUD, trust state, and safe import** backed by the live typed services. It adds owner-scoped contact storage with optimistic concurrency, per-contact live resolution (identity, key freshness, sender rule), a duplicate-safe CSV/vCard import flow with preview + explicit-trust commit, and a frontend wired to the live API — replacing the in-memory demo policy API whenever the owner is a valid Stellar G-address.

## Related Issue

Closes [#1973](https://github.com/Stellar-Mail/stealth/issues/1973)

## Changes

### 📇 Contacts Repository

- **[ADD]** `listContacts`, `getContact`, `createContact`, `updateContact` (compare-and-swap on `expectedVersion`), `deleteContact` on `ApiRepository`.
- **[ADD]** Implementations across `MemoryApiRepository`, hybrid KV (`kv-repository`), `ValidatedApiRepository` (`registerRecordSchema("contact", 1, contactSchema)`), and `RetryableApiRepository` (contact reads/lists added to the retry-safe set).
- **[ADD]** `PAGINATED_QUERY_ORDERINGS.listContacts` (createdAt desc, contactId tie-breaker) with case-insensitive name/address `query` filtering.

### ⚙️ Contact Service & Safe Import

- **[ADD]** `src/server/api/contact-service.ts` — owner-scoped CRUD, `resolveContactState` (identity, key-freshness, sender rule; resolution failures degrade to `null` instead of breaking listings), `mergeContacts`, `previewContactImport`, and idempotent `commitContactImport` (upsert by address, `IMPORT_MAX_ROWS = 1000`).
- **[ADD]** `src/server/api/contact-import.ts` — CSV/TSV + vCard parsers with per-row errors, row-limit truncation, and duplicate detection.
- **Trust safety guarantee:** contact rows never implicitly mutate policy. Only `applyTrust: true` in the commit path touches `setSenderRule`, and even then only `allow`/`block` rows apply rules.

### 🛣️ API Routes

- **[ADD]** `/api/v1/contacts` (GET list+search, POST create), `/api/v1/contacts/{contactId}` (GET/PUT/DELETE), `/api/v1/contacts/merge`, `/api/v1/contacts/import/preview`, `/api/v1/contacts/import/commit` — all `requireActor`-scoped with body limits.
- **[ADD]** `scripts/generate-route-tree.ts` and regenerated `src/routeTree.gen.ts` so the new routes are registered with the react-start typed router.
- **[ADD]** OpenAPI `Contact`, `ContactResolution`, `ContactWithResolution`, `ContactListResult`, import preview/commit schemas and all five paths; coverage and body-limit tests updated.

### 🖥️ Frontend

- **[ADD]** `src/features/contacts/api.ts` live client (CRUD, merge, preview, commit) forwarding the `x-stealth-address` actor.
- **[MODIFY]** Import wizard defaults to `createLivePolicyApi(owner)` (commit + `applyTrust`) when the owner is a valid G-address, falling back to the in-memory demo API otherwise.

### 🧪 Tests

- **[ADD]** Repository contract suite additions (contact CRUD, CAS, ownership isolation, pagination).
- **[ADD]** `contact-service.test.ts` (parsing, CRUD, import idempotency, trust opt-in) and `contact-routes.test.ts` (authz, scope, round-trips).

## Verification Results

```
npx tsc --noEmit      ✅ clean
npm run lint          ✅ clean
npm test              ✅ 192 files / 2289 passed (+ contact suites)
npm run build         ✅ client + ssr build succeed
```

Acceptance Criteria | Status
--- | ---
User-owned contacts CRUD with live resolution | ✅ owner-scoped, optimistic concurrency, resolution degraded gracefully
Trust state never implicitly mutates policy | ✅ only opt-in `applyTrust`; only allow/block rows call `setSenderRule`
Safe CSV/vCard import with preview + explicit commit | ✅ idempotent upsert, preview never writes, 1000-row limit
OpenAPI documentation for every new endpoint | ✅ schemas + paths registered, coverage tests updated
Frontend connected to live API | ✅ wizard uses live commit API for valid G-address owners
