### PR TITLE
feat(beta-081): add encrypted backups and tested restore procedures for beta data stores #1988

### DIFF
--- a/docs/deployment/BACKUPS.md
+++ b/docs/deployment/BACKUPS.md
@@ -1,0 +1,136 @@
+# Encrypted Backups & Restore Procedures
+
+This document defines the backup and restore runbook for the Stealth beta data
+stores, as required by **BETA-081 (Issue #1988)**. It covers backup scope,
+encryption, schedules, retention, access control, restoration order, measured
+RTO/RPO, and the documented isolated restore rehearsal.
+
+## Backup Scope
+
+A backup captures the recoverable state of the three beta data stores:
+
+| Store          | Binding                | Content                                                                                                                                  |
+| :------------- | :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| Durable Object | `STEALTH_COORDINATOR`  | Authoritative identity, session, credential, profile, wallet, policy, postage, receipt, idempotency, and counter records.                |
+| KV             | `STEALTH_KV`           | Mirror/cache records: policies, sender rules, contacts, key directory, keys, external wallets, relay metadata and job state (`relay:*`). |
+| R2             | `STEALTH_OBJECT_STORE` | Encrypted envelope payloads (`envelopes/…`), attachment chunks (`attachments/…`), and transient staging (`staged/…`).                    |
+
+A backup therefore contains **everything needed to recover a beta environment**:
+identity, session, policy, relay metadata, object storage, and job state.
+
+## Encryption
+
+Backups are sealed with **AES-256-GCM** using a key derived via
+**HKDF-SHA256** from a dedicated `STEALTH_BACKUP_KEY` secret (base64-encoded
+32 bytes), bound to the purpose label `stealth-backup-v1`.
+
+- The archive **header is plaintext but never contains keys or values**; it
+  carries only format/version/timestamp/source and a non-secret `keyId`
+  fingerprint so operators can confirm which key version sealed the archive.
+- The **ciphertext** carries the integrity manifest (one SHA-256 digest per
+  entry) plus all store entries. Keys inside the manifest are **fingerprinted**
+  (never echoed verbatim), and values never appear in any report or log.
+- The header fields are bound as AEAD additional data, so tampering with the
+  timestamp or source fails authentication.
+- `STEALTH_BACKUP_KEY` is **separate from production keys** (cursor, storage,
+  relay, operator, …), so rotating backup material never touches live
+  signing/wrapping material.
+
+Guarantees (verified by `tests/unit/backup/*`):
+
+- **Backups never contain plaintext wallet seeds or decrypted mail.** Wallet
+  seeds are stored as managed-wallet envelopes and mail bodies as encrypted R2
+  payloads, and the entire archive is additionally AEAD-sealed.
+- **Restore preserves message and idempotency identities without double side
+  effects.** Restore performs raw key/value writes (never application replay),
+  so `idempotency:` and `counter:` records are restored verbatim — a message
+  already processed stays recognized as a duplicate.
+- **Integrity manifests**: `verify` authenticates the AEAD seal and recomputes
+  every digest; any mismatch or tamper fails the command closed.
+
+## Rotation & Access Control
+
+- Rotate `STEALTH_BACKUP_KEY` on the **90-day cadence** (same as the standard
+  inventory in `SECRETS.md`). Rotation creates a new `keyId` in future archives;
+  past archives remain decryptable under their original key, so retain prior
+  keys until all archives sealed under them reach end of retention.
+- Access to `STEALTH_BACKUP_KEY` and to archive files is restricted to the
+  operator role. No plaintext credentials or backup values ever appear in
+  repository files, client bundles, or CI logs.
+
+## CLI & Retention
+
+The commands run the repository's own backup worker against a local Cloudflare
+emulation (Miniflare). State persists under `.wrangler/state/backups`, so
+create/restore are restartable and operate on the same emulated store.
+
+```bash
+npm run backup:create                      # create an encrypted archive
+npm run backup:verify -- <archive.json>    # integrity + tamper check
+npm run backup:restore -- <archive.json>   # restore all stores
+npm run backup:restore -- <archive.json> -- --wipe-first   # isolated rehearsal (wipes first)
+npm run backup:list                        # per-store key counts
+npm run backup:rehearsal                   # seed → create → verify → wipe → restore → verify
+```
+
+Options: `--key <base64>` overrides the bound secret; `--stores
+<durable-object,kv,r2>` restricts create/restore; `--source <label>` records a
+redacted environment label; `--persist <dir>` overrides the emulation state
+directory.
+
+Archives are written as `.json` files (created under the persist directory by
+default). Keep archives in a location with **at-least-daily RPO** coverage and
+a **retention period** of at least the maximum re-runnable scheduler horizon
+plus one rotation period; retain each key version until its last archive is
+past retention. A scheduled backup (daily minimum) plus the on-demand CLI above
+satisfies the documented RPO.
+
+## Restoration Order
+
+`restore` applies entries in a documented stage order so dependent records
+exist before they are referenced:
+
+1. **Identity & sessions** — `user:*`, `session:*`, `credential:*`,
+   `profile:*`, `provisioning:*`, `verification*`, `wallet:*`, `policy-init:*`.
+2. **Mailbox policy & sender rules** — `policy:*`, `policy-write:*`,
+   `sender-rule:*`, `contacts:*`, `key-directory:*`, `keys:*`,
+   `external-wallet:*`, `wallet-challenge:*`.
+3. **Relay metadata & job state** — `relay:*`, `envelope:*`, `postage:*`,
+   `receipt:*`, `sender-request:*`, `idempotency:*`, `counter:*`.
+4. **Object storage payloads** — R2 `staged/`, `envelopes/`, `attachments/`.
+
+Restore is **failing-closed**: the AEAD seal must authenticate and every entry
+digest must match the manifest before any write occurs.
+
+## RTO / RPO Targets
+
+- **RTO target**: full restore of a beta environment **≤ 30 minutes**.
+  The rehearsal CLI prints measured restore time; the emulated round-trip
+  typically completes in milliseconds-to-seconds for fixture data, and the
+  duration is recorded per run as evidence.
+- **RPO target**: **≤ 24 hours** (daily scheduled backups), improved to the
+  archive cadence actually configured.
+
+## Rehearsal (Isolated Restore Evidence)
+
+Run the documented isolated restore rehearsal with **redacted evidence**:
+
+```bash
+npm run backup:rehearsal
+```
+
+This seeds fixture identity/policy/relay/object-storage data, creates an
+encrypted archive, verifies it, **wipes all three stores**, restores from the
+archive, and verifies again — printing per-store key counts and the measured
+restore duration. No plaintext seeds, mail, emails, or usernames are printed at
+any point; the archive header and all reports contain only fingerprints and
+counts.
+
+### Production Invocation
+
+A separate backup worker **cannot** share Durable Object storage with the app
+worker, so the same engine also runs in-process on the real coordinator via the
+operator-facing backup commands (mirroring `StealthCoordinator`
+identity-migration behavior); wiring an authenticated admin route is a
+follow-up. Locally, the CLI exercises the full engine against Miniflare
+emulation before it is ever pointed at real storage.

--- a/docs/deployment/RELEASE_GATES.md
+++ b/docs/deployment/RELEASE_GATES.md
@@ -63,6 +63,7 @@ Record these values before beginning a deployment:
       migration, and its location, encryption key reference, timestamp, and retention
       period are in the release record.
 - [ ] A restore rehearsal has proven the backup can be read in an isolated environment.
+      (BETA-081: run `npm run backup:rehearsal` per `docs/deployment/BACKUPS.md`.)
 - [ ] Append-only financial transitions, externally published events, and on-chain
       writes affected by the release are identified as irreversible.
 

--- a/docs/deployment/SECRETS.md
+++ b/docs/deployment/SECRETS.md
@@ -14,6 +14,7 @@ Secrets are scoped to specific runtime identities via the `STEALTH_ROLE` environ
 | `STEALTH_SMTP_PASSWORD`   | Credentials to authenticate the system against the outbound SMTP provider.           | `web`, `all`                 |
 | `STEALTH_RPC_API_KEY`     | Token for making authenticated calls against the Soroban RPC.                        | `operator`, `indexer`, `all` |
 | `STEALTH_OPERATOR_SECRET` | Custody secret key for the operator wallet to broadcast signed network transactions. | `operator`, `all`            |
+| `STEALTH_BACKUP_KEY`      | Base64-encoded 32-byte key sealing encrypted backups (AES-256-GCM, BETA-081).        | `operator`, `all`            |
 
 ## Environment Ownership
 
@@ -26,7 +27,7 @@ All production secrets must be provisioned and managed strictly through the desi
 
 ## Rotation Cadence
 
-1. **Standard Rotation**: Secrets (Cursor, Storage, Relay, RPC, and SMTP) must be rotated on a **90-day** cadence.
+1. **Standard Rotation**: Secrets (Cursor, Storage, Relay, RPC, and SMTP) must be rotated on a **90-day** cadence. `STEALTH_BACKUP_KEY` follows the same cadence; retain prior backup keys until every archive sealed under them passes retention.
 2. **Wallet/Operator Rotation**: Operator keys should follow the same 90-day cadence. The application supports updating credentials without breaking user wallet encryption.
 3. **Automated Audits**: Ensure a scheduled check verifies that secrets are up-to-date and have not leaked in scanning pipelines.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,12 @@
     "migrations:dry-run": "node scripts/identity-migrate.mjs dry-run",
     "migrations:forward": "node scripts/identity-migrate.mjs forward",
     "migrations:rollback": "node scripts/identity-migrate.mjs rollback",
-    "migrations:integrity-check": "node scripts/identity-migrate.mjs integrity-check"
+    "migrations:integrity-check": "node scripts/identity-migrate.mjs integrity-check",
+    "backup:create": "node scripts/backup/backup.mjs create",
+    "backup:verify": "node scripts/backup/backup.mjs verify",
+    "backup:restore": "node scripts/backup/backup.mjs restore",
+    "backup:list": "node scripts/backup/backup.mjs list",
+    "backup:rehearsal": "node scripts/backup/backup.mjs rehearsal"
   },
   "overrides": {
     "ws": "8.21.0"

--- a/scripts/backup/backup.mjs
+++ b/scripts/backup/backup.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * BETA-081 (Issue #1988) — encrypted backup CLI.
+ *
+ * Runs the backup commands (create / verify / restore / list / rehearsal)
+ * against a local Cloudflare emulation of the beta data stores (Durable Object
+ * identity records, KV, R2) using the repository's own backup worker. State
+ * persists under `.wrangler/state/backups` (overridable with --persist).
+ *
+ * The archive is an AES-256-GCM sealed JSON file whose header never contains
+ * keys or plaintext; the manifest inside the ciphertext fingerprints keys, and
+ * a restore never replays application side effects (it writes keys verbatim),
+ * so message and idempotency identities are preserved exactly.
+ *
+ * Usage:
+ *   node scripts/backup/backup.mjs create [--out <file>] [--source <label>] [--stores <durable-object,kv,r2>] [--key <base64>]
+ *   node scripts/backup/backup.mjs verify <archive-file> [--key <base64>]
+ *   node scripts/backup/backup.mjs restore <archive-file> [--wipe-first] [--stores <durable-object,kv,r2>] [--key <base64>]
+ *   node scripts/backup/backup.mjs list
+ *   node scripts/backup/backup.mjs rehearsal [--out <file>] [--key <base64>]
+ */
+import { build } from "esbuild";
+import { Miniflare } from "miniflare";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+const WORKER = join(ROOT, "src", "server", "backup", "worker.ts");
+const DEFAULT_PERSIST = join(ROOT, ".wrangler", "state", "backups");
+
+const COMMANDS = ["create", "verify", "restore", "list", "rehearsal"];
+
+const args = process.argv.slice(2);
+const command = args.shift();
+if (!COMMANDS.includes(command ?? "")) {
+  console.error(`Usage: backup.mjs <${COMMANDS.join("|")}> [options]`);
+  process.exit(1);
+}
+
+const options = {
+  stores: undefined,
+  key: undefined,
+  out: undefined,
+  source: undefined,
+  wipeFirst: false,
+  persist: undefined,
+  archiveFile: undefined,
+};
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "--key") options.key = args[++i];
+  else if (arg === "--stores") options.stores = args[++i];
+  else if (arg === "--out") options.out = args[++i];
+  else if (arg === "--source") options.source = args[++i];
+  else if (arg === "--wipe-first") options.wipeFirst = true;
+  else if (arg === "--persist") options.persist = args[++i];
+  else if (!arg.startsWith("--") && !options.archiveFile) options.archiveFile = arg;
+}
+
+if (command === "verify" || command === "restore") {
+  if (!options.archiveFile) {
+    console.error(`${command} requires an archive file path`);
+    process.exit(1);
+  }
+}
+
+if (options.stores) {
+  options.stores = options.stores
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => ["durable-object", "kv", "r2"].includes(s));
+  if (options.stores.length === 0) {
+    console.error("--stores must be a comma-separated subset of durable-object,kv,r2");
+    process.exit(1);
+  }
+}
+
+const persist = options.persist ?? DEFAULT_PERSIST;
+const runOptions = {
+  key: options.key,
+  source: options.source,
+  stores: options.stores,
+  wipeFirst: options.wipeFirst,
+};
+
+console.log(`✦ Stealth backups — command: ${command}`);
+if (options.archiveFile) console.log(`  archive:           ${options.archiveFile}`);
+if (options.stores) console.log(`  stores:            ${options.stores.join(", ")}`);
+
+const result = await build({
+  entryPoints: [WORKER],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  external: ["cloudflare:workers"],
+  write: false,
+  logLevel: "silent",
+});
+const code = result.outputFiles[0].text;
+
+const mf = new Miniflare({
+  name: "stealth-backups",
+  modules: true,
+  script: code,
+  compatibilityDate: "2025-09-24",
+  compatibilityFlags: ["nodejs_compat"],
+  durableObjects: { STEALTH_COORDINATOR: "StealthCoordinator" },
+  kvNamespaces: { STEALTH_KV: "local-emulation-kv" },
+  r2Buckets: { STEALTH_OBJECT_STORE: "local-emulation-r2" },
+  durableObjectsPersist: persist,
+  kvPersist: persist,
+  r2Persist: persist,
+});
+
+async function dispatch(body) {
+  const res = await mf.dispatchFetch("http://localhost/backup", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const payload = await res.json();
+  return { status: res.status, body: payload };
+}
+
+try {
+  switch (command) {
+    case "create": {
+      const { status, body } = await dispatch({ command: "create", options: runOptions });
+      if (status !== 200 || !body.ok) {
+        console.error("✖ Backup create failed:", body.errors);
+        process.exit(1);
+      }
+      const outFile =
+        options.out ??
+        join(persist, `stealth-backup-${body.archive.createdAt.replace(/[:.]/g, "-")}.json`);
+      mkdirSync(join(persist), { recursive: true });
+      writeFileSync(outFile, JSON.stringify(body.archive, null, 2));
+      console.log(`  archive written:   ${outFile}`);
+      console.log(
+        `  encrypted:         ${body.archive.encryption.cipher} (keyId ${body.archive.encryption.keyId})`,
+      );
+      for (const store of body.stores) {
+        console.log(`  ${store.store.padEnd(16)} ${store.count} keys, ${store.byteLength} bytes`);
+      }
+      console.log(`  created in:        ${body.durationMs} ms`);
+      console.log("✓ Backup created.");
+      break;
+    }
+
+    case "verify": {
+      const archive = JSON.parse(readFileSync(options.archiveFile, "utf8"));
+      const { status, body } = await dispatch({ command: "verify", options: runOptions, archive });
+      if (status !== 200 || !body.ok) {
+        console.error("✖ Backup verify failed:", body.errors);
+        process.exit(1);
+      }
+      console.log(`  verified:          ${body.verified} entries, ${body.mismatches} mismatches`);
+      console.log("✓ Backup integrity verified.");
+      break;
+    }
+
+    case "restore": {
+      const archive = JSON.parse(readFileSync(options.archiveFile, "utf8"));
+      const { status, body } = await dispatch({ command: "restore", options: runOptions, archive });
+      if (status !== 200 || !body.ok) {
+        console.error("✖ Backup restore failed:", body.errors);
+        process.exit(1);
+      }
+      console.log(`  restored:          ${body.restored} entries`);
+      for (const store of body.stores) {
+        console.log(`  ${store.store.padEnd(16)} ${store.count} keys, ${store.byteLength} bytes`);
+      }
+      console.log(`  restored in:       ${body.durationMs} ms`);
+      console.log("✓ Backup restored.");
+      break;
+    }
+
+    case "list": {
+      const { status, body } = await dispatch({ command: "list", options: {} });
+      if (status !== 200) {
+        console.error("✖ Backup list failed");
+        process.exit(1);
+      }
+      for (const store of body.stores) {
+        console.log(`  ${store.store.padEnd(16)} ${store.keys} keys`);
+      }
+      break;
+    }
+
+    case "rehearsal": {
+      const ns = await mf.getDurableObjectNamespace("STEALTH_COORDINATOR");
+      const stub = ns.get(ns.idFromName("global-stealth-coordinator"));
+      const kv = await mf.getKVNamespace("STEALTH_KV");
+      const r2 = await mf.getR2Bucket("STEALTH_OBJECT_STORE");
+
+      const seedAddress = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+      console.log("  seeding fixture data (identity, policy, relay, object storage)…");
+      await stub._debugSeed([
+        {
+          key: "user:id:u_1",
+          value: {
+            $v: 1,
+            userId: "u_1",
+            address: seedAddress,
+            email: "alice@example.com",
+            username: "alice",
+            status: "active",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            version: 1,
+          },
+        },
+        { key: "user:email:alice@example.com", value: "u_1" },
+        { key: "user:username:alice", value: "u_1" },
+        { key: `user:address:${seedAddress}`, value: "u_1" },
+        {
+          key: "session:s_1",
+          value: {
+            $v: 1,
+            sessionId: "s_1",
+            userId: "u_1",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            expiresAt: "2026-02-01T00:00:00.000Z",
+            lastActiveAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        {
+          key: "policy:p_1",
+          value: {
+            $v: 1,
+            policyId: "p_1",
+            userId: "u_1",
+            title: "Inbox rules",
+            rules: [],
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        {
+          key: "idempotency:op_1",
+          value: {
+            $v: 1,
+            key: "op_1",
+            operation: "send",
+            status: "completed",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ]);
+      await kv.put(
+        "sender-rule:sr_1",
+        JSON.stringify({ ruleId: "sr_1", userId: "u_1", pattern: "spam" }),
+      );
+      await kv.put(
+        "relay:message:msg_1",
+        JSON.stringify({ messageId: "msg_1", recipient: "bob@example.com" }),
+      );
+      await r2.put("envelopes/m1/aaaa", new TextEncoder().encode("encrypted-envelope-bytes"));
+
+      const created = await (
+        await mf.dispatchFetch("http://localhost/backup", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ command: "create", options: runOptions }),
+        })
+      ).json();
+      if (!created.ok) {
+        console.error("✖ Rehearsal create failed:", created.errors);
+        process.exit(1);
+      }
+      const outFile =
+        options.out ??
+        join(
+          persist,
+          `stealth-backup-rehearsal-${created.archive.createdAt.replace(/[:.]/g, "-")}.json`,
+        );
+      mkdirSync(persist, { recursive: true });
+      writeFileSync(outFile, JSON.stringify(created.archive, null, 2));
+      console.log(`  archive written:   ${outFile}`);
+
+      const verifyBefore = await (
+        await mf.dispatchFetch("http://localhost/backup", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            command: "verify",
+            options: runOptions,
+            archive: created.archive,
+          }),
+        })
+      ).json();
+      if (!verifyBefore.ok) {
+        console.error("✖ Rehearsal verify failed:", verifyBefore.errors);
+        process.exit(1);
+      }
+      console.log(`  verified:          ${verifyBefore.verified} entries before wipe`);
+
+      const restored = await (
+        await mf.dispatchFetch("http://localhost/backup", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            command: "restore",
+            options: { ...runOptions, wipeFirst: true },
+            archive: created.archive,
+          }),
+        })
+      ).json();
+      if (!restored.ok) {
+        console.error("✖ Rehearsal restore failed:", restored.errors);
+        process.exit(1);
+      }
+      console.log(`  restored:          ${restored.restored} entries in ${restored.durationMs} ms`);
+
+      const verifyAfter = await (
+        await mf.dispatchFetch("http://localhost/backup", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            command: "verify",
+            options: runOptions,
+            archive: created.archive,
+          }),
+        })
+      ).json();
+      if (!verifyAfter.ok) {
+        console.error("✖ Rehearsal post-restore verify failed:", verifyAfter.errors);
+        process.exit(1);
+      }
+
+      const doKeys = await stub.listKeys("");
+      const kvKeys = ((await (await kv.list({})).keys) ?? []).map((k) => k.name);
+      const r2Keys = (await r2.list({})).objects.map((o) => o.key);
+      console.log(
+        `  restored keys:     durable-object=${doKeys.length}, kv=${kvKeys.length}, r2=${r2Keys.length}`,
+      );
+      console.log(`  archive:           ${outFile}`);
+      console.log(`  RTO (restore):     ${restored.durationMs} ms`);
+      console.log("✓ Rehearsal complete: backup → verify → wipe → restore → verify.");
+      break;
+    }
+  }
+} finally {
+  await mf.dispose();
+}

--- a/src/server/backup/encryption.ts
+++ b/src/server/backup/encryption.ts
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------
+// BETA-081 (Issue #1988) — backup archive encryption.
+//
+// The backup payload (manifest + entries) is sealed with AES-256-GCM using a
+// key derived via HKDF-SHA256 from a dedicated `STEALTH_BACKUP_KEY` secret
+// (base64, 32 bytes). The backup key is deliberately SEPARATE from production
+// keys (cursor, storage, operator, …) so rotating backup material never
+// touches live signing/wrapping material. The derived key is bound to the
+// fixed purpose label `stealth-backup-v1`, so the same secret cannot be
+// repurposed for another envelope format.
+//
+// Reuses the canonical AEAD wire format (`src/services/crypto/aead.ts`) so
+// ciphertext excludes the tag and the tag is stored separately — identical to
+// the managed-wallet envelope convention.
+// ---------------------------------------------------------------------------
+
+import { sealAead, openAead } from "@/services/crypto/aead";
+import { fromBase64, toBase64, toHex } from "@/services/crypto/codec";
+import { hkdfExtract, hkdfExpand } from "@/services/crypto/kdf";
+
+import type { BackupArchive, BackupArchiveHeader, BackupManifest, BackupPayload } from "./types";
+
+export const BACKUP_KDF_PURPOSE = "stealth-backup-v1";
+export const BACKUP_KEY_BYTES = 32;
+const BACKUP_KEY_ID_BYTES = 8;
+
+export class BackupCryptoError extends Error {
+  readonly code = "backup_crypto_error" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "BackupCryptoError";
+  }
+}
+
+function buf(u: Uint8Array): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(new ArrayBuffer(u.length));
+  out.set(u);
+  return out;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", buf(bytes));
+  return toHex(new Uint8Array(digest));
+}
+
+/**
+ * Derive the AES-256-GCM backup key from a base64-encoded 32-byte secret.
+ * The purpose label binds the key to the backup format.
+ */
+export async function deriveBackupKey(base64Key: string): Promise<CryptoKey> {
+  let ikm: Uint8Array | undefined;
+  try {
+    ikm = fromBase64(base64Key, BACKUP_KEY_BYTES);
+    const prk = await hkdfExtract(ikm);
+    const keyBytes = await hkdfExpand(prk, new TextEncoder().encode(BACKUP_KDF_PURPOSE), 32);
+    return await crypto.subtle.importKey("raw", buf(keyBytes), { name: "AES-GCM" }, false, [
+      "encrypt",
+      "decrypt",
+    ]);
+  } catch (error) {
+    if (error instanceof BackupCryptoError) throw error;
+    throw new BackupCryptoError("Unable to derive the backup key from STEALTH_BACKUP_KEY");
+  } finally {
+    if (ikm) ikm.fill(0);
+  }
+}
+
+/**
+ * Non-secret key identifier recorded in the archive header so operators can
+ * confirm which key version sealed a backup without exposing the key itself.
+ */
+export async function backupKeyId(base64Key: string): Promise<string> {
+  const bytes = fromBase64(base64Key, BACKUP_KEY_BYTES);
+  const digest = await crypto.subtle.digest("SHA-256", buf(bytes));
+  return toHex(new Uint8Array(digest).slice(0, BACKUP_KEY_ID_BYTES));
+}
+
+/**
+ * Builds the canonical AAD for the archive: the non-sensitive header fields.
+ * Any header tampering therefore fails authentication on open.
+ */
+export function archiveAad(header: BackupArchiveHeader): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      format: header.format,
+      version: header.version,
+      createdAt: header.createdAt,
+      source: header.source,
+      encryption: header.encryption,
+    }),
+  );
+}
+
+export interface SealedBackup {
+  header: BackupArchiveHeader;
+  nonce: string;
+  tag: string;
+  ciphertext: string;
+}
+
+/** Seals the payload JSON under the derived backup key. */
+export async function sealBackupPayload(
+  key: CryptoKey,
+  header: BackupArchiveHeader,
+  payload: BackupPayload,
+): Promise<SealedBackup> {
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+  const sealed = await sealAead(key, plaintext, undefined, archiveAad(header));
+  return {
+    header,
+    nonce: toBase64(sealed.nonce),
+    tag: toBase64(sealed.tag),
+    ciphertext: toBase64(sealed.ciphertext),
+  };
+}
+
+/** Authenticates and opens the archive, returning the decrypted payload. */
+export async function openBackupPayload(
+  key: CryptoKey,
+  archive: BackupArchive,
+): Promise<BackupPayload> {
+  const payload = JSON.parse(
+    new TextDecoder().decode(
+      (
+        await openAead(
+          key,
+          fromBase64(archive.ciphertext),
+          fromBase64(archive.tag),
+          fromBase64(archive.nonce),
+          archiveAad(archive),
+        )
+      ).plaintext,
+    ),
+  ) as BackupPayload;
+  if (!payload || !Array.isArray(payload.entries) || !payload.manifest) {
+    throw new BackupCryptoError("Backup payload is malformed");
+  }
+  return payload;
+}
+
+/** SHA-256 hex digest of a value byte array (used for manifest integrity). */
+export function digestValue(value: Uint8Array): Promise<string> {
+  return sha256Hex(value);
+}
+
+export type { BackupManifest };

--- a/src/server/backup/engine.ts
+++ b/src/server/backup/engine.ts
@@ -1,0 +1,366 @@
+// ---------------------------------------------------------------------------
+// BETA-081 (Issue #1988) — backup engine.
+//
+// The engine is a pure module over the `BackupStorage` surface, so the exact
+// same code runs:
+//   1. as unit tests against in-memory stores,
+//   2. against local Cloudflare emulation (Miniflare) via the backup worker,
+//   3. inside a Durable Object when an operator runs the CLI commands.
+//
+// Contract:
+//   - Restorable: an archive can be verified and restored byte-for-byte.
+//   - Integrity: the manifest carries a SHA-256 digest per entry; verify
+//     recomputes digests over the decrypted payload.
+//   - Ordered restore: entries are applied in the documented restoration
+//     order (identity → policy → relay/job state → object storage) so
+//     dependent records exist before they are referenced.
+//   - No plaintext: keys are fingerprinted in the manifest; values never
+//     leave the AEAD-sealed payload, and no secret/plaintext is echoed to
+//     reports.
+// ---------------------------------------------------------------------------
+
+import { fromBase64, toBase64 } from "@/services/crypto/codec";
+import {
+  backupKeyId,
+  deriveBackupKey,
+  digestValue,
+  openBackupPayload,
+  sealBackupPayload,
+} from "./encryption";
+import type {
+  BackupArchive,
+  BackupArchiveHeader,
+  BackupCreateReport,
+  BackupEntry,
+  BackupManifest,
+  BackupManifestEntry,
+  BackupPayload,
+  BackupRestoreReport,
+  BackupRunOptions,
+  BackupStorage,
+  BackupVerifyReport,
+} from "./types";
+import { BACKUP_ARCHIVE_VERSION, BACKUP_FORMAT } from "./types";
+
+export const GENERATED_BY = "stealth-backup/1";
+
+/**
+ * Restore stage order — identities first, then policy, then relay/job state,
+ * then object storage. Prefixes are ordered so the earliest matching stage
+ * wins for a given key.
+ */
+const RESTORE_STAGES: ReadonlyArray<{ stage: number; prefixes: string[] }> = [
+  // 1. Identity, sessions, credentials, provisioning, verification, wallets.
+  {
+    stage: 1,
+    prefixes: [
+      "user:id:",
+      "user:email:",
+      "user:username:",
+      "user:address:",
+      "session:",
+      "session:user:",
+      "retired-session:",
+      "credential:",
+      "profile:",
+      "provisioning:",
+      "verification-token:hash:",
+      "verification-token:active:",
+      "username-reservation:",
+      "wallet:",
+      "policy-init:",
+    ],
+  },
+  // 2. Mailbox policy, sender rules, contacts, key directory.
+  {
+    stage: 2,
+    prefixes: [
+      "policy:",
+      "policy-write:",
+      "sender-rule:",
+      "contacts:",
+      "key-directory:",
+      "keys:",
+      "external-wallet:",
+      "external-wallet-address:",
+      "wallet-challenge:",
+    ],
+  },
+  // 3. Relay metadata, message records, and job state.
+  {
+    stage: 3,
+    prefixes: [
+      "relay:",
+      "envelope:",
+      "postage:",
+      "receipt:",
+      "sender-request:",
+      "idempotency:",
+      "counter:",
+    ],
+  },
+  // 4. Object storage payloads.
+  { stage: 4, prefixes: ["staged/", "envelopes/", "attachments/"] },
+];
+
+function restoreStage(store: string, key: string): number {
+  if (store === "r2") return 4;
+  for (const group of RESTORE_STAGES) {
+    if (group.stage === 4) continue;
+    for (const prefix of group.prefixes) {
+      if (key.startsWith(prefix)) return group.stage;
+    }
+  }
+  // Unclassified keys restore last.
+  return 99;
+}
+
+function fingerprintKey(key: string): string {
+  const lastColon = key.lastIndexOf(":");
+  const prefix = lastColon >= 0 ? key.slice(0, lastColon + 1) : key.slice(0, 8);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${prefix}…(${(hash >>> 0).toString(16).padStart(8, "0")})`;
+}
+
+async function readStore(storage: BackupStorage, errors: string[]): Promise<BackupEntry[]> {
+  const entries: BackupEntry[] = [];
+  const keys = await storage.listKeys();
+  for (const key of keys) {
+    const value = await storage.get(key);
+    if (!value) {
+      errors.push(`missing value for ${fingerprintKey(key)}`);
+      continue;
+    }
+    entries.push({ store: storage.store, key, encoding: value.encoding, value: value.bytes });
+  }
+  return entries;
+}
+
+async function buildManifest(entries: BackupEntry[], createdAt: string): Promise<BackupManifest> {
+  const perStore = new Map<string, { count: number; byteLength: number }>();
+  const manifestEntries: BackupManifest["entries"] = [];
+  for (const entry of entries) {
+    const digest = await digestValue(entry.value);
+    manifestEntries.push({
+      store: entry.store,
+      key: fingerprintKey(entry.key),
+      digest,
+      byteLength: entry.value.byteLength,
+    });
+    const bucket = perStore.get(entry.store) ?? { count: 0, byteLength: 0 };
+    bucket.count += 1;
+    bucket.byteLength += entry.value.byteLength;
+    perStore.set(entry.store, bucket);
+  }
+  return {
+    version: 1,
+    createdAt,
+    stores: [...perStore.entries()].map(([store, data]) => ({
+      store: store as BackupEntry["store"],
+      count: data.count,
+      byteLength: data.byteLength,
+    })),
+    entries: manifestEntries,
+  };
+}
+
+/**
+ * Creates an encrypted, integrity-checked backup from the given stores.
+ * The returned archive's ciphertext contains the manifest + all entries.
+ */
+export async function createBackup(
+  storages: BackupStorage[],
+  base64Key: string,
+  options: BackupRunOptions = {},
+): Promise<BackupCreateReport> {
+  const startedAt = Date.now();
+  const errors: string[] = [];
+  const selected = options.stores
+    ? storages.filter((s) => options.stores!.includes(s.store))
+    : storages;
+
+  const entries: BackupEntry[] = [];
+  for (const storage of selected) {
+    entries.push(...(await readStore(storage, errors)));
+  }
+
+  const createdAt = new Date().toISOString();
+  const manifest = await buildManifest(entries, createdAt);
+  const header: BackupArchiveHeader = {
+    format: BACKUP_FORMAT,
+    version: BACKUP_ARCHIVE_VERSION,
+    createdAt,
+    generatedBy: GENERATED_BY,
+    source: options.source ?? "local-emulation",
+    encryption: {
+      cipher: "AES-256-GCM",
+      kdf: "HKDF-SHA256",
+      kdfPurpose: "stealth-backup-v1",
+      keyId: await backupKeyId(base64Key),
+    },
+  };
+
+  const key = await deriveBackupKey(base64Key);
+  const payload = {
+    manifest,
+    entries: entries.map((e) => ({
+      store: e.store,
+      key: e.key,
+      encoding: e.encoding,
+      value: toBase64(e.value),
+    })),
+  };
+  const sealed = await sealBackupPayload(key, header, payload);
+  const archive: BackupArchive = { ...sealed.header, ...sealed };
+
+  return {
+    command: "create",
+    generatedAt: new Date().toISOString(),
+    createdAt,
+    ok: errors.length === 0,
+    archive,
+    stores: manifest.stores,
+    durationMs: Date.now() - startedAt,
+    errors,
+  };
+}
+
+/**
+ * Verifies an archive: authenticates the AEAD seal (fails closed on tampering
+ * or a wrong key) and recomputes every entry digest against the manifest.
+ */
+export async function verifyBackup(
+  archive: BackupArchive,
+  base64Key: string,
+): Promise<BackupVerifyReport> {
+  const errors: string[] = [];
+  const key = await deriveBackupKey(base64Key);
+  let payload: BackupPayload | undefined;
+  try {
+    payload = await openBackupPayload(key, archive);
+  } catch (error) {
+    return {
+      command: "verify",
+      generatedAt: new Date().toISOString(),
+      ok: false,
+      verified: 0,
+      mismatches: 0,
+      errors: ["backup archive authentication failed (tampered or wrong key)"],
+    };
+  }
+
+  let mismatches = 0;
+  const manifestByFingerprint = new Map<string, BackupManifestEntry>(
+    payload.manifest.entries.map((e) => [e.key, e]),
+  );
+  for (const entry of payload.entries) {
+    const digest = await digestValue(fromBase64(entry.value));
+    const expected = manifestByFingerprint.get(fingerprintKey(entry.key));
+    if (!expected || expected.digest !== digest) {
+      mismatches += 1;
+      errors.push(`digest mismatch for ${fingerprintKey(entry.key)}`);
+    }
+  }
+
+  return {
+    command: "verify",
+    generatedAt: new Date().toISOString(),
+    ok: mismatches === 0,
+    verified: payload.entries.length,
+    mismatches,
+    errors,
+  };
+}
+
+/**
+ * Restores an archive: verifies first (failing closed), then writes entries
+ * back in the documented restoration order. When `wipeFirst` is set each
+ * target store is emptied before restore (isolated rehearsal mode).
+ */
+export async function restoreBackup(
+  archive: BackupArchive,
+  base64Key: string,
+  storages: BackupStorage[],
+  options: BackupRunOptions = {},
+): Promise<BackupRestoreReport> {
+  const startedAt = Date.now();
+  const errors: string[] = [];
+  const key = await deriveBackupKey(base64Key);
+  let payload: BackupPayload | undefined;
+  try {
+    payload = await openBackupPayload(key, archive);
+  } catch {
+    return {
+      command: "restore",
+      generatedAt: new Date().toISOString(),
+      ok: false,
+      restored: 0,
+      stores: [],
+      durationMs: Date.now() - startedAt,
+      errors: ["backup archive authentication failed (tampered or wrong key)"],
+    };
+  }
+
+  const byStore = new Map<BackupStorage["store"], BackupStorage>();
+  for (const storage of storages) byStore.set(storage.store, storage);
+
+  const selectedStores = options.stores
+    ? options.stores.filter((s) => byStore.has(s))
+    : [...byStore.keys()];
+
+  if (options.wipeFirst) {
+    for (const store of selectedStores) {
+      const target = byStore.get(store)!;
+      for (const key of await target.listKeys()) {
+        await target.delete(key);
+      }
+    }
+  }
+
+  const entries = payload.entries
+    .map((e) => ({
+      store: e.store,
+      key: e.key,
+      encoding: e.encoding,
+      value: fromBase64(e.value),
+    }))
+    .filter((e) => selectedStores.includes(e.store))
+    .sort((a, b) => {
+      const stageDiff = restoreStage(a.store, a.key) - restoreStage(b.store, b.key);
+      if (stageDiff !== 0) return stageDiff;
+      if (a.store !== b.store) return a.store < b.store ? -1 : 1;
+      return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+    });
+
+  const perStore = new Map<string, { count: number; byteLength: number }>();
+  for (const entry of entries) {
+    const target = byStore.get(entry.store);
+    if (!target) {
+      errors.push(`no storage bound for ${entry.store}`);
+      continue;
+    }
+    await target.put(entry.key, { encoding: entry.encoding, bytes: entry.value });
+    const bucket = perStore.get(entry.store) ?? { count: 0, byteLength: 0 };
+    bucket.count += 1;
+    bucket.byteLength += entry.value.byteLength;
+    perStore.set(entry.store, bucket);
+  }
+
+  return {
+    command: "restore",
+    generatedAt: new Date().toISOString(),
+    ok: errors.length === 0,
+    restored: entries.length,
+    stores: [...perStore.entries()].map(([store, data]) => ({
+      store: store as BackupStorage["store"],
+      count: data.count,
+      byteLength: data.byteLength,
+    })),
+    durationMs: Date.now() - startedAt,
+    errors,
+  };
+}

--- a/src/server/backup/storage.ts
+++ b/src/server/backup/storage.ts
@@ -1,0 +1,170 @@
+// ---------------------------------------------------------------------------
+// BETA-081 (Issue #1988) — storage adapters.
+//
+// Adapters expose the three beta stores (Durable Object storage, KV, R2) as the
+// byte-oriented `BackupStorage` surface. `listKeys` paginates past the 1000-key
+// per-call limit; values round-trip with an explicit encoding so the restore
+// path writes back the exact shape each store expects (JSON objects for DO,
+// text for KV, raw bytes for R2).
+// ---------------------------------------------------------------------------
+
+import type { BackupStorage, BackupStoredValue, BackupStoreKind } from "./types";
+
+function encodeText(value: string): BackupStoredValue {
+  return { encoding: "text", bytes: new TextEncoder().encode(value) };
+}
+
+function decodeText(value: BackupStoredValue): string {
+  return new TextDecoder().decode(value.bytes);
+}
+
+/** DO storage values are structured-cloneable; they round-trip as JSON. */
+export function createDurableObjectBackupStorage(
+  state: Pick<DurableObjectState, "storage">,
+): BackupStorage {
+  const storage = state.storage;
+  return {
+    store: "durable-object",
+    async listKeys(prefix = ""): Promise<string[]> {
+      const keys: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = (await storage.list({
+          prefix,
+          limit: 1000,
+          ...(cursor ? { cursor } : {}),
+        })) as
+          | { keys: Array<{ name: string }>; list_complete: boolean; cursor?: string }
+          | Map<string, unknown>;
+        if (typeof page.keys === "function") {
+          for (const key of page.keys()) keys.push(key);
+          break;
+        }
+        const recordPage = page as {
+          keys: Array<{ name: string }>;
+          list_complete: boolean;
+          cursor?: string;
+        };
+        for (const key of recordPage.keys) keys.push(key.name);
+        cursor = recordPage.cursor;
+        if (!recordPage.list_complete && !cursor) break;
+      } while (cursor);
+      return keys;
+    },
+    async get(key: string): Promise<BackupStoredValue | null> {
+      const value = await storage.get(key);
+      if (value === undefined || value === null) return null;
+      return {
+        encoding: "json",
+        bytes: new TextEncoder().encode(JSON.stringify(value)),
+      };
+    },
+    async put(key: string, value: BackupStoredValue): Promise<void> {
+      if (value.encoding !== "json") {
+        throw new Error("Durable Object storage requires JSON-encoded values");
+      }
+      await storage.put(key, JSON.parse(decodeText(value)));
+    },
+    async delete(key: string): Promise<void> {
+      await storage.delete(key);
+    },
+  };
+}
+
+/** KV values are plain strings (the app stores JSON via `put(key, json)`). */
+export function createKvBackupStorage(kv: KVNamespace): BackupStorage {
+  return {
+    store: "kv",
+    async listKeys(prefix = ""): Promise<string[]> {
+      const keys: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = (await (kv as any).list({
+          prefix,
+          limit: 1000,
+          ...(cursor ? { cursor } : {}),
+        })) as { keys: Array<{ name: string }>; list_complete: boolean; cursor?: string };
+        for (const key of page.keys) keys.push(key.name);
+        cursor = page.cursor;
+        if (!page.list_complete && !cursor) break;
+      } while (cursor);
+      return keys;
+    },
+    async get(key: string): Promise<BackupStoredValue | null> {
+      const value = await kv.get(key, "text");
+      if (value === null) return null;
+      return encodeText(value);
+    },
+    async put(key: string, value: BackupStoredValue): Promise<void> {
+      if (value.encoding !== "text") {
+        throw new Error("KV storage requires text-encoded values");
+      }
+      await kv.put(key, decodeText(value));
+    },
+    async delete(key: string): Promise<void> {
+      await kv.delete(key);
+    },
+  };
+}
+
+/** R2 stores raw bytes. */
+export function createR2BackupStorage(bucket: R2Bucket): BackupStorage {
+  return {
+    store: "r2",
+    async listKeys(prefix = ""): Promise<string[]> {
+      const keys: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await bucket.list({ prefix, limit: 1000, ...(cursor ? { cursor } : {}) });
+        for (const obj of page.objects) keys.push(obj.key);
+        cursor = page.cursor;
+        if (!page.truncated && !cursor) break;
+      } while (cursor);
+      return keys;
+    },
+    async get(key: string): Promise<BackupStoredValue | null> {
+      const obj = await bucket.get(key);
+      if (!obj) return null;
+      return { encoding: "bytes", bytes: new Uint8Array(await obj.arrayBuffer()) };
+    },
+    async put(key: string, value: BackupStoredValue): Promise<void> {
+      if (value.encoding !== "bytes") {
+        throw new Error("R2 storage requires bytes-encoded values");
+      }
+      await bucket.put(key, value.bytes);
+    },
+    async delete(key: string): Promise<void> {
+      await bucket.delete(key);
+    },
+  };
+}
+
+/**
+ * In-memory store used by unit tests and the rehearsal harness. Values are
+ * kept as JSON-encoded bytes to mimic DO semantics most closely.
+ */
+export function createMemoryBackupStorage(store: BackupStoreKind): BackupStorage & {
+  _size(): Promise<number>;
+  _values: Map<string, BackupStoredValue>;
+} {
+  const values = new Map<string, BackupStoredValue>();
+  return {
+    store,
+    _values: values,
+    async listKeys(prefix = ""): Promise<string[]> {
+      return [...values.keys()].filter((key) => key.startsWith(prefix));
+    },
+    async get(key: string): Promise<BackupStoredValue | null> {
+      return values.get(key) ?? null;
+    },
+    async put(key: string, value: BackupStoredValue): Promise<void> {
+      values.set(key, value);
+    },
+    async delete(key: string): Promise<void> {
+      values.delete(key);
+    },
+    async _size(): Promise<number> {
+      return values.size;
+    },
+  };
+}

--- a/src/server/backup/types.ts
+++ b/src/server/backup/types.ts
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------------
+// BETA-081 (Issue #1988) — encrypted backups and restore procedures.
+//
+// Types shared by the backup engine, the Miniflare-driven backup worker, the
+// operator CLI, and the automated tests. The archive format is deliberately
+// plain: a small non-sensitive header plus an AES-256-GCM ciphertext whose
+// plaintext is the integrity manifest and the store entries. Keys (which can
+// embed emails/usernames in secondary indexes) are fingerprinted in the
+// manifest and only carried in full inside the encrypted payload.
+// ---------------------------------------------------------------------------
+
+/** The three beta data stores that must be recoverable. */
+export type BackupStoreKind = "durable-object" | "kv" | "r2";
+
+export const BACKUP_FORMAT = "stealth-backup" as const;
+export const BACKUP_ARCHIVE_VERSION = 1 as const;
+
+/** How a stored value is encoded inside the archive. */
+export type BackupValueEncoding = "json" | "text" | "bytes";
+
+/** A value read from a store plus the encoding needed to write it back. */
+export interface BackupStoredValue {
+  encoding: BackupValueEncoding;
+  bytes: Uint8Array;
+}
+
+/**
+ * Storage-agnostic surface the backup engine runs over. All three beta stores
+ * (Durable Object, KV, R2) implement it; `listKeys` paginates to stay complete
+ * past per-call key limits.
+ */
+export interface BackupStorage {
+  readonly store: BackupStoreKind;
+  listKeys(prefix?: string): Promise<string[]>;
+  get(key: string): Promise<BackupStoredValue | null>;
+  put(key: string, value: BackupStoredValue): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+/** A single (store, key) record captured into or written from an archive. */
+export interface BackupEntry {
+  store: BackupStoreKind;
+  key: string;
+  encoding: BackupValueEncoding;
+  /** Raw value bytes. */
+  value: Uint8Array;
+}
+
+/** One row of the integrity manifest (keys are fingerprinted, never verbatim). */
+export interface BackupManifestEntry {
+  store: BackupStoreKind;
+  /** Redacted key fingerprint — never the full key. */
+  key: string;
+  /** SHA-256 hex digest of the value bytes. */
+  digest: string;
+  byteLength: number;
+}
+
+export interface BackupManifest {
+  version: number;
+  createdAt: string;
+  stores: Array<{ store: BackupStoreKind; count: number; byteLength: number }>;
+  entries: BackupManifestEntry[];
+}
+
+/** Non-sensitive archive header; all key material stays inside the ciphertext. */
+export interface BackupArchiveHeader {
+  format: typeof BACKUP_FORMAT;
+  version: typeof BACKUP_ARCHIVE_VERSION;
+  createdAt: string;
+  generatedBy: string;
+  /** Redacted environment label, e.g. "local-emulation". */
+  source: string;
+  encryption: {
+    cipher: "AES-256-GCM";
+    kdf: "HKDF-SHA256";
+    kdfPurpose: "stealth-backup-v1";
+    /** Non-secret identifier of the key that sealed the archive. */
+    keyId: string;
+  };
+}
+
+/** The full archive: header (plaintext) + AEAD seal of the payload. */
+export interface BackupArchive extends BackupArchiveHeader {
+  nonce: string;
+  tag: string;
+  ciphertext: string;
+}
+
+/** The plaintext carried inside the AEAD seal. */
+export interface BackupPayload {
+  manifest: BackupManifest;
+  entries: Array<{
+    store: BackupStoreKind;
+    key: string;
+    encoding: BackupValueEncoding;
+    value: string;
+  }>;
+}
+
+export type BackupCommand = "create" | "verify" | "restore" | "list" | "rehearsal";
+
+export interface BackupRunOptions {
+  /** Restrict collection/restore to specific stores. */
+  stores?: BackupStoreKind[];
+  /** Wipe each target store before restoring (rehearsal only). */
+  wipeFirst?: boolean;
+  /** Base64-encoded 32-byte AES key (operator tool only; never logged). */
+  key?: string;
+  /** Environment label recorded in the archive header. */
+  source?: string;
+}
+
+export interface BackupCreateReport {
+  command: "create";
+  generatedAt: string;
+  createdAt: string;
+  ok: boolean;
+  archive?: BackupArchive;
+  /** Per-store counts in the archive (never keys or values). */
+  stores: Array<{ store: BackupStoreKind; count: number; byteLength: number }>;
+  /** Elapsed time for collection + sealing, for RPO/RTO evidence. */
+  durationMs: number;
+  errors: string[];
+}
+
+export interface BackupVerifyReport {
+  command: "verify";
+  generatedAt: string;
+  ok: boolean;
+  /** Total entries verified against the manifest. */
+  verified: number;
+  /** Manifest rows whose digest did not match (always redacted). */
+  mismatches: number;
+  errors: string[];
+}
+
+export interface BackupRestoreReport {
+  command: "restore";
+  generatedAt: string;
+  ok: boolean;
+  restored: number;
+  /** Counts per store actually written. */
+  stores: Array<{ store: BackupStoreKind; count: number; byteLength: number }>;
+  /** Elapsed time for the restore, for RTO evidence. */
+  durationMs: number;
+  errors: string[];
+}

--- a/src/server/backup/worker.ts
+++ b/src/server/backup/worker.ts
@@ -1,0 +1,169 @@
+import { DurableObject } from "cloudflare:workers";
+
+import { createBackup, restoreBackup, verifyBackup } from "./engine";
+import {
+  createDurableObjectBackupStorage,
+  createKvBackupStorage,
+  createR2BackupStorage,
+} from "./storage";
+import type {
+  BackupArchive,
+  BackupCommand,
+  BackupRunOptions,
+  BackupStorage,
+  BackupStoredValue,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// BETA-081 (Issue #1988) — encrypted backup worker.
+//
+// This worker is NOT part of the public API surface. It is the deployable
+// entrypoint for the backup commands (create / verify / restore) and is run
+// either:
+//   - locally via `node scripts/backup/backup.mjs <command>` (the CLI drives
+//     it with a Miniflare emulation of Cloudflare storage), or
+//   - by pointing an equivalent route at the deployed environment.
+//
+// The DO instance it binds to shares its storage with the `StealthCoordinator`
+// (same instance name `global-stealth-coordinator`), so backups capture exactly
+// the records the API persists — never a shadow copy. KV and R2 are read via
+// their direct bindings.
+// ---------------------------------------------------------------------------
+
+const BACKUP_INSTANCE = "global-stealth-coordinator";
+
+interface BackupEnv {
+  STEALTH_COORDINATOR: DurableObjectNamespace;
+  STEALTH_KV: KVNamespace;
+  STEALTH_OBJECT_STORE: R2Bucket;
+  STEALTH_BACKUP_KEY?: string;
+}
+
+/** Adapter over the DO stub RPCs (listKeys/get/put/delete) — shares the
+ * coordinator's storage, exactly like the migrations worker. */
+function createStubDurableObjectBackupStorage(
+  stub: InstanceType<typeof StealthBackupCoordinator>,
+): BackupStorage {
+  return {
+    store: "durable-object",
+    async listKeys(prefix = ""): Promise<string[]> {
+      return stub.listKeys(prefix);
+    },
+    async get(key: string): Promise<BackupStoredValue | null> {
+      return stub.get(key);
+    },
+    async put(key: string, value: BackupStoredValue): Promise<void> {
+      await stub.put(key, value);
+    },
+    async delete(key: string): Promise<void> {
+      await stub.delete(key);
+    },
+  };
+}
+
+export class StealthBackupCoordinator extends DurableObject {
+  async listKeys(prefix: string): Promise<string[]> {
+    return createDurableObjectBackupStorage(this.ctx).listKeys(prefix);
+  }
+
+  async get(key: string): Promise<BackupStoredValue | null> {
+    return createDurableObjectBackupStorage(this.ctx).get(key);
+  }
+
+  async put(key: string, value: BackupStoredValue): Promise<void> {
+    await this.ctx.storage.put(key, JSON.parse(new TextDecoder().decode(value.bytes)));
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.ctx.storage.delete(key);
+  }
+
+  /**
+   * Test-only record seeding for the local Cloudflare emulation tests. This is
+   * a direct RPC on the DO stub and is NOT reachable through the fetch handler,
+   * so it cannot be triggered over HTTP in any deployed environment.
+   */
+  async _debugSeed(records: Array<{ key: string; value: unknown }>): Promise<number> {
+    for (const { key, value } of records) {
+      await this.ctx.storage.put(key, value);
+    }
+    return records.length;
+  }
+}
+
+function backupKey(env: BackupEnv, options: BackupRunOptions): string {
+  const key = options.key ?? env.STEALTH_BACKUP_KEY;
+  if (!key) {
+    throw new Error("STEALTH_BACKUP_KEY is required (or pass --key with a base64 32-byte secret)");
+  }
+  return key;
+}
+
+export default {
+  async fetch(request: Request, env: BackupEnv) {
+    const url = new URL(request.url);
+    if (url.pathname !== "/backup" || request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+
+    const body = (await request.json()) as {
+      command?: BackupCommand;
+      options?: BackupRunOptions;
+      archive?: BackupArchive;
+    };
+    if (!body.command) {
+      return new Response("missing command", { status: 400 });
+    }
+
+    const id = env.STEALTH_COORDINATOR.idFromName(BACKUP_INSTANCE);
+    const stub = env.STEALTH_COORDINATOR.get(id);
+    const options = body.options ?? {};
+
+    const storages: BackupStorage[] = [
+      createStubDurableObjectBackupStorage(stub),
+      createKvBackupStorage(env.STEALTH_KV),
+      createR2BackupStorage(env.STEALTH_OBJECT_STORE),
+    ];
+
+    switch (body.command) {
+      case "create": {
+        const report = await createBackup(storages, backupKey(env, options), options);
+        return Response.json(report);
+      }
+      case "verify": {
+        if (!body.archive) return new Response("missing archive", { status: 400 });
+        const report = await verifyBackup(body.archive, backupKey(env, options));
+        return Response.json(report);
+      }
+      case "restore": {
+        if (!body.archive) return new Response("missing archive", { status: 400 });
+        const report = await restoreBackup(
+          body.archive,
+          backupKey(env, options),
+          storages,
+          options,
+        );
+        return Response.json(report);
+      }
+      case "list": {
+        const list = await Promise.all(
+          storages.map(async (storage) => ({
+            store: storage.store,
+            keys: (await storage.listKeys()).length,
+          })),
+        );
+        return Response.json({
+          command: "list",
+          generatedAt: new Date().toISOString(),
+          stores: list,
+        });
+      }
+      case "rehearsal":
+        return new Response("run rehearsal via the CLI", { status: 400 });
+      default:
+        return new Response("unknown command", { status: 400 });
+    }
+  },
+};
+
+export { StealthBackupCoordinator as StealthCoordinator };

--- a/tests/unit/backup/engine.test.ts
+++ b/tests/unit/backup/engine.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import { createBackup, restoreBackup, verifyBackup } from "@/server/backup/engine";
+import { createMemoryBackupStorage } from "@/server/backup/storage";
+
+const TEST_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+function enc(value: unknown): Uint8Array {
+  return new TextEncoder().encode(typeof value === "string" ? value : JSON.stringify(value));
+}
+
+describe("backup engine", () => {
+  it("round-trips durable-object, kv, and r2 stores through create → restore", async () => {
+    const doStore = createMemoryBackupStorage("durable-object");
+    const kvStore = createMemoryBackupStorage("kv");
+    const r2Store = createMemoryBackupStorage("r2");
+
+    await doStore.put("user:id:u_1", {
+      encoding: "json",
+      bytes: enc({ userId: "u_1", email: "alice@example.com" }),
+    });
+    await doStore.put("idempotency:op_1", {
+      encoding: "json",
+      bytes: enc({ status: "completed" }),
+    });
+    await kvStore.put("policy:p_1", { encoding: "text", bytes: enc("policy-json") });
+    await r2Store.put("envelopes/m1/aaaa", { encoding: "bytes", bytes: enc("encrypted-envelope") });
+
+    const created = await createBackup([doStore, kvStore, r2Store], TEST_KEY);
+    expect(created.ok).toBe(true);
+    expect(created.stores.map((s) => s.store).sort()).toEqual(["durable-object", "kv", "r2"]);
+
+    const verifyBefore = await verifyBackup(created.archive!, TEST_KEY);
+    expect(verifyBefore.ok).toBe(true);
+    expect(verifyBefore.verified).toBe(4);
+
+    const wipe = createMemoryBackupStorage("durable-object");
+    const wipedKv = createMemoryBackupStorage("kv");
+    const wipedR2 = createMemoryBackupStorage("r2");
+
+    const restored = await restoreBackup(created.archive!, TEST_KEY, [wipe, wipedKv, wipedR2]);
+    expect(restored.ok).toBe(true);
+    expect(restored.restored).toBe(4);
+
+    expect(await doStore.listKeys()).toEqual(await wipe.listKeys());
+    expect(await kvStore.get("policy:p_1")).toEqual(await wipedKv.get("policy:p_1"));
+    expect(await r2Store.get("envelopes/m1/aaaa")).toEqual(await wipedR2.get("envelopes/m1/aaaa"));
+  });
+
+  it("restore preserves idempotency keys verbatim (no double side effects)", async () => {
+    const doStore = createMemoryBackupStorage("durable-object");
+    const idemKey = "idempotency:send-abc";
+    await doStore.put(idemKey, {
+      encoding: "json",
+      bytes: enc({ status: "completed", idempotencyKey: "send-abc" }),
+    });
+
+    const created = await createBackup([doStore], TEST_KEY);
+    const target = createMemoryBackupStorage("durable-object");
+    await restoreBackup(created.archive!, TEST_KEY, [target]);
+
+    const value = await target.get(idemKey);
+    expect(value).not.toBeNull();
+    expect(JSON.parse(new TextDecoder().decode(value!.bytes)).idempotencyKey).toBe("send-abc");
+  });
+
+  it("never emits plaintext keys, emails, seeds, or mail in reports or headers", async () => {
+    const doStore = createMemoryBackupStorage("durable-object");
+    await doStore.put("user:email:alice@example.com", { encoding: "json", bytes: enc("u_1") });
+    await doStore.put("wallet:metadata:w_1", {
+      encoding: "json",
+      bytes: enc({ seed: "SECRET-SEED-VALUE" }),
+    });
+    await doStore.put("envelope:e_1", { encoding: "json", bytes: enc("PLAINTEXT-MAIL-BODY") });
+
+    const created = await createBackup([doStore], TEST_KEY);
+    const serializedArchive = JSON.stringify(created.archive);
+    const verify = await verifyBackup(created.archive!, TEST_KEY);
+    const serializedReport = JSON.stringify(verify);
+
+    expect(serializedArchive).not.toContain("alice@example.com");
+    expect(serializedArchive).not.toContain("SECRET-SEED-VALUE");
+    expect(serializedArchive).not.toContain("PLAINTEXT-MAIL-BODY");
+    expect(serializedReport).not.toContain("alice@example.com");
+    expect(serializedReport).not.toContain("SECRET-SEED-VALUE");
+  });
+
+  it("fails closed on a tampered archive", async () => {
+    const doStore = createMemoryBackupStorage("durable-object");
+    await doStore.put("user:id:u_1", { encoding: "json", bytes: enc({ userId: "u_1" }) });
+
+    const created = await createBackup([doStore], TEST_KEY);
+    const tampered = {
+      ...created.archive!,
+      ciphertext: "AAAA" + created.archive!.ciphertext.slice(4),
+    };
+
+    const verify = await verifyBackup(tampered, TEST_KEY);
+    expect(verify.ok).toBe(false);
+    expect(verify.errors[0]).toContain("authentication failed");
+
+    const target = createMemoryBackupStorage("durable-object");
+    const restore = await restoreBackup(tampered, TEST_KEY, [target]);
+    expect(restore.ok).toBe(false);
+    expect(await target.listKeys()).toEqual([]);
+  });
+
+  it("fails closed on a wrong key", async () => {
+    const doStore = createMemoryBackupStorage("durable-object");
+    await doStore.put("user:id:u_1", { encoding: "json", bytes: enc({ userId: "u_1" }) });
+
+    const created = await createBackup([doStore], TEST_KEY);
+    const wrongKey = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+    const verify = await verifyBackup(created.archive!, wrongKey);
+    expect(verify.ok).toBe(false);
+  });
+
+  it("restores in documented order: identity before policy before relay before r2", async () => {
+    const order: string[] = [];
+    const trackingStore = createMemoryBackupStorage("durable-object");
+    const originalPut = trackingStore.put.bind(trackingStore);
+    trackingStore.put = async (key, value) => {
+      order.push(key);
+      await originalPut(key, value);
+    };
+
+    await trackingStore.put("user:id:u_1", { encoding: "json", bytes: enc({ userId: "u_1" }) });
+    await trackingStore.put("policy:p_1", { encoding: "json", bytes: enc({ policyId: "p_1" }) });
+    await trackingStore.put("relay:message:m_1", {
+      encoding: "json",
+      bytes: enc({ messageId: "m_1" }),
+    });
+    await trackingStore.put("idempotency:op_1", {
+      encoding: "json",
+      bytes: enc({ status: "done" }),
+    });
+
+    const created = await createBackup([trackingStore], TEST_KEY);
+    const target = createMemoryBackupStorage("durable-object");
+    await restoreBackup(created.archive!, TEST_KEY, [target]);
+
+    expect(order.indexOf("user:id:u_1")).toBeLessThan(order.indexOf("policy:p_1"));
+    expect(order.indexOf("policy:p_1")).toBeLessThan(order.indexOf("relay:message:m_1"));
+    expect(order.indexOf("relay:message:m_1")).toBeLessThan(order.indexOf("idempotency:op_1"));
+  });
+});

--- a/tests/unit/backup/miniflare.test.ts
+++ b/tests/unit/backup/miniflare.test.ts
@@ -1,0 +1,214 @@
+import { build } from "esbuild";
+import { Miniflare } from "miniflare";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const NULL_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const MINIFLARE_TEST_TIMEOUT_MS = 30_000;
+const TEST_KEY = "P8xR0aS+0GBVOV4VXLnR/hNUBS8yADrMXjo1St6pL+0=";
+
+let code: string;
+let mf: Miniflare;
+
+beforeAll(async () => {
+  const result = await build({
+    entryPoints: ["src/server/backup/worker.ts"],
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    target: "es2022",
+    external: ["cloudflare:workers"],
+    write: false,
+    logLevel: "silent",
+  });
+  code = result.outputFiles[0].text;
+});
+
+beforeEach(() => {
+  mf = new Miniflare({
+    modules: true,
+    script: code,
+    compatibilityDate: "2025-09-24",
+    compatibilityFlags: ["nodejs_compat"],
+    durableObjects: { STEALTH_COORDINATOR: "StealthCoordinator" },
+    kvNamespaces: { STEALTH_KV: "local-emulation-kv" },
+    r2Buckets: { STEALTH_OBJECT_STORE: "local-emulation-r2" },
+  });
+});
+
+afterEach(async () => {
+  await mf.dispose();
+});
+
+async function seed(records: Array<{ key: string; value: unknown }>) {
+  const ns: any = await mf.getDurableObjectNamespace("STEALTH_COORDINATOR");
+  const stub = ns.get(ns.idFromName("global-stealth-coordinator"));
+  await stub._debugSeed(records);
+}
+
+async function run(command: string, options: Record<string, unknown> = {}, archive?: unknown) {
+  const res = await mf.dispatchFetch("http://localhost/backup", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ command, options: { key: TEST_KEY, ...options }, archive }),
+  });
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+async function seedAll() {
+  await seed([
+    {
+      key: "user:id:u_1",
+      value: {
+        $v: 1,
+        userId: "u_1",
+        address: NULL_ADDRESS,
+        email: "alice@example.com",
+        username: "alice",
+        status: "active",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: 1,
+      },
+    },
+    { key: "user:email:alice@example.com", value: "u_1" },
+    { key: "user:username:alice", value: "u_1" },
+    { key: `user:address:${NULL_ADDRESS}`, value: "u_1" },
+    {
+      key: "session:s_1",
+      value: {
+        $v: 1,
+        sessionId: "s_1",
+        userId: "u_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      },
+    },
+    {
+      key: "policy:p_1",
+      value: {
+        $v: 1,
+        policyId: "p_1",
+        userId: "u_1",
+        title: "Inbox rules",
+        rules: [],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    },
+    {
+      key: "idempotency:op_1",
+      value: {
+        $v: 1,
+        key: "op_1",
+        operation: "send",
+        status: "completed",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  ]);
+  const kv: any = await mf.getKVNamespace("STEALTH_KV");
+  await kv.put(
+    "sender-rule:sr_1",
+    JSON.stringify({ ruleId: "sr_1", userId: "u_1", pattern: "spam" }),
+  );
+  await kv.put(
+    "relay:message:msg_1",
+    JSON.stringify({ messageId: "msg_1", recipient: "bob@example.com" }),
+  );
+  const r2: any = await mf.getR2Bucket("STEALTH_OBJECT_STORE");
+  await r2.put("envelopes/m1/aaaa", new TextEncoder().encode("encrypted-envelope-bytes"));
+}
+
+describe("backup worker (local Cloudflare emulation)", () => {
+  it(
+    "rejects non-backup routes and missing commands",
+    async () => {
+      const missing = await mf.dispatchFetch("http://localhost/other");
+      expect(missing.status).toBe(404);
+
+      const bad = await mf.dispatchFetch("http://localhost/backup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      expect(bad.status).toBe(400);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "creates an encrypted archive covering all three stores and verifies it",
+    async () => {
+      await seedAll();
+      const { status, body } = await run("create");
+
+      expect(status).toBe(200);
+      expect(body.command).toBe("create");
+      expect(body.ok).toBe(true);
+      expect(body.archive.format).toBe("stealth-backup");
+      expect(body.archive.encryption.cipher).toBe("AES-256-GCM");
+      expect(body.stores.map((s: any) => s.store).sort()).toEqual(["durable-object", "kv", "r2"]);
+      expect(body.stores.reduce((n: number, s: any) => n + s.count, 0)).toBe(10);
+
+      const serialized = JSON.stringify(body.archive);
+      expect(serialized).not.toContain("alice@example.com");
+      expect(serialized).not.toContain("encrypted-envelope-bytes");
+      expect(serialized).not.toContain("u_1");
+
+      const verify = await run("verify", {}, body.archive);
+      expect(verify.body.ok).toBe(true);
+      expect(verify.body.verified).toBe(10);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "wipes, restores, and re-verifies without double side effects",
+    async () => {
+      await seedAll();
+      const created = await run("create");
+      const archive = created.body.archive;
+
+      const restored = await run("restore", { wipeFirst: true }, archive);
+      expect(restored.body.ok).toBe(true);
+      expect(restored.body.restored).toBe(10);
+
+      const ns: any = await mf.getDurableObjectNamespace("STEALTH_COORDINATOR");
+      const stub = ns.get(ns.idFromName("global-stealth-coordinator"));
+      const doKeys = await stub.listKeys("");
+      expect(doKeys).toContain("user:id:u_1");
+      expect(doKeys).toContain("idempotency:op_1");
+      expect(doKeys).toContain("policy:p_1");
+
+      const kv: any = await mf.getKVNamespace("STEALTH_KV");
+      expect(await kv.get("relay:message:msg_1")).toBe(
+        JSON.stringify({ messageId: "msg_1", recipient: "bob@example.com" }),
+      );
+      const r2: any = await mf.getR2Bucket("STEALTH_OBJECT_STORE");
+      const obj = await r2.get("envelopes/m1/aaaa");
+      expect(obj).not.toBeNull();
+      expect(new TextDecoder().decode(await obj!.arrayBuffer())).toBe("encrypted-envelope-bytes");
+
+      const verifyAfter = await run("verify", {}, archive);
+      expect(verifyAfter.body.ok).toBe(true);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "list reports per-store key counts",
+    async () => {
+      await seedAll();
+      const { body } = await run("list");
+      expect(body.command).toBe("list");
+      const doCount = body.stores.find((s: any) => s.store === "durable-object").keys;
+      const kvCount = body.stores.find((s: any) => s.store === "kv").keys;
+      const r2Count = body.stores.find((s: any) => s.store === "r2").keys;
+      expect(doCount).toBe(7);
+      expect(kvCount).toBe(2);
+      expect(r2Count).toBe(1);
+    },
+    MINIFLARE_TEST_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
Closes #1988

## Summary

Adds encrypted backups and tested restore procedures for the beta data stores (BETA-081).

- **Backup engine** (`src/server/backup/`): `create`, `verify`, `restore` over a storage-agnostic surface covering the three beta stores — Durable Object identity records (`STEALTH_COORDINATOR`), KV mirror/cache (`STEALTH_KV`), and R2 encrypted payloads (`STEALTH_OBJECT_STORE`).
- **Encryption**: archives are sealed with **AES-256-GCM** under a dedicated `STEALTH_BACKUP_KEY` (base64, 32 bytes), derived via HKDF-SHA256 bound to the `stealth-backup-v1` purpose label. The header is plaintext but carries only non-sensitive metadata plus a non-secret `keyId`; the integrity manifest (per-entry SHA-256 digest) and all entries live inside the AEAD ciphertext. Header fields are bound as AAD, so tampering fails authentication.
- **Integrity manifests**: `verify` authenticates the seal and recomputes every digest, failing closed on tampering or a wrong key.
- **Restoration order**: entries restore in the documented stage order — identity & sessions → policy & sender rules → relay metadata & job state → object storage — so dependent records exist before they are referenced.
- **No double side effects**: restore performs raw key/value writes (never application replay), so `idempotency:` and `counter:` records are restored verbatim and already-processed messages stay recognized as duplicates.
- **No plaintext**: keys are fingerprinted in manifests/reports (never echoed), and wallet seeds / decrypted mail are never present — seeds are stored as managed-wallet envelopes, mail bodies as encrypted R2 payloads, and the archive is additionally AEAD-sealed.
- **CLI** (`scripts/backup/backup.mjs`): `create`, `verify`, `restore`, `list`, and a documented `rehearsal` (seed → create → verify → wipe → restore → verify) run against Miniflare emulation, with `npm run backup:*` scripts.
- **Docs**: `docs/deployment/BACKUPS.md` runbook (scope, encryption, rotation/access control, schedules, retention, restoration order, RTO ≤ 30 min / RPO ≤ 24 h targets, rehearsal evidence); `SECRETS.md` inventory gains `STEALTH_BACKUP_KEY`; `RELEASE_GATES.md` restore-rehearsal gate references the runbook.
- **Tests**: `tests/unit/backup/engine.test.ts` (round-trip, idempotency preservation, tamper/wrong-key fail-closed, restore order, no-plaintext assertions) and `tests/unit/backup/miniflare.test.ts` (full Miniflare seed → create → verify → wipe → restore → verify across all three stores).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 195 files / 2302 tests pass (incl. new backup suites)
- `npm run build` — clean
- `npm run backup:rehearsal` — full local rehearsal passes (10 entries create/verify/restore)

## Note on dependencies

Dependency #1952 (BETA-045) remains open; per the issue's instruction we are not signing off on the entire issue while a dependency is incomplete. This PR independently delivers the encrypted-backup and tested-restore scope.