### PR TITLE
feat(auth): add authenticated route guards and remove demo-as-default (BETA-012)

### DIFF
--- a/src/features/identity/BootstrapStateView.tsx
+++ b/src/features/identity/BootstrapStateView.tsx
@@ -1,14 +1,4 @@
-import { Link } from "@tanstack/react-router";
-import {
-  AlertTriangle,
-  ArrowRight,
-  CheckCircle2,
-  LoaderCircle,
-  Lock,
-  RefreshCw,
-  ShieldAlert,
-  WifiOff,
-} from "lucide-react";
+import { AlertTriangle, LoaderCircle, RefreshCw, ShieldAlert, WifiOff } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -53,77 +43,6 @@ export function BootstrapStateView() {
 
   if (branch === "loading") {
     return <BootstrapLoadingSkeleton />;
-  }
-
-  if (branch === "unauthorized") {
-    return (
-      <main className="ambient-bg flex min-h-screen items-center justify-center p-4 sm:p-6">
-        <Card className="w-full max-w-md border-border/80 bg-card/95 shadow-xl backdrop-blur">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-              <Lock className="size-6" />
-            </div>
-            <CardTitle tabIndex={-1} ref={headingRef} className="outline-none">
-              Sign in to continue
-            </CardTitle>
-            <CardDescription>
-              {error?.message ??
-                "Your session has expired. Please sign in to access your private mailbox."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Button className="w-full" asChild size="lg">
-              <Link to="/auth/sign-in">
-                Sign in <ArrowRight className="ml-2 size-4" />
-              </Link>
-            </Button>
-            <p className="text-center text-xs text-muted-foreground">
-              New user?{" "}
-              <Link to="/auth/sign-up" className="text-primary underline-offset-4 hover:underline">
-                Create an account
-              </Link>
-            </p>
-          </CardContent>
-        </Card>
-      </main>
-    );
-  }
-
-  if (branch === "onboarding") {
-    return (
-      <main className="ambient-bg flex min-h-screen items-center justify-center p-4 sm:p-6">
-        <Card className="w-full max-w-md border-border/80 bg-card/95 shadow-xl backdrop-blur">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-amber-500/10 text-amber-500">
-              <CheckCircle2 className="size-6" />
-            </div>
-            <CardTitle tabIndex={-1} ref={headingRef} className="outline-none">
-              Email verification required
-            </CardTitle>
-            <CardDescription>
-              We sent a verification link to {data?.user.email ?? "your email"}. Please check your
-              inbox to finish activating your mailbox.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Button variant="outline" className="w-full" asChild>
-              <Link to="/auth/verify" search={{ email: data?.user.email }}>
-                View verification status
-              </Link>
-            </Button>
-            <Button
-              variant="ghost"
-              className="w-full"
-              onClick={() => void retry()}
-              disabled={isRetrying}
-            >
-              {isRetrying && <RefreshCw className="mr-2 size-4 animate-spin" />}
-              Check again
-            </Button>
-          </CardContent>
-        </Card>
-      </main>
-    );
   }
 
   if (branch === "suspended") {

--- a/src/features/identity/RouteGate.tsx
+++ b/src/features/identity/RouteGate.tsx
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// BETA-012 — authenticated route guard component.
+//
+// Mounted in the root route shell, this component resolves the server-backed
+// bootstrap state into a definite guard decision before rendering the app
+// outlet. Redirects use `replace` so repeated guard evaluations can never
+// accumulate history entries (double-redirect / back-button thrash safety).
+// ---------------------------------------------------------------------------
+
+import { Navigate, useLocation } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+import { BootstrapStateView } from "./BootstrapStateView";
+import { deriveGateState, resolveRouteGuard } from "./route-guard";
+import { useBootstrap } from "./useBootstrap";
+
+export function RouteGate({ children }: { children: ReactNode }) {
+  const { branch, data } = useBootstrap();
+  const location = useLocation();
+
+  const decision = resolveRouteGuard({
+    state: deriveGateState(branch, data),
+    pathname: location.pathname,
+    search: location.searchStr.includes("?") ? location.searchStr.slice(1) : location.searchStr,
+    isDev: import.meta.env.DEV,
+    demoFlag:
+      typeof window !== "undefined"
+        ? window.localStorage?.getItem("STEALTH_DEMO_BYPASS_FETCH") === "true"
+        : false,
+  });
+
+  switch (decision.kind) {
+    case "render":
+      return children;
+    case "loading-view":
+    case "state-view":
+      return <BootstrapStateView />;
+    case "redirect":
+      return <Navigate to={decision.to} search={decision.search} replace />;
+  }
+}

--- a/src/features/identity/auth-pages.tsx
+++ b/src/features/identity/auth-pages.tsx
@@ -7,10 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 
 import { sharedTypedApi as api, errorLabel, ApiClientError } from "@/lib/api";
-
-function safeDestination(destination?: string) {
-  return destination?.startsWith("/") && !destination.startsWith("//") ? destination : "/";
-}
+import { safeReturnTo } from "./returnTo";
 
 function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -60,7 +57,7 @@ export function SignUpPage({ destination }: { destination?: string }) {
         to: "/auth/verify",
         search: {
           email: registration.maskedEmail ?? "your email",
-          next: safeDestination(destination),
+          next: safeReturnTo(destination),
         },
       });
     } catch (cause) {
@@ -129,7 +126,7 @@ export function SignUpPage({ destination }: { destination?: string }) {
           <Link
             className="text-primary underline-offset-4 hover:underline"
             to="/auth/sign-in"
-            search={{ next: safeDestination(destination) }}
+            search={{ next: safeReturnTo(destination) }}
           >
             Sign in
           </Link>
@@ -152,7 +149,7 @@ export function SignInPage({ destination }: { destination?: string }) {
         identifier: String(form.get("identifier") ?? ""),
         password: String(form.get("password") ?? ""),
       });
-      window.location.assign(safeDestination(destination));
+      window.location.assign(safeReturnTo(destination));
     } catch (cause) {
       setError(
         cause instanceof ApiClientError
@@ -197,7 +194,7 @@ export function SignInPage({ destination }: { destination?: string }) {
           <Link
             className="text-primary underline-offset-4 hover:underline"
             to="/auth/sign-up"
-            search={{ next: safeDestination(destination) }}
+            search={{ next: safeReturnTo(destination) }}
           >
             Create an account
           </Link>

--- a/src/features/identity/bootstrap.ts
+++ b/src/features/identity/bootstrap.ts
@@ -297,11 +297,6 @@ export async function fetchBootstrap(options?: {
       return successState;
     } catch (cause) {
       clearTimeout(timer);
-      if (!import.meta.env.PROD) {
-        const demo = getDemoState();
-        cachedState = demo;
-        return demo;
-      }
       const isAbort = cause instanceof Error && cause.name === "AbortError";
       const errorState: BootstrapState = {
         data: null,

--- a/src/features/identity/index.ts
+++ b/src/features/identity/index.ts
@@ -2,6 +2,16 @@ export * from "./types";
 export * from "./useBootstrap";
 export * from "./BootstrapStateView";
 export * from "./auth-pages";
+export * from "./RouteGate";
+export { validateReturnTo, safeReturnTo } from "./returnTo";
+export {
+  deriveGateState,
+  isPublicAuthPath,
+  resolveRouteGuard,
+  SIGN_IN_ROUTE,
+  ONBOARDING_ROUTE,
+  DEMO_ROUTE,
+} from "./route-guard";
 export {
   isKeyValidAtTimestamp,
   publishedKeySchema,

--- a/src/features/identity/returnTo.ts
+++ b/src/features/identity/returnTo.ts
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// BETA-012 — return-to (post-login redirect) validation.
+//
+// The `next` search parameter carried through the sign-in flow is attacker
+// controllable. Only same-origin relative paths may be honored: absolute
+// URLs, protocol-relative URLs, backslash-aliased authorities and control
+// characters are rejected so a crafted value can never bounce the browser
+// off this origin.
+// ---------------------------------------------------------------------------
+
+/** C0 control characters (including CR/LF/TAB) can smuggle headers or URLs. */
+function hasControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Bytes that alias a protocol-relative or authority-prefixed URL. */
+const FORBIDDEN_PREFIX = /^(\/\/|\/\\)/;
+
+/** Any backslash anywhere is rejected: browsers may alias it to a separator. */
+const FORBIDDEN_BACKSLASH = /\\/;
+
+/**
+ * Validates an untrusted return-to value.
+ *
+ * Returns the sanitized same-origin relative path (with a leading `/`),
+ * or `null` when the value is missing or unsafe.
+ */
+export function validateReturnTo(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (!trimmed.startsWith("/")) return null;
+  if (FORBIDDEN_PREFIX.test(trimmed)) return null;
+  if (FORBIDDEN_BACKSLASH.test(trimmed)) return null;
+  if (hasControlChars(trimmed)) return null;
+  try {
+    if (decodeURIComponent(trimmed).startsWith("//")) return null;
+  } catch {
+    return null;
+  }
+  return trimmed;
+}
+
+/**
+ * Convenience wrapper: unsafe or missing values fall back to the home path.
+ * Intended for call sites that must always produce a destination.
+ */
+export function safeReturnTo(value: unknown): string {
+  return validateReturnTo(value) ?? "/";
+}

--- a/src/features/identity/route-guard.ts
+++ b/src/features/identity/route-guard.ts
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------------
+// BETA-012 — authenticated route guards.
+//
+// The server bootstrap endpoint resolves a definite per-visitor state; this
+// module turns that state into a guard decision for the protected app shell.
+// The decision function is pure so every state transition is unit testable
+// and repeat calls are idempotent (no double redirects / session thrashing).
+// ---------------------------------------------------------------------------
+
+import type { BootstrapBranch, BootstrapData } from "./bootstrap";
+import { validateReturnTo } from "./returnTo";
+
+/**
+ * Normalized authentication gates. `verified` covers an account whose email
+ * is verified but whose account provisioning is not yet complete; it is the
+ * "verified-but-incomplete-onboarding" state.
+ */
+export type GateState =
+  | "loading"
+  | "anonymous"
+  | "onboarding"
+  | "verified"
+  | "suspended"
+  | "outage"
+  | "active";
+
+export const SIGN_IN_ROUTE = "/auth/sign-in";
+export const ONBOARDING_ROUTE = "/onboarding";
+export const DEMO_ROUTE = "/demo";
+export const HOME_ROUTE = "/";
+
+const AUTH_PUBLIC_PREFIX = "/auth/";
+
+export function isPublicAuthPath(pathname: string): boolean {
+  return pathname === "/auth" || pathname.startsWith(AUTH_PUBLIC_PREFIX);
+}
+
+/** Maps the server-resolved bootstrap state to a definite gate state. */
+export function deriveGateState(branch: BootstrapBranch, data: BootstrapData | null): GateState {
+  switch (branch) {
+    case "loading":
+      return "loading";
+    case "unauthorized":
+      return "anonymous";
+    case "suspended":
+      return "suspended";
+    case "outage":
+    case "maintenance":
+      return "outage";
+    case "onboarding":
+      return "onboarding";
+    case "active": {
+      const provisioning = data?.provisioning;
+      if (provisioning && provisioning.status !== "active") return "verified";
+      return "active";
+    }
+  }
+}
+
+export type GuardDecision =
+  | { kind: "render" }
+  | { kind: "loading-view" }
+  | { kind: "state-view"; view: "suspended" | "outage" }
+  | { kind: "redirect"; to: "/auth/sign-in"; search?: { next: string } }
+  | { kind: "redirect"; to: "/onboarding" | "/"; search?: { next: string } };
+
+export interface RouteGuardInput {
+  state: GateState;
+  pathname: string;
+  /** Raw query string (without `?`) carried on the current location. */
+  search?: string;
+  /** Statically false in production builds; explicit demo gate. */
+  isDev?: boolean;
+  /** Explicit development-only demo flag (`STEALTH_DEMO_BYPASS_FETCH`). */
+  demoFlag?: boolean;
+}
+
+/**
+ * Pure guard decision for a single navigation. The same input always
+ * produces the same decision; destinations are chosen so that re-running the
+ * guard on the target never produces a redirect back to the source.
+ */
+export function resolveRouteGuard(input: RouteGuardInput): GuardDecision {
+  const { state, pathname } = input;
+  const search = input.search ?? "";
+  const isDev = input.isDev ?? false;
+  const demoFlag = input.demoFlag ?? false;
+
+  switch (state) {
+    case "loading":
+      return { kind: "loading-view" };
+
+    case "anonymous": {
+      if (isPublicAuthPath(pathname)) return { kind: "render" };
+      // Demo mode is reachable only on its isolated route, only in dev,
+      // only when the explicit demo flag is present.
+      if (isDev && demoFlag && pathname === DEMO_ROUTE) return { kind: "render" };
+      const next = validateReturnTo(pathname + (search.length ? `?${search}` : ""));
+      return next
+        ? { kind: "redirect", to: SIGN_IN_ROUTE, search: { next } }
+        : { kind: "redirect", to: SIGN_IN_ROUTE };
+    }
+
+    case "onboarding":
+    case "verified": {
+      if (pathname === ONBOARDING_ROUTE || pathname === "/auth/verify") {
+        return { kind: "render" };
+      }
+      return { kind: "redirect", to: ONBOARDING_ROUTE };
+    }
+
+    case "suspended":
+      return { kind: "state-view", view: "suspended" };
+
+    case "outage":
+      return { kind: "state-view", view: "outage" };
+
+    case "active": {
+      if (isPublicAuthPath(pathname) || pathname === ONBOARDING_ROUTE) {
+        return { kind: "redirect", to: HOME_ROUTE };
+      }
+      return { kind: "render" };
+    }
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as MotionGalleryRouteImport } from './routes/motion-gallery'
+import { Route as DemoRouteImport } from './routes/demo'
 import { Route as PolicyEditorRouteRouteImport } from './routes/policy-editor/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
@@ -80,9 +82,19 @@ import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/
 import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
 import { Route as ApiV1AccountsUserIdWalletProvisionRouteImport } from './routes/api/v1/accounts/$userId/wallet/provision'
 
+const OnboardingRoute = OnboardingRouteImport.update({
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MotionGalleryRoute = MotionGalleryRouteImport.update({
   id: '/motion-gallery',
   path: '/motion-gallery',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DemoRoute = DemoRouteImport.update({
+  id: '/demo',
+  path: '/demo',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PolicyEditorRouteRoute = PolicyEditorRouteRouteImport.update({
@@ -450,7 +462,9 @@ const ApiV1AccountsUserIdWalletProvisionRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
+  '/demo': typeof DemoRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/onboarding': typeof OnboardingRoute
   '/auth/sign-in': typeof AuthSignInRoute
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify': typeof AuthVerifyRoute
@@ -522,7 +536,9 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
+  '/demo': typeof DemoRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/onboarding': typeof OnboardingRoute
   '/auth/sign-in': typeof AuthSignInRoute
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify': typeof AuthVerifyRoute
@@ -595,7 +611,9 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/policy-editor': typeof PolicyEditorRouteRoute
+  '/demo': typeof DemoRoute
   '/motion-gallery': typeof MotionGalleryRoute
+  '/onboarding': typeof OnboardingRoute
   '/auth/sign-in': typeof AuthSignInRoute
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify': typeof AuthVerifyRoute
@@ -669,7 +687,9 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/policy-editor'
+    | '/demo'
     | '/motion-gallery'
+    | '/onboarding'
     | '/auth/sign-in'
     | '/auth/sign-up'
     | '/auth/verify'
@@ -741,7 +761,9 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/policy-editor'
+    | '/demo'
     | '/motion-gallery'
+    | '/onboarding'
     | '/auth/sign-in'
     | '/auth/sign-up'
     | '/auth/verify'
@@ -813,7 +835,9 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/policy-editor'
+    | '/demo'
     | '/motion-gallery'
+    | '/onboarding'
     | '/auth/sign-in'
     | '/auth/sign-up'
     | '/auth/verify'
@@ -886,7 +910,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   PolicyEditorRouteRoute: typeof PolicyEditorRouteRoute
+  DemoRoute: typeof DemoRoute
   MotionGalleryRoute: typeof MotionGalleryRoute
+  OnboardingRoute: typeof OnboardingRoute
   AuthSignInRoute: typeof AuthSignInRoute
   AuthSignUpRoute: typeof AuthSignUpRoute
   AuthVerifyRoute: typeof AuthVerifyRoute
@@ -949,11 +975,25 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/onboarding': {
+      id: '/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/motion-gallery': {
       id: '/motion-gallery'
       path: '/motion-gallery'
       fullPath: '/motion-gallery'
       preLoaderRoute: typeof MotionGalleryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/demo': {
+      id: '/demo'
+      path: '/demo'
+      fullPath: '/demo'
+      preLoaderRoute: typeof DemoRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/policy-editor': {
@@ -1517,7 +1557,9 @@ const ApiV1AdminDlqIdRouteWithChildren = ApiV1AdminDlqIdRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   PolicyEditorRouteRoute: PolicyEditorRouteRoute,
+  DemoRoute: DemoRoute,
   MotionGalleryRoute: MotionGalleryRoute,
+  OnboardingRoute: OnboardingRoute,
   AuthSignInRoute: AuthSignInRoute,
   AuthSignUpRoute: AuthSignUpRoute,
   AuthVerifyRoute: AuthVerifyRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,7 +3,7 @@ import { MailQuestion } from "lucide-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ActionButton, EmptyState, Surface } from "@/features/design-system";
-import { BootstrapProvider } from "@/features/identity";
+import { BootstrapProvider, RouteGate } from "@/features/identity";
 import appCss from "../styles.css?url";
 
 function NotFoundComponent() {
@@ -78,7 +78,9 @@ function RootComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <BootstrapProvider>
-        <Outlet />
+        <RouteGate>
+          <Outlet />
+        </RouteGate>
       </BootstrapProvider>
     </QueryClientProvider>
   );

--- a/src/routes/api/v1/bootstrap.ts
+++ b/src/routes/api/v1/bootstrap.ts
@@ -18,57 +18,7 @@ export const Route = createFileRoute("/api/v1/bootstrap")({
           const sessionId = parseSessionCookie(request.headers.get("cookie"));
 
           if (!sessionId) {
-            if (import.meta.env.PROD || process.env.VITEST === "true") {
-              throw new ApiError(401, "unauthorized", "No active session cookie found");
-            }
-
-            return apiSuccess(request, {
-              user: {
-                userId: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                email: "demo@stealth.mail",
-                username: "demo_user",
-                status: "active",
-                accountStatus: "active",
-                displayName: "Demo User",
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-              },
-              session: {
-                sessionId: "sess_demo_default",
-                userId: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                createdAt: new Date().toISOString(),
-                expiresAt: new Date(Date.now() + 86400000).toISOString(),
-              },
-              address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-              provisioning: null,
-              policy: {
-                allowUnknown: true,
-                requireVerified: false,
-                requireReceipt: false,
-                minimumPostage: "0",
-              },
-              wallet: {
-                connected: true,
-                address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                signerType: "managed",
-                capabilities: ["sign", "send", "read"],
-                network: "testnet",
-                balanceXlm: "100.0000000",
-              },
-              health: {
-                ready: true,
-                status: "ok",
-                dependencies: { bindings: "ok", storage: "ok", coordinator: "ok" },
-              },
-              syncCursor: `sync_${Date.now()}`,
-              featureFlags: {
-                betaStateMachines: true,
-                sorobanPostage: true,
-                liveMailboxSync: true,
-              },
-              branch: "active",
-            });
+            throw new ApiError(401, "unauthorized", "No active session cookie found");
           }
 
           const sessionRecord = await apiContext.repository.getSession(sessionId);

--- a/src/routes/demo.tsx
+++ b/src/routes/demo.tsx
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// BETA-012 — isolated demo route.
+//
+// Demo mode is reachable ONLY here: an explicit development-only flag
+// (`STEALTH_DEMO_BYPASS_FETCH`) AND the `/demo` route. In production builds
+// `import.meta.env.DEV` is statically false, so this page can never render
+// the demo mailbox; anonymous visitors are also redirected by RouteGate
+// before this component runs.
+// ---------------------------------------------------------------------------
+
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+
+import { BootstrapLoadingSkeleton } from "@/features/identity";
+import { MailApp } from "./index";
+
+export const Route = createFileRoute("/demo")({
+  component: DemoRoute,
+});
+
+function DemoRoute() {
+  if (typeof window === "undefined") {
+    return <BootstrapLoadingSkeleton />;
+  }
+  const demoEnabled =
+    import.meta.env.DEV && window.localStorage?.getItem("STEALTH_DEMO_BYPASS_FETCH") === "true";
+  if (!demoEnabled) {
+    return <Navigate to="/auth/sign-in" replace />;
+  }
+  return <MailApp isDemoMode />;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -70,7 +70,6 @@ import { RequestsTriageBoard } from "@/features/requests";
 import { ProofInspectorModal } from "@/features/proof-inspector";
 import { SenderJourney } from "@/features/sender-journey";
 import { AuthModal } from "@/components/mail/AuthModal";
-import { BootstrapStateView, useBootstrap } from "@/features/identity";
 
 export const Route = createFileRoute("/")({
   head: () => ({
@@ -91,25 +90,18 @@ export const Route = createFileRoute("/")({
 });
 
 function IndexPage() {
-  const { branch } = useBootstrap();
-
-  if (branch !== "active") {
-    return <BootstrapStateView />;
-  }
-
-  // Demo mode is a development-only escape hatch: `import.meta.env.DEV` is
-  // statically false in production builds, so the demo branch (and its dynamic
-  // import of the mock fixtures) is removed by the bundler. The production app
-  // shell has no route to `initialEmails` or the demo adapter.
-  const isDemo = import.meta.env.DEV;
-  return <MailApp isDemoMode={isDemo} />;
+  // BETA-012: the root route is a protected route. The root route guard
+  // (RouteGate) only ever lets authenticated, active visitors reach this page,
+  // so the app shell never renders in demo mode here. Demo mode lives on the
+  // isolated `/demo` route behind an explicit development-only flag.
+  return <MailApp isDemoMode={false} />;
 }
 
 function delay(ms: number) {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
-function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
+export function MailApp({ isDemoMode = false }: { isDemoMode?: boolean }) {
   const [showSenderJourney, setShowSenderJourney] = useState(false);
   const [folder, setFolder] = useState<MailFolder>("inbox");
   const [emails, setEmails] = useState<Email[]>([]);
@@ -165,7 +157,7 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
   const mailboxHydrated = useRef(false);
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!import.meta.env.DEV || !isDemoMode) return;
     if (mailboxHydrated.current) return;
     let cancelled = false;
     void import("@/features/mail/demo/demo-data").then(({ getDemoEmails }) => {
@@ -178,7 +170,7 @@ function MailApp({ isDemoMode }: { isDemoMode?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isDemoMode]);
 
   useEffect(() => {
     if (isDemoMode) return;

--- a/src/routes/onboarding.tsx
+++ b/src/routes/onboarding.tsx
@@ -1,0 +1,58 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight, CheckCircle2, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useBootstrap } from "@/features/identity/useBootstrap";
+
+export const Route = createFileRoute("/onboarding")({
+  component: OnboardingPage,
+});
+
+function OnboardingPage() {
+  const { data, retry, isRetrying } = useBootstrap();
+
+  const pendingVerification = data?.user.accountStatus === "pending_verification";
+
+  return (
+    <main className="ambient-bg flex min-h-screen items-center justify-center p-4 sm:p-6">
+      <Card className="w-full max-w-md border-border/80 bg-card/95 shadow-xl backdrop-blur">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex size-12 items-center justify-center rounded-full bg-amber-500/10 text-amber-500">
+            <CheckCircle2 className="size-6" />
+          </div>
+          <CardTitle tabIndex={-1} className="outline-none">
+            {pendingVerification ? "Email verification required" : "Finish setting up your account"}
+          </CardTitle>
+          <CardDescription>
+            {pendingVerification
+              ? `We sent a verification link to ${data?.user.email ?? "your email"}. Please check your inbox to finish activating your mailbox.`
+              : "Your mailbox is still being prepared. This usually takes a moment — check again shortly."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button variant="outline" className="w-full" asChild>
+            <Link to="/auth/verify" search={{ email: data?.user.email }}>
+              View verification status
+            </Link>
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => void retry()}
+            disabled={isRetrying}
+          >
+            {isRetrying && <RefreshCw className="mr-2 size-4 animate-spin" />}
+            Check again
+          </Button>
+          <p className="text-center text-xs text-muted-foreground">
+            Already verified?{" "}
+            <Link to="/auth/sign-in" className="text-primary underline-offset-4 hover:underline">
+              Sign in to your account <ArrowRight className="ml-1 inline size-3" />
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/tests/e2e/bootstrap-recovery.spec.ts
+++ b/tests/e2e/bootstrap-recovery.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("App Bootstrap & Failure Recovery Journey", () => {
-  test("renders sign-in prompt when bootstrap returns 401 unauthorized", async ({ page }) => {
+  test("redirects anonymous visitors to sign-in with a validated return-to when bootstrap returns 401", async ({
+    page,
+  }) => {
     await page.route("**/api/v1/bootstrap", async (route) => {
       await route.fulfill({
         status: 401,
@@ -17,11 +19,31 @@ test.describe("App Bootstrap & Failure Recovery Journey", () => {
       });
     });
 
-    await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Sign in to continue" })).toBeVisible({
+    await page.goto("/mail/123?tab=preview");
+    await expect(page).toHaveURL(/\/auth\/sign-in/, { timeout: 60000 });
+    const redirected = new URL(page.url());
+    expect(redirected.searchParams.get("next")).toBe("/mail/123?tab=preview");
+    await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible({
       timeout: 60000,
     });
-    await expect(page.getByRole("link", { name: /Sign in/i })).toBeVisible();
+  });
+
+  test("never lands an anonymous visitor on demo data in production mode", async ({ page }) => {
+    await page.route("**/api/v1/bootstrap", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: { code: "unauthorized", message: "No session." },
+          branch: "unauthorized",
+        }),
+      });
+    });
+
+    await page.goto("/demo");
+    await expect(page).toHaveURL(/\/auth\/sign-in/, { timeout: 60000 });
+    await expect(page.getByText(/Demo Mode/i)).toHaveCount(0);
   });
 
   test("renders service outage branch and recovers via retry button", async ({ page }) => {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -180,7 +180,10 @@ export async function openDemoMailbox(page: Page) {
     },
   );
 
-  await page.goto("/");
+  // Demo mode lives on the isolated `/demo` route behind the explicit
+  // development-only flag set above (BETA-012). The production root never
+  // serves demo or seeded mail data.
+  await page.goto("/demo");
   await expect(page.getByRole("heading", { name: /Inbox/i })).toBeVisible({ timeout: 60000 });
   await page.waitForFunction(() => Boolean(document.documentElement.dataset.theme));
 }

--- a/tests/unit/identity/return-to.test.ts
+++ b/tests/unit/identity/return-to.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { safeReturnTo, validateReturnTo } from "@/features/identity/returnTo";
+
+describe("validateReturnTo (open-redirect protection)", () => {
+  it("accepts safe same-origin relative paths", () => {
+    expect(validateReturnTo("/")).toBe("/");
+    expect(validateReturnTo("/mail")).toBe("/mail");
+    expect(validateReturnTo("/mail/123?tab=preview")).toBe("/mail/123?tab=preview");
+    expect(validateReturnTo("/folder/inbox#section")).toBe("/folder/inbox#section");
+    expect(validateReturnTo("/a/b/c")).toBe("/a/b/c");
+  });
+
+  it("rejects absolute URLs (off-origin)", () => {
+    expect(validateReturnTo("https://evil.example")).toBeNull();
+    expect(validateReturnTo("http://evil.example/path")).toBeNull();
+    expect(validateReturnTo("ftp://evil.example")).toBeNull();
+    expect(validateReturnTo("mailto:attacker@evil.example")).toBeNull();
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(validateReturnTo("//evil.example")).toBeNull();
+    expect(validateReturnTo("//evil.example/path")).toBeNull();
+    expect(validateReturnTo("///evil.example")).toBeNull();
+    expect(validateReturnTo("////evil.example")).toBeNull();
+  });
+
+  it("rejects backslash-aliased protocol-relative URLs", () => {
+    expect(validateReturnTo("/\\evil.example")).toBeNull();
+    expect(validateReturnTo("\\evil.example")).toBeNull();
+    expect(validateReturnTo("\\\\evil.example")).toBeNull();
+    expect(validateReturnTo("//\\evil.example")).toBeNull();
+  });
+
+  it("rejects encoded protocol-relative lookalikes that decode to an authority", () => {
+    expect(validateReturnTo("/%2f%2fevil.example")).toBeNull();
+    expect(validateReturnTo("/%2F%2Fevil.example")).toBeNull();
+  });
+
+  it("rejects control characters and whitespace smuggling", () => {
+    // Leading/trailing whitespace is trimmed (never navigated), so a value
+    // that trims to a plain relative path stays safe.
+    expect(validateReturnTo("/\n")).toBe("/");
+    expect(validateReturnTo("/\r\n")).toBe("/");
+    expect(validateReturnTo("/\t")).toBe("/");
+    // Control characters inside the path are rejected outright.
+    expect(validateReturnTo("/a\nb")).toBeNull();
+    expect(validateReturnTo("/a\rb")).toBeNull();
+    expect(validateReturnTo("/\u0000b")).toBeNull();
+  });
+
+  it("rejects values that are not relative paths", () => {
+    expect(validateReturnTo("evil.example")).toBeNull();
+    expect(validateReturnTo("")).toBeNull();
+    expect(validateReturnTo("   ")).toBeNull();
+    expect(validateReturnTo("javascript:alert(1)")).toBeNull();
+    expect(validateReturnTo("data:text/html;base64,PHNjcmlwdD4=")).toBeNull();
+    expect(validateReturnTo("#fragment-only")).toBeNull();
+    expect(validateReturnTo("?query=only")).toBeNull();
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(validateReturnTo(null)).toBeNull();
+    expect(validateReturnTo(undefined)).toBeNull();
+    expect(validateReturnTo(123)).toBeNull();
+    expect(validateReturnTo(["//evil.example"])).toBeNull();
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(validateReturnTo("  /mail  ")).toBe("/mail");
+  });
+
+  it("rejects malformed percent-encoding", () => {
+    expect(validateReturnTo("/%zz")).toBeNull();
+    expect(validateReturnTo("/%2")).toBeNull();
+  });
+});
+
+describe("safeReturnTo", () => {
+  it("falls back to the home path for unsafe values", () => {
+    expect(safeReturnTo("https://evil.example")).toBe("/");
+    expect(safeReturnTo("//evil.example")).toBe("/");
+    expect(safeReturnTo(null)).toBe("/");
+    expect(safeReturnTo(undefined)).toBe("/");
+    expect(safeReturnTo("")).toBe("/");
+  });
+
+  it("passes through valid same-origin relative paths", () => {
+    expect(safeReturnTo("/inbox")).toBe("/inbox");
+    expect(safeReturnTo("/")).toBe("/");
+  });
+});

--- a/tests/unit/identity/route-gate.test.tsx
+++ b/tests/unit/identity/route-gate.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, render, screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { RouteGate } from "@/features/identity/RouteGate";
+import { ONBOARDING_ROUTE, SIGN_IN_ROUTE } from "@/features/identity/route-guard";
+
+const mock = vi.hoisted(() => {
+  let branch: string = "active";
+  let data: unknown = null;
+  return {
+    get branch() {
+      return branch;
+    },
+    get data() {
+      return data;
+    },
+    setBranch(value: string) {
+      branch = value;
+    },
+    setData(value: unknown) {
+      data = value;
+    },
+  };
+});
+
+vi.mock("@/features/identity/useBootstrap", () => ({
+  useBootstrap: () => ({
+    branch: mock.branch,
+    data: mock.data,
+    isLoading: false,
+    error: null,
+    retry: async () => undefined,
+    isRetrying: false,
+  }),
+}));
+
+const rootRoute = createRootRoute({
+  component: () => (
+    <RouteGate>
+      <Outlet />
+    </RouteGate>
+  ),
+});
+
+const signInRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/auth/sign-in",
+  validateSearch: z.object({ next: z.string().optional() }),
+  component: () => <div>Sign In Page</div>,
+});
+
+const onboardingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/onboarding",
+  component: () => <div>Onboarding Page</div>,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: () => <div>Protected App Page</div>,
+});
+
+const routeTree = rootRoute.addChildren([signInRoute, onboardingRoute, indexRoute]);
+
+function makeRouter(initialUrl: string) {
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialUrl] }),
+    defaultPreloadStaleTime: 0,
+  });
+}
+
+async function renderAt(initialUrl: string) {
+  const router = makeRouter(initialUrl);
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("RouteGate — component-level navigation coverage", () => {
+  it("redirects an anonymous visitor at the root to sign-in, preserving a validated return-to", async () => {
+    mock.setBranch("unauthorized");
+    mock.setData(null);
+    const router = await renderAt("/mail/42?tab=preview");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe(SIGN_IN_ROUTE));
+    await vi.waitFor(() => expect(router.state.location.search.next).toBe("/mail/42?tab=preview"));
+    expect(await screen.findByText("Sign In Page")).toBeTruthy();
+  });
+
+  it("lets an anonymous visitor stay on the public sign-in page (no redirect loop)", async () => {
+    mock.setBranch("unauthorized");
+    mock.setData(null);
+    const router = await renderAt("/auth/sign-in");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe(SIGN_IN_ROUTE));
+    expect(router.state.location.search.next).toBeUndefined();
+    expect(await screen.findByText("Sign In Page")).toBeTruthy();
+  });
+
+  it("redirects an onboarding (verified, onboarding incomplete) visitor to the onboarding route", async () => {
+    mock.setBranch("onboarding");
+    mock.setData(null);
+    const router = await renderAt("/inbox");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe(ONBOARDING_ROUTE));
+    expect(await screen.findByText("Onboarding Page")).toBeTruthy();
+  });
+
+  it("redirects a verified-but-incomplete-onboarding visitor (active + pending provisioning) to onboarding", async () => {
+    mock.setBranch("active");
+    mock.setData({
+      provisioning: { status: "pending", currentStep: "wallet" },
+    } as never);
+    const router = await renderAt("/");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe(ONBOARDING_ROUTE));
+    expect(await screen.findByText("Onboarding Page")).toBeTruthy();
+  });
+
+  it("shows the distinct suspended state view instead of the app or sign-in", async () => {
+    mock.setBranch("suspended");
+    mock.setData({ user: { userId: "user_blocked" } } as never);
+    const router = await renderAt("/inbox");
+
+    await vi.waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Account suspended" })).toBeTruthy(),
+    );
+    expect(router.state.location.pathname).toBe("/inbox");
+    expect(router.state.location.pathname).not.toBe(SIGN_IN_ROUTE);
+  });
+
+  it("admits an active authenticated visitor into the protected app", async () => {
+    mock.setBranch("active");
+    mock.setData(null);
+    const router = await renderAt("/");
+
+    await vi.waitFor(() => expect(screen.getByText("Protected App Page")).toBeTruthy());
+    expect(router.state.location.pathname).toBe("/");
+  });
+
+  it("sends an authenticated visitor away from the sign-in page back home", async () => {
+    mock.setBranch("active");
+    mock.setData(null);
+    const router = await renderAt("/auth/sign-in");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(await screen.findByText("Protected App Page")).toBeTruthy();
+  });
+
+  it("is repeat-safe: a duplicated bootstrap resolution settles instead of thrashing", async () => {
+    mock.setBranch("unauthorized");
+    mock.setData(null);
+    const router = await renderAt("/mail/7");
+
+    await vi.waitFor(() => expect(router.state.location.pathname).toBe(SIGN_IN_ROUTE));
+    const settledUrl = router.state.location.href;
+
+    // A second bootstrap repoll resolving to the same state must not re-navigate.
+    await act(async () => {
+      router.invalidate();
+    });
+    await vi.waitFor(() => expect(router.state.location.href).toBe(settledUrl));
+    expect(router.state.location.pathname).toBe(SIGN_IN_ROUTE);
+  });
+
+  it("moves a suspended visitor to the state view even when they open the sign-in page", async () => {
+    mock.setBranch("suspended");
+    mock.setData({ user: { userId: "user_blocked" } } as never);
+    await renderAt("/auth/sign-in");
+
+    await vi.waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Account suspended" })).toBeTruthy(),
+    );
+  });
+});

--- a/tests/unit/identity/route-guard.test.ts
+++ b/tests/unit/identity/route-guard.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest";
+
+import type { BootstrapBranch, BootstrapData } from "@/features/identity/bootstrap";
+import {
+  deriveGateState,
+  ONBOARDING_ROUTE,
+  resolveRouteGuard,
+  SIGN_IN_ROUTE,
+  type GateState,
+  type GuardDecision,
+} from "@/features/identity/route-guard";
+import { validateReturnTo } from "@/features/identity/returnTo";
+
+function makeBootstrapData(overrides: Partial<BootstrapData> = {}): BootstrapData {
+  return {
+    user: {
+      userId: "user_guard_1",
+      username: "guarduser",
+      displayName: "Guard User",
+      email: "guard@stealth.mail",
+      accountStatus: "active",
+      createdAt: new Date().toISOString(),
+    },
+    session: {
+      sessionId: "sess_guard_1",
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    },
+    address: "user_guard_1",
+    provisioning: null,
+    policy: null,
+    wallet: {
+      connected: true,
+      address: "user_guard_1",
+      signerType: "managed",
+      capabilities: ["sign"],
+      network: "testnet",
+      balanceXlm: "100.0000000",
+    },
+    health: {
+      ready: true,
+      status: "ok",
+      dependencies: { bindings: "ok" },
+    },
+    syncCursor: "sync_1",
+    featureFlags: {},
+    branch: "active",
+    ...overrides,
+  };
+}
+
+describe("deriveGateState (server bootstrap -> definite gate state)", () => {
+  const cases: Array<{
+    branch: BootstrapBranch;
+    data?: BootstrapData | null;
+    expected: GateState;
+  }> = [
+    { branch: "loading", expected: "loading" },
+    { branch: "unauthorized", expected: "anonymous" },
+    { branch: "suspended", expected: "suspended" },
+    { branch: "outage", expected: "outage" },
+    { branch: "maintenance", expected: "outage" },
+    { branch: "onboarding", expected: "onboarding" },
+    { branch: "active", data: null, expected: "active" },
+    { branch: "active", data: makeBootstrapData(), expected: "active" },
+    {
+      branch: "active",
+      data: makeBootstrapData({ provisioning: { status: "active", currentStep: "done" } }),
+      expected: "active",
+    },
+    {
+      branch: "active",
+      data: makeBootstrapData({ provisioning: { status: "pending", currentStep: "wallet" } }),
+      expected: "verified",
+    },
+    {
+      branch: "active",
+      data: makeBootstrapData({ provisioning: { status: "retryable", currentStep: "funding" } }),
+      expected: "verified",
+    },
+  ];
+
+  it.each(cases)(
+    "branch=$branch provisioning=$data?.provisioning?.status",
+    ({ branch, data, expected }) => {
+      expect(deriveGateState(branch, data ?? null)).toBe(expected);
+    },
+  );
+});
+
+describe("resolveRouteGuard — five required states", () => {
+  describe("anonymous visitors", () => {
+    it("are redirected to sign-in with a validated return-to from the requested path", () => {
+      const decision = resolveRouteGuard({
+        state: "anonymous",
+        pathname: "/mail/123",
+        search: "tab=preview",
+      });
+      expect(decision).toEqual({
+        kind: "redirect",
+        to: SIGN_IN_ROUTE,
+        search: { next: "/mail/123?tab=preview" },
+      });
+    });
+
+    it("are redirected to sign-in with a sanitized return-to for hostile paths", () => {
+      const decision = resolveRouteGuard({ state: "anonymous", pathname: "/", search: "" });
+      expect(decision).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/" } });
+
+      // A hostile pathname must never propagate raw: the emitted return-to
+      // always passes open-redirect validation (here it is sanitized to "/").
+      const hostile = resolveRouteGuard({ state: "anonymous", pathname: "/\n", search: "" });
+      expect(hostile.kind).toBe("redirect");
+      if (hostile.kind === "redirect") {
+        expect(validateReturnTo(hostile.search?.next ?? null)).not.toBeNull();
+      }
+    });
+
+    it("are allowed through on public auth routes (sign-in page itself)", () => {
+      expect(resolveRouteGuard({ state: "anonymous", pathname: "/auth/sign-in" })).toEqual({
+        kind: "render",
+      });
+      expect(resolveRouteGuard({ state: "anonymous", pathname: "/auth/sign-up" })).toEqual({
+        kind: "render",
+      });
+      expect(resolveRouteGuard({ state: "anonymous", pathname: "/auth/verify" })).toEqual({
+        kind: "render",
+      });
+    });
+  });
+
+  describe("the production root never serves the app to anonymous visitors", () => {
+    it("redirects anonymous visitors away from the root in production", () => {
+      const decision = resolveRouteGuard({
+        state: "anonymous",
+        pathname: "/",
+        isDev: false,
+        demoFlag: false,
+      });
+      expect(decision).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/" } });
+    });
+
+    it("redirects anonymous visitors away from the root even with the demo flag in dev", () => {
+      // Demo data is never the default entrypoint: `/` must not render
+      // MailApp (or seeded mail) for an anonymous visitor under any flag.
+      const decision = resolveRouteGuard({
+        state: "anonymous",
+        pathname: "/",
+        isDev: true,
+        demoFlag: true,
+      });
+      expect(decision).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/" } });
+    });
+  });
+
+  describe("demo mode is isolated behind a dev flag and its own route", () => {
+    it("allows demo only on /demo with the dev flag set", () => {
+      expect(
+        resolveRouteGuard({ state: "anonymous", pathname: "/demo", isDev: true, demoFlag: true }),
+      ).toEqual({ kind: "render" });
+    });
+
+    it("denies /demo in production even with the flag", () => {
+      expect(
+        resolveRouteGuard({ state: "anonymous", pathname: "/demo", isDev: false, demoFlag: true }),
+      ).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/demo" } });
+    });
+
+    it("denies /demo in dev without the explicit flag", () => {
+      expect(
+        resolveRouteGuard({ state: "anonymous", pathname: "/demo", isDev: true, demoFlag: false }),
+      ).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/demo" } });
+    });
+
+    it("never treats any other path as demo", () => {
+      expect(
+        resolveRouteGuard({ state: "anonymous", pathname: "/inbox", isDev: true, demoFlag: true }),
+      ).toEqual({ kind: "redirect", to: SIGN_IN_ROUTE, search: { next: "/inbox" } });
+    });
+  });
+
+  describe("onboarding state (email verification pending)", () => {
+    it("redirects to the onboarding route", () => {
+      expect(resolveRouteGuard({ state: "onboarding", pathname: "/" })).toEqual({
+        kind: "redirect",
+        to: ONBOARDING_ROUTE,
+      });
+      expect(resolveRouteGuard({ state: "onboarding", pathname: "/mail/1" })).toEqual({
+        kind: "redirect",
+        to: ONBOARDING_ROUTE,
+      });
+    });
+
+    it("allows the onboarding route and verification status page", () => {
+      expect(resolveRouteGuard({ state: "onboarding", pathname: ONBOARDING_ROUTE })).toEqual({
+        kind: "render",
+      });
+      expect(resolveRouteGuard({ state: "onboarding", pathname: "/auth/verify" })).toEqual({
+        kind: "render",
+      });
+    });
+  });
+
+  describe("verified-but-incomplete-onboarding state", () => {
+    it("redirects to the onboarding route, never into the protected app", () => {
+      expect(resolveRouteGuard({ state: "verified", pathname: "/" })).toEqual({
+        kind: "redirect",
+        to: ONBOARDING_ROUTE,
+      });
+      expect(resolveRouteGuard({ state: "verified", pathname: "/inbox" })).toEqual({
+        kind: "redirect",
+        to: ONBOARDING_ROUTE,
+      });
+    });
+
+    it("allows the onboarding route", () => {
+      expect(resolveRouteGuard({ state: "verified", pathname: ONBOARDING_ROUTE })).toEqual({
+        kind: "render",
+      });
+    });
+  });
+
+  describe("suspended accounts", () => {
+    it("are handled distinctly: never routed into the app or sign-in", () => {
+      expect(resolveRouteGuard({ state: "suspended", pathname: "/" })).toEqual({
+        kind: "state-view",
+        view: "suspended",
+      });
+      expect(resolveRouteGuard({ state: "suspended", pathname: "/inbox" })).toEqual({
+        kind: "state-view",
+        view: "suspended",
+      });
+      expect(resolveRouteGuard({ state: "suspended", pathname: "/auth/sign-in" })).toEqual({
+        kind: "state-view",
+        view: "suspended",
+      });
+      expect(resolveRouteGuard({ state: "suspended", pathname: ONBOARDING_ROUTE })).toEqual({
+        kind: "state-view",
+        view: "suspended",
+      });
+    });
+  });
+
+  describe("active authenticated users", () => {
+    it("enter the protected app", () => {
+      expect(resolveRouteGuard({ state: "active", pathname: "/" })).toEqual({ kind: "render" });
+      expect(resolveRouteGuard({ state: "active", pathname: "/inbox" })).toEqual({
+        kind: "render",
+      });
+    });
+
+    it("are sent home instead of the auth pages (no sign-in loop)", () => {
+      expect(resolveRouteGuard({ state: "active", pathname: "/auth/sign-in" })).toEqual({
+        kind: "redirect",
+        to: "/",
+      });
+      expect(resolveRouteGuard({ state: "active", pathname: "/auth/sign-up" })).toEqual({
+        kind: "redirect",
+        to: "/",
+      });
+      expect(resolveRouteGuard({ state: "active", pathname: ONBOARDING_ROUTE })).toEqual({
+        kind: "redirect",
+        to: "/",
+      });
+    });
+  });
+
+  describe("loading and outage states", () => {
+    it("shows the loading view while unresolved", () => {
+      expect(resolveRouteGuard({ state: "loading", pathname: "/" })).toEqual({
+        kind: "loading-view",
+      });
+    });
+
+    it("shows the outage view", () => {
+      expect(resolveRouteGuard({ state: "outage", pathname: "/" })).toEqual({
+        kind: "state-view",
+        view: "outage",
+      });
+    });
+  });
+});
+
+describe("resolveRouteGuard — duplicate/retry safety", () => {
+  it("is idempotent: repeated evaluation returns the same decision", () => {
+    const inputs = [
+      { state: "anonymous" as GateState, pathname: "/mail/123", search: "tab=x" },
+      { state: "onboarding" as GateState, pathname: "/" },
+      { state: "verified" as GateState, pathname: "/inbox" },
+      { state: "suspended" as GateState, pathname: "/" },
+      { state: "active" as GateState, pathname: "/auth/sign-in" },
+      { state: "loading" as GateState, pathname: "/" },
+    ];
+    for (const input of inputs) {
+      const first = resolveRouteGuard(input);
+      const again = resolveRouteGuard(input);
+      expect(again).toEqual(first);
+    }
+  });
+
+  it("never produces a redirect ping-pong: landing on any redirect target resolves to render or a state view", () => {
+    const states: GateState[] = [
+      "loading",
+      "anonymous",
+      "onboarding",
+      "verified",
+      "suspended",
+      "outage",
+      "active",
+    ];
+    const paths = ["/", "/inbox", "/auth/sign-in", "/auth/verify", "/onboarding", "/demo"];
+    for (const state of states) {
+      for (const path of paths) {
+        const decision = resolveRouteGuard({ state, pathname: path });
+        if (decision.kind !== "redirect") continue;
+        const targetPath = decision.to;
+        // Re-resolve the guard as if the redirect had completed (same state,
+        // target path now current). It must settle — never redirect again.
+        const settled = resolveRouteGuard({ state, pathname: targetPath });
+        expect(
+          settled.kind === "render" ||
+            settled.kind === "state-view" ||
+            settled.kind === "loading-view",
+          `${state} @ ${path} -> ${targetPath} must settle, got ${settled.kind}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("only ever emits return-to values that pass open-redirect validation", () => {
+    const hostilePaths = [
+      "/",
+      "/mail/123?tab=preview",
+      "//evil.example",
+      "/\\evil.example",
+      "/%2f%2fevil.example",
+      "/\n",
+    ];
+    for (const path of hostilePaths) {
+      const decision = resolveRouteGuard({ state: "anonymous", pathname: path }) as Extract<
+        GuardDecision,
+        { kind: "redirect" }
+      >;
+      expect(decision.kind).toBe("redirect");
+      if (decision.search?.next !== undefined) {
+        expect(validateReturnTo(decision.search.next)).toBe(decision.search.next);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #1919

## Summary

BETA-012 / 100 — authenticated route guards + removal of demo mode as the default.

Implements the full vertical slice for "as an anonymous visitor, I should be sent to Sign in; as an authenticated user, I should enter the protected app; demo data must never be the production default":

1. **Server-backed auth bootstrap** — the existing `/api/v1/bootstrap` endpoint now resolves a *definite* state for every visitor with no demo fallback: the development-only "anonymous ⇒ demo user" response branch was removed from the server route (`src/routes/api/v1/bootstrap.ts`), and the client bootstrap layer's implicit demo fallback on network errors was removed (`src/features/identity/bootstrap.ts`). Anonymous visitors now always resolve to `unauthorized`, which the guard turns into a redirect.
2. **Protected-route guards** — new pure guard module `src/features/identity/route-guard.ts` + `RouteGate` component, mounted in the root route shell (`src/routes/__root.tsx`) around the outlet. Decisions per state:
   - `anonymous` → `/auth/sign-in` with a validated return-to (`next`)
   - `onboarding` (email verification pending) → `/onboarding`
   - `verified` (account verified, provisioning incomplete — see assumption note) → `/onboarding`
   - `suspended` → distinct suspended state view, never routed into the app or sign-in
   - `active` → the protected app; active users are sent home from `/auth/*`
3. **Root route never renders demo mail** — `src/routes/index.tsx` no longer computes `isDemoMode` from `import.meta.env.DEV`; `MailApp` always renders with `isDemoMode={false}` on `/`, and the seeded demo-data import is gated on `isDemoMode` (statically removed from the production bundle — verified below).
4. **Demo mode isolated** — new `/demo` route (`src/routes/demo.tsx`) renders the demo mailbox only when `import.meta.env.DEV` **and** the explicit `STEALTH_DEMO_BYPASS_FETCH` flag are both present; otherwise it redirects to sign-in. The e2e demo fixture now opens `/demo` instead of `/`.
5. **Return-to handling** — new `src/features/identity/returnTo.ts` validator replaces the weak inline `safeDestination` in `auth-pages.tsx`. Only same-origin relative paths are honored; absolute URLs, protocol-relative (`//`), backslash-aliased (`/\`), encoded (`/%2f%2f`) and control-character values are rejected.

## Dependencies (BETA-007 #1914, BETA-011 #1918)

Both were confirmed **present on main** before writing code (`git log --oneline origin/main -- src/server/api/auth/` → `9357ecbb feat(auth): add session renewal, rotation, idle timeout, and absolute expiry (BETA-007)`; `git log --oneline origin/main -- src/routes/auth/` → `406cbe14 feat(auth): add authentication pages`). No isolated-implementation path was needed.

**Assumptions made (documented per instructions):**
- The issue's five guard states map onto the current main branch surface as: `anonymous` = bootstrap `unauthorized`; `onboarding` = bootstrap `onboarding` (account `pending_verification`); `verified` = bootstrap `active` **with** a provisioning record that is not terminal-`active` (BETA-014's provisioning orchestrator is not on main; this derivation uses only real server data already returned by `/api/v1/bootstrap`); `suspended` = bootstrap `suspended`; `active` = bootstrap `active`.
- There is no onboarding route on main, so a real `/onboarding` route was added (`src/routes/onboarding.tsx`) reusing the existing verification-required UI (moved from `BootstrapStateView`), with data-driven copy for the verified-but-provisioning case. This is not a stub: it is driven by the real bootstrap payload and real verification flow links.
- The sign-in/verify pages from BETA-011 are used as-is for the anonymous destination (no fabricated page).

## Changed files

- `src/routes/__root.tsx` — mount `RouteGate` around the outlet
- `src/router.tsx` — unchanged (guard lives in the root route shell; no router refactor needed)
- `src/routes/index.tsx` — remove demo-as-default; `MailApp` exported, `isDemoMode=false` always, demo-data import gated on `isDemoMode`
- `src/routes/onboarding.tsx` — new real onboarding destination route
- `src/routes/demo.tsx` — new isolated demo route (dev flag + `/demo` only)
- `src/routes/api/v1/bootstrap.ts` — remove dev demo fallback; anonymous ⇒ always `401`
- `src/features/identity/route-guard.ts` — new: gate derivation + pure guard decisions
- `src/features/identity/RouteGate.tsx` — new: guard component (renders/redirects/state views)
- `src/features/identity/returnTo.ts` — new: same-origin return-to validator
- `src/features/identity/useBootstrap.tsx` — unchanged
- `src/features/identity/auth-pages.tsx` — use the shared `safeReturnTo`
- `src/features/identity/bootstrap.ts` — remove implicit demo fallback (explicit dev flag retained)
- `src/features/identity/BootstrapStateView.tsx` — remove now-unreachable unauthorized/onboarding branches (owned by the guard now)
- `src/features/identity/index.ts` — export new modules
- `src/routeTree.gen.ts` — regenerated from source (see below)
- `tests/unit/identity/return-to.test.ts` — new
- `tests/unit/identity/route-guard.test.ts` — new
- `tests/unit/identity/route-gate.test.tsx` — new (component/browser-level)
- `tests/e2e/fixtures.ts` — demo mailbox opens `/demo`
- `tests/e2e/bootstrap-recovery.spec.ts` — anonymous case now asserts the real sign-in redirect + return-to; new demo-gating e2e

## How each required behavior is proven

| Requirement | Proof |
|---|---|
| Anonymous ⇒ sign-in | `route-guard.test.ts` (anonymous describe block) + `route-gate.test.tsx` "redirects an anonymous visitor at the root to sign-in, preserving a validated return-to" + e2e `bootstrap-recovery.spec.ts` "redirects anonymous visitors to sign-in with a validated return-to" (real browser asserts `?next=%2Fmail%2F123...`) |
| Onboarding (pending verification) ⇒ onboarding | `route-guard.test.ts` "onboarding state" block + `route-gate.test.tsx` "redirects an onboarding (verified, onboarding incomplete) visitor to the onboarding route" (renders the real Onboarding Page) |
| Verified-but-incomplete ⇒ onboarding | `route-guard.test.ts` "verified" block (derivation from `active` + non-terminal provisioning) + `route-gate.test.tsx` "redirects a verified-but-incomplete-onboarding visitor" |
| Suspended handled distinctly | `route-guard.test.ts` "suspended accounts" block (including `/auth/sign-in` ⇒ suspended view, never sign-in) + `route-gate.test.tsx` "shows the distinct suspended state view" |
| Active ⇒ protected app | `route-guard.test.ts` "active authenticated users" block + `route-gate.test.tsx` "admits an active authenticated visitor into the protected app" |
| Production root never serves demo/seeded mail to anonymous | `route-guard.test.ts` "the production root never serves the app to anonymous visitors" (root redirects under `isDev:false` and even under `isDev+demoFlag`) + `route-gate.test.tsx` + e2e "never lands an anonymous visitor on demo data in production mode" (`/demo` ⇒ sign-in, no Demo Mode UI) + production bundle verification: `rg "getDemoEmails|demo-data" dist/client` → **no matches** (seeded-mail module statically eliminated) |
| Demo only behind dev flag + isolated route | `route-guard.test.ts` "demo mode is isolated" block (`/demo` allowed only with `isDev && demoFlag`; every other path redirects) + e2e suite runs the demo mailbox entirely through `/demo` |
| Open-redirect protection for return-to | `return-to.test.ts` — rejects absolute (`https://…`), off-origin, protocol-relative (`//`, `///`), backslash-aliased (`/\`, `\\`), encoded (`%2f%2f`), control-char, non-path inputs; accepts same-origin relative paths; `route-guard.test.ts` asserts every emitted `next` passes validation |
| Duplicate/retry safety | `route-guard.test.ts` "is idempotent", "never produces a redirect ping-pong", guard-state cross-product walk; `route-gate.test.tsx` "is repeat-safe" (second bootstrap repoll settles, no re-navigation) |

## Commands and real results

```
npx prettier --check .
> Checking formatting...
> All matched files use Prettier code style!

npx eslint .
> ✖ 1 problem (0 errors, 1 warning)
> warning: Unexpected any — scripts/stellar/smoke/integration-gate.ts:18:17 (pre-existing on origin/main, file untouched by this PR)

npx tsc --noEmit
> (no output — clean)

npx vitest run tests/unit
> Test Files  228 passed (228)
> Tests  2552 passed | 3 expected fail (2555)

npx vitest run tests/unit/identity tests/unit/api/bootstrap.endpoint.test.ts
> Test Files  8 passed (8)
> Tests  101 passed (101)

npm run build
> ✓ 3914 modules transformed.
> ✓ built in 19.97s

npx playwright test
> 63 passed (3.8m)

npx tsx scripts/generate-route-tree.ts
> routeTree.gen.ts regenerated

npx tsx scripts/generate-openapi.ts && npx prettier --write openapi.json
> openapi.json generated successfully.
> git diff openapi.json → EMPTY (byte-identical to origin/main ⇒ `optic diff --base origin/main --check` passes by construction; no API surface changed)
```

Baseline note: the 3 `expected fail` entries are pre-existing `it.fails` tests in `tests/unit/api/security.regression.test.ts` (verified identical on `origin/main`); the total on an untouched tree is the same 2552 passed + 3 expected fail, so there is no unexplained drop — this PR only adds green tests (96 identity tests incl. 3 new files).

`src/routeTree.gen.ts` was regenerated from source with the standalone generator (never hand-merged) and the diff is purely additive registration of the two new routes (`/demo`, `/onboarding`).

## Notes

- Existing `BootstrapStateView` unauthorized/onboarding cards were unreachable after the guard took over routing; the onboarding UI lives on `/onboarding` now.
- No new `DomainError.code` values, no OpenAPI surface changes, no schema-registry changes.