### PR TITLE
fix(motion): complete WCAG 2.1 reduced-motion compliance in motion presets

### DIFF
--- a/src/lib/motion-presets.test.ts
+++ b/src/lib/motion-presets.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { motionPresets, getMotionPreference, isReducedMotion } from "./motion-presets";
+
+describe("motionPresets reduced motion compliance", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  function setReducedMotion(matches: boolean) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes("prefers-reduced-motion: reduce") ? matches : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+
+  describe("getMotionPreference & isReducedMotion", () => {
+    it("returns full when prefers-reduced-motion is false", () => {
+      setReducedMotion(false);
+      expect(isReducedMotion()).toBe(false);
+      expect(getMotionPreference()).toBe("full");
+    });
+
+    it("returns reduced when prefers-reduced-motion is true", () => {
+      setReducedMotion(true);
+      expect(isReducedMotion()).toBe(true);
+      expect(getMotionPreference()).toBe("reduced");
+    });
+  });
+
+  describe("Entrance Presets", () => {
+    it("returns spring configuration when motion is full", () => {
+      setReducedMotion(false);
+      const preset = motionPresets.entrance.slideUp();
+      expect(preset.initial).toEqual({ opacity: 0, y: 16 });
+      expect(preset.transition.type).toBe("spring");
+      expect(preset.transition.duration).toBe(0.3);
+    });
+
+    it("returns simplified configuration when motion is reduced", () => {
+      setReducedMotion(true);
+      const preset = motionPresets.entrance.slideUp();
+      expect(preset.initial).toEqual({ opacity: 0 });
+      expect(preset.transition.duration).toBe(0.01);
+    });
+  });
+
+  describe("Promote Presets", () => {
+    it("includes hover/tap effects when motion is full", () => {
+      setReducedMotion(false);
+      const preset = motionPresets.promote.scale();
+      expect(preset.whileHover).toEqual({ scale: 1.02 });
+      expect(preset.whileTap).toBeDefined();
+    });
+
+    it("disables hover/tap effects when motion is reduced", () => {
+      setReducedMotion(true);
+      const preset = motionPresets.promote.scale();
+      expect(preset.whileHover).toBeUndefined();
+      expect(preset.whileTap).toBeUndefined();
+    });
+  });
+
+  describe("Danger Presets", () => {
+    it("oscillates keyframes when motion is full", () => {
+      setReducedMotion(false);
+      const preset = motionPresets.danger.shake();
+      expect(preset.animate).toEqual({ x: [0, -6, 6, -6, 0] });
+    });
+
+    it("suppresses keyframe oscillations when motion is reduced", () => {
+      setReducedMotion(true);
+      const preset = motionPresets.danger.shake();
+      expect(preset.animate).toEqual({ x: 0 });
+    });
+  });
+});

--- a/src/lib/motion-presets.ts
+++ b/src/lib/motion-presets.ts
@@ -13,9 +13,13 @@
  *   <motion.div {...motionPresets.entrance.slideUp()} />
  */
 
-// Check if user prefers reduced motion
-const prefersReducedMotion =
-  typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+/**
+ * Helper function to check if user prefers reduced motion dynamically
+ */
+export function isReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
 
 // Base animation configuration
 const baseConfig = {
@@ -33,7 +37,7 @@ const reducedConfig = {
   springDamping: 999,
 } as const;
 
-const getConfig = () => (prefersReducedMotion ? reducedConfig : baseConfig);
+const getConfig = () => (isReducedMotion() ? reducedConfig : baseConfig);
 
 export type AnimationPreset = {
   initial: Record<string, any>;
@@ -55,11 +59,12 @@ export const entrance = {
    */
   slideUp: (custom?: number): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, y: 16 + (custom ?? 0) },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, y: 16 + (custom ?? 0) },
       animate: { opacity: 1, y: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -88,11 +93,12 @@ export const entrance = {
    */
   scaleIn: (scale: number = 0.96): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, scale },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, scale },
       animate: { opacity: 1, scale: 1 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -106,11 +112,12 @@ export const entrance = {
    */
   slideLeft: (distance: number = 24): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, x: -distance },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, x: -distance },
       animate: { opacity: 1, x: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -124,11 +131,12 @@ export const entrance = {
    */
   slideRight: (distance: number = 24): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, x: distance },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, x: distance },
       animate: { opacity: 1, x: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -148,12 +156,13 @@ export const exit = {
    */
   slideDown: (custom?: number): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, y: 0 },
-      exit: { opacity: 0, y: 16 + (custom ?? 0) },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, y: 16 + (custom ?? 0) },
       animate: { opacity: 1, y: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -183,12 +192,13 @@ export const exit = {
    */
   scaleOut: (scale: number = 0.96): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, scale: 1 },
-      exit: { opacity: 0, scale },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, scale },
       animate: { opacity: 1, scale: 1 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -202,12 +212,13 @@ export const exit = {
    */
   slideToLeft: (distance: number = 24): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, x: 0 },
-      exit: { opacity: 0, x: -distance },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, x: -distance },
       animate: { opacity: 1, x: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -221,12 +232,13 @@ export const exit = {
    */
   slideToRight: (distance: number = 24): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, x: 0 },
-      exit: { opacity: 0, x: distance },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, x: distance },
       animate: { opacity: 1, x: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -246,16 +258,18 @@ export const promote = {
    * Good for buttons, cards, interactive elements
    */
   scale: (scale: number = 1.02): AnimationPreset => {
+    const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { scale: 1 },
       animate: { scale: 1 },
-      whileHover: { scale },
-      whileTap: { scale: scale * 0.98 },
+      whileHover: reduced ? undefined : { scale },
+      whileTap: reduced ? undefined : { scale: scale * 0.98 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: 400,
         damping: 17,
-        duration: 0.2,
+        duration: config.duration,
       },
     };
   },
@@ -265,19 +279,23 @@ export const promote = {
    * Good for cards, elevated elements
    */
   lift: (): AnimationPreset => {
+    const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { y: 0, boxShadow: "0px 1px 3px rgba(0, 0, 0, 0.1)" },
       animate: { y: 0 },
-      whileHover: {
-        y: -4,
-        boxShadow: "0px 8px 24px rgba(0, 0, 0, 0.15)",
-      },
-      whileTap: { y: -2 },
+      whileHover: reduced
+        ? undefined
+        : {
+            y: -4,
+            boxShadow: "0px 8px 24px rgba(0, 0, 0, 0.15)",
+          },
+      whileTap: reduced ? undefined : { y: -2 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: 400,
         damping: 17,
-        duration: 0.2,
+        duration: config.duration,
       },
     };
   },
@@ -287,12 +305,14 @@ export const promote = {
    * Good for focus states, highlighting active items
    */
   glow: (): AnimationPreset => {
+    const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1 },
       animate: { opacity: 1 },
-      whileHover: { opacity: 1.1 },
+      whileHover: reduced ? undefined : { opacity: 1.1 },
       transition: {
-        duration: 0.2,
+        duration: config.duration,
       },
     };
   },
@@ -310,12 +330,13 @@ export const remove = {
    */
   spinOut: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, rotate: 0, scale: 1 },
-      exit: { opacity: 0, rotate: 90, scale: 0.8 },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, rotate: 90, scale: 0.8 },
       animate: { opacity: 1, rotate: 0, scale: 1 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -348,12 +369,13 @@ export const remove = {
    */
   slideAwayRight: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1, x: 0 },
-      exit: { opacity: 0, x: 100 },
+      exit: reduced ? { opacity: 0 } : { opacity: 0, x: 100 },
       animate: { opacity: 1, x: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -374,11 +396,12 @@ export const confirm = {
    */
   bounce: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, scale: 0.8, y: 12 },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, scale: 0.8, y: 12 },
       animate: { opacity: 1, scale: 1, y: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -392,11 +415,12 @@ export const confirm = {
    */
   pulse: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { scale: 1 },
-      animate: { scale: [1, 1.05, 1] },
+      animate: reduced ? { scale: 1 } : { scale: [1, 1.05, 1] },
       transition: {
-        duration: config.duration * 1.5,
+        duration: config.duration * (reduced ? 1 : 1.5),
         ease: "easeInOut",
       },
     };
@@ -408,11 +432,12 @@ export const confirm = {
    */
   checkmark: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, scale: 0 },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, scale: 0 },
       animate: { opacity: 1, scale: 1 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -433,11 +458,12 @@ export const danger = {
    */
   shake: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { x: 0 },
-      animate: { x: [0, -6, 6, -6, 0] },
+      animate: reduced ? { x: 0 } : { x: [0, -6, 6, -6, 0] },
       transition: {
-        duration: config.duration * 1.2,
+        duration: config.duration * (reduced ? 1 : 1.2),
         ease: "easeInOut",
       },
     };
@@ -449,11 +475,12 @@ export const danger = {
    */
   pulse: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
       initial: { opacity: 1 },
-      animate: { opacity: [1, 0.7, 1] },
+      animate: reduced ? { opacity: 1 } : { opacity: [1, 0.7, 1] },
       transition: {
-        duration: config.duration * 1.5,
+        duration: config.duration * (reduced ? 1 : 1.5),
         ease: "easeInOut",
       },
     };
@@ -465,11 +492,12 @@ export const danger = {
    */
   spinWarn: (): AnimationPreset => {
     const config = getConfig();
+    const reduced = isReducedMotion();
     return {
-      initial: { opacity: 0, rotate: -180 },
+      initial: reduced ? { opacity: 0 } : { opacity: 0, rotate: -180 },
       animate: { opacity: 1, rotate: 0 },
       transition: {
-        type: "spring",
+        type: reduced ? "tween" : "spring",
         stiffness: config.springStiffness,
         damping: config.springDamping,
         duration: config.duration,
@@ -605,7 +633,7 @@ export const easings = {
  * Helper function to check if user prefers reduced motion
  */
 export function getMotionPreference(): "full" | "reduced" {
-  return prefersReducedMotion ? "reduced" : "full";
+  return isReducedMotion() ? "reduced" : "full";
 }
 
 /**
@@ -623,6 +651,7 @@ export const motionPresets = {
   durations,
   easings,
   getMotionPreference,
+  isReducedMotion,
 } as const;
 
 export type MotionPreset = typeof motionPresets;


### PR DESCRIPTION
This PR completes motion accessibility requirements for issue #BETA-073):

1. **Dynamic Reduced Motion Evaluation**: Replaced static evaluation of `window.matchMedia` with `isReducedMotion()`, ensuring motion preferences update dynamically at runtime.
2. **Hover/Tap & Keyframe Suppression**: Updated `promote`, `confirm`, `danger`, `entrance`, `exit`, and `remove` motion presets so hover scaling/lifting and keyframe oscillations (shake, pulse) are suppressed or simplified when `prefers-reduced-motion: reduce` is active.
3. **Unit Tests**: Added `src/lib/motion-presets.test.ts` to verify preset behavior under standard and reduced motion preferences.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
