### PR TITLE
feat(relay): add durable job retries, idempotency, dlq, and receipt i…

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,6 +47,8 @@ import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
 import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/accounts/provisioning'
 import { Route as ApiV1WalletLinkIndexRouteImport } from './routes/api/v1/wallet/link/index'
 import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/identity/keys/index'
+import { Route as ApiV1AdminJobsIndexRouteImport } from './routes/api/v1/admin/jobs/index'
+import { Route as ApiV1AdminDlqIndexRouteImport } from './routes/api/v1/admin/dlq/index'
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
 import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
 import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
@@ -62,8 +64,12 @@ import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/ide
 import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
 import { Route as ApiV1ContactsImportPreviewRouteImport } from './routes/api/v1/contacts/import/preview'
 import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/contacts/import/commit'
+import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
+import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
 import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
+import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
+import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
   id: '/motion-gallery',
@@ -257,6 +263,16 @@ const ApiV1IdentityKeysIndexRoute = ApiV1IdentityKeysIndexRouteImport.update({
   path: '/api/v1/identity/keys/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AdminJobsIndexRoute = ApiV1AdminJobsIndexRouteImport.update({
+  id: '/api/v1/admin/jobs/',
+  path: '/api/v1/admin/jobs/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AdminDlqIndexRoute = ApiV1AdminDlqIndexRouteImport.update({
+  id: '/api/v1/admin/dlq/',
+  path: '/api/v1/admin/dlq/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1WalletLinkVerifyRoute = ApiV1WalletLinkVerifyRouteImport.update({
   id: '/api/v1/wallet/link/verify',
   path: '/api/v1/wallet/link/verify',
@@ -341,6 +357,16 @@ const ApiV1ContactsImportCommitRoute =
     path: '/api/v1/contacts/import/commit',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiV1AdminJobsIdRoute = ApiV1AdminJobsIdRouteImport.update({
+  id: '/api/v1/admin/jobs/$id',
+  path: '/api/v1/admin/jobs/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AdminDlqIdRoute = ApiV1AdminDlqIdRouteImport.update({
+  id: '/api/v1/admin/dlq/$id',
+  path: '/api/v1/admin/dlq/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AccountsProvisioningRetryRoute =
   ApiV1AccountsProvisioningRetryRouteImport.update({
     id: '/retry',
@@ -353,6 +379,16 @@ const ApiV1PoliciesOwnerSendersSenderRoute =
     path: '/senders/$sender',
     getParentRoute: () => ApiV1PoliciesOwnerRoute,
   } as any)
+const ApiV1AdminDlqIdRetryRoute = ApiV1AdminDlqIdRetryRouteImport.update({
+  id: '/retry',
+  path: '/retry',
+  getParentRoute: () => ApiV1AdminDlqIdRoute,
+} as any)
+const ApiV1AdminDlqIdAbandonRoute = ApiV1AdminDlqIdAbandonRouteImport.update({
+  id: '/abandon',
+  path: '/abandon',
+  getParentRoute: () => ApiV1AdminDlqIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -392,6 +428,8 @@ export interface FileRoutesByFullPath {
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
+  '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -407,8 +445,12 @@ export interface FileRoutesByFullPath {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
+  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
+  '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesByTo {
@@ -449,6 +491,8 @@ export interface FileRoutesByTo {
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
+  '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -464,8 +508,12 @@ export interface FileRoutesByTo {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/admin/dlq': typeof ApiV1AdminDlqIndexRoute
+  '/api/v1/admin/jobs': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
+  '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRoutesById {
@@ -507,6 +555,8 @@ export interface FileRoutesById {
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
+  '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -522,8 +572,12 @@ export interface FileRoutesById {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
+  '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
+  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
+  '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
 }
 export interface FileRouteTypes {
@@ -566,6 +620,8 @@ export interface FileRouteTypes {
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/admin/dlq/$id'
+    | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -581,8 +637,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/admin/dlq/'
+    | '/api/v1/admin/jobs/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
+    | '/api/v1/admin/dlq/$id/abandon'
+    | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -623,6 +683,8 @@ export interface FileRouteTypes {
     | '/api/v1/receipts'
     | '/api/v1/requests'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/admin/dlq/$id'
+    | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -638,8 +700,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/admin/dlq'
+    | '/api/v1/admin/jobs'
     | '/api/v1/identity/keys'
     | '/api/v1/wallet/link'
+    | '/api/v1/admin/dlq/$id/abandon'
+    | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
   id:
     | '__root__'
@@ -680,6 +746,8 @@ export interface FileRouteTypes {
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/admin/dlq/$id'
+    | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -695,8 +763,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
+    | '/api/v1/admin/dlq/'
+    | '/api/v1/admin/jobs/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
+    | '/api/v1/admin/dlq/$id/abandon'
+    | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
   fileRoutesById: FileRoutesById
 }
@@ -737,6 +809,8 @@ export interface RootRouteChildren {
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
   ApiV1RequestsIndexRoute: typeof ApiV1RequestsIndexRoute
+  ApiV1AdminDlqIdRoute: typeof ApiV1AdminDlqIdRouteWithChildren
+  ApiV1AdminJobsIdRoute: typeof ApiV1AdminJobsIdRoute
   ApiV1ContactsImportCommitRoute: typeof ApiV1ContactsImportCommitRoute
   ApiV1ContactsImportPreviewRoute: typeof ApiV1ContactsImportPreviewRoute
   ApiV1IdentityKeysKeyIdRoute: typeof ApiV1IdentityKeysKeyIdRoute
@@ -747,6 +821,8 @@ export interface RootRouteChildren {
   ApiV1WalletLinkAddressRoute: typeof ApiV1WalletLinkAddressRoute
   ApiV1WalletLinkChallengeRoute: typeof ApiV1WalletLinkChallengeRoute
   ApiV1WalletLinkVerifyRoute: typeof ApiV1WalletLinkVerifyRoute
+  ApiV1AdminDlqIndexRoute: typeof ApiV1AdminDlqIndexRoute
+  ApiV1AdminJobsIndexRoute: typeof ApiV1AdminJobsIndexRoute
   ApiV1IdentityKeysIndexRoute: typeof ApiV1IdentityKeysIndexRoute
   ApiV1WalletLinkIndexRoute: typeof ApiV1WalletLinkIndexRoute
 }
@@ -1019,6 +1095,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1IdentityKeysIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/admin/jobs/': {
+      id: '/api/v1/admin/jobs/'
+      path: '/api/v1/admin/jobs'
+      fullPath: '/api/v1/admin/jobs/'
+      preLoaderRoute: typeof ApiV1AdminJobsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/admin/dlq/': {
+      id: '/api/v1/admin/dlq/'
+      path: '/api/v1/admin/dlq'
+      fullPath: '/api/v1/admin/dlq/'
+      preLoaderRoute: typeof ApiV1AdminDlqIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/wallet/link/verify': {
       id: '/api/v1/wallet/link/verify'
       path: '/api/v1/wallet/link/verify'
@@ -1124,6 +1214,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1ContactsImportCommitRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/admin/jobs/$id': {
+      id: '/api/v1/admin/jobs/$id'
+      path: '/api/v1/admin/jobs/$id'
+      fullPath: '/api/v1/admin/jobs/$id'
+      preLoaderRoute: typeof ApiV1AdminJobsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/admin/dlq/$id': {
+      id: '/api/v1/admin/dlq/$id'
+      path: '/api/v1/admin/dlq/$id'
+      fullPath: '/api/v1/admin/dlq/$id'
+      preLoaderRoute: typeof ApiV1AdminDlqIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/accounts/provisioning/retry': {
       id: '/api/v1/accounts/provisioning/retry'
       path: '/retry'
@@ -1137,6 +1241,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/v1/policies/$owner/senders/$sender'
       preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderRouteImport
       parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/admin/dlq/$id/retry': {
+      id: '/api/v1/admin/dlq/$id/retry'
+      path: '/retry'
+      fullPath: '/api/v1/admin/dlq/$id/retry'
+      preLoaderRoute: typeof ApiV1AdminDlqIdRetryRouteImport
+      parentRoute: typeof ApiV1AdminDlqIdRoute
+    }
+    '/api/v1/admin/dlq/$id/abandon': {
+      id: '/api/v1/admin/dlq/$id/abandon'
+      path: '/abandon'
+      fullPath: '/api/v1/admin/dlq/$id/abandon'
+      preLoaderRoute: typeof ApiV1AdminDlqIdAbandonRouteImport
+      parentRoute: typeof ApiV1AdminDlqIdRoute
     }
   }
 }
@@ -1199,6 +1317,20 @@ const ApiV1ReceiptsMessageIdRouteWithChildren =
     ApiV1ReceiptsMessageIdRouteChildren,
   )
 
+interface ApiV1AdminDlqIdRouteChildren {
+  ApiV1AdminDlqIdAbandonRoute: typeof ApiV1AdminDlqIdAbandonRoute
+  ApiV1AdminDlqIdRetryRoute: typeof ApiV1AdminDlqIdRetryRoute
+}
+
+const ApiV1AdminDlqIdRouteChildren: ApiV1AdminDlqIdRouteChildren = {
+  ApiV1AdminDlqIdAbandonRoute: ApiV1AdminDlqIdAbandonRoute,
+  ApiV1AdminDlqIdRetryRoute: ApiV1AdminDlqIdRetryRoute,
+}
+
+const ApiV1AdminDlqIdRouteWithChildren = ApiV1AdminDlqIdRoute._addFileChildren(
+  ApiV1AdminDlqIdRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   PolicyEditorRouteRoute: PolicyEditorRouteRoute,
@@ -1236,6 +1368,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
   ApiV1RequestsIndexRoute: ApiV1RequestsIndexRoute,
+  ApiV1AdminDlqIdRoute: ApiV1AdminDlqIdRouteWithChildren,
+  ApiV1AdminJobsIdRoute: ApiV1AdminJobsIdRoute,
   ApiV1ContactsImportCommitRoute: ApiV1ContactsImportCommitRoute,
   ApiV1ContactsImportPreviewRoute: ApiV1ContactsImportPreviewRoute,
   ApiV1IdentityKeysKeyIdRoute: ApiV1IdentityKeysKeyIdRoute,
@@ -1246,6 +1380,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1WalletLinkAddressRoute: ApiV1WalletLinkAddressRoute,
   ApiV1WalletLinkChallengeRoute: ApiV1WalletLinkChallengeRoute,
   ApiV1WalletLinkVerifyRoute: ApiV1WalletLinkVerifyRoute,
+  ApiV1AdminDlqIndexRoute: ApiV1AdminDlqIndexRoute,
+  ApiV1AdminJobsIndexRoute: ApiV1AdminJobsIndexRoute,
   ApiV1IdentityKeysIndexRoute: ApiV1IdentityKeysIndexRoute,
   ApiV1WalletLinkIndexRoute: ApiV1WalletLinkIndexRoute,
 }

--- a/src/routes/api/v1/admin/dlq/$id.ts
+++ b/src/routes/api/v1/admin/dlq/$id.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { getDeadLetter } from "@/server/api/job-service";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/admin/dlq/$id")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const deadLetter = await getDeadLetter(context.repository, params.id);
+          return apiSuccess(request, { deadLetter });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/dlq/$id/abandon.ts
+++ b/src/routes/api/v1/admin/dlq/$id/abandon.ts
@@ -1,0 +1,31 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { getApiContext } from "@/server/api/context";
+import { abandonDeadLetter } from "@/server/api/job-service";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { parseJsonBody } from "@/server/api/request";
+
+const abandonBodySchema = z.object({
+  adminNotes: z.string().max(500).optional(),
+});
+
+export const Route = createFileRoute("/api/v1/admin/dlq/$id/abandon")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          let adminNotes: string | undefined;
+          try {
+            const body = await parseJsonBody(request, abandonBodySchema);
+            adminNotes = body.adminNotes;
+          } catch {
+            // Optional body
+          }
+
+          const deadLetter = await abandonDeadLetter(context.repository, params.id, adminNotes);
+          return apiSuccess(request, { deadLetter });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/dlq/$id/retry.ts
+++ b/src/routes/api/v1/admin/dlq/$id/retry.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { retryDeadLetter } from "@/server/api/job-service";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/admin/dlq/$id/retry")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const result = await retryDeadLetter(context.repository, params.id);
+          return apiSuccess(request, result);
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/dlq/index.ts
+++ b/src/routes/api/v1/admin/dlq/index.ts
@@ -1,0 +1,32 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { getApiContext } from "@/server/api/context";
+import { durableJobTypeSchema, deadLetterStatusSchema } from "@/server/api/domain";
+import { listDeadLetters } from "@/server/api/job-service";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const querySchema = z.object({
+  jobType: durableJobTypeSchema.optional(),
+  status: deadLetterStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export const Route = createFileRoute("/api/v1/admin/dlq/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const url = new URL(request.url);
+          const parsed = querySchema.parse({
+            jobType: url.searchParams.get("jobType") || undefined,
+            status: url.searchParams.get("status") || undefined,
+            limit: url.searchParams.get("limit") || undefined,
+          });
+
+          const deadLetters = await listDeadLetters(context.repository, parsed);
+          return apiSuccess(request, { deadLetters });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/jobs/$id.ts
+++ b/src/routes/api/v1/admin/jobs/$id.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getApiContext } from "@/server/api/context";
+import { ApiError } from "@/server/api/errors";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/admin/jobs/$id")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const job = await context.repository.getJob(params.id);
+          if (!job) {
+            throw new ApiError(404, "not_found", `Job ${params.id} was not found`);
+          }
+          return apiSuccess(request, { job });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/jobs/index.ts
+++ b/src/routes/api/v1/admin/jobs/index.ts
@@ -1,0 +1,31 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { getApiContext } from "@/server/api/context";
+import { durableJobTypeSchema, jobStatusSchema } from "@/server/api/domain";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const querySchema = z.object({
+  type: durableJobTypeSchema.optional(),
+  status: jobStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export const Route = createFileRoute("/api/v1/admin/jobs/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const url = new URL(request.url);
+          const parsed = querySchema.parse({
+            type: url.searchParams.get("type") || undefined,
+            status: url.searchParams.get("status") || undefined,
+            limit: url.searchParams.get("limit") || undefined,
+          });
+
+          const jobs = await context.repository.listJobs(parsed);
+          return apiSuccess(request, { jobs });
+        }),
+    },
+  },
+});

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -720,3 +720,106 @@ export type Contact = z.infer<typeof contactSchema>;
 export type ContactSource = z.infer<typeof contactSourceSchema>;
 export type ContactCreateInput = z.infer<typeof contactCreateSchema>;
 export type ContactUpdateInput = z.infer<typeof contactUpdateSchema>;
+
+// ---------------------------------------------------------------------------
+// Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+// ---------------------------------------------------------------------------
+
+export const durableJobTypeSchema = z.enum([
+  "funding",
+  "anchoring",
+  "postage",
+  "delivery",
+  "receipts",
+  "cleanup",
+  "reconciliation",
+]);
+export type DurableJobType = z.infer<typeof durableJobTypeSchema>;
+
+export const jobStatusSchema = z.enum([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "dead_letter",
+  "abandoned",
+]);
+export type JobStatus = z.infer<typeof jobStatusSchema>;
+
+export const jobErrorCodeSchema = z.enum([
+  "ERR_NETWORK_TRANSIENT",
+  "ERR_RPC_TIMEOUT",
+  "ERR_RATE_LIMITED",
+  "ERR_INSUFFICIENT_FUNDS",
+  "ERR_CONTRACT_REVERT",
+  "ERR_DOMAIN_NOT_FOUND",
+  "ERR_UNAUTHORIZED",
+  "ERR_PAYLOAD_REJECTED",
+  "ERR_DELIVERY_EXPIRED",
+  "ERR_POISON_PAYLOAD",
+  "ERR_CHECKPOINT_GAP",
+  "ERR_UNKNOWN_PERMANENT",
+]);
+export type JobErrorCode = z.infer<typeof jobErrorCodeSchema>;
+
+export const durableJobSchema = z.object({
+  jobId: z.string().trim().min(1),
+  type: durableJobTypeSchema,
+  idempotencyKey: z.string().trim().min(1),
+  payload: z.record(z.unknown()),
+  status: jobStatusSchema.default("pending"),
+  attempts: z.number().int().nonnegative().default(0),
+  maxAttempts: z.number().int().positive().default(5),
+  backoffMs: z.number().int().positive().default(1000),
+  nextRunAt: z.string().datetime(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  completedAt: z.string().datetime().optional(),
+  failedAt: z.string().datetime().optional(),
+  lastError: z.string().max(500).optional(),
+  errorCode: z.string().optional(),
+  checkpoint: z.string().optional(),
+});
+export type DurableJob = z.infer<typeof durableJobSchema>;
+
+export const deadLetterStatusSchema = z.enum(["dead", "retried", "abandoned"]);
+export type DeadLetterStatus = z.infer<typeof deadLetterStatusSchema>;
+
+export const deadLetterSchema = z.object({
+  deadLetterId: z.string().trim().min(1),
+  jobId: z.string().trim().min(1),
+  jobType: durableJobTypeSchema,
+  idempotencyKey: z.string().trim().min(1),
+  payload: z.record(z.unknown()),
+  attempts: z.number().int().nonnegative(),
+  errorCode: z.string(),
+  errorMessage: z.string(),
+  deadLetteredAt: z.string().datetime(),
+  status: deadLetterStatusSchema.default("dead"),
+  retriedAt: z.string().datetime().optional(),
+  abandonedAt: z.string().datetime().optional(),
+  adminNotes: z.string().max(500).optional(),
+});
+export type DeadLetter = z.infer<typeof deadLetterSchema>;
+
+export const receiptEventSchema = z.object({
+  eventId: z.string().trim().min(1),
+  streamId: z.string().trim().min(1),
+  sequence: z.number().int().nonnegative(),
+  messageId: hash32Schema,
+  recipient: stellarAddressSchema,
+  sender: stellarAddressSchema,
+  deliveredAt: z.string().datetime(),
+  readAt: z.string().datetime().nullable().optional(),
+});
+export type ReceiptEvent = z.infer<typeof receiptEventSchema>;
+
+export const receiptCheckpointSchema = z.object({
+  streamId: z.string().trim().min(1),
+  lastSequence: z.number().int().nonnegative(),
+  processedCount: z.number().int().nonnegative(),
+  lastIndexedAt: z.string().datetime(),
+  gapCount: z.number().int().nonnegative().default(0),
+});
+export type ReceiptCheckpoint = z.infer<typeof receiptCheckpointSchema>;
+

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -822,4 +822,3 @@ export const receiptCheckpointSchema = z.object({
   gapCount: z.number().int().nonnegative().default(0),
 });
 export type ReceiptCheckpoint = z.infer<typeof receiptCheckpointSchema>;
-

--- a/src/server/api/job-service.ts
+++ b/src/server/api/job-service.ts
@@ -54,7 +54,7 @@ export function redactErrorMessage(error: unknown): string {
 /** Classifies an error into a structured reason taxonomy code. */
 export function classifyError(error: unknown): { code: JobErrorCode; retryable: boolean } {
   if (error instanceof ApiError) {
-    if (error.code === "rate_limit_exceeded" || error.status === 429) {
+    if (error.code === "too_many_requests" || error.status === 429) {
       return { code: "ERR_RATE_LIMITED", retryable: true };
     }
     if (error.code === "unauthorized" || error.status === 401 || error.status === 403) {

--- a/src/server/api/job-service.ts
+++ b/src/server/api/job-service.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import type {
+  DeadLetter,
+  DeadLetterStatus,
+  DurableJob,
+  DurableJobType,
+  JobErrorCode,
+  JobStatus,
+  ReceiptCheckpoint,
+  ReceiptEvent,
+} from "./domain";
+import { ApiError } from "./errors";
+import type { ApiRepository } from "./repository";
+
+// ---------------------------------------------------------------------------
+// Error Taxonomy & Redaction
+// ---------------------------------------------------------------------------
+
+export const ERROR_TAXONOMY: Record<string, JobErrorCode> = {
+  ERR_NETWORK_TRANSIENT: "ERR_NETWORK_TRANSIENT",
+  ERR_RPC_TIMEOUT: "ERR_RPC_TIMEOUT",
+  ERR_RATE_LIMITED: "ERR_RATE_LIMITED",
+  ERR_INSUFFICIENT_FUNDS: "ERR_INSUFFICIENT_FUNDS",
+  ERR_CONTRACT_REVERT: "ERR_CONTRACT_REVERT",
+  ERR_DOMAIN_NOT_FOUND: "ERR_DOMAIN_NOT_FOUND",
+  ERR_UNAUTHORIZED: "ERR_UNAUTHORIZED",
+  ERR_PAYLOAD_REJECTED: "ERR_PAYLOAD_REJECTED",
+  ERR_DELIVERY_EXPIRED: "ERR_DELIVERY_EXPIRED",
+  ERR_POISON_PAYLOAD: "ERR_POISON_PAYLOAD",
+  ERR_CHECKPOINT_GAP: "ERR_CHECKPOINT_GAP",
+  ERR_UNKNOWN_PERMANENT: "ERR_UNKNOWN_PERMANENT",
+};
+
+/** Redacts sensitive tokens, private keys, secret keys, or seeds from error text. */
+export function redactErrorMessage(error: unknown): string {
+  if (!error) return "Unknown error";
+  let message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : JSON.stringify(error);
+
+  // Redact Stellar S-seeds (S followed by 55 chars)
+  message = message.replace(/S[A-Z2-7]{55}/g, "[REDACTED_SEED]");
+  // Redact bearer tokens or authorization headers
+  message = message.replace(/Bearer\s+[A-Za-z0-9._~+/-]+/gi, "Bearer [REDACTED_TOKEN]");
+  // Redact hex private keys (64 char hex)
+  message = message.replace(/(?:private|secret)[_-\s]?key["':\s]+[a-f0-9]{64}/gi, "[REDACTED_KEY]");
+  // Bound the error length to prevent unbounded memory usage
+  return message.slice(0, 300);
+}
+
+/** Classifies an error into a structured reason taxonomy code. */
+export function classifyError(error: unknown): { code: JobErrorCode; retryable: boolean } {
+  if (error instanceof ApiError) {
+    if (error.code === "rate_limit_exceeded" || error.status === 429) {
+      return { code: "ERR_RATE_LIMITED", retryable: true };
+    }
+    if (error.code === "unauthorized" || error.status === 401 || error.status === 403) {
+      return { code: "ERR_UNAUTHORIZED", retryable: false };
+    }
+    if (error.code === "not_found" || error.status === 404) {
+      return { code: "ERR_DOMAIN_NOT_FOUND", retryable: false };
+    }
+    if (error.status === 400 || error.status === 422) {
+      return { code: "ERR_PAYLOAD_REJECTED", retryable: false };
+    }
+    if (error.retryable) {
+      return { code: "ERR_NETWORK_TRANSIENT", retryable: true };
+    }
+  }
+
+  const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (msg.includes("timeout") || msg.includes("etimedout")) {
+    return { code: "ERR_RPC_TIMEOUT", retryable: true };
+  }
+  if (msg.includes("rate limit") || msg.includes("429")) {
+    return { code: "ERR_RATE_LIMITED", retryable: true };
+  }
+  if (msg.includes("insufficient") || msg.includes("underfunded")) {
+    return { code: "ERR_INSUFFICIENT_FUNDS", retryable: false };
+  }
+  if (msg.includes("revert") || msg.includes("contract failed")) {
+    return { code: "ERR_CONTRACT_REVERT", retryable: false };
+  }
+  if (msg.includes("domain not found") || msg.includes("enotfound")) {
+    return { code: "ERR_DOMAIN_NOT_FOUND", retryable: false };
+  }
+  if (msg.includes("unauthorized") || msg.includes("forbidden")) {
+    return { code: "ERR_UNAUTHORIZED", retryable: false };
+  }
+  if (msg.includes("expired") || msg.includes("ttl")) {
+    return { code: "ERR_DELIVERY_EXPIRED", retryable: false };
+  }
+  if (msg.includes("poison") || msg.includes("malformed") || msg.includes("invalid payload")) {
+    return { code: "ERR_POISON_PAYLOAD", retryable: false };
+  }
+  if (msg.includes("gap") || msg.includes("sequence")) {
+    return { code: "ERR_CHECKPOINT_GAP", retryable: true };
+  }
+
+  return { code: "ERR_NETWORK_TRANSIENT", retryable: true };
+}
+
+// ---------------------------------------------------------------------------
+// Backoff with Jitter
+// ---------------------------------------------------------------------------
+
+export function calculateBackoff(
+  attempt: number,
+  baseBackoffMs = 1000,
+  maxBackoffMs = 60000,
+  jitterRatio = 0.25,
+): number {
+  const cappedAttempt = Math.max(1, attempt);
+  const exponential = Math.min(maxBackoffMs, baseBackoffMs * Math.pow(2, cappedAttempt - 1));
+  const jitter = Math.random() * exponential * jitterRatio;
+  return Math.round(exponential + jitter);
+}
+
+// ---------------------------------------------------------------------------
+// Job Lifecycle Operations
+// ---------------------------------------------------------------------------
+
+export interface EnqueueJobInput {
+  jobId?: string;
+  type: DurableJobType;
+  idempotencyKey: string;
+  payload: Record<string, unknown>;
+  maxAttempts?: number;
+  backoffMs?: number;
+  nextRunAt?: string;
+  checkpoint?: string;
+}
+
+export async function enqueueDurableJob(
+  repository: ApiRepository,
+  input: EnqueueJobInput,
+  now = new Date(),
+): Promise<{ enqueued: boolean; job: DurableJob }> {
+  const nowIso = now.toISOString();
+  const job: DurableJob = {
+    jobId: input.jobId ?? randomUUID(),
+    type: input.type,
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+    status: "pending",
+    attempts: 0,
+    maxAttempts: input.maxAttempts ?? 5,
+    backoffMs: input.backoffMs ?? 1000,
+    nextRunAt: input.nextRunAt ?? nowIso,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    checkpoint: input.checkpoint,
+  };
+
+  return repository.enqueueJob(job);
+}
+
+export async function recordJobSuccess(
+  repository: ApiRepository,
+  job: DurableJob,
+  checkpoint?: string,
+  now = new Date(),
+): Promise<DurableJob> {
+  const nowIso = now.toISOString();
+  const updated: DurableJob = {
+    ...job,
+    status: "completed",
+    completedAt: nowIso,
+    updatedAt: nowIso,
+    checkpoint: checkpoint ?? job.checkpoint,
+  };
+  return repository.updateJob(updated);
+}
+
+export async function recordJobFailure(
+  repository: ApiRepository,
+  job: DurableJob,
+  error: unknown,
+  options: { forceNonRetryable?: boolean; now?: Date } = {},
+): Promise<{ job: DurableJob; deadLetter?: DeadLetter }> {
+  const now = options.now ?? new Date();
+  const nowIso = now.toISOString();
+  const classification = classifyError(error);
+  const isRetryable = !options.forceNonRetryable && classification.retryable;
+  const newAttempts = job.attempts + 1;
+  const redactedMessage = redactErrorMessage(error);
+
+  if (isRetryable && newAttempts < job.maxAttempts) {
+    const delayMs = calculateBackoff(newAttempts, job.backoffMs);
+    const nextRun = new Date(now.getTime() + delayMs).toISOString();
+
+    const updatedJob: DurableJob = {
+      ...job,
+      attempts: newAttempts,
+      status: "pending",
+      nextRunAt: nextRun,
+      updatedAt: nowIso,
+      lastError: redactedMessage,
+      errorCode: classification.code,
+    };
+
+    const saved = await repository.updateJob(updatedJob);
+    return { job: saved };
+  }
+
+  // Exhausted or non-retryable -> Dead Letter Queue
+  const updatedJob: DurableJob = {
+    ...job,
+    attempts: newAttempts,
+    status: "dead_letter",
+    failedAt: nowIso,
+    updatedAt: nowIso,
+    lastError: redactedMessage,
+    errorCode: classification.code,
+  };
+
+  const savedJob = await repository.updateJob(updatedJob);
+
+  const deadLetter: DeadLetter = {
+    deadLetterId: randomUUID(),
+    jobId: savedJob.jobId,
+    jobType: savedJob.type,
+    idempotencyKey: savedJob.idempotencyKey,
+    payload: savedJob.payload,
+    attempts: newAttempts,
+    errorCode: classification.code,
+    errorMessage: redactedMessage,
+    deadLetteredAt: nowIso,
+    status: "dead",
+  };
+
+  const savedDLQ = await repository.createDeadLetter(deadLetter);
+  return { job: savedJob, deadLetter: savedDLQ };
+}
+
+// ---------------------------------------------------------------------------
+// Dead Letter Queue Administrator Operations
+// ---------------------------------------------------------------------------
+
+export async function listDeadLetters(
+  repository: ApiRepository,
+  filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number },
+): Promise<DeadLetter[]> {
+  return repository.listDeadLetters(filter);
+}
+
+export async function getDeadLetter(
+  repository: ApiRepository,
+  deadLetterId: string,
+): Promise<DeadLetter> {
+  const dlq = await repository.getDeadLetter(deadLetterId);
+  if (!dlq) {
+    throw new ApiError(404, "not_found", `Dead letter record ${deadLetterId} was not found`);
+  }
+  return dlq;
+}
+
+export async function retryDeadLetter(
+  repository: ApiRepository,
+  deadLetterId: string,
+  now = new Date(),
+): Promise<{ deadLetter: DeadLetter; job: DurableJob }> {
+  const dlq = await getDeadLetter(repository, deadLetterId);
+  if (dlq.status === "retried") {
+    const job = await repository.getJob(dlq.jobId);
+    if (!job) throw new ApiError(404, "not_found", "Associated job not found");
+    return { deadLetter: dlq, job };
+  }
+
+  const nowIso = now.toISOString();
+  const updatedDLQ: DeadLetter = {
+    ...dlq,
+    status: "retried",
+    retriedAt: nowIso,
+  };
+
+  await repository.updateDeadLetter(updatedDLQ);
+
+  const existingJob = await repository.getJob(dlq.jobId);
+  let job: DurableJob;
+  if (existingJob) {
+    job = await repository.updateJob({
+      ...existingJob,
+      status: "pending",
+      attempts: 0,
+      nextRunAt: nowIso,
+      updatedAt: nowIso,
+      lastError: undefined,
+      errorCode: undefined,
+    });
+  } else {
+    const res = await enqueueDurableJob(
+      repository,
+      {
+        jobId: dlq.jobId,
+        type: dlq.jobType,
+        idempotencyKey: dlq.idempotencyKey,
+        payload: dlq.payload,
+        nextRunAt: nowIso,
+      },
+      now,
+    );
+    job = res.job;
+  }
+
+  return { deadLetter: updatedDLQ, job };
+}
+
+export async function abandonDeadLetter(
+  repository: ApiRepository,
+  deadLetterId: string,
+  adminNotes?: string,
+  now = new Date(),
+): Promise<DeadLetter> {
+  const dlq = await getDeadLetter(repository, deadLetterId);
+  const nowIso = now.toISOString();
+
+  const updatedDLQ: DeadLetter = {
+    ...dlq,
+    status: "abandoned",
+    abandonedAt: nowIso,
+    adminNotes: adminNotes ?? dlq.adminNotes,
+  };
+
+  const savedDLQ = await repository.updateDeadLetter(updatedDLQ);
+
+  const existingJob = await repository.getJob(dlq.jobId);
+  if (existingJob) {
+    await repository.updateJob({
+      ...existingJob,
+      status: "abandoned",
+      updatedAt: nowIso,
+    });
+  }
+
+  return savedDLQ;
+}
+
+// ---------------------------------------------------------------------------
+// Receipt Event Indexing with Checkpoints & Gap Detection
+// ---------------------------------------------------------------------------
+
+export interface IndexReceiptResult {
+  indexedCount: number;
+  duplicateCount: number;
+  gapsDetected: number;
+  checkpoint: ReceiptCheckpoint;
+}
+
+export async function indexReceiptEvents(
+  repository: ApiRepository,
+  streamId: string,
+  events: ReceiptEvent[],
+  now = new Date(),
+): Promise<IndexReceiptResult> {
+  const existingCheckpoint = await repository.getReceiptCheckpoint(streamId);
+  const checkpoint: ReceiptCheckpoint = existingCheckpoint ?? {
+    streamId,
+    lastSequence: -1,
+    processedCount: 0,
+    lastIndexedAt: now.toISOString(),
+    gapCount: 0,
+  };
+
+  let indexedCount = 0;
+  let duplicateCount = 0;
+  let gapsDetected = 0;
+
+  // Sort events strictly by sequence ascending
+  const sortedEvents = [...events].sort((a, b) => a.sequence - b.sequence);
+
+  for (const event of sortedEvents) {
+    // Duplicate suppression: sequence already <= lastSequence
+    if (event.sequence <= checkpoint.lastSequence) {
+      duplicateCount++;
+      continue;
+    }
+
+    // Gap detection: sequence > lastSequence + 1
+    if (event.sequence > checkpoint.lastSequence + 1) {
+      gapsDetected += event.sequence - (checkpoint.lastSequence + 1);
+    }
+
+    // Create delivery receipt with duplicate safety
+    await repository.createReceiptIfAbsent({
+      messageId: event.messageId,
+      recipient: event.recipient,
+      sender: event.sender,
+      deliveredAt: event.deliveredAt,
+      readAt: event.readAt ?? null,
+    });
+
+    checkpoint.lastSequence = event.sequence;
+    checkpoint.processedCount += 1;
+    indexedCount++;
+  }
+
+  checkpoint.gapCount += gapsDetected;
+  checkpoint.lastIndexedAt = now.toISOString();
+
+  const savedCheckpoint = await repository.setReceiptCheckpoint(checkpoint);
+
+  return {
+    indexedCount,
+    duplicateCount,
+    gapsDetected,
+    checkpoint: savedCheckpoint,
+  };
+}

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -657,7 +657,11 @@ export class HybridApiRepository implements ApiRepository {
     return this.getStub().claimNextPendingJob(types, now);
   }
 
-  async listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+  async listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]> {
     return this.getStub().listJobs(filter);
   }
 
@@ -669,7 +673,11 @@ export class HybridApiRepository implements ApiRepository {
     return this.getStub().getDeadLetter(deadLetterId);
   }
 
-  async listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+  async listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]> {
     return this.getStub().listDeadLetters(filter);
   }
 

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -12,9 +12,14 @@ import type {
 import type {
   Contact,
   Credential,
+  DeadLetter,
+  DeadLetterStatus,
+  DurableJob,
+  DurableJobType,
   ExternalWallet,
   ExternalWalletChallenge,
   IdempotencyRecord,
+  JobStatus,
   KeyDirectoryRecord,
   MailboxPolicy,
   PolicyWriteIntent,
@@ -24,6 +29,7 @@ import type {
   ProvisioningRecord,
   PublishedKey,
   Receipt,
+  ReceiptCheckpoint,
   RetiredSession,
   SenderRule,
   Session,
@@ -625,5 +631,57 @@ export class HybridApiRepository implements ApiRepository {
     }
     contacts.splice(index, 1);
     await this.kv.put(this.contactKey(normOwner), JSON.stringify(contacts));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+
+  async enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
+    return this.getStub().enqueueJob(job);
+  }
+
+  async getJob(jobId: string): Promise<DurableJob | null> {
+    return this.getStub().getJob(jobId);
+  }
+
+  async getJobByIdempotencyKey(key: string): Promise<DurableJob | null> {
+    return this.getStub().getJobByIdempotencyKey(key);
+  }
+
+  async updateJob(job: DurableJob): Promise<DurableJob> {
+    return this.getStub().updateJob(job);
+  }
+
+  async claimNextPendingJob(types?: DurableJobType[], now?: Date): Promise<DurableJob | null> {
+    return this.getStub().claimNextPendingJob(types, now);
+  }
+
+  async listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+    return this.getStub().listJobs(filter);
+  }
+
+  async createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.getStub().createDeadLetter(deadLetter);
+  }
+
+  async getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
+    return this.getStub().getDeadLetter(deadLetterId);
+  }
+
+  async listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+    return this.getStub().listDeadLetters(filter);
+  }
+
+  async updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.getStub().updateDeadLetter(deadLetter);
+  }
+
+  async getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null> {
+    return this.getStub().getReceiptCheckpoint(streamId);
+  }
+
+  async setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
+    return this.getStub().setReceiptCheckpoint(checkpoint);
   }
 }

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -1127,7 +1127,10 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(stored);
   }
 
-  async claimNextPendingJob(types?: DurableJobType[], now = new Date()): Promise<DurableJob | null> {
+  async claimNextPendingJob(
+    types?: DurableJobType[],
+    now = new Date(),
+  ): Promise<DurableJob | null> {
     const nowTime = now.getTime();
     for (const job of this.jobs.values()) {
       if (job.status === "pending" && new Date(job.nextRunAt).getTime() <= nowTime) {
@@ -1145,7 +1148,11 @@ export class MemoryApiRepository implements ApiRepository {
     return null;
   }
 
-  async listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+  async listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]> {
     const limit = filter?.limit ?? 50;
     const matches: DurableJob[] = [];
     for (const job of this.jobs.values()) {
@@ -1168,7 +1175,11 @@ export class MemoryApiRepository implements ApiRepository {
     return dl ? structuredClone(dl) : null;
   }
 
-  async listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+  async listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]> {
     const limit = filter?.limit ?? 50;
     const matches: DeadLetter[] = [];
     for (const dl of this.deadLetters.values()) {
@@ -1176,7 +1187,9 @@ export class MemoryApiRepository implements ApiRepository {
       if (filter?.status && dl.status !== filter.status) continue;
       matches.push(structuredClone(dl));
     }
-    matches.sort((a, b) => new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime());
+    matches.sort(
+      (a, b) => new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime(),
+    );
     return matches.slice(0, limit);
   }
 

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -1,9 +1,14 @@
 import type {
   Contact,
   Credential,
+  DeadLetter,
+  DeadLetterStatus,
+  DurableJob,
+  DurableJobType,
   ExternalWallet,
   ExternalWalletChallenge,
   IdempotencyRecord,
+  JobStatus,
   KeyDirectoryRecord,
   MailboxPolicy,
   PolicyWriteIntent,
@@ -13,6 +18,7 @@ import type {
   ProvisioningRecord,
   PublishedKey,
   Receipt,
+  ReceiptCheckpoint,
   RetiredSession,
   SenderRule,
   Session,
@@ -67,6 +73,12 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly senderRequestLocks = new Map<string, Promise<void>>();
   // Issue #1973: owner-scoped contact store keyed by `${owner}:${contactId}`.
   private readonly contacts = new Map<string, Contact>();
+  // Issue #1952: durable jobs, DLQ, and receipt checkpoints
+  private readonly jobs = new Map<string, DurableJob>();
+  private readonly jobsByIdempotencyKey = new Map<string, string>();
+  private readonly deadLetters = new Map<string, DeadLetter>();
+  private readonly receiptCheckpoints = new Map<string, ReceiptCheckpoint>();
+  private readonly jobLocks = new Map<string, Promise<void>>();
 
   // BETA-002: User Account, Profile, Credential storage & unique index maps
   private readonly usersById = new Map<string, User>();
@@ -1078,6 +1090,113 @@ export class MemoryApiRepository implements ApiRepository {
     return `${owner.toUpperCase().trim()}:${contactId}`;
   }
 
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+
+  async enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
+    const existingId = this.jobsByIdempotencyKey.get(job.idempotencyKey);
+    if (existingId) {
+      const existing = this.jobs.get(existingId);
+      if (existing) {
+        return { enqueued: false, job: structuredClone(existing) };
+      }
+    }
+
+    const stored = structuredClone(job);
+    this.jobs.set(stored.jobId, stored);
+    this.jobsByIdempotencyKey.set(stored.idempotencyKey, stored.jobId);
+    return { enqueued: true, job: structuredClone(stored) };
+  }
+
+  async getJob(jobId: string): Promise<DurableJob | null> {
+    const job = this.jobs.get(jobId);
+    return job ? structuredClone(job) : null;
+  }
+
+  async getJobByIdempotencyKey(key: string): Promise<DurableJob | null> {
+    const jobId = this.jobsByIdempotencyKey.get(key);
+    if (!jobId) return null;
+    return this.getJob(jobId);
+  }
+
+  async updateJob(job: DurableJob): Promise<DurableJob> {
+    const stored = structuredClone(job);
+    this.jobs.set(stored.jobId, stored);
+    this.jobsByIdempotencyKey.set(stored.idempotencyKey, stored.jobId);
+    return structuredClone(stored);
+  }
+
+  async claimNextPendingJob(types?: DurableJobType[], now = new Date()): Promise<DurableJob | null> {
+    const nowTime = now.getTime();
+    for (const job of this.jobs.values()) {
+      if (job.status === "pending" && new Date(job.nextRunAt).getTime() <= nowTime) {
+        if (!types || types.includes(job.type)) {
+          const claimed: DurableJob = {
+            ...job,
+            status: "running",
+            updatedAt: now.toISOString(),
+          };
+          this.jobs.set(claimed.jobId, claimed);
+          return structuredClone(claimed);
+        }
+      }
+    }
+    return null;
+  }
+
+  async listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+    const limit = filter?.limit ?? 50;
+    const matches: DurableJob[] = [];
+    for (const job of this.jobs.values()) {
+      if (filter?.type && job.type !== filter.type) continue;
+      if (filter?.status && job.status !== filter.status) continue;
+      matches.push(structuredClone(job));
+    }
+    matches.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return matches.slice(0, limit);
+  }
+
+  async createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    const stored = structuredClone(deadLetter);
+    this.deadLetters.set(stored.deadLetterId, stored);
+    return structuredClone(stored);
+  }
+
+  async getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
+    const dl = this.deadLetters.get(deadLetterId);
+    return dl ? structuredClone(dl) : null;
+  }
+
+  async listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+    const limit = filter?.limit ?? 50;
+    const matches: DeadLetter[] = [];
+    for (const dl of this.deadLetters.values()) {
+      if (filter?.jobType && dl.jobType !== filter.jobType) continue;
+      if (filter?.status && dl.status !== filter.status) continue;
+      matches.push(structuredClone(dl));
+    }
+    matches.sort((a, b) => new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime());
+    return matches.slice(0, limit);
+  }
+
+  async updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    const stored = structuredClone(deadLetter);
+    this.deadLetters.set(stored.deadLetterId, stored);
+    return structuredClone(stored);
+  }
+
+  async getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null> {
+    const cp = this.receiptCheckpoints.get(streamId);
+    return cp ? structuredClone(cp) : null;
+  }
+
+  async setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
+    const stored = structuredClone(checkpoint);
+    this.receiptCheckpoints.set(checkpoint.streamId, stored);
+    return structuredClone(stored);
+  }
+
   reset() {
     this.policies.clear();
     this.policyWriteIntents.clear();
@@ -1112,5 +1231,10 @@ export class MemoryApiRepository implements ApiRepository {
     this.publishedKeys.clear();
     this.keyDirectoryLocks.clear();
     this.contacts.clear();
+    this.jobs.clear();
+    this.jobsByIdempotencyKey.clear();
+    this.deadLetters.clear();
+    this.receiptCheckpoints.clear();
+    this.jobLocks.clear();
   }
 }

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -1,9 +1,14 @@
 import type {
   Contact,
   Credential,
+  DeadLetter,
+  DeadLetterStatus,
+  DurableJob,
+  DurableJobType,
   ExternalWallet,
   ExternalWalletChallenge,
   IdempotencyRecord,
+  JobStatus,
   KeyDirectoryRecord,
   MailboxPolicy,
   PolicyWriteIntent,
@@ -13,6 +18,7 @@ import type {
   ProvisioningRecord,
   PublishedKey,
   Receipt,
+  ReceiptCheckpoint,
   RetiredSession,
   SenderRule,
   Session,
@@ -424,9 +430,23 @@ export interface ApiRepository {
    * conflict (ApiError 409 "conflict") so imports can never create ambiguous
    * address-book state.
    */
-  createContact(contact: Contact): Promise<Contact>;
-  updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult>;
-  deleteContact(owner: string, contactId: string): Promise<void>;
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+  enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }>;
+  getJob(jobId: string): Promise<DurableJob | null>;
+  getJobByIdempotencyKey(key: string): Promise<DurableJob | null>;
+  updateJob(job: DurableJob): Promise<DurableJob>;
+  claimNextPendingJob(types?: DurableJobType[], now?: Date): Promise<DurableJob | null>;
+  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]>;
+
+  createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter>;
+  getDeadLetter(deadLetterId: string): Promise<DeadLetter | null>;
+  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]>;
+  updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter>;
+
+  getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null>;
+  setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint>;
 
   reset?(): void;
 }
@@ -1035,6 +1055,57 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.deleteContact(owner, contactId);
   }
 
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+  enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
+    return this.inner.enqueueJob(job);
+  }
+
+  getJob(jobId: string): Promise<DurableJob | null> {
+    return this.inner.getJob(jobId);
+  }
+
+  getJobByIdempotencyKey(key: string): Promise<DurableJob | null> {
+    return this.inner.getJobByIdempotencyKey(key);
+  }
+
+  updateJob(job: DurableJob): Promise<DurableJob> {
+    return this.inner.updateJob(job);
+  }
+
+  claimNextPendingJob(types?: DurableJobType[], now?: Date): Promise<DurableJob | null> {
+    return this.inner.claimNextPendingJob(types, now);
+  }
+
+  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+    return this.inner.listJobs(filter);
+  }
+
+  createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.inner.createDeadLetter(deadLetter);
+  }
+
+  getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
+    return this.inner.getDeadLetter(deadLetterId);
+  }
+
+  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+    return this.inner.listDeadLetters(filter);
+  }
+
+  updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.inner.updateDeadLetter(deadLetter);
+  }
+
+  getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null> {
+    return this.inner.getReceiptCheckpoint(streamId);
+  }
+
+  setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
+    return this.inner.setReceiptCheckpoint(checkpoint);
+  }
+
   reset(): void {
     this.inner.reset?.();
   }
@@ -1101,6 +1172,14 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getWalletChallenge",
   "listContacts",
   "getContact",
+  "getJob",
+  "getJobByIdempotencyKey",
+  "listJobs",
+  "getDeadLetter",
+  "listDeadLetters",
+  "updateDeadLetter",
+  "getReceiptCheckpoint",
+  "setReceiptCheckpoint",
 ]);
 
 function isRetryableError(error: unknown): boolean {
@@ -1555,6 +1634,57 @@ export class RetryableApiRepository implements ApiRepository {
 
   deleteContact(owner: string, contactId: string): Promise<void> {
     return this.withRetry("deleteContact", () => this.inner.deleteContact(owner, contactId));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+  enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
+    return this.inner.enqueueJob(job);
+  }
+
+  getJob(jobId: string): Promise<DurableJob | null> {
+    return this.withRetry("getJob", () => this.inner.getJob(jobId));
+  }
+
+  getJobByIdempotencyKey(key: string): Promise<DurableJob | null> {
+    return this.withRetry("getJobByIdempotencyKey", () => this.inner.getJobByIdempotencyKey(key));
+  }
+
+  updateJob(job: DurableJob): Promise<DurableJob> {
+    return this.inner.updateJob(job);
+  }
+
+  claimNextPendingJob(types?: DurableJobType[], now?: Date): Promise<DurableJob | null> {
+    return this.inner.claimNextPendingJob(types, now);
+  }
+
+  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+    return this.withRetry("listJobs", () => this.inner.listJobs(filter));
+  }
+
+  createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.inner.createDeadLetter(deadLetter);
+  }
+
+  getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
+    return this.withRetry("getDeadLetter", () => this.inner.getDeadLetter(deadLetterId));
+  }
+
+  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+    return this.withRetry("listDeadLetters", () => this.inner.listDeadLetters(filter));
+  }
+
+  updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    return this.withRetry("updateDeadLetter", () => this.inner.updateDeadLetter(deadLetter));
+  }
+
+  getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null> {
+    return this.withRetry("getReceiptCheckpoint", () => this.inner.getReceiptCheckpoint(streamId));
+  }
+
+  setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
+    return this.withRetry("setReceiptCheckpoint", () => this.inner.setReceiptCheckpoint(checkpoint));
   }
 
   reset(): void {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -430,6 +430,10 @@ export interface ApiRepository {
    * conflict (ApiError 409 "conflict") so imports can never create ambiguous
    * address-book state.
    */
+  createContact(contact: Contact): Promise<Contact>;
+  updateContact(contact: Contact, expectedVersion: number): Promise<UpdateContactResult>;
+  deleteContact(owner: string, contactId: string): Promise<void>;
+
   // ---------------------------------------------------------------------------
   // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
   // ---------------------------------------------------------------------------

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -438,11 +438,19 @@ export interface ApiRepository {
   getJobByIdempotencyKey(key: string): Promise<DurableJob | null>;
   updateJob(job: DurableJob): Promise<DurableJob>;
   claimNextPendingJob(types?: DurableJobType[], now?: Date): Promise<DurableJob | null>;
-  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]>;
+  listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]>;
 
   createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter>;
   getDeadLetter(deadLetterId: string): Promise<DeadLetter | null>;
-  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]>;
+  listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]>;
   updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter>;
 
   getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null>;
@@ -1078,7 +1086,11 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.claimNextPendingJob(types, now);
   }
 
-  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+  listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]> {
     return this.inner.listJobs(filter);
   }
 
@@ -1090,7 +1102,11 @@ export class ValidatedApiRepository implements ApiRepository {
     return this.inner.getDeadLetter(deadLetterId);
   }
 
-  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+  listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]> {
     return this.inner.listDeadLetters(filter);
   }
 
@@ -1659,7 +1675,11 @@ export class RetryableApiRepository implements ApiRepository {
     return this.inner.claimNextPendingJob(types, now);
   }
 
-  listJobs(filter?: { type?: DurableJobType; status?: JobStatus; limit?: number }): Promise<DurableJob[]> {
+  listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]> {
     return this.withRetry("listJobs", () => this.inner.listJobs(filter));
   }
 
@@ -1671,7 +1691,11 @@ export class RetryableApiRepository implements ApiRepository {
     return this.withRetry("getDeadLetter", () => this.inner.getDeadLetter(deadLetterId));
   }
 
-  listDeadLetters(filter?: { jobType?: DurableJobType; status?: DeadLetterStatus; limit?: number }): Promise<DeadLetter[]> {
+  listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]> {
     return this.withRetry("listDeadLetters", () => this.inner.listDeadLetters(filter));
   }
 
@@ -1684,7 +1708,9 @@ export class RetryableApiRepository implements ApiRepository {
   }
 
   setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
-    return this.withRetry("setReceiptCheckpoint", () => this.inner.setReceiptCheckpoint(checkpoint));
+    return this.withRetry("setReceiptCheckpoint", () =>
+      this.inner.setReceiptCheckpoint(checkpoint),
+    );
   }
 
   reset(): void {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -880,14 +880,14 @@ export class StealthCoordinator extends DurableObjectBase {
 
   async enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
     return this.runExclusive(`job_idemp:${job.idempotencyKey}`, async () => {
-      const existingJobId = (await this.ctx.storage.get(
-        `job_idemp:${job.idempotencyKey}`,
-      )) as string | undefined;
+      const existingJobId = (await this.ctx.storage.get(`job_idemp:${job.idempotencyKey}`)) as
+        | string
+        | undefined;
 
       if (existingJobId) {
-        const existing = (await this.ctx.storage.get(
-          `job:${existingJobId}`,
-        )) as DurableJob | undefined;
+        const existing = (await this.ctx.storage.get(`job:${existingJobId}`)) as
+          | DurableJob
+          | undefined;
         if (existing) {
           return { enqueued: false, job: existing };
         }
@@ -923,10 +923,7 @@ export class StealthCoordinator extends DurableObjectBase {
     now = new Date(),
   ): Promise<DurableJob | null> {
     return this.runExclusive("claim_job", async () => {
-      const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<
-        string,
-        DurableJob
-      >;
+      const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<string, DurableJob>;
       const nowTime = now.getTime();
 
       for (const [k, job] of jobsMap.entries()) {
@@ -953,10 +950,7 @@ export class StealthCoordinator extends DurableObjectBase {
     limit?: number;
   }): Promise<DurableJob[]> {
     const limit = filter?.limit ?? 50;
-    const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<
-      string,
-      DurableJob
-    >;
+    const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<string, DurableJob>;
     const matches: DurableJob[] = [];
 
     for (const [k, job] of jobsMap.entries()) {
@@ -967,9 +961,7 @@ export class StealthCoordinator extends DurableObjectBase {
       matches.push(job);
     }
 
-    matches.sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+    matches.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     return matches.slice(0, limit);
   }
 
@@ -979,9 +971,7 @@ export class StealthCoordinator extends DurableObjectBase {
   }
 
   async getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
-    const dl = (await this.ctx.storage.get(`dlq:${deadLetterId}`)) as
-      | DeadLetter
-      | undefined;
+    const dl = (await this.ctx.storage.get(`dlq:${deadLetterId}`)) as DeadLetter | undefined;
     return dl ?? null;
   }
 
@@ -991,10 +981,7 @@ export class StealthCoordinator extends DurableObjectBase {
     limit?: number;
   }): Promise<DeadLetter[]> {
     const limit = filter?.limit ?? 50;
-    const dlqMap = (await this.ctx.storage.list({ prefix: "dlq:" })) as Map<
-      string,
-      DeadLetter
-    >;
+    const dlqMap = (await this.ctx.storage.list({ prefix: "dlq:" })) as Map<string, DeadLetter>;
     const matches: DeadLetter[] = [];
 
     for (const dl of dlqMap.values()) {
@@ -1005,8 +992,7 @@ export class StealthCoordinator extends DurableObjectBase {
     }
 
     matches.sort(
-      (a, b) =>
-        new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime(),
+      (a, b) => new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime(),
     );
     return matches.slice(0, limit);
   }
@@ -1023,9 +1009,7 @@ export class StealthCoordinator extends DurableObjectBase {
     return cp ?? null;
   }
 
-  async setReceiptCheckpoint(
-    checkpoint: ReceiptCheckpoint,
-  ): Promise<ReceiptCheckpoint> {
+  async setReceiptCheckpoint(checkpoint: ReceiptCheckpoint): Promise<ReceiptCheckpoint> {
     await this.ctx.storage.put(`receipt_cp:${checkpoint.streamId}`, checkpoint);
     return checkpoint;
   }

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1,11 +1,17 @@
 import type {
   Credential,
+  DeadLetter,
+  DeadLetterStatus,
+  DurableJob,
+  DurableJobType,
   IdempotencyRecord,
+  JobStatus,
   Postage,
   PostageStatus,
   Profile,
   ProvisioningRecord,
   Receipt,
+  ReceiptCheckpoint,
   RetiredSession,
   Session,
   StoredEnvelope,
@@ -866,5 +872,161 @@ export class StealthCoordinator extends DurableObjectBase {
       await this.ctx.storage.put(`envelope:${messageId}`, updated);
       return updated;
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
+  // ---------------------------------------------------------------------------
+
+  async enqueueJob(job: DurableJob): Promise<{ enqueued: boolean; job: DurableJob }> {
+    return this.runExclusive(`job_idemp:${job.idempotencyKey}`, async () => {
+      const existingJobId = (await this.ctx.storage.get(
+        `job_idemp:${job.idempotencyKey}`,
+      )) as string | undefined;
+
+      if (existingJobId) {
+        const existing = (await this.ctx.storage.get(
+          `job:${existingJobId}`,
+        )) as DurableJob | undefined;
+        if (existing) {
+          return { enqueued: false, job: existing };
+        }
+      }
+
+      await this.ctx.storage.put(`job:${job.jobId}`, job);
+      await this.ctx.storage.put(`job_idemp:${job.idempotencyKey}`, job.jobId);
+      return { enqueued: true, job };
+    });
+  }
+
+  async getJob(jobId: string): Promise<DurableJob | null> {
+    const job = (await this.ctx.storage.get(`job:${jobId}`)) as DurableJob | undefined;
+    return job ?? null;
+  }
+
+  async getJobByIdempotencyKey(key: string): Promise<DurableJob | null> {
+    const jobId = (await this.ctx.storage.get(`job_idemp:${key}`)) as string | undefined;
+    if (!jobId) return null;
+    return this.getJob(jobId);
+  }
+
+  async updateJob(job: DurableJob): Promise<DurableJob> {
+    return this.runExclusive(`job:${job.jobId}`, async () => {
+      await this.ctx.storage.put(`job:${job.jobId}`, job);
+      await this.ctx.storage.put(`job_idemp:${job.idempotencyKey}`, job.jobId);
+      return job;
+    });
+  }
+
+  async claimNextPendingJob(
+    types?: DurableJobType[],
+    now = new Date(),
+  ): Promise<DurableJob | null> {
+    return this.runExclusive("claim_job", async () => {
+      const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<
+        string,
+        DurableJob
+      >;
+      const nowTime = now.getTime();
+
+      for (const [k, job] of jobsMap.entries()) {
+        if (k.startsWith("job_idemp:")) continue;
+        if (!job || job.status !== "pending") continue;
+        if (new Date(job.nextRunAt).getTime() > nowTime) continue;
+        if (types && !types.includes(job.type)) continue;
+
+        const claimed: DurableJob = {
+          ...job,
+          status: "running",
+          updatedAt: now.toISOString(),
+        };
+        await this.ctx.storage.put(`job:${job.jobId}`, claimed);
+        return claimed;
+      }
+      return null;
+    });
+  }
+
+  async listJobs(filter?: {
+    type?: DurableJobType;
+    status?: JobStatus;
+    limit?: number;
+  }): Promise<DurableJob[]> {
+    const limit = filter?.limit ?? 50;
+    const jobsMap = (await this.ctx.storage.list({ prefix: "job:" })) as Map<
+      string,
+      DurableJob
+    >;
+    const matches: DurableJob[] = [];
+
+    for (const [k, job] of jobsMap.entries()) {
+      if (k.startsWith("job_idemp:")) continue;
+      if (!job || typeof job !== "object" || !job.jobId) continue;
+      if (filter?.type && job.type !== filter.type) continue;
+      if (filter?.status && job.status !== filter.status) continue;
+      matches.push(job);
+    }
+
+    matches.sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+    return matches.slice(0, limit);
+  }
+
+  async createDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    await this.ctx.storage.put(`dlq:${deadLetter.deadLetterId}`, deadLetter);
+    return deadLetter;
+  }
+
+  async getDeadLetter(deadLetterId: string): Promise<DeadLetter | null> {
+    const dl = (await this.ctx.storage.get(`dlq:${deadLetterId}`)) as
+      | DeadLetter
+      | undefined;
+    return dl ?? null;
+  }
+
+  async listDeadLetters(filter?: {
+    jobType?: DurableJobType;
+    status?: DeadLetterStatus;
+    limit?: number;
+  }): Promise<DeadLetter[]> {
+    const limit = filter?.limit ?? 50;
+    const dlqMap = (await this.ctx.storage.list({ prefix: "dlq:" })) as Map<
+      string,
+      DeadLetter
+    >;
+    const matches: DeadLetter[] = [];
+
+    for (const dl of dlqMap.values()) {
+      if (!dl || typeof dl !== "object" || !dl.deadLetterId) continue;
+      if (filter?.jobType && dl.jobType !== filter.jobType) continue;
+      if (filter?.status && dl.status !== filter.status) continue;
+      matches.push(dl);
+    }
+
+    matches.sort(
+      (a, b) =>
+        new Date(b.deadLetteredAt).getTime() - new Date(a.deadLetteredAt).getTime(),
+    );
+    return matches.slice(0, limit);
+  }
+
+  async updateDeadLetter(deadLetter: DeadLetter): Promise<DeadLetter> {
+    await this.ctx.storage.put(`dlq:${deadLetter.deadLetterId}`, deadLetter);
+    return deadLetter;
+  }
+
+  async getReceiptCheckpoint(streamId: string): Promise<ReceiptCheckpoint | null> {
+    const cp = (await this.ctx.storage.get(`receipt_cp:${streamId}`)) as
+      | ReceiptCheckpoint
+      | undefined;
+    return cp ?? null;
+  }
+
+  async setReceiptCheckpoint(
+    checkpoint: ReceiptCheckpoint,
+  ): Promise<ReceiptCheckpoint> {
+    await this.ctx.storage.put(`receipt_cp:${checkpoint.streamId}`, checkpoint);
+    return checkpoint;
   }
 }

--- a/src/services/relay/in-process-worker.ts
+++ b/src/services/relay/in-process-worker.ts
@@ -10,20 +10,24 @@ import type { RelayWorker, RelayWorkerStatus } from "./worker";
 
 export interface InProcessRelayWorkerOptions {
   pollIntervalMs?: number;
+  maxRetries?: number;
   onMessage?: (envelope: RelayEnvelope) => Promise<void>;
 }
 
 export class InProcessRelayWorker implements RelayWorker {
   private readonly pollIntervalMs: number;
+  private readonly maxRetries: number;
   private readonly onMessage: (envelope: RelayEnvelope) => Promise<void>;
   private status: RelayWorkerStatus = "stopped";
   private timer: ReturnType<typeof setTimeout> | undefined;
+  private readonly attempts = new Map<string, number>();
 
   constructor(
     private readonly persistence: RelayPersistence,
     options: InProcessRelayWorkerOptions = {},
   ) {
     this.pollIntervalMs = options.pollIntervalMs ?? 1_000;
+    this.maxRetries = options.maxRetries ?? 5;
     this.onMessage = options.onMessage ?? (async () => {});
   }
 
@@ -55,10 +59,29 @@ export class InProcessRelayWorker implements RelayWorker {
   private async drain(): Promise<void> {
     const envelope = await this.persistence.dequeue();
     if (!envelope) return;
+
+    const currentAttempts = (this.attempts.get(envelope.messageId) ?? 0) + 1;
+    this.attempts.set(envelope.messageId, currentAttempts);
+
     try {
       await this.onMessage(envelope);
-    } catch {
-      await this.persistence.recordRetry();
+      this.attempts.delete(envelope.messageId);
+    } catch (error) {
+      const isPoisonOrPermanent =
+        error instanceof Error &&
+        (error.message.includes("poison") ||
+          error.message.includes("invalid") ||
+          error.message.includes("rejected") ||
+          error.message.includes("expired"));
+
+      if (isPoisonOrPermanent || currentAttempts >= this.maxRetries) {
+        this.attempts.delete(envelope.messageId);
+        await this.persistence.recordDeadLetter();
+      } else {
+        await this.persistence.recordRetry();
+        // Re-enqueue for next cycle
+        await this.persistence.enqueue(envelope);
+      }
     }
   }
 }

--- a/tests/unit/api/admin-routes.test.ts
+++ b/tests/unit/api/admin-routes.test.ts
@@ -26,7 +26,11 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
       maxAttempts: 1,
     });
 
-    const { deadLetter } = await recordJobFailure(repository, job, new Error("Unrecoverable error"));
+    const { deadLetter } = await recordJobFailure(
+      repository,
+      job,
+      new Error("Unrecoverable error"),
+    );
     expect(deadLetter).toBeDefined();
 
     // GET /api/v1/admin/dlq
@@ -64,9 +68,12 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
     expect(deadLetter).toBeDefined();
 
     // Retry
-    const retryReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter!.deadLetterId}/retry`, {
-      method: "POST",
-    });
+    const retryReq = new Request(
+      `http://localhost/api/v1/admin/dlq/${deadLetter!.deadLetterId}/retry`,
+      {
+        method: "POST",
+      },
+    );
     const retryRes = await DlqRetryRoute.options.server!.handlers!.POST!({
       request: retryReq,
       params: { id: deadLetter!.deadLetterId },
@@ -83,13 +90,20 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
       payload: { root: "r1" },
       maxAttempts: 1,
     });
-    const { deadLetter: deadLetter2 } = await recordJobFailure(repository, job2, new Error("Fatal"));
+    const { deadLetter: deadLetter2 } = await recordJobFailure(
+      repository,
+      job2,
+      new Error("Fatal"),
+    );
 
-    const abandonReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter2!.deadLetterId}/abandon`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ adminNotes: "Abandoned after triage" }),
-    });
+    const abandonReq = new Request(
+      `http://localhost/api/v1/admin/dlq/${deadLetter2!.deadLetterId}/abandon`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ adminNotes: "Abandoned after triage" }),
+      },
+    );
     const abandonRes = await DlqAbandonRoute.options.server!.handlers!.POST!({
       request: abandonReq,
       params: { id: deadLetter2!.deadLetterId },
@@ -115,7 +129,9 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
     expect(listBody.data.jobs.length).toBeGreaterThanOrEqual(1);
 
     // Get item
-    const itemReq = new Request(`http://localhost/api/v1/admin/jobs/${job.jobId}`, { method: "GET" });
+    const itemReq = new Request(`http://localhost/api/v1/admin/jobs/${job.jobId}`, {
+      method: "GET",
+    });
     const itemRes = await JobItemRoute.options.server!.handlers!.GET!({
       request: itemReq,
       params: { id: job.jobId },

--- a/tests/unit/api/admin-routes.test.ts
+++ b/tests/unit/api/admin-routes.test.ts
@@ -9,6 +9,13 @@ import { Route as JobItemRoute } from "@/routes/api/v1/admin/jobs/$id";
 import { enqueueDurableJob, recordJobFailure } from "@/server/api/job-service";
 import { getApiContext } from "@/server/api/context";
 
+const dlqListHandler = (DlqRoute.options as any).server?.handlers?.GET;
+const dlqItemHandler = (DlqItemRoute.options as any).server?.handlers?.GET;
+const dlqRetryHandler = (DlqRetryRoute.options as any).server?.handlers?.POST;
+const dlqAbandonHandler = (DlqAbandonRoute.options as any).server?.handlers?.POST;
+const jobsListHandler = (JobsRoute.options as any).server?.handlers?.GET;
+const jobsItemHandler = (JobItemRoute.options as any).server?.handlers?.GET;
+
 describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
   let repository: MemoryApiRepository;
 
@@ -37,7 +44,7 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
     const listReq = new Request("http://localhost/api/v1/admin/dlq?jobType=funding", {
       method: "GET",
     });
-    const listRes = await DlqRoute.options.server!.handlers!.GET!({ request: listReq } as any);
+    const listRes = await dlqListHandler({ request: listReq });
     expect(listRes.status).toBe(200);
     const listBody = (await listRes.json()) as any;
     expect(listBody.data.deadLetters).toHaveLength(1);
@@ -47,10 +54,10 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
     const itemReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter!.deadLetterId}`, {
       method: "GET",
     });
-    const itemRes = await DlqItemRoute.options.server!.handlers!.GET!({
+    const itemRes = await dlqItemHandler({
       request: itemReq,
       params: { id: deadLetter!.deadLetterId },
-    } as any);
+    });
     expect(itemRes.status).toBe(200);
     const itemBody = (await itemRes.json()) as any;
     expect(itemBody.data.deadLetter.deadLetterId).toBe(deadLetter!.deadLetterId);
@@ -74,10 +81,10 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
         method: "POST",
       },
     );
-    const retryRes = await DlqRetryRoute.options.server!.handlers!.POST!({
+    const retryRes = await dlqRetryHandler({
       request: retryReq,
       params: { id: deadLetter!.deadLetterId },
-    } as any);
+    });
     expect(retryRes.status).toBe(200);
     const retryBody = (await retryRes.json()) as any;
     expect(retryBody.data.deadLetter.status).toBe("retried");
@@ -104,10 +111,10 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
         body: JSON.stringify({ adminNotes: "Abandoned after triage" }),
       },
     );
-    const abandonRes = await DlqAbandonRoute.options.server!.handlers!.POST!({
+    const abandonRes = await dlqAbandonHandler({
       request: abandonReq,
       params: { id: deadLetter2!.deadLetterId },
-    } as any);
+    });
     expect(abandonRes.status).toBe(200);
     const abandonBody = (await abandonRes.json()) as any;
     expect(abandonBody.data.deadLetter.status).toBe("abandoned");
@@ -123,7 +130,7 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
 
     // List
     const listReq = new Request("http://localhost/api/v1/admin/jobs", { method: "GET" });
-    const listRes = await JobsRoute.options.server!.handlers!.GET!({ request: listReq } as any);
+    const listRes = await jobsListHandler({ request: listReq });
     expect(listRes.status).toBe(200);
     const listBody = (await listRes.json()) as any;
     expect(listBody.data.jobs.length).toBeGreaterThanOrEqual(1);
@@ -132,10 +139,10 @@ describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
     const itemReq = new Request(`http://localhost/api/v1/admin/jobs/${job.jobId}`, {
       method: "GET",
     });
-    const itemRes = await JobItemRoute.options.server!.handlers!.GET!({
+    const itemRes = await jobsItemHandler({
       request: itemReq,
       params: { id: job.jobId },
-    } as any);
+    });
     expect(itemRes.status).toBe(200);
     const itemBody = (await itemRes.json()) as any;
     expect(itemBody.data.job.jobId).toBe(job.jobId);

--- a/tests/unit/api/admin-routes.test.ts
+++ b/tests/unit/api/admin-routes.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryApiRepository } from "@/server/api/memory-repository";
+import { Route as DlqRoute } from "@/routes/api/v1/admin/dlq/index";
+import { Route as DlqItemRoute } from "@/routes/api/v1/admin/dlq/$id";
+import { Route as DlqRetryRoute } from "@/routes/api/v1/admin/dlq/$id/retry";
+import { Route as DlqAbandonRoute } from "@/routes/api/v1/admin/dlq/$id/abandon";
+import { Route as JobsRoute } from "@/routes/api/v1/admin/jobs/index";
+import { Route as JobItemRoute } from "@/routes/api/v1/admin/jobs/$id";
+import { enqueueDurableJob, recordJobFailure } from "@/server/api/job-service";
+import { getApiContext } from "@/server/api/context";
+
+describe("Admin DLQ & Jobs Routes (Issue #1952 BETA-045)", () => {
+  let repository: MemoryApiRepository;
+
+  beforeEach(async () => {
+    const ctx = await getApiContext();
+    repository = ctx.repository as MemoryApiRepository;
+    repository.reset?.();
+  });
+
+  it("serves GET /api/v1/admin/dlq and GET /api/v1/admin/dlq/:id", async () => {
+    const { job } = await enqueueDurableJob(repository, {
+      type: "funding",
+      idempotencyKey: "admin-route-test-1",
+      payload: { amount: 100 },
+      maxAttempts: 1,
+    });
+
+    const { deadLetter } = await recordJobFailure(repository, job, new Error("Unrecoverable error"));
+    expect(deadLetter).toBeDefined();
+
+    // GET /api/v1/admin/dlq
+    const listReq = new Request("http://localhost/api/v1/admin/dlq?jobType=funding", {
+      method: "GET",
+    });
+    const listRes = await DlqRoute.options.server!.handlers!.GET!({ request: listReq } as any);
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as any;
+    expect(listBody.data.deadLetters).toHaveLength(1);
+    expect(listBody.data.deadLetters[0].deadLetterId).toBe(deadLetter!.deadLetterId);
+
+    // GET /api/v1/admin/dlq/:id
+    const itemReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter!.deadLetterId}`, {
+      method: "GET",
+    });
+    const itemRes = await DlqItemRoute.options.server!.handlers!.GET!({
+      request: itemReq,
+      params: { id: deadLetter!.deadLetterId },
+    } as any);
+    expect(itemRes.status).toBe(200);
+    const itemBody = (await itemRes.json()) as any;
+    expect(itemBody.data.deadLetter.deadLetterId).toBe(deadLetter!.deadLetterId);
+  });
+
+  it("handles POST /api/v1/admin/dlq/:id/retry and POST /api/v1/admin/dlq/:id/abandon", async () => {
+    const { job } = await enqueueDurableJob(repository, {
+      type: "delivery",
+      idempotencyKey: "admin-route-test-2",
+      payload: { messageId: "m1" },
+      maxAttempts: 1,
+    });
+
+    const { deadLetter } = await recordJobFailure(repository, job, new Error("Delivery timeout"));
+    expect(deadLetter).toBeDefined();
+
+    // Retry
+    const retryReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter!.deadLetterId}/retry`, {
+      method: "POST",
+    });
+    const retryRes = await DlqRetryRoute.options.server!.handlers!.POST!({
+      request: retryReq,
+      params: { id: deadLetter!.deadLetterId },
+    } as any);
+    expect(retryRes.status).toBe(200);
+    const retryBody = (await retryRes.json()) as any;
+    expect(retryBody.data.deadLetter.status).toBe("retried");
+    expect(retryBody.data.job.status).toBe("pending");
+
+    // Abandon on another dead letter
+    const { job: job2 } = await enqueueDurableJob(repository, {
+      type: "anchoring",
+      idempotencyKey: "admin-route-test-3",
+      payload: { root: "r1" },
+      maxAttempts: 1,
+    });
+    const { deadLetter: deadLetter2 } = await recordJobFailure(repository, job2, new Error("Fatal"));
+
+    const abandonReq = new Request(`http://localhost/api/v1/admin/dlq/${deadLetter2!.deadLetterId}/abandon`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ adminNotes: "Abandoned after triage" }),
+    });
+    const abandonRes = await DlqAbandonRoute.options.server!.handlers!.POST!({
+      request: abandonReq,
+      params: { id: deadLetter2!.deadLetterId },
+    } as any);
+    expect(abandonRes.status).toBe(200);
+    const abandonBody = (await abandonRes.json()) as any;
+    expect(abandonBody.data.deadLetter.status).toBe("abandoned");
+    expect(abandonBody.data.deadLetter.adminNotes).toBe("Abandoned after triage");
+  });
+
+  it("serves GET /api/v1/admin/jobs and GET /api/v1/admin/jobs/:id", async () => {
+    const { job } = await enqueueDurableJob(repository, {
+      type: "reconciliation",
+      idempotencyKey: "admin-route-test-4",
+      payload: { date: "2026-08-18" },
+    });
+
+    // List
+    const listReq = new Request("http://localhost/api/v1/admin/jobs", { method: "GET" });
+    const listRes = await JobsRoute.options.server!.handlers!.GET!({ request: listReq } as any);
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as any;
+    expect(listBody.data.jobs.length).toBeGreaterThanOrEqual(1);
+
+    // Get item
+    const itemReq = new Request(`http://localhost/api/v1/admin/jobs/${job.jobId}`, { method: "GET" });
+    const itemRes = await JobItemRoute.options.server!.handlers!.GET!({
+      request: itemReq,
+      params: { id: job.jobId },
+    } as any);
+    expect(itemRes.status).toBe(200);
+    const itemBody = (await itemRes.json()) as any;
+    expect(itemBody.data.job.jobId).toBe(job.jobId);
+  });
+});

--- a/tests/unit/api/coordinator-jobs-dlq.test.ts
+++ b/tests/unit/api/coordinator-jobs-dlq.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => {
+  return {
+    DurableObject: class DurableObject {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+    },
+  };
+});
+
+import { StealthCoordinator } from "@/server/api/stealth-coordinator";
+import type { DeadLetter, DurableJob, ReceiptCheckpoint } from "@/server/api/domain";
+
+class MockDurableObjectState {
+  public id = { toString: () => "mock-do-id" };
+  public storage = {
+    store: new Map<string, any>(),
+    async get(key: string) {
+      return this.store.get(key);
+    },
+    async put(key: string, value: any) {
+      this.store.set(key, value);
+    },
+    async delete(key: string) {
+      return this.store.delete(key);
+    },
+    async list(options?: { prefix?: string }) {
+      const result = new Map<string, any>();
+      const prefix = options?.prefix ?? "";
+      for (const [k, v] of this.store.entries()) {
+        if (k.startsWith(prefix)) {
+          result.set(k, v);
+        }
+      }
+      return result;
+    },
+  };
+}
+
+describe("StealthCoordinator - Durable Jobs & DLQ Operations", () => {
+  let state: MockDurableObjectState;
+  let coordinator: StealthCoordinator;
+
+  beforeEach(() => {
+    state = new MockDurableObjectState();
+    coordinator = new StealthCoordinator(state as any, {});
+  });
+
+  it("handles durable job enqueue, deduplication, and update", async () => {
+    const job: DurableJob = {
+      jobId: "job-100",
+      type: "funding",
+      idempotencyKey: "idemp-key-100",
+      payload: { amount: 100 },
+      status: "pending",
+      attempts: 0,
+      maxAttempts: 5,
+      backoffMs: 1000,
+      nextRunAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const first = await coordinator.enqueueJob(job);
+    expect(first.enqueued).toBe(true);
+
+    const second = await coordinator.enqueueJob(job);
+    expect(second.enqueued).toBe(false);
+    expect(second.job.jobId).toBe("job-100");
+
+    const fetched = await coordinator.getJob("job-100");
+    expect(fetched?.jobId).toBe("job-100");
+
+    const fetchedByIdemp = await coordinator.getJobByIdempotencyKey("idemp-key-100");
+    expect(fetchedByIdemp?.jobId).toBe("job-100");
+
+    const updated = await coordinator.updateJob({ ...job, status: "completed" });
+    expect(updated.status).toBe("completed");
+  });
+
+  it("handles claiming pending jobs and listing with filters", async () => {
+    const job1: DurableJob = {
+      jobId: "job-1",
+      type: "delivery",
+      idempotencyKey: "idemp-1",
+      payload: {},
+      status: "pending",
+      attempts: 0,
+      maxAttempts: 5,
+      backoffMs: 1000,
+      nextRunAt: new Date(Date.now() - 10000).toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const job2: DurableJob = {
+      jobId: "job-2",
+      type: "anchoring",
+      idempotencyKey: "idemp-2",
+      payload: {},
+      status: "pending",
+      attempts: 0,
+      maxAttempts: 5,
+      backoffMs: 1000,
+      nextRunAt: new Date(Date.now() + 60000).toISOString(), // future
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await coordinator.enqueueJob(job1);
+    await coordinator.enqueueJob(job2);
+
+    const claimed = await coordinator.claimNextPendingJob(["delivery"]);
+    expect(claimed?.jobId).toBe("job-1");
+    expect(claimed?.status).toBe("running");
+
+    const listAll = await coordinator.listJobs();
+    expect(listAll).toHaveLength(2);
+  });
+
+  it("handles dead-letter persistence and listing", async () => {
+    const dlq: DeadLetter = {
+      deadLetterId: "dlq-1",
+      jobId: "job-1",
+      jobType: "delivery",
+      idempotencyKey: "idemp-1",
+      payload: {},
+      attempts: 5,
+      errorCode: "ERR_RPC_TIMEOUT",
+      errorMessage: "Connection timed out",
+      deadLetteredAt: new Date().toISOString(),
+      status: "dead",
+    };
+
+    await coordinator.createDeadLetter(dlq);
+    const fetched = await coordinator.getDeadLetter("dlq-1");
+    expect(fetched?.deadLetterId).toBe("dlq-1");
+
+    const list = await coordinator.listDeadLetters();
+    expect(list).toHaveLength(1);
+
+    const updated = await coordinator.updateDeadLetter({ ...dlq, status: "retried" });
+    expect(updated.status).toBe("retried");
+  });
+
+  it("handles receipt checkpoints", async () => {
+    const cp: ReceiptCheckpoint = {
+      streamId: "stream-1",
+      lastSequence: 10,
+      processedCount: 11,
+      lastIndexedAt: new Date().toISOString(),
+      gapCount: 0,
+    };
+
+    expect(await coordinator.getReceiptCheckpoint("stream-1")).toBeNull();
+    await coordinator.setReceiptCheckpoint(cp);
+
+    const fetched = await coordinator.getReceiptCheckpoint("stream-1");
+    expect(fetched?.lastSequence).toBe(10);
+    expect(fetched?.processedCount).toBe(11);
+  });
+});

--- a/tests/unit/api/durable-jobs-dlq.test.ts
+++ b/tests/unit/api/durable-jobs-dlq.test.ts
@@ -82,7 +82,9 @@ describe("Durable Jobs, Retries, DLQ, and Receipt Indexing (Issue #1952 BETA-045
       const redacted = redactErrorMessage(sensitiveError);
       expect(redacted).not.toContain(`S${"A".repeat(55)}`);
       expect(redacted).not.toContain("secret-token-xyz");
-      expect(redacted).not.toContain("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+      expect(redacted).not.toContain(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      );
       expect(redacted).toContain("[REDACTED_SEED]");
       expect(redacted).toContain("[REDACTED_TOKEN]");
       expect(redacted).toContain("[REDACTED_KEY]");
@@ -156,13 +158,21 @@ describe("Durable Jobs, Retries, DLQ, and Receipt Indexing (Issue #1952 BETA-045
       expect(res1.deadLetter).toBeUndefined();
 
       // Attempt 2: Transient failure -> pending (attempt 2)
-      const res2 = await recordJobFailure(repository, res1.job, new Error("Temporary network timeout"));
+      const res2 = await recordJobFailure(
+        repository,
+        res1.job,
+        new Error("Temporary network timeout"),
+      );
       expect(res2.job.status).toBe("pending");
       expect(res2.job.attempts).toBe(2);
       expect(res2.deadLetter).toBeUndefined();
 
       // Attempt 3: Transient failure -> exhausted -> dead_letter
-      const res3 = await recordJobFailure(repository, res2.job, new Error("Temporary network timeout"));
+      const res3 = await recordJobFailure(
+        repository,
+        res2.job,
+        new Error("Temporary network timeout"),
+      );
       expect(res3.job.status).toBe("dead_letter");
       expect(res3.job.attempts).toBe(3);
       expect(res3.deadLetter).toBeDefined();

--- a/tests/unit/api/durable-jobs-dlq.test.ts
+++ b/tests/unit/api/durable-jobs-dlq.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from "vitest";
+import { MemoryApiRepository } from "@/server/api/memory-repository";
+import {
+  calculateBackoff,
+  classifyError,
+  enqueueDurableJob,
+  recordJobFailure,
+  recordJobSuccess,
+  redactErrorMessage,
+  listDeadLetters,
+  getDeadLetter,
+  retryDeadLetter,
+  abandonDeadLetter,
+  indexReceiptEvents,
+} from "@/server/api/job-service";
+import type { DurableJob, DurableJobType, ReceiptEvent } from "@/server/api/domain";
+import { ApiError } from "@/server/api/errors";
+import { withIdempotency } from "@/server/api/idempotency-service";
+
+const testSender = `G${"A".repeat(55)}`;
+const testRecipient = `G${"B".repeat(55)}`;
+const testMessageId = "a".repeat(64);
+
+describe("Durable Jobs, Retries, DLQ, and Receipt Indexing (Issue #1952 BETA-045)", () => {
+  describe("Job Definitions & Idempotent Enqueue", () => {
+    it("defines durable jobs across all required domains", async () => {
+      const repository = new MemoryApiRepository();
+      const jobTypes: DurableJobType[] = [
+        "funding",
+        "anchoring",
+        "postage",
+        "delivery",
+        "receipts",
+        "cleanup",
+        "reconciliation",
+      ];
+
+      for (const type of jobTypes) {
+        const { enqueued, job } = await enqueueDurableJob(repository, {
+          type,
+          idempotencyKey: `key-${type}-001`,
+          payload: { account: testSender, amount: "1000" },
+        });
+
+        expect(enqueued).toBe(true);
+        expect(job.type).toBe(type);
+        expect(job.status).toBe("pending");
+        expect(job.attempts).toBe(0);
+        expect(job.maxAttempts).toBe(5);
+      }
+
+      const allJobs = await repository.listJobs({ limit: 100 });
+      expect(allJobs).toHaveLength(7);
+    });
+
+    it("suppresses duplicate enqueues with the same idempotency key", async () => {
+      const repository = new MemoryApiRepository();
+      const input = {
+        type: "funding" as const,
+        idempotencyKey: "unique-funding-key-999",
+        payload: { account: testSender, amount: "50000" },
+      };
+
+      const first = await enqueueDurableJob(repository, input);
+      expect(first.enqueued).toBe(true);
+
+      const second = await enqueueDurableJob(repository, input);
+      expect(second.enqueued).toBe(false);
+      expect(second.job.jobId).toBe(first.job.jobId);
+
+      const listed = await repository.listJobs({ type: "funding" });
+      expect(listed).toHaveLength(1);
+    });
+  });
+
+  describe("Reason Taxonomy & Redaction", () => {
+    it("redacts sensitive Stellar seeds, bearer tokens, and private keys from error messages", () => {
+      const sensitiveError = new Error(
+        `Failed to submit tx: S${"A".repeat(55)} secret_key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef with Bearer secret-token-xyz`,
+      );
+
+      const redacted = redactErrorMessage(sensitiveError);
+      expect(redacted).not.toContain(`S${"A".repeat(55)}`);
+      expect(redacted).not.toContain("secret-token-xyz");
+      expect(redacted).not.toContain("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+      expect(redacted).toContain("[REDACTED_SEED]");
+      expect(redacted).toContain("[REDACTED_TOKEN]");
+      expect(redacted).toContain("[REDACTED_KEY]");
+    });
+
+    it("classifies transient vs permanent errors according to taxonomy", () => {
+      expect(classifyError(new Error("ETIMEDOUT connection failed"))).toEqual({
+        code: "ERR_RPC_TIMEOUT",
+        retryable: true,
+      });
+
+      expect(classifyError(new Error("rate limit exceeded (429)"))).toEqual({
+        code: "ERR_RATE_LIMITED",
+        retryable: true,
+      });
+
+      expect(classifyError(new Error("Contract failed: custom revert"))).toEqual({
+        code: "ERR_CONTRACT_REVERT",
+        retryable: false,
+      });
+
+      expect(classifyError(new Error("Invalid poison payload structure"))).toEqual({
+        code: "ERR_POISON_PAYLOAD",
+        retryable: false,
+      });
+
+      expect(classifyError(new ApiError(401, "unauthorized", "Bad auth"))).toEqual({
+        code: "ERR_UNAUTHORIZED",
+        retryable: false,
+      });
+    });
+  });
+
+  describe("Exponential Backoff with Jitter", () => {
+    it("calculates exponential delays with bounded jitter", () => {
+      const b1 = calculateBackoff(1, 1000, 60000, 0.1);
+      const b2 = calculateBackoff(2, 1000, 60000, 0.1);
+      const b3 = calculateBackoff(3, 1000, 60000, 0.1);
+
+      expect(b1).toBeGreaterThanOrEqual(1000);
+      expect(b1).toBeLessThanOrEqual(1200);
+
+      expect(b2).toBeGreaterThanOrEqual(2000);
+      expect(b2).toBeLessThanOrEqual(2400);
+
+      expect(b3).toBeGreaterThanOrEqual(4000);
+      expect(b3).toBeLessThanOrEqual(4800);
+    });
+
+    it("respects the maximum backoff ceiling", () => {
+      const b10 = calculateBackoff(10, 1000, 10000, 0.1);
+      expect(b10).toBeLessThanOrEqual(11500);
+    });
+  });
+
+  describe("Job Retries & Dead Letter Queue", () => {
+    it("retries recoverable errors up to attempt ceiling, then dead-letters on exhaustion", async () => {
+      const repository = new MemoryApiRepository();
+      const { job } = await enqueueDurableJob(repository, {
+        type: "anchoring",
+        idempotencyKey: "anchor-retry-test",
+        payload: { rootHash: "b".repeat(64) },
+        maxAttempts: 3,
+      });
+
+      // Attempt 1: Transient failure -> pending (attempt 1)
+      const res1 = await recordJobFailure(repository, job, new Error("Temporary network timeout"));
+      expect(res1.job.status).toBe("pending");
+      expect(res1.job.attempts).toBe(1);
+      expect(res1.job.errorCode).toBe("ERR_RPC_TIMEOUT");
+      expect(res1.deadLetter).toBeUndefined();
+
+      // Attempt 2: Transient failure -> pending (attempt 2)
+      const res2 = await recordJobFailure(repository, res1.job, new Error("Temporary network timeout"));
+      expect(res2.job.status).toBe("pending");
+      expect(res2.job.attempts).toBe(2);
+      expect(res2.deadLetter).toBeUndefined();
+
+      // Attempt 3: Transient failure -> exhausted -> dead_letter
+      const res3 = await recordJobFailure(repository, res2.job, new Error("Temporary network timeout"));
+      expect(res3.job.status).toBe("dead_letter");
+      expect(res3.job.attempts).toBe(3);
+      expect(res3.deadLetter).toBeDefined();
+      expect(res3.deadLetter?.status).toBe("dead");
+      expect(res3.deadLetter?.errorCode).toBe("ERR_RPC_TIMEOUT");
+
+      const dlq = await repository.listDeadLetters();
+      expect(dlq).toHaveLength(1);
+      expect(dlq[0].jobId).toBe(job.jobId);
+    });
+
+    it("immediately moves poison / non-retryable jobs to dead-letter queue without blocking others", async () => {
+      const repository = new MemoryApiRepository();
+
+      // User 1 submits a poison job
+      const { job: poisonJob } = await enqueueDurableJob(repository, {
+        type: "delivery",
+        idempotencyKey: "poison-job-user-1",
+        payload: { recipient: testRecipient, payload: "bad-payload" },
+      });
+
+      // User 2 submits a normal valid job
+      const { job: normalJob } = await enqueueDurableJob(repository, {
+        type: "delivery",
+        idempotencyKey: "normal-job-user-2",
+        payload: { recipient: testRecipient, payload: "good-payload" },
+      });
+
+      // Poison job fails with non-retryable poison error
+      const poisonResult = await recordJobFailure(
+        repository,
+        poisonJob,
+        new Error("Invalid poison payload structure"),
+      );
+      expect(poisonResult.job.status).toBe("dead_letter");
+      expect(poisonResult.deadLetter).toBeDefined();
+      expect(poisonResult.deadLetter?.errorCode).toBe("ERR_POISON_PAYLOAD");
+
+      // Normal job can now be claimed and succeeded without being blocked by poison job
+      const claimed = await repository.claimNextPendingJob(["delivery"]);
+      expect(claimed).not.toBeNull();
+      expect(claimed?.jobId).toBe(normalJob.jobId);
+
+      const success = await recordJobSuccess(repository, claimed!);
+      expect(success.status).toBe("completed");
+    });
+  });
+
+  describe("Administrator DLQ Operations (Inspect, Retry, Abandon)", () => {
+    it("allows administrator to inspect, retry, and re-enqueue a dead-lettered job", async () => {
+      const repository = new MemoryApiRepository();
+      const { job } = await enqueueDurableJob(repository, {
+        type: "postage",
+        idempotencyKey: "postage-dlq-admin-test",
+        payload: { messageId: testMessageId, amount: "100" },
+        maxAttempts: 1,
+      });
+
+      const { deadLetter } = await recordJobFailure(repository, job, new Error("Contract revert"));
+      expect(deadLetter).toBeDefined();
+
+      // Admin inspects DLQ
+      const dlqList = await listDeadLetters(repository, { jobType: "postage" });
+      expect(dlqList).toHaveLength(1);
+
+      const inspected = await getDeadLetter(repository, deadLetter!.deadLetterId);
+      expect(inspected.deadLetterId).toBe(deadLetter!.deadLetterId);
+
+      // Admin retries DLQ
+      const retryResult = await retryDeadLetter(repository, deadLetter!.deadLetterId);
+      expect(retryResult.deadLetter.status).toBe("retried");
+      expect(retryResult.deadLetter.retriedAt).toBeDefined();
+      expect(retryResult.job.status).toBe("pending");
+      expect(retryResult.job.attempts).toBe(0);
+
+      // Claim again
+      const claimed = await repository.claimNextPendingJob(["postage"]);
+      expect(claimed).not.toBeNull();
+      expect(claimed?.jobId).toBe(job.jobId);
+    });
+
+    it("allows administrator to abandon a dead-lettered job with notes", async () => {
+      const repository = new MemoryApiRepository();
+      const { job } = await enqueueDurableJob(repository, {
+        type: "cleanup",
+        idempotencyKey: "cleanup-abandon-test",
+        payload: { scope: "all" },
+        maxAttempts: 1,
+      });
+
+      const { deadLetter } = await recordJobFailure(repository, job, new Error("Permanent fatal"));
+      expect(deadLetter).toBeDefined();
+
+      const abandoned = await abandonDeadLetter(
+        repository,
+        deadLetter!.deadLetterId,
+        "Confirmed invalid test request by admin",
+      );
+
+      expect(abandoned.status).toBe("abandoned");
+      expect(abandoned.adminNotes).toBe("Confirmed invalid test request by admin");
+      expect(abandoned.abandonedAt).toBeDefined();
+
+      const fetchedJob = await repository.getJob(job.jobId);
+      expect(fetchedJob?.status).toBe("abandoned");
+    });
+  });
+
+  describe("Worker Restart Safety & Idempotent Side Effects", () => {
+    it("ensures a worker restart / crash after side effect does not duplicate side effects", async () => {
+      const repository = new MemoryApiRepository();
+      let sideEffectCounter = 0;
+
+      const scope = {
+        actor: testSender,
+        method: "POST",
+        route: "POST /api/v1/funding",
+        rawKey: "funding-idemp-key-100",
+      };
+
+      const doMoneyMove = async () => {
+        sideEffectCounter++;
+        return { status: 200, body: { balance: 500 } };
+      };
+
+      // Execution 1: First attempt executes operation
+      const first = await withIdempotency(repository, scope, { amount: 100 }, doMoneyMove);
+      expect(first.replayed).toBe(false);
+      expect(first.body).toEqual({ balance: 500 });
+      expect(sideEffectCounter).toBe(1);
+
+      // Simulated worker crash & restart: retry of the exact same operation with same idempotency key
+      const restartAttempt = await withIdempotency(repository, scope, { amount: 100 }, doMoneyMove);
+      expect(restartAttempt.replayed).toBe(true);
+      expect(restartAttempt.body).toEqual({ balance: 500 });
+      expect(sideEffectCounter).toBe(1); // Crucial: Side effect was NOT duplicated!
+    });
+  });
+
+  describe("Receipt Event Indexing with Durable Checkpoints & Gap Detection", () => {
+    it("indexes receipt events sequentially, suppresses duplicates, and detects gaps", async () => {
+      const repository = new MemoryApiRepository();
+      const streamId = "receipts-stream-alpha";
+
+      const batch1: ReceiptEvent[] = [
+        {
+          eventId: "ev-0",
+          streamId,
+          sequence: 0,
+          messageId: "1".repeat(64),
+          recipient: testRecipient,
+          sender: testSender,
+          deliveredAt: new Date().toISOString(),
+        },
+        {
+          eventId: "ev-1",
+          streamId,
+          sequence: 1,
+          messageId: "2".repeat(64),
+          recipient: testRecipient,
+          sender: testSender,
+          deliveredAt: new Date().toISOString(),
+        },
+      ];
+
+      const res1 = await indexReceiptEvents(repository, streamId, batch1);
+      expect(res1.indexedCount).toBe(2);
+      expect(res1.duplicateCount).toBe(0);
+      expect(res1.gapsDetected).toBe(0);
+      expect(res1.checkpoint.lastSequence).toBe(1);
+      expect(res1.checkpoint.processedCount).toBe(2);
+
+      // Re-indexing batch1 (duplicate delivery) -> duplicates suppressed
+      const res2 = await indexReceiptEvents(repository, streamId, batch1);
+      expect(res2.indexedCount).toBe(0);
+      expect(res2.duplicateCount).toBe(2);
+      expect(res2.checkpoint.lastSequence).toBe(1);
+
+      // Ingesting batch3 with a sequence gap (skipping sequence 2, 3 and receiving sequence 4)
+      const batch3: ReceiptEvent[] = [
+        {
+          eventId: "ev-4",
+          streamId,
+          sequence: 4,
+          messageId: "4".repeat(64),
+          recipient: testRecipient,
+          sender: testSender,
+          deliveredAt: new Date().toISOString(),
+        },
+      ];
+
+      const res3 = await indexReceiptEvents(repository, streamId, batch3);
+      expect(res3.indexedCount).toBe(1);
+      expect(res3.gapsDetected).toBe(2); // Sequences 2 and 3 were skipped
+      expect(res3.checkpoint.lastSequence).toBe(4);
+      expect(res3.checkpoint.gapCount).toBe(2);
+    });
+  });
+});

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -422,6 +422,67 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("deleteContact");
     return this.inner.deleteContact(owner, contactId);
   }
+  async enqueueJob(job: import("../../../src/server/api/domain").DurableJob) {
+    this.maybeFail("enqueueJob");
+    return this.inner.enqueueJob(job);
+  }
+  async getJob(jobId: string) {
+    this.maybeFail("getJob");
+    return this.inner.getJob(jobId);
+  }
+  async getJobByIdempotencyKey(key: string) {
+    this.maybeFail("getJobByIdempotencyKey");
+    return this.inner.getJobByIdempotencyKey(key);
+  }
+  async updateJob(job: import("../../../src/server/api/domain").DurableJob) {
+    this.maybeFail("updateJob");
+    return this.inner.updateJob(job);
+  }
+  async claimNextPendingJob(
+    types?: import("../../../src/server/api/domain").DurableJobType[],
+    now?: Date,
+  ) {
+    this.maybeFail("claimNextPendingJob");
+    return this.inner.claimNextPendingJob(types, now);
+  }
+  async listJobs(filter?: {
+    type?: import("../../../src/server/api/domain").DurableJobType;
+    status?: import("../../../src/server/api/domain").JobStatus;
+    limit?: number;
+  }) {
+    this.maybeFail("listJobs");
+    return this.inner.listJobs(filter);
+  }
+  async createDeadLetter(deadLetter: import("../../../src/server/api/domain").DeadLetter) {
+    this.maybeFail("createDeadLetter");
+    return this.inner.createDeadLetter(deadLetter);
+  }
+  async getDeadLetter(deadLetterId: string) {
+    this.maybeFail("getDeadLetter");
+    return this.inner.getDeadLetter(deadLetterId);
+  }
+  async listDeadLetters(filter?: {
+    jobType?: import("../../../src/server/api/domain").DurableJobType;
+    status?: import("../../../src/server/api/domain").DeadLetterStatus;
+    limit?: number;
+  }) {
+    this.maybeFail("listDeadLetters");
+    return this.inner.listDeadLetters(filter);
+  }
+  async updateDeadLetter(deadLetter: import("../../../src/server/api/domain").DeadLetter) {
+    this.maybeFail("updateDeadLetter");
+    return this.inner.updateDeadLetter(deadLetter);
+  }
+  async getReceiptCheckpoint(streamId: string) {
+    this.maybeFail("getReceiptCheckpoint");
+    return this.inner.getReceiptCheckpoint(streamId);
+  }
+  async setReceiptCheckpoint(
+    checkpoint: import("../../../src/server/api/domain").ReceiptCheckpoint,
+  ) {
+    this.maybeFail("setReceiptCheckpoint");
+    return this.inner.setReceiptCheckpoint(checkpoint);
+  }
   reset(): void {
     this.inner.reset();
   }


### PR DESCRIPTION
## Summary

- Implemented durable job lifecycle management for funding, anchoring, postage, delivery, receipts, cleanup, and reconciliation.
- Added idempotency key deduplication, exponential backoff with jitter, attempt ceilings, structured reason taxonomy, and credential redaction.
- Added Dead-Letter Queue (DLQ) persistence and administrator inspect/retry/abandon endpoints.
- Implemented receipt event indexing with durable checkpoints, duplicate suppression, and sequence gap detection.
- Updated relay worker execution to isolate poison jobs from blocking active deliveries.

## Why

Asynchronous background operations across relay storage, testnet submissions, indexing, and delivery require resilient retry semantics, duplicate protection on restarts, and observable operator recovery workflows when retries are exhausted.

## Implementation

- `src/server/api/domain.ts`: Added Zod schemas and TypeScript domain models for `DurableJob`, `DeadLetter`, `ReceiptCheckpoint`, `ReceiptEvent`, `JobErrorCode`, and `JobStatus`.
- `src/server/api/repository.ts`: Extended `ApiRepository`, `ValidatedApiRepository`, and `RetryableApiRepository` with durable job, dead letter, and receipt checkpoint methods.
- `src/server/api/memory-repository.ts` & `src/server/api/kv-repository.ts`: Added in-memory and KV-backed persistence for jobs, DLQ entries, and checkpoints.
- `src/server/api/stealth-coordinator.ts`: Added per-key serialized Durable Object storage coordination for jobs, DLQ records, and receipt checkpoints.
- `src/server/api/job-service.ts`: Implemented backoff calculation with jitter, error taxonomy classification, secret redaction, DLQ admin actions, and receipt checkpoint indexing with gap detection.
- `src/services/relay/in-process-worker.ts`: Updated queue draining to isolate poison jobs directly to DLQ without stalling unrelated messages.
- `src/routes/api/v1/admin/`: Added `/api/v1/admin/dlq` (list, inspect, retry, abandon) and `/api/v1/admin/jobs` routes.

## Testing

- `npm run lint` — Passed (ESLint clean).
- `npm run build` — Passed (Vite client and SSR server build succeeded).
- `npx vitest run tests/unit/api/durable-jobs-dlq.test.ts` — Passed (12/12 unit tests).
- `npx vitest run tests/unit/api/coordinator-jobs-dlq.test.ts` — Passed (4/4 tests).
- `npx vitest run tests/unit/api/admin-routes.test.ts` — Passed (3/3 route integration tests).
- `npm test` — Passed (All unit test suites green).

## Scope / Risk

- Scoped to durable job infrastructure, DLQ administration, and receipt indexing.
- Backward compatible with existing repository methods and routes.

## Issue

closes #1952
