### PR TITLE
feat(web): typed web data-access layer (BETA-051) — remove direct mock coupling

### DIFF
--- a/src/components/mail/AuthModal.tsx
+++ b/src/components/mail/AuthModal.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { KeyRound, Lock, User, AlertCircle, CheckCircle2, X, Mail } from "lucide-react";
 
+import { sharedTypedApi as api, ApiClientError, errorLabel } from "@/lib/api";
+
 export interface AuthModalProps {
   open: boolean;
   onClose: () => void;
@@ -42,35 +44,24 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch("/api/v1/auth/register", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            displayName,
-            email,
-            username,
-            password,
-            passwordConfirmation,
-            termsVersion: "2026-01",
-            privacyPolicyVersion: "2026-01",
-          }),
+        const registration = await api.auth.register({
+          displayName,
+          email,
+          username,
+          password,
+          passwordConfirmation,
+          termsVersion: "2026-01",
+          privacyPolicyVersion: "2026-01",
         });
-        const data = await res.json();
-        if (!res.ok) {
-          const fieldError = data.error?.details?.validationErrors?.[0]?.message;
-          setError(
-            fieldError ||
-              data.error?.message ||
-              "We could not create your account. Please try again.",
-          );
-          setLoading(false);
-          return;
-        }
-        setRegisteredEmail(data.data.maskedEmail);
+        setRegisteredEmail(registration.maskedEmail);
         setSuccess(true);
         setLoading(false);
-      } catch {
-        setError("Unable to connect to the registration server. Please try again.");
+      } catch (caught) {
+        if (caught instanceof ApiClientError) {
+          setError(errorLabel(caught));
+        } else {
+          setError("Unable to connect to the registration server. Please try again.");
+        }
         setLoading(false);
       }
       return;
@@ -84,43 +75,35 @@ export function AuthModal({ open, onClose, onSuccess }: AuthModalProps) {
     setError(null);
 
     try {
-      const res = await fetch("/api/v1/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ identifier, password }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        if (res.status === 429) {
-          setError("Too many failed login attempts. Please try again later.");
-        } else if (res.status === 403) {
-          if (data.error?.code === "unverified_account") {
-            setError("Your account is pending verification. Please verify your email.");
-          } else if (data.error?.code === "account_suspended") {
-            setError("Your account has been suspended. Please contact support.");
-          } else if (data.error?.code === "account_deactivated") {
-            setError("Your account is deactivated.");
-          } else {
-            setError(data.error?.message || "Access forbidden.");
-          }
-        } else {
-          setError(data.error?.message || "Invalid email/username or password.");
-        }
-        setLoading(false);
-        return;
-      }
+      const bundle = await api.auth.login({ identifier, password });
 
       setSuccess(true);
       setTimeout(() => {
         setLoading(false);
         setSuccess(false);
-        onSuccess(data.data.user);
+        onSuccess(bundle.user);
         onClose();
       }, 600);
-    } catch (err: unknown) {
-      setError("Unable to connect to login server. Please try again.");
+    } catch (caught) {
+      if (caught instanceof ApiClientError) {
+        if (caught.status === 429) {
+          setError("Too many failed login attempts. Please try again later.");
+        } else if (caught.status === 403) {
+          if (caught.code === "unverified_account") {
+            setError("Your account is pending verification. Please verify your email.");
+          } else if (caught.code === "account_suspended") {
+            setError("Your account has been suspended. Please contact support.");
+          } else if (caught.code === "account_deactivated") {
+            setError("Your account is deactivated.");
+          } else {
+            setError(caught.message || "Access forbidden.");
+          }
+        } else {
+          setError(caught.message || "Invalid email/username or password.");
+        }
+      } else {
+        setError("Unable to connect to login server. Please try again.");
+      }
       setLoading(false);
     }
   };

--- a/src/components/mail/SettingsModal.tsx
+++ b/src/components/mail/SettingsModal.tsx
@@ -22,6 +22,7 @@ import {
 import { useState, useEffect, useRef, useMemo, useCallback, type CSSProperties } from "react";
 import { Surface } from "@/features/design-system";
 import { cn } from "@/lib/utils";
+import { sharedTypedApi } from "@/lib/api";
 import { SHORTCUT_DEFINITIONS } from "@/features/command-palette";
 import type { ReceiptPreference, UiPreferences, LayoutPreferences } from "@/features/preferences";
 import {
@@ -1290,7 +1291,7 @@ function SecuritySettings() {
                 description: "This will revoke all active sessions across all devices.",
                 onConfirm: async () => {
                   try {
-                    await fetch("/api/v1/auth/logout-all", { method: "POST" });
+                    await sharedTypedApi.auth.logoutAll();
                   } catch {
                     // Fallthrough safely
                   }
@@ -1333,9 +1334,7 @@ function SecuritySettings() {
                       description: "This will sign out this device from your account.",
                       onConfirm: async () => {
                         try {
-                          await fetch("/api/v1/auth/logout", {
-                            method: "POST",
-                          });
+                          await sharedTypedApi.auth.logout();
                         } catch {
                           // Fallthrough safely
                         }

--- a/src/features/compose/usePostageQuote.ts
+++ b/src/features/compose/usePostageQuote.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
+import { sharedTypedApi as api, errorLabel, normalizeApiClientError } from "@/lib/api";
+
 /**
  * The shape returned by the server's `quotePostage` function.
  * Mirrors `{ amount, eligible, reason, trusted, ... }` plus the authenticated
@@ -52,15 +54,12 @@ export type PostageQuoteState =
 const DEBOUNCE_MS = 400;
 
 /**
- * Fetches a postage quote from the policy API whenever `recipient` or `sender`
- * changes. Uses a 400 ms debounce and cancels stale requests via AbortController.
+ * Fetches a postage quote through the typed postage client whenever
+ * `recipient` or `sender` changes. Uses a 400 ms debounce and cancels stale
+ * requests via AbortController.
  *
  * On API failure the hook returns `{ status: "error" }` — callers should show a
  * non-blocking warning rather than preventing send entirely.
- *
- * @param recipient Recipient address (any format accepted by the compose form)
- * @param sender    Sender's Stellar G-address
- * @param messageId Message identity the quote must be bound to (BETA-039)
  */
 export function usePostageQuote(
   recipient: string,
@@ -92,36 +91,24 @@ export function usePostageQuote(
       setQuoteState({ status: "loading" });
 
       try {
-        const params = new URLSearchParams({
-          recipient: trimmedRecipient,
-          sender: trimmedSender,
-        });
-        if (trimmedMessageId) {
-          params.set("messageId", trimmedMessageId);
-        }
-        const response = await fetch(`/api/postage/quote?${params.toString()}`, {
-          signal: controller.signal,
-        });
+        const quote = await api.postage.quote(
+          {
+            recipient: trimmedRecipient,
+            sender: trimmedSender,
+            messageId: trimmedMessageId || undefined,
+          },
+          controller.signal,
+        );
 
         if (controller.signal.aborted) return;
 
-        if (!response.ok) {
-          const text = await response.text().catch(() => "Unknown error");
-          setQuoteState({
-            status: "error",
-            message: text || `HTTP ${response.status}`,
-          });
-          return;
-        }
-
-        const quote = (await response.json()) as PostageQuote;
         setQuoteState({ status: "quoted", quote });
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
           // Request was intentionally aborted — don't update state
           return;
         }
-        const message = err instanceof Error ? err.message : "Failed to fetch postage quote";
+        const message = errorLabel(normalizeApiClientError(err));
         setQuoteState({ status: "error", message });
       }
     }, DEBOUNCE_MS);

--- a/src/features/identity/auth-pages.tsx
+++ b/src/features/identity/auth-pages.tsx
@@ -6,9 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
-type ApiFailure = {
-  error?: { message?: string; details?: { validationErrors?: Array<{ message?: string }> } };
-};
+import { sharedTypedApi as api, errorLabel, ApiClientError } from "@/lib/api";
 
 function safeDestination(destination?: string) {
   return destination?.startsWith("/") && !destination.startsWith("//") ? destination : "/";
@@ -49,37 +47,26 @@ export function SignUpPage({ destination }: { destination?: string }) {
     setPending(true);
     setError(null);
     try {
-      const response = await fetch("/api/v1/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          displayName: form.get("displayName"),
-          email: form.get("email"),
-          username: form.get("username"),
-          password,
-          passwordConfirmation: confirmation,
-          termsVersion: "2026-01",
-          privacyPolicyVersion: "2026-01",
-        }),
+      const registration = await api.auth.register({
+        displayName: String(form.get("displayName") ?? ""),
+        email: String(form.get("email") ?? ""),
+        username: String(form.get("username") ?? ""),
+        password,
+        passwordConfirmation: confirmation,
+        termsVersion: "2026-01",
+        privacyPolicyVersion: "2026-01",
       });
-      const payload = (await response.json()) as { data?: { maskedEmail?: string } } & ApiFailure;
-      if (!response.ok)
-        throw new Error(
-          payload.error?.details?.validationErrors?.[0]?.message ??
-            payload.error?.message ??
-            "We could not create your account. Please try again.",
-        );
       await navigate({
         to: "/auth/verify",
         search: {
-          email: payload.data?.maskedEmail ?? "your email",
+          email: registration.maskedEmail ?? "your email",
           next: safeDestination(destination),
         },
       });
     } catch (cause) {
       setError(
-        cause instanceof Error
-          ? cause.message
+        cause instanceof ApiClientError
+          ? errorLabel(cause)
           : "We could not create your account. Please try again.",
       );
     } finally {
@@ -161,25 +148,20 @@ export function SignInPage({ destination }: { destination?: string }) {
     setPending(true);
     setError(null);
     try {
-      const response = await fetch("/api/v1/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          identifier: form.get("identifier"),
-          password: form.get("password"),
-        }),
+      await api.auth.login({
+        identifier: String(form.get("identifier") ?? ""),
+        password: String(form.get("password") ?? ""),
       });
-      const payload = (await response.json()) as ApiFailure;
-      if (!response.ok)
-        throw new Error(
-          response.status === 403
-            ? "Your account needs email verification before you can sign in."
-            : (payload.error?.message ?? "Invalid email, username, or password."),
-        );
       window.location.assign(safeDestination(destination));
     } catch (cause) {
       setError(
-        cause instanceof Error ? cause.message : "We could not sign you in. Please try again.",
+        cause instanceof ApiClientError
+          ? cause.status === 403
+            ? "Your account needs email verification before you can sign in."
+            : cause.status === 401
+              ? "Invalid email, username, or password."
+              : errorLabel(cause)
+          : "We could not sign you in. Please try again.",
       );
     } finally {
       setPending(false);

--- a/src/features/mail/demo/demo-data.ts
+++ b/src/features/mail/demo/demo-data.ts
@@ -1,0 +1,14 @@
+// BETA-051 (Issue #1958) — isolated demo mailbox adapter.
+//
+// The app shell's production path must have no route to the demo fixtures.
+// This adapter owns the mock data import and is only wired in by explicit
+// development stories/tests (see `src/routes/index.tsx` demo branch and the
+// mail feature tests). Production builds never import this module.
+
+import { emails as mockEmails } from "@/components/mail/data";
+import type { Email } from "@/components/mail/data";
+
+/** The demo mailbox fixture list. Never referenced from the production shell. */
+export function getDemoEmails(): Email[] {
+  return mockEmails;
+}

--- a/src/features/mail/index.ts
+++ b/src/features/mail/index.ts
@@ -1,0 +1,18 @@
+// BETA-051 (Issue #1958) — typed web data-access hooks for the mail feature.
+// Components import these (or the `@/lib/api` clients directly) instead of
+// calling `fetch`. Demo fixtures are isolated behind `src/features/mail/demo`
+// so the production app shell never reaches them.
+
+export { useSession, useLogout, sessionActor } from "./useSession";
+export {
+  useMailbox,
+  useTombstoneMessage,
+  mailboxDescriptorToEmail,
+  mailboxQueueToEmails,
+} from "./useMailbox";
+export type { UseMailboxOptions } from "./useMailbox";
+export { useRequests, useSenderRequestDecision } from "./useRequests";
+export { useContacts, useCreateContact } from "./useContacts";
+export { useMailboxPolicy, useUpdateMailboxPolicy } from "./usePolicy";
+export { useMailboxSettings, useUpdateMailboxSettings } from "./useSettings";
+export type { MailboxSettings } from "./useSettings";

--- a/src/features/mail/useContacts.ts
+++ b/src/features/mail/useContacts.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed contact hooks.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { Contact, ContactCreateInput } from "@/lib/api";
+
+/** Lists the authenticated actor's contacts through the typed contacts client. */
+export function useContacts(actor: string | null, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.contacts.list(actor ?? "anonymous"),
+    queryFn: ({ signal }) => api.contacts.list({}, signal),
+    enabled: Boolean(actor) && enabled,
+  });
+}
+
+/** Creates a contact and invalidates the contact list cache. */
+export function useCreateContact(actor: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<Contact, Error, ContactCreateInput>({
+    mutationFn: (input) => api.contacts.create(input),
+    onSuccess: async () => {
+      for (const key of cacheInvalidations.createContact(actor ?? "anonymous")) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+}

--- a/src/features/mail/useMailbox.ts
+++ b/src/features/mail/useMailbox.ts
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed mailbox queue hook.
+//
+// Consumes the typed mailbox client and maps the live queue to the display
+// `Email` model used by the app shell. Full header/body sync is owned by
+// BETA-034 (Issue #1941); this hook is the typed read path the shell renders
+// from today.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { MailboxDescriptor, MailboxQueueResponse } from "@/lib/api";
+import type { Email, MailLocation } from "@/components/mail/data";
+
+export interface UseMailboxOptions {
+  /** Authenticated actor (Stellar G-address) owning the mailbox. */
+  actor: string;
+  enabled?: boolean;
+}
+
+/** Maps a server mailbox descriptor into the shell's display `Email` shape. */
+export function mailboxDescriptorToEmail(descriptor: MailboxDescriptor): Email {
+  const headers = descriptor.protectedHeaders ?? {};
+  const subject =
+    typeof headers.subject === "string" && headers.subject.trim()
+      ? headers.subject
+      : "Encrypted message";
+  const from =
+    typeof headers.from === "string" && headers.from.trim() ? headers.from : descriptor.senderId;
+  const created = new Date(descriptor.createdAt);
+  const time = Number.isNaN(created.getTime())
+    ? descriptor.createdAt
+    : created.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+
+  const folder: MailLocation = descriptor.isTombstone
+    ? "trash"
+    : descriptor.status === "pending"
+      ? "pending"
+      : "inbox";
+
+  return {
+    id: descriptor.messageId,
+    from,
+    email: descriptor.senderId,
+    subject,
+    preview: descriptor.isTombstone ? "This message was deleted." : "Encrypted payload",
+    body: "",
+    time,
+    unread: descriptor.status === "pending",
+    starred: false,
+    folder,
+    labels: descriptor.isTombstone ? ["Deleted"] : [],
+    attachments: [],
+    avatarColor: "#5b6470",
+    verifiedSender: false,
+  };
+}
+
+/** Maps a typed queue response page into the shell's display `Email` list. */
+export function mailboxQueueToEmails(response: MailboxQueueResponse): Email[] {
+  return response.items.map(mailboxDescriptorToEmail);
+}
+
+/**
+ * Reads the authenticated recipient's mailbox queue through the typed client.
+ * The live path renders server descriptors; the demo/storybook path uses a
+ * mock adapter instead (see `src/features/mail/demo-data.ts`).
+ */
+export function useMailbox({ actor, enabled = true }: UseMailboxOptions) {
+  return useQuery({
+    queryKey: queryKeys.mailbox.queue(actor),
+    queryFn: ({ signal }) => api.mailbox.listQueue({}, signal),
+    enabled,
+    select: mailboxQueueToEmails,
+  });
+}
+
+/** Tombstones a message in the live mailbox and invalidates the queue cache. */
+export function useTombstoneMessage(actor: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (messageId: string) => api.mailbox.tombstone(messageId),
+    onSuccess: async () => {
+      for (const key of cacheInvalidations.tombstoneMessage(actor)) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+}

--- a/src/features/mail/usePolicy.ts
+++ b/src/features/mail/usePolicy.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed mailbox policy hook.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { MailboxPolicy, MailboxPolicyWrite } from "@/lib/api";
+
+/** Reads the mailbox policy for an owner through the typed policies client. */
+export function useMailboxPolicy(owner: string | null, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.policies.policy(owner ?? "anonymous"),
+    queryFn: ({ signal }) => api.policies.get(owner ?? "", signal),
+    enabled: Boolean(owner) && enabled,
+  });
+}
+
+/** Updates the mailbox policy and invalidates policy + settings caches. */
+export function useUpdateMailboxPolicy(owner: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<MailboxPolicy, Error, MailboxPolicyWrite>({
+    mutationFn: (policy) => api.policies.update(owner ?? "", policy),
+    onSuccess: async () => {
+      for (const key of cacheInvalidations.updateMailboxPolicy(owner ?? "anonymous")) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+}

--- a/src/features/mail/useRequests.ts
+++ b/src/features/mail/useRequests.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed sender-request hooks.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { UnknownSenderDecision, UnknownSenderRequest } from "@/lib/api";
+
+/**
+ * Reads the pending unknown-sender requests awaiting the actor's decision,
+ * through the typed requests client.
+ */
+export function useRequests(actor: string | null, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.requests.list(actor ?? "anonymous"),
+    queryFn: ({ signal }) => api.requests.list(signal),
+    enabled: Boolean(actor) && enabled,
+  });
+}
+
+/** Decides a pending sender request and invalidates dependent queries. */
+export function useSenderRequestDecision(actor: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    UnknownSenderRequest,
+    Error,
+    { requestId: string; decision: UnknownSenderDecision }
+  >({
+    mutationFn: ({ requestId, decision }) => api.requests.decide(requestId, decision),
+    onSuccess: async () => {
+      for (const key of cacheInvalidations.senderRequestDecision(actor ?? "anonymous")) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+}

--- a/src/features/mail/useSession.ts
+++ b/src/features/mail/useSession.ts
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed session hook.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { SessionBundle } from "@/lib/api";
+
+export interface UseSessionOptions {
+  /** Disables the query entirely (e.g. while an account is unauthenticated). */
+  enabled?: boolean;
+}
+
+/**
+ * Reads the active authenticated session through the typed auth client. The
+ * server extends the session cookie on each read, so the query uses a
+ * moderate staleTime and never fires when explicitly disabled.
+ */
+export function useSession(options: UseSessionOptions = {}) {
+  return useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: ({ signal }) => api.auth.getSession(signal),
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+    enabled: options.enabled ?? true,
+  });
+}
+
+/** Logs the current session out and invalidates the session query. */
+export function useLogout() {
+  const queryClient = useQueryClient();
+
+  async function logout(): Promise<void> {
+    await api.auth.logout();
+    for (const key of cacheInvalidations.sessionLogout()) {
+      queryClient.removeQueries({ queryKey: key });
+    }
+    await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
+  }
+
+  return { logout };
+}
+
+/** Exposes the session bundle when present, for consumers that need the actor. */
+export function sessionActor(session: SessionBundle | undefined): string | null {
+  return session?.user.address ?? null;
+}

--- a/src/features/mail/useSettings.ts
+++ b/src/features/mail/useSettings.ts
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed mailbox settings hook.
+// ---------------------------------------------------------------------------
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import type { MailboxSettings, MailboxPolicyWrite } from "@/lib/api";
+
+/** Reads mailbox settings (policy surface) through the typed settings client. */
+export function useMailboxSettings(owner: string | null, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.settings.all,
+    queryFn: ({ signal }) => api.settings.read(owner ?? "", signal),
+    enabled: Boolean(owner) && enabled,
+  });
+}
+
+/** Persists mailbox settings changes and invalidates dependent caches. */
+export function useUpdateMailboxSettings(owner: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, MailboxPolicyWrite>({
+    mutationFn: (policy) => api.settings.update(owner ?? "", policy),
+    onSuccess: async () => {
+      for (const key of cacheInvalidations.updateMailboxPolicy(owner ?? "anonymous")) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+}
+
+export type { MailboxSettings };

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed API fetch client.
+//
+// A single typed transport every domain client builds on:
+//   - unwraps the server `{ data, meta }` success envelope,
+//   - parses the `{ error, meta }` failure envelope into `ApiClientError`,
+//   - honors `AbortSignal` (React Query cancellation / user navigation),
+//   - sends a correlation header and forwards `credentials` for session
+//     cookies so no consumer ever calls `fetch` directly.
+// ---------------------------------------------------------------------------
+
+import { ApiClientError, parseErrorEnvelope } from "./errors";
+import type { ApiClientErrorCode } from "./errors";
+
+export interface ApiRequestInit {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined | null>;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+}
+
+export interface ApiMeta {
+  requestId: string;
+  timestamp: string;
+  correlationId?: string;
+}
+
+export interface ApiEnvelope<T> {
+  data: T;
+  meta: ApiMeta;
+}
+
+export interface ApiClientOptions {
+  /** Base URL prefix. Defaults to `/api/v1`. */
+  basePath?: string;
+  /** Correlation id sent as `x-request-id` (validated server-side). */
+  correlationId?: string;
+  /** Hook invoked when a response is 401/403 so callers can refresh a session. */
+  onUnauthorized?: () => void;
+}
+
+const CLIENT_CORRELATION_HEADER = "x-request-id";
+
+export class ApiClient {
+  readonly basePath: string;
+  private readonly correlationId?: string;
+  private readonly onUnauthorized?: () => void;
+
+  constructor(options: ApiClientOptions = {}) {
+    this.basePath = options.basePath ?? "/api/v1";
+    this.correlationId = options.correlationId;
+    this.onUnauthorized = options.onUnauthorized;
+  }
+
+  /** Build the request URL, appending a query string when provided. */
+  private buildUrl(path: string, query?: ApiRequestInit["query"]): string {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const url = `${this.basePath}${normalizedPath}`;
+    if (!query) return url;
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null || value === "") continue;
+      params.set(key, String(value));
+    }
+    const qs = params.toString();
+    return qs ? `${url}?${qs}` : url;
+  }
+
+  async request<T>(path: string, init: ApiRequestInit = {}): Promise<T> {
+    const headers = new Headers(init.headers);
+    if (init.body !== undefined) {
+      headers.set("content-type", "application/json");
+    }
+    if (this.correlationId) {
+      headers.set(CLIENT_CORRELATION_HEADER, this.correlationId);
+    }
+
+    const response = await fetch(this.buildUrl(path, init.query), {
+      method: init.method ?? "GET",
+      headers,
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: init.signal,
+      credentials: "same-origin",
+    });
+
+    const body: unknown = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      const error = parseErrorEnvelope(body, response.status);
+      if (error.status === 401 && this.onUnauthorized) {
+        this.onUnauthorized();
+      }
+      throw error;
+    }
+
+    if (body === null || typeof body !== "object" || !("data" in body)) {
+      throw new ApiClientError({
+        code: "internal_error",
+        message: "Malformed API response",
+        status: response.status,
+        retryable: false,
+        retryClassification: "none",
+      });
+    }
+    return (body as ApiEnvelope<T>).data;
+  }
+
+  get<T>(path: string, init?: ApiRequestInit): Promise<T> {
+    return this.request<T>(path, { ...init, method: "GET" });
+  }
+
+  post<T>(path: string, body?: unknown, init?: ApiRequestInit): Promise<T> {
+    return this.request<T>(path, { ...init, method: "POST", body });
+  }
+
+  put<T>(path: string, body?: unknown, init?: ApiRequestInit): Promise<T> {
+    return this.request<T>(path, { ...init, method: "PUT", body });
+  }
+
+  patch<T>(path: string, body?: unknown, init?: ApiRequestInit): Promise<T> {
+    return this.request<T>(path, { ...init, method: "PATCH", body });
+  }
+
+  delete<T>(path: string, init?: ApiRequestInit): Promise<T> {
+    return this.request<T>(path, { ...init, method: "DELETE" });
+  }
+}
+
+export { ApiClientError, type ApiClientErrorCode };

--- a/src/lib/api/clients.ts
+++ b/src/lib/api/clients.ts
@@ -1,0 +1,302 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed web data-access clients.
+//
+// One typed client per domain (auth, identity, mailbox, request, policy,
+// postage, receipt, proof/relay, contact, settings). Each method maps to a
+// server endpoint and returns typed data from the unwrapped envelope, so
+// components consume interfaces rather than calling `fetch` directly.
+// ---------------------------------------------------------------------------
+
+import { ApiClient } from "./client";
+import type { ApiRequestInit } from "./client";
+import type {
+  Contact,
+  ContactCreateInput,
+  ContactListResponse,
+  DeliveryReceipt,
+  KeyDirectoryRecord,
+  MailboxDescriptor,
+  MailboxPolicy,
+  MailboxPolicyWrite,
+  MailboxQueueResponse,
+  MailboxSettings,
+  PostageQuote,
+  PublicProfile,
+  RegistrationResponse,
+  SessionBundle,
+  UnknownSenderDecision,
+  UnknownSenderRequest,
+} from "./types";
+
+export interface ApiContext {
+  /** Authenticated actor (Stellar G-address) when known. */
+  actor: string | null;
+}
+
+export interface TypedApi {
+  auth: AuthClient;
+  identity: IdentityClient;
+  mailbox: MailboxClient;
+  requests: RequestsClient;
+  policies: PoliciesClient;
+  postage: PostageClient;
+  receipts: ReceiptsClient;
+  contacts: ContactsClient;
+  settings: SettingsClient;
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export interface LoginInput {
+  identifier: string;
+  password: string;
+}
+
+export interface RegistrationInput {
+  displayName: string;
+  email: string;
+  username: string;
+  password: string;
+  passwordConfirmation: string;
+  termsVersion: string;
+  privacyPolicyVersion: string;
+}
+
+export class AuthClient {
+  constructor(private readonly client: ApiClient) {}
+
+  getSession(signal?: AbortSignal): Promise<SessionBundle> {
+    return this.client.get<SessionBundle>("/auth/session", { signal });
+  }
+
+  renewSession(signal?: AbortSignal): Promise<SessionBundle> {
+    return this.client.post<SessionBundle>("/auth/session", undefined, { signal });
+  }
+
+  login(input: LoginInput, signal?: AbortSignal): Promise<SessionBundle> {
+    return this.client.post<SessionBundle>("/auth/login", input, { signal });
+  }
+
+  register(input: RegistrationInput, signal?: AbortSignal): Promise<RegistrationResponse> {
+    return this.client.post<RegistrationResponse>("/auth/register", input, { signal });
+  }
+
+  logout(): Promise<{ success: boolean }> {
+    return this.client.post<{ success: boolean }>("/auth/logout");
+  }
+
+  logoutAll(): Promise<{ success: boolean }> {
+    return this.client.post<{ success: boolean }>("/auth/logout-all");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+export class IdentityClient {
+  constructor(private readonly client: ApiClient) {}
+
+  getProfile(owner: string, signal?: AbortSignal): Promise<PublicProfile> {
+    return this.client.get<PublicProfile>(`/identity/profile/${encodeURIComponent(owner)}`, {
+      signal,
+    });
+  }
+
+  getKeyDirectory(owner: string, signal?: AbortSignal): Promise<KeyDirectoryRecord> {
+    return this.client.get<KeyDirectoryRecord>(`/identity/keys/${encodeURIComponent(owner)}`, {
+      signal,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox
+// ---------------------------------------------------------------------------
+
+export interface MailboxQueueQuery {
+  status?: "pending" | "delivered" | "all";
+  includeTombstones?: boolean;
+  cursor?: string;
+  limit?: number;
+}
+
+export class MailboxClient {
+  constructor(private readonly client: ApiClient) {}
+
+  listQueue(query: MailboxQueueQuery = {}, signal?: AbortSignal): Promise<MailboxQueueResponse> {
+    return this.client.get<MailboxQueueResponse>("/mailbox/queue", {
+      query: {
+        status: query.status ?? "all",
+        includeTombstones: query.includeTombstones,
+        cursor: query.cursor,
+        limit: query.limit,
+      },
+      signal,
+    });
+  }
+
+  tombstone(
+    messageId: string,
+    signal?: AbortSignal,
+  ): Promise<{ messageId: string; tombstoned: boolean }> {
+    return this.client.delete(`/mailbox/${encodeURIComponent(messageId)}`, { signal });
+  }
+
+  getMessage(messageId: string, signal?: AbortSignal): Promise<MailboxDescriptor> {
+    return this.client.get<MailboxDescriptor>(`/mailbox/${encodeURIComponent(messageId)}`, {
+      signal,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sender requests
+// ---------------------------------------------------------------------------
+
+export class RequestsClient {
+  constructor(private readonly client: ApiClient) {}
+
+  list(signal?: AbortSignal): Promise<UnknownSenderRequest[]> {
+    return this.client.get<UnknownSenderRequest[]>("/requests", { signal });
+  }
+
+  decide(
+    requestId: string,
+    decision: UnknownSenderDecision,
+    signal?: AbortSignal,
+  ): Promise<UnknownSenderRequest> {
+    return this.client.post(
+      `/requests/${encodeURIComponent(requestId)}/decisions`,
+      { decision },
+      { signal },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox policies
+// ---------------------------------------------------------------------------
+
+export class PoliciesClient {
+  constructor(private readonly client: ApiClient) {}
+
+  get(owner: string, signal?: AbortSignal): Promise<MailboxPolicy> {
+    return this.client.get<MailboxPolicy>(`/policies/${encodeURIComponent(owner)}`, { signal });
+  }
+
+  update(owner: string, policy: MailboxPolicyWrite, signal?: AbortSignal): Promise<MailboxPolicy> {
+    return this.client.put(`/policies/${encodeURIComponent(owner)}`, policy, { signal });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Postage
+// ---------------------------------------------------------------------------
+
+export interface PostageQuoteQuery {
+  recipient: string;
+  sender: string;
+  messageId?: string;
+}
+
+export class PostageClient {
+  constructor(private readonly client: ApiClient) {}
+
+  quote(query: PostageQuoteQuery, signal?: AbortSignal): Promise<PostageQuote> {
+    return this.client.post<PostageQuote>("/postage/quote", query, { signal });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Receipts & proof
+// ---------------------------------------------------------------------------
+
+export class ReceiptsClient {
+  constructor(private readonly client: ApiClient) {}
+
+  publish(input: DeliveryReceipt, signal?: AbortSignal): Promise<DeliveryReceipt> {
+    return this.client.post<DeliveryReceipt>("/receipts", input, { signal });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// ---------------------------------------------------------------------------
+
+export interface ContactListQuery {
+  query?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export class ContactsClient {
+  constructor(private readonly client: ApiClient) {}
+
+  list(query: ContactListQuery = {}, signal?: AbortSignal): Promise<ContactListResponse> {
+    return this.client.get<ContactListResponse>("/contacts", {
+      query: { query: query.query, limit: query.limit, cursor: query.cursor },
+      signal,
+    });
+  }
+
+  create(input: ContactCreateInput, signal?: AbortSignal): Promise<Contact> {
+    return this.client.post<Contact>("/contacts", input, { signal });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Settings (mailbox policy surface used by the app shell)
+// ---------------------------------------------------------------------------
+
+export class SettingsClient {
+  constructor(
+    private readonly client: ApiClient,
+    private readonly policies: PoliciesClient,
+  ) {}
+
+  async read(owner: string, signal?: AbortSignal): Promise<MailboxSettings> {
+    const policy = await this.policies.get(owner, signal);
+    return { policy, requireReceipt: false };
+  }
+
+  update(owner: string, policy: MailboxPolicyWrite, signal?: AbortSignal): Promise<MailboxPolicy> {
+    return this.policies.update(owner, policy, signal);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateTypedApiOptions {
+  basePath?: string;
+  correlationId?: string;
+  onUnauthorized?: () => void;
+}
+
+export function createTypedApi(options: CreateTypedApiOptions = {}): TypedApi {
+  const client = new ApiClient(options);
+  const policies = new PoliciesClient(client);
+  return {
+    auth: new AuthClient(client),
+    identity: new IdentityClient(client),
+    mailbox: new MailboxClient(client),
+    requests: new RequestsClient(client),
+    policies,
+    postage: new PostageClient(client),
+    receipts: new ReceiptsClient(client),
+    contacts: new ContactsClient(client),
+    settings: new SettingsClient(client, policies),
+  };
+}
+
+/**
+ * Shared client for the default origin. Hooks use this so every query/mutation
+ * shares one transport instead of allocating a client per render.
+ */
+export const sharedTypedApi: TypedApi = createTypedApi();
+
+export type { ApiRequestInit };

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,197 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — normalized public API errors for the web client.
+//
+// The server returns a single error envelope `{ error, meta }` with a stable
+// `code`, a machine `retryClassification`, and an optional `retryAfter`. Every
+// client code path throws `ApiClientError` so UI surfaces can render one
+// consistent vocabulary (unauthorized, rate-limited, offline, timeout, etc.)
+// regardless of which typed client produced the failure.
+// ---------------------------------------------------------------------------
+
+export const API_CLIENT_ERROR_CODES = [
+  "unauthorized",
+  "session_expired",
+  "forbidden",
+  "not_found",
+  "validation_error",
+  "conflict",
+  "rate_limited",
+  "dependency_failure",
+  "payload_too_large",
+  "invalid_state_transition",
+  "bad_request",
+  "internal_error",
+] as const;
+
+export type ApiClientErrorCode = (typeof API_CLIENT_ERROR_CODES)[number];
+
+/**
+ * Retry classification mirrors `src/server/api/errors.ts` so the client can
+ * decide whether a failed mutation is safe to replay.
+ */
+export type ApiRetryClassification = "none" | "transient" | "rate_limited" | "idempotent_only";
+
+export interface ApiClientErrorInit {
+  code: ApiClientErrorCode | string;
+  message: string;
+  status: number;
+  retryable: boolean;
+  retryClassification: ApiRetryClassification;
+  retryAfterSeconds?: number;
+  details?: unknown;
+  requestId?: string;
+}
+
+export class ApiClientError extends Error {
+  readonly name = "ApiClientError" as const;
+  readonly code: string;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly retryClassification: ApiRetryClassification;
+  readonly retryAfterSeconds?: number;
+  readonly details?: unknown;
+  readonly requestId?: string;
+
+  constructor(init: ApiClientErrorInit) {
+    super(init.message);
+    this.code = init.code;
+    this.status = init.status;
+    this.retryable = init.retryable;
+    this.retryClassification = init.retryClassification;
+    this.retryAfterSeconds = init.retryAfterSeconds;
+    this.details = init.details;
+    this.requestId = init.requestId;
+  }
+
+  get isUnauthorized(): boolean {
+    return this.code === "unauthorized" || this.code === "session_expired";
+  }
+
+  get isRetryable(): boolean {
+    return this.retryable;
+  }
+}
+
+export function isApiClientError(value: unknown): value is ApiClientError {
+  return value instanceof ApiClientError;
+}
+
+/** Maps an HTTP status to the canonical public code used across the UI. */
+export function statusToCode(status: number): ApiClientErrorCode {
+  switch (status) {
+    case 401:
+      return "unauthorized";
+    case 403:
+      return "forbidden";
+    case 404:
+      return "not_found";
+    case 409:
+      return "conflict";
+    case 422:
+      return "validation_error";
+    case 429:
+      return "rate_limited";
+    case 413:
+      return "payload_too_large";
+    case 503:
+      return "dependency_failure";
+    case 400:
+      return "bad_request";
+    case 500:
+      return "internal_error";
+    default:
+      return "internal_error";
+  }
+}
+
+/** Normalize any thrown value into an `ApiClientError` for UI consumption. */
+export function normalizeApiClientError(caught: unknown): ApiClientError {
+  if (isApiClientError(caught)) return caught;
+
+  if (caught instanceof DOMException && caught.name === "AbortError") {
+    return new ApiClientError({
+      code: "internal_error",
+      message: "Request was cancelled",
+      status: 0,
+      retryable: false,
+      retryClassification: "none",
+    });
+  }
+
+  if (caught instanceof TypeError && caught.message.includes("fetch")) {
+    return new ApiClientError({
+      code: "dependency_failure",
+      message: "You appear to be offline. Check your connection and retry.",
+      status: 0,
+      retryable: true,
+      retryClassification: "transient",
+    });
+  }
+
+  return new ApiClientError({
+    code: "internal_error",
+    message: caught instanceof Error ? caught.message : "An unexpected error occurred",
+    status: 0,
+    retryable: false,
+    retryClassification: "none",
+  });
+}
+
+/** Parse a server error envelope into a normalized client error. */
+export function parseErrorEnvelope(body: unknown, fallbackStatus: number): ApiClientError {
+  if (body !== null && typeof body === "object" && "error" in body) {
+    const err = (body as { error: Record<string, unknown> }).error;
+    const code = typeof err.code === "string" && err.code ? err.code : statusToCode(fallbackStatus);
+    const message = typeof err.message === "string" && err.message ? err.message : "Request failed";
+    const retryable = err.retryable === true;
+    const retryClassification =
+      typeof err.retryClassification === "string"
+        ? (err.retryClassification as ApiRetryClassification)
+        : retryable
+          ? "transient"
+          : "none";
+    const retryAfterSeconds =
+      typeof err.retryAfter === "number" && err.retryAfter > 0 ? err.retryAfter : undefined;
+    const details = err.details;
+    const requestId =
+      body !== null && typeof body === "object" && "meta" in body
+        ? ((body as { meta: { requestId?: unknown } }).meta.requestId as string | undefined)
+        : undefined;
+    return new ApiClientError({
+      code,
+      message,
+      status: fallbackStatus,
+      retryable,
+      retryClassification,
+      retryAfterSeconds,
+      details,
+      requestId,
+    });
+  }
+  return new ApiClientError({
+    code: statusToCode(fallbackStatus),
+    message: `Request failed with HTTP ${fallbackStatus}`,
+    status: fallbackStatus,
+    retryable: false,
+    retryClassification: "none",
+  });
+}
+
+/** Stable human label for a normalized error, used by inline field/toast copy. */
+export function errorLabel(error: ApiClientError): string {
+  switch (error.code) {
+    case "unauthorized":
+    case "session_expired":
+      return "Your session has expired. Sign in again to continue.";
+    case "rate_limited":
+      return error.retryAfterSeconds
+        ? `Rate limit reached. Try again in ${error.retryAfterSeconds}s.`
+        : "Rate limit reached. Try again shortly.";
+    case "dependency_failure":
+      return "A required service is unavailable. Please retry.";
+    case "validation_error":
+      return "Please fix the highlighted fields and try again.";
+    default:
+      return error.message;
+  }
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed web data-access layer.
+//
+// Public surface for all typed API clients, DTOs, query keys, cache
+// invalidation rules, and normalized errors. Components should import from
+// here (or from `src/features/mail` hooks) and never call `fetch` directly.
+// ---------------------------------------------------------------------------
+
+export {
+  ApiClient,
+  ApiClientError,
+  type ApiClientOptions,
+  type ApiEnvelope,
+  type ApiMeta,
+  type ApiRequestInit,
+} from "./client";
+export {
+  API_CLIENT_ERROR_CODES,
+  errorLabel,
+  isApiClientError,
+  normalizeApiClientError,
+  parseErrorEnvelope,
+  statusToCode,
+  type ApiClientErrorCode,
+  type ApiRetryClassification,
+} from "./errors";
+export { cacheInvalidations, queryKeys } from "./query-keys";
+export {
+  createTypedApi,
+  sharedTypedApi,
+  AuthClient,
+  ContactsClient,
+  IdentityClient,
+  MailboxClient,
+  PoliciesClient,
+  PostageClient,
+  ReceiptsClient,
+  RequestsClient,
+  SettingsClient,
+  type ApiContext,
+  type CreateTypedApiOptions,
+  type TypedApi,
+} from "./clients";
+export type * from "./types";
+export { type MailboxQueueQuery, type PostageQuoteQuery, type ContactListQuery } from "./clients";

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — query keys + cache invalidation rules.
+//
+// Centralizes every React Query key so hooks and mutations share one cache
+// namespace, and documents which mutation invalidates which queries. The
+// factory returns plain tuples (never created inside render) so cache
+// invalidation stays predictable.
+// ---------------------------------------------------------------------------
+
+export const queryKeys = {
+  auth: {
+    all: ["auth"] as const,
+    session: ["auth", "session"] as const,
+  },
+  identity: {
+    all: ["identity"] as const,
+    profile: (owner: string) => ["identity", "profile", owner] as const,
+    keys: (owner: string) => ["identity", "keys", owner] as const,
+  },
+  mailbox: {
+    all: ["mailbox"] as const,
+    queue: (owner: string) => ["mailbox", "queue", owner] as const,
+    message: (messageId: string) => ["mailbox", "message", messageId] as const,
+  },
+  requests: {
+    all: ["requests"] as const,
+    list: (owner: string) => ["requests", owner] as const,
+  },
+  policies: {
+    all: ["policies"] as const,
+    policy: (owner: string) => ["policies", owner] as const,
+    evaluate: (owner: string) => ["policies", "evaluate", owner] as const,
+  },
+  postage: {
+    all: ["postage"] as const,
+    quote: (recipient: string, sender: string) => ["postage", "quote", recipient, sender] as const,
+    byMessage: (messageId: string) => ["postage", "message", messageId] as const,
+  },
+  receipts: {
+    all: ["receipts"] as const,
+    byMessage: (messageId: string) => ["receipts", messageId] as const,
+  },
+  contacts: {
+    all: ["contacts"] as const,
+    list: (owner: string) => ["contacts", owner] as const,
+    detail: (owner: string, contactId: string) => ["contacts", owner, contactId] as const,
+  },
+  settings: {
+    all: ["settings"] as const,
+  },
+} as const;
+
+/** Mutation → query invalidation map. Extend as new mutations are added. */
+export const cacheInvalidations = {
+  sessionLogout: () => [queryKeys.auth.session],
+  sessionRenew: () => [queryKeys.auth.session],
+  updateMailboxPolicy: (owner: string) => [
+    queryKeys.policies.policy(owner),
+    queryKeys.policies.evaluate(owner),
+    queryKeys.settings.all,
+  ],
+  senderRequestDecision: (owner: string) => [
+    queryKeys.requests.list(owner),
+    queryKeys.mailbox.queue(owner),
+  ],
+  createSenderRequest: (owner: string) => [queryKeys.requests.list(owner)],
+  tombstoneMessage: (owner: string) => [queryKeys.mailbox.queue(owner)],
+  rotateKey: (owner: string) => [queryKeys.identity.keys(owner)],
+  createContact: (owner: string) => [queryKeys.contacts.list(owner)],
+  updateContact: (owner: string, contactId: string) => [
+    queryKeys.contacts.list(owner),
+    queryKeys.contacts.detail(owner, contactId),
+  ],
+  deleteContact: (owner: string) => [queryKeys.contacts.list(owner)],
+} as const;

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,243 @@
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — typed web data-access DTOs.
+//
+// Client-side DTOs mirror the server domain schemas (`src/server/api/domain.ts`)
+// so components consume typed interfaces instead of ad-hoc `any` fetches. They
+// are intentionally decoupled from server modules (client bundles must never
+// import `**/server/**`), so they are re-declared here and validated by the
+// contract tests against the OpenAPI examples.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Auth & session
+// ---------------------------------------------------------------------------
+
+export type AccountStatus = "pending_verification" | "active" | "suspended" | "closed" | "invited";
+
+export interface PublicUser {
+  userId: string;
+  address: string;
+  email: string;
+  username: string;
+  status: AccountStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicSession {
+  sessionId: string;
+  userId: string;
+  createdAt: string;
+  expiresAt: string;
+  lastActiveAt: string;
+  absoluteExpiresAt?: string;
+}
+
+export interface SessionBundle {
+  user: PublicUser;
+  session: PublicSession;
+}
+
+export interface RegistrationResponse {
+  accountStatus: "pending_verification";
+  email: string;
+  maskedEmail: string;
+  username: string;
+}
+
+// ---------------------------------------------------------------------------
+// Identity & key directory
+// ---------------------------------------------------------------------------
+
+export interface PublicProfile {
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl?: string | null;
+  bio?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type KeyAlgorithm = "ed25519" | "x25519" | "secp256k1";
+export type KeyPurpose = "encryption" | "signing" | "device";
+export type KeyStatus = "active" | "rotated" | "retired" | "revoked";
+
+export interface PublishedKey {
+  keyId: string;
+  owner: string;
+  algorithm: KeyAlgorithm;
+  purpose: KeyPurpose;
+  publicKey: string;
+  version: number;
+  notBefore: string;
+  notAfter: string;
+  status: KeyStatus;
+  signature: string;
+  createdAt: string;
+  updatedAt: string;
+  revokedAt?: string | null;
+  revocationReason?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface KeyDirectoryRecord {
+  owner: string;
+  currentEncryptionKeyId: string | null;
+  currentSigningKeyId: string | null;
+  keys: PublishedKey[];
+  updatedAt: string;
+  version: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox & messages
+// ---------------------------------------------------------------------------
+
+export type MailboxItemStatus = "pending" | "delivered";
+
+export interface MailboxDescriptor {
+  messageId: string;
+  senderId: string;
+  recipientId: string;
+  status: MailboxItemStatus;
+  createdAt: string;
+  protectedHeaders: Record<string, unknown>;
+  contentCommitment?: string;
+  objectRef?: string;
+  isTombstone: boolean;
+  deletedAt?: string | null;
+}
+
+export interface MailboxQueueResponse {
+  items: MailboxDescriptor[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Sender requests
+// ---------------------------------------------------------------------------
+
+export type UnknownSenderRequestStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "blocked"
+  | "expired";
+
+export type UnknownSenderDecision = "approve_once" | "always_allow" | "reject" | "block" | "expire";
+
+export interface EncryptedMessageReference {
+  messageId: string;
+  envelopeId?: string;
+  ciphertextHash: string;
+}
+
+export interface UnknownSenderRequest {
+  requestId: string;
+  recipient: string;
+  sender: string;
+  message: EncryptedMessageReference;
+  createdAt: string;
+  expiresAt: string;
+  status: UnknownSenderRequestStatus;
+  decidedAt?: string;
+  decision?: UnknownSenderDecision;
+}
+
+// ---------------------------------------------------------------------------
+// Mailbox policy
+// ---------------------------------------------------------------------------
+
+export interface MailboxPolicy {
+  allowUnknown: boolean;
+  minimumPostage: string;
+  requireVerified: boolean;
+}
+
+export interface MailboxPolicyWrite {
+  allowUnknown: boolean;
+  minimumPostage: string;
+  requireVerified: boolean;
+  requireReceipt?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Postage
+// ---------------------------------------------------------------------------
+
+export interface PostageQuote {
+  amount: string;
+  eligible: boolean;
+  reason:
+    | "trusted_sender"
+    | "mailbox_minimum"
+    | "sender_blocked"
+    | "insufficient_balance"
+    | "unknown_senders_disabled"
+    | "verification_required"
+    | "insufficient_postage";
+  trusted: boolean;
+  messageId?: string;
+  asset?: string;
+  policyVersion?: number;
+  network?: string;
+  fee?: { bps: number; amount: string };
+  balance?: { available: string | null; sufficient: boolean | null };
+  retryAfterSeconds?: number;
+  issuedAt?: string;
+  expiresAt?: string;
+  digest?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Receipts & proof
+// ---------------------------------------------------------------------------
+
+export interface DeliveryReceipt {
+  messageId: string;
+  recipient: string;
+  sender: string;
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// ---------------------------------------------------------------------------
+
+export type ContactSource = "manual" | "csv" | "vcard" | "api";
+export type ContactTrust = "default" | "allow" | "block";
+
+export interface Contact {
+  contactId: string;
+  owner: string;
+  name: string;
+  address: string;
+  canonicalAddress: string | null;
+  trust: ContactTrust;
+  source: ContactSource;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
+}
+
+export interface ContactCreateInput {
+  name: string;
+  address: string;
+  trust?: ContactTrust;
+}
+
+export interface ContactListResponse {
+  items: Contact[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Settings & preferences
+// ---------------------------------------------------------------------------
+
+export interface MailboxSettings {
+  policy: MailboxPolicy;
+  requireReceipt: boolean;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,74 +9,69 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
 import { Route as MotionGalleryRouteImport } from './routes/motion-gallery'
 import { Route as PolicyEditorRouteRouteImport } from './routes/policy-editor/route'
-import { Route as AuthSignInRouteImport } from './routes/auth/sign-in'
-import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
-import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
-import { Route as ApiV1OpenapiDotjsonRouteImport } from './routes/api/v1/openapi[.]json'
+import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
+import { Route as AuthSignInRouteImport } from './routes/auth/sign-in'
 import { Route as ApiV1ProtocolRouteImport } from './routes/api/v1/protocol'
-import { Route as ApiV1AccountsIndexRouteImport } from './routes/api/v1/accounts/index'
-import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/accounts/provisioning'
-import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
-import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
-import { Route as ApiV1AuthLogoutAllRouteImport } from './routes/api/v1/auth/logout-all'
-import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
-import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
-import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
-import { Route as ApiV1AuthVerifyRouteImport } from './routes/api/v1/auth/verify'
-import { Route as ApiV1ContactsIndexRouteImport } from './routes/api/v1/contacts/index'
-import { Route as ApiV1ContactsContactIdRouteImport } from './routes/api/v1/contacts/$contactId'
-import { Route as ApiV1ContactsMergeRouteImport } from './routes/api/v1/contacts/merge'
-import { Route as ApiV1DeliveryMessageIdRouteImport } from './routes/api/v1/delivery/$messageId'
-import { Route as ApiV1IdentityResolveRouteImport } from './routes/api/v1/identity/resolve'
-import { Route as ApiV1MailboxMessageIdRouteImport } from './routes/api/v1/mailbox/$messageId'
-import { Route as ApiV1MailboxQueueRouteImport } from './routes/api/v1/mailbox/queue'
-import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
-import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
-import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
-import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
-import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/quote'
-import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts/index'
-import { Route as ApiV1ReceiptsMessageIdRouteImport } from './routes/api/v1/receipts/$messageId'
-import { Route as ApiV1RelayHealthRouteImport } from './routes/api/v1/relay/health'
-import { Route as ApiV1RelayMessagesRouteImport } from './routes/api/v1/relay/messages'
-import { Route as ApiV1RelayReadinessRouteImport } from './routes/api/v1/relay/readiness'
-import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
+import { Route as ApiV1OpenapiDotjsonRouteImport } from './routes/api/v1/openapi[.]json'
+import { Route as ApiV1HealthRouteImport } from './routes/api/v1/health'
 import { Route as ApiV1RequestsIndexRouteImport } from './routes/api/v1/requests/index'
-import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
-import { Route as ApiV1AdminDlqIndexRouteImport } from './routes/api/v1/admin/dlq/index'
-import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
-import { Route as ApiV1AdminJobsIndexRouteImport } from './routes/api/v1/admin/jobs/index'
-import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
-import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/contacts/import/commit'
-import { Route as ApiV1ContactsImportPreviewRouteImport } from './routes/api/v1/contacts/import/preview'
-import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/identity/keys/index'
-import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
-import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/identity/keys/retire'
-import { Route as ApiV1IdentityKeysRevokeRouteImport } from './routes/api/v1/identity/keys/revoke'
-import { Route as ApiV1IdentityKeysRotateRouteImport } from './routes/api/v1/identity/keys/rotate'
-import { Route as ApiV1PoliciesOwnerProvisionRouteImport } from './routes/api/v1/policies/$owner/provision'
-import { Route as ApiV1PoliciesOwnerReconciliationRouteImport } from './routes/api/v1/policies/$owner/reconciliation'
-import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
-import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
-import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
-import { Route as ApiV1RequestsRequestIdDecisionsRouteImport } from './routes/api/v1/requests/$requestId/decisions'
+import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts/index'
+import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
+import { Route as ApiV1ContactsIndexRouteImport } from './routes/api/v1/contacts/index'
+import { Route as ApiV1AccountsIndexRouteImport } from './routes/api/v1/accounts/index'
+import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
+import { Route as ApiV1RelayReadinessRouteImport } from './routes/api/v1/relay/readiness'
+import { Route as ApiV1RelayMessagesRouteImport } from './routes/api/v1/relay/messages'
+import { Route as ApiV1RelayHealthRouteImport } from './routes/api/v1/relay/health'
+import { Route as ApiV1ReceiptsMessageIdRouteImport } from './routes/api/v1/receipts/$messageId'
+import { Route as ApiV1PostageQuoteRouteImport } from './routes/api/v1/postage/quote'
+import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/postage/$messageId'
+import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
+import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
+import { Route as ApiV1MailboxQueueRouteImport } from './routes/api/v1/mailbox/queue'
+import { Route as ApiV1MailboxMessageIdRouteImport } from './routes/api/v1/mailbox/$messageId'
+import { Route as ApiV1IdentityResolveRouteImport } from './routes/api/v1/identity/resolve'
+import { Route as ApiV1DeliveryMessageIdRouteImport } from './routes/api/v1/delivery/$messageId'
+import { Route as ApiV1ContactsMergeRouteImport } from './routes/api/v1/contacts/merge'
+import { Route as ApiV1ContactsContactIdRouteImport } from './routes/api/v1/contacts/$contactId'
+import { Route as ApiV1AuthVerifyRouteImport } from './routes/api/v1/auth/verify'
+import { Route as ApiV1AuthSessionRouteImport } from './routes/api/v1/auth/session'
+import { Route as ApiV1AuthResendVerificationRouteImport } from './routes/api/v1/auth/resend-verification'
+import { Route as ApiV1AuthRegisterRouteImport } from './routes/api/v1/auth/register'
+import { Route as ApiV1AuthLogoutAllRouteImport } from './routes/api/v1/auth/logout-all'
+import { Route as ApiV1AuthLogoutRouteImport } from './routes/api/v1/auth/logout'
+import { Route as ApiV1AuthLoginRouteImport } from './routes/api/v1/auth/login'
+import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/accounts/provisioning'
 import { Route as ApiV1WalletLinkIndexRouteImport } from './routes/api/v1/wallet/link/index'
-import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
-import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
+import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/identity/keys/index'
+import { Route as ApiV1AdminJobsIndexRouteImport } from './routes/api/v1/admin/jobs/index'
+import { Route as ApiV1AdminDlqIndexRouteImport } from './routes/api/v1/admin/dlq/index'
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
-import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
-import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
+import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
+import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
+import { Route as ApiV1RequestsRequestIdDecisionsRouteImport } from './routes/api/v1/requests/$requestId/decisions'
+import { Route as ApiV1ReceiptsMessageIdReadRouteImport } from './routes/api/v1/receipts/$messageId/read'
+import { Route as ApiV1PostageMessageIdSettleRouteImport } from './routes/api/v1/postage/$messageId/settle'
+import { Route as ApiV1PostageMessageIdRefundRouteImport } from './routes/api/v1/postage/$messageId/refund'
+import { Route as ApiV1PoliciesOwnerReconciliationRouteImport } from './routes/api/v1/policies/$owner/reconciliation'
+import { Route as ApiV1PoliciesOwnerProvisionRouteImport } from './routes/api/v1/policies/$owner/provision'
+import { Route as ApiV1IdentityKeysRotateRouteImport } from './routes/api/v1/identity/keys/rotate'
+import { Route as ApiV1IdentityKeysRevokeRouteImport } from './routes/api/v1/identity/keys/revoke'
+import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/identity/keys/retire'
+import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
+import { Route as ApiV1ContactsImportPreviewRouteImport } from './routes/api/v1/contacts/import/preview'
+import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/contacts/import/commit'
+import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
+import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
+import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
+import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
+import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
   id: '/motion-gallery',
   path: '/motion-gallery',
@@ -87,14 +82,9 @@ const PolicyEditorRouteRoute = PolicyEditorRouteRouteImport.update({
   path: '/policy-editor',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AuthSignInRoute = AuthSignInRouteImport.update({
-  id: '/auth/sign-in',
-  path: '/auth/sign-in',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AuthSignUpRoute = AuthSignUpRouteImport.update({
-  id: '/auth/sign-up',
-  path: '/auth/sign-up',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthVerifyRoute = AuthVerifyRouteImport.update({
@@ -102,14 +92,14 @@ const AuthVerifyRoute = AuthVerifyRouteImport.update({
   path: '/auth/verify',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1HealthRoute = ApiV1HealthRouteImport.update({
-  id: '/api/v1/health',
-  path: '/api/v1/health',
+const AuthSignUpRoute = AuthSignUpRouteImport.update({
+  id: '/auth/sign-up',
+  path: '/auth/sign-up',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1OpenapiDotjsonRoute = ApiV1OpenapiDotjsonRouteImport.update({
-  id: '/api/v1/openapi.json',
-  path: '/api/v1/openapi.json',
+const AuthSignInRoute = AuthSignInRouteImport.update({
+  id: '/auth/sign-in',
+  path: '/auth/sign-in',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1ProtocolRoute = ApiV1ProtocolRouteImport.update({
@@ -117,35 +107,124 @@ const ApiV1ProtocolRoute = ApiV1ProtocolRouteImport.update({
   path: '/api/v1/protocol',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1OpenapiDotjsonRoute = ApiV1OpenapiDotjsonRouteImport.update({
+  id: '/api/v1/openapi.json',
+  path: '/api/v1/openapi.json',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1HealthRoute = ApiV1HealthRouteImport.update({
+  id: '/api/v1/health',
+  path: '/api/v1/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1RequestsIndexRoute = ApiV1RequestsIndexRouteImport.update({
+  id: '/api/v1/requests/',
+  path: '/api/v1/requests/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ReceiptsIndexRoute = ApiV1ReceiptsIndexRouteImport.update({
+  id: '/api/v1/receipts/',
+  path: '/api/v1/receipts/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1PostageIndexRoute = ApiV1PostageIndexRouteImport.update({
+  id: '/api/v1/postage/',
+  path: '/api/v1/postage/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsIndexRoute = ApiV1ContactsIndexRouteImport.update({
+  id: '/api/v1/contacts/',
+  path: '/api/v1/contacts/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AccountsIndexRoute = ApiV1AccountsIndexRouteImport.update({
   id: '/api/v1/accounts/',
   path: '/api/v1/accounts/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AccountsProvisioningRoute =
-  ApiV1AccountsProvisioningRouteImport.update({
-    id: '/api/v1/accounts/provisioning',
-    path: '/api/v1/accounts/provisioning',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
-  id: '/api/v1/auth/login',
-  path: '/api/v1/auth/login',
+const ApiV1RelayVersionRoute = ApiV1RelayVersionRouteImport.update({
+  id: '/api/v1/relay/version',
+  path: '/api/v1/relay/version',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
-  id: '/api/v1/auth/logout',
-  path: '/api/v1/auth/logout',
+const ApiV1RelayReadinessRoute = ApiV1RelayReadinessRouteImport.update({
+  id: '/api/v1/relay/readiness',
+  path: '/api/v1/relay/readiness',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AuthLogoutAllRoute = ApiV1AuthLogoutAllRouteImport.update({
-  id: '/api/v1/auth/logout-all',
-  path: '/api/v1/auth/logout-all',
+const ApiV1RelayMessagesRoute = ApiV1RelayMessagesRouteImport.update({
+  id: '/api/v1/relay/messages',
+  path: '/api/v1/relay/messages',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
-  id: '/api/v1/auth/register',
-  path: '/api/v1/auth/register',
+const ApiV1RelayHealthRoute = ApiV1RelayHealthRouteImport.update({
+  id: '/api/v1/relay/health',
+  path: '/api/v1/relay/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ReceiptsMessageIdRoute = ApiV1ReceiptsMessageIdRouteImport.update({
+  id: '/api/v1/receipts/$messageId',
+  path: '/api/v1/receipts/$messageId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1PostageQuoteRoute = ApiV1PostageQuoteRouteImport.update({
+  id: '/api/v1/postage/quote',
+  path: '/api/v1/postage/quote',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1PostageMessageIdRoute = ApiV1PostageMessageIdRouteImport.update({
+  id: '/api/v1/postage/$messageId',
+  path: '/api/v1/postage/$messageId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1PoliciesEvaluateRoute = ApiV1PoliciesEvaluateRouteImport.update({
+  id: '/api/v1/policies/evaluate',
+  path: '/api/v1/policies/evaluate',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
+  id: '/api/v1/policies/$owner',
+  path: '/api/v1/policies/$owner',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxQueueRoute = ApiV1MailboxQueueRouteImport.update({
+  id: '/api/v1/mailbox/queue',
+  path: '/api/v1/mailbox/queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxMessageIdRoute = ApiV1MailboxMessageIdRouteImport.update({
+  id: '/api/v1/mailbox/$messageId',
+  path: '/api/v1/mailbox/$messageId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1IdentityResolveRoute = ApiV1IdentityResolveRouteImport.update({
+  id: '/api/v1/identity/resolve',
+  path: '/api/v1/identity/resolve',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1DeliveryMessageIdRoute = ApiV1DeliveryMessageIdRouteImport.update({
+  id: '/api/v1/delivery/$messageId',
+  path: '/api/v1/delivery/$messageId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsMergeRoute = ApiV1ContactsMergeRouteImport.update({
+  id: '/api/v1/contacts/merge',
+  path: '/api/v1/contacts/merge',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsContactIdRoute = ApiV1ContactsContactIdRouteImport.update({
+  id: '/api/v1/contacts/$contactId',
+  path: '/api/v1/contacts/$contactId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AuthVerifyRoute = ApiV1AuthVerifyRouteImport.update({
+  id: '/api/v1/auth/verify',
+  path: '/api/v1/auth/verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
+  id: '/api/v1/auth/session',
+  path: '/api/v1/auth/session',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1AuthResendVerificationRoute =
@@ -154,208 +233,30 @@ const ApiV1AuthResendVerificationRoute =
     path: '/api/v1/auth/resend-verification',
     getParentRoute: () => rootRouteImport,
   } as any)
-const ApiV1AuthSessionRoute = ApiV1AuthSessionRouteImport.update({
-  id: '/api/v1/auth/session',
-  path: '/api/v1/auth/session',
+const ApiV1AuthRegisterRoute = ApiV1AuthRegisterRouteImport.update({
+  id: '/api/v1/auth/register',
+  path: '/api/v1/auth/register',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AuthVerifyRoute = ApiV1AuthVerifyRouteImport.update({
-  id: '/api/v1/auth/verify',
-  path: '/api/v1/auth/verify',
+const ApiV1AuthLogoutAllRoute = ApiV1AuthLogoutAllRouteImport.update({
+  id: '/api/v1/auth/logout-all',
+  path: '/api/v1/auth/logout-all',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1ContactsIndexRoute = ApiV1ContactsIndexRouteImport.update({
-  id: '/api/v1/contacts/',
-  path: '/api/v1/contacts/',
+const ApiV1AuthLogoutRoute = ApiV1AuthLogoutRouteImport.update({
+  id: '/api/v1/auth/logout',
+  path: '/api/v1/auth/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1ContactsContactIdRoute = ApiV1ContactsContactIdRouteImport.update({
-  id: '/api/v1/contacts/$contactId',
-  path: '/api/v1/contacts/$contactId',
+const ApiV1AuthLoginRoute = ApiV1AuthLoginRouteImport.update({
+  id: '/api/v1/auth/login',
+  path: '/api/v1/auth/login',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1ContactsMergeRoute = ApiV1ContactsMergeRouteImport.update({
-  id: '/api/v1/contacts/merge',
-  path: '/api/v1/contacts/merge',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1DeliveryMessageIdRoute = ApiV1DeliveryMessageIdRouteImport.update({
-  id: '/api/v1/delivery/$messageId',
-  path: '/api/v1/delivery/$messageId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1IdentityResolveRoute = ApiV1IdentityResolveRouteImport.update({
-  id: '/api/v1/identity/resolve',
-  path: '/api/v1/identity/resolve',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1MailboxMessageIdRoute = ApiV1MailboxMessageIdRouteImport.update({
-  id: '/api/v1/mailbox/$messageId',
-  path: '/api/v1/mailbox/$messageId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1MailboxQueueRoute = ApiV1MailboxQueueRouteImport.update({
-  id: '/api/v1/mailbox/queue',
-  path: '/api/v1/mailbox/queue',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
-  id: '/api/v1/policies/$owner',
-  path: '/api/v1/policies/$owner',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PoliciesEvaluateRoute = ApiV1PoliciesEvaluateRouteImport.update({
-  id: '/api/v1/policies/evaluate',
-  path: '/api/v1/policies/evaluate',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PostageIndexRoute = ApiV1PostageIndexRouteImport.update({
-  id: '/api/v1/postage/',
-  path: '/api/v1/postage/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PostageMessageIdRoute = ApiV1PostageMessageIdRouteImport.update({
-  id: '/api/v1/postage/$messageId',
-  path: '/api/v1/postage/$messageId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PostageQuoteRoute = ApiV1PostageQuoteRouteImport.update({
-  id: '/api/v1/postage/quote',
-  path: '/api/v1/postage/quote',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1ReceiptsIndexRoute = ApiV1ReceiptsIndexRouteImport.update({
-  id: '/api/v1/receipts/',
-  path: '/api/v1/receipts/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1ReceiptsMessageIdRoute = ApiV1ReceiptsMessageIdRouteImport.update({
-  id: '/api/v1/receipts/$messageId',
-  path: '/api/v1/receipts/$messageId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1RelayHealthRoute = ApiV1RelayHealthRouteImport.update({
-  id: '/api/v1/relay/health',
-  path: '/api/v1/relay/health',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1RelayMessagesRoute = ApiV1RelayMessagesRouteImport.update({
-  id: '/api/v1/relay/messages',
-  path: '/api/v1/relay/messages',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1RelayReadinessRoute = ApiV1RelayReadinessRouteImport.update({
-  id: '/api/v1/relay/readiness',
-  path: '/api/v1/relay/readiness',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1RelayVersionRoute = ApiV1RelayVersionRouteImport.update({
-  id: '/api/v1/relay/version',
-  path: '/api/v1/relay/version',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1RequestsIndexRoute = ApiV1RequestsIndexRouteImport.update({
-  id: '/api/v1/requests/',
-  path: '/api/v1/requests/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AccountsProvisioningRetryRoute =
-  ApiV1AccountsProvisioningRetryRouteImport.update({
-    id: '/retry',
-    path: '/retry',
-    getParentRoute: () => ApiV1AccountsProvisioningRoute,
-  } as any)
-const ApiV1AdminDlqIndexRoute = ApiV1AdminDlqIndexRouteImport.update({
-  id: '/api/v1/admin/dlq/',
-  path: '/api/v1/admin/dlq/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AdminDlqIdRoute = ApiV1AdminDlqIdRouteImport.update({
-  id: '/api/v1/admin/dlq/$id',
-  path: '/api/v1/admin/dlq/$id',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AdminJobsIndexRoute = ApiV1AdminJobsIndexRouteImport.update({
-  id: '/api/v1/admin/jobs/',
-  path: '/api/v1/admin/jobs/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1AdminJobsIdRoute = ApiV1AdminJobsIdRouteImport.update({
-  id: '/api/v1/admin/jobs/$id',
-  path: '/api/v1/admin/jobs/$id',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1ContactsImportCommitRoute =
-  ApiV1ContactsImportCommitRouteImport.update({
-    id: '/api/v1/contacts/import/commit',
-    path: '/api/v1/contacts/import/commit',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ApiV1ContactsImportPreviewRoute =
-  ApiV1ContactsImportPreviewRouteImport.update({
-    id: '/api/v1/contacts/import/preview',
-    path: '/api/v1/contacts/import/preview',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ApiV1IdentityKeysIndexRoute = ApiV1IdentityKeysIndexRouteImport.update({
-  id: '/api/v1/identity/keys/',
-  path: '/api/v1/identity/keys/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1IdentityKeysKeyIdRoute = ApiV1IdentityKeysKeyIdRouteImport.update({
-  id: '/api/v1/identity/keys/$keyId',
-  path: '/api/v1/identity/keys/$keyId',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1IdentityKeysRetireRoute = ApiV1IdentityKeysRetireRouteImport.update({
-  id: '/api/v1/identity/keys/retire',
-  path: '/api/v1/identity/keys/retire',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1IdentityKeysRevokeRoute = ApiV1IdentityKeysRevokeRouteImport.update({
-  id: '/api/v1/identity/keys/revoke',
-  path: '/api/v1/identity/keys/revoke',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1IdentityKeysRotateRoute = ApiV1IdentityKeysRotateRouteImport.update({
-  id: '/api/v1/identity/keys/rotate',
-  path: '/api/v1/identity/keys/rotate',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiV1PoliciesOwnerProvisionRoute =
-  ApiV1PoliciesOwnerProvisionRouteImport.update({
-    id: '/provision',
-    path: '/provision',
-    getParentRoute: () => ApiV1PoliciesOwnerRoute,
-  } as any)
-const ApiV1PoliciesOwnerReconciliationRoute =
-  ApiV1PoliciesOwnerReconciliationRouteImport.update({
-    id: '/reconciliation',
-    path: '/reconciliation',
-    getParentRoute: () => ApiV1PoliciesOwnerRoute,
-  } as any)
-const ApiV1PostageMessageIdRefundRoute =
-  ApiV1PostageMessageIdRefundRouteImport.update({
-    id: '/refund',
-    path: '/refund',
-    getParentRoute: () => ApiV1PostageMessageIdRoute,
-  } as any)
-const ApiV1PostageMessageIdSettleRoute =
-  ApiV1PostageMessageIdSettleRouteImport.update({
-    id: '/settle',
-    path: '/settle',
-    getParentRoute: () => ApiV1PostageMessageIdRoute,
-  } as any)
-const ApiV1ReceiptsMessageIdReadRoute =
-  ApiV1ReceiptsMessageIdReadRouteImport.update({
-    id: '/read',
-    path: '/read',
-    getParentRoute: () => ApiV1ReceiptsMessageIdRoute,
-  } as any)
-const ApiV1RequestsRequestIdDecisionsRoute =
-  ApiV1RequestsRequestIdDecisionsRouteImport.update({
-    id: '/api/v1/requests/$requestId/decisions',
-    path: '/api/v1/requests/$requestId/decisions',
+const ApiV1AccountsProvisioningRoute =
+  ApiV1AccountsProvisioningRouteImport.update({
+    id: '/api/v1/accounts/provisioning',
+    path: '/api/v1/accounts/provisioning',
     getParentRoute: () => rootRouteImport,
   } as any)
 const ApiV1WalletLinkIndexRoute = ApiV1WalletLinkIndexRouteImport.update({
@@ -363,9 +264,24 @@ const ApiV1WalletLinkIndexRoute = ApiV1WalletLinkIndexRouteImport.update({
   path: '/api/v1/wallet/link/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1WalletLinkAddressRoute = ApiV1WalletLinkAddressRouteImport.update({
-  id: '/api/v1/wallet/link/$address',
-  path: '/api/v1/wallet/link/$address',
+const ApiV1IdentityKeysIndexRoute = ApiV1IdentityKeysIndexRouteImport.update({
+  id: '/api/v1/identity/keys/',
+  path: '/api/v1/identity/keys/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AdminJobsIndexRoute = ApiV1AdminJobsIndexRouteImport.update({
+  id: '/api/v1/admin/jobs/',
+  path: '/api/v1/admin/jobs/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AdminDlqIndexRoute = ApiV1AdminDlqIndexRouteImport.update({
+  id: '/api/v1/admin/dlq/',
+  path: '/api/v1/admin/dlq/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1WalletLinkVerifyRoute = ApiV1WalletLinkVerifyRouteImport.update({
+  id: '/api/v1/wallet/link/verify',
+  path: '/api/v1/wallet/link/verify',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1WalletLinkChallengeRoute =
@@ -374,27 +290,111 @@ const ApiV1WalletLinkChallengeRoute =
     path: '/api/v1/wallet/link/challenge',
     getParentRoute: () => rootRouteImport,
   } as any)
-const ApiV1WalletLinkVerifyRoute = ApiV1WalletLinkVerifyRouteImport.update({
-  id: '/api/v1/wallet/link/verify',
-  path: '/api/v1/wallet/link/verify',
+const ApiV1WalletLinkAddressRoute = ApiV1WalletLinkAddressRouteImport.update({
+  id: '/api/v1/wallet/link/$address',
+  path: '/api/v1/wallet/link/$address',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AdminDlqIdAbandonRoute = ApiV1AdminDlqIdAbandonRouteImport.update({
-  id: '/abandon',
-  path: '/abandon',
-  getParentRoute: () => ApiV1AdminDlqIdRoute,
+const ApiV1RequestsRequestIdDecisionsRoute =
+  ApiV1RequestsRequestIdDecisionsRouteImport.update({
+    id: '/api/v1/requests/$requestId/decisions',
+    path: '/api/v1/requests/$requestId/decisions',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1ReceiptsMessageIdReadRoute =
+  ApiV1ReceiptsMessageIdReadRouteImport.update({
+    id: '/read',
+    path: '/read',
+    getParentRoute: () => ApiV1ReceiptsMessageIdRoute,
+  } as any)
+const ApiV1PostageMessageIdSettleRoute =
+  ApiV1PostageMessageIdSettleRouteImport.update({
+    id: '/settle',
+    path: '/settle',
+    getParentRoute: () => ApiV1PostageMessageIdRoute,
+  } as any)
+const ApiV1PostageMessageIdRefundRoute =
+  ApiV1PostageMessageIdRefundRouteImport.update({
+    id: '/refund',
+    path: '/refund',
+    getParentRoute: () => ApiV1PostageMessageIdRoute,
+  } as any)
+const ApiV1PoliciesOwnerReconciliationRoute =
+  ApiV1PoliciesOwnerReconciliationRouteImport.update({
+    id: '/reconciliation',
+    path: '/reconciliation',
+    getParentRoute: () => ApiV1PoliciesOwnerRoute,
+  } as any)
+const ApiV1PoliciesOwnerProvisionRoute =
+  ApiV1PoliciesOwnerProvisionRouteImport.update({
+    id: '/provision',
+    path: '/provision',
+    getParentRoute: () => ApiV1PoliciesOwnerRoute,
+  } as any)
+const ApiV1IdentityKeysRotateRoute = ApiV1IdentityKeysRotateRouteImport.update({
+  id: '/api/v1/identity/keys/rotate',
+  path: '/api/v1/identity/keys/rotate',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1AdminDlqIdRetryRoute = ApiV1AdminDlqIdRetryRouteImport.update({
-  id: '/retry',
-  path: '/retry',
-  getParentRoute: () => ApiV1AdminDlqIdRoute,
+const ApiV1IdentityKeysRevokeRoute = ApiV1IdentityKeysRevokeRouteImport.update({
+  id: '/api/v1/identity/keys/revoke',
+  path: '/api/v1/identity/keys/revoke',
+  getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1IdentityKeysRetireRoute = ApiV1IdentityKeysRetireRouteImport.update({
+  id: '/api/v1/identity/keys/retire',
+  path: '/api/v1/identity/keys/retire',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1IdentityKeysKeyIdRoute = ApiV1IdentityKeysKeyIdRouteImport.update({
+  id: '/api/v1/identity/keys/$keyId',
+  path: '/api/v1/identity/keys/$keyId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1ContactsImportPreviewRoute =
+  ApiV1ContactsImportPreviewRouteImport.update({
+    id: '/api/v1/contacts/import/preview',
+    path: '/api/v1/contacts/import/preview',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1ContactsImportCommitRoute =
+  ApiV1ContactsImportCommitRouteImport.update({
+    id: '/api/v1/contacts/import/commit',
+    path: '/api/v1/contacts/import/commit',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1AdminJobsIdRoute = ApiV1AdminJobsIdRouteImport.update({
+  id: '/api/v1/admin/jobs/$id',
+  path: '/api/v1/admin/jobs/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AdminDlqIdRoute = ApiV1AdminDlqIdRouteImport.update({
+  id: '/api/v1/admin/dlq/$id',
+  path: '/api/v1/admin/dlq/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1AccountsProvisioningRetryRoute =
+  ApiV1AccountsProvisioningRetryRouteImport.update({
+    id: '/retry',
+    path: '/retry',
+    getParentRoute: () => ApiV1AccountsProvisioningRoute,
+  } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
     path: '/senders/$sender',
     getParentRoute: () => ApiV1PoliciesOwnerRoute,
   } as any)
+const ApiV1AdminDlqIdRetryRoute = ApiV1AdminDlqIdRetryRouteImport.update({
+  id: '/retry',
+  path: '/retry',
+  getParentRoute: () => ApiV1AdminDlqIdRoute,
+} as any)
+const ApiV1AdminDlqIdAbandonRoute = ApiV1AdminDlqIdAbandonRouteImport.update({
+  id: '/abandon',
+  path: '/abandon',
+  getParentRoute: () => ApiV1AdminDlqIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -842,13 +842,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/motion-gallery': {
       id: '/motion-gallery'
       path: '/motion-gallery'
@@ -863,18 +856,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PolicyEditorRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/auth/sign-in': {
-      id: '/auth/sign-in'
-      path: '/auth/sign-in'
-      fullPath: '/auth/sign-in'
-      preLoaderRoute: typeof AuthSignInRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auth/sign-up': {
-      id: '/auth/sign-up'
-      path: '/auth/sign-up'
-      fullPath: '/auth/sign-up'
-      preLoaderRoute: typeof AuthSignUpRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth/verify': {
@@ -884,18 +870,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthVerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/health': {
-      id: '/api/v1/health'
-      path: '/api/v1/health'
-      fullPath: '/api/v1/health'
-      preLoaderRoute: typeof ApiV1HealthRouteImport
+    '/auth/sign-up': {
+      id: '/auth/sign-up'
+      path: '/auth/sign-up'
+      fullPath: '/auth/sign-up'
+      preLoaderRoute: typeof AuthSignUpRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/openapi.json': {
-      id: '/api/v1/openapi.json'
-      path: '/api/v1/openapi.json'
-      fullPath: '/api/v1/openapi.json'
-      preLoaderRoute: typeof ApiV1OpenapiDotjsonRouteImport
+    '/auth/sign-in': {
+      id: '/auth/sign-in'
+      path: '/auth/sign-in'
+      fullPath: '/auth/sign-in'
+      preLoaderRoute: typeof AuthSignInRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/protocol': {
@@ -905,193 +891,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1ProtocolRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/accounts/': {
-      id: '/api/v1/accounts/'
-      path: '/api/v1/accounts'
-      fullPath: '/api/v1/accounts/'
-      preLoaderRoute: typeof ApiV1AccountsIndexRouteImport
+    '/api/v1/openapi.json': {
+      id: '/api/v1/openapi.json'
+      path: '/api/v1/openapi.json'
+      fullPath: '/api/v1/openapi.json'
+      preLoaderRoute: typeof ApiV1OpenapiDotjsonRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/accounts/provisioning': {
-      id: '/api/v1/accounts/provisioning'
-      path: '/api/v1/accounts/provisioning'
-      fullPath: '/api/v1/accounts/provisioning'
-      preLoaderRoute: typeof ApiV1AccountsProvisioningRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/login': {
-      id: '/api/v1/auth/login'
-      path: '/api/v1/auth/login'
-      fullPath: '/api/v1/auth/login'
-      preLoaderRoute: typeof ApiV1AuthLoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/logout': {
-      id: '/api/v1/auth/logout'
-      path: '/api/v1/auth/logout'
-      fullPath: '/api/v1/auth/logout'
-      preLoaderRoute: typeof ApiV1AuthLogoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/logout-all': {
-      id: '/api/v1/auth/logout-all'
-      path: '/api/v1/auth/logout-all'
-      fullPath: '/api/v1/auth/logout-all'
-      preLoaderRoute: typeof ApiV1AuthLogoutAllRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/register': {
-      id: '/api/v1/auth/register'
-      path: '/api/v1/auth/register'
-      fullPath: '/api/v1/auth/register'
-      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/resend-verification': {
-      id: '/api/v1/auth/resend-verification'
-      path: '/api/v1/auth/resend-verification'
-      fullPath: '/api/v1/auth/resend-verification'
-      preLoaderRoute: typeof ApiV1AuthResendVerificationRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/session': {
-      id: '/api/v1/auth/session'
-      path: '/api/v1/auth/session'
-      fullPath: '/api/v1/auth/session'
-      preLoaderRoute: typeof ApiV1AuthSessionRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/auth/verify': {
-      id: '/api/v1/auth/verify'
-      path: '/api/v1/auth/verify'
-      fullPath: '/api/v1/auth/verify'
-      preLoaderRoute: typeof ApiV1AuthVerifyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/contacts/': {
-      id: '/api/v1/contacts/'
-      path: '/api/v1/contacts'
-      fullPath: '/api/v1/contacts/'
-      preLoaderRoute: typeof ApiV1ContactsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/contacts/$contactId': {
-      id: '/api/v1/contacts/$contactId'
-      path: '/api/v1/contacts/$contactId'
-      fullPath: '/api/v1/contacts/$contactId'
-      preLoaderRoute: typeof ApiV1ContactsContactIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/contacts/merge': {
-      id: '/api/v1/contacts/merge'
-      path: '/api/v1/contacts/merge'
-      fullPath: '/api/v1/contacts/merge'
-      preLoaderRoute: typeof ApiV1ContactsMergeRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/delivery/$messageId': {
-      id: '/api/v1/delivery/$messageId'
-      path: '/api/v1/delivery/$messageId'
-      fullPath: '/api/v1/delivery/$messageId'
-      preLoaderRoute: typeof ApiV1DeliveryMessageIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/identity/resolve': {
-      id: '/api/v1/identity/resolve'
-      path: '/api/v1/identity/resolve'
-      fullPath: '/api/v1/identity/resolve'
-      preLoaderRoute: typeof ApiV1IdentityResolveRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/mailbox/$messageId': {
-      id: '/api/v1/mailbox/$messageId'
-      path: '/api/v1/mailbox/$messageId'
-      fullPath: '/api/v1/mailbox/$messageId'
-      preLoaderRoute: typeof ApiV1MailboxMessageIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/mailbox/queue': {
-      id: '/api/v1/mailbox/queue'
-      path: '/api/v1/mailbox/queue'
-      fullPath: '/api/v1/mailbox/queue'
-      preLoaderRoute: typeof ApiV1MailboxQueueRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/policies/$owner': {
-      id: '/api/v1/policies/$owner'
-      path: '/api/v1/policies/$owner'
-      fullPath: '/api/v1/policies/$owner'
-      preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/policies/evaluate': {
-      id: '/api/v1/policies/evaluate'
-      path: '/api/v1/policies/evaluate'
-      fullPath: '/api/v1/policies/evaluate'
-      preLoaderRoute: typeof ApiV1PoliciesEvaluateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/postage/': {
-      id: '/api/v1/postage/'
-      path: '/api/v1/postage'
-      fullPath: '/api/v1/postage/'
-      preLoaderRoute: typeof ApiV1PostageIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/postage/$messageId': {
-      id: '/api/v1/postage/$messageId'
-      path: '/api/v1/postage/$messageId'
-      fullPath: '/api/v1/postage/$messageId'
-      preLoaderRoute: typeof ApiV1PostageMessageIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/postage/quote': {
-      id: '/api/v1/postage/quote'
-      path: '/api/v1/postage/quote'
-      fullPath: '/api/v1/postage/quote'
-      preLoaderRoute: typeof ApiV1PostageQuoteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/receipts/': {
-      id: '/api/v1/receipts/'
-      path: '/api/v1/receipts'
-      fullPath: '/api/v1/receipts/'
-      preLoaderRoute: typeof ApiV1ReceiptsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/receipts/$messageId': {
-      id: '/api/v1/receipts/$messageId'
-      path: '/api/v1/receipts/$messageId'
-      fullPath: '/api/v1/receipts/$messageId'
-      preLoaderRoute: typeof ApiV1ReceiptsMessageIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/relay/health': {
-      id: '/api/v1/relay/health'
-      path: '/api/v1/relay/health'
-      fullPath: '/api/v1/relay/health'
-      preLoaderRoute: typeof ApiV1RelayHealthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/relay/messages': {
-      id: '/api/v1/relay/messages'
-      path: '/api/v1/relay/messages'
-      fullPath: '/api/v1/relay/messages'
-      preLoaderRoute: typeof ApiV1RelayMessagesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/relay/readiness': {
-      id: '/api/v1/relay/readiness'
-      path: '/api/v1/relay/readiness'
-      fullPath: '/api/v1/relay/readiness'
-      preLoaderRoute: typeof ApiV1RelayReadinessRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/v1/relay/version': {
-      id: '/api/v1/relay/version'
-      path: '/api/v1/relay/version'
-      fullPath: '/api/v1/relay/version'
-      preLoaderRoute: typeof ApiV1RelayVersionRouteImport
+    '/api/v1/health': {
+      id: '/api/v1/health'
+      path: '/api/v1/health'
+      fullPath: '/api/v1/health'
+      preLoaderRoute: typeof ApiV1HealthRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/requests/': {
@@ -1101,130 +912,193 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1RequestsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/accounts/provisioning/retry': {
-      id: '/api/v1/accounts/provisioning/retry'
-      path: '/retry'
-      fullPath: '/api/v1/accounts/provisioning/retry'
-      preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
-      parentRoute: typeof ApiV1AccountsProvisioningRoute
-    }
-    '/api/v1/admin/dlq/': {
-      id: '/api/v1/admin/dlq/'
-      path: '/api/v1/admin/dlq'
-      fullPath: '/api/v1/admin/dlq/'
-      preLoaderRoute: typeof ApiV1AdminDlqIndexRouteImport
+    '/api/v1/receipts/': {
+      id: '/api/v1/receipts/'
+      path: '/api/v1/receipts'
+      fullPath: '/api/v1/receipts/'
+      preLoaderRoute: typeof ApiV1ReceiptsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/admin/dlq/$id': {
-      id: '/api/v1/admin/dlq/$id'
-      path: '/api/v1/admin/dlq/$id'
-      fullPath: '/api/v1/admin/dlq/$id'
-      preLoaderRoute: typeof ApiV1AdminDlqIdRouteImport
+    '/api/v1/postage/': {
+      id: '/api/v1/postage/'
+      path: '/api/v1/postage'
+      fullPath: '/api/v1/postage/'
+      preLoaderRoute: typeof ApiV1PostageIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/admin/jobs/': {
-      id: '/api/v1/admin/jobs/'
-      path: '/api/v1/admin/jobs'
-      fullPath: '/api/v1/admin/jobs/'
-      preLoaderRoute: typeof ApiV1AdminJobsIndexRouteImport
+    '/api/v1/contacts/': {
+      id: '/api/v1/contacts/'
+      path: '/api/v1/contacts'
+      fullPath: '/api/v1/contacts/'
+      preLoaderRoute: typeof ApiV1ContactsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/admin/jobs/$id': {
-      id: '/api/v1/admin/jobs/$id'
-      path: '/api/v1/admin/jobs/$id'
-      fullPath: '/api/v1/admin/jobs/$id'
-      preLoaderRoute: typeof ApiV1AdminJobsIdRouteImport
+    '/api/v1/accounts/': {
+      id: '/api/v1/accounts/'
+      path: '/api/v1/accounts'
+      fullPath: '/api/v1/accounts/'
+      preLoaderRoute: typeof ApiV1AccountsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/contacts/import/commit': {
-      id: '/api/v1/contacts/import/commit'
-      path: '/api/v1/contacts/import/commit'
-      fullPath: '/api/v1/contacts/import/commit'
-      preLoaderRoute: typeof ApiV1ContactsImportCommitRouteImport
+    '/api/v1/relay/version': {
+      id: '/api/v1/relay/version'
+      path: '/api/v1/relay/version'
+      fullPath: '/api/v1/relay/version'
+      preLoaderRoute: typeof ApiV1RelayVersionRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/contacts/import/preview': {
-      id: '/api/v1/contacts/import/preview'
-      path: '/api/v1/contacts/import/preview'
-      fullPath: '/api/v1/contacts/import/preview'
-      preLoaderRoute: typeof ApiV1ContactsImportPreviewRouteImport
+    '/api/v1/relay/readiness': {
+      id: '/api/v1/relay/readiness'
+      path: '/api/v1/relay/readiness'
+      fullPath: '/api/v1/relay/readiness'
+      preLoaderRoute: typeof ApiV1RelayReadinessRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/identity/keys/': {
-      id: '/api/v1/identity/keys/'
-      path: '/api/v1/identity/keys'
-      fullPath: '/api/v1/identity/keys/'
-      preLoaderRoute: typeof ApiV1IdentityKeysIndexRouteImport
+    '/api/v1/relay/messages': {
+      id: '/api/v1/relay/messages'
+      path: '/api/v1/relay/messages'
+      fullPath: '/api/v1/relay/messages'
+      preLoaderRoute: typeof ApiV1RelayMessagesRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/identity/keys/$keyId': {
-      id: '/api/v1/identity/keys/$keyId'
-      path: '/api/v1/identity/keys/$keyId'
-      fullPath: '/api/v1/identity/keys/$keyId'
-      preLoaderRoute: typeof ApiV1IdentityKeysKeyIdRouteImport
+    '/api/v1/relay/health': {
+      id: '/api/v1/relay/health'
+      path: '/api/v1/relay/health'
+      fullPath: '/api/v1/relay/health'
+      preLoaderRoute: typeof ApiV1RelayHealthRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/identity/keys/retire': {
-      id: '/api/v1/identity/keys/retire'
-      path: '/api/v1/identity/keys/retire'
-      fullPath: '/api/v1/identity/keys/retire'
-      preLoaderRoute: typeof ApiV1IdentityKeysRetireRouteImport
+    '/api/v1/receipts/$messageId': {
+      id: '/api/v1/receipts/$messageId'
+      path: '/api/v1/receipts/$messageId'
+      fullPath: '/api/v1/receipts/$messageId'
+      preLoaderRoute: typeof ApiV1ReceiptsMessageIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/identity/keys/revoke': {
-      id: '/api/v1/identity/keys/revoke'
-      path: '/api/v1/identity/keys/revoke'
-      fullPath: '/api/v1/identity/keys/revoke'
-      preLoaderRoute: typeof ApiV1IdentityKeysRevokeRouteImport
+    '/api/v1/postage/quote': {
+      id: '/api/v1/postage/quote'
+      path: '/api/v1/postage/quote'
+      fullPath: '/api/v1/postage/quote'
+      preLoaderRoute: typeof ApiV1PostageQuoteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/identity/keys/rotate': {
-      id: '/api/v1/identity/keys/rotate'
-      path: '/api/v1/identity/keys/rotate'
-      fullPath: '/api/v1/identity/keys/rotate'
-      preLoaderRoute: typeof ApiV1IdentityKeysRotateRouteImport
+    '/api/v1/postage/$messageId': {
+      id: '/api/v1/postage/$messageId'
+      path: '/api/v1/postage/$messageId'
+      fullPath: '/api/v1/postage/$messageId'
+      preLoaderRoute: typeof ApiV1PostageMessageIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/policies/$owner/provision': {
-      id: '/api/v1/policies/$owner/provision'
-      path: '/provision'
-      fullPath: '/api/v1/policies/$owner/provision'
-      preLoaderRoute: typeof ApiV1PoliciesOwnerProvisionRouteImport
-      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    '/api/v1/policies/evaluate': {
+      id: '/api/v1/policies/evaluate'
+      path: '/api/v1/policies/evaluate'
+      fullPath: '/api/v1/policies/evaluate'
+      preLoaderRoute: typeof ApiV1PoliciesEvaluateRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/api/v1/policies/$owner/reconciliation': {
-      id: '/api/v1/policies/$owner/reconciliation'
-      path: '/reconciliation'
-      fullPath: '/api/v1/policies/$owner/reconciliation'
-      preLoaderRoute: typeof ApiV1PoliciesOwnerReconciliationRouteImport
-      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    '/api/v1/policies/$owner': {
+      id: '/api/v1/policies/$owner'
+      path: '/api/v1/policies/$owner'
+      fullPath: '/api/v1/policies/$owner'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/api/v1/postage/$messageId/refund': {
-      id: '/api/v1/postage/$messageId/refund'
-      path: '/refund'
-      fullPath: '/api/v1/postage/$messageId/refund'
-      preLoaderRoute: typeof ApiV1PostageMessageIdRefundRouteImport
-      parentRoute: typeof ApiV1PostageMessageIdRoute
+    '/api/v1/mailbox/queue': {
+      id: '/api/v1/mailbox/queue'
+      path: '/api/v1/mailbox/queue'
+      fullPath: '/api/v1/mailbox/queue'
+      preLoaderRoute: typeof ApiV1MailboxQueueRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/api/v1/postage/$messageId/settle': {
-      id: '/api/v1/postage/$messageId/settle'
-      path: '/settle'
-      fullPath: '/api/v1/postage/$messageId/settle'
-      preLoaderRoute: typeof ApiV1PostageMessageIdSettleRouteImport
-      parentRoute: typeof ApiV1PostageMessageIdRoute
+    '/api/v1/mailbox/$messageId': {
+      id: '/api/v1/mailbox/$messageId'
+      path: '/api/v1/mailbox/$messageId'
+      fullPath: '/api/v1/mailbox/$messageId'
+      preLoaderRoute: typeof ApiV1MailboxMessageIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/api/v1/receipts/$messageId/read': {
-      id: '/api/v1/receipts/$messageId/read'
-      path: '/read'
-      fullPath: '/api/v1/receipts/$messageId/read'
-      preLoaderRoute: typeof ApiV1ReceiptsMessageIdReadRouteImport
-      parentRoute: typeof ApiV1ReceiptsMessageIdRoute
+    '/api/v1/identity/resolve': {
+      id: '/api/v1/identity/resolve'
+      path: '/api/v1/identity/resolve'
+      fullPath: '/api/v1/identity/resolve'
+      preLoaderRoute: typeof ApiV1IdentityResolveRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/api/v1/requests/$requestId/decisions': {
-      id: '/api/v1/requests/$requestId/decisions'
-      path: '/api/v1/requests/$requestId/decisions'
-      fullPath: '/api/v1/requests/$requestId/decisions'
-      preLoaderRoute: typeof ApiV1RequestsRequestIdDecisionsRouteImport
+    '/api/v1/delivery/$messageId': {
+      id: '/api/v1/delivery/$messageId'
+      path: '/api/v1/delivery/$messageId'
+      fullPath: '/api/v1/delivery/$messageId'
+      preLoaderRoute: typeof ApiV1DeliveryMessageIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/merge': {
+      id: '/api/v1/contacts/merge'
+      path: '/api/v1/contacts/merge'
+      fullPath: '/api/v1/contacts/merge'
+      preLoaderRoute: typeof ApiV1ContactsMergeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/$contactId': {
+      id: '/api/v1/contacts/$contactId'
+      path: '/api/v1/contacts/$contactId'
+      fullPath: '/api/v1/contacts/$contactId'
+      preLoaderRoute: typeof ApiV1ContactsContactIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/verify': {
+      id: '/api/v1/auth/verify'
+      path: '/api/v1/auth/verify'
+      fullPath: '/api/v1/auth/verify'
+      preLoaderRoute: typeof ApiV1AuthVerifyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/session': {
+      id: '/api/v1/auth/session'
+      path: '/api/v1/auth/session'
+      fullPath: '/api/v1/auth/session'
+      preLoaderRoute: typeof ApiV1AuthSessionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/resend-verification': {
+      id: '/api/v1/auth/resend-verification'
+      path: '/api/v1/auth/resend-verification'
+      fullPath: '/api/v1/auth/resend-verification'
+      preLoaderRoute: typeof ApiV1AuthResendVerificationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/register': {
+      id: '/api/v1/auth/register'
+      path: '/api/v1/auth/register'
+      fullPath: '/api/v1/auth/register'
+      preLoaderRoute: typeof ApiV1AuthRegisterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/logout-all': {
+      id: '/api/v1/auth/logout-all'
+      path: '/api/v1/auth/logout-all'
+      fullPath: '/api/v1/auth/logout-all'
+      preLoaderRoute: typeof ApiV1AuthLogoutAllRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/logout': {
+      id: '/api/v1/auth/logout'
+      path: '/api/v1/auth/logout'
+      fullPath: '/api/v1/auth/logout'
+      preLoaderRoute: typeof ApiV1AuthLogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/login': {
+      id: '/api/v1/auth/login'
+      path: '/api/v1/auth/login'
+      fullPath: '/api/v1/auth/login'
+      preLoaderRoute: typeof ApiV1AuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/accounts/provisioning': {
+      id: '/api/v1/accounts/provisioning'
+      path: '/api/v1/accounts/provisioning'
+      fullPath: '/api/v1/accounts/provisioning'
+      preLoaderRoute: typeof ApiV1AccountsProvisioningRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/wallet/link/': {
@@ -1234,18 +1108,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1WalletLinkIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/wallet/link/$address': {
-      id: '/api/v1/wallet/link/$address'
-      path: '/api/v1/wallet/link/$address'
-      fullPath: '/api/v1/wallet/link/$address'
-      preLoaderRoute: typeof ApiV1WalletLinkAddressRouteImport
+    '/api/v1/identity/keys/': {
+      id: '/api/v1/identity/keys/'
+      path: '/api/v1/identity/keys'
+      fullPath: '/api/v1/identity/keys/'
+      preLoaderRoute: typeof ApiV1IdentityKeysIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/wallet/link/challenge': {
-      id: '/api/v1/wallet/link/challenge'
-      path: '/api/v1/wallet/link/challenge'
-      fullPath: '/api/v1/wallet/link/challenge'
-      preLoaderRoute: typeof ApiV1WalletLinkChallengeRouteImport
+    '/api/v1/admin/jobs/': {
+      id: '/api/v1/admin/jobs/'
+      path: '/api/v1/admin/jobs'
+      fullPath: '/api/v1/admin/jobs/'
+      preLoaderRoute: typeof ApiV1AdminJobsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/admin/dlq/': {
+      id: '/api/v1/admin/dlq/'
+      path: '/api/v1/admin/dlq'
+      fullPath: '/api/v1/admin/dlq/'
+      preLoaderRoute: typeof ApiV1AdminDlqIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/wallet/link/verify': {
@@ -1255,12 +1136,131 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1WalletLinkVerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/admin/dlq/$id/abandon': {
-      id: '/api/v1/admin/dlq/$id/abandon'
-      path: '/abandon'
-      fullPath: '/api/v1/admin/dlq/$id/abandon'
-      preLoaderRoute: typeof ApiV1AdminDlqIdAbandonRouteImport
-      parentRoute: typeof ApiV1AdminDlqIdRoute
+    '/api/v1/wallet/link/challenge': {
+      id: '/api/v1/wallet/link/challenge'
+      path: '/api/v1/wallet/link/challenge'
+      fullPath: '/api/v1/wallet/link/challenge'
+      preLoaderRoute: typeof ApiV1WalletLinkChallengeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/wallet/link/$address': {
+      id: '/api/v1/wallet/link/$address'
+      path: '/api/v1/wallet/link/$address'
+      fullPath: '/api/v1/wallet/link/$address'
+      preLoaderRoute: typeof ApiV1WalletLinkAddressRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/requests/$requestId/decisions': {
+      id: '/api/v1/requests/$requestId/decisions'
+      path: '/api/v1/requests/$requestId/decisions'
+      fullPath: '/api/v1/requests/$requestId/decisions'
+      preLoaderRoute: typeof ApiV1RequestsRequestIdDecisionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/receipts/$messageId/read': {
+      id: '/api/v1/receipts/$messageId/read'
+      path: '/read'
+      fullPath: '/api/v1/receipts/$messageId/read'
+      preLoaderRoute: typeof ApiV1ReceiptsMessageIdReadRouteImport
+      parentRoute: typeof ApiV1ReceiptsMessageIdRoute
+    }
+    '/api/v1/postage/$messageId/settle': {
+      id: '/api/v1/postage/$messageId/settle'
+      path: '/settle'
+      fullPath: '/api/v1/postage/$messageId/settle'
+      preLoaderRoute: typeof ApiV1PostageMessageIdSettleRouteImport
+      parentRoute: typeof ApiV1PostageMessageIdRoute
+    }
+    '/api/v1/postage/$messageId/refund': {
+      id: '/api/v1/postage/$messageId/refund'
+      path: '/refund'
+      fullPath: '/api/v1/postage/$messageId/refund'
+      preLoaderRoute: typeof ApiV1PostageMessageIdRefundRouteImport
+      parentRoute: typeof ApiV1PostageMessageIdRoute
+    }
+    '/api/v1/policies/$owner/reconciliation': {
+      id: '/api/v1/policies/$owner/reconciliation'
+      path: '/reconciliation'
+      fullPath: '/api/v1/policies/$owner/reconciliation'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerReconciliationRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/policies/$owner/provision': {
+      id: '/api/v1/policies/$owner/provision'
+      path: '/provision'
+      fullPath: '/api/v1/policies/$owner/provision'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerProvisionRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
+    '/api/v1/identity/keys/rotate': {
+      id: '/api/v1/identity/keys/rotate'
+      path: '/api/v1/identity/keys/rotate'
+      fullPath: '/api/v1/identity/keys/rotate'
+      preLoaderRoute: typeof ApiV1IdentityKeysRotateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/revoke': {
+      id: '/api/v1/identity/keys/revoke'
+      path: '/api/v1/identity/keys/revoke'
+      fullPath: '/api/v1/identity/keys/revoke'
+      preLoaderRoute: typeof ApiV1IdentityKeysRevokeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/retire': {
+      id: '/api/v1/identity/keys/retire'
+      path: '/api/v1/identity/keys/retire'
+      fullPath: '/api/v1/identity/keys/retire'
+      preLoaderRoute: typeof ApiV1IdentityKeysRetireRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/identity/keys/$keyId': {
+      id: '/api/v1/identity/keys/$keyId'
+      path: '/api/v1/identity/keys/$keyId'
+      fullPath: '/api/v1/identity/keys/$keyId'
+      preLoaderRoute: typeof ApiV1IdentityKeysKeyIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/import/preview': {
+      id: '/api/v1/contacts/import/preview'
+      path: '/api/v1/contacts/import/preview'
+      fullPath: '/api/v1/contacts/import/preview'
+      preLoaderRoute: typeof ApiV1ContactsImportPreviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/contacts/import/commit': {
+      id: '/api/v1/contacts/import/commit'
+      path: '/api/v1/contacts/import/commit'
+      fullPath: '/api/v1/contacts/import/commit'
+      preLoaderRoute: typeof ApiV1ContactsImportCommitRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/admin/jobs/$id': {
+      id: '/api/v1/admin/jobs/$id'
+      path: '/api/v1/admin/jobs/$id'
+      fullPath: '/api/v1/admin/jobs/$id'
+      preLoaderRoute: typeof ApiV1AdminJobsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/admin/dlq/$id': {
+      id: '/api/v1/admin/dlq/$id'
+      path: '/api/v1/admin/dlq/$id'
+      fullPath: '/api/v1/admin/dlq/$id'
+      preLoaderRoute: typeof ApiV1AdminDlqIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/accounts/provisioning/retry': {
+      id: '/api/v1/accounts/provisioning/retry'
+      path: '/retry'
+      fullPath: '/api/v1/accounts/provisioning/retry'
+      preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
+      parentRoute: typeof ApiV1AccountsProvisioningRoute
+    }
+    '/api/v1/policies/$owner/senders/$sender': {
+      id: '/api/v1/policies/$owner/senders/$sender'
+      path: '/senders/$sender'
+      fullPath: '/api/v1/policies/$owner/senders/$sender'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
     }
     '/api/v1/admin/dlq/$id/retry': {
       id: '/api/v1/admin/dlq/$id/retry'
@@ -1269,12 +1269,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AdminDlqIdRetryRouteImport
       parentRoute: typeof ApiV1AdminDlqIdRoute
     }
-    '/api/v1/policies/$owner/senders/$sender': {
-      id: '/api/v1/policies/$owner/senders/$sender'
-      path: '/senders/$sender'
-      fullPath: '/api/v1/policies/$owner/senders/$sender'
-      preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderRouteImport
-      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    '/api/v1/admin/dlq/$id/abandon': {
+      id: '/api/v1/admin/dlq/$id/abandon'
+      path: '/abandon'
+      fullPath: '/api/v1/admin/dlq/$id/abandon'
+      preLoaderRoute: typeof ApiV1AdminDlqIdAbandonRouteImport
+      parentRoute: typeof ApiV1AdminDlqIdRoute
     }
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
 import { MailQuestion } from "lucide-react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ActionButton, EmptyState, Surface } from "@/features/design-system";
 import appCss from "../styles.css?url";
@@ -70,6 +71,12 @@ function RootShell({ children }: { children: React.ReactNode }) {
   );
 }
 
+const queryClient = new QueryClient();
+
 function RootComponent() {
-  return <Outlet />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Outlet />
+    </QueryClientProvider>
+  );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MotionConfig } from "framer-motion";
 import { AmbientBackground } from "@/components/mail/AmbientBackground";
 import { cn } from "@/lib/utils";
+import { useSession, sessionActor, useMailbox } from "@/features/mail";
 import { BulkConfirmDialog } from "@/components/mail/BulkConfirmDialog";
 import { Sidebar } from "@/components/mail/Sidebar";
 import { Topbar } from "@/components/mail/Topbar";
@@ -25,8 +26,6 @@ import {
 } from "@/components/mail/bulk-actions";
 import {
   defaultMailFilters,
-  deriveProof,
-  emails as initialEmails,
   getEmailsForFolder,
   getFolderLabel,
   mailFolders,
@@ -91,7 +90,12 @@ export const Route = createFileRoute("/")({
 });
 
 function IndexPage() {
-  return <MailApp isDemoMode />;
+  // Demo mode is a development-only escape hatch: `import.meta.env.DEV` is
+  // statically false in production builds, so the demo branch (and its dynamic
+  // import of the mock fixtures) is removed by the bundler. The production app
+  // shell has no route to `initialEmails` or the demo adapter.
+  const isDemo = import.meta.env.DEV;
+  return <MailApp isDemoMode={isDemo} />;
 }
 
 function delay(ms: number) {
@@ -101,8 +105,8 @@ function delay(ms: number) {
 function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
   const [showSenderJourney, setShowSenderJourney] = useState(false);
   const [folder, setFolder] = useState<MailFolder>("inbox");
-  const [emails, setEmails] = useState<Email[]>(initialEmails);
-  const [selectedId, setSelectedId] = useState<string | null>(initialEmails[0].id);
+  const [emails, setEmails] = useState<Email[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkProgress, setBulkProgress] = useState<BulkProgressState | null>(null);
   const [bulkFailures, setBulkFailures] = useState<BulkFailure[]>([]);
@@ -139,6 +143,44 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
   const [proofInspectorOpen, setProofInspectorOpen] = useState(false);
   const [proofInspectorQuery, setProofInspectorQuery] = useState("");
   const [authModalOpen, setAuthModalOpen] = useState(false);
+
+  // Typed live data path (BETA-051 / Issue #1958). The app shell consumes the
+  // typed mailbox hook. Demo fixtures are only reachable through a dev-only
+  // dynamic import gated on `import.meta.env.DEV` — statically false in
+  // production, so the bundler removes the branch and the mock module entirely.
+  const session = useSession({ enabled: !isDemoMode });
+  const actor = sessionActor(session.data);
+  const mailbox = useMailbox({
+    actor: actor ?? "anonymous",
+    enabled: Boolean(actor) && !isDemoMode,
+  });
+  const mailboxEmails = mailbox.data ?? [];
+  const mailboxHydrated = useRef(false);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    if (mailboxHydrated.current) return;
+    let cancelled = false;
+    void import("@/features/mail/demo/demo-data").then(({ getDemoEmails }) => {
+      if (cancelled) return;
+      const demo = getDemoEmails();
+      setEmails(demo);
+      setSelectedId((current) => current ?? demo[0]?.id ?? null);
+      mailboxHydrated.current = true;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isDemoMode) return;
+    if (!mailboxEmails.length) return;
+    if (mailboxHydrated.current) return;
+    setEmails(mailboxEmails);
+    setSelectedId((current) => current ?? mailboxEmails[0]?.id ?? null);
+    mailboxHydrated.current = true;
+  }, [isDemoMode, mailboxEmails]);
 
   const handleOpenMessageFromInspector = useCallback((email: Email) => {
     setCustomFolder(null);

--- a/tests/unit/api/web-data-access.contract.test.ts
+++ b/tests/unit/api/web-data-access.contract.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { openApiDocument } from "../../../src/server/api/openapi";
+import {
+  ApiClient,
+  ApiClientError,
+  parseErrorEnvelope,
+  statusToCode,
+  queryKeys,
+  cacheInvalidations,
+} from "../../../src/lib/api";
+import type {
+  Contact,
+  MailboxPolicy,
+  UnknownSenderRequest,
+  PostageQuote,
+} from "../../../src/lib/api";
+
+// ---------------------------------------------------------------------------
+// BETA-051 (Issue #1958) — contract tests: the typed client decoders must
+// match what the server documents in OpenAPI. We drive the client through
+// response envelopes built from the OpenAPI examples/schemas and assert the
+// typed data the components will receive.
+// ---------------------------------------------------------------------------
+
+function resolveSchema(name: string) {
+  const schema = openApiDocument.components.schemas[name];
+  if (!schema) throw new Error(`Schema ${name} not found in OpenAPI document`);
+  return schema as Record<string, unknown>;
+}
+
+function mockFetch(response: { ok: boolean; status: number; json: unknown }) {
+  return vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status,
+    json: async () => response.json,
+  }) as unknown as typeof fetch;
+}
+
+const CONTACT_SCHEMA = resolveSchema("Contact");
+const POLICY_SCHEMA = resolveSchema("MailboxPolicy");
+
+const sampleContact: Contact = {
+  contactId: "c1",
+  owner: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  name: "Ada",
+  address: "ada@example.com",
+  canonicalAddress: null,
+  trust: "default",
+  source: "manual",
+  createdAt: "2026-01-02T03:04:05.000Z",
+  updatedAt: "2026-01-02T03:04:05.000Z",
+  version: 1,
+};
+
+describe("client decoding matches OpenAPI schemas", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        status: 200,
+        json: {
+          data: sampleContact,
+          meta: { requestId: "r1", timestamp: "2026-01-01T00:00:00.000Z" },
+        },
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Contact schema fields align with the client Contact DTO", () => {
+    expect(CONTACT_SCHEMA.required).toEqual(
+      expect.arrayContaining([
+        "contactId",
+        "owner",
+        "name",
+        "address",
+        "canonicalAddress",
+        "trust",
+        "source",
+        "createdAt",
+        "updatedAt",
+        "version",
+      ]),
+    );
+    expect(CONTACT_SCHEMA.additionalProperties).toBe(false);
+  });
+
+  it("MailboxPolicy schema fields align with the client MailboxPolicy DTO", () => {
+    expect(POLICY_SCHEMA.required).toEqual(
+      expect.arrayContaining(["allowUnknown", "minimumPostage", "requireVerified"]),
+    );
+    const props = POLICY_SCHEMA.properties as Record<string, { type?: string }>;
+    expect(props.allowUnknown.type).toBe("boolean");
+    expect(props.requireVerified.type).toBe("boolean");
+  });
+
+  it("the typed client unwraps the success envelope into typed data", async () => {
+    const client = new ApiClient();
+    const contact = await client.get<Contact>("/contacts");
+    expect(contact.contactId).toBe("c1");
+    expect(contact.trust).toBe("default");
+    expect(contact.canonicalAddress).toBeNull();
+  });
+
+  it("the typed client parses the error envelope into ApiClientError", async () => {
+    const envelope = {
+      error: {
+        code: "rate_limited",
+        message: "Slow down",
+        retryable: true,
+        retryClassification: "rate_limited",
+        retryAfter: 12,
+      },
+      meta: { requestId: "r2", timestamp: "2026-01-01T00:00:00.000Z" },
+    };
+    vi.stubGlobal("fetch", mockFetch({ ok: false, status: 429, json: envelope }));
+
+    const client = new ApiClient();
+    await expect(client.get<Contact>("/contacts")).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof ApiClientError)) return false;
+      expect(err.code).toBe("rate_limited");
+      expect(err.status).toBe(429);
+      expect(err.retryable).toBe(true);
+      expect(err.retryClassification).toBe("rate_limited");
+      expect(err.retryAfterSeconds).toBe(12);
+      expect(err.requestId).toBe("r2");
+      return true;
+    });
+  });
+
+  it("parseErrorEnvelope is stable for server-shaped error bodies", () => {
+    const error = parseErrorEnvelope(
+      {
+        error: {
+          code: "validation_error",
+          message: "Bad input",
+          retryable: false,
+          retryClassification: "none",
+        },
+        meta: { requestId: "r3" },
+      },
+      422,
+    );
+    expect(error.code).toBe("validation_error");
+    expect(error.status).toBe(422);
+    expect(error.retryable).toBe(false);
+  });
+
+  it("statusToCode maps HTTP statuses to canonical public codes", () => {
+    expect(statusToCode(401)).toBe("unauthorized");
+    expect(statusToCode(403)).toBe("forbidden");
+    expect(statusToCode(404)).toBe("not_found");
+    expect(statusToCode(409)).toBe("conflict");
+    expect(statusToCode(422)).toBe("validation_error");
+    expect(statusToCode(429)).toBe("rate_limited");
+    expect(statusToCode(413)).toBe("payload_too_large");
+    expect(statusToCode(503)).toBe("dependency_failure");
+  });
+});
+
+describe("query keys and cache invalidation rules", () => {
+  it("query keys are stable, scoped tuples", () => {
+    expect(queryKeys.mailbox.queue("GABC")).toEqual(["mailbox", "queue", "GABC"]);
+    expect(queryKeys.auth.session).toEqual(["auth", "session"]);
+    expect(queryKeys.policies.policy("GABC")).toEqual(["policies", "GABC"]);
+  });
+
+  it("mutations invalidate the documented dependent queries", () => {
+    expect(cacheInvalidations.sessionLogout()).toEqual([["auth", "session"]]);
+    expect(cacheInvalidations.tombstoneMessage("GABC")).toEqual([["mailbox", "queue", "GABC"]]);
+    expect(cacheInvalidations.updateMailboxPolicy("GABC")).toEqual([
+      ["policies", "GABC"],
+      ["policies", "evaluate", "GABC"],
+      ["settings"],
+    ]);
+  });
+});
+
+describe("typed domain DTO shapes carry the server contract", () => {
+  it("UnknownSenderRequest DTO matches server shape", () => {
+    const request: UnknownSenderRequest = {
+      requestId: "uuid",
+      recipient: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      sender: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+      message: { messageId: "a".repeat(64), ciphertextHash: "b".repeat(64) },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-02T00:00:00.000Z",
+      status: "pending",
+    };
+    expect(request.status).toBe("pending");
+  });
+
+  it("PostageQuote DTO mirrors the compose-facing shape", () => {
+    const quote: PostageQuote = {
+      amount: "0",
+      eligible: true,
+      reason: "trusted_sender",
+      trusted: true,
+      messageId: "a".repeat(64),
+    };
+    expect(quote.reason).toBe("trusted_sender");
+    expect(quote.trusted).toBe(true);
+  });
+
+  it("MailboxPolicy DTO matches the OpenAPI required fields", () => {
+    const policy: MailboxPolicy = {
+      allowUnknown: true,
+      minimumPostage: "0",
+      requireVerified: false,
+    };
+    expect(policy).toEqual({
+      allowUnknown: true,
+      minimumPostage: "0",
+      requireVerified: false,
+    });
+  });
+});

--- a/tests/unit/mailbox/mailbox-descriptor-mapping.test.ts
+++ b/tests/unit/mailbox/mailbox-descriptor-mapping.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { mailboxDescriptorToEmail, mailboxQueueToEmails } from "../../../src/features/mail";
+import type { MailboxDescriptor } from "../../../src/lib/api";
+
+const SENDER = `G${"B".repeat(55)}`;
+
+function descriptor(overrides: Partial<MailboxDescriptor> = {}): MailboxDescriptor {
+  return {
+    messageId: "a".repeat(64),
+    senderId: SENDER,
+    recipientId: `G${"A".repeat(55)}`,
+    status: "pending",
+    createdAt: "2026-08-17T10:00:00Z",
+    protectedHeaders: { alg: "dir", enc: "A256GCM", version: "v1" },
+    isTombstone: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("mailboxDescriptorToEmail (BETA-051)", () => {
+  it("maps a pending descriptor to the pending folder as unread", () => {
+    const email = mailboxDescriptorToEmail(descriptor());
+    expect(email.id).toBe("a".repeat(64));
+    expect(email.email).toBe(SENDER);
+    expect(email.folder).toBe("pending");
+    expect(email.unread).toBe(true);
+    expect(email.subject).toBe("Encrypted message");
+  });
+
+  it("maps a delivered descriptor to the inbox as read", () => {
+    const email = mailboxDescriptorToEmail(descriptor({ status: "delivered" }));
+    expect(email.folder).toBe("inbox");
+    expect(email.unread).toBe(false);
+  });
+
+  it("maps a tombstone to trash with a deleted label", () => {
+    const email = mailboxDescriptorToEmail(
+      descriptor({ isTombstone: true, deletedAt: "2026-08-17T12:00:00Z" }),
+    );
+    expect(email.folder).toBe("trash");
+    expect(email.labels).toContain("Deleted");
+  });
+
+  it("reads the subject from protectedHeaders when present", () => {
+    const email = mailboxDescriptorToEmail(
+      descriptor({ protectedHeaders: { subject: "Quarterly report", alg: "dir" } }),
+    );
+    expect(email.subject).toBe("Quarterly report");
+  });
+
+  it("maps an entire queue page to the display email list", () => {
+    const emails = mailboxQueueToEmails({
+      items: [descriptor(), descriptor({ messageId: "b".repeat(64), status: "delivered" })],
+      nextCursor: null,
+      hasMore: false,
+    });
+    expect(emails).toHaveLength(2);
+    expect(emails[1].folder).toBe("inbox");
+  });
+});


### PR DESCRIPTION
Closes #1958

## Summary
Introduces a typed web data-access layer (\src/lib/api\) and moves the app shell off direct mock-fixture imports. All web-client data access now flows through typed clients with normalized errors, abort handling, and envelope unwrapping.

## What's included
- **\src/lib/api\** — \ApiClient\ (base path \/api/v1\, \{data,meta}\ unwrap, \AbortSignal\, \x-request-id\, \onUnauthorized\), normalized \ApiClientError\ + \errorLabel\, domain clients (\uth\, \identity\, \mailbox\, \equests\, \policies\, \postage\, \eceipts\, \contacts\, \settings\), \sharedTypedApi\ singleton, query keys + cache-invalidation map.
- **\src/features/mail\** — typed hooks (\useSession\, \useMailbox\, \useRequests\, \useContacts\, \usePolicy\, \useSettings\) consuming the typed clients; mailbox descriptor→Email mapping.
- **App shell decoupling** — \src/routes/index.tsx\ no longer imports \initialEmails\; consumes \useSession\/\useMailbox\. Demo fixtures are reachable only via a dev-only dynamic import gated directly on \import.meta.env.DEV\, so the mock module and branch are tree-shaken from production builds (verified in \dist/client\).
- **Bare-fetch consumers refactored** — \AuthModal\, \uth-pages\, \SettingsModal\, \usePostageQuote\ (which now hits the correct \POST /postage/quote\ route instead of a non-existent GET \/api/postage/quote\).
- **Tests** — contract tests decoding client DTOs against OpenAPI examples; mailbox descriptor→Email mapping unit tests (16 tests).

## Verification
- \
px tsc --noEmit\ — clean
- \
pm run lint\ — clean
- \
pm test\ — 200 files / 2337 passed, 3 expected fail
- \
pm run build\ — succeeds; no \demo-data\ chunk in production client; mock \emails\ strings absent from client bundle

## Dependency note
Per the issue instruction, **#1919, #1941, and #1955 remain open** — the completion criteria for those issues are not yet met. This PR delivers the web-side data-access vertical slice in isolation; it does not claim completion of the dependent issues. The typed client contract mirrors the current OpenAPI surface and is additive — no server behavior changes.