### PR TITLE
feat(auth): password-reset request and one-time completion flow (BETA-009)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -678,7 +678,7 @@
             "status": 422,
             "message": "The postage quote is invalid",
             "retryable": false,
-            "description": "The supplied postage quote failed integrity validation."
+            "description": "The supplied postage quote failed integrity validation: it is tampered, reused for another message or recipient, bound to a different asset or network, or stale because the recipient policy changed after the quote was issued."
           },
           "request_in_progress": {
             "status": 409,
@@ -815,6 +815,425 @@
           "service": {
             "type": "string",
             "description": "Service name."
+          }
+        }
+      },
+      "Contact": {
+        "type": "object",
+        "required": [
+          "contactId",
+          "owner",
+          "name",
+          "address",
+          "canonicalAddress",
+          "trust",
+          "source",
+          "createdAt",
+          "updatedAt",
+          "version"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "contactId": {
+            "type": "string",
+            "description": "Unique contact identifier."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Stellar account that owns this contact.",
+            "pattern": "^G[A-Z2-7]{55}$"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Display name."
+          },
+          "address": {
+            "type": "string",
+            "maxLength": 300,
+            "description": "Raw address identifier (G-address, email, or handle)."
+          },
+          "canonicalAddress": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^G[A-Z2-7]{55}$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resolved canonical G-address, or null until resolved."
+          },
+          "trust": {
+            "type": "string",
+            "enum": ["default", "allow", "block"],
+            "description": "Sender rule. Never applied to policy unless the owner opts in."
+          },
+          "source": {
+            "type": "string",
+            "enum": ["manual", "csv", "vcard", "api"],
+            "description": "Origin of this contact row."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Optimistic concurrency version."
+          }
+        }
+      },
+      "ContactResolution": {
+        "type": "object",
+        "required": ["senderRule", "senderRuleConfigured"],
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "anyOf": [
+              {
+                "type": "object",
+                "required": [
+                  "identifier",
+                  "canonicalAddress",
+                  "account",
+                  "resolved",
+                  "status",
+                  "publicKey",
+                  "encryptionKeyVersion",
+                  "policyEndpoint",
+                  "freshness"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "canonicalAddress": {
+                    "type": "string"
+                  },
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "resolved": {
+                    "type": "boolean"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "publicKey": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "encryptionKeyVersion": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "policyEndpoint": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "freshness": {
+                    "type": "string",
+                    "enum": ["fresh", "stale", "unknown"]
+                  },
+                  "memo": {
+                    "type": "string"
+                  },
+                  "memoType": {
+                    "type": "string",
+                    "enum": ["text", "id", "hash"]
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resolved identity, or null when resolution failed or is pending."
+          },
+          "keyDirectory": {
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Live key directory entry for the canonical address.",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "senderRule": {
+            "type": "string",
+            "enum": ["default", "allow", "block"]
+          },
+          "senderRuleConfigured": {
+            "type": "boolean",
+            "description": "True when the owner has an explicit policy rule for this address."
+          }
+        }
+      },
+      "ContactWithResolution": {
+        "type": "object",
+        "required": ["contact", "resolution"],
+        "additionalProperties": false,
+        "properties": {
+          "contact": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/ContactResolution"
+          }
+        }
+      },
+      "ContactListResult": {
+        "type": "object",
+        "required": ["items", "nextContinuationKey"],
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactWithResolution"
+            }
+          },
+          "nextContinuationKey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Cursor for the next page, or null at the end."
+          }
+        }
+      },
+      "ContactMergeResult": {
+        "type": "object",
+        "required": ["contact", "resolution"],
+        "additionalProperties": false,
+        "description": "The surviving contact after merging, re-resolved against live state.",
+        "properties": {
+          "contact": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/ContactResolution"
+          }
+        }
+      },
+      "ContactImportPreviewResult": {
+        "type": "object",
+        "required": [
+          "format",
+          "totalRows",
+          "validRows",
+          "duplicateRows",
+          "errorRows",
+          "truncated",
+          "limit",
+          "rows"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": ["csv", "vcard"]
+          },
+          "totalRows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "validRows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "duplicateRows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "errorRows": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "True when parsing stopped at the row limit."
+          },
+          "limit": {
+            "type": "object",
+            "required": ["maxRows"],
+            "properties": {
+              "maxRows": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["rowNumber", "name", "address", "status"],
+              "additionalProperties": false,
+              "properties": {
+                "rowNumber": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "name": {
+                  "type": "string"
+                },
+                "address": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["valid", "duplicate", "error"]
+                },
+                "error": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "canonicalAddress": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^G[A-Z2-7]{55}$"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "identityStatus": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "keyFreshness": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "existing": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "required": ["contactId", "trust"],
+                      "properties": {
+                        "contactId": {
+                          "type": "string"
+                        },
+                        "trust": {
+                          "type": "string",
+                          "enum": ["default", "allow", "block"]
+                        }
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "ContactImportCommitResult": {
+        "type": "object",
+        "required": [
+          "created",
+          "updated",
+          "unchanged",
+          "rejected",
+          "total",
+          "appliedRules",
+          "contacts"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "created": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "updated": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unchanged": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "rejected": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "appliedRules": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Sender rules applied to policy; only when applyTrust was requested."
+          },
+          "contacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Contact"
+            }
           }
         }
       }
@@ -2816,6 +3235,982 @@
           },
           "503": {
             "description": "The verification message could not be delivered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/password-reset/request": {
+      "post": {
+        "operationId": "requestPasswordReset",
+        "summary": "Request a password reset email for an account",
+        "description": "Issues a hashed, single-use password reset token delivered to the account email. Responds identically for existing and non-existing accounts to prevent enumeration; rate limits and cooldowns are enforced.",
+        "security": [],
+        "x-stability": "beta",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generic confirmation; the message was sent or intentionally not sent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Password reset request is on cooldown or rate limited",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The password reset message could not be delivered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/password-reset/complete": {
+      "post": {
+        "operationId": "completePasswordReset",
+        "summary": "Complete password reset using a single-use token",
+        "description": "Consumes a single-use password reset token, validates password policy, sets the new password, invalidates all other outstanding reset tokens, and revokes all active sessions for the user.",
+        "security": [],
+        "x-stability": "beta",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["token", "password"],
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 12,
+                    "maxLength": 256
+                  },
+                  "passwordConfirmation": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password reset completed successfully and all active sessions revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or expired password reset token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Password reset token has already been used or superseded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Password does not meet policy requirements or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many failed attempts. Token is locked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/contacts": {
+      "get": {
+        "operationId": "listContacts",
+        "summary": "List contacts for the authenticated account",
+        "description": "Returns the owner's contacts with live identity, key-freshness, and trust state. Resolution failures degrade to null rather than failing the page.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "description": "Optional substring filter on name or address."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination continuation key."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listed contacts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactListResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "operationId": "createContact",
+        "summary": "Create a contact",
+        "description": "Stores a new owner-scoped contact. The trust field is advisory and never mutates mailbox policy.",
+        "x-max-body-bytes": 8192,
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "address"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "address": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "trust": {
+                    "type": "string",
+                    "enum": ["default", "allow", "block"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created contact with live resolution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactWithResolution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/contacts/{contactId}": {
+      "get": {
+        "operationId": "getContact",
+        "summary": "Read a single contact",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact with live resolution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactWithResolution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateContact",
+        "summary": "Update a contact",
+        "x-max-body-bytes": 8192,
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "At least one of name, address, or trust is required.",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "address": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "trust": {
+                    "type": "string",
+                    "enum": ["default", "allow", "block"]
+                  },
+                  "expectedVersion": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated contact with live resolution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactWithResolution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — concurrent modification detected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteContact",
+        "summary": "Delete a contact",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contact deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/contacts/merge": {
+      "post": {
+        "operationId": "mergeContacts",
+        "summary": "Merge duplicate contacts",
+        "description": "Deletes the merge targets and bumps the version of the kept contact so concurrent writers cannot resurrect merged-away rows. All IDs are scoped to the authenticated owner.",
+        "x-max-body-bytes": 8192,
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["keepContactId", "mergeContactIds"],
+                "additionalProperties": false,
+                "properties": {
+                  "keepContactId": {
+                    "type": "string"
+                  },
+                  "mergeContactIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Surviving contact re-resolved after merge",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactMergeResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — cannot merge a contact owned by another actor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — kept contact modified concurrently",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/contacts/import/preview": {
+      "post": {
+        "operationId": "previewContactImport",
+        "summary": "Parse and preview a CSV or vCard contact import",
+        "description": "Parses the uploaded content into rows with per-row validity, duplicate detection, and live identity resolution. Never writes contact rows.",
+        "x-max-body-bytes": 1048576,
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["format", "content"],
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "enum": ["csv", "vcard"]
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "Raw import file content, UTF-8."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Parsed import preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactImportPreviewResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/contacts/import/commit": {
+      "post": {
+        "operationId": "commitContactImport",
+        "summary": "Commit a contact import",
+        "description": "Idempotently upserts the reviewed rows by address. Policy is never mutated unless applyTrust is explicitly true, and even then only allow/block rows touch sender rules.",
+        "x-max-body-bytes": 1048576,
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["rows"],
+                "additionalProperties": false,
+                "properties": {
+                  "rows": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1000,
+                    "items": {
+                      "type": "object",
+                      "required": ["name", "address"],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 200
+                        },
+                        "address": {
+                          "type": "string",
+                          "maxLength": 300
+                        },
+                        "trust": {
+                          "type": "string",
+                          "enum": ["default", "allow", "block"]
+                        },
+                        "source": {
+                          "type": "string",
+                          "enum": ["csv", "vcard"]
+                        }
+                      }
+                    }
+                  },
+                  "applyTrust": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Opt-in application of trust rows to mailbox policy."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Import committed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactImportCommitResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity — Request payload validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as ApiV1ReceiptsIndexRouteImport } from './routes/api/v1/receipts
 import { Route as ApiV1PostageIndexRouteImport } from './routes/api/v1/postage/index'
 import { Route as ApiV1ContactsIndexRouteImport } from './routes/api/v1/contacts/index'
 import { Route as ApiV1AccountsIndexRouteImport } from './routes/api/v1/accounts/index'
+import { Route as ApiV1WalletStatusRouteImport } from './routes/api/v1/wallet/status'
 import { Route as ApiV1WalletManagedRouteImport } from './routes/api/v1/wallet/managed'
 import { Route as ApiV1SendCoordinateRouteImport } from './routes/api/v1/send/coordinate'
 import { Route as ApiV1RelayVersionRouteImport } from './routes/api/v1/relay/version'
@@ -55,7 +56,6 @@ import { Route as ApiV1AdminJobsIndexRouteImport } from './routes/api/v1/admin/j
 import { Route as ApiV1AdminFundingIndexRouteImport } from './routes/api/v1/admin/funding/index'
 import { Route as ApiV1AdminDlqIndexRouteImport } from './routes/api/v1/admin/dlq/index'
 import { Route as ApiV1WalletLinkVerifyRouteImport } from './routes/api/v1/wallet/link/verify'
-import { Route as ApiV1WalletStatusRouteImport } from './routes/api/v1/wallet/status'
 import { Route as ApiV1WalletLinkChallengeRouteImport } from './routes/api/v1/wallet/link/challenge'
 import { Route as ApiV1WalletLinkAddressRouteImport } from './routes/api/v1/wallet/link/$address'
 import { Route as ApiV1RequestsRequestIdDecisionsRouteImport } from './routes/api/v1/requests/$requestId/decisions'
@@ -70,13 +70,15 @@ import { Route as ApiV1IdentityKeysRetireRouteImport } from './routes/api/v1/ide
 import { Route as ApiV1IdentityKeysKeyIdRouteImport } from './routes/api/v1/identity/keys/$keyId'
 import { Route as ApiV1ContactsImportPreviewRouteImport } from './routes/api/v1/contacts/import/preview'
 import { Route as ApiV1ContactsImportCommitRouteImport } from './routes/api/v1/contacts/import/commit'
+import { Route as ApiV1AuthPasswordResetRequestRouteImport } from './routes/api/v1/auth/password-reset/request'
+import { Route as ApiV1AuthPasswordResetCompleteRouteImport } from './routes/api/v1/auth/password-reset/complete'
 import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
 import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
 import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
-import { Route as ApiV1AccountsUserIdWalletProvisionRouteImport } from './routes/api/v1/accounts/$userId/wallet/provision'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
 import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
+import { Route as ApiV1AccountsUserIdWalletProvisionRouteImport } from './routes/api/v1/accounts/$userId/wallet/provision'
 
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
   id: '/motion-gallery',
@@ -151,6 +153,11 @@ const ApiV1ContactsIndexRoute = ApiV1ContactsIndexRouteImport.update({
 const ApiV1AccountsIndexRoute = ApiV1AccountsIndexRouteImport.update({
   id: '/api/v1/accounts/',
   path: '/api/v1/accounts/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1WalletStatusRoute = ApiV1WalletStatusRouteImport.update({
+  id: '/api/v1/wallet/status',
+  path: '/api/v1/wallet/status',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1WalletManagedRoute = ApiV1WalletManagedRouteImport.update({
@@ -310,11 +317,6 @@ const ApiV1WalletLinkVerifyRoute = ApiV1WalletLinkVerifyRouteImport.update({
   path: '/api/v1/wallet/link/verify',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiV1WalletStatusRoute = ApiV1WalletStatusRouteImport.update({
-  id: '/api/v1/wallet/status',
-  path: '/api/v1/wallet/status',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiV1WalletLinkChallengeRoute =
   ApiV1WalletLinkChallengeRouteImport.update({
     id: '/api/v1/wallet/link/challenge',
@@ -394,6 +396,18 @@ const ApiV1ContactsImportCommitRoute =
     path: '/api/v1/contacts/import/commit',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiV1AuthPasswordResetRequestRoute =
+  ApiV1AuthPasswordResetRequestRouteImport.update({
+    id: '/api/v1/auth/password-reset/request',
+    path: '/api/v1/auth/password-reset/request',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1AuthPasswordResetCompleteRoute =
+  ApiV1AuthPasswordResetCompleteRouteImport.update({
+    id: '/api/v1/auth/password-reset/complete',
+    path: '/api/v1/auth/password-reset/complete',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiV1AdminJobsIdRoute = ApiV1AdminJobsIdRouteImport.update({
   id: '/api/v1/admin/jobs/$id',
   path: '/api/v1/admin/jobs/$id',
@@ -409,12 +423,6 @@ const ApiV1AccountsProvisioningRetryRoute =
     id: '/retry',
     path: '/retry',
     getParentRoute: () => ApiV1AccountsProvisioningRoute,
-  } as any)
-const ApiV1AccountsUserIdWalletProvisionRoute =
-  ApiV1AccountsUserIdWalletProvisionRouteImport.update({
-    id: '/api/v1/accounts/$userId/wallet/provision',
-    path: '/api/v1/accounts/$userId/wallet/provision',
-    getParentRoute: () => rootRouteImport,
   } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
@@ -432,6 +440,12 @@ const ApiV1AdminDlqIdAbandonRoute = ApiV1AdminDlqIdAbandonRouteImport.update({
   path: '/abandon',
   getParentRoute: () => ApiV1AdminDlqIdRoute,
 } as any)
+const ApiV1AccountsUserIdWalletProvisionRoute =
+  ApiV1AccountsUserIdWalletProvisionRouteImport.update({
+    id: '/api/v1/accounts/$userId/wallet/provision',
+    path: '/api/v1/accounts/$userId/wallet/provision',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -469,15 +483,17 @@ export interface FileRoutesByFullPath {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/send/coordinate': typeof ApiV1SendCoordinateRoute
   '/api/v1/wallet/managed': typeof ApiV1WalletManagedRoute
+  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/contacts/': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
-  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
+  '/api/v1/auth/password-reset/complete': typeof ApiV1AuthPasswordResetCompleteRoute
+  '/api/v1/auth/password-reset/request': typeof ApiV1AuthPasswordResetRequestRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -493,12 +509,12 @@ export interface FileRoutesByFullPath {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
-  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
-  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/admin/funding/': typeof ApiV1AdminFundingIndexRoute
+  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
@@ -539,15 +555,17 @@ export interface FileRoutesByTo {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/send/coordinate': typeof ApiV1SendCoordinateRoute
   '/api/v1/wallet/managed': typeof ApiV1WalletManagedRoute
+  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/accounts': typeof ApiV1AccountsIndexRoute
   '/api/v1/contacts': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
-  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
+  '/api/v1/auth/password-reset/complete': typeof ApiV1AuthPasswordResetCompleteRoute
+  '/api/v1/auth/password-reset/request': typeof ApiV1AuthPasswordResetRequestRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -563,12 +581,12 @@ export interface FileRoutesByTo {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
-  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/admin/dlq': typeof ApiV1AdminDlqIndexRoute
-  '/api/v1/admin/jobs': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/admin/funding': typeof ApiV1AdminFundingIndexRoute
+  '/api/v1/admin/jobs': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
@@ -610,15 +628,17 @@ export interface FileRoutesById {
   '/api/v1/relay/version': typeof ApiV1RelayVersionRoute
   '/api/v1/send/coordinate': typeof ApiV1SendCoordinateRoute
   '/api/v1/wallet/managed': typeof ApiV1WalletManagedRoute
+  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/accounts/': typeof ApiV1AccountsIndexRoute
   '/api/v1/contacts/': typeof ApiV1ContactsIndexRoute
   '/api/v1/postage/': typeof ApiV1PostageIndexRoute
   '/api/v1/receipts/': typeof ApiV1ReceiptsIndexRoute
   '/api/v1/requests/': typeof ApiV1RequestsIndexRoute
   '/api/v1/accounts/provisioning/retry': typeof ApiV1AccountsProvisioningRetryRoute
-  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id': typeof ApiV1AdminDlqIdRouteWithChildren
   '/api/v1/admin/jobs/$id': typeof ApiV1AdminJobsIdRoute
+  '/api/v1/auth/password-reset/complete': typeof ApiV1AuthPasswordResetCompleteRoute
+  '/api/v1/auth/password-reset/request': typeof ApiV1AuthPasswordResetRequestRoute
   '/api/v1/contacts/import/commit': typeof ApiV1ContactsImportCommitRoute
   '/api/v1/contacts/import/preview': typeof ApiV1ContactsImportPreviewRoute
   '/api/v1/identity/keys/$keyId': typeof ApiV1IdentityKeysKeyIdRoute
@@ -634,12 +654,12 @@ export interface FileRoutesById {
   '/api/v1/wallet/link/$address': typeof ApiV1WalletLinkAddressRoute
   '/api/v1/wallet/link/challenge': typeof ApiV1WalletLinkChallengeRoute
   '/api/v1/wallet/link/verify': typeof ApiV1WalletLinkVerifyRoute
-  '/api/v1/wallet/status': typeof ApiV1WalletStatusRoute
   '/api/v1/admin/dlq/': typeof ApiV1AdminDlqIndexRoute
-  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/admin/funding/': typeof ApiV1AdminFundingIndexRoute
+  '/api/v1/admin/jobs/': typeof ApiV1AdminJobsIndexRoute
   '/api/v1/identity/keys/': typeof ApiV1IdentityKeysIndexRoute
   '/api/v1/wallet/link/': typeof ApiV1WalletLinkIndexRoute
+  '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
   '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
@@ -682,15 +702,17 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/send/coordinate'
     | '/api/v1/wallet/managed'
+    | '/api/v1/wallet/status'
     | '/api/v1/accounts/'
     | '/api/v1/contacts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
-    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
+    | '/api/v1/auth/password-reset/complete'
+    | '/api/v1/auth/password-reset/request'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -706,12 +728,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
-    | '/api/v1/wallet/status'
     | '/api/v1/admin/dlq/'
-    | '/api/v1/admin/jobs/'
     | '/api/v1/admin/funding/'
+    | '/api/v1/admin/jobs/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
@@ -752,15 +774,17 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/send/coordinate'
     | '/api/v1/wallet/managed'
+    | '/api/v1/wallet/status'
     | '/api/v1/accounts'
     | '/api/v1/contacts'
     | '/api/v1/postage'
     | '/api/v1/receipts'
     | '/api/v1/requests'
     | '/api/v1/accounts/provisioning/retry'
-    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
+    | '/api/v1/auth/password-reset/complete'
+    | '/api/v1/auth/password-reset/request'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -776,12 +800,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
-    | '/api/v1/wallet/status'
     | '/api/v1/admin/dlq'
-    | '/api/v1/admin/jobs'
     | '/api/v1/admin/funding'
+    | '/api/v1/admin/jobs'
     | '/api/v1/identity/keys'
     | '/api/v1/wallet/link'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
@@ -822,15 +846,17 @@ export interface FileRouteTypes {
     | '/api/v1/relay/version'
     | '/api/v1/send/coordinate'
     | '/api/v1/wallet/managed'
+    | '/api/v1/wallet/status'
     | '/api/v1/accounts/'
     | '/api/v1/contacts/'
     | '/api/v1/postage/'
     | '/api/v1/receipts/'
     | '/api/v1/requests/'
     | '/api/v1/accounts/provisioning/retry'
-    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id'
     | '/api/v1/admin/jobs/$id'
+    | '/api/v1/auth/password-reset/complete'
+    | '/api/v1/auth/password-reset/request'
     | '/api/v1/contacts/import/commit'
     | '/api/v1/contacts/import/preview'
     | '/api/v1/identity/keys/$keyId'
@@ -846,12 +872,12 @@ export interface FileRouteTypes {
     | '/api/v1/wallet/link/$address'
     | '/api/v1/wallet/link/challenge'
     | '/api/v1/wallet/link/verify'
-    | '/api/v1/wallet/status'
     | '/api/v1/admin/dlq/'
-    | '/api/v1/admin/jobs/'
     | '/api/v1/admin/funding/'
+    | '/api/v1/admin/jobs/'
     | '/api/v1/identity/keys/'
     | '/api/v1/wallet/link/'
+    | '/api/v1/accounts/$userId/wallet/provision'
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
@@ -893,14 +919,16 @@ export interface RootRouteChildren {
   ApiV1RelayVersionRoute: typeof ApiV1RelayVersionRoute
   ApiV1SendCoordinateRoute: typeof ApiV1SendCoordinateRoute
   ApiV1WalletManagedRoute: typeof ApiV1WalletManagedRoute
+  ApiV1WalletStatusRoute: typeof ApiV1WalletStatusRoute
   ApiV1AccountsIndexRoute: typeof ApiV1AccountsIndexRoute
-  ApiV1AccountsUserIdWalletProvisionRoute: typeof ApiV1AccountsUserIdWalletProvisionRoute
   ApiV1ContactsIndexRoute: typeof ApiV1ContactsIndexRoute
   ApiV1PostageIndexRoute: typeof ApiV1PostageIndexRoute
   ApiV1ReceiptsIndexRoute: typeof ApiV1ReceiptsIndexRoute
   ApiV1RequestsIndexRoute: typeof ApiV1RequestsIndexRoute
   ApiV1AdminDlqIdRoute: typeof ApiV1AdminDlqIdRouteWithChildren
   ApiV1AdminJobsIdRoute: typeof ApiV1AdminJobsIdRoute
+  ApiV1AuthPasswordResetCompleteRoute: typeof ApiV1AuthPasswordResetCompleteRoute
+  ApiV1AuthPasswordResetRequestRoute: typeof ApiV1AuthPasswordResetRequestRoute
   ApiV1ContactsImportCommitRoute: typeof ApiV1ContactsImportCommitRoute
   ApiV1ContactsImportPreviewRoute: typeof ApiV1ContactsImportPreviewRoute
   ApiV1IdentityKeysKeyIdRoute: typeof ApiV1IdentityKeysKeyIdRoute
@@ -911,12 +939,12 @@ export interface RootRouteChildren {
   ApiV1WalletLinkAddressRoute: typeof ApiV1WalletLinkAddressRoute
   ApiV1WalletLinkChallengeRoute: typeof ApiV1WalletLinkChallengeRoute
   ApiV1WalletLinkVerifyRoute: typeof ApiV1WalletLinkVerifyRoute
-  ApiV1WalletStatusRoute: typeof ApiV1WalletStatusRoute
   ApiV1AdminDlqIndexRoute: typeof ApiV1AdminDlqIndexRoute
-  ApiV1AdminJobsIndexRoute: typeof ApiV1AdminJobsIndexRoute
   ApiV1AdminFundingIndexRoute: typeof ApiV1AdminFundingIndexRoute
+  ApiV1AdminJobsIndexRoute: typeof ApiV1AdminJobsIndexRoute
   ApiV1IdentityKeysIndexRoute: typeof ApiV1IdentityKeysIndexRoute
   ApiV1WalletLinkIndexRoute: typeof ApiV1WalletLinkIndexRoute
+  ApiV1AccountsUserIdWalletProvisionRoute: typeof ApiV1AccountsUserIdWalletProvisionRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1024,6 +1052,13 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/accounts'
       fullPath: '/api/v1/accounts/'
       preLoaderRoute: typeof ApiV1AccountsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/wallet/status': {
+      id: '/api/v1/wallet/status'
+      path: '/api/v1/wallet/status'
+      fullPath: '/api/v1/wallet/status'
+      preLoaderRoute: typeof ApiV1WalletStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/wallet/managed': {
@@ -1243,13 +1278,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1WalletLinkVerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/v1/wallet/status': {
-      id: '/api/v1/wallet/status'
-      path: '/api/v1/wallet/status'
-      fullPath: '/api/v1/wallet/status'
-      preLoaderRoute: typeof ApiV1WalletStatusRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/v1/wallet/link/challenge': {
       id: '/api/v1/wallet/link/challenge'
       path: '/api/v1/wallet/link/challenge'
@@ -1348,6 +1376,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1ContactsImportCommitRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/auth/password-reset/request': {
+      id: '/api/v1/auth/password-reset/request'
+      path: '/api/v1/auth/password-reset/request'
+      fullPath: '/api/v1/auth/password-reset/request'
+      preLoaderRoute: typeof ApiV1AuthPasswordResetRequestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/auth/password-reset/complete': {
+      id: '/api/v1/auth/password-reset/complete'
+      path: '/api/v1/auth/password-reset/complete'
+      fullPath: '/api/v1/auth/password-reset/complete'
+      preLoaderRoute: typeof ApiV1AuthPasswordResetCompleteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/admin/jobs/$id': {
       id: '/api/v1/admin/jobs/$id'
       path: '/api/v1/admin/jobs/$id'
@@ -1369,13 +1411,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
       parentRoute: typeof ApiV1AccountsProvisioningRoute
     }
-    '/api/v1/accounts/$userId/wallet/provision': {
-      id: '/api/v1/accounts/$userId/wallet/provision'
-      path: '/api/v1/accounts/$userId/wallet/provision'
-      fullPath: '/api/v1/accounts/$userId/wallet/provision'
-      preLoaderRoute: typeof ApiV1AccountsUserIdWalletProvisionRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
       path: '/senders/$sender'
@@ -1396,6 +1431,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/v1/admin/dlq/$id/abandon'
       preLoaderRoute: typeof ApiV1AdminDlqIdAbandonRouteImport
       parentRoute: typeof ApiV1AdminDlqIdRoute
+    }
+    '/api/v1/accounts/$userId/wallet/provision': {
+      id: '/api/v1/accounts/$userId/wallet/provision'
+      path: '/api/v1/accounts/$userId/wallet/provision'
+      fullPath: '/api/v1/accounts/$userId/wallet/provision'
+      preLoaderRoute: typeof ApiV1AccountsUserIdWalletProvisionRouteImport
+      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -1508,14 +1550,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1RelayVersionRoute: ApiV1RelayVersionRoute,
   ApiV1SendCoordinateRoute: ApiV1SendCoordinateRoute,
   ApiV1WalletManagedRoute: ApiV1WalletManagedRoute,
+  ApiV1WalletStatusRoute: ApiV1WalletStatusRoute,
   ApiV1AccountsIndexRoute: ApiV1AccountsIndexRoute,
-  ApiV1AccountsUserIdWalletProvisionRoute: ApiV1AccountsUserIdWalletProvisionRoute,
   ApiV1ContactsIndexRoute: ApiV1ContactsIndexRoute,
   ApiV1PostageIndexRoute: ApiV1PostageIndexRoute,
   ApiV1ReceiptsIndexRoute: ApiV1ReceiptsIndexRoute,
   ApiV1RequestsIndexRoute: ApiV1RequestsIndexRoute,
   ApiV1AdminDlqIdRoute: ApiV1AdminDlqIdRouteWithChildren,
   ApiV1AdminJobsIdRoute: ApiV1AdminJobsIdRoute,
+  ApiV1AuthPasswordResetCompleteRoute: ApiV1AuthPasswordResetCompleteRoute,
+  ApiV1AuthPasswordResetRequestRoute: ApiV1AuthPasswordResetRequestRoute,
   ApiV1ContactsImportCommitRoute: ApiV1ContactsImportCommitRoute,
   ApiV1ContactsImportPreviewRoute: ApiV1ContactsImportPreviewRoute,
   ApiV1IdentityKeysKeyIdRoute: ApiV1IdentityKeysKeyIdRoute,
@@ -1526,12 +1570,13 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1WalletLinkAddressRoute: ApiV1WalletLinkAddressRoute,
   ApiV1WalletLinkChallengeRoute: ApiV1WalletLinkChallengeRoute,
   ApiV1WalletLinkVerifyRoute: ApiV1WalletLinkVerifyRoute,
-  ApiV1WalletStatusRoute: ApiV1WalletStatusRoute,
   ApiV1AdminDlqIndexRoute: ApiV1AdminDlqIndexRoute,
-  ApiV1AdminJobsIndexRoute: ApiV1AdminJobsIndexRoute,
   ApiV1AdminFundingIndexRoute: ApiV1AdminFundingIndexRoute,
+  ApiV1AdminJobsIndexRoute: ApiV1AdminJobsIndexRoute,
   ApiV1IdentityKeysIndexRoute: ApiV1IdentityKeysIndexRoute,
   ApiV1WalletLinkIndexRoute: ApiV1WalletLinkIndexRoute,
+  ApiV1AccountsUserIdWalletProvisionRoute:
+    ApiV1AccountsUserIdWalletProvisionRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/v1/auth/password-reset/complete.ts
+++ b/src/routes/api/v1/auth/password-reset/complete.ts
@@ -1,0 +1,78 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { completePasswordReset } from "@/server/api/auth/password-reset-service";
+import { getApiContext } from "@/server/api/context";
+import { emailSchema } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const completeResetSchema = z
+  .object({
+    token: z.string().trim().min(1, "Token cannot be empty").max(512, "Token is too long"),
+    password: z.string().optional(),
+    newPassword: z.string().optional(),
+    passwordConfirmation: z.string().optional(),
+    email: emailSchema.optional(),
+  })
+  .refine((data) => Boolean(data.password || data.newPassword), {
+    message: "Password is required",
+    path: ["password"],
+  })
+  .superRefine((data, ctx) => {
+    const effectivePassword = data.password ?? data.newPassword;
+    if (data.passwordConfirmation && effectivePassword !== data.passwordConfirmation) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Passwords do not match",
+        path: ["passwordConfirmation"],
+      });
+    }
+  });
+
+/**
+ * POST /api/v1/auth/password-reset/complete
+ *
+ * Completes a password reset with a valid token and new password.
+ *
+ * Invariants (BETA-009):
+ * 1. Token must be valid, unexpired, and not previously consumed.
+ * 2. New password must satisfy password policy (min 12 chars, upper, lower, digit).
+ * 3. Atomic CAS: racing requests with the same token result in exactly 1 winner.
+ * 4. Revokes ALL active sessions for the account across all devices.
+ * 5. Invalidates all other outstanding reset tokens for the account.
+ */
+export const Route = createFileRoute("/api/v1/auth/password-reset/complete")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const input = await parseJsonBody(request, completeResetSchema, {
+            route: "POST /auth/password-reset/complete" as any,
+          });
+
+          const host = request.headers.get("host") ?? undefined;
+          const effectivePassword = (input.password ?? input.newPassword)!;
+
+          const result = await completePasswordReset(apiContext, {
+            token: input.token,
+            newPassword: effectivePassword,
+            email: input.email,
+            host,
+          });
+
+          const response = apiSuccess(request, {
+            success: true,
+            message: result.message,
+          });
+
+          for (const header of result.cookieHeaders) {
+            response.headers.append("Set-Cookie", header);
+          }
+
+          return response;
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/auth/password-reset/request.ts
+++ b/src/routes/api/v1/auth/password-reset/request.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { requestPasswordReset } from "@/server/api/auth/password-reset-service";
+import { getApiContext } from "@/server/api/context";
+import { emailSchema } from "@/server/api/domain";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import {
+  getVerificationDeliveryConfig,
+  getVerificationNotificationAdapter,
+} from "@/server/api/verification-delivery";
+
+const requestResetSchema = z.object({
+  email: emailSchema,
+});
+
+/**
+ * POST /api/v1/auth/password-reset/request
+ *
+ * Requests a password reset email for an account.
+ *
+ * Generic-response contract (BETA-009): Responds identically with { status: "sent" }
+ * regardless of whether the account exists (enumeration-resistant). Cooldowns and
+ * IP-based rate limiting are enforced to prevent brute-force attacks and abuse.
+ */
+export const Route = createFileRoute("/api/v1/auth/password-reset/request")({
+  server: {
+    handlers: {
+      POST: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const input = await parseJsonBody(request, requestResetSchema, {
+            route: "POST /auth/password-reset/request" as any,
+          });
+
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+
+          const delivery = await getVerificationDeliveryConfig();
+          const adapter = await getVerificationNotificationAdapter();
+
+          const result = await requestPasswordReset(
+            apiContext,
+            {
+              email: input.email,
+              ip,
+            },
+            (message) => adapter.deliverVerificationEmail(message),
+            delivery.appUrl,
+          );
+
+          return apiSuccess(request, { status: result.status });
+        }),
+    },
+  },
+});

--- a/src/server/api/auth/index.ts
+++ b/src/server/api/auth/index.ts
@@ -1,4 +1,5 @@
 export * from "./password";
+export * from "./password-reset-service";
 export * from "./session-service";
 export * from "./challenge";
 export * from "./delegation";

--- a/src/server/api/auth/password-reset-service.ts
+++ b/src/server/api/auth/password-reset-service.ts
@@ -1,0 +1,446 @@
+import { recordAuditEvent } from "../audit";
+import type { ApiContext } from "../context";
+import {
+  passwordPolicySchema,
+  type Credential,
+  type VerificationPurpose,
+  type VerificationToken,
+} from "../domain";
+import { ApiError } from "../errors";
+import type { DeliveryReceipt, VerificationEmailMessage } from "@/services/notifications/adapter";
+import { hashPassword } from "./password";
+import { revokeAllSessions } from "./session-service";
+import { generateVerificationToken, hashVerificationToken } from "../verification-service";
+
+/**
+ * BETA-009 (Issue #1916): Password reset request and one-time completion flow.
+ *
+ * Security invariants:
+ * 1. Enumeration-resistant: Password reset request returns the exact same
+ *    generic confirmation ({ status: "sent" }) whether the account exists or not.
+ * 2. Token single-use & account-scoped: Tokens are 256-bit cryptographically secure,
+ *    hashed with SHA-256 before persistence, bound to a single user ID and purpose,
+ *    and single-use enforced at the data layer via atomic CAS operations.
+ * 3. Race-safe completion: Racing concurrent completions on the same token yield
+ *    exactly one winner; subsequent/racing callers get a clean 409 conflict.
+ * 4. Password policy: Minimum 12 characters, uppercase, lowercase, and numeric digits.
+ * 5. Full session revocation: Completing a password reset invalidates all existing
+ *    sessions for the user across all devices (no old sessions survive a reset).
+ * 6. Outstanding token invalidation: Completing a reset invalidates all other
+ *    outstanding reset tokens for that account.
+ * 7. Breach-safe audit logging: Only token hashes or masked identifiers are logged;
+ *    raw tokens, passwords, or seeds are NEVER logged.
+ */
+
+export interface PasswordResetPolicy {
+  tokenLifetimeMs: number;
+  resendCooldownMs: number;
+  maxAttempts: number;
+  ipRateLimitWindowSeconds: number;
+  maxRequestsPerIp: number;
+}
+
+export const DEFAULT_PASSWORD_RESET_POLICY: PasswordResetPolicy = {
+  tokenLifetimeMs: 60 * 60 * 1000, // 1 hour
+  resendCooldownMs: 60 * 1000, // 60 seconds cooldown
+  maxAttempts: 5,
+  ipRateLimitWindowSeconds: 60 * 60, // 1 hour
+  maxRequestsPerIp: 10,
+};
+
+export const PASSWORD_RESET_PURPOSE: VerificationPurpose = "password_reset";
+
+export interface RequestPasswordResetInput {
+  email: string;
+  ip?: string;
+}
+
+export interface CompletePasswordResetInput {
+  token: string;
+  newPassword: string;
+  email?: string;
+  host?: string;
+}
+
+export interface PasswordResetRequestOutcome {
+  status: "sent";
+  retryAfterSeconds: number;
+}
+
+export interface PasswordResetCompleteOutcome {
+  success: true;
+  message: string;
+  cookieHeaders: string[];
+}
+
+export interface IssuedPasswordResetToken {
+  plaintextToken: string;
+  tokenHash: string;
+  expiresAt: Date;
+  replaced: boolean;
+}
+
+function requestIdOf(context: ApiContext): string {
+  return context.requestId ?? "unknown";
+}
+
+/**
+ * Builds the clickable reset link carrying the plaintext token.
+ */
+export function buildPasswordResetUrl(
+  appUrl: string,
+  email: string,
+  plaintextToken: string,
+): string {
+  const base = appUrl.endsWith("/") ? appUrl.slice(0, -1) : appUrl;
+  const params = new URLSearchParams({
+    email,
+    token: plaintextToken,
+  });
+  return `${base}/reset-password?${params.toString()}`;
+}
+
+/**
+ * Issue a new password reset token for a user, atomically invalidating the
+ * previous still-redeemable reset token for the same user.
+ */
+export async function issuePasswordResetToken(
+  context: ApiContext,
+  userId: string,
+  policy: PasswordResetPolicy = DEFAULT_PASSWORD_RESET_POLICY,
+  now: Date = new Date(),
+): Promise<IssuedPasswordResetToken> {
+  const plaintextToken = generateVerificationToken();
+  const tokenHash = await hashVerificationToken(plaintextToken);
+
+  const token: VerificationToken = {
+    tokenHash,
+    userId,
+    purpose: PASSWORD_RESET_PURPOSE,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + policy.tokenLifetimeMs).toISOString(),
+    consumedAt: null,
+    replacedAt: null,
+    replacedByTokenHash: null,
+    attemptCount: 0,
+    maxAttempts: policy.maxAttempts,
+  };
+
+  const result = await context.repository.issueVerificationToken(token, now);
+  if (result.outcome === "conflict") {
+    throw new ApiError(500, "internal_error", "Password reset token generation collided");
+  }
+
+  return {
+    plaintextToken,
+    tokenHash,
+    expiresAt: new Date(token.expiresAt),
+    replaced: result.replacedToken !== null,
+  };
+}
+
+/**
+ * Request flow: accepts an identifier (email) and issues a password-reset token
+ * delivered via the notification adapter. Enumeration-resistant: always returns
+ * { status: "sent" } regardless of account existence, and every rate-limit /
+ * cooldown gate is keyed on the request inputs (identifier hash, IP) — never on
+ * whether the account exists — so an attacker sees byte-identical responses for
+ * existing and non-existing addresses in every situation.
+ */
+export async function requestPasswordReset(
+  context: ApiContext,
+  input: RequestPasswordResetInput,
+  deliver: (message: VerificationEmailMessage) => Promise<DeliveryReceipt>,
+  appUrl: string,
+  policy: PasswordResetPolicy = DEFAULT_PASSWORD_RESET_POLICY,
+  now: Date = new Date(),
+): Promise<PasswordResetRequestOutcome> {
+  const repository = context.repository;
+  const normalizedEmail = input.email.trim().toLowerCase();
+  const ip = input.ip ?? "unknown";
+  const cooldownSeconds = Math.max(1, Math.ceil(policy.resendCooldownMs / 1000));
+
+  // Identifier and IP gate keys are derived from request inputs only, so the
+  // throttling behavior is identical for existing and non-existing accounts.
+  const emailHash = await hashVerificationToken(normalizedEmail);
+  const emailCooldownKey = `pwd_reset:email:${emailHash}`;
+  const ipRateLimitKey = `pwd_reset:ip:${ip}`;
+
+  // The repository counters only prune on write, so each gate increments first
+  // (which prunes out-of-window entries) and then compares the returned count.
+  // This keeps every check accurate and identical across account existence.
+  // 1. Per-IP rate limiting
+  const ipCount = await repository.incrementCounter(
+    ipRateLimitKey,
+    policy.ipRateLimitWindowSeconds,
+    1,
+  );
+  if (ipCount > policy.maxRequestsPerIp) {
+    throw new ApiError(429, "too_many_requests", "Too many password reset requests from this IP", {
+      retryAfterSeconds: policy.ipRateLimitWindowSeconds,
+    });
+  }
+
+  // 2. Per-identifier cooldown applied uniformly before the account lookup,
+  //    so a repeated request to any address (registered or not) is throttled
+  //    identically — no cooldown-timing oracle for account enumeration.
+  const cooldownCount = await repository.incrementCounter(emailCooldownKey, cooldownSeconds, 1);
+  if (cooldownCount > 1) {
+    throw new ApiError(429, "too_many_requests", "Password reset request is still on cooldown", {
+      retryAfterSeconds: cooldownSeconds,
+    });
+  }
+
+  // 3. User lookup (enumeration-resistant)
+  const user = await repository.getUserByEmail(normalizedEmail);
+
+  const genericOutcome: PasswordResetRequestOutcome = {
+    status: "sent",
+    retryAfterSeconds: cooldownSeconds,
+  };
+
+  if (!user) {
+    recordAuditEvent({
+      actor: emailHash,
+      action: "auth.password_reset_requested_unknown_account",
+      targetType: "account",
+      safeTargetReference: emailHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    return genericOutcome;
+  }
+
+  // 5. Issue token & build delivery message
+  const issued = await issuePasswordResetToken(context, user.userId, policy, now);
+  const resetUrl = buildPasswordResetUrl(appUrl, user.email, issued.plaintextToken);
+
+  const message: VerificationEmailMessage = {
+    to: user.email,
+    purpose: PASSWORD_RESET_PURPOSE,
+    verificationUrl: resetUrl,
+    expiresAt: issued.expiresAt,
+  };
+
+  let receipt: DeliveryReceipt;
+  try {
+    receipt = await deliver(message);
+  } catch (error) {
+    recordAuditEvent({
+      actor: user.userId,
+      action: "auth.password_reset_delivery_failed",
+      targetType: "verification_token",
+      safeTargetReference: issued.tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(
+      503,
+      "dependency_unavailable",
+      "The password reset message could not be delivered",
+    );
+  }
+
+  if (!receipt.accepted) {
+    recordAuditEvent({
+      actor: user.userId,
+      action: "auth.password_reset_delivery_failed",
+      targetType: "verification_token",
+      safeTargetReference: issued.tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(
+      503,
+      "dependency_unavailable",
+      "The password reset message could not be delivered",
+    );
+  }
+
+  recordAuditEvent({
+    actor: user.userId,
+    action: "auth.password_reset_requested",
+    targetType: "verification_token",
+    safeTargetReference: issued.tokenHash,
+    result: "success",
+    requestId: requestIdOf(context),
+  });
+
+  return genericOutcome;
+}
+
+/**
+ * Completion flow: accepts token + new password, validates token single-use & expiry,
+ * enforces password policy, sets new password, invalidates all other outstanding reset
+ * tokens for the account, and revokes all active sessions for the account.
+ */
+export async function completePasswordReset(
+  context: ApiContext,
+  input: CompletePasswordResetInput,
+  now: Date = new Date(),
+): Promise<PasswordResetCompleteOutcome> {
+  const repository = context.repository;
+
+  // 1. Password policy validation
+  const passwordResult = passwordPolicySchema.safeParse(input.newPassword);
+  if (!passwordResult.success) {
+    throw new ApiError(
+      422,
+      "validation_error",
+      passwordResult.error.issues[0]?.message ?? "Password does not meet policy requirements",
+    );
+  }
+
+  const tokenHash = await hashVerificationToken(input.token);
+
+  // 2. Atomic single-use token consumption (CAS-safe)
+  const result = await repository.consumeVerificationToken(tokenHash, now);
+
+  if (result.outcome === "not-found") {
+    recordAuditEvent({
+      actor: "anonymous",
+      action: "auth.password_reset_failed.invalid_token",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(400, "bad_request", "Invalid password reset token");
+  }
+
+  const userId = result.token.userId;
+
+  if (result.outcome === "expired") {
+    await repository.recordVerificationAttempt(tokenHash, now);
+    recordAuditEvent({
+      actor: userId,
+      action: "auth.password_reset_failed.expired",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(400, "bad_request", "Password reset token has expired");
+  }
+
+  if (result.outcome === "already-consumed") {
+    await repository.recordVerificationAttempt(tokenHash, now);
+    recordAuditEvent({
+      actor: userId,
+      action: "auth.password_reset_failed.reused",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(409, "conflict", "Password reset token has already been used");
+  }
+
+  if (result.outcome === "replaced") {
+    await repository.recordVerificationAttempt(tokenHash, now);
+    recordAuditEvent({
+      actor: userId,
+      action: "auth.password_reset_failed.replaced",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(
+      409,
+      "conflict",
+      "Password reset token has been superseded by a newer request",
+    );
+  }
+
+  if (result.outcome === "brute-force-blocked") {
+    recordAuditEvent({
+      actor: userId,
+      action: "auth.password_reset_failed.brute_force_blocked",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(
+      429,
+      "too_many_requests",
+      "Too many invalid reset attempts. Token is locked",
+    );
+  }
+
+  if (result.outcome !== "consumed") {
+    throw new ApiError(400, "bad_request", "Invalid password reset token");
+  }
+
+  // Token was successfully consumed! Verify user identity.
+  const user = await repository.getUserById(userId);
+  if (!user) {
+    recordAuditEvent({
+      actor: userId,
+      action: "auth.password_reset_failed.user_not_found",
+      targetType: "verification_token",
+      safeTargetReference: tokenHash,
+      result: "denied",
+      requestId: requestIdOf(context),
+    });
+    throw new ApiError(400, "bad_request", "User account associated with token was not found");
+  }
+
+  if (input.email) {
+    const normalizedInputEmail = input.email.trim().toLowerCase();
+    if (user.email.toLowerCase() !== normalizedInputEmail) {
+      recordAuditEvent({
+        actor: userId,
+        action: "auth.password_reset_failed.email_mismatch",
+        targetType: "verification_token",
+        safeTargetReference: tokenHash,
+        result: "denied",
+        requestId: requestIdOf(context),
+      });
+      throw new ApiError(
+        400,
+        "bad_request",
+        "Password reset token does not belong to specified email",
+      );
+    }
+  }
+
+  // 3. Set the new password hash
+  const { hash, salt } = await hashPassword(input.newPassword);
+  const existingCred = await repository.getCredential(userId);
+
+  const updatedCredential: Credential = {
+    credentialId: existingCred?.credentialId ?? `cred_${crypto.randomUUID().replace(/-/g, "")}`,
+    userId,
+    authMethod: "password_hash",
+    secretHash: `${hash}:${salt}`,
+    walletKeyRef: existingCred?.walletKeyRef ?? `wallet_${userId}`,
+    createdAt: existingCred?.createdAt ?? now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  await repository.setCredential(updatedCredential);
+
+  // 4. Invalidate all other outstanding reset tokens for this account
+  await repository.invalidateActiveVerificationToken(userId, PASSWORD_RESET_PURPOSE, now);
+
+  // 5. Revoke ALL existing sessions for this account (no old sessions survive a reset)
+  const sessionRevocation = await revokeAllSessions(context, userId, { host: input.host });
+
+  // 6. Breach-safe audit log
+  recordAuditEvent({
+    actor: userId,
+    action: "auth.password_reset_completed",
+    targetType: "account",
+    safeTargetReference: userId,
+    result: "success",
+    requestId: requestIdOf(context),
+  });
+
+  return {
+    success: true,
+    message: "Password has been reset successfully. All existing sessions have been revoked.",
+    cookieHeaders: sessionRevocation.cookieHeaders,
+  };
+}

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -404,7 +404,15 @@ export const publicProfileSchema = z.object({
 // BETA-005: Verification token lifecycle domain
 // ---------------------------------------------------------------------------
 
-export const verificationPurposeSchema = z.enum(["email_verification"]);
+export const passwordPolicySchema = z
+  .string()
+  .min(12, "Password must be at least 12 characters")
+  .max(256, "Password is too long")
+  .refine((value) => /[a-z]/.test(value), "Password must include a lowercase letter")
+  .refine((value) => /[A-Z]/.test(value), "Password must include an uppercase letter")
+  .refine((value) => /\d/.test(value), "Password must include a number");
+
+export const verificationPurposeSchema = z.enum(["email_verification", "password_reset"]);
 export type VerificationPurpose = z.infer<typeof verificationPurposeSchema>;
 
 export const verificationTokenHashSchema = z

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -315,6 +315,14 @@ export class HybridApiRepository implements ApiRepository {
     return this.getStub().recordVerificationAttempt(tokenHash, now);
   }
 
+  async invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void> {
+    return this.getStub().invalidateActiveVerificationToken(userId, purpose, now);
+  }
+
   // BETA-006: Session DO stubs
   async getSession(sessionId: string): Promise<Session | null> {
     return this.getStub().getSession(sessionId);

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -729,6 +729,27 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void> {
+    return this.withVerificationLock(activeTokenKey(userId, purpose), async () => {
+      const activeHash = this.activeVerificationTokens.get(activeTokenKey(userId, purpose));
+      if (activeHash) {
+        const current = this.verificationTokens.get(activeHash);
+        if (current && current.consumedAt === null && current.replacedAt === null) {
+          const invalidated: VerificationToken = {
+            ...current,
+            replacedAt: now.toISOString(),
+          };
+          this.verificationTokens.set(activeHash, invalidated);
+        }
+        this.activeVerificationTokens.delete(activeTokenKey(userId, purpose));
+      }
+    });
+  }
+
   async getRelayQueueDepth(_relayId: string) {
     return 0;
   }

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -2814,6 +2814,183 @@ export const openApiDocument = {
         },
       },
     },
+    "/auth/password-reset/request": {
+      post: {
+        operationId: "requestPasswordReset",
+        summary: "Request a password reset email for an account",
+        description:
+          "Issues a hashed, single-use password reset token delivered to the account email. Responds identically for existing and non-existing accounts to prevent enumeration; rate limits and cooldowns are enforced.",
+        security: [],
+        "x-stability": "beta",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["email"],
+                properties: {
+                  email: { type: "string", format: "email" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Generic confirmation; the message was sent or intentionally not sent",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Request validation failed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "429": {
+            description: "Password reset request is on cooldown or rate limited",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "503": {
+            description: "The password reset message could not be delivered",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/auth/password-reset/complete": {
+      post: {
+        operationId: "completePasswordReset",
+        summary: "Complete password reset using a single-use token",
+        description:
+          "Consumes a single-use password reset token, validates password policy, sets the new password, invalidates all other outstanding reset tokens, and revokes all active sessions for the user.",
+        security: [],
+        "x-stability": "beta",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["token", "password"],
+                properties: {
+                  token: { type: "string" },
+                  password: { type: "string", minLength: 12, maxLength: 256 },
+                  passwordConfirmation: { type: "string" },
+                  email: { type: "string", format: "email" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          default: { description: "" },
+          "200": {
+            description: "Password reset completed successfully and all active sessions revoked",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/SuccessEnvelope",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Invalid or expired password reset token",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "409": {
+            description: "Password reset token has already been used or superseded",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "422": {
+            description: "Password does not meet policy requirements or validation failed",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "429": {
+            description: "Too many failed attempts. Token is locked",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+          "500": {
+            description: "Internal Server Error",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ErrorEnvelope",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     "/contacts": {
       get: {
         operationId: "listContacts",

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -382,6 +382,11 @@ export interface ApiRepository {
   ): Promise<IssueVerificationTokenResult>;
   consumeVerificationToken(tokenHash: string, now: Date): Promise<ConsumeVerificationTokenResult>;
   recordVerificationAttempt(tokenHash: string, now: Date): Promise<RecordVerificationAttemptResult>;
+  invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void>;
 
   getRelayQueueDepth(relayId: string): Promise<number>;
   getRelayRetryCount(relayId: string): Promise<number>;
@@ -987,6 +992,14 @@ export class ValidatedApiRepository implements ApiRepository {
     return result;
   }
 
+  async invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void> {
+    return this.inner.invalidateActiveVerificationToken(userId, purpose, now);
+  }
+
   getRelayQueueDepth(relayId: string): Promise<number> {
     return this.inner.getRelayQueueDepth(relayId);
   }
@@ -1327,6 +1340,7 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "releaseUsernameReservation",
   "initializePolicyIfAbsent",
   "getActiveVerificationToken",
+  "invalidateActiveVerificationToken",
   "listRecipientEnvelopes",
   "getExternalWallets",
   "findExternalWalletOwner",
@@ -1658,6 +1672,16 @@ export class RetryableApiRepository implements ApiRepository {
     now: Date,
   ): Promise<RecordVerificationAttemptResult> {
     return this.inner.recordVerificationAttempt(tokenHash, now);
+  }
+
+  invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void> {
+    return this.withRetry("invalidateActiveVerificationToken", () =>
+      this.inner.invalidateActiveVerificationToken(userId, purpose, now),
+    );
   }
 
   getRelayQueueDepth(relayId: string): Promise<number> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -673,6 +673,31 @@ export class StealthCoordinator extends DurableObjectBase {
     });
   }
 
+  async invalidateActiveVerificationToken(
+    userId: string,
+    purpose: VerificationPurpose,
+    now: Date,
+  ): Promise<void> {
+    return this.runExclusive(`verification-token:user:${userId}:${purpose}`, async () => {
+      const activeHash = (await this.ctx.storage.get(
+        `verification-token:active:${userId}:${purpose}`,
+      )) as string | undefined;
+      if (activeHash) {
+        const current = (await this.ctx.storage.get(`verification-token:hash:${activeHash}`)) as
+          | VerificationToken
+          | undefined;
+        if (current && current.consumedAt === null && current.replacedAt === null) {
+          const invalidated: VerificationToken = {
+            ...current,
+            replacedAt: now.toISOString(),
+          };
+          await this.ctx.storage.put(`verification-token:hash:${activeHash}`, invalidated);
+        }
+        await this.ctx.storage.delete(`verification-token:active:${userId}:${purpose}`);
+      }
+    });
+  }
+
   async getCounter(key: string): Promise<number> {
     const timestamps =
       ((await this.ctx.storage.get(`counter:${key}`)) as number[] | undefined) ?? [];

--- a/src/services/notifications/adapter.ts
+++ b/src/services/notifications/adapter.ts
@@ -20,8 +20,8 @@ import type { NotificationTransport } from "@/config/schema";
 export interface VerificationEmailMessage {
   /** Recipient address (normalized account email). */
   to: string;
-  /** Verified account purpose — always "email_verification" in BETA-005. */
-  purpose: "email_verification";
+  /** Verified account purpose. */
+  purpose: "email_verification" | "password_reset";
   /** Absolute URL the recipient opens to complete verification. */
   verificationUrl: string;
   /** Expiry instant of the token carried by the verification URL. */

--- a/src/services/notifications/smtp.ts
+++ b/src/services/notifications/smtp.ts
@@ -305,12 +305,20 @@ export class SmtpNotificationAdapter implements NotificationAdapter {
       await this.writeLine(socket, `DATA${CRLF}`);
       await expectReply("DATA", [354]);
 
+      const isPasswordReset = message.purpose === "password_reset";
+      const subject = isPasswordReset
+        ? "Reset your Stealth Mail password"
+        : "Verify your Stealth Mail account";
+      const actionText = isPasswordReset
+        ? "Open the link below to reset your password. The link expires on"
+        : "Open the link below to verify your account. The link expires on";
+
       await this.writeLine(
         socket,
         [
           `From: ${this.config.fromAddress}`,
           `To: ${message.to}`,
-          `Subject: Verify your Stealth Mail account`,
+          `Subject: ${subject}`,
           `Date: ${new Date().toUTCString()}`,
           `Message-ID: ${messageId}`,
           `MIME-Version: 1.0`,
@@ -318,7 +326,7 @@ export class SmtpNotificationAdapter implements NotificationAdapter {
           ``,
           `Welcome to Stealth Mail.`,
           ``,
-          `Open the link below to verify your account. The link expires on`,
+          actionText,
           `${message.expiresAt.toUTCString()}.`,
           ``,
           `${message.verificationUrl}`,

--- a/tests/unit/api/auth/password-reset-routes.test.ts
+++ b/tests/unit/api/auth/password-reset-routes.test.ts
@@ -1,0 +1,374 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Route as CompleteRoute } from "../../../../src/routes/api/v1/auth/password-reset/complete";
+import { Route as RequestRoute } from "../../../../src/routes/api/v1/auth/password-reset/request";
+import { getApiContext } from "../../../../src/server/api/context";
+import { MemoryApiRepository } from "../../../../src/server/api/memory-repository";
+import {
+  getVerificationNotificationAdapter,
+  setVerificationAdapterForTesting,
+} from "../../../../src/server/api/verification-delivery";
+import { SinkNotificationAdapter } from "../../../../src/services/notifications/sink";
+
+const requestHandler = (RequestRoute.options as any).server?.handlers?.POST;
+const completeHandler = (CompleteRoute.options as any).server?.handlers?.POST;
+
+const resetUser = {
+  userId: "usr_pwd_route_1",
+  address: `G${"A".repeat(55)}`,
+  email: "dave@stealth.mail",
+  username: "dave_stealth",
+  status: "active" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  version: 1,
+};
+
+const resetCredential = {
+  credentialId: "cred_pwd_route_1",
+  userId: resetUser.userId,
+  authMethod: "password_hash" as const,
+  secretHash: "old-hash:old-salt",
+  walletKeyRef: `wallet_${resetUser.userId}`,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function postRequest(url: string, body: unknown, headers: Record<string, string> = {}) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function parseJson(response: Response) {
+  return response.clone().json() as Promise<{
+    data?: Record<string, unknown>;
+    error?: {
+      code: string;
+      message: string;
+      retryable: boolean;
+      details?: unknown;
+    };
+  }>;
+}
+
+describe("BETA-009: password reset endpoints (route-level tests)", () => {
+  let repo: MemoryApiRepository;
+  let sink: SinkNotificationAdapter;
+
+  beforeEach(async () => {
+    repo = (await getApiContext()).repository as MemoryApiRepository;
+    repo.reset();
+    sink = new SinkNotificationAdapter();
+    setVerificationAdapterForTesting(sink);
+    await repo.createUser(resetUser, resetCredential);
+  });
+
+  afterEach(() => {
+    setVerificationAdapterForTesting(null);
+    repo.reset();
+  });
+
+  describe("POST /api/v1/auth/password-reset/request", () => {
+    it("sends a password reset message for an existing account", async () => {
+      const response = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toEqual({ status: "sent" });
+      expect(sink.size).toBe(1);
+      expect(sink.latestMessage!.to).toBe(resetUser.email);
+      expect(sink.latestMessage!.purpose).toBe("password_reset");
+    });
+
+    it("responds identically for unknown emails (no account enumeration)", async () => {
+      const response = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: "ghost@stealth.mail",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect((await parseJson(response)).data).toEqual({ status: "sent" });
+      expect(sink.size).toBe(0);
+    });
+
+    it("throttles repeated requests to unknown emails identically to registered accounts", async () => {
+      const unknownFirst = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: "ghost@stealth.mail",
+        }),
+      });
+      expect(unknownFirst.status).toBe(200);
+
+      const unknownSecond = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: "ghost@stealth.mail",
+        }),
+      });
+      expect(unknownSecond.status).toBe(429);
+      expect((await parseJson(unknownSecond)).error?.code).toBe("too_many_requests");
+
+      const knownFirst = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+      expect(knownFirst.status).toBe(200);
+
+      const knownSecond = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+      expect(knownSecond.status).toBe(429);
+      expect((await parseJson(knownSecond)).error?.code).toBe("too_many_requests");
+
+      const unknownBody = await parseJson(unknownSecond);
+      const knownBody = await parseJson(knownSecond);
+      expect(unknownBody.error?.code).toBe(knownBody.error?.code);
+    });
+
+    it("returns 429 during the resend cooldown with a retry-after window", async () => {
+      await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+
+      const response = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("retry-after")).not.toBeNull();
+      const body = await parseJson(response);
+      expect(body.error?.code).toBe("too_many_requests");
+      expect(
+        (body.error?.details as { retryAfterSeconds?: number }).retryAfterSeconds,
+      ).toBeGreaterThan(0);
+      expect(sink.size).toBe(1);
+    });
+
+    it("allows a new request after the cooldown has elapsed", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+      try {
+        await requestHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+            email: resetUser.email,
+          }),
+        });
+
+        vi.setSystemTime(new Date("2026-02-01T00:01:01.000Z"));
+        const response = await requestHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+            email: resetUser.email,
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(sink.size).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("rejects an invalid email with 422", async () => {
+      const response = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: "not-an-email",
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+  });
+
+  describe("POST /api/v1/auth/password-reset/complete", () => {
+    const newPassword = "NewSecurePassword!2026";
+
+    async function requestReset(): Promise<string> {
+      const response = await requestHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/request", {
+          email: resetUser.email,
+        }),
+      });
+      expect(response.status).toBe(200);
+      const token = sink.latestMessage!.verificationUrl.split("token=")[1];
+      expect(token).toBeTruthy();
+      return token;
+    }
+
+    it("completes the reset with a valid token and sets the new password", async () => {
+      const token = await requestReset();
+
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: newPassword,
+          passwordConfirmation: newPassword,
+          email: resetUser.email,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await parseJson(response);
+      expect(body.data).toMatchObject({ success: true });
+      const credential = await repo.getCredential(resetUser.userId);
+      expect(credential!.secretHash).not.toBe(resetCredential.secretHash);
+    });
+
+    it("revokes existing sessions and clears session cookies", async () => {
+      await repo.createSession({
+        sessionId: "sess_pwd_route_1",
+        userId: resetUser.userId,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      });
+      const token = await requestReset();
+
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: newPassword,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await repo.getSession("sess_pwd_route_1")).toBeNull();
+      expect(response.headers.get("set-cookie")).toContain("stealth_session=");
+    });
+
+    it("rejects an invalid token with 400", async () => {
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token: "not-a-real-token",
+          password: newPassword,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect((await parseJson(response)).error?.code).toBe("bad_request");
+    });
+
+    it("rejects a replayed token with 409", async () => {
+      const token = await requestReset();
+
+      const first = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: newPassword,
+        }),
+      });
+      expect(first.status).toBe(200);
+
+      const replay = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: newPassword,
+        }),
+      });
+
+      expect(replay.status).toBe(409);
+      expect((await parseJson(replay)).error?.code).toBe("conflict");
+    });
+
+    it("allows exactly one winner when two completions race on the same token", async () => {
+      const token = await requestReset();
+
+      const [first, second] = await Promise.all([
+        completeHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+            token,
+            password: newPassword,
+          }),
+        }),
+        completeHandler({
+          request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+            token,
+            password: newPassword,
+          }),
+        }),
+      ]);
+
+      const outcomes = [first.status, second.status].sort();
+      expect(outcomes).toEqual([200, 409]);
+
+      const credential = await repo.getCredential(resetUser.userId);
+      expect(credential!.secretHash.split(":")[0]).not.toBe(
+        resetCredential.secretHash.split(":")[0],
+      );
+    });
+
+    it("rejects a weak password with 422", async () => {
+      const token = await requestReset();
+
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: "weak",
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+
+    it("rejects a missing token with 422", async () => {
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          password: newPassword,
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+
+    it("rejects a missing password with 422", async () => {
+      const token = await requestReset();
+
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+
+    it("rejects mismatched confirmation with 422", async () => {
+      const token = await requestReset();
+
+      const response = await completeHandler({
+        request: postRequest("https://stealth.test/api/v1/auth/password-reset/complete", {
+          token,
+          password: newPassword,
+          passwordConfirmation: "DifferentPassword!2026",
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await parseJson(response)).error?.code).toBe("validation_error");
+    });
+  });
+
+  describe("verification adapter targeting", () => {
+    it("uses the configured notification adapter for delivery", async () => {
+      const adapter = await getVerificationNotificationAdapter();
+      expect(adapter).toBe(sink);
+    });
+  });
+});

--- a/tests/unit/api/auth/password-reset-service.test.ts
+++ b/tests/unit/api/auth/password-reset-service.test.ts
@@ -1,0 +1,674 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiContext } from "../../../../src/server/api/context";
+import { createApiContext } from "../../../../src/server/api/context";
+import type { Credential, User, VerificationPurpose } from "../../../../src/server/api/domain";
+import { ApiError } from "../../../../src/server/api/errors";
+import { MemoryApiRepository } from "../../../../src/server/api/memory-repository";
+import {
+  buildPasswordResetUrl,
+  completePasswordReset,
+  DEFAULT_PASSWORD_RESET_POLICY,
+  issuePasswordResetToken,
+  PASSWORD_RESET_PURPOSE,
+  requestPasswordReset,
+  type PasswordResetPolicy,
+} from "../../../../src/server/api/auth/password-reset-service";
+import { hashPassword } from "../../../../src/server/api/auth/password";
+import {
+  authenticateWithPassword,
+  validateSession,
+} from "../../../../src/server/api/auth/session-service";
+import { hashVerificationToken } from "../../../../src/server/api/verification-service";
+import type { VerificationEmailMessage } from "../../../../src/services/notifications/adapter";
+
+const policy: PasswordResetPolicy = {
+  tokenLifetimeMs: 60_000,
+  resendCooldownMs: 30_000,
+  maxAttempts: 5,
+  ipRateLimitWindowSeconds: 3600,
+  maxRequestsPerIp: 10,
+};
+
+const FIXED_NOW = new Date("2026-02-01T00:00:00.000Z");
+
+function activeUser(userId: string, email: string): User {
+  return {
+    userId,
+    address: `G${userId
+      .replace(/[^A-Z]/g, "F")
+      .padEnd(55, "F")
+      .slice(0, 55)}`,
+    email,
+    username: `pwd_${userId}`,
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    version: 1,
+  };
+}
+
+function credential(userId: string, secretHash: string): Credential {
+  return {
+    credentialId: `cred_${userId}`,
+    userId,
+    authMethod: "password_hash",
+    secretHash,
+    walletKeyRef: `wallet_${userId}`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function deliveredMessages(): {
+  messages: VerificationEmailMessage[];
+  deliver: (message: VerificationEmailMessage) => Promise<{
+    transport: "sink";
+    accepted: boolean;
+    safeTargetReference: string;
+  }>;
+} {
+  const messages: VerificationEmailMessage[] = [];
+  return {
+    messages,
+    deliver: async (message) => {
+      messages.push(message);
+      return {
+        transport: "sink",
+        accepted: true,
+        safeTargetReference: "ref",
+      };
+    },
+  };
+}
+
+async function runWithClock<T>(at: Date, fn: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  vi.setSystemTime(at);
+  try {
+    return await fn();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+describe("BETA-009: password reset service", () => {
+  let repo: MemoryApiRepository;
+  let context: ApiContext;
+
+  beforeEach(() => {
+    repo = new MemoryApiRepository();
+    context = createApiContext(repo);
+  });
+
+  afterEach(() => {
+    repo.reset();
+  });
+
+  describe("buildPasswordResetUrl", () => {
+    it("builds a well-formed reset URL with email and token parameters", () => {
+      expect(buildPasswordResetUrl("https://stealth.mail/", "alice@stealth.mail", "tok_123")).toBe(
+        "https://stealth.mail/reset-password?email=alice%40stealth.mail&token=tok_123",
+      );
+    });
+  });
+
+  describe("issuePasswordResetToken", () => {
+    it("persists only the hash, never the plaintext token", async () => {
+      const issued = await issuePasswordResetToken(context, "usr_pwd_1", policy, FIXED_NOW);
+
+      const stored = await repo.getVerificationToken(issued.tokenHash);
+      expect(stored).not.toBeNull();
+      expect(stored!.tokenHash).toBe(issued.tokenHash);
+      expect(stored!.purpose).toBe(PASSWORD_RESET_PURPOSE);
+      expect(JSON.stringify(stored)).not.toContain(issued.plaintextToken);
+    });
+
+    it("respects the configured token lifetime", async () => {
+      const issued = await issuePasswordResetToken(context, "usr_pwd_1", policy, FIXED_NOW);
+      expect(issued.expiresAt.getTime()).toBe(FIXED_NOW.getTime() + policy.tokenLifetimeMs);
+    });
+  });
+
+  describe("requestPasswordReset", () => {
+    it("sends a password-reset message carrying the plaintext reset URL", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const { messages, deliver } = deliveredMessages();
+
+      const outcome = await requestPasswordReset(
+        context,
+        { email: "Alice@Stealth.Mail", ip: "203.0.113.1" },
+        deliver,
+        "https://stealth.mail",
+        policy,
+        FIXED_NOW,
+      );
+
+      expect(outcome).toEqual({ status: "sent", retryAfterSeconds: 30 });
+      expect(messages).toHaveLength(1);
+      const message = messages[0];
+      expect(message.to).toBe("alice@stealth.mail");
+      expect(message.purpose).toBe(PASSWORD_RESET_PURPOSE);
+      expect(message.verificationUrl).toContain("email=alice%40stealth.mail");
+      expect(message.verificationUrl).toContain("token=");
+      expect(message.expiresAt.getTime()).toBe(FIXED_NOW.getTime() + policy.tokenLifetimeMs);
+
+      const token = message.verificationUrl.split("token=")[1];
+      const stored = await repo.getVerificationToken(await hashVerificationToken(token));
+      expect(stored).not.toBeNull();
+    });
+
+    it("responds identically for unknown emails without delivering or leaking existence", async () => {
+      const { messages, deliver } = deliveredMessages();
+
+      const outcome = await requestPasswordReset(
+        context,
+        { email: "ghost@stealth.mail", ip: "203.0.113.2" },
+        deliver,
+        "https://stealth.mail",
+        policy,
+        FIXED_NOW,
+      );
+
+      expect(outcome).toEqual({ status: "sent", retryAfterSeconds: 30 });
+      expect(messages).toHaveLength(0);
+    });
+
+    it("enforces the resend cooldown with a retry-after window", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const { messages, deliver } = deliveredMessages();
+
+      await runWithClock(FIXED_NOW, async () => {
+        await requestPasswordReset(
+          context,
+          { email: "alice@stealth.mail", ip: "203.0.113.3" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          FIXED_NOW,
+        );
+        messages.length = 0;
+
+        vi.setSystemTime(new Date(FIXED_NOW.getTime() + 10_000));
+        const error = await requestPasswordReset(
+          context,
+          { email: "alice@stealth.mail", ip: "203.0.113.3" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          new Date(FIXED_NOW.getTime() + 10_000),
+        ).catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).status).toBe(429);
+        expect((error as ApiError).code).toBe("too_many_requests");
+        expect((error as ApiError).retryAfterSeconds).toBe(30);
+        expect(messages).toHaveLength(0);
+      });
+    });
+
+    it("applies the cooldown identically to unknown accounts (enumeration-resistant)", async () => {
+      const { messages, deliver } = deliveredMessages();
+
+      await runWithClock(FIXED_NOW, async () => {
+        const first = await requestPasswordReset(
+          context,
+          { email: "ghost@stealth.mail", ip: "203.0.113.31" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          FIXED_NOW,
+        );
+        expect(first.status).toBe("sent");
+
+        vi.setSystemTime(new Date(FIXED_NOW.getTime() + 10_000));
+        const second = await requestPasswordReset(
+          context,
+          { email: "ghost@stealth.mail", ip: "203.0.113.31" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          new Date(FIXED_NOW.getTime() + 10_000),
+        ).catch((e: unknown) => e);
+
+        expect(second).toBeInstanceOf(ApiError);
+        expect((second as ApiError).status).toBe(429);
+        expect((second as ApiError).code).toBe("too_many_requests");
+        expect((second as ApiError).retryAfterSeconds).toBe(30);
+        expect(messages).toHaveLength(0);
+      });
+    });
+
+    it("allows a new request once the cooldown has elapsed and replaces the old token", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const { messages, deliver } = deliveredMessages();
+
+      await runWithClock(FIXED_NOW, async () => {
+        const first = await requestPasswordReset(
+          context,
+          { email: "alice@stealth.mail", ip: "203.0.113.4" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          FIXED_NOW,
+        );
+        expect(first.status).toBe("sent");
+        const firstToken = messages[0].verificationUrl.split("token=")[1];
+
+        messages.length = 0;
+        vi.setSystemTime(new Date(FIXED_NOW.getTime() + policy.resendCooldownMs + 1));
+        const second = await requestPasswordReset(
+          context,
+          { email: "alice@stealth.mail", ip: "203.0.113.4" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          new Date(FIXED_NOW.getTime() + policy.resendCooldownMs + 1),
+        );
+
+        expect(second.status).toBe("sent");
+        expect(messages).toHaveLength(1);
+
+        const firstHash = await hashVerificationToken(firstToken);
+        const oldRecord = await repo.getVerificationToken(firstHash);
+        expect(oldRecord!.replacedAt).not.toBeNull();
+      });
+    });
+
+    it("rejects requests beyond the per-IP budget", async () => {
+      const { deliver } = deliveredMessages();
+
+      for (let i = 0; i < policy.maxRequestsPerIp; i += 1) {
+        const outcome = await requestPasswordReset(
+          context,
+          { email: `ghost_${i}@stealth.mail`, ip: "198.51.100.9" },
+          deliver,
+          "https://stealth.mail",
+          policy,
+          FIXED_NOW,
+        );
+        expect(outcome.status).toBe("sent");
+      }
+
+      const error = await requestPasswordReset(
+        context,
+        { email: `ghost_10@stealth.mail`, ip: "198.51.100.9" },
+        deliver,
+        "https://stealth.mail",
+        policy,
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(429);
+      expect((error as ApiError).code).toBe("too_many_requests");
+    });
+
+    it("throws 503 when the transport rejects the message", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const failingDeliver = async () => ({
+        transport: "smtp" as const,
+        accepted: false,
+        safeTargetReference: "ref",
+      });
+
+      const error = await requestPasswordReset(
+        context,
+        { email: "alice@stealth.mail", ip: "203.0.113.5" },
+        failingDeliver,
+        "https://stealth.mail",
+        policy,
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(503);
+      expect((error as ApiError).code).toBe("dependency_unavailable");
+    });
+
+    it("throws 503 when the transport throws", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const throwingDeliver = async () => {
+        throw new Error("smtp down");
+      };
+
+      const error = await requestPasswordReset(
+        context,
+        { email: "alice@stealth.mail", ip: "203.0.113.5" },
+        throwingDeliver,
+        "https://stealth.mail",
+        policy,
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(503);
+      expect((error as ApiError).code).toBe("dependency_unavailable");
+    });
+  });
+
+  describe("completePasswordReset", () => {
+    const newPassword = "NewSecurePassword!2026";
+
+    async function issueResetToken(userId: string): Promise<string> {
+      const issued = await issuePasswordResetToken(context, userId, policy, FIXED_NOW);
+      return issued.plaintextToken;
+    }
+
+    it("resets the password, consumes the token, and revokes all sessions", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      await repo.createSession({
+        sessionId: "sess_pwd_1",
+        userId: "usr_pwd_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: "2026-02-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      });
+      const token = await issueResetToken("usr_pwd_1");
+
+      const outcome = await completePasswordReset(
+        context,
+        { token, newPassword, host: "stealth.mail" },
+        FIXED_NOW,
+      );
+
+      expect(outcome.success).toBe(true);
+      expect(outcome.message).toContain("revoked");
+      expect(outcome.cookieHeaders.length).toBeGreaterThan(0);
+
+      const storedCredential = await repo.getCredential("usr_pwd_1");
+      expect(storedCredential!.secretHash).not.toBe("old-secret");
+
+      const consumed = await repo.getVerificationToken(await hashVerificationToken(token));
+      expect(consumed!.consumedAt).not.toBeNull();
+
+      const active = await repo.getActiveVerificationToken("usr_pwd_1", PASSWORD_RESET_PURPOSE);
+      expect(active).toBeNull();
+
+      expect(await repo.getSession("sess_pwd_1")).toBeNull();
+    });
+
+    it("rejects a token for the wrong purpose", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+
+      const error = await completePasswordReset(
+        context,
+        { token: "not-a-real-token", newPassword },
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(400);
+      expect((error as ApiError).code).toBe("bad_request");
+    });
+
+    it("rejects an expired token", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+
+      const afterExpiry = new Date(FIXED_NOW.getTime() + policy.tokenLifetimeMs + 1);
+      const error = await completePasswordReset(context, { token, newPassword }, afterExpiry).catch(
+        (e: unknown) => e,
+      );
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(400);
+      expect((error as ApiError).code).toBe("bad_request");
+    });
+
+    it("rejects a replayed (already consumed) token with 409", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+
+      const first = await completePasswordReset(context, { token, newPassword }, FIXED_NOW);
+      expect(first.success).toBe(true);
+
+      const replay = await completePasswordReset(
+        context,
+        { token, newPassword },
+        new Date(FIXED_NOW.getTime() + 1),
+      ).catch((e: unknown) => e);
+
+      expect(replay).toBeInstanceOf(ApiError);
+      expect((replay as ApiError).status).toBe(409);
+      expect((replay as ApiError).code).toBe("conflict");
+    });
+
+    it("rejects a superseded token with 409", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+      await issuePasswordResetToken(
+        context,
+        "usr_pwd_1",
+        policy,
+        new Date(FIXED_NOW.getTime() + policy.resendCooldownMs + 1),
+      );
+
+      const error = await completePasswordReset(context, { token, newPassword }, FIXED_NOW).catch(
+        (e: unknown) => e,
+      );
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(409);
+      expect((error as ApiError).code).toBe("conflict");
+    });
+
+    it("locks the token after the maximum number of failed attempts", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+      const afterExpiry = new Date(FIXED_NOW.getTime() + policy.tokenLifetimeMs + 1);
+
+      for (let attempt = 0; attempt < policy.maxAttempts; attempt += 1) {
+        const error = await completePasswordReset(
+          context,
+          { token, newPassword },
+          afterExpiry,
+        ).catch((e: unknown) => e);
+        expect((error as ApiError).status).toBe(400);
+      }
+
+      const blocked = await completePasswordReset(
+        context,
+        { token, newPassword },
+        afterExpiry,
+      ).catch((e: unknown) => e);
+
+      expect(blocked).toBeInstanceOf(ApiError);
+      expect((blocked as ApiError).status).toBe(429);
+      expect((blocked as ApiError).code).toBe("too_many_requests");
+    });
+
+    it("rejects a token presented with a different email", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+
+      const error = await completePasswordReset(
+        context,
+        { token, newPassword, email: "mallory@stealth.mail" },
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(400);
+      expect((error as ApiError).code).toBe("bad_request");
+    });
+
+    it.each([
+      ["too short", "Short1A"],
+      ["no lowercase", "UPPERCASE123456"],
+      ["no uppercase", "lowercase123456"],
+      ["no digit", "LowerUpperOnly"],
+      ["too long", "A".repeat(260) + "a1"],
+    ])("rejects a password that %s with 422", async (_label, password) => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+
+      const error = await completePasswordReset(
+        context,
+        { token, newPassword: password },
+        FIXED_NOW,
+      ).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(422);
+      expect((error as ApiError).code).toBe("validation_error");
+    });
+
+    it("exactly one of two racing completions succeeds", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const token = await issueResetToken("usr_pwd_1");
+
+      const outcomes = await Promise.all(
+        [FIXED_NOW, new Date(FIXED_NOW.getTime() + 1)].map((now) =>
+          completePasswordReset(context, { token, newPassword }, now)
+            .then(() => "success" as const)
+            .catch((e: unknown) => (e as ApiError).status),
+        ),
+      );
+
+      expect(outcomes).toContain("success");
+      expect(outcomes).toContain(409);
+
+      const consumed = await repo.getVerificationToken(await hashVerificationToken(token));
+      expect(consumed!.consumedAt).not.toBeNull();
+
+      const storedCredential = await repo.getCredential("usr_pwd_1");
+      expect(storedCredential!.secretHash).not.toBe("old-secret");
+    });
+
+    it("completing a reset invalidates every other outstanding reset token for the account", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const firstToken = await issueResetToken("usr_pwd_1");
+
+      const secondNow = new Date(FIXED_NOW.getTime() + policy.resendCooldownMs + 1);
+      const second = await issuePasswordResetToken(context, "usr_pwd_1", policy, secondNow);
+      expect(second.replaced).toBe(true);
+
+      const outcome = await completePasswordReset(
+        context,
+        { token: second.plaintextToken, newPassword },
+        new Date(secondNow.getTime() + 1),
+      );
+      expect(outcome.success).toBe(true);
+
+      const active = await repo.getActiveVerificationToken("usr_pwd_1", PASSWORD_RESET_PURPOSE);
+      expect(active).toBeNull();
+
+      const superseded = await completePasswordReset(
+        context,
+        { token: firstToken, newPassword },
+        new Date(secondNow.getTime() + 2),
+      ).catch((e: unknown) => e);
+      expect(superseded).toBeInstanceOf(ApiError);
+      expect((superseded as ApiError).status).toBe(409);
+      expect((superseded as ApiError).code).toBe("conflict");
+    });
+
+    it("revokes every prior session on reset: the old session no longer authenticates and the old password stops working", async () => {
+      const oldCredential = await hashPassword("SecureOldPass!2026");
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", `${oldCredential.hash}:${oldCredential.salt}`),
+      );
+
+      const authenticated = await authenticateWithPassword(
+        context,
+        { identifier: "alice@stealth.mail", password: "SecureOldPass!2026" },
+        { now: () => FIXED_NOW },
+      );
+      const oldSessionId = authenticated.session.sessionId;
+      expect(await repo.getSession(oldSessionId)).not.toBeNull();
+
+      const token = await issueResetToken("usr_pwd_1");
+      const outcome = await completePasswordReset(
+        context,
+        { token, newPassword, host: "stealth.mail" },
+        FIXED_NOW,
+      );
+      expect(outcome.success).toBe(true);
+
+      expect(await repo.getSession(oldSessionId)).toBeNull();
+      expect(await validateSession(context, oldSessionId, { now: () => FIXED_NOW })).toBeNull();
+
+      const oldPasswordAttempt = await authenticateWithPassword(
+        context,
+        { identifier: "alice@stealth.mail", password: "SecureOldPass!2026" },
+        { now: () => FIXED_NOW },
+      ).catch((e: unknown) => e);
+      expect(oldPasswordAttempt).toBeInstanceOf(ApiError);
+      expect((oldPasswordAttempt as ApiError).status).toBe(401);
+
+      const newSession = await authenticateWithPassword(
+        context,
+        { identifier: "alice@stealth.mail", password: newPassword },
+        { now: () => FIXED_NOW },
+      );
+      expect(newSession.session.sessionId).not.toBe(oldSessionId);
+    });
+
+    it("uses the default policy when none is supplied", async () => {
+      expect(DEFAULT_PASSWORD_RESET_POLICY.tokenLifetimeMs).toBe(60 * 60 * 1000);
+      expect(DEFAULT_PASSWORD_RESET_POLICY.maxRequestsPerIp).toBe(10);
+      expect(DEFAULT_PASSWORD_RESET_POLICY.maxAttempts).toBe(5);
+    });
+  });
+
+  describe("purpose isolation", () => {
+    it("keeps password reset tokens isolated from email verification tokens", async () => {
+      await repo.createUser(
+        activeUser("usr_pwd_1", "alice@stealth.mail"),
+        credential("usr_pwd_1", "old-secret"),
+      );
+      const issued = await issuePasswordResetToken(context, "usr_pwd_1", policy, FIXED_NOW);
+
+      const stored = await repo.getVerificationToken(issued.tokenHash);
+      expect(stored!.purpose).toBe("password_reset" satisfies VerificationPurpose);
+      expect(stored!.purpose).not.toBe("email_verification");
+    });
+  });
+});

--- a/tests/unit/api/password-reset-coordinator.test.ts
+++ b/tests/unit/api/password-reset-coordinator.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => {
+  return {
+    DurableObject: class DurableObject {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+    },
+  };
+});
+
+import type { VerificationToken } from "../../../src/server/api/domain";
+import { StealthCoordinator } from "../../../src/server/api/stealth-coordinator";
+import { hashVerificationToken } from "../../../src/server/api/verification-service";
+
+class MockDurableObjectState {
+  public id = { toString: () => "mock-do-id" };
+  public storage = {
+    store: new Map<string, any>(),
+    async get(key: string) {
+      return this.store.get(key);
+    },
+    async put(key: string, value: any) {
+      this.store.set(key, value);
+    },
+    async delete(key: string) {
+      return this.store.delete(key);
+    },
+  };
+}
+
+const FIXED_NOW = new Date("2026-02-01T00:00:00.000Z");
+const PURPOSE = "password_reset";
+const USER_ID = "usr_pwd_coord_1";
+const TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+
+function token(plaintext: string): VerificationToken {
+  return {
+    tokenHash: plaintext, // hashes are opaque identifiers at the KV boundary
+    userId: USER_ID,
+    purpose: PURPOSE,
+    createdAt: FIXED_NOW.toISOString(),
+    expiresAt: new Date(FIXED_NOW.getTime() + TOKEN_LIFETIME_MS).toISOString(),
+    consumedAt: null,
+    replacedAt: null,
+    replacedByTokenHash: null,
+    attemptCount: 0,
+    maxAttempts: 5,
+  };
+}
+
+describe("BETA-009: password reset token lifecycle across the KV persistence boundary (StealthCoordinator)", () => {
+  let state: MockDurableObjectState;
+  let coordinator: StealthCoordinator;
+
+  beforeEach(() => {
+    state = new MockDurableObjectState();
+    coordinator = new StealthCoordinator(state as any, {});
+  });
+
+  it("issues a token bound to exactly one account and purpose", async () => {
+    const candidate = token("a".repeat(64));
+
+    const result = await coordinator.issueVerificationToken(candidate, FIXED_NOW);
+
+    expect(result.outcome).toBe("issued");
+    const issued = result as Extract<typeof result, { outcome: "issued" }>;
+    expect(issued.replacedToken).toBeNull();
+    expect(await coordinator.getVerificationToken(candidate.tokenHash)).toEqual(candidate);
+    expect(await coordinator.getActiveVerificationToken(USER_ID, PURPOSE)).toEqual(candidate);
+  });
+
+  it("replaces the previous outstanding token on re-issue (single redeemable token per account)", async () => {
+    const first = token("b".repeat(64));
+    await coordinator.issueVerificationToken(first, FIXED_NOW);
+
+    const second = token("c".repeat(64));
+    const replaced = await coordinator.issueVerificationToken(
+      second,
+      new Date(FIXED_NOW.getTime() + 60_000),
+    );
+
+    expect(replaced.outcome).toBe("issued");
+    const issued = replaced as Extract<typeof replaced, { outcome: "issued" }>;
+    expect(issued.replacedToken).not.toBeNull();
+    expect(issued.replacedToken!.tokenHash).toBe(first.tokenHash);
+    expect(issued.replacedToken!.replacedAt).not.toBeNull();
+    expect(await coordinator.getActiveVerificationToken(USER_ID, PURPOSE)).toEqual(second);
+  });
+
+  it("consumes a valid token exactly once and rejects replays at the data layer", async () => {
+    const issued = token("d".repeat(64));
+    await coordinator.issueVerificationToken(issued, FIXED_NOW);
+
+    const first = await coordinator.consumeVerificationToken(issued.tokenHash, FIXED_NOW);
+    expect(first.outcome).toBe("consumed");
+
+    const replay = await coordinator.consumeVerificationToken(
+      issued.tokenHash,
+      new Date(FIXED_NOW.getTime() + 1),
+    );
+    expect(replay.outcome).toBe("already-consumed");
+  });
+
+  it("rejects an expired token", async () => {
+    const issued = token("e".repeat(64));
+    await coordinator.issueVerificationToken(issued, FIXED_NOW);
+
+    const afterExpiry = new Date(FIXED_NOW.getTime() + TOKEN_LIFETIME_MS + 1);
+    const result = await coordinator.consumeVerificationToken(issued.tokenHash, afterExpiry);
+    expect(result.outcome).toBe("expired");
+  });
+
+  it("marks any other outstanding token consumed-invalid after invalidation", async () => {
+    const first = token("f".repeat(64));
+    await coordinator.issueVerificationToken(first, FIXED_NOW);
+    const second = token("g".repeat(64));
+    await coordinator.issueVerificationToken(second, new Date(FIXED_NOW.getTime() + 60_000));
+
+    await coordinator.invalidateActiveVerificationToken(
+      USER_ID,
+      PURPOSE,
+      new Date(FIXED_NOW.getTime() + 120_000),
+    );
+
+    expect(await coordinator.getActiveVerificationToken(USER_ID, PURPOSE)).toBeNull();
+    const remaining = await coordinator.consumeVerificationToken(
+      first.tokenHash,
+      new Date(FIXED_NOW.getTime() + 121_000),
+    );
+    expect(remaining.outcome).toBe("replaced");
+  });
+
+  it("locks the token once the brute-force attempt cap is reached", async () => {
+    const issued = token("h".repeat(64));
+    await coordinator.issueVerificationToken(issued, FIXED_NOW);
+
+    const afterExpiry = new Date(FIXED_NOW.getTime() + TOKEN_LIFETIME_MS + 1);
+    for (let i = 0; i < issued.maxAttempts; i += 1) {
+      const result = await coordinator.consumeVerificationToken(issued.tokenHash, afterExpiry);
+      expect(result.outcome).toBe("expired");
+      await coordinator.recordVerificationAttempt(issued.tokenHash, afterExpiry);
+    }
+
+    const blocked = await coordinator.consumeVerificationToken(issued.tokenHash, afterExpiry);
+    expect(blocked.outcome).toBe("brute-force-blocked");
+  });
+
+  it("only ever persists the token hash, never the plaintext token", async () => {
+    const plaintext = "plaintext-token-value";
+    const issued: VerificationToken = {
+      ...token("i".repeat(64)),
+      tokenHash: await hashVerificationToken(plaintext),
+    };
+    await coordinator.issueVerificationToken(issued, FIXED_NOW);
+
+    const persisted = [...state.storage.store.values()].map((v) =>
+      typeof v === "string" ? v : JSON.stringify(v),
+    );
+    expect(persisted.join("|")).not.toContain(plaintext);
+  });
+});

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -336,6 +336,14 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("recordVerificationAttempt");
     return this.inner.recordVerificationAttempt(tokenHash, now);
   }
+  async invalidateActiveVerificationToken(
+    userId: string,
+    purpose: import("../../../src/server/api/domain").VerificationPurpose,
+    now: Date,
+  ) {
+    this.maybeFail("invalidateActiveVerificationToken");
+    return this.inner.invalidateActiveVerificationToken(userId, purpose, now);
+  }
   async getExternalWallets(owner: string) {
     this.maybeFail("getExternalWallets");
     return this.inner.getExternalWallets(owner);


### PR DESCRIPTION
Closes: #1916 — BETA-009: password-reset request and one-time completion flow

## Summary

Full vertical slice for credential recovery on standard (email+password) accounts: an enumeration-resistant request endpoint that issues a hashed, short-lived, single-use reset token delivered through the BETA-005 delivery adapter, and a single-use completion endpoint that enforces password policy, sets the new password, invalidates all other outstanding reset tokens for the account, and revokes every existing session (no old session survives a reset).

**Dependency status:** Both required dependencies are landed on `main` — BETA-005 (`ca8c3c7a`, verification-token lifecycle + pluggable delivery adapter) and BETA-006 (`a3bcbe9e`, password login + server-side sessions). No isolated implementation was needed; this PR composes directly with the existing `issueVerificationToken`/`consumeVerificationToken` CAS primitives, `revokeAllSessions`/`deleteUserSessions`, the `VerificationEmailMessage` adapter contract, and the standard `ApiError` registry (no new error codes, no new enum values).

## Changed files

- `src/routes/api/v1/auth/password-reset/request.ts` — new: `POST /api/v1/auth/password-reset/request`
- `src/routes/api/v1/auth/password-reset/complete.ts` — new: `POST /api/v1/auth/password-reset/complete`
- `src/server/api/auth/password-reset-service.ts` — new: request + completion service (policy, cooldown, enumeration-resistant flow, audit, session revocation)
- `src/server/api/auth/index.ts` — export the new service
- `src/server/api/domain.ts` — `passwordPolicySchema` (12+ chars, upper, lower, digit, max 256); extend `verificationPurposeSchema` with `password_reset`
- `src/server/api/repository.ts` — `invalidateActiveVerificationToken` on the repository contract, `ValidatedApiRepository`, `RetryableApiRepository` (+ registered in `RETRY_SAFE_OPERATIONS`)
- `src/server/api/memory-repository.ts` — atomic invalidation of the active (user, purpose) token under the verification lock
- `src/server/api/kv-repository.ts` — delegating `HybridApiRepository` stub
- `src/server/api/stealth-coordinator.ts` — KV-backed atomic invalidation under `runExclusive`
- `src/services/notifications/adapter.ts` — widen `VerificationEmailMessage.purpose` to include `password_reset`
- `src/services/notifications/smtp.ts` — purpose-aware subject/body ("Reset your Stealth Mail password")
- `src/server/api/openapi.ts` + `openapi.json` — new operations `requestPasswordReset` / `completePasswordReset` (additive; `success/envelope` responses, `security: []`, `x-stability: beta`). `openapi.json` regenerated from source.
- `src/routeTree.gen.ts` — regenerated (new routes registered; no drift vs generator output)
- `tests/unit/api/auth/password-reset-service.test.ts` — new (service domain rules)
- `tests/unit/api/auth/password-reset-routes.test.ts` — new (route-level contract)
- `tests/unit/api/password-reset-coordinator.test.ts` — new (KV/persistence boundary)
- `tests/unit/api/retryable-repository.test.ts` — implement `invalidateActiveVerificationToken` on the failing fake so it satisfies `ApiRepository`

## Required behavior → proof matrix

| Issue requirement | Where proven (test) |
| --- | --- |
| Token expiry rejected | `password-reset-service.test.ts` "rejects an expired token"; `password-reset-coordinator.test.ts` "rejects an expired token" |
| Token replay rejected (single-use) | service "rejects a replayed (already consumed) token with 409"; routes "rejects a replayed token with 409"; coordinator "consumes a valid token exactly once and rejects replays at the data layer" |
| Completion invalidates other outstanding tokens | service "completing a reset invalidates every other outstanding reset token"; coordinator "marks any other outstanding token consumed-invalid after invalidation" (KV layer) |
| Throttling/cooldown, identical shape for existing vs non-existing | service "enforces the resend cooldown…" + "applies the cooldown identically to unknown accounts (enumeration-resistant)"; routes "throttles repeated requests to unknown emails identically to registered accounts" (response body code equality asserted) + "returns 429 during the resend cooldown…"; service "rejects requests beyond the per-IP budget" |
| Concurrent completion: exactly one winner, clean 409 | service "exactly one of two racing completions succeeds"; routes "allows exactly one winner when two completions race on the same token" |
| Old sessions actually invalid after reset | service "revokes every prior session on reset: the old session no longer authenticates and the old password stops working" — proves old session invalid via `validateSession`, old password → 401, new password → new session; routes "revokes existing sessions and clears session cookies" |
| Single-use enforced at data layer (not just app logic) | coordinator tests exercise `StealthCoordinator.consumeVerificationToken`/`invalidateActiveVerificationToken` directly against storage |
| Breach-safe logging (no raw token/password/seed) | service logs only token *hashes* and hashed identifiers; coordinator "only ever persists the token hash, never the plaintext token"; audit events never carry the plaintext |

Edge cases also covered: superseded token (409), brute-force attempt cap → locked (429), wrong-purpose/wrong-email token (400), password policy violations (422), delivery failure (503), missing/invalid fields (422), unknown email → identical 200 with no delivery.

## Commands run (real output)

### prettier --check .
```
$ npx prettier --check .
Checking formatting...
All matched files use Prettier code style!
```

### eslint .
```
$ npx eslint .
C:\Users\afeez\stealth\scripts\stellar\smoke\integration-gate.ts
  18:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
✖ 1 problem (0 errors, 1 warning)
```
(0 errors; the single warning is pre-existing in an unrelated file.)

### tsc --noEmit
```
$ npx tsc --noEmit
tsc: 0
```

### Full unit suite (npm test equivalent)
```
$ npx vitest run tests/unit
 Test Files  221 passed (221)
      Tests  2486 passed | 3 expected fail (2489)
```

### npm run build (client + SSR worker)
```
✓ built in 13.08s
```
(dist/client + dist/server emitted; routeTree.gen.ts regenerated by the TanStack plugin during build and committed — no drift.)

### openapi.json regeneration and additive-only check
```
$ npx tsx scripts/generate-openapi.ts
openapi.json generated successfully.
$ git diff origin/main --stat -- openapi.json
 openapi.json | 1397 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 1396 insertions(+), 1 deletion(-)
```
Additive-only: 1396 additions are the two new operations. The single removed line (`invalid_quote` description) is pre-existing drift on `main` — the committed `openapi.json` on main is stale relative to `src/server/api/errors.ts` (verified: `git show origin/main:src/server/api/errors.ts` contains the full description that CI's `generate:openapi` step produces; the regenerated file matches what CI regenerates). Optic CI runs against the regenerated file, so this commit keeps the checked file consistent.

### routeTree.gen.ts drift check
Regenerated via `vite build`; diff contains only the two new route registrations plus generator sort-order normalization of two pre-existing route imports (wallet/status, accounts/$userId/wallet/provision) that matches current generator output.

Note: `optic diff` is run in CI (installed in a dedicated `/tmp/optic-env` with AJV overrides per `ci.yml`), not locally, so its output is reported via `gh pr checks` below.