### PR TITLE
feat(stellar): rate limits + durable retry logic for wallet funding (BETA-018)

### DIFF
--- a/infra/stellar/README.md
+++ b/infra/stellar/README.md
@@ -1,3 +1,12 @@
 # Stellar
 
 Stellar network configuration, account funding, Horizon/RPC settings, federation setup, and testnet notes.
+
+## Managed wallet funding (BETA-015)
+
+Beta accounts receive a system-managed Stellar testnet wallet during registration. Funding is performed through a swappable adapter:
+
+- `src/services/stellar/funding-adapter.ts` — `FriendbotFundingAdapter` for live testnet funding and `FakeFundingAdapter` for unit/integration tests.
+- `src/services/stellar/funding-config.ts` — friendbot URL configuration (`STEALTH_TESTNET_FRIENDBOT_URL`, default `https://friendbot.stellar.org`).
+
+Production and preview deployments use the real friendbot adapter on testnet. Development and test profiles use the fake adapter so CI does not require network access.

--- a/infra/stellar/config.ts
+++ b/infra/stellar/config.ts
@@ -1,0 +1,1 @@
+export * from "../../src/services/stellar/funding-config";

--- a/infra/stellar/funding-adapter.ts
+++ b/infra/stellar/funding-adapter.ts
@@ -1,0 +1,1 @@
+export * from "../../src/services/stellar/funding-adapter";

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -50,6 +50,7 @@ import { Route as ApiV1AccountsProvisioningRouteImport } from './routes/api/v1/a
 import { Route as ApiV1WalletLinkIndexRouteImport } from './routes/api/v1/wallet/link/index'
 import { Route as ApiV1IdentityKeysIndexRouteImport } from './routes/api/v1/identity/keys/index'
 import { Route as ApiV1AdminJobsIndexRouteImport } from './routes/api/v1/admin/jobs/index'
+import { Route as ApiV1AdminFundingIndexRouteImport } from './routes/api/v1/admin/funding/index'
 import { Route as ApiV1AdminDlqIndexRouteImport } from './routes/api/v1/admin/dlq/index'
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
 import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
@@ -281,6 +282,11 @@ const ApiV1AdminJobsIndexRoute = ApiV1AdminJobsIndexRouteImport.update({
   path: '/api/v1/admin/jobs/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV1AdminFundingIndexRoute = ApiV1AdminFundingIndexRouteImport.update({
+  id: '/api/v1/admin/funding/',
+  path: '/api/v1/admin/funding/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiV1AdminDlqIndexRoute = ApiV1AdminDlqIndexRouteImport.update({
   id: '/api/v1/admin/dlq/',
   path: '/api/v1/admin/dlq/',
@@ -469,6 +475,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
   '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
   '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
+  '/api/v1/admin/funding/': typeof ApiV1AdminFundingIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
@@ -535,6 +542,7 @@ export interface FileRoutesByTo {
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
   '/api/v1/admin/dlq': typeof ApiV1AdminDlqIndexRoute
   '/api/v1/admin/jobs': typeof ApiV1AdminJobsIndexRoute
+  '/api/v1/admin/funding': typeof ApiV1AdminFundingIndexRoute
   '/api/v1/identity/keys': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
@@ -602,6 +610,7 @@ export interface FileRoutesById {
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
   '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
   '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
+  '/api/v1/admin/funding/': typeof ApiV1AdminFundingIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
@@ -670,6 +679,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/verify'
     | '/api/v1/admin/dlq/'
     | '/api/v1/admin/jobs/'
+    | '/api/v1/admin/funding/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
     | '/api/v1/admin/dlq/$id/abandon'
@@ -736,6 +746,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/verify'
     | '/api/v1/admin/dlq'
     | '/api/v1/admin/jobs'
+    | '/api/v1/admin/funding'
     | '/api/v1/identity/keys'
     | '/api/v1/wallet/link'
     | '/api/v1/admin/dlq/$id/abandon'
@@ -802,6 +813,7 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/verify'
     | '/api/v1/admin/dlq/'
     | '/api/v1/admin/jobs/'
+    | '/api/v1/admin/funding/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
     | '/api/v1/admin/dlq/$id/abandon'
@@ -863,6 +875,7 @@ export interface RootRouteChildren {
   ApiV1WalletLinkVerifyRoute: typeof ApiV1WalletLinkVerifyRoute
   ApiV1AdminDlqIndexRoute: typeof ApiV1AdminDlqIndexRoute
   ApiV1AdminJobsIndexRoute: typeof ApiV1AdminJobsIndexRoute
+  ApiV1AdminFundingIndexRoute: typeof ApiV1AdminFundingIndexRoute
   ApiV1IdentityKeysIndexRoute: typeof ApiV1IdentityKeysIndexRoute
   ApiV1WalletLinkIndexRoute: typeof ApiV1WalletLinkIndexRoute
 }
@@ -1156,6 +1169,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AdminJobsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/admin/funding/': {
+      id: '/api/v1/admin/funding/'
+      path: '/api/v1/admin/funding'
+      fullPath: '/api/v1/admin/funding/'
+      preLoaderRoute: typeof ApiV1AdminFundingIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/admin/dlq/': {
       id: '/api/v1/admin/dlq/'
       path: '/api/v1/admin/dlq'
@@ -1446,6 +1466,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1WalletLinkVerifyRoute: ApiV1WalletLinkVerifyRoute,
   ApiV1AdminDlqIndexRoute: ApiV1AdminDlqIndexRoute,
   ApiV1AdminJobsIndexRoute: ApiV1AdminJobsIndexRoute,
+  ApiV1AdminFundingIndexRoute: ApiV1AdminFundingIndexRoute,
   ApiV1IdentityKeysIndexRoute: ApiV1IdentityKeysIndexRoute,
   ApiV1WalletLinkIndexRoute: ApiV1WalletLinkIndexRoute,
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -69,6 +69,7 @@ import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/c
 import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
 import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
 import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
+import { Route as ApiV1AccountsUserIdWalletProvisionRouteImport } from './routes/api/v1/accounts/$userId/wallet/provision'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
 import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
@@ -385,6 +386,12 @@ const ApiV1AccountsProvisioningRetryRoute =
     path: '/retry',
     getParentRoute: () => ApiV1AccountsProvisioningRoute,
   } as any)
+const ApiV1AccountsUserIdWalletProvisionRoute =
+  ApiV1AccountsUserIdWalletProvisionRouteImport.update({
+    id: '/api/v1/accounts/$userId/wallet/provision',
+    path: '/api/v1/accounts/$userId/wallet/provision',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
@@ -442,6 +449,7 @@ export interface FileRoutesByFullPath {
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
@@ -507,6 +515,7 @@ export interface FileRoutesByTo {
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
@@ -573,6 +582,7 @@ export interface FileRoutesById {
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
@@ -640,6 +650,7 @@ export interface FileRouteTypes {
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
@@ -705,6 +716,7 @@ export interface FileRouteTypes {
     | '/api/v1/receipts'
     | '/api/v1/requests'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
@@ -770,6 +782,7 @@ export interface FileRouteTypes {
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
     | '/api/v1/contacts/import/commit'
@@ -831,6 +844,7 @@ export interface RootRouteChildren {
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
   ApiV1SendCoordinateRoute: typeof ApiV1SendCoordinateRoute
   ApiV1AccountsIndexRoute: typeof ApiV1AccountsIndexRoute
+  ApiV1AccountsUserIdWalletProvisionRoute: typeof ApiV1AccountsUserIdWalletProvisionRoute
   ApiV1ContactsIndexRoute: typeof ApiV1ContactsIndexRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
@@ -1275,6 +1289,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
       parentRoute: typeof ApiV1AccountsProvisioningRoute
     }
+    '/api/v1/accounts/$userId/wallet/provision': {
+      id: '/api/v1/accounts/$userId/wallet/provision'
+      path: '/api/v1/accounts/$userId/wallet/provision'
+      fullPath: '/api/v1/accounts/$userId/wallet/provision'
+      preLoaderRoute: typeof ApiV1AccountsUserIdWalletProvisionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
       path: '/senders/$sender'
@@ -1406,6 +1427,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
   ApiV1SendCoordinateRoute: ApiV1SendCoordinateRoute,
   ApiV1AccountsIndexRoute: ApiV1AccountsIndexRoute,
+  ApiV1AccountsUserIdWalletProvisionRoute: ApiV1AccountsUserIdWalletProvisionRoute,
   ApiV1ContactsIndexRoute: ApiV1ContactsIndexRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,

--- a/src/routes/api/v1/accounts/$userId/wallet/provision.ts
+++ b/src/routes/api/v1/accounts/$userId/wallet/provision.ts
@@ -34,6 +34,10 @@ export const Route = createFileRoute("/api/v1/accounts/$userId/wallet/provision"
 
           requireActorMatches(apiContext, user.address);
 
+          const origin =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
           const config = loadRuntimeConfig();
           const storageSecret = config.secrets?.storageSecret ?? "dev-storage-secret-change-me";
           const rawIdempotencyKey = request.headers.get("x-idempotency-key");
@@ -48,6 +52,8 @@ export const Route = createFileRoute("/api/v1/accounts/$userId/wallet/provision"
                   useFake: config.profile === "development" || config.profile === "test",
                 }),
                 storageSecret,
+                accountId: userId,
+                origin,
               },
             );
             return { status: 200, body: result };

--- a/src/routes/api/v1/accounts/$userId/wallet/provision.ts
+++ b/src/routes/api/v1/accounts/$userId/wallet/provision.ts
@@ -1,0 +1,76 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requireActorMatches } from "@/server/api/actor";
+import { provisionManagedStellarWallet } from "@/server/api/account-provisioning";
+import { getApiContext } from "@/server/api/context";
+import { ApiError } from "@/server/api/errors";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { withIdempotency } from "@/server/api/idempotency-service";
+import { loadRuntimeConfig } from "@/config";
+import { createFundingAdapter } from "@/services/stellar/funding-adapter";
+
+const paramsSchema = z.object({
+  userId: z.string().min(1, "User ID cannot be empty"),
+});
+
+/**
+ * POST /api/v1/accounts/{userId}/wallet/provision
+ *
+ * Idempotently provisions (or returns) the system-managed Stellar testnet wallet
+ * for the account. Responses never include seed phrases or raw private keys.
+ */
+export const Route = createFileRoute("/api/v1/accounts/$userId/wallet/provision")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const { userId } = paramsSchema.parse(params);
+          const user = await apiContext.repository.getUserById(userId);
+          if (!user) {
+            throw new ApiError(404, "not_found", "Account not found");
+          }
+
+          requireActorMatches(apiContext, user.address);
+
+          const config = loadRuntimeConfig();
+          const storageSecret = config.secrets?.storageSecret ?? "dev-storage-secret-change-me";
+          const rawIdempotencyKey = request.headers.get("x-idempotency-key");
+
+          const provision = async () => {
+            const result = await provisionManagedStellarWallet(
+              apiContext.repository,
+              userId,
+              config,
+              {
+                fundingAdapter: createFundingAdapter({
+                  useFake: config.profile === "development" || config.profile === "test",
+                }),
+                storageSecret,
+              },
+            );
+            return { status: 200, body: result };
+          };
+
+          const result = rawIdempotencyKey
+            ? await withIdempotency(
+                apiContext.repository,
+                {
+                  actor: user.address,
+                  method: request.method,
+                  route: "POST /accounts/{userId}/wallet/provision",
+                  rawKey: rawIdempotencyKey,
+                },
+                { userId },
+                provision,
+              )
+            : { ...(await provision()), replayed: false };
+
+          return apiSuccess(request, result.body, {
+            ...(result.replayed ? { headers: { "x-idempotency-replayed": "true" } } : {}),
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/admin/funding/index.ts
+++ b/src/routes/api/v1/admin/funding/index.ts
@@ -1,0 +1,36 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { fundingOperationStatusSchema } from "@/server/api/domain";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { listPublicFundingQueue } from "@/services/stellar/funding";
+
+const querySchema = z.object({
+  status: fundingOperationStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+/**
+ * GET /api/v1/admin/funding/
+ *
+ * Administrator-visible funding queue. Returns public operation metadata only —
+ * never seeds, encrypted secrets, or storage keys.
+ */
+export const Route = createFileRoute("/api/v1/admin/funding/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const url = new URL(request.url);
+          const parsed = querySchema.parse({
+            status: url.searchParams.get("status") || undefined,
+            limit: url.searchParams.get("limit") || undefined,
+          });
+          const operations = await listPublicFundingQueue(context.repository, parsed);
+          return apiSuccess(request, { operations });
+        }),
+    },
+  },
+});

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -4,9 +4,10 @@ import type { BetaRuntimeConfig } from "../../config/schema";
 import { loadRuntimeConfig } from "../../config";
 import type { StellarFundingAdapter } from "@/services/stellar/funding-adapter";
 import { createFundingAdapter } from "@/services/stellar/funding-adapter";
+import { runFundingOperation } from "@/services/stellar/funding";
+import { consumeProvisioningQuota } from "./rate-limit";
 import {
   assertTestnetManagedWalletNetwork,
-  fundManagedWalletAccount,
   prepareManagedWalletSecret,
   type PreparedManagedWallet,
 } from "../../services/stellar/account-provision";
@@ -48,15 +49,14 @@ export interface ProvisionManagedStellarWalletOptions {
   now?: Date;
   /** When supplied (e.g. during registration), skip fresh keypair generation. */
   prepared?: PreparedManagedWallet;
+  /** Account subject for BETA-018 provisioning quotas. Defaults to `userId`. */
+  accountId?: string;
+  /** Request origin / IP for BETA-018 per-origin provisioning quotas. */
+  origin?: string;
 }
 
 function managedWalletKeyRef(userId: string): string {
   return `wallet:managed:${userId}`;
-}
-
-function redactFundingError(error: unknown): string {
-  const message = error instanceof Error ? error.message : "Funding failed";
-  return message.slice(0, 300);
 }
 
 /**
@@ -86,6 +86,23 @@ export async function provisionManagedStellarWallet(
   const now = options.now ?? new Date();
   const nowIso = now.toISOString();
   const existing = await repository.getManagedWallet(userId);
+
+  if (existing?.fundingStatus === "funded") {
+    return {
+      wallet: toPublicManagedWallet(existing, false),
+    };
+  }
+
+  const quota = await consumeProvisioningQuota(repository, {
+    accountId: options.accountId ?? userId,
+    origin: options.origin ?? "unknown",
+  });
+  if (!quota.allowed) {
+    throw new ApiError("too_many_requests", {
+      retryAfterSeconds: quota.retryAfterSeconds,
+      limitedBy: quota.limitedBy,
+    });
+  }
 
   if (existing) {
     const wallet = await ensureManagedWalletFunded(
@@ -158,26 +175,39 @@ async function ensureManagedWalletFunded(
     return wallet;
   }
 
-  try {
-    await fundManagedWalletAccount(fundingAdapter, wallet.address);
-    const funded: ManagedWalletRecord = {
+  const operation = await runFundingOperation({
+    repository,
+    adapter: fundingAdapter,
+    userId: wallet.userId,
+    address: wallet.address,
+    now,
+  });
+
+  if (operation.status === "succeeded") {
+    return repository.setManagedWallet({
       ...wallet,
       fundingStatus: "funded",
-      fundedAt: now.toISOString(),
+      fundedAt: wallet.fundedAt ?? now.toISOString(),
       updatedAt: now.toISOString(),
       lastError: null,
-    };
-    return repository.setManagedWallet(funded);
-  } catch (error) {
-    const failed: ManagedWalletRecord = {
+    });
+  }
+
+  if (operation.status === "failed") {
+    return repository.setManagedWallet({
       ...wallet,
       fundingStatus: "failed",
       updatedAt: now.toISOString(),
-      lastError: redactFundingError(error),
-    };
-    await repository.setManagedWallet(failed);
-    throw new ApiError(503, "dependency_unavailable", "Managed wallet funding failed");
+      lastError: operation.lastError,
+    });
   }
+
+  return repository.setManagedWallet({
+    ...wallet,
+    fundingStatus: "pending",
+    updatedAt: now.toISOString(),
+    lastError: operation.lastError,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/api/account-provisioning.ts
+++ b/src/server/api/account-provisioning.ts
@@ -1,4 +1,29 @@
-import type { ChainMailboxPolicy } from "./domain";
+import { randomUUID } from "node:crypto";
+
+import type { BetaRuntimeConfig } from "../../config/schema";
+import { loadRuntimeConfig } from "../../config";
+import type { StellarFundingAdapter } from "@/services/stellar/funding-adapter";
+import { createFundingAdapter } from "@/services/stellar/funding-adapter";
+import {
+  assertTestnetManagedWalletNetwork,
+  fundManagedWalletAccount,
+  prepareManagedWalletSecret,
+  type PreparedManagedWallet,
+} from "../../services/stellar/account-provision";
+import type {
+  AccountStatus,
+  ChainMailboxPolicy,
+  ManagedWalletRecord,
+  Profile,
+  ProvisioningFailure,
+  ProvisioningRecord,
+  ProvisioningStep,
+  ProvisioningStatus,
+  PublicManagedWallet,
+  User,
+  Wallet,
+} from "./domain";
+import { stellarAddressSchema, toPublicManagedWallet, usernameSchema } from "./domain";
 import {
   betaDefaultMailboxPolicy,
   getMailboxPolicy,
@@ -6,19 +31,158 @@ import {
   setMailboxPolicy,
   toChainMailboxPolicy,
 } from "./policy-service";
+import type { ApiRepository, UpdateProvisioningResult } from "./repository";
+import { ApiError } from "./errors";
+
+// ---------------------------------------------------------------------------
+// BETA-015 (Issue #1922) — system-managed Stellar testnet wallet provisioning
+// ---------------------------------------------------------------------------
+
+export interface ProvisionManagedStellarWalletResult {
+  wallet: PublicManagedWallet;
+}
+
+export interface ProvisionManagedStellarWalletOptions {
+  fundingAdapter: StellarFundingAdapter;
+  storageSecret: string;
+  now?: Date;
+  /** When supplied (e.g. during registration), skip fresh keypair generation. */
+  prepared?: PreparedManagedWallet;
+}
+
+function managedWalletKeyRef(userId: string): string {
+  return `wallet:managed:${userId}`;
+}
+
+function redactFundingError(error: unknown): string {
+  const message = error instanceof Error ? error.message : "Funding failed";
+  return message.slice(0, 300);
+}
+
+/**
+ * Idempotently provisions a system-managed Stellar testnet wallet for `userId`.
+ */
+export async function provisionManagedStellarWallet(
+  repository: ApiRepository,
+  userId: string,
+  config: BetaRuntimeConfig,
+  options: ProvisionManagedStellarWalletOptions,
+): Promise<ProvisionManagedStellarWalletResult> {
+  try {
+    assertTestnetManagedWalletNetwork(config);
+  } catch {
+    throw new ApiError(
+      400,
+      "bad_request",
+      "Managed wallet provisioning is testnet-only during beta",
+    );
+  }
+
+  const storageSecret = options.storageSecret?.trim();
+  if (!storageSecret) {
+    throw new ApiError(500, "internal_error", "Managed wallet storage secret is not configured");
+  }
+
+  const now = options.now ?? new Date();
+  const nowIso = now.toISOString();
+  const existing = await repository.getManagedWallet(userId);
+
+  if (existing) {
+    const wallet = await ensureManagedWalletFunded(
+      existing,
+      options.fundingAdapter,
+      repository,
+      now,
+    );
+    return {
+      wallet: toPublicManagedWallet(wallet, false),
+    };
+  }
+
+  const prepared =
+    options.prepared ??
+    (await prepareManagedWalletSecret({
+      userId,
+      storageSecret,
+      now,
+    }));
+
+  const pendingRecord: ManagedWalletRecord = {
+    userId,
+    address: prepared.address,
+    network: "testnet",
+    fundingStatus: "pending",
+    encryptedSecret: prepared.encryptedSecret,
+    fundedAt: null,
+    createdAt: prepared.createdAt,
+    updatedAt: prepared.updatedAt,
+    lastError: null,
+  };
+
+  const created = await repository.createManagedWalletIfAbsent(pendingRecord);
+  const stored =
+    created.outcome === "existing"
+      ? created.wallet
+      : await bindManagedWalletCredential(repository, userId, created.wallet, nowIso);
+
+  const wallet = await ensureManagedWalletFunded(stored, options.fundingAdapter, repository, now);
+  return {
+    wallet: toPublicManagedWallet(wallet, created.outcome === "created"),
+  };
+}
+
+async function bindManagedWalletCredential(
+  repository: ApiRepository,
+  userId: string,
+  wallet: ManagedWalletRecord,
+  nowIso: string,
+): Promise<ManagedWalletRecord> {
+  const credential = await repository.getCredential(userId);
+  if (credential && credential.walletKeyRef.startsWith("pending_")) {
+    await repository.setCredential({
+      ...credential,
+      walletKeyRef: managedWalletKeyRef(userId),
+      updatedAt: nowIso,
+    });
+  }
+  return wallet;
+}
+
+async function ensureManagedWalletFunded(
+  wallet: ManagedWalletRecord,
+  fundingAdapter: StellarFundingAdapter,
+  repository: ApiRepository,
+  now: Date,
+): Promise<ManagedWalletRecord> {
+  if (wallet.fundingStatus === "funded") {
+    return wallet;
+  }
+
+  try {
+    await fundManagedWalletAccount(fundingAdapter, wallet.address);
+    const funded: ManagedWalletRecord = {
+      ...wallet,
+      fundingStatus: "funded",
+      fundedAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      lastError: null,
+    };
+    return repository.setManagedWallet(funded);
+  } catch (error) {
+    const failed: ManagedWalletRecord = {
+      ...wallet,
+      fundingStatus: "failed",
+      updatedAt: now.toISOString(),
+      lastError: redactFundingError(error),
+    };
+    await repository.setManagedWallet(failed);
+    throw new ApiError(503, "dependency_unavailable", "Managed wallet funding failed");
+  }
+}
 
 // ---------------------------------------------------------------------------
 // BETA-023 (Issue #1930) — privacy-safe mailbox policy defaults during
 // provisioning.
-//
-// This module is the isolated policy-initialization slice of the transactional
-// account-provisioning orchestrator (BETA-014 / Issue #1921). It guarantees
-// that provisioning leaves every account with an evaluable, privacy-safe
-// default policy and a durable intent for the matching testnet contract write.
-//
-// The orchestrator (once BETA-014 merges) calls `initializeMailboxPolicyDefaults`
-// inside its transactional flow; the POST /policies/{owner}/provision route
-// exposes the same entrypoint for the beta walkthrough and retries.
 // ---------------------------------------------------------------------------
 
 export interface InitializePolicyDefaultsResult {
@@ -33,12 +197,6 @@ export interface InitializePolicyDefaultsResult {
 /**
  * Idempotently initializes the privacy-safe beta mailbox policy defaults for
  * `owner`.
- *
- * - No policy exists: persists the beta default off-chain and schedules the
- *   matching testnet contract write at off-chain version 1.
- * - A policy already exists (including a user-customized one): no write and no
- *   version bump. Provisioning retries therefore never re-submit an identical
- *   write and never inflate the on-chain policy version.
  */
 export async function initializeMailboxPolicyDefaults(
   repository: ApiRepository,
@@ -81,53 +239,6 @@ export async function initializeMailboxPolicyDefaults(
 
 // ---------------------------------------------------------------------------
 // BETA-014 (Issue #1921) - transactional account-provisioning orchestrator
-// ---------------------------------------------------------------------------
-
-import { randomUUID } from "node:crypto";
-
-import type { ApiRepository, UpdateProvisioningResult } from "./repository";
-import type {
-  AccountStatus,
-  Profile,
-  ProvisioningFailure,
-  ProvisioningRecord,
-  ProvisioningStep,
-  ProvisioningStatus,
-  User,
-  Wallet,
-} from "./domain";
-import { stellarAddressSchema, usernameSchema } from "./domain";
-import { ApiError } from "./errors";
-
-// ---------------------------------------------------------------------------
-// BETA-014 (Issue #1921): Transactional account-provisioning orchestrator
-//
-// Convergence contract
-// --------------------
-// Signup data (username reservation), profile defaults, wallet creation and
-// mailbox policy initialization must converge without leaving a partial
-// *active* account behind. The orchestrator owns a durable, idempotent
-// state machine per user:
-//
-//   pending   -> active            (all steps completed, account activated)
-//   pending   -> retryable/failed  (a step failed transiently / permanently)
-//   retryable -> pending           (owner/administrator retry restarts it)
-//   retryable -> active            (retry completed)
-//   retryable -> failed            (permanent failure or exhausted attempts)
-//   active / failed are terminal.
-//
-// Safety properties
-// -----------------
-// - Every step is individually idempotent (re-claimable reservation,
-//   profile upsert, insert-once wallet, initialize-if-absent policy), so a
-//   resumed or retried flow never double-creates wallets, addresses, or
-//   policies.
-// - The user record only flips pending_verification -> active after ALL
-//   steps persist; a mid-flow failure leaves the account pending (never a
-//   live half-account) and releases the username reservation as the sole
-//   compensation action.
-// - All state-machine writes are compare-and-swap (expectedVersion), so a
-//   stale writer can never clobber progress made by a concurrent retry.
 // ---------------------------------------------------------------------------
 
 export const PROVISIONING_STEPS = [
@@ -464,9 +575,9 @@ async function profileDefaultsStep(
 }
 
 /**
- * Insert-once wallet creation. The initial on-chain address is the account's
- * own Stellar address until an external wallet provider exists (dependency
- * BETA-013); "already-exists" is a successful, idempotent retry.
+ * BETA-015: generate and fund a system-managed testnet wallet (encrypted at
+ * rest). The public Wallet row stays bound to the account's existing address so
+ * identity lookups and BETA-014 tests remain stable.
  */
 async function walletCreationStep(
   repository: ApiRepository,
@@ -474,6 +585,16 @@ async function walletCreationStep(
   now: Date,
 ): Promise<void> {
   const user = await requireUser(repository, userId);
+  const config = loadRuntimeConfig();
+  const storageSecret = config.secrets?.storageSecret ?? "dev-storage-secret-change-me";
+  await provisionManagedStellarWallet(repository, userId, config, {
+    fundingAdapter: createFundingAdapter({
+      useFake: config.profile === "development" || config.profile === "test",
+    }),
+    storageSecret,
+    now,
+  });
+
   const wallet: Wallet = {
     walletId: `wallet_${user.userId}`,
     userId: user.userId,

--- a/src/server/api/auth/registration-service.ts
+++ b/src/server/api/auth/registration-service.ts
@@ -1,18 +1,16 @@
 import type { RegistrationRequest, RegistrationResponse } from "@/features/identity/registration";
 import { maskEmail } from "@/features/identity/registration";
+import { loadRuntimeConfig } from "@/config";
 import type { ApiContext } from "../context";
 import type { Credential, Profile, User } from "../domain";
 import { ApiError } from "../errors";
 import { hashPassword } from "./password";
+import { provisionManagedStellarWallet } from "../account-provisioning";
+import { prepareManagedWalletSecret } from "@/services/stellar/account-provision";
+import { createFundingAdapter } from "@/services/stellar/funding-adapter";
 
 const SIGNUP_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const MAX_SIGNUPS_PER_IP = 10;
-const BASE32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-
-function generatedAccountAddress(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(55));
-  return `G${Array.from(bytes, (byte) => BASE32[byte % BASE32.length]).join("")}`;
-}
 
 export async function registerWithPassword(
   apiContext: ApiContext,
@@ -26,18 +24,27 @@ export async function registerWithPassword(
     });
   }
 
-  const now = new Date().toISOString();
+  const now = new Date();
+  const nowIso = now.toISOString();
   const userId = `usr_${crypto.randomUUID().replace(/-/g, "")}`;
   const { hash, salt } = await hashPassword(input.password);
+
+  const config = loadRuntimeConfig();
+  const storageSecret = config.secrets?.storageSecret ?? "dev-storage-secret-change-me";
+  const prepared = await prepareManagedWalletSecret({
+    userId,
+    storageSecret,
+    now,
+  });
+
   const user: User = {
     userId,
-    // This is an internal unique placeholder, not an external wallet connection.
-    address: generatedAccountAddress(),
+    address: prepared.address,
     email: input.email,
     username: input.username,
     status: "pending_verification",
-    createdAt: now,
-    updatedAt: now,
+    createdAt: nowIso,
+    updatedAt: nowIso,
     version: 1,
   };
   const credential: Credential = {
@@ -46,26 +53,34 @@ export async function registerWithPassword(
     authMethod: "password_hash",
     secretHash: `${hash}:${salt}`,
     walletKeyRef: `pending_${userId}`,
-    createdAt: now,
-    updatedAt: now,
+    createdAt: nowIso,
+    updatedAt: nowIso,
   };
   const profile: Profile = {
     userId,
     username: input.username,
     displayName: input.displayName,
-    createdAt: now,
-    updatedAt: now,
+    createdAt: nowIso,
+    updatedAt: nowIso,
   };
 
   try {
     await apiContext.repository.createUser(user, credential, profile);
   } catch (error) {
     if (error instanceof ApiError && error.code === "conflict") {
-      // Keep email and username ownership private.
       throw new ApiError("conflict");
     }
     throw error;
   }
+
+  await provisionManagedStellarWallet(apiContext.repository, userId, config, {
+    fundingAdapter: createFundingAdapter({
+      useFake: config.profile === "development" || config.profile === "test",
+    }),
+    storageSecret,
+    now,
+    prepared,
+  });
 
   await apiContext.repository.incrementCounter(rateLimitKey, SIGNUP_RATE_LIMIT_WINDOW_SECONDS, 1);
   return {

--- a/src/server/api/auth/registration-service.ts
+++ b/src/server/api/auth/registration-service.ts
@@ -80,6 +80,8 @@ export async function registerWithPassword(
     storageSecret,
     now,
     prepared,
+    accountId: userId,
+    origin: ip,
   });
 
   await apiContext.repository.incrementCounter(rateLimitKey, SIGNUP_RATE_LIMIT_WINDOW_SECONDS, 1);

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -24,6 +24,7 @@ import {
   keyDirectoryRecordSchema,
   contactSchema,
   managedWalletRecordSchema,
+  fundingOperationSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -239,6 +240,7 @@ registerRecordSchema("keyDirectoryRecord", 1, keyDirectoryRecordSchema);
 // validated at the adapter boundary like every other durable record.
 registerRecordSchema("contact", 1, contactSchema);
 registerRecordSchema("managedWalletRecord", 1, managedWalletRecordSchema);
+registerRecordSchema("fundingOperation", 1, fundingOperationSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -23,6 +23,7 @@ import {
   publishedKeySchema,
   keyDirectoryRecordSchema,
   contactSchema,
+  managedWalletRecordSchema,
 } from "./domain";
 import { ApiError } from "./errors";
 
@@ -237,6 +238,7 @@ registerRecordSchema("keyDirectoryRecord", 1, keyDirectoryRecordSchema);
 // Issue #1973 (BETA-066): durable user-owned contacts are versioned and
 // validated at the adapter boundary like every other durable record.
 registerRecordSchema("contact", 1, contactSchema);
+registerRecordSchema("managedWalletRecord", 1, managedWalletRecordSchema);
 
 /**
  * Issue #1461: Verified API Principal model representing authenticated request identity.

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -418,6 +418,66 @@ export const verificationTokenSchema = z.object({
 
 export type VerificationToken = z.infer<typeof verificationTokenSchema>;
 
+// ---------------------------------------------------------------------------
+// BETA-015 (Issue #1922) — system-managed Stellar testnet wallet provisioning
+//
+// Public metadata and encrypted secret material are stored together under a
+// user-scoped record. Plaintext seeds never reach durable storage, API
+// responses, or logs — only the public Stellar address and funding status are
+// exposed to clients.
+// ---------------------------------------------------------------------------
+
+export const managedWalletFundingStatusSchema = z.enum(["pending", "funded", "failed"]);
+export type ManagedWalletFundingStatus = z.infer<typeof managedWalletFundingStatusSchema>;
+
+export const encryptedWalletSecretSchema = z.object({
+  ciphertext: z.string().min(1, "Encrypted ciphertext cannot be empty"),
+  nonce: z.string().min(1, "Encrypted nonce cannot be empty"),
+  tag: z.string().min(1, "Encrypted tag cannot be empty"),
+  keyVersion: z.number().int().positive().default(1),
+});
+
+export type EncryptedWalletSecret = z.infer<typeof encryptedWalletSecretSchema>;
+
+export const managedWalletRecordSchema = z.object({
+  userId: z.string().min(1, "User ID cannot be empty"),
+  address: stellarAddressSchema,
+  /** Beta managed wallets are testnet-only. */
+  network: z.literal("testnet"),
+  fundingStatus: managedWalletFundingStatusSchema,
+  encryptedSecret: encryptedWalletSecretSchema,
+  fundedAt: z.string().datetime().nullable().default(null),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  lastError: z.string().max(300).nullable().default(null),
+});
+
+export type ManagedWalletRecord = z.infer<typeof managedWalletRecordSchema>;
+
+/** Client-safe wallet metadata — never includes seed material. */
+export const publicManagedWalletSchema = z.object({
+  address: stellarAddressSchema,
+  network: z.literal("testnet"),
+  fundingStatus: managedWalletFundingStatusSchema,
+  provisioned: z.boolean(),
+  fundedAt: z.string().datetime().nullable().optional(),
+});
+
+export type PublicManagedWallet = z.infer<typeof publicManagedWalletSchema>;
+
+export function toPublicManagedWallet(
+  wallet: ManagedWalletRecord,
+  provisioned: boolean,
+): PublicManagedWallet {
+  return {
+    address: wallet.address,
+    network: wallet.network,
+    fundingStatus: wallet.fundingStatus,
+    provisioned,
+    fundedAt: wallet.fundedAt ?? null,
+  };
+}
+
 export type AccountStatus = z.infer<typeof accountStatusSchema>;
 export type User = z.infer<typeof userSchema>;
 export type Profile = z.infer<typeof profileSchema>;

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -478,6 +478,57 @@ export function toPublicManagedWallet(
   };
 }
 
+// ---------------------------------------------------------------------------
+// BETA-018 (Issue #1925) — durable testnet funding operations
+//
+// One operation per account. Retries resume the same operationId so worker
+// restarts never double-fund. Queue projections never include seed material.
+// ---------------------------------------------------------------------------
+
+export const fundingErrorClassSchema = z.enum(["transient", "permanent"]);
+export type FundingErrorClass = z.infer<typeof fundingErrorClassSchema>;
+
+export const fundingOperationStatusSchema = z.enum(["pending", "retrying", "succeeded", "failed"]);
+export type FundingOperationStatus = z.infer<typeof fundingOperationStatusSchema>;
+
+export const fundingOperationSchema = z.object({
+  operationId: z.string().min(1, "Funding operation ID cannot be empty"),
+  userId: z.string().min(1, "User ID cannot be empty"),
+  address: stellarAddressSchema,
+  status: fundingOperationStatusSchema,
+  attempt: z.number().int().nonnegative(),
+  maxAttempts: z.number().int().positive(),
+  nextRetryAt: z.string().datetime().nullable().default(null),
+  lastErrorClass: fundingErrorClassSchema.nullable().default(null),
+  lastError: z.string().max(300).nullable().default(null),
+  transactionId: z.string().max(128).nullable().default(null),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type FundingOperation = z.infer<typeof fundingOperationSchema>;
+
+/** Administrator-visible queue item — never includes key material. */
+export const publicFundingOperationSchema = fundingOperationSchema.omit({});
+export type PublicFundingOperation = z.infer<typeof publicFundingOperationSchema>;
+
+export function toPublicFundingOperation(operation: FundingOperation): PublicFundingOperation {
+  return {
+    operationId: operation.operationId,
+    userId: operation.userId,
+    address: operation.address,
+    status: operation.status,
+    attempt: operation.attempt,
+    maxAttempts: operation.maxAttempts,
+    nextRetryAt: operation.nextRetryAt,
+    lastErrorClass: operation.lastErrorClass,
+    lastError: operation.lastError,
+    transactionId: operation.transactionId,
+    createdAt: operation.createdAt,
+    updatedAt: operation.updatedAt,
+  };
+}
+
 export type AccountStatus = z.infer<typeof accountStatusSchema>;
 export type User = z.infer<typeof userSchema>;
 export type Profile = z.infer<typeof profileSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -40,6 +40,7 @@ import type {
   VerificationPurpose,
   VerificationToken,
   ManagedWalletRecord,
+  FundingOperation,
   Wallet,
 } from "./domain";
 import { ApiError } from "./errors";
@@ -570,6 +571,27 @@ export class HybridApiRepository implements ApiRepository {
     wallet: ManagedWalletRecord,
   ): Promise<import("./repository").CreateManagedWalletResult> {
     return this.getStub().createManagedWalletIfAbsent(wallet);
+  }
+
+  async getFundingOperation(operationId: string): Promise<FundingOperation | null> {
+    return this.getStub().getFundingOperation(operationId);
+  }
+
+  async setFundingOperation(operation: FundingOperation): Promise<FundingOperation> {
+    return this.getStub().setFundingOperation(operation);
+  }
+
+  async createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }> {
+    return this.getStub().createFundingOperationIfAbsent(operation);
+  }
+
+  async listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]> {
+    return this.getStub().listFundingOperations(filter);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -39,6 +39,7 @@ import type {
   UsernameReservation,
   VerificationPurpose,
   VerificationToken,
+  ManagedWalletRecord,
   Wallet,
 } from "./domain";
 import { ApiError } from "./errors";
@@ -555,6 +556,20 @@ export class HybridApiRepository implements ApiRepository {
       JSON.stringify(record),
     );
     return record;
+  }
+
+  async getManagedWallet(userId: string): Promise<ManagedWalletRecord | null> {
+    return this.getStub().getManagedWallet(userId);
+  }
+
+  async setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord> {
+    return this.getStub().setManagedWallet(wallet);
+  }
+
+  async createManagedWalletIfAbsent(
+    wallet: ManagedWalletRecord,
+  ): Promise<import("./repository").CreateManagedWalletResult> {
+    return this.getStub().createManagedWalletIfAbsent(wallet);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -30,12 +30,14 @@ import type {
   UsernameReservation,
   VerificationPurpose,
   VerificationToken,
+  ManagedWalletRecord,
   Wallet,
 } from "./domain";
 import type {
   ApiRepository,
   ContactQueryOptions,
   ConsumeVerificationTokenResult,
+  CreateManagedWalletResult,
   InsertEnvelopeResult,
   IssueVerificationTokenResult,
   PostageTransitionResult,
@@ -152,6 +154,7 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly keyDirectories = new Map<string, KeyDirectoryRecord>();
   private readonly publishedKeys = new Map<string, PublishedKey>(); // key: `${owner}:${keyId}`
   private readonly keyDirectoryLocks = new Map<string, Promise<void>>();
+  private readonly managedWallets = new Map<string, ManagedWalletRecord>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -1038,6 +1041,28 @@ export class MemoryApiRepository implements ApiRepository {
     return structuredClone(stored);
   }
 
+  async getManagedWallet(userId: string): Promise<ManagedWalletRecord | null> {
+    return structuredClone(this.managedWallets.get(userId) ?? null);
+  }
+
+  async setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord> {
+    const stored = structuredClone(wallet);
+    this.managedWallets.set(wallet.userId, stored);
+    return structuredClone(stored);
+  }
+
+  async createManagedWalletIfAbsent(
+    wallet: ManagedWalletRecord,
+  ): Promise<CreateManagedWalletResult> {
+    const existing = this.managedWallets.get(wallet.userId);
+    if (existing) {
+      return { outcome: "existing", wallet: structuredClone(existing) };
+    }
+    const stored = structuredClone(wallet);
+    this.managedWallets.set(wallet.userId, stored);
+    return { outcome: "created", wallet: structuredClone(stored) };
+  }
+
   async listContacts(
     owner: string,
     options: ContactQueryOptions = {},
@@ -1261,6 +1286,7 @@ export class MemoryApiRepository implements ApiRepository {
     this.keyDirectories.clear();
     this.publishedKeys.clear();
     this.keyDirectoryLocks.clear();
+    this.managedWallets.clear();
     this.contacts.clear();
     this.jobs.clear();
     this.jobsByIdempotencyKey.clear();

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -31,6 +31,7 @@ import type {
   VerificationPurpose,
   VerificationToken,
   ManagedWalletRecord,
+  FundingOperation,
   Wallet,
 } from "./domain";
 import type {
@@ -155,6 +156,7 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly publishedKeys = new Map<string, PublishedKey>(); // key: `${owner}:${keyId}`
   private readonly keyDirectoryLocks = new Map<string, Promise<void>>();
   private readonly managedWallets = new Map<string, ManagedWalletRecord>();
+  private readonly fundingOperations = new Map<string, FundingOperation>();
 
   private async withReceiptLock<T>(messageId: string, action: () => Promise<T>): Promise<T> {
     const previous = this.receiptLocks.get(messageId) ?? Promise.resolve();
@@ -1063,6 +1065,42 @@ export class MemoryApiRepository implements ApiRepository {
     return { outcome: "created", wallet: structuredClone(stored) };
   }
 
+  async getFundingOperation(operationId: string): Promise<FundingOperation | null> {
+    return structuredClone(this.fundingOperations.get(operationId) ?? null);
+  }
+
+  async setFundingOperation(operation: FundingOperation): Promise<FundingOperation> {
+    const stored = structuredClone(operation);
+    this.fundingOperations.set(operation.operationId, stored);
+    return structuredClone(stored);
+  }
+
+  async createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }> {
+    const existing = this.fundingOperations.get(operation.operationId);
+    if (existing) {
+      return { created: false, operation: structuredClone(existing) };
+    }
+    const stored = structuredClone(operation);
+    this.fundingOperations.set(operation.operationId, stored);
+    return { created: true, operation: structuredClone(stored) };
+  }
+
+  async listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]> {
+    const limit = filter?.limit ?? 50;
+    const matches: FundingOperation[] = [];
+    for (const operation of this.fundingOperations.values()) {
+      if (filter?.status && operation.status !== filter.status) continue;
+      matches.push(structuredClone(operation));
+    }
+    matches.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return matches.slice(0, limit);
+  }
+
   async listContacts(
     owner: string,
     options: ContactQueryOptions = {},
@@ -1287,6 +1325,7 @@ export class MemoryApiRepository implements ApiRepository {
     this.publishedKeys.clear();
     this.keyDirectoryLocks.clear();
     this.managedWallets.clear();
+    this.fundingOperations.clear();
     this.contacts.clear();
     this.jobs.clear();
     this.jobsByIdempotencyKey.clear();

--- a/src/server/api/rate-limit.ts
+++ b/src/server/api/rate-limit.ts
@@ -44,6 +44,54 @@ export async function consumeRouteQuota(
   return { allowed: true };
 }
 
+export const PROVISIONING_LIMITS = {
+  account: { max: 3, windowSeconds: 3600 },
+  origin: { max: 10, windowSeconds: 3600 },
+} as const;
+
+export type ProvisioningQuotaResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number; limitedBy: "account" | "origin" };
+
+/**
+ * BETA-018: per-account and per-origin caps on managed-wallet funding attempts.
+ * Unknown origins fail open (same as the IP limiter) so edge-less local runs
+ * still enforce the account quota.
+ */
+export async function consumeProvisioningQuota(
+  repository: ApiRepository,
+  subjects: { accountId: string; origin: string },
+): Promise<ProvisioningQuotaResult> {
+  const accountCount = await repository.incrementCounter(
+    `abuse:provisioning:account:${subjects.accountId}`,
+    PROVISIONING_LIMITS.account.windowSeconds,
+  );
+  if (accountCount > PROVISIONING_LIMITS.account.max) {
+    return {
+      allowed: false,
+      retryAfterSeconds: PROVISIONING_LIMITS.account.windowSeconds,
+      limitedBy: "account",
+    };
+  }
+
+  const origin = subjects.origin.trim();
+  if (origin !== "" && origin !== "unknown") {
+    const originCount = await repository.incrementCounter(
+      `abuse:provisioning:origin:${origin}`,
+      PROVISIONING_LIMITS.origin.windowSeconds,
+    );
+    if (originCount > PROVISIONING_LIMITS.origin.max) {
+      return {
+        allowed: false,
+        retryAfterSeconds: PROVISIONING_LIMITS.origin.windowSeconds,
+        limitedBy: "origin",
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
 export const AUTH_FAILURE_LIMITS = {
   ipAndAccount: { max: 5, windowSeconds: 900 },
   ipWide: { max: 20, windowSeconds: 900 },

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -30,6 +30,7 @@ import type {
   UsernameReservation,
   VerificationPurpose,
   VerificationToken,
+  ManagedWalletRecord,
   Wallet,
 } from "./domain";
 import type { ZodSchema } from "zod";
@@ -190,6 +191,16 @@ export interface MailboxQueryOptions {
   limit?: number;
   after?: string;
 }
+
+/**
+ * Outcome of an atomic managed-wallet create.
+ *
+ * - "created": a new managed wallet record was stored for the user.
+ * - "existing": a wallet already existed; the stored record is returned unchanged.
+ */
+export type CreateManagedWalletResult =
+  | { outcome: "created"; wallet: ManagedWalletRecord }
+  | { outcome: "existing"; wallet: ManagedWalletRecord };
 
 // ---------------------------------------------------------------------------
 // Issue #1973 (BETA-066) — Live contacts repository
@@ -437,6 +448,11 @@ export interface ApiRepository {
   getPublishedKey(owner: string, keyId: string): Promise<PublishedKey | null>;
   savePublishedKey(owner: string, key: PublishedKey): Promise<PublishedKey>;
   saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord>;
+
+  // BETA-015 (Issue #1922): managed Stellar testnet wallet persistence.
+  getManagedWallet(userId: string): Promise<ManagedWalletRecord | null>;
+  setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord>;
+  createManagedWalletIfAbsent(wallet: ManagedWalletRecord): Promise<CreateManagedWalletResult>;
 
   // ---------------------------------------------------------------------------
   // Issue #1973 (BETA-066) — Live contacts CRUD
@@ -1095,6 +1111,26 @@ export class ValidatedApiRepository implements ApiRepository {
     return validateRecord<KeyDirectoryRecord>("keyDirectoryRecord", result);
   }
 
+  async getManagedWallet(userId: string): Promise<ManagedWalletRecord | null> {
+    const raw = await this.inner.getManagedWallet(userId);
+    return raw ? validateRecord<ManagedWalletRecord>("managedWalletRecord", raw) : null;
+  }
+
+  async setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord> {
+    const result = await this.inner.setManagedWallet(versionRecord("managedWalletRecord", wallet));
+    return validateRecord<ManagedWalletRecord>("managedWalletRecord", result);
+  }
+
+  async createManagedWalletIfAbsent(
+    wallet: ManagedWalletRecord,
+  ): Promise<CreateManagedWalletResult> {
+    const result = await this.inner.createManagedWalletIfAbsent(
+      versionRecord("managedWalletRecord", wallet),
+    );
+    result.wallet = validateRecord<ManagedWalletRecord>("managedWalletRecord", result.wallet);
+    return result;
+  }
+
   async listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {
     const page = await this.inner.listContacts(owner, options);
     return {
@@ -1254,6 +1290,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "findExternalWalletOwner",
   "getVerificationToken",
   "getWalletChallenge",
+  "getManagedWallet",
+  "setManagedWallet",
   "listContacts",
   "getContact",
   "getJob",
@@ -1713,6 +1751,18 @@ export class RetryableApiRepository implements ApiRepository {
 
   saveKeyDirectory(record: KeyDirectoryRecord): Promise<KeyDirectoryRecord> {
     return this.withRetry("saveKeyDirectory", () => this.inner.saveKeyDirectory(record));
+  }
+
+  getManagedWallet(userId: string): Promise<ManagedWalletRecord | null> {
+    return this.withRetry("getManagedWallet", () => this.inner.getManagedWallet(userId));
+  }
+
+  setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord> {
+    return this.withRetry("setManagedWallet", () => this.inner.setManagedWallet(wallet));
+  }
+
+  createManagedWalletIfAbsent(wallet: ManagedWalletRecord): Promise<CreateManagedWalletResult> {
+    return this.inner.createManagedWalletIfAbsent(wallet);
   }
 
   listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -31,6 +31,7 @@ import type {
   VerificationPurpose,
   VerificationToken,
   ManagedWalletRecord,
+  FundingOperation,
   Wallet,
 } from "./domain";
 import type { ZodSchema } from "zod";
@@ -453,6 +454,17 @@ export interface ApiRepository {
   getManagedWallet(userId: string): Promise<ManagedWalletRecord | null>;
   setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord>;
   createManagedWalletIfAbsent(wallet: ManagedWalletRecord): Promise<CreateManagedWalletResult>;
+
+  // BETA-018 (Issue #1925): durable testnet funding operations.
+  getFundingOperation(operationId: string): Promise<FundingOperation | null>;
+  setFundingOperation(operation: FundingOperation): Promise<FundingOperation>;
+  createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }>;
+  listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]>;
 
   // ---------------------------------------------------------------------------
   // Issue #1973 (BETA-066) — Live contacts CRUD
@@ -1131,6 +1143,36 @@ export class ValidatedApiRepository implements ApiRepository {
     return result;
   }
 
+  async getFundingOperation(operationId: string): Promise<FundingOperation | null> {
+    const raw = await this.inner.getFundingOperation(operationId);
+    return raw ? validateRecord<FundingOperation>("fundingOperation", raw) : null;
+  }
+
+  async setFundingOperation(operation: FundingOperation): Promise<FundingOperation> {
+    const result = await this.inner.setFundingOperation(
+      versionRecord("fundingOperation", operation),
+    );
+    return validateRecord<FundingOperation>("fundingOperation", result);
+  }
+
+  async createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }> {
+    const result = await this.inner.createFundingOperationIfAbsent(
+      versionRecord("fundingOperation", operation),
+    );
+    result.operation = validateRecord<FundingOperation>("fundingOperation", result.operation);
+    return result;
+  }
+
+  async listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]> {
+    const operations = await this.inner.listFundingOperations(filter);
+    return operations.map((item) => validateRecord<FundingOperation>("fundingOperation", item));
+  }
+
   async listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {
     const page = await this.inner.listContacts(owner, options);
     return {
@@ -1292,6 +1334,9 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getWalletChallenge",
   "getManagedWallet",
   "setManagedWallet",
+  "getFundingOperation",
+  "setFundingOperation",
+  "listFundingOperations",
   "listContacts",
   "getContact",
   "getJob",
@@ -1763,6 +1808,27 @@ export class RetryableApiRepository implements ApiRepository {
 
   createManagedWalletIfAbsent(wallet: ManagedWalletRecord): Promise<CreateManagedWalletResult> {
     return this.inner.createManagedWalletIfAbsent(wallet);
+  }
+
+  getFundingOperation(operationId: string): Promise<FundingOperation | null> {
+    return this.withRetry("getFundingOperation", () => this.inner.getFundingOperation(operationId));
+  }
+
+  setFundingOperation(operation: FundingOperation): Promise<FundingOperation> {
+    return this.withRetry("setFundingOperation", () => this.inner.setFundingOperation(operation));
+  }
+
+  createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }> {
+    return this.inner.createFundingOperationIfAbsent(operation);
+  }
+
+  listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]> {
+    return this.withRetry("listFundingOperations", () => this.inner.listFundingOperations(filter));
   }
 
   listContacts(owner: string, options?: ContactQueryOptions): Promise<Page<Contact>> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -7,6 +7,7 @@ import type {
   IdempotencyRecord,
   JobStatus,
   ManagedWalletRecord,
+  FundingOperation,
   Postage,
   PostageStatus,
   Profile,
@@ -826,6 +827,52 @@ export class StealthCoordinator extends DurableObjectBase {
       await this.ctx.storage.put(`managed-wallet:${wallet.userId}`, wallet);
       return { outcome: "created", wallet };
     });
+  }
+
+  async getFundingOperation(operationId: string): Promise<FundingOperation | null> {
+    const operation = (await this.ctx.storage.get(`funding-op:${operationId}`)) as
+      | FundingOperation
+      | undefined;
+    return operation ?? null;
+  }
+
+  async setFundingOperation(operation: FundingOperation): Promise<FundingOperation> {
+    return this.runExclusive(`funding-op:${operation.operationId}`, async () => {
+      await this.ctx.storage.put(`funding-op:${operation.operationId}`, operation);
+      return operation;
+    });
+  }
+
+  async createFundingOperationIfAbsent(
+    operation: FundingOperation,
+  ): Promise<{ created: boolean; operation: FundingOperation }> {
+    return this.runExclusive(`funding-op:${operation.operationId}`, async () => {
+      const existing = await this.getFundingOperation(operation.operationId);
+      if (existing) {
+        return { created: false, operation: existing };
+      }
+      await this.ctx.storage.put(`funding-op:${operation.operationId}`, operation);
+      return { created: true, operation };
+    });
+  }
+
+  async listFundingOperations(filter?: {
+    status?: FundingOperation["status"];
+    limit?: number;
+  }): Promise<FundingOperation[]> {
+    const stored = (await this.ctx.storage.list({ prefix: "funding-op:" })) as Map<
+      string,
+      FundingOperation
+    >;
+    const limit = filter?.limit ?? 50;
+    const matches: FundingOperation[] = [];
+    for (const operation of stored.values()) {
+      if (!operation?.operationId) continue;
+      if (filter?.status && operation.status !== filter.status) continue;
+      matches.push(operation);
+    }
+    matches.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return matches.slice(0, limit);
   }
 
   async listRecipientEnvelopes(

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -6,6 +6,7 @@ import type {
   DurableJobType,
   IdempotencyRecord,
   JobStatus,
+  ManagedWalletRecord,
   Postage,
   PostageStatus,
   Profile,
@@ -26,6 +27,7 @@ import type {
 import type {
   AcquireIdempotencyResult,
   ConsumeVerificationTokenResult,
+  CreateManagedWalletResult,
   InsertEnvelopeResult,
   IssueVerificationTokenResult,
   PostageTransitionResult,
@@ -794,6 +796,35 @@ export class StealthCoordinator extends DurableObjectBase {
       } as import("./domain").UnknownSenderRequest;
       await this.ctx.storage.put(`sender-request:${requestId}`, request);
       return { outcome: "applied" as const, request };
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // BETA-015 (Issue #1922) — Managed Stellar testnet wallet persistence
+  // ---------------------------------------------------------------------------
+
+  async getManagedWallet(userId: string): Promise<ManagedWalletRecord | null> {
+    const wallet = (await this.ctx.storage.get(`managed-wallet:${userId}`)) as
+      | ManagedWalletRecord
+      | undefined;
+    return wallet ?? null;
+  }
+
+  async setManagedWallet(wallet: ManagedWalletRecord): Promise<ManagedWalletRecord> {
+    await this.ctx.storage.put(`managed-wallet:${wallet.userId}`, wallet);
+    return wallet;
+  }
+
+  async createManagedWalletIfAbsent(
+    wallet: ManagedWalletRecord,
+  ): Promise<CreateManagedWalletResult> {
+    return this.runExclusive(`managed-wallet:${wallet.userId}`, async () => {
+      const existing = await this.getManagedWallet(wallet.userId);
+      if (existing) {
+        return { outcome: "existing", wallet: existing };
+      }
+      await this.ctx.storage.put(`managed-wallet:${wallet.userId}`, wallet);
+      return { outcome: "created", wallet };
     });
   }
 

--- a/src/services/stellar/README.md
+++ b/src/services/stellar/README.md
@@ -1,3 +1,9 @@
 # Stellar Services
 
-Client-side Stellar RPC/Horizon adapters, transaction builders, memo helpers, and wallet integration.
+Client-side Stellar RPC/Horizon adapters, transaction builders, memo helpers, wallet integration, and server-side managed wallet provisioning (BETA-015).
+
+- `keypair.ts` — trusted-server Stellar keypair generation.
+- `wallet-secret-crypto.ts` — encrypt/decrypt managed wallet seeds at rest.
+- `account-provision.ts` — prepare and fund managed testnet accounts.
+- `funding-adapter.ts` — friendbot/fake funding adapter for testnet accounts.
+- `managed-wallet.ts` — intent-bound signing for managed operator flows.

--- a/src/services/stellar/account-provision.ts
+++ b/src/services/stellar/account-provision.ts
@@ -1,0 +1,50 @@
+import type { BetaRuntimeConfig } from "../../config/schema";
+import type { StellarFundingAdapter } from "@/services/stellar/funding-adapter";
+import { generateStellarKeypair } from "./keypair";
+import { encryptWalletSecret } from "./wallet-secret-crypto";
+
+export interface PrepareManagedWalletInput {
+  userId: string;
+  storageSecret: string;
+  now?: Date;
+}
+
+export interface PreparedManagedWallet {
+  address: string;
+  encryptedSecret: Awaited<ReturnType<typeof encryptWalletSecret>>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Generate and encrypt a managed Stellar keypair on the trusted server.
+ *
+ * The plaintext seed exists only for the duration of this call and must never
+ * be logged or returned to clients.
+ */
+export async function prepareManagedWalletSecret(
+  input: PrepareManagedWalletInput,
+): Promise<PreparedManagedWallet> {
+  const now = (input.now ?? new Date()).toISOString();
+  const { publicKey, secretKey } = generateStellarKeypair();
+  const encryptedSecret = await encryptWalletSecret(secretKey, input.storageSecret);
+  return {
+    address: publicKey,
+    encryptedSecret,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function assertTestnetManagedWalletNetwork(config: BetaRuntimeConfig): void {
+  if (config.network.stellarNetwork !== "testnet") {
+    throw new Error("Managed wallet provisioning is testnet-only during beta");
+  }
+}
+
+export async function fundManagedWalletAccount(
+  fundingAdapter: StellarFundingAdapter,
+  publicKey: string,
+): Promise<{ funded: boolean; transactionId?: string }> {
+  return fundingAdapter.fundAccount(publicKey);
+}

--- a/src/services/stellar/funding-adapter.ts
+++ b/src/services/stellar/funding-adapter.ts
@@ -1,0 +1,54 @@
+import { DEFAULT_TESTNET_FRIENDBOT_URL } from "./funding-config";
+
+export interface FundAccountResult {
+  funded: boolean;
+  transactionId?: string;
+}
+
+export interface StellarFundingAdapter {
+  fundAccount(publicKey: string): Promise<FundAccountResult>;
+}
+
+export class FriendbotFundingAdapter implements StellarFundingAdapter {
+  constructor(private readonly friendbotUrl: string = DEFAULT_TESTNET_FRIENDBOT_URL) {}
+
+  async fundAccount(publicKey: string): Promise<FundAccountResult> {
+    const url = `${this.friendbotUrl}?addr=${encodeURIComponent(publicKey)}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Friendbot funding failed with status ${response.status}`);
+    }
+
+    const payload = (await response.json()) as { hash?: string };
+    return {
+      funded: true,
+      transactionId: typeof payload.hash === "string" ? payload.hash : undefined,
+    };
+  }
+}
+
+/** Deterministic in-memory funding adapter for unit/integration tests. */
+export class FakeFundingAdapter implements StellarFundingAdapter {
+  readonly fundedAccounts = new Set<string>();
+  readonly failures = new Set<string>();
+
+  async fundAccount(publicKey: string): Promise<FundAccountResult> {
+    if (this.failures.has(publicKey)) {
+      throw new Error("Simulated funding failure");
+    }
+    this.fundedAccounts.add(publicKey);
+    return { funded: true, transactionId: `fake-tx-${publicKey.slice(0, 8)}` };
+  }
+}
+
+export function createFundingAdapter(
+  options: {
+    friendbotUrl?: string;
+    useFake?: boolean;
+  } = {},
+): StellarFundingAdapter {
+  if (options.useFake) {
+    return new FakeFundingAdapter();
+  }
+  return new FriendbotFundingAdapter(options.friendbotUrl ?? DEFAULT_TESTNET_FRIENDBOT_URL);
+}

--- a/src/services/stellar/funding-adapter.ts
+++ b/src/services/stellar/funding-adapter.ts
@@ -1,3 +1,4 @@
+import type { FundingErrorClass } from "../../server/api/domain";
 import { DEFAULT_TESTNET_FRIENDBOT_URL } from "./funding-config";
 
 export interface FundAccountResult {
@@ -9,17 +10,97 @@ export interface StellarFundingAdapter {
   fundAccount(publicKey: string): Promise<FundAccountResult>;
 }
 
+export class FundingError extends Error {
+  readonly errorClass: FundingErrorClass;
+  readonly code: string;
+  readonly httpStatus?: number;
+  readonly alreadyFunded: boolean;
+
+  constructor(
+    message: string,
+    options: {
+      errorClass: FundingErrorClass;
+      code: string;
+      httpStatus?: number;
+      alreadyFunded?: boolean;
+    },
+  ) {
+    super(message);
+    this.name = "FundingError";
+    this.errorClass = options.errorClass;
+    this.code = options.code;
+    this.httpStatus = options.httpStatus;
+    this.alreadyFunded = options.alreadyFunded === true;
+  }
+}
+
 export class FriendbotFundingAdapter implements StellarFundingAdapter {
-  constructor(private readonly friendbotUrl: string = DEFAULT_TESTNET_FRIENDBOT_URL) {}
+  constructor(
+    private readonly friendbotUrl: string = DEFAULT_TESTNET_FRIENDBOT_URL,
+    private readonly timeoutMs = 8_000,
+  ) {}
 
   async fundAccount(publicKey: string): Promise<FundAccountResult> {
     const url = `${this.friendbotUrl}?addr=${encodeURIComponent(publicKey)}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Friendbot funding failed with status ${response.status}`);
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: AbortSignal.timeout(this.timeoutMs) });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        throw new FundingError("Funding request timed out", {
+          errorClass: "transient",
+          code: "timeout",
+        });
+      }
+      throw new FundingError("Funding provider is unreachable", {
+        errorClass: "transient",
+        code: "network_error",
+      });
     }
 
-    const payload = (await response.json()) as { hash?: string };
+    const payload = (await response.json().catch(() => ({}))) as {
+      hash?: string;
+      detail?: string;
+      title?: string;
+      extras?: { result_codes?: { operations?: string[] } };
+    };
+    const bodyText = `${payload.detail ?? ""} ${payload.title ?? ""} ${JSON.stringify(payload.extras ?? {})}`;
+
+    if (
+      /already (exists|funded|created)/i.test(bodyText) ||
+      payload.extras?.result_codes?.operations?.includes("op_already_exists")
+    ) {
+      return {
+        funded: true,
+        transactionId: typeof payload.hash === "string" ? payload.hash : undefined,
+      };
+    }
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        throw new FundingError(`Friendbot funding failed with status ${response.status}`, {
+          errorClass: "transient",
+          code: "rate_limited",
+          httpStatus: response.status,
+        });
+      }
+      if (response.status >= 500 || response.status === 408) {
+        throw new FundingError(`Friendbot funding failed with status ${response.status}`, {
+          errorClass: "transient",
+          code: "dependency_unavailable",
+          httpStatus: response.status,
+        });
+      }
+      throw new FundingError(`Friendbot funding failed with status ${response.status}`, {
+        errorClass: "permanent",
+        code: "invalid_account",
+        httpStatus: response.status,
+      });
+    }
+
     return {
       funded: true,
       transactionId: typeof payload.hash === "string" ? payload.hash : undefined,
@@ -27,17 +108,89 @@ export class FriendbotFundingAdapter implements StellarFundingAdapter {
   }
 }
 
+export type FakeFundingFailure =
+  | "timeout"
+  | "rate_limited"
+  | "invalid"
+  | "exhausted"
+  | "already_funded"
+  | "generic";
+
 /** Deterministic in-memory funding adapter for unit/integration tests. */
 export class FakeFundingAdapter implements StellarFundingAdapter {
   readonly fundedAccounts = new Set<string>();
   readonly failures = new Set<string>();
+  readonly callCounts = new Map<string, number>();
+  readonly failureMode = new Map<string, FakeFundingFailure>();
+  readonly remainingFailures = new Map<string, number>();
+  globalMode?: FakeFundingFailure;
+
+  failAll(mode: FakeFundingFailure): void {
+    this.globalMode = mode;
+  }
 
   async fundAccount(publicKey: string): Promise<FundAccountResult> {
-    if (this.failures.has(publicKey)) {
+    this.callCounts.set(publicKey, (this.callCounts.get(publicKey) ?? 0) + 1);
+
+    const remaining = this.remainingFailures.get(publicKey) ?? 0;
+    const mode = remaining > 0 ? this.failureMode.get(publicKey) : (this.globalMode ?? undefined);
+    if (remaining > 0) {
+      this.remainingFailures.set(publicKey, remaining - 1);
+      if (remaining - 1 <= 0) {
+        this.remainingFailures.delete(publicKey);
+        this.failureMode.delete(publicKey);
+      }
+    }
+
+    if (mode === "already_funded") {
+      this.fundedAccounts.add(publicKey);
+      throw new FundingError("Account already exists", {
+        errorClass: "permanent",
+        code: "already_funded",
+        alreadyFunded: true,
+      });
+    }
+    if (mode === "timeout") {
+      throw new FundingError("Funding request timed out", {
+        errorClass: "transient",
+        code: "timeout",
+      });
+    }
+    if (mode === "rate_limited") {
+      throw new FundingError("Friendbot funding failed with status 429", {
+        errorClass: "transient",
+        code: "rate_limited",
+        httpStatus: 429,
+      });
+    }
+    if (mode === "invalid") {
+      throw new FundingError("Invalid public key", {
+        errorClass: "permanent",
+        code: "invalid_account",
+        httpStatus: 400,
+      });
+    }
+    if (mode === "exhausted") {
+      throw new FundingError("Funding source exhausted", {
+        errorClass: "permanent",
+        code: "funding_source_exhausted",
+      });
+    }
+    if (mode === "generic" || this.failures.has(publicKey)) {
       throw new Error("Simulated funding failure");
     }
+
+    if (this.fundedAccounts.has(publicKey)) {
+      return { funded: true, transactionId: `fake-tx-${publicKey.slice(0, 8)}` };
+    }
+
     this.fundedAccounts.add(publicKey);
     return { funded: true, transactionId: `fake-tx-${publicKey.slice(0, 8)}` };
+  }
+
+  failNext(publicKey: string, mode: FakeFundingFailure, times = 1): void {
+    this.failureMode.set(publicKey, mode);
+    this.remainingFailures.set(publicKey, times);
   }
 }
 

--- a/src/services/stellar/funding-config.ts
+++ b/src/services/stellar/funding-config.ts
@@ -1,0 +1,14 @@
+/** Default Horizon friendbot endpoint for Stellar testnet account funding. */
+export const DEFAULT_TESTNET_FRIENDBOT_URL = "https://friendbot.stellar.org";
+
+export interface StellarFundingConfig {
+  friendbotUrl: string;
+}
+
+export function resolveStellarFundingConfig(
+  env: Record<string, string | undefined> = {},
+): StellarFundingConfig {
+  return {
+    friendbotUrl: env.STEALTH_TESTNET_FRIENDBOT_URL ?? DEFAULT_TESTNET_FRIENDBOT_URL,
+  };
+}

--- a/src/services/stellar/funding.ts
+++ b/src/services/stellar/funding.ts
@@ -1,0 +1,260 @@
+import type { ApiRepository } from "../../server/api/repository";
+import type {
+  FundingErrorClass,
+  FundingOperation,
+  PublicFundingOperation,
+} from "../../server/api/domain";
+import { toPublicFundingOperation } from "../../server/api/domain";
+import { FundingError, type StellarFundingAdapter } from "./funding-adapter";
+
+export { FundingError };
+
+export const MAX_FUNDING_ATTEMPTS = 5;
+export const FUNDING_BACKOFF_BASE_MS = 1_000;
+export const FUNDING_BACKOFF_CAP_MS = 16_000;
+
+export type FundingClassification = {
+  errorClass: FundingErrorClass;
+  code: string;
+  message: string;
+  alreadyFunded: boolean;
+};
+
+export function fundingOperationIdForUser(userId: string): string {
+  return `fund:${userId}`;
+}
+
+export function redactFundingMessage(message: string): string {
+  return message
+    .replace(/S[A-Z0-9]{55,}/g, "[redacted-secret]")
+    .replace(/secret[^=\s]*=\S+/gi, "secret=[redacted]")
+    .slice(0, 300);
+}
+
+export function computeFundingBackoffMs(attempt: number): number {
+  const exponential = FUNDING_BACKOFF_BASE_MS * Math.pow(2, Math.max(0, attempt - 1));
+  return Math.min(FUNDING_BACKOFF_CAP_MS, exponential);
+}
+
+export function classifyFundingFailure(error: unknown): FundingClassification {
+  if (error instanceof FundingError) {
+    return {
+      errorClass: error.errorClass,
+      code: error.code,
+      message: redactFundingMessage(error.message),
+      alreadyFunded: error.alreadyFunded,
+    };
+  }
+
+  const name = error instanceof Error ? error.name : "";
+  const raw = error instanceof Error ? error.message : "Funding failed";
+  const message = redactFundingMessage(raw);
+
+  if (name === "AbortError" || name === "TimeoutError" || /time\s*out|timed\s+out/i.test(raw)) {
+    return {
+      errorClass: "transient",
+      code: "timeout",
+      message: "Funding request timed out",
+      alreadyFunded: false,
+    };
+  }
+
+  if (/already (exists|funded|created)|op_already_exists/i.test(raw)) {
+    return {
+      errorClass: "permanent",
+      code: "already_funded",
+      message: "Account is already funded",
+      alreadyFunded: true,
+    };
+  }
+
+  if (/invalid (account|address|public key)/i.test(raw)) {
+    return {
+      errorClass: "permanent",
+      code: "invalid_account",
+      message: "Account address is invalid",
+      alreadyFunded: false,
+    };
+  }
+
+  if (/insufficient|exhausted|funding source/i.test(raw)) {
+    return {
+      errorClass: "permanent",
+      code: "funding_source_exhausted",
+      message: "Funding source is exhausted",
+      alreadyFunded: false,
+    };
+  }
+
+  const statusMatch = raw.match(/status (\d{3})/i);
+  const status = statusMatch ? Number(statusMatch[1]) : undefined;
+  if (status === 429) {
+    return {
+      errorClass: "transient",
+      code: "rate_limited",
+      message: "Funding provider rate-limited the request",
+      alreadyFunded: false,
+    };
+  }
+  if (
+    status === 408 ||
+    status === 425 ||
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  ) {
+    return {
+      errorClass: "transient",
+      code: "dependency_unavailable",
+      message: "Funding provider is temporarily unavailable",
+      alreadyFunded: false,
+    };
+  }
+  if (
+    status === 400 ||
+    status === 401 ||
+    status === 403 ||
+    status === 404 ||
+    status === 402 ||
+    status === 422
+  ) {
+    return {
+      errorClass: "permanent",
+      code: "invalid_account",
+      message: "Funding provider rejected the account",
+      alreadyFunded: false,
+    };
+  }
+
+  if (/network|fetch failed|ECONNRESET|ENOTFOUND|ECONNREFUSED/i.test(raw)) {
+    return {
+      errorClass: "transient",
+      code: "network_error",
+      message: "Funding dependency is unavailable",
+      alreadyFunded: false,
+    };
+  }
+
+  return {
+    errorClass: "transient",
+    code: "funding_failed",
+    message,
+    alreadyFunded: false,
+  };
+}
+
+function newOperation(userId: string, address: string, now: Date): FundingOperation {
+  const nowIso = now.toISOString();
+  return {
+    operationId: fundingOperationIdForUser(userId),
+    userId,
+    address,
+    status: "pending",
+    attempt: 0,
+    maxAttempts: MAX_FUNDING_ATTEMPTS,
+    nextRetryAt: null,
+    lastErrorClass: null,
+    lastError: null,
+    transactionId: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+function isDue(operation: FundingOperation, now: Date): boolean {
+  if (operation.status === "pending") return true;
+  if (operation.status !== "retrying") return false;
+  if (!operation.nextRetryAt) return true;
+  return now.getTime() >= new Date(operation.nextRetryAt).getTime();
+}
+
+/**
+ * Execute (or resume) the durable funding operation for one account.
+ *
+ * Idempotent across worker restarts: the operation ID is derived from `userId`,
+ * succeeded operations are never re-funded, and duplicate callbacks that report
+ * an already-funded account are treated as success.
+ */
+export async function runFundingOperation(options: {
+  repository: ApiRepository;
+  adapter: StellarFundingAdapter;
+  userId: string;
+  address: string;
+  now?: Date;
+}): Promise<FundingOperation> {
+  const now = options.now ?? new Date();
+  const created = await options.repository.createFundingOperationIfAbsent(
+    newOperation(options.userId, options.address, now),
+  );
+  const current = created.operation;
+
+  if (current.status === "succeeded" || current.status === "failed") {
+    return current;
+  }
+
+  if (!isDue(current, now)) {
+    return current;
+  }
+
+  try {
+    const result = await options.adapter.fundAccount(options.address);
+    const succeeded: FundingOperation = {
+      ...current,
+      status: "succeeded",
+      attempt: current.attempt + 1,
+      nextRetryAt: null,
+      lastErrorClass: null,
+      lastError: null,
+      transactionId: result.transactionId ?? current.transactionId,
+      updatedAt: now.toISOString(),
+    };
+    return options.repository.setFundingOperation(succeeded);
+  } catch (error) {
+    const classified = classifyFundingFailure(error);
+    if (classified.alreadyFunded) {
+      const succeeded: FundingOperation = {
+        ...current,
+        status: "succeeded",
+        attempt: current.attempt + 1,
+        nextRetryAt: null,
+        lastErrorClass: null,
+        lastError: null,
+        transactionId: current.transactionId,
+        updatedAt: now.toISOString(),
+      };
+      return options.repository.setFundingOperation(succeeded);
+    }
+
+    const attempt = current.attempt + 1;
+    const exhausted = classified.errorClass === "permanent" || attempt >= current.maxAttempts;
+    const failed: FundingOperation = {
+      ...current,
+      status: exhausted ? "failed" : "retrying",
+      attempt,
+      nextRetryAt: exhausted
+        ? null
+        : new Date(now.getTime() + computeFundingBackoffMs(attempt)).toISOString(),
+      lastErrorClass: classified.errorClass,
+      lastError: classified.message,
+      updatedAt: now.toISOString(),
+    };
+    return options.repository.setFundingOperation(failed);
+  }
+}
+
+export interface FundingQueueQuery {
+  status?: FundingOperation["status"];
+  limit?: number;
+}
+
+export async function listPublicFundingQueue(
+  repository: ApiRepository,
+  query: FundingQueueQuery = {},
+): Promise<PublicFundingOperation[]> {
+  const operations = await repository.listFundingOperations({
+    status: query.status,
+    limit: query.limit ?? 50,
+  });
+  return operations.map(toPublicFundingOperation);
+}

--- a/src/services/stellar/keypair.ts
+++ b/src/services/stellar/keypair.ts
@@ -1,0 +1,20 @@
+import { Keypair } from "@stellar/stellar-sdk";
+
+export interface GeneratedStellarKeypair {
+  publicKey: string;
+  secretKey: string;
+}
+
+/**
+ * Generate a fresh Stellar keypair on the trusted server.
+ *
+ * Callers MUST encrypt `secretKey` before persistence and MUST NOT return it
+ * to clients or emit it in logs.
+ */
+export function generateStellarKeypair(): GeneratedStellarKeypair {
+  const keypair = Keypair.random();
+  return {
+    publicKey: keypair.publicKey(),
+    secretKey: keypair.secret(),
+  };
+}

--- a/src/services/stellar/wallet-secret-crypto.ts
+++ b/src/services/stellar/wallet-secret-crypto.ts
@@ -1,0 +1,65 @@
+import { GCM_NONCE_BYTES, openAead, sealAead } from "../crypto/aead";
+import type { EncryptedWalletSecret } from "../../server/api/domain";
+
+const MANAGED_WALLET_KEY_VERSION = 1;
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(value);
+  const out = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let index = 0; index < binary.length; index += 1) {
+    out[index] = binary.charCodeAt(index);
+  }
+  return out;
+}
+
+async function deriveWalletEncryptionKey(storageSecret: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(storageSecret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+/**
+ * Encrypt a managed-wallet seed for durable storage using the server storage
+ * secret. Plaintext seeds must never be written to storage.
+ */
+export async function encryptWalletSecret(
+  secretKey: string,
+  storageSecret: string,
+): Promise<EncryptedWalletSecret> {
+  const key = await deriveWalletEncryptionKey(storageSecret);
+  const sealed = await sealAead(key, new TextEncoder().encode(secretKey));
+  if (sealed.nonce.length !== GCM_NONCE_BYTES) {
+    throw new Error("Managed wallet encryption produced an invalid nonce length");
+  }
+  return {
+    ciphertext: toBase64(sealed.ciphertext),
+    nonce: toBase64(sealed.nonce),
+    tag: toBase64(sealed.tag),
+    keyVersion: MANAGED_WALLET_KEY_VERSION,
+  };
+}
+
+/**
+ * Decrypt a managed-wallet seed for server-side signing. Never expose the
+ * returned value to clients.
+ */
+export async function decryptWalletSecret(
+  encrypted: EncryptedWalletSecret,
+  storageSecret: string,
+): Promise<string> {
+  const key = await deriveWalletEncryptionKey(storageSecret);
+  const opened = await openAead(
+    key,
+    fromBase64(encrypted.ciphertext),
+    fromBase64(encrypted.tag),
+    fromBase64(encrypted.nonce),
+  );
+  return new TextDecoder().decode(opened.plaintext);
+}

--- a/tests/integration/stellar/managed-wallet-provision.test.ts
+++ b/tests/integration/stellar/managed-wallet-provision.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { provisionManagedStellarWallet } from "../../../src/server/api/account-provisioning";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { loadRuntimeConfig } from "../../../src/config";
+import { FakeFundingAdapter } from "@/services/stellar/funding-adapter";
+
+describe("managed wallet provisioning integration (BETA-015)", () => {
+  it("persists encrypted material and funds through the fake adapter boundary", async () => {
+    const repository = new MemoryApiRepository();
+    const config = loadRuntimeConfig({ profile: "test" });
+    const userId = "usr_integration_wallet";
+    const now = "2026-01-01T00:00:00.000Z";
+    const fundingAdapter = new FakeFundingAdapter();
+
+    await repository.createUser({
+      userId,
+      address: `G${"C".repeat(55)}`,
+      email: "integration@example.test",
+      username: "integration",
+      status: "pending_verification",
+      createdAt: now,
+      updatedAt: now,
+      version: 1,
+    });
+
+    const result = await provisionManagedStellarWallet(repository, userId, config, {
+      fundingAdapter,
+      storageSecret: "integration-storage-secret",
+    });
+
+    const stored = await repository.getManagedWallet(userId);
+    expect(stored).not.toBeNull();
+    expect(stored?.fundingStatus).toBe("funded");
+    expect(result.wallet.address).toBe(stored?.address);
+    expect(JSON.stringify(result)).not.toMatch(/S[A-Z0-9]{55}/);
+  });
+
+  it.skipIf(process.env.STEALTH_LIVE_TESTNET !== "1")(
+    "funds a wallet on live testnet when explicitly enabled",
+    async () => {
+      const { FriendbotFundingAdapter } = await import("@/services/stellar/funding-adapter");
+      const repository = new MemoryApiRepository();
+      const config = loadRuntimeConfig({ profile: "preview" });
+      const userId = `usr_live_${Date.now()}`;
+      const now = new Date().toISOString();
+
+      await repository.createUser({
+        userId,
+        address: `G${"D".repeat(55)}`,
+        email: `live-${Date.now()}@example.test`,
+        username: `live${Date.now()}`.slice(0, 20),
+        status: "pending_verification",
+        createdAt: now,
+        updatedAt: now,
+        version: 1,
+      });
+
+      await provisionManagedStellarWallet(repository, userId, config, {
+        fundingAdapter: new FriendbotFundingAdapter(),
+        storageSecret: process.env.STEALTH_STORAGE_SECRET ?? "live-test-storage-secret",
+      });
+    },
+  );
+});

--- a/tests/unit/api/account-provisioning-funding.test.ts
+++ b/tests/unit/api/account-provisioning-funding.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { provisionManagedStellarWallet } from "../../../src/server/api/account-provisioning";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { ApiError } from "../../../src/server/api/errors";
+import type { BetaRuntimeConfig } from "../../../src/config/schema";
+import { FakeFundingAdapter } from "@/services/stellar/funding-adapter";
+import { PROVISIONING_LIMITS } from "../../../src/server/api/rate-limit";
+import { fundingOperationIdForUser, listPublicFundingQueue } from "@/services/stellar/funding";
+import type { Credential, Profile, User } from "../../../src/server/api/domain";
+
+const storageSecret = "test-storage-secret-for-managed-wallets";
+const testConfig = {
+  profile: "test",
+  network: {
+    stellarNetwork: "testnet",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+  },
+} as BetaRuntimeConfig;
+
+function sampleUser(userId: string, pad = "D"): User {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    userId,
+    address: `G${pad.repeat(55)}`,
+    email: `${userId}@example.test`,
+    username: userId.replace(/[^a-z0-9_]/gi, "_").slice(0, 20),
+    status: "pending_verification",
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+  };
+}
+
+async function seedAccount(repository: MemoryApiRepository, userId: string, pad = "D") {
+  const user = sampleUser(userId, pad);
+  await repository.createUser(
+    user,
+    {
+      credentialId: `cred_${userId}`,
+      userId,
+      authMethod: "password_hash",
+      secretHash: "hash:salt",
+      walletKeyRef: `pending_${userId}`,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    } satisfies Credential,
+    {
+      userId,
+      username: user.username,
+      displayName: "Bob",
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    } satisfies Profile,
+  );
+}
+
+describe("provisionManagedStellarWallet abuse-safe funding (BETA-018)", () => {
+  it("rejects repeated provisioning from the same account", async () => {
+    const repository = new MemoryApiRepository();
+    const userId = "usr_limit_account";
+    await seedAccount(repository, userId);
+    const adapter = new FakeFundingAdapter();
+    adapter.failAll("timeout");
+
+    for (let i = 0; i < PROVISIONING_LIMITS.account.max; i += 1) {
+      await provisionManagedStellarWallet(repository, userId, testConfig, {
+        fundingAdapter: adapter,
+        storageSecret,
+        accountId: userId,
+        origin: "203.0.113.10",
+      });
+    }
+
+    await expect(
+      provisionManagedStellarWallet(repository, userId, testConfig, {
+        fundingAdapter: adapter,
+        storageSecret,
+        accountId: userId,
+        origin: "203.0.113.10",
+      }),
+    ).rejects.toMatchObject({ code: "too_many_requests" } satisfies Partial<ApiError>);
+  });
+
+  it("rejects repeated provisioning from the same origin across accounts", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    const origin = "198.51.100.9";
+
+    for (let i = 0; i < PROVISIONING_LIMITS.origin.max; i += 1) {
+      const userId = `usr_origin_${i}`;
+      const pad = "234567ABCDEFGHIJKLMNOPQRSTUVWXYZ".charAt(i) || "A";
+      await seedAccount(repository, userId, pad);
+      await provisionManagedStellarWallet(repository, userId, testConfig, {
+        fundingAdapter: adapter,
+        storageSecret,
+        accountId: userId,
+        origin,
+      });
+    }
+
+    const extra = "usr_origin_extra";
+    await seedAccount(repository, extra, "Q");
+    await expect(
+      provisionManagedStellarWallet(repository, extra, testConfig, {
+        fundingAdapter: adapter,
+        storageSecret,
+        accountId: extra,
+        origin,
+      }),
+    ).rejects.toMatchObject({ code: "too_many_requests" });
+  });
+
+  it("keeps a pending funding state and surfaces it on the admin queue", async () => {
+    const repository = new MemoryApiRepository();
+    const userId = "usr_pending_queue";
+    await seedAccount(repository, userId);
+    const adapter = new FakeFundingAdapter();
+    adapter.failAll("timeout");
+
+    const result = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter: adapter,
+      storageSecret,
+    });
+
+    expect(result.wallet.fundingStatus).toBe("pending");
+    expect(result.wallet).not.toHaveProperty("encryptedSecret");
+
+    const queue = await listPublicFundingQueue(repository);
+    expect(queue[0]?.operationId).toBe(fundingOperationIdForUser(userId));
+    expect(queue[0]?.status).toBe("retrying");
+    expect(JSON.stringify(queue[0])).not.toMatch(/encryptedSecret|secretKey/i);
+  });
+
+  it("does not create a second funded account on replay", async () => {
+    const repository = new MemoryApiRepository();
+    const userId = "usr_no_repeat";
+    await seedAccount(repository, userId);
+    const adapter = new FakeFundingAdapter();
+
+    const first = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter: adapter,
+      storageSecret,
+    });
+    const second = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter: adapter,
+      storageSecret,
+    });
+
+    expect(first.wallet.fundingStatus).toBe("funded");
+    expect(second.wallet.address).toBe(first.wallet.address);
+    expect(adapter.callCounts.get(first.wallet.address)).toBe(1);
+  });
+});

--- a/tests/unit/api/rate-limit.test.ts
+++ b/tests/unit/api/rate-limit.test.ts
@@ -7,6 +7,8 @@ import {
   checkAuthFailureThrottle,
   recordAuthFailure,
   AUTH_FAILURE_LIMITS,
+  consumeProvisioningQuota,
+  PROVISIONING_LIMITS,
 } from "../../../src/server/api/rate-limit";
 
 describe("weighted route rate limits", () => {
@@ -37,6 +39,45 @@ describe("weighted route rate limits", () => {
   it("keeps operation costs in immutable server configuration", () => {
     expect(Object.isFrozen(RATE_LIMIT_OPERATION_COSTS)).toBe(true);
     expect(Object.values(RATE_LIMIT_OPERATION_COSTS)).toEqual([1, 3, 5, 10]);
+  });
+
+  describe("provisioning quotas (BETA-018)", () => {
+    it("enforces a per-account provisioning cap", async () => {
+      const repository = new MemoryApiRepository();
+
+      for (let i = 0; i < PROVISIONING_LIMITS.account.max; i += 1) {
+        await expect(
+          consumeProvisioningQuota(repository, { accountId: "usr_a", origin: "unknown" }),
+        ).resolves.toEqual({ allowed: true });
+      }
+
+      await expect(
+        consumeProvisioningQuota(repository, { accountId: "usr_a", origin: "unknown" }),
+      ).resolves.toEqual({
+        allowed: false,
+        retryAfterSeconds: PROVISIONING_LIMITS.account.windowSeconds,
+        limitedBy: "account",
+      });
+    });
+
+    it("enforces a per-origin provisioning cap independently of account", async () => {
+      const repository = new MemoryApiRepository();
+      const origin = "192.0.2.44";
+
+      for (let i = 0; i < PROVISIONING_LIMITS.origin.max; i += 1) {
+        await expect(
+          consumeProvisioningQuota(repository, { accountId: `usr_${i}`, origin }),
+        ).resolves.toEqual({ allowed: true });
+      }
+
+      await expect(
+        consumeProvisioningQuota(repository, { accountId: "usr_other", origin }),
+      ).resolves.toEqual({
+        allowed: false,
+        retryAfterSeconds: PROVISIONING_LIMITS.origin.windowSeconds,
+        limitedBy: "origin",
+      });
+    });
   });
 
   describe("authentication failure throttling", () => {

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -390,6 +390,19 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("saveKeyDirectory");
     return this.inner.saveKeyDirectory(record);
   }
+  async getManagedWallet(userId: string) {
+    this.maybeFail("getManagedWallet");
+    return this.inner.getManagedWallet(userId);
+  }
+  async setManagedWallet(wallet: import("../../../src/server/api/domain").ManagedWalletRecord) {
+    this.maybeFail("setManagedWallet");
+    return this.inner.setManagedWallet(wallet);
+  }
+  async createManagedWalletIfAbsent(
+    wallet: import("../../../src/server/api/domain").ManagedWalletRecord,
+  ) {
+    return this.inner.createManagedWalletIfAbsent(wallet);
+  }
   async listRecipientEnvelopes(
     recipient: string,
     options?: import("../../../src/server/api/repository").MailboxQueryOptions,

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -403,6 +403,26 @@ class FailingRepository implements ApiRepository {
   ) {
     return this.inner.createManagedWalletIfAbsent(wallet);
   }
+  async getFundingOperation(operationId: string) {
+    this.maybeFail("getFundingOperation");
+    return this.inner.getFundingOperation(operationId);
+  }
+  async setFundingOperation(operation: import("../../../src/server/api/domain").FundingOperation) {
+    this.maybeFail("setFundingOperation");
+    return this.inner.setFundingOperation(operation);
+  }
+  async createFundingOperationIfAbsent(
+    operation: import("../../../src/server/api/domain").FundingOperation,
+  ) {
+    return this.inner.createFundingOperationIfAbsent(operation);
+  }
+  async listFundingOperations(filter?: {
+    status?: import("../../../src/server/api/domain").FundingOperation["status"];
+    limit?: number;
+  }) {
+    this.maybeFail("listFundingOperations");
+    return this.inner.listFundingOperations(filter);
+  }
   async listRecipientEnvelopes(
     recipient: string,
     options?: import("../../../src/server/api/repository").MailboxQueryOptions,

--- a/tests/unit/identity/two-user-acceptance.test.ts
+++ b/tests/unit/identity/two-user-acceptance.test.ts
@@ -93,8 +93,8 @@ describe("BETA-025 (Issue #1932): Two-User Identity Acceptance Suite", () => {
       expect(bobCred).not.toBeNull();
       expect(aliceCred?.credentialId).not.toBe(bobCred?.credentialId);
       expect(aliceCred?.secretHash).not.toBe(bobCred?.secretHash);
-      expect(aliceCred?.walletKeyRef).toBe(`pending_${aliceUser!.userId}`);
-      expect(bobCred?.walletKeyRef).toBe(`pending_${bobUser!.userId}`);
+      expect(aliceCred?.walletKeyRef).toBe(`wallet:managed:${aliceUser!.userId}`);
+      expect(bobCred?.walletKeyRef).toBe(`wallet:managed:${bobUser!.userId}`);
     });
 
     it("prevents duplicate registration with conflicting email or username", async () => {

--- a/tests/unit/stellar/account-provision.test.ts
+++ b/tests/unit/stellar/account-provision.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { provisionManagedStellarWallet } from "../../../src/server/api/account-provisioning";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import type { BetaRuntimeConfig } from "../../../src/config/schema";
+import { FakeFundingAdapter } from "@/services/stellar/funding-adapter";
+import type { Credential, Profile, User } from "../../../src/server/api/domain";
+
+const storageSecret = "test-storage-secret-for-managed-wallets";
+
+const testConfig = {
+  profile: "test",
+  network: {
+    stellarNetwork: "testnet",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+  },
+} as BetaRuntimeConfig;
+
+function sampleUser(userId: string, address: string): User {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    userId,
+    address,
+    email: "alice@example.test",
+    username: "alice",
+    status: "pending_verification",
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+  };
+}
+
+describe("provisionManagedStellarWallet (BETA-015 / Issue #1922)", () => {
+  it("creates, funds, and persists a managed wallet without exposing secrets", async () => {
+    const repository = new MemoryApiRepository();
+    const userId = "usr_test_wallet";
+    const fundingAdapter = new FakeFundingAdapter();
+    const user = sampleUser(userId, `G${"A".repeat(55)}`);
+
+    await repository.createUser(
+      user,
+      {
+        credentialId: "cred_test",
+        userId,
+        authMethod: "password_hash",
+        secretHash: "hash:salt",
+        walletKeyRef: `pending_${userId}`,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      } satisfies Credential,
+      {
+        userId,
+        username: "alice",
+        displayName: "Alice",
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      } satisfies Profile,
+    );
+
+    const first = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter,
+      storageSecret,
+    });
+
+    expect(first.wallet.provisioned).toBe(true);
+    expect(first.wallet.network).toBe("testnet");
+    expect(first.wallet.fundingStatus).toBe("funded");
+    expect(first.wallet.address).toMatch(/^G[A-Z2-7]{55}$/);
+    expect(first.wallet).not.toHaveProperty("secretKey");
+    expect(first.wallet).not.toHaveProperty("encryptedSecret");
+    expect(fundingAdapter.fundedAccounts.has(first.wallet.address)).toBe(true);
+
+    const stored = await repository.getManagedWallet(userId);
+    expect(stored?.address).toBe(first.wallet.address);
+    expect(stored?.encryptedSecret.ciphertext.length).toBeGreaterThan(0);
+
+    const credential = await repository.getCredential(userId);
+    expect(credential?.walletKeyRef).toBe(`wallet:managed:${userId}`);
+  });
+
+  it("is idempotent and does not create duplicate wallets", async () => {
+    const repository = new MemoryApiRepository();
+    const userId = "usr_idempotent_wallet";
+    const fundingAdapter = new FakeFundingAdapter();
+    const user = sampleUser(userId, `G${"B".repeat(55)}`);
+
+    await repository.createUser(user, {
+      credentialId: "cred_idem",
+      userId,
+      authMethod: "password_hash",
+      secretHash: "hash:salt",
+      walletKeyRef: `pending_${userId}`,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    });
+
+    const first = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter,
+      storageSecret,
+    });
+    const second = await provisionManagedStellarWallet(repository, userId, testConfig, {
+      fundingAdapter,
+      storageSecret,
+    });
+
+    expect(second.wallet.provisioned).toBe(false);
+    expect(second.wallet.address).toBe(first.wallet.address);
+    expect(fundingAdapter.fundedAccounts.size).toBe(1);
+  });
+});

--- a/tests/unit/stellar/funding.test.ts
+++ b/tests/unit/stellar/funding.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { FakeFundingAdapter } from "../../../src/services/stellar/funding-adapter";
+import {
+  classifyFundingFailure,
+  computeFundingBackoffMs,
+  fundingOperationIdForUser,
+  listPublicFundingQueue,
+  MAX_FUNDING_ATTEMPTS,
+  redactFundingMessage,
+  runFundingOperation,
+} from "../../../src/services/stellar/funding";
+import { FundingError } from "../../../src/services/stellar/funding-adapter";
+
+const ADDRESS = `G${"C".repeat(55)}`;
+
+describe("BETA-018 funding operations", () => {
+  it("classifies timeout, rate-limit, invalid account, and exhausted source", () => {
+    expect(classifyFundingFailure(new Error("Funding request timed out")).code).toBe("timeout");
+    expect(classifyFundingFailure(new Error("Friendbot funding failed with status 429")).code).toBe(
+      "rate_limited",
+    );
+    expect(classifyFundingFailure(new Error("Invalid public key")).errorClass).toBe("permanent");
+    expect(classifyFundingFailure(new Error("Funding source exhausted")).code).toBe(
+      "funding_source_exhausted",
+    );
+    expect(classifyFundingFailure(new Error("Account already exists")).alreadyFunded).toBe(true);
+    expect(
+      classifyFundingFailure(new FundingError("boom", { errorClass: "transient", code: "timeout" }))
+        .code,
+    ).toBe("timeout");
+  });
+
+  it("redacts secret material from funding error text", () => {
+    const secret = `S${"A".repeat(55)}`;
+    expect(redactFundingMessage(`seed=${secret} failed`)).not.toContain(secret);
+  });
+
+  it("uses bounded exponential backoff", () => {
+    expect(computeFundingBackoffMs(1)).toBe(1_000);
+    expect(computeFundingBackoffMs(2)).toBe(2_000);
+    expect(computeFundingBackoffMs(5)).toBe(16_000);
+  });
+
+  it("funds once and treats duplicate callbacks as the same operation", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    const first = await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_dup",
+      address: ADDRESS,
+    });
+    const second = await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_dup",
+      address: ADDRESS,
+    });
+
+    expect(first.operationId).toBe(fundingOperationIdForUser("usr_dup"));
+    expect(first.status).toBe("succeeded");
+    expect(second.operationId).toBe(first.operationId);
+    expect(second.status).toBe("succeeded");
+    expect(adapter.callCounts.get(ADDRESS)).toBe(1);
+  });
+
+  it("treats an already-funded provider callback as success without a new credit", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    adapter.failNext(ADDRESS, "already_funded", 1);
+
+    const operation = await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_already",
+      address: ADDRESS,
+    });
+
+    expect(operation.status).toBe("succeeded");
+    expect(operation.operationId).toBe(fundingOperationIdForUser("usr_already"));
+  });
+
+  it("retries a timeout with backoff instead of failing immediately", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    adapter.failNext(ADDRESS, "timeout", 1);
+    const now = new Date("2026-08-18T12:00:00.000Z");
+
+    const operation = await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_timeout",
+      address: ADDRESS,
+      now,
+    });
+
+    expect(operation.status).toBe("retrying");
+    expect(operation.lastErrorClass).toBe("transient");
+    expect(operation.nextRetryAt).toBe("2026-08-18T12:00:01.000Z");
+
+    const tooSoon = await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_timeout",
+      address: ADDRESS,
+      now: new Date("2026-08-18T12:00:00.500Z"),
+    });
+    expect(tooSoon.status).toBe("retrying");
+    expect(adapter.callCounts.get(ADDRESS)).toBe(1);
+  });
+
+  it("lands in failed after exhausted retries", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    adapter.failNext(ADDRESS, "timeout", MAX_FUNDING_ATTEMPTS);
+    let now = new Date("2026-08-18T12:00:00.000Z");
+    let operation;
+
+    for (let attempt = 0; attempt < MAX_FUNDING_ATTEMPTS; attempt += 1) {
+      operation = await runFundingOperation({
+        repository,
+        adapter,
+        userId: "usr_exhausted",
+        address: ADDRESS,
+        now,
+      });
+      now = new Date(now.getTime() + 60_000);
+    }
+
+    expect(operation?.status).toBe("failed");
+    expect(operation?.attempt).toBe(MAX_FUNDING_ATTEMPTS);
+    expect(operation?.nextRetryAt).toBeNull();
+  });
+
+  it("resumes the same operation ID after a simulated worker restart", async () => {
+    const adapter = new FakeFundingAdapter();
+    adapter.failNext(ADDRESS, "rate_limited", 1);
+    const firstRepo = new MemoryApiRepository();
+    const pending = await runFundingOperation({
+      repository: firstRepo,
+      adapter,
+      userId: "usr_restart",
+      address: ADDRESS,
+      now: new Date("2026-08-18T12:00:00.000Z"),
+    });
+    expect(pending.status).toBe("retrying");
+
+    const restarted = new MemoryApiRepository();
+    await restarted.setFundingOperation(pending);
+    const resumed = await runFundingOperation({
+      repository: restarted,
+      adapter,
+      userId: "usr_restart",
+      address: ADDRESS,
+      now: new Date("2026-08-18T12:00:05.000Z"),
+    });
+
+    expect(resumed.operationId).toBe(pending.operationId);
+    expect(resumed.status).toBe("succeeded");
+    expect(adapter.callCounts.get(ADDRESS)).toBe(2);
+  });
+
+  it("exposes admin queue state without seed fields", async () => {
+    const repository = new MemoryApiRepository();
+    const adapter = new FakeFundingAdapter();
+    await runFundingOperation({
+      repository,
+      adapter,
+      userId: "usr_queue",
+      address: ADDRESS,
+    });
+
+    const queue = await listPublicFundingQueue(repository, { status: "succeeded" });
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      userId: "usr_queue",
+      address: ADDRESS,
+      status: "succeeded",
+    });
+    expect(JSON.stringify(queue[0])).not.toMatch(/encryptedSecret|secretKey|seed/i);
+  });
+});


### PR DESCRIPTION
Closes Closes #1925
Implements BETA-018

**Stacked on BETA-015** — if Closes #1925 hasn't merged yet, this PR will include those commits too. Wait for that merge and rebase, or open this after Closes #1925 lands.

## Summary
Adds rate limiting and durable, retry-safe funding to the managed wallet flow from BETA-015, so wallet provisioning can't be abused or double-funded.

## What shipped
1. **Rate limits** (`rate-limit.ts`) — 3/hour per account, 10/hour per origin. Enforced before funding on both wallet provision and registration.
2. **Durable funding operations** (`src/services/stellar/funding.ts`) — one operation ID per user (`fund:{userId}`), so retries and worker restarts resume the same operation instead of double-funding.
   - Transient failures (timeout, 429, 5xx) get bounded backoff, up to 5 attempts.
   - Permanent failures (invalid account, source exhausted) fail closed.
   - Already-funded callbacks are treated as success, not a retry.
3. **Admin queue endpoint** — `GET /api/v1/admin/funding/` — shows pending/retrying/succeeded/failed, public metadata only (no seeds exposed).

## Result
Users see `pending` or `failed` status on their wallet as appropriate; a funded wallet is never provisioned twice.

## Tests
26 focused unit tests passing.

Branch: `feat/beta-018-funding-limits-retries`