### PR TITLE
feat(mail): live mailbox sync, folder counts, optimistic updates, and DOM virtualization (#1961)

### DIFF
--- a/src/components/mail/EmailList.tsx
+++ b/src/components/mail/EmailList.tsx
@@ -41,6 +41,9 @@ export function EmailList({
   onStar,
   onSnooze,
   onMove,
+  hasMore = false,
+  onLoadMore,
+  isLoadingMore = false,
 }: {
   emails: Email[];
   selectedId: string | null;
@@ -61,6 +64,9 @@ export function EmailList({
   onStar?: (email: Email) => void;
   onSnooze?: (email: Email) => void;
   onMove?: (emailIds: string[], target: MailLocation) => void;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  isLoadingMore?: boolean;
 }) {
   const [activeTab, setActiveTab] = useState<FilterTab>("all");
   const folderLabel = customFolder ?? getFolderLabel(folder);
@@ -77,7 +83,10 @@ export function EmailList({
     if (activeTab === "flagged") return e.starred;
     return true;
   });
-  const visibleIds = filtered.map((email) => email.id);
+  const RENDER_CAP = 200;
+  const rendered = filtered.slice(0, RENDER_CAP);
+  const loadMoreRef = useRef<HTMLLIElement>(null);
+  const visibleIds = rendered.map((email) => email.id);
   const selectedVisibleIds = visibleIds.filter((id) => selectedIds.includes(id));
   const selectedEmails = selectedIds
     .map((id) => emails.find((email) => email.id === id))
@@ -136,6 +145,22 @@ export function EmailList({
     node.addEventListener("keydown", onKeyDown);
     return () => node.removeEventListener("keydown", onKeyDown);
   });
+
+  useEffect(() => {
+    if (!hasMore || !onLoadMore || rendered.length === 0) return;
+    const node = loadMoreRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting) && !isLoadingMore) {
+          onLoadMore();
+        }
+      },
+      { root: listRef.current, rootMargin: "120px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasMore, isLoadingMore, onLoadMore, rendered.length]);
 
   useEffect(() => {
     const node = listRef.current;
@@ -280,7 +305,7 @@ export function EmailList({
             </div>
           </li>
         )}
-        {filtered.map((e, idx) => {
+        {rendered.map((e, idx) => {
           const active = selectedId === e.id || selectedIds.includes(e.id);
           const selected = selectedIds.includes(e.id);
           const selectMessage = (shiftKey = false) => {
@@ -298,7 +323,7 @@ export function EmailList({
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{
-                  delay: idx * 0.03,
+                  delay: Math.min(idx, 8) * 0.02,
                   duration: 0.25,
                   ease: [0.2, 0.8, 0.2, 1],
                 }}
@@ -463,6 +488,19 @@ export function EmailList({
             </motion.li>
           );
         })}
+        {hasMore ? (
+          <li ref={loadMoreRef} className="px-3 py-3">
+            <button
+              type="button"
+              onClick={() => onLoadMore?.()}
+              disabled={isLoadingMore}
+              aria-busy={isLoadingMore}
+              className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-muted-foreground transition hover:bg-white/[0.07] hover:text-foreground disabled:opacity-60"
+            >
+              {isLoadingMore ? "Loading more conversations" : "Load more conversations"}
+            </button>
+          </li>
+        ) : null}
       </ul>
 
       {/* M-key folder picker overlay */}

--- a/src/features/mail/index.ts
+++ b/src/features/mail/index.ts
@@ -3,6 +3,8 @@ export * from "./quarantine";
 export * from "./recipient-pipeline";
 export * from "./useSession";
 export * from "./useMailbox";
+export * from "./useMailboxSync";
+export * from "./live-mailbox";
 export * from "./useContacts";
 export * from "./usePolicy";
 export * from "./useRequests";

--- a/src/features/mail/live-mailbox.ts
+++ b/src/features/mail/live-mailbox.ts
@@ -16,7 +16,14 @@ export const MAILBOX_RENDER_CAP = 200;
 export const MAILBOX_SYNC_CHANNEL = "stealth_mailbox_sync";
 export const MAILBOX_DELTA_INTERVAL_MS = 15_000;
 
-const INBOX_COUNT_FOLDERS = new Set<string>(["inbox", "pending", "requests", "priority", "verified", "encrypted"]);
+const INBOX_COUNT_FOLDERS = new Set<string>([
+  "inbox",
+  "pending",
+  "requests",
+  "priority",
+  "verified",
+  "encrypted",
+]);
 
 export function emptyMailboxCounts(): MailboxCounts {
   return {
@@ -122,7 +129,11 @@ export function flagsPatchFromEmail(patch: Partial<Email>): MailboxFlagsPatch | 
 
 type CountableMail = Pick<Email, "folder" | "unread" | "starred">;
 
-function contributeCounts(counts: MailboxCounts, email: CountableMail, delta: 1 | -1): MailboxCounts {
+function contributeCounts(
+  counts: MailboxCounts,
+  email: CountableMail,
+  delta: 1 | -1,
+): MailboxCounts {
   const next = { ...counts };
   const bump = (key: keyof MailboxCounts) => {
     next[key] = Math.max(0, next[key] + delta);

--- a/src/features/mail/live-mailbox.ts
+++ b/src/features/mail/live-mailbox.ts
@@ -1,0 +1,217 @@
+// ---------------------------------------------------------------------------
+// BETA-054 (Issue #1961) — client mailbox merge, count overlay, cursor, broadcast.
+// ---------------------------------------------------------------------------
+
+import type { Email, MailFolder, MailLocation } from "@/components/mail/data";
+import type {
+  MailboxCounts,
+  MailboxDescriptor,
+  MailboxFlagsPatch,
+  MailboxLiveFolder,
+} from "@/lib/api";
+import type { MailWorkspaceOverlay } from "./workspace";
+
+export const MAILBOX_PAGE_SIZE = 50;
+export const MAILBOX_RENDER_CAP = 200;
+export const MAILBOX_SYNC_CHANNEL = "stealth_mailbox_sync";
+export const MAILBOX_DELTA_INTERVAL_MS = 15_000;
+
+const INBOX_COUNT_FOLDERS = new Set<string>(["inbox", "pending", "requests", "priority", "verified", "encrypted"]);
+
+export function emptyMailboxCounts(): MailboxCounts {
+  return {
+    inbox: 0,
+    requests: 0,
+    sent: 0,
+    drafts: 0,
+    outbox: 0,
+    archive: 0,
+    spam: 0,
+    trash: 0,
+    unread: 0,
+    starred: 0,
+  };
+}
+
+export function mergeMailboxDescriptors(
+  existing: MailboxDescriptor[],
+  incoming: MailboxDescriptor[],
+  deletedIds: string[] = [],
+): MailboxDescriptor[] {
+  const map = new Map(existing.map((item) => [item.messageId, item]));
+  for (const id of deletedIds) map.delete(id);
+  for (const item of incoming) {
+    if (item.isTombstone) map.delete(item.messageId);
+    else map.set(item.messageId, item);
+  }
+  return [...map.values()].sort((a, b) => {
+    const byTime = b.createdAt.localeCompare(a.createdAt);
+    return byTime !== 0 ? byTime : b.messageId.localeCompare(a.messageId);
+  });
+}
+
+export function capMailboxWindow(
+  items: MailboxDescriptor[],
+  cap = MAILBOX_RENDER_CAP,
+): MailboxDescriptor[] {
+  return items.length <= cap ? items : items.slice(0, cap);
+}
+
+export function syncCursorStorageKey(actor: string): string {
+  return `stealth.mailbox.syncCursor.${actor}`;
+}
+
+export function readSyncCursor(actor: string): string | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    return localStorage.getItem(syncCursorStorageKey(actor));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSyncCursor(actor: string, cursor: string): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(syncCursorStorageKey(actor), cursor);
+  } catch {
+    // Ignore quota / private-mode failures; the next full sync still works.
+  }
+}
+
+export function claimMailboxMutation(pending: Set<string>, key: string): boolean {
+  if (pending.has(key)) return false;
+  pending.add(key);
+  return true;
+}
+
+export function mailboxMutationKey(messageId: string, patch: MailboxFlagsPatch): string {
+  if (patch.folder === "archive") return `${messageId}:archive`;
+  if (patch.folder === "trash") return `${messageId}:trash`;
+  if (patch.starred !== undefined) return `${messageId}:star`;
+  if (patch.unread !== undefined) return `${messageId}:read`;
+  if (patch.folder) return `${messageId}:folder:${patch.folder}`;
+  return `${messageId}:patch`;
+}
+
+export function emailPatchFromFlags(patch: MailboxFlagsPatch): Partial<Email> {
+  const next: Partial<Email> = {};
+  if (patch.unread !== undefined) next.unread = patch.unread;
+  if (patch.starred !== undefined) next.starred = patch.starred;
+  if (patch.folder) next.folder = patch.folder as MailLocation;
+  return next;
+}
+
+export function flagsPatchFromEmail(patch: Partial<Email>): MailboxFlagsPatch | null {
+  const flags: MailboxFlagsPatch = {};
+  if (patch.unread !== undefined) flags.unread = patch.unread;
+  if (patch.starred !== undefined) flags.starred = patch.starred;
+  if (
+    patch.folder === "archive" ||
+    patch.folder === "inbox" ||
+    patch.folder === "spam" ||
+    patch.folder === "trash"
+  ) {
+    flags.folder = patch.folder;
+  }
+  if (flags.unread === undefined && flags.starred === undefined && flags.folder === undefined) {
+    return null;
+  }
+  return flags;
+}
+
+type CountableMail = Pick<Email, "folder" | "unread" | "starred">;
+
+function contributeCounts(counts: MailboxCounts, email: CountableMail, delta: 1 | -1): MailboxCounts {
+  const next = { ...counts };
+  const bump = (key: keyof MailboxCounts) => {
+    next[key] = Math.max(0, next[key] + delta);
+  };
+
+  if (email.folder === "trash") {
+    bump("trash");
+    return next;
+  }
+  if (INBOX_COUNT_FOLDERS.has(email.folder)) bump("inbox");
+  if (email.folder === "requests") bump("requests");
+  if (email.folder === "sent") bump("sent");
+  if (email.folder === "drafts") bump("drafts");
+  if (email.folder === "outbox") bump("outbox");
+  if (email.folder === "archive") bump("archive");
+  if (email.folder === "spam") bump("spam");
+  if (email.unread && email.folder !== "spam") bump("unread");
+  if (email.starred) bump("starred");
+  return next;
+}
+
+export function applyOverlayToCounts(
+  counts: MailboxCounts,
+  overlay: MailWorkspaceOverlay,
+  serverEmails: Email[],
+): MailboxCounts {
+  const byId = new Map(serverEmails.map((email) => [email.id, email]));
+  let next = { ...counts };
+
+  for (const insert of overlay.inserts) {
+    if (!byId.has(insert.id)) {
+      next = contributeCounts(next, insert, 1);
+    }
+  }
+
+  for (const [id, patch] of Object.entries(overlay.patches)) {
+    const before = byId.get(id);
+    if (!before) continue;
+    const after = { ...before, ...patch };
+    next = contributeCounts(next, before, -1);
+    next = contributeCounts(next, after, 1);
+  }
+
+  return next;
+}
+
+export function mergeLiveFolderCounts(
+  local: Record<MailFolder, number>,
+  live?: MailboxCounts | null,
+): Record<MailFolder, number> {
+  if (!live) return local;
+  return {
+    ...local,
+    inbox: live.inbox,
+    requests: live.requests,
+    sent: live.sent,
+    drafts: live.drafts,
+    outbox: live.outbox,
+    archive: live.archive,
+    spam: live.spam,
+    trash: live.trash,
+    starred: live.starred,
+  };
+}
+
+export type MailboxBroadcast =
+  | {
+      type: "MAILBOX_MUTATION";
+      actor: string;
+      tabId: string;
+      descriptor: MailboxDescriptor;
+    }
+  | {
+      type: "MAILBOX_INVALIDATE";
+      actor: string;
+      tabId: string;
+    };
+
+export function descriptorFolder(descriptor: MailboxDescriptor): MailLocation {
+  if (descriptor.isTombstone) return "trash";
+  const folder = descriptor.folder as MailboxLiveFolder | undefined;
+  if (folder === "pending") return "pending";
+  if (folder === "requests") return "requests";
+  if (folder === "archive") return "archive";
+  if (folder === "spam") return "spam";
+  if (folder === "trash") return "trash";
+  if (folder === "sent") return "sent";
+  if (folder === "drafts") return "drafts";
+  if (folder === "outbox") return "outbox";
+  if (folder === "inbox") return "inbox";
+  return descriptor.status === "pending" ? "pending" : "inbox";
+}

--- a/src/features/mail/shell/MailApp.tsx
+++ b/src/features/mail/shell/MailApp.tsx
@@ -44,7 +44,7 @@ export interface MailAppProps {
 
 export function MailApp({ isDemoMode = false }: MailAppProps) {
   const source = useMailSource({ isDemoMode });
-  const navigation = useMailNavigation(source.emails);
+  const navigation = useMailNavigation(source.emails, source.folderCounts);
   const overlays = useMailOverlays();
   const { layout, setLayout, resetLayout, hydrated: layoutHydrated } = useLayoutPreferences();
   const { preferences, setPreferences, hydrated: prefHydrated } = usePreferences();
@@ -70,6 +70,7 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
     updateEmail: source.updateEmail,
     insertEmail: source.insertEmail,
     trashEmail: source.trashEmail,
+    mutateMailbox: source.mutateMailbox,
     showToast,
     openCompose: overlays.openCompose,
     openCalendar: overlays.openCalendar,
@@ -87,6 +88,7 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
     selectedEmails: navigation.selectedEmails,
     updateEmail: source.updateEmail,
     trashEmail: source.trashEmail,
+    mutateMailbox: source.mutateMailbox,
     onToast: showToast,
     onClearSelection: () => navigation.setSelectedIds([]),
   });
@@ -112,8 +114,8 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
   useEffect(() => {
     if (!navigation.selectedId) return;
     const current = source.emails.find((email) => email.id === navigation.selectedId);
-    if (current?.unread) source.updateEmail(navigation.selectedId, { unread: false });
-  }, [navigation.selectedId, source.emails, source.updateEmail]);
+    if (current?.unread) void source.mutateMailbox(current, { unread: false });
+  }, [navigation.selectedId, source.emails, source.mutateMailbox]);
 
   const handleImportSave = useCallback(
     (result: { writes: number; rows: Array<{ name: string; address: string }> }) => {
@@ -300,6 +302,11 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
                           snooze.open({ emailId: email.id, subject: email.subject })
                         }
                         onMove={actions.handleMove}
+                        hasMore={source.hasMore}
+                        onLoadMore={() => {
+                          void source.loadMore();
+                        }}
+                        isLoadingMore={source.isLoadingMore}
                       />
                     </ResizablePanel>
                     {!isMobile && (

--- a/src/features/mail/useMailActions.ts
+++ b/src/features/mail/useMailActions.ts
@@ -20,6 +20,8 @@ import {
 } from "@/features/snooze";
 import type { TrashResult } from "./useMailSource";
 import type { FeedbackTone } from "@/features/design-system/feedback/use-feedback";
+import type { MailboxFlagsPatch } from "@/lib/api";
+import { flagsPatchFromEmail } from "./live-mailbox";
 
 export function quoteBody(email: Email): string {
   return `\n\n---\nOn ${email.time}, ${email.from} <${email.email}> wrote:\n${email.body
@@ -33,6 +35,7 @@ export function useMailActions(input: {
   updateEmail: (id: string, patch: Partial<Email>) => void;
   insertEmail: (email: Email) => void;
   trashEmail: (email: Email) => Promise<TrashResult>;
+  mutateMailbox?: (email: Email, patch: MailboxFlagsPatch) => Promise<TrashResult>;
   showToast: (message: string, options?: { tone: FeedbackTone }) => void;
   openCompose: (initial?: { to?: string; subject?: string; body?: string }) => void;
   openCalendar: (eventId?: string | null) => void;
@@ -50,6 +53,7 @@ export function useMailActions(input: {
     updateEmail,
     insertEmail,
     trashEmail,
+    mutateMailbox,
     showToast,
     openCompose,
     openCalendar,
@@ -108,20 +112,43 @@ export function useMailActions(input: {
     [handleSnooze],
   );
 
+  const commitFlags = useCallback(
+    async (email: Email, patch: MailboxFlagsPatch, successMessage: string) => {
+      if (!mutateMailbox) {
+        updateEmail(email.id, {
+          ...(patch.unread !== undefined ? { unread: patch.unread } : {}),
+          ...(patch.starred !== undefined ? { starred: patch.starred } : {}),
+          ...(patch.folder ? { folder: patch.folder } : {}),
+        });
+        showToast(successMessage);
+        return;
+      }
+      const result = await mutateMailbox(email, patch);
+      if (!result.ok) {
+        showToast(result.reason, { tone: "danger" });
+        return;
+      }
+      showToast(successMessage);
+    },
+    [mutateMailbox, showToast, updateEmail],
+  );
+
   const handleArchive = useCallback(
     (email: Email) => {
-      updateEmail(email.id, { folder: "archive" });
-      showToast(`"${email.subject}" archived`);
+      void commitFlags(email, { folder: "archive" }, `"${email.subject}" archived`);
     },
-    [showToast, updateEmail],
+    [commitFlags],
   );
 
   const handleStar = useCallback(
     (email: Email) => {
-      updateEmail(email.id, { starred: !email.starred });
-      showToast(email.starred ? `Unstarred "${email.subject}"` : `Starred "${email.subject}"`);
+      void commitFlags(
+        email,
+        { starred: !email.starred },
+        email.starred ? `Unstarred "${email.subject}"` : `Starred "${email.subject}"`,
+      );
     },
-    [showToast, updateEmail],
+    [commitFlags],
   );
 
   const handleMove = useCallback(
@@ -136,7 +163,16 @@ export function useMailActions(input: {
           else showToast(result.reason, { tone: "danger" });
           continue;
         }
-        updateEmail(id, { folder: target as MailLocation });
+        const flags = flagsPatchFromEmail({ folder: target as MailLocation });
+        if (flags && mutateMailbox) {
+          const result = await mutateMailbox(email, flags);
+          if (!result.ok) {
+            showToast(result.reason, { tone: "danger" });
+            continue;
+          }
+        } else {
+          updateEmail(id, { folder: target as MailLocation });
+        }
         moved += 1;
       }
       if (moved > 0) {
@@ -145,7 +181,7 @@ export function useMailActions(input: {
         );
       }
     },
-    [emails, showToast, trashEmail, updateEmail],
+    [emails, mutateMailbox, showToast, trashEmail, updateEmail],
   );
 
   const handleTrash = useCallback(
@@ -239,15 +275,13 @@ export function useMailActions(input: {
         });
       },
       onArchive: (email: Email) => {
-        updateEmail(email.id, { folder: "archive" });
-        showToast(`Archived "${email.subject}"`);
+        void handleArchive(email);
       },
       onTrash: (email: Email) => {
         void handleTrash(email);
       },
       onToggleStar: (email: Email) => {
-        updateEmail(email.id, { starred: !email.starred });
-        showToast(email.starred ? "Removed star" : "Starred");
+        void handleStar(email);
       },
       onConvertSender: openSenderConversion,
       onSnooze: openSnoozeDialog,
@@ -269,6 +303,8 @@ export function useMailActions(input: {
     [
       addMailEvent,
       calendarEvents,
+      handleArchive,
+      handleStar,
       handleTrash,
       handleUnsnooze,
       input.updateCalendarReminder,

--- a/src/features/mail/useMailBulkActions.ts
+++ b/src/features/mail/useMailBulkActions.ts
@@ -12,6 +12,8 @@ import {
 import type { Email } from "@/components/mail/data";
 import type { TrashResult } from "./useMailSource";
 import type { FeedbackTone } from "@/features/design-system/feedback/use-feedback";
+import type { MailboxFlagsPatch } from "@/lib/api";
+import { flagsPatchFromEmail } from "./live-mailbox";
 
 function delay(ms: number) {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
@@ -21,6 +23,7 @@ export function useMailBulkActions({
   selectedEmails,
   updateEmail,
   trashEmail,
+  mutateMailbox,
   onToast,
   onClearSelection,
   paceMs = 90,
@@ -28,6 +31,7 @@ export function useMailBulkActions({
   selectedEmails: Email[];
   updateEmail: (id: string, patch: Partial<Email>) => void;
   trashEmail: (email: Email) => Promise<TrashResult>;
+  mutateMailbox?: (email: Email, patch: MailboxFlagsPatch) => Promise<TrashResult>;
   onToast: (message: string, options?: { tone: FeedbackTone }) => void;
   onClearSelection: () => void;
   paceMs?: number;
@@ -79,7 +83,18 @@ export function useMailBulkActions({
             ];
           }
         } else {
-          updateEmail(email.id, result.patch);
+          const flags = flagsPatchFromEmail(result.patch);
+          if (flags && mutateMailbox) {
+            const live = await mutateMailbox(email, flags);
+            if (!live.ok) {
+              failures = [
+                ...failures,
+                { id: email.id, subject: email.subject, reason: live.reason },
+              ];
+            }
+          } else {
+            updateEmail(email.id, result.patch);
+          }
         }
 
         await delay(paceMs);
@@ -118,7 +133,7 @@ export function useMailBulkActions({
         onToast(`${getBulkActionProgressLabel(request, successCount)} complete`);
       }
     },
-    [onClearSelection, onToast, paceMs, selectedEmails, trashEmail, updateEmail],
+    [mutateMailbox, onClearSelection, onToast, paceMs, selectedEmails, trashEmail, updateEmail],
   );
 
   const handleBulkActionRequest = useCallback(

--- a/src/features/mail/useMailNavigation.ts
+++ b/src/features/mail/useMailNavigation.ts
@@ -13,14 +13,20 @@ import {
   visibleEmailsFor,
 } from "./navigation";
 
-export function useMailNavigation(emails: Email[]) {
+export function useMailNavigation(
+  emails: Email[],
+  liveCounts?: Record<MailFolder, number> | null,
+) {
   const [folder, setFolder] = useState<MailFolder>("inbox");
   const [customFolder, setCustomFolder] = useState<string | null>(null);
   const [filters, setFilters] = useState<MailFilters>(defaultMailFilters);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  const folderCounts = useMemo(() => buildFolderCounts(emails), [emails]);
+  const folderCounts = useMemo(
+    () => liveCounts ?? buildFolderCounts(emails),
+    [emails, liveCounts],
+  );
   const visibleEmails = useMemo(
     () => visibleEmailsFor(emails, folder, customFolder),
     [customFolder, emails, folder],

--- a/src/features/mail/useMailNavigation.ts
+++ b/src/features/mail/useMailNavigation.ts
@@ -13,20 +13,14 @@ import {
   visibleEmailsFor,
 } from "./navigation";
 
-export function useMailNavigation(
-  emails: Email[],
-  liveCounts?: Record<MailFolder, number> | null,
-) {
+export function useMailNavigation(emails: Email[], liveCounts?: Record<MailFolder, number> | null) {
   const [folder, setFolder] = useState<MailFolder>("inbox");
   const [customFolder, setCustomFolder] = useState<string | null>(null);
   const [filters, setFilters] = useState<MailFilters>(defaultMailFilters);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  const folderCounts = useMemo(
-    () => liveCounts ?? buildFolderCounts(emails),
-    [emails, liveCounts],
-  );
+  const folderCounts = useMemo(() => liveCounts ?? buildFolderCounts(emails), [emails, liveCounts]);
   const visibleEmails = useMemo(
     () => visibleEmailsFor(emails, folder, customFolder),
     [customFolder, emails, folder],

--- a/src/features/mail/useMailSource.ts
+++ b/src/features/mail/useMailSource.ts
@@ -105,7 +105,9 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
         return { ok: true };
       } catch (error) {
         pendingMutations.current.delete(key);
-        setOverlay((current) => revertEmailPatch(current, email.id, displayPatchRestore(email, patch)));
+        setOverlay((current) =>
+          revertEmailPatch(current, email.id, displayPatchRestore(email, patch)),
+        );
         return { ok: false, reason: errorLabel(normalizeApiClientError(error)) };
       }
     },

--- a/src/features/mail/useMailSource.ts
+++ b/src/features/mail/useMailSource.ts
@@ -1,13 +1,14 @@
 // ---------------------------------------------------------------------------
-// BETA-053 (Issue #1960) — live mailbox source + workspace overlay.
+// BETA-053 / BETA-054 — live mailbox source + workspace overlay.
 // ---------------------------------------------------------------------------
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Email } from "@/components/mail/data";
-import { errorLabel, normalizeApiClientError } from "@/lib/api";
+import { errorLabel, normalizeApiClientError, type MailboxFlagsPatch } from "@/lib/api";
 import { sessionActor, useSession } from "./useSession";
-import { useMailbox, useTombstoneMessage } from "./useMailbox";
+import { useTombstoneMessage } from "./useMailbox";
+import { useMailboxSync } from "./useMailboxSync";
 import { resolveMailSourceView, type MailSourceView } from "./source-view";
 import {
   applyEmailPatch,
@@ -17,17 +18,26 @@ import {
   revertEmailPatch,
   type MailWorkspaceOverlay,
 } from "./workspace";
+import {
+  applyOverlayToCounts,
+  claimMailboxMutation,
+  emailPatchFromFlags,
+  mailboxMutationKey,
+  mergeLiveFolderCounts,
+} from "./live-mailbox";
+import { buildFolderCounts } from "./navigation";
 
 export interface UseMailSourceOptions {
   isDemoMode: boolean;
 }
 
-export type TrashResult = { ok: true } | { ok: false; reason: string };
+export type MailMutationResult = { ok: true } | { ok: false; reason: string };
+export type TrashResult = MailMutationResult;
 
 export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   const session = useSession({ enabled: !isDemoMode });
   const actor = sessionActor(session.data);
-  const mailbox = useMailbox({
+  const mailbox = useMailboxSync({
     actor: actor ?? "anonymous",
     enabled: Boolean(actor) && !isDemoMode,
   });
@@ -36,7 +46,7 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   const [demoEmails, setDemoEmails] = useState<Email[]>([]);
   const [demoReady, setDemoReady] = useState(!isDemoMode);
   const [overlay, setOverlay] = useState<MailWorkspaceOverlay>(EMPTY_MAIL_WORKSPACE);
-  const pendingTrash = useRef(new Set<string>());
+  const pendingMutations = useRef(new Set<string>());
 
   useEffect(() => {
     if (!import.meta.env.DEV || !isDemoMode) return;
@@ -51,8 +61,16 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     };
   }, [isDemoMode]);
 
-  const serverEmails = isDemoMode ? demoEmails : (mailbox.data ?? []);
+  const serverEmails = isDemoMode ? demoEmails : mailbox.emails;
   const emails = useMemo(() => mergeMailWorkspace(serverEmails, overlay), [overlay, serverEmails]);
+  const folderCounts = useMemo(() => {
+    const local = buildFolderCounts(emails);
+    if (isDemoMode) return local;
+    const live = mailbox.counts
+      ? applyOverlayToCounts(mailbox.counts, overlay, serverEmails)
+      : null;
+    return mergeLiveFolderCounts(local, live);
+  }, [emails, isDemoMode, mailbox.counts, overlay, serverEmails]);
 
   const updateEmail = useCallback((id: string, patch: Partial<Email>) => {
     setOverlay((current) => applyEmailPatch(current, id, patch));
@@ -62,31 +80,44 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     setOverlay((current) => insertWorkspaceEmail(current, email));
   }, []);
 
-  const trashEmail = useCallback(
-    async (email: Email): Promise<TrashResult> => {
-      if (email.folder === "trash") return { ok: true };
-      if (pendingTrash.current.has(email.id)) {
-        return { ok: false, reason: "This message is already being updated" };
+  const mutateMailbox = useCallback(
+    async (email: Email, patch: MailboxFlagsPatch): Promise<MailMutationResult> => {
+      const key = mailboxMutationKey(email.id, patch);
+      if (!claimMailboxMutation(pendingMutations.current, key)) {
+        return { ok: true };
       }
-      pendingTrash.current.add(email.id);
-      setOverlay((current) => applyEmailPatch(current, email.id, { folder: "trash" }));
+
+      const displayPatch = emailPatchFromFlags(patch);
+      setOverlay((current) => applyEmailPatch(current, email.id, displayPatch));
 
       if (isDemoMode || !actor) {
-        pendingTrash.current.delete(email.id);
+        pendingMutations.current.delete(key);
         return { ok: true };
       }
 
       try {
-        await tombstone.mutateAsync(email.id);
-        pendingTrash.current.delete(email.id);
+        if (patch.folder === "trash") {
+          await tombstone.mutateAsync(email.id);
+        } else {
+          await mailbox.patchFlags({ messageId: email.id, patch });
+        }
+        pendingMutations.current.delete(key);
         return { ok: true };
       } catch (error) {
-        pendingTrash.current.delete(email.id);
-        setOverlay((current) => revertEmailPatch(current, email.id, { folder: email.folder }));
+        pendingMutations.current.delete(key);
+        setOverlay((current) => revertEmailPatch(current, email.id, displayPatchRestore(email, patch)));
         return { ok: false, reason: errorLabel(normalizeApiClientError(error)) };
       }
     },
-    [actor, isDemoMode, tombstone],
+    [actor, isDemoMode, mailbox, tombstone],
+  );
+
+  const trashEmail = useCallback(
+    async (email: Email): Promise<TrashResult> => {
+      if (email.folder === "trash") return { ok: true };
+      return mutateMailbox(email, { folder: "trash" });
+    },
+    [mutateMailbox],
   );
 
   const retry = useCallback(async () => {
@@ -111,11 +142,24 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   return {
     actor,
     emails,
+    folderCounts,
     updateEmail,
     insertEmail,
     trashEmail,
+    mutateMailbox,
     retry,
     sourceView,
     isDemoMode,
+    hasMore: isDemoMode ? false : mailbox.hasMore,
+    isLoadingMore: isDemoMode ? false : mailbox.isFetchingNextPage,
+    loadMore: mailbox.fetchNextPage,
   };
+}
+
+function displayPatchRestore(email: Email, patch: MailboxFlagsPatch): Partial<Email> {
+  const restore: Partial<Email> = {};
+  if (patch.unread !== undefined) restore.unread = email.unread;
+  if (patch.starred !== undefined) restore.starred = email.starred;
+  if (patch.folder) restore.folder = email.folder;
+  return restore;
 }

--- a/src/features/mail/useMailbox.ts
+++ b/src/features/mail/useMailbox.ts
@@ -39,7 +39,7 @@ export function mailboxDescriptorToEmail(descriptor: MailboxDescriptor): Email {
         minute: "2-digit",
       });
 
-  const folder: MailLocation = descriptorFolder(descriptor);
+  const folder = descriptorFolder(descriptor);
   const unread =
     typeof descriptor.unread === "boolean" ? descriptor.unread : descriptor.status === "pending";
 

--- a/src/features/mail/useMailbox.ts
+++ b/src/features/mail/useMailbox.ts
@@ -11,7 +11,8 @@ import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 
 import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
 import type { MailboxDescriptor, MailboxQueueResponse } from "@/lib/api";
-import type { Email, MailLocation } from "@/components/mail/data";
+import type { Email } from "@/components/mail/data";
+import { descriptorFolder } from "./live-mailbox";
 
 export interface UseMailboxOptions {
   /** Authenticated actor (Stellar G-address) owning the mailbox. */
@@ -38,11 +39,9 @@ export function mailboxDescriptorToEmail(descriptor: MailboxDescriptor): Email {
         minute: "2-digit",
       });
 
-  const folder: MailLocation = descriptor.isTombstone
-    ? "trash"
-    : descriptor.status === "pending"
-      ? "pending"
-      : "inbox";
+  const folder: MailLocation = descriptorFolder(descriptor);
+  const unread =
+    typeof descriptor.unread === "boolean" ? descriptor.unread : descriptor.status === "pending";
 
   return {
     id: descriptor.messageId,
@@ -52,8 +51,8 @@ export function mailboxDescriptorToEmail(descriptor: MailboxDescriptor): Email {
     preview: descriptor.isTombstone ? "This message was deleted." : "Encrypted payload",
     body: "",
     time,
-    unread: descriptor.status === "pending",
-    starred: false,
+    unread,
+    starred: Boolean(descriptor.starred),
     folder,
     labels: descriptor.isTombstone ? ["Deleted"] : [],
     attachments: [],

--- a/src/features/mail/useMailboxSync.ts
+++ b/src/features/mail/useMailboxSync.ts
@@ -70,7 +70,8 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
     queryFn: ({ pageParam, signal }) =>
       api.mailbox.sync({ cursor: pageParam, limit: MAILBOX_PAGE_SIZE }, signal),
     initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage) => (lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
     enabled,
   });
 
@@ -127,14 +128,19 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
       const message = event.data;
       if (!message || message.actor !== actor || message.tabId === tabIdRef.current) return;
       if (message.type === "MAILBOX_MUTATION") {
-        queryClient.setQueryData(syncKey, (current: InfiniteData<MailboxSyncResponse> | undefined) =>
-          mergeSyncPages(
-            current,
-            [message.descriptor],
-            message.descriptor.isTombstone ? [message.descriptor.messageId] : [],
-            latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? emptyCountsFallback(),
-            latestPage?.syncCursor ?? firstPage?.syncCursor ?? readSyncCursor(actor) ?? "",
-          ),
+        queryClient.setQueryData(
+          syncKey,
+          (current: InfiniteData<MailboxSyncResponse> | undefined) =>
+            mergeSyncPages(
+              current,
+              [message.descriptor],
+              message.descriptor.isTombstone ? [message.descriptor.messageId] : [],
+              latestPage?.counts ??
+                firstPage?.counts ??
+                countsQuery.data?.counts ??
+                emptyCountsFallback(),
+              latestPage?.syncCursor ?? firstPage?.syncCursor ?? readSyncCursor(actor) ?? "",
+            ),
         );
         void queryClient.invalidateQueries({ queryKey: countsKey });
         void queryClient.invalidateQueries({ queryKey: queryKeys.mailbox.delta(actor) });
@@ -146,7 +152,16 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
     return () => {
       channel.close();
     };
-  }, [actor, countsKey, countsQuery.data, firstPage?.counts, firstPage?.syncCursor, latestPage, queryClient, syncKey]);
+  }, [
+    actor,
+    countsKey,
+    countsQuery.data,
+    firstPage?.counts,
+    firstPage?.syncCursor,
+    latestPage,
+    queryClient,
+    syncKey,
+  ]);
 
   const patchMutation = useMutation({
     mutationFn: ({ messageId, patch }: { messageId: string; patch: MailboxFlagsPatch }) =>
@@ -157,7 +172,10 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
           current,
           [descriptor],
           descriptor.isTombstone ? [descriptor.messageId] : [],
-          latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? emptyCountsFallback(),
+          latestPage?.counts ??
+            firstPage?.counts ??
+            countsQuery.data?.counts ??
+            emptyCountsFallback(),
           latestPage?.syncCursor ?? firstPage?.syncCursor ?? readSyncCursor(actor) ?? "",
         ),
       );
@@ -179,7 +197,8 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
   }, [listQuery.data]);
 
   const emails = useMemo(() => descriptors.map(mailboxDescriptorToEmail), [descriptors]);
-  const atCap = (listQuery.data?.pages.flatMap((page) => page.items).length ?? 0) >= MAILBOX_RENDER_CAP;
+  const atCap =
+    (listQuery.data?.pages.flatMap((page) => page.items).length ?? 0) >= MAILBOX_RENDER_CAP;
   const hasMore = !atCap && Boolean(latestPage?.hasMore);
   const counts = latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? null;
 

--- a/src/features/mail/useMailboxSync.ts
+++ b/src/features/mail/useMailboxSync.ts
@@ -1,0 +1,230 @@
+// ---------------------------------------------------------------------------
+// BETA-054 (Issue #1961) — cursor mailbox sync, counts, and live mutations.
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+
+import { cacheInvalidations, queryKeys, sharedTypedApi as api } from "@/lib/api";
+import type { MailboxDescriptor, MailboxFlagsPatch, MailboxSyncResponse } from "@/lib/api";
+import { mailboxDescriptorToEmail } from "./useMailbox";
+import {
+  MAILBOX_DELTA_INTERVAL_MS,
+  MAILBOX_PAGE_SIZE,
+  MAILBOX_RENDER_CAP,
+  MAILBOX_SYNC_CHANNEL,
+  capMailboxWindow,
+  mergeMailboxDescriptors,
+  readSyncCursor,
+  writeSyncCursor,
+  type MailboxBroadcast,
+} from "./live-mailbox";
+
+export interface UseMailboxSyncOptions {
+  actor: string;
+  enabled?: boolean;
+}
+
+function mergeSyncPages(
+  current: InfiniteData<MailboxSyncResponse> | undefined,
+  incoming: MailboxDescriptor[],
+  deletedIds: string[],
+  counts: MailboxSyncResponse["counts"],
+  syncCursor: string,
+): InfiniteData<MailboxSyncResponse> {
+  const existing = current?.pages.flatMap((page) => page.items) ?? [];
+  const merged = capMailboxWindow(
+    mergeMailboxDescriptors(existing, incoming, deletedIds),
+    MAILBOX_RENDER_CAP,
+  );
+  const last = current?.pages.at(-1);
+  return {
+    pageParams: current?.pageParams?.length ? current.pageParams : [undefined],
+    pages: [
+      {
+        items: merged,
+        deletedIds: [],
+        nextCursor: last?.nextCursor ?? null,
+        hasMore: last?.hasMore ?? false,
+        syncCursor,
+        counts,
+      },
+    ],
+  };
+}
+
+export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions) {
+  const queryClient = useQueryClient();
+  const tabIdRef = useRef(`tab_${Math.random().toString(36).slice(2, 10)}`);
+  const syncKey = queryKeys.mailbox.sync(actor);
+  const countsKey = queryKeys.mailbox.counts(actor);
+
+  const listQuery = useInfiniteQuery({
+    queryKey: syncKey,
+    queryFn: ({ pageParam, signal }) =>
+      api.mailbox.sync({ cursor: pageParam, limit: MAILBOX_PAGE_SIZE }, signal),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined),
+    enabled,
+  });
+
+  const latestPage = listQuery.data?.pages.at(-1);
+  const firstPage = listQuery.data?.pages[0];
+
+  useEffect(() => {
+    const cursor = latestPage?.syncCursor;
+    if (!enabled || !actor || !cursor) return;
+    writeSyncCursor(actor, cursor);
+  }, [actor, enabled, latestPage?.syncCursor]);
+
+  const sinceCursor = enabled ? readSyncCursor(actor) : null;
+
+  const deltaQuery = useQuery({
+    queryKey: queryKeys.mailbox.delta(actor),
+    queryFn: ({ signal }) => {
+      const since = readSyncCursor(actor);
+      if (!since) return null;
+      return api.mailbox.sync({ sinceCursor: since, limit: 100 }, signal);
+    },
+    enabled: enabled && Boolean(sinceCursor),
+    refetchInterval: MAILBOX_DELTA_INTERVAL_MS,
+    refetchOnWindowFocus: true,
+  });
+
+  useEffect(() => {
+    const delta = deltaQuery.data;
+    if (!delta) return;
+    writeSyncCursor(actor, delta.syncCursor);
+    queryClient.setQueryData(syncKey, (current: InfiniteData<MailboxSyncResponse> | undefined) =>
+      mergeSyncPages(current, delta.items, delta.deletedIds, delta.counts, delta.syncCursor),
+    );
+    queryClient.setQueryData(countsKey, { counts: delta.counts });
+  }, [actor, countsKey, deltaQuery.dataUpdatedAt, deltaQuery.data, queryClient, syncKey]);
+
+  const countsQuery = useQuery({
+    queryKey: countsKey,
+    queryFn: ({ signal }) => api.mailbox.getCounts(signal),
+    enabled,
+    staleTime: 10_000,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") return;
+    let channel: BroadcastChannel;
+    try {
+      channel = new BroadcastChannel(MAILBOX_SYNC_CHANNEL);
+    } catch {
+      return;
+    }
+
+    channel.onmessage = (event: MessageEvent<MailboxBroadcast>) => {
+      const message = event.data;
+      if (!message || message.actor !== actor || message.tabId === tabIdRef.current) return;
+      if (message.type === "MAILBOX_MUTATION") {
+        queryClient.setQueryData(syncKey, (current: InfiniteData<MailboxSyncResponse> | undefined) =>
+          mergeSyncPages(
+            current,
+            [message.descriptor],
+            message.descriptor.isTombstone ? [message.descriptor.messageId] : [],
+            latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? emptyCountsFallback(),
+            latestPage?.syncCursor ?? firstPage?.syncCursor ?? readSyncCursor(actor) ?? "",
+          ),
+        );
+        void queryClient.invalidateQueries({ queryKey: countsKey });
+        void queryClient.invalidateQueries({ queryKey: queryKeys.mailbox.delta(actor) });
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: queryKeys.mailbox.all });
+    };
+
+    return () => {
+      channel.close();
+    };
+  }, [actor, countsKey, countsQuery.data, firstPage?.counts, firstPage?.syncCursor, latestPage, queryClient, syncKey]);
+
+  const patchMutation = useMutation({
+    mutationFn: ({ messageId, patch }: { messageId: string; patch: MailboxFlagsPatch }) =>
+      api.mailbox.patchFlags(messageId, patch),
+    onSuccess: async (descriptor) => {
+      queryClient.setQueryData(syncKey, (current: InfiniteData<MailboxSyncResponse> | undefined) =>
+        mergeSyncPages(
+          current,
+          [descriptor],
+          descriptor.isTombstone ? [descriptor.messageId] : [],
+          latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? emptyCountsFallback(),
+          latestPage?.syncCursor ?? firstPage?.syncCursor ?? readSyncCursor(actor) ?? "",
+        ),
+      );
+      for (const key of cacheInvalidations.patchMailboxFlags(actor)) {
+        await queryClient.invalidateQueries({ queryKey: key });
+      }
+      broadcast({
+        type: "MAILBOX_MUTATION",
+        actor,
+        tabId: tabIdRef.current,
+        descriptor,
+      });
+    },
+  });
+
+  const descriptors = useMemo(() => {
+    const flat = listQuery.data?.pages.flatMap((page) => page.items) ?? [];
+    return capMailboxWindow(flat, MAILBOX_RENDER_CAP);
+  }, [listQuery.data]);
+
+  const emails = useMemo(() => descriptors.map(mailboxDescriptorToEmail), [descriptors]);
+  const atCap = (listQuery.data?.pages.flatMap((page) => page.items).length ?? 0) >= MAILBOX_RENDER_CAP;
+  const hasMore = !atCap && Boolean(latestPage?.hasMore);
+  const counts = latestPage?.counts ?? firstPage?.counts ?? countsQuery.data?.counts ?? null;
+
+  const refetch = useCallback(async () => {
+    await Promise.all([listQuery.refetch(), countsQuery.refetch(), deltaQuery.refetch()]);
+  }, [countsQuery, deltaQuery, listQuery]);
+
+  return {
+    emails,
+    counts,
+    hasMore,
+    fetchNextPage: listQuery.fetchNextPage,
+    isFetchingNextPage: listQuery.isFetchingNextPage,
+    isLoading: listQuery.isLoading,
+    isFetching: listQuery.isFetching,
+    isFetched: listQuery.isFetched,
+    isError: listQuery.isError,
+    error: listQuery.error,
+    refetch,
+    patchFlags: patchMutation.mutateAsync,
+  };
+}
+
+function emptyCountsFallback() {
+  return {
+    inbox: 0,
+    requests: 0,
+    sent: 0,
+    drafts: 0,
+    outbox: 0,
+    archive: 0,
+    spam: 0,
+    trash: 0,
+    unread: 0,
+    starred: 0,
+  };
+}
+
+function broadcast(message: MailboxBroadcast) {
+  if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") return;
+  try {
+    const channel = new BroadcastChannel(MAILBOX_SYNC_CHANNEL);
+    channel.postMessage(message);
+    channel.close();
+  } catch {
+    // Ignore broadcast failures; polling still reconciles.
+  }
+}

--- a/src/lib/api/clients.ts
+++ b/src/lib/api/clients.ts
@@ -16,9 +16,12 @@ import type {
   DeliveryReceipt,
   KeyDirectoryRecord,
   MailboxDescriptor,
+  MailboxCountsResponse,
+  MailboxFlagsPatch,
   MailboxPolicy,
   MailboxPolicyWrite,
   MailboxQueueResponse,
+  MailboxSyncResponse,
   MailboxSettings,
   PolicyReconciliation,
   PostageQuote,
@@ -150,6 +153,12 @@ export interface MailboxQueueQuery {
   limit?: number;
 }
 
+export interface MailboxSyncQuery {
+  sinceCursor?: string;
+  cursor?: string;
+  limit?: number;
+}
+
 export class MailboxClient {
   constructor(private readonly client: ApiClient) {}
 
@@ -163,6 +172,33 @@ export class MailboxClient {
       },
       signal,
     });
+  }
+
+  sync(query: MailboxSyncQuery = {}, signal?: AbortSignal): Promise<MailboxSyncResponse> {
+    return this.client.get<MailboxSyncResponse>("/mailbox/sync", {
+      query: {
+        sinceCursor: query.sinceCursor,
+        cursor: query.cursor,
+        limit: query.limit,
+      },
+      signal,
+    });
+  }
+
+  getCounts(signal?: AbortSignal): Promise<MailboxCountsResponse> {
+    return this.client.get<MailboxCountsResponse>("/mailbox/counts", { signal });
+  }
+
+  patchFlags(
+    messageId: string,
+    patch: MailboxFlagsPatch,
+    signal?: AbortSignal,
+  ): Promise<MailboxDescriptor> {
+    return this.client.patch<MailboxDescriptor>(
+      `/mailbox/${encodeURIComponent(messageId)}`,
+      patch,
+      { signal },
+    );
   }
 
   tombstone(

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -43,4 +43,9 @@ export {
   type TypedApi,
 } from "./clients";
 export type * from "./types";
-export { type MailboxQueueQuery, type MailboxSyncQuery, type PostageQuoteQuery, type ContactListQuery } from "./clients";
+export {
+  type MailboxQueueQuery,
+  type MailboxSyncQuery,
+  type PostageQuoteQuery,
+  type ContactListQuery,
+} from "./clients";

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -43,4 +43,4 @@ export {
   type TypedApi,
 } from "./clients";
 export type * from "./types";
-export { type MailboxQueueQuery, type PostageQuoteQuery, type ContactListQuery } from "./clients";
+export { type MailboxQueueQuery, type MailboxSyncQuery, type PostageQuoteQuery, type ContactListQuery } from "./clients";

--- a/src/lib/api/query-keys.ts
+++ b/src/lib/api/query-keys.ts
@@ -25,6 +25,9 @@ export const queryKeys = {
   mailbox: {
     all: ["mailbox"] as const,
     queue: (owner: string) => ["mailbox", "queue", owner] as const,
+    sync: (owner: string) => ["mailbox", "sync", owner] as const,
+    counts: (owner: string) => ["mailbox", "counts", owner] as const,
+    delta: (owner: string) => ["mailbox", "delta", owner] as const,
     message: (messageId: string) => ["mailbox", "message", messageId] as const,
   },
   requests: {
@@ -76,9 +79,22 @@ export const cacheInvalidations = {
   senderRequestDecision: (owner: string) => [
     queryKeys.requests.list(owner),
     queryKeys.mailbox.queue(owner),
+    queryKeys.mailbox.sync(owner),
+    queryKeys.mailbox.counts(owner),
   ],
   createSenderRequest: (owner: string) => [queryKeys.requests.list(owner)],
-  tombstoneMessage: (owner: string) => [queryKeys.mailbox.queue(owner)],
+  tombstoneMessage: (owner: string) => [
+    queryKeys.mailbox.queue(owner),
+    queryKeys.mailbox.sync(owner),
+    queryKeys.mailbox.counts(owner),
+    queryKeys.mailbox.delta(owner),
+  ],
+  patchMailboxFlags: (owner: string) => [
+    queryKeys.mailbox.queue(owner),
+    queryKeys.mailbox.sync(owner),
+    queryKeys.mailbox.counts(owner),
+    queryKeys.mailbox.delta(owner),
+  ],
   rotateKey: (owner: string) => [queryKeys.identity.keys(owner)],
   createContact: (owner: string) => [queryKeys.contacts.list(owner)],
   updateContact: (owner: string, contactId: string) => [

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -153,12 +153,59 @@ export interface MailboxDescriptor {
   objectRef?: string;
   isTombstone: boolean;
   deletedAt?: string | null;
+  starred?: boolean;
+  unread?: boolean;
+  folder?: MailboxLiveFolder;
+}
+
+export type MailboxLiveFolder =
+  | "inbox"
+  | "pending"
+  | "requests"
+  | "archive"
+  | "spam"
+  | "trash"
+  | "sent"
+  | "drafts"
+  | "outbox";
+
+export type MailboxCountKey =
+  | "inbox"
+  | "requests"
+  | "sent"
+  | "drafts"
+  | "outbox"
+  | "archive"
+  | "spam"
+  | "trash"
+  | "unread"
+  | "starred";
+
+export type MailboxCounts = Record<MailboxCountKey, number>;
+
+export interface MailboxFlagsPatch {
+  unread?: boolean;
+  starred?: boolean;
+  folder?: "inbox" | "archive" | "spam" | "trash";
 }
 
 export interface MailboxQueueResponse {
   items: MailboxDescriptor[];
   nextCursor: string | null;
   hasMore: boolean;
+}
+
+export interface MailboxSyncResponse {
+  items: MailboxDescriptor[];
+  deletedIds: string[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  syncCursor: string;
+  counts: MailboxCounts;
+}
+
+export interface MailboxCountsResponse {
+  counts: MailboxCounts;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -39,6 +39,8 @@ import { Route as ApiV1PostageMessageIdRouteImport } from './routes/api/v1/posta
 import { Route as ApiV1PoliciesEvaluateRouteImport } from './routes/api/v1/policies/evaluate'
 import { Route as ApiV1PoliciesOwnerRouteImport } from './routes/api/v1/policies/$owner'
 import { Route as ApiV1MailboxQueueRouteImport } from './routes/api/v1/mailbox/queue'
+import { Route as ApiV1MailboxSyncRouteImport } from './routes/api/v1/mailbox/sync'
+import { Route as ApiV1MailboxCountsRouteImport } from './routes/api/v1/mailbox/counts'
 import { Route as ApiV1MailboxMessageIdRouteImport } from './routes/api/v1/mailbox/$messageId'
 import { Route as ApiV1LifecycleMessageIdRouteImport } from './routes/api/v1/lifecycle/$messageId'
 import { Route as ApiV1IdentityResolveRouteImport } from './routes/api/v1/identity/resolve'
@@ -238,6 +240,16 @@ const ApiV1PoliciesOwnerRoute = ApiV1PoliciesOwnerRouteImport.update({
 const ApiV1MailboxQueueRoute = ApiV1MailboxQueueRouteImport.update({
   id: '/api/v1/mailbox/queue',
   path: '/api/v1/mailbox/queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxSyncRoute = ApiV1MailboxSyncRouteImport.update({
+  id: '/api/v1/mailbox/sync',
+  path: '/api/v1/mailbox/sync',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiV1MailboxCountsRoute = ApiV1MailboxCountsRouteImport.update({
+  id: '/api/v1/mailbox/counts',
+  path: '/api/v1/mailbox/counts',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiV1MailboxMessageIdRoute = ApiV1MailboxMessageIdRouteImport.update({
@@ -540,7 +552,9 @@ export interface FileRoutesByFullPath {
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/lifecycle/$messageId': typeof ApiV1LifecycleMessageIdRouteWithChildren
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/counts': typeof ApiV1MailboxCountsRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
+  '/api/v1/mailbox/sync': typeof ApiV1MailboxSyncRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -622,7 +636,9 @@ export interface FileRoutesByTo {
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/lifecycle/$messageId': typeof ApiV1LifecycleMessageIdRouteWithChildren
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/counts': typeof ApiV1MailboxCountsRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
+  '/api/v1/mailbox/sync': typeof ApiV1MailboxSyncRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -705,7 +721,9 @@ export interface FileRoutesById {
   '/api/v1/identity/resolve': typeof ApiV1IdentityResolveRoute
   '/api/v1/lifecycle/$messageId': typeof ApiV1LifecycleMessageIdRouteWithChildren
   '/api/v1/mailbox/$messageId': typeof ApiV1MailboxMessageIdRoute
+  '/api/v1/mailbox/counts': typeof ApiV1MailboxCountsRoute
   '/api/v1/mailbox/queue': typeof ApiV1MailboxQueueRoute
+  '/api/v1/mailbox/sync': typeof ApiV1MailboxSyncRoute
   '/api/v1/policies/$owner': typeof ApiV1PoliciesOwnerRouteWithChildren
   '/api/v1/policies/evaluate': typeof ApiV1PoliciesEvaluateRoute
   '/api/v1/postage/$messageId': typeof ApiV1PostageMessageIdRouteWithChildren
@@ -789,7 +807,9 @@ export interface FileRouteTypes {
     | '/api/v1/identity/resolve'
     | '/api/v1/lifecycle/$messageId'
     | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/counts'
     | '/api/v1/mailbox/queue'
+    | '/api/v1/mailbox/sync'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -871,7 +891,9 @@ export interface FileRouteTypes {
     | '/api/v1/identity/resolve'
     | '/api/v1/lifecycle/$messageId'
     | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/counts'
     | '/api/v1/mailbox/queue'
+    | '/api/v1/mailbox/sync'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -953,7 +975,9 @@ export interface FileRouteTypes {
     | '/api/v1/identity/resolve'
     | '/api/v1/lifecycle/$messageId'
     | '/api/v1/mailbox/$messageId'
+    | '/api/v1/mailbox/counts'
     | '/api/v1/mailbox/queue'
+    | '/api/v1/mailbox/sync'
     | '/api/v1/policies/$owner'
     | '/api/v1/policies/evaluate'
     | '/api/v1/postage/$messageId'
@@ -1035,8 +1059,10 @@ export interface RootRouteChildren {
   ApiV1DeliveryMessageIdRoute: typeof ApiV1DeliveryMessageIdRoute
   ApiV1IdentityResolveRoute: typeof ApiV1IdentityResolveRoute
   ApiV1LifecycleMessageIdRoute: typeof ApiV1LifecycleMessageIdRouteWithChildren
+  ApiV1MailboxCountsRoute: typeof ApiV1MailboxCountsRoute
   ApiV1MailboxMessageIdRoute: typeof ApiV1MailboxMessageIdRoute
   ApiV1MailboxQueueRoute: typeof ApiV1MailboxQueueRoute
+  ApiV1MailboxSyncRoute: typeof ApiV1MailboxSyncRoute
   ApiV1PoliciesOwnerRoute: typeof ApiV1PoliciesOwnerRouteWithChildren
   ApiV1PoliciesEvaluateRoute: typeof ApiV1PoliciesEvaluateRoute
   ApiV1PostageMessageIdRoute: typeof ApiV1PostageMessageIdRouteWithChildren
@@ -1284,11 +1310,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1PoliciesOwnerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v1/mailbox/counts': {
+      id: '/api/v1/mailbox/counts'
+      path: '/api/v1/mailbox/counts'
+      fullPath: '/api/v1/mailbox/counts'
+      preLoaderRoute: typeof ApiV1MailboxCountsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/v1/mailbox/queue': {
       id: '/api/v1/mailbox/queue'
       path: '/api/v1/mailbox/queue'
       fullPath: '/api/v1/mailbox/queue'
       preLoaderRoute: typeof ApiV1MailboxQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/mailbox/sync': {
+      id: '/api/v1/mailbox/sync'
+      path: '/api/v1/mailbox/sync'
+      fullPath: '/api/v1/mailbox/sync'
+      preLoaderRoute: typeof ApiV1MailboxSyncRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/v1/mailbox/$messageId': {
@@ -1761,8 +1801,10 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1DeliveryMessageIdRoute: ApiV1DeliveryMessageIdRoute,
   ApiV1IdentityResolveRoute: ApiV1IdentityResolveRoute,
   ApiV1LifecycleMessageIdRoute: ApiV1LifecycleMessageIdRouteWithChildren,
+  ApiV1MailboxCountsRoute: ApiV1MailboxCountsRoute,
   ApiV1MailboxMessageIdRoute: ApiV1MailboxMessageIdRoute,
   ApiV1MailboxQueueRoute: ApiV1MailboxQueueRoute,
+  ApiV1MailboxSyncRoute: ApiV1MailboxSyncRoute,
   ApiV1PoliciesOwnerRoute: ApiV1PoliciesOwnerRouteWithChildren,
   ApiV1PoliciesEvaluateRoute: ApiV1PoliciesEvaluateRoute,
   ApiV1PostageMessageIdRoute: ApiV1PostageMessageIdRouteWithChildren,

--- a/src/routes/api/v1/mailbox/$messageId.ts
+++ b/src/routes/api/v1/mailbox/$messageId.ts
@@ -2,12 +2,40 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { requireActor } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
-import { hash32Schema } from "@/server/api/domain";
+import { hash32Schema, mailboxFlagsPatchSchema } from "@/server/api/domain";
+import { envelopeToMailboxDescriptor } from "@/server/api/mailbox-live";
+import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
+import { ApiError } from "@/server/api/errors";
 
 export const Route = createFileRoute("/api/v1/mailbox/$messageId")({
   server: {
     handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+          const messageId = hash32Schema.parse(params.messageId);
+          const envelope = await apiContext.repository.getEnvelope(messageId);
+          if (!envelope) {
+            throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+          }
+          if (envelope.recipientId.toUpperCase().trim() !== actor.toUpperCase().trim()) {
+            throw new ApiError(403, "forbidden", "Cannot read another recipient's message");
+          }
+          return apiSuccess(request, envelopeToMailboxDescriptor(envelope), { status: 200 });
+        }),
+
+      PATCH: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+          const messageId = hash32Schema.parse(params.messageId);
+          const patch = await parseJsonBody(request, mailboxFlagsPatchSchema);
+          const updated = await apiContext.repository.patchMailboxFlags(messageId, actor, patch);
+          return apiSuccess(request, envelopeToMailboxDescriptor(updated), { status: 200 });
+        }),
+
       DELETE: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const apiContext = await getApiContext(request);

--- a/src/routes/api/v1/mailbox/counts.ts
+++ b/src/routes/api/v1/mailbox/counts.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { countMailbox, listAllRecipientEnvelopes } from "@/server/api/mailbox-live";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/mailbox/counts")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+          const envelopes = await listAllRecipientEnvelopes(apiContext.repository, actor, true);
+          return apiSuccess(
+            request,
+            { counts: countMailbox(envelopes) },
+            { status: 200 },
+          );
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/mailbox/counts.ts
+++ b/src/routes/api/v1/mailbox/counts.ts
@@ -13,11 +13,7 @@ export const Route = createFileRoute("/api/v1/mailbox/counts")({
           const apiContext = await getApiContext(request);
           const actor = requireActor(apiContext);
           const envelopes = await listAllRecipientEnvelopes(apiContext.repository, actor, true);
-          return apiSuccess(
-            request,
-            { counts: countMailbox(envelopes) },
-            { status: 200 },
-          );
+          return apiSuccess(request, { counts: countMailbox(envelopes) }, { status: 200 });
         }),
     },
   },

--- a/src/routes/api/v1/mailbox/queue.ts
+++ b/src/routes/api/v1/mailbox/queue.ts
@@ -2,7 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { requireActor, requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
-import { mailboxQueueQuerySchema, type MailboxDescriptor } from "@/server/api/domain";
+import { mailboxQueueQuerySchema } from "@/server/api/domain";
+import { envelopeToMailboxDescriptor } from "@/server/api/mailbox-live";
 import { encodeCursor, decodeCursor } from "@/server/api/pagination";
 import { parseSearchParams } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
@@ -34,18 +35,7 @@ export const Route = createFileRoute("/api/v1/mailbox/queue")({
             after: afterKey,
           });
 
-          const items: MailboxDescriptor[] = page.items.map((item) => ({
-            messageId: item.messageId,
-            senderId: item.senderId,
-            recipientId: item.recipientId,
-            status: item.status ?? "pending",
-            createdAt: item.createdAt,
-            protectedHeaders: item.protectedHeaders,
-            contentCommitment: item.contentCommitment,
-            objectRef: item.objectRef,
-            isTombstone: Boolean(item.deletedAt),
-            deletedAt: item.deletedAt ?? null,
-          }));
+          const items = page.items.map(envelopeToMailboxDescriptor);
 
           const hasMore = Boolean(page.nextContinuationKey);
           const nextCursor = page.nextContinuationKey

--- a/src/routes/api/v1/mailbox/sync.ts
+++ b/src/routes/api/v1/mailbox/sync.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireActor } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { mailboxSyncQuerySchema } from "@/server/api/domain";
+import { buildMailboxSync } from "@/server/api/mailbox-live";
+import { parseSearchParams } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+export const Route = createFileRoute("/api/v1/mailbox/sync")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        handleApiRequest(request, async () => {
+          const apiContext = await getApiContext(request);
+          const actor = requireActor(apiContext);
+          const query = parseSearchParams(request, mailboxSyncQuerySchema);
+          const payload = await buildMailboxSync(apiContext.repository, actor, query);
+          return apiSuccess(request, payload, { status: 200 });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/mailbox/sync.ts
+++ b/src/routes/api/v1/mailbox/sync.ts
@@ -15,7 +15,10 @@ export const Route = createFileRoute("/api/v1/mailbox/sync")({
           const apiContext = await getApiContext(request);
           const actor = requireActor(apiContext);
           const query = parseSearchParams(request, mailboxSyncQuerySchema);
-          const payload = await buildMailboxSync(apiContext.repository, actor, query);
+          const payload = await buildMailboxSync(apiContext.repository, actor, {
+            ...query,
+            limit: query.limit ?? 50,
+          });
           return apiSuccess(request, payload, { status: 200 });
         }),
     },

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -956,6 +956,67 @@ export const mailboxQueueQuerySchema = z.object({
 
 export type MailboxQueueQuery = z.infer<typeof mailboxQueueQuerySchema>;
 
+export const mailboxLiveFolderSchema = z.enum([
+  "inbox",
+  "pending",
+  "requests",
+  "archive",
+  "spam",
+  "trash",
+  "sent",
+  "drafts",
+  "outbox",
+]);
+export type MailboxLiveFolder = z.infer<typeof mailboxLiveFolderSchema>;
+
+export const mailboxCountKeySchema = z.enum([
+  "inbox",
+  "requests",
+  "sent",
+  "drafts",
+  "outbox",
+  "archive",
+  "spam",
+  "trash",
+  "unread",
+  "starred",
+]);
+export type MailboxCountKey = z.infer<typeof mailboxCountKeySchema>;
+
+export const mailboxCountsSchema = z.object({
+  inbox: z.number().int().nonnegative(),
+  requests: z.number().int().nonnegative(),
+  sent: z.number().int().nonnegative(),
+  drafts: z.number().int().nonnegative(),
+  outbox: z.number().int().nonnegative(),
+  archive: z.number().int().nonnegative(),
+  spam: z.number().int().nonnegative(),
+  trash: z.number().int().nonnegative(),
+  unread: z.number().int().nonnegative(),
+  starred: z.number().int().nonnegative(),
+});
+export type MailboxCounts = z.infer<typeof mailboxCountsSchema>;
+
+export const mailboxFlagsPatchSchema = z
+  .object({
+    unread: z.boolean().optional(),
+    starred: z.boolean().optional(),
+    folder: z.enum(["inbox", "archive", "spam", "trash"]).optional(),
+  })
+  .refine(
+    (value) =>
+      value.unread !== undefined || value.starred !== undefined || value.folder !== undefined,
+    { message: "At least one mailbox flag is required" },
+  );
+export type MailboxFlagsPatch = z.infer<typeof mailboxFlagsPatchSchema>;
+
+export const mailboxSyncQuerySchema = z.object({
+  sinceCursor: z.string().trim().min(1).optional(),
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+export type MailboxSyncQuery = z.infer<typeof mailboxSyncQuerySchema>;
+
 export const mailboxDescriptorSchema = z.object({
   messageId: hash32Schema,
   senderId: stellarAddressSchema,
@@ -967,6 +1028,9 @@ export const mailboxDescriptorSchema = z.object({
   objectRef: z.string().optional(),
   isTombstone: z.boolean(),
   deletedAt: z.string().datetime().nullable().optional(),
+  starred: z.boolean().optional(),
+  unread: z.boolean().optional(),
+  folder: mailboxLiveFolderSchema.optional(),
 });
 
 export type MailboxDescriptor = z.infer<typeof mailboxDescriptorSchema>;

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -563,6 +563,16 @@ export class HybridApiRepository implements ApiRepository {
     return result;
   }
 
+  async patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: import("./domain").MailboxFlagsPatch,
+  ): Promise<StoredEnvelope> {
+    const result = await this.getStub().patchMailboxFlags(messageId, recipient, patch);
+    await this.kv.put(this.key("envelope", messageId), JSON.stringify(result));
+    return result;
+  }
+
   // ---------------------------------------------------------------------------
   // Issue #1934 (BETA-027) — Versioned Public Encryption-Key Directory & Rotation
   // ---------------------------------------------------------------------------

--- a/src/server/api/mailbox-live.ts
+++ b/src/server/api/mailbox-live.ts
@@ -1,0 +1,261 @@
+// ---------------------------------------------------------------------------
+// BETA-054 (Issue #1961) — live mailbox descriptors, folder counts, and sync.
+// ---------------------------------------------------------------------------
+
+import type {
+  MailboxCounts,
+  MailboxDescriptor,
+  MailboxFlagsPatch,
+  MailboxLiveFolder,
+  StoredEnvelope,
+} from "./domain";
+import { encodeCursor, decodeCursor } from "./pagination";
+import {
+  paginate,
+  PAGINATED_QUERY_ORDERINGS,
+  type ApiRepository,
+} from "./repository";
+
+export const MAILBOX_SYNC_SCOPE = "mailbox_sync";
+export const MAILBOX_SYNC_PAGE_SCOPE = "mailbox_sync_page";
+const LIST_WALK_PAGE_SIZE = 100;
+const LIST_WALK_MAX_PAGES = 40;
+
+const INBOX_COUNT_FOLDERS = new Set<MailboxLiveFolder>([
+  "inbox",
+  "pending",
+  "requests",
+]);
+
+const LIVE_FOLDERS = new Set<MailboxLiveFolder>([
+  "inbox",
+  "pending",
+  "requests",
+  "archive",
+  "spam",
+  "trash",
+  "sent",
+  "drafts",
+  "outbox",
+]);
+
+export interface MailboxLiveFlags {
+  starred: boolean;
+  unread: boolean;
+  folder: MailboxLiveFolder;
+  updatedAt: string | null;
+}
+
+export interface MailboxSyncPayload {
+  items: MailboxDescriptor[];
+  deletedIds: string[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  syncCursor: string;
+  counts: MailboxCounts;
+}
+
+export function emptyMailboxCounts(): MailboxCounts {
+  return {
+    inbox: 0,
+    requests: 0,
+    sent: 0,
+    drafts: 0,
+    outbox: 0,
+    archive: 0,
+    spam: 0,
+    trash: 0,
+    unread: 0,
+    starred: 0,
+  };
+}
+
+function isLiveFolder(value: unknown): value is MailboxLiveFolder {
+  return typeof value === "string" && LIVE_FOLDERS.has(value as MailboxLiveFolder);
+}
+
+export function readMailboxFlags(envelope: StoredEnvelope): MailboxLiveFlags {
+  const metadata = envelope.metadata;
+  const raw =
+    metadata && typeof metadata === "object" && "mailbox" in metadata
+      ? (metadata as Record<string, unknown>).mailbox
+      : undefined;
+  const mailbox = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const tombstone = Boolean(envelope.deletedAt);
+  const defaultFolder: MailboxLiveFolder = tombstone
+    ? "trash"
+    : envelope.status === "pending"
+      ? "pending"
+      : "inbox";
+  const folder = tombstone
+    ? "trash"
+    : isLiveFolder(mailbox.folder)
+      ? mailbox.folder
+      : defaultFolder;
+  return {
+    starred: typeof mailbox.starred === "boolean" ? mailbox.starred : false,
+    unread: typeof mailbox.unread === "boolean" ? mailbox.unread : envelope.status === "pending",
+    folder,
+    updatedAt: typeof mailbox.updatedAt === "string" ? mailbox.updatedAt : null,
+  };
+}
+
+export function applyMailboxFlags(
+  envelope: StoredEnvelope,
+  patch: MailboxFlagsPatch,
+  now: string,
+): StoredEnvelope {
+  const current = readMailboxFlags(envelope);
+  const starred = patch.starred ?? current.starred;
+  const unread = patch.unread ?? current.unread;
+  const folder = patch.folder ?? current.folder;
+  const deletedAt =
+    patch.folder === "trash" ? (envelope.deletedAt ?? now) : envelope.deletedAt;
+  let status = envelope.status ?? "pending";
+  if (patch.unread === false) status = "delivered";
+  if (patch.unread === true) status = "pending";
+
+  return {
+    ...envelope,
+    status,
+    deletedAt,
+    metadata: {
+      ...(envelope.metadata ?? {}),
+      mailbox: {
+        starred,
+        unread,
+        folder: deletedAt ? "trash" : folder,
+        updatedAt: now,
+      },
+    },
+  };
+}
+
+export function envelopeToMailboxDescriptor(envelope: StoredEnvelope): MailboxDescriptor {
+  const flags = readMailboxFlags(envelope);
+  return {
+    messageId: envelope.messageId,
+    senderId: envelope.senderId,
+    recipientId: envelope.recipientId,
+    status: envelope.status ?? "pending",
+    createdAt: envelope.createdAt,
+    protectedHeaders: envelope.protectedHeaders,
+    contentCommitment: envelope.contentCommitment,
+    objectRef: envelope.objectRef,
+    isTombstone: Boolean(envelope.deletedAt),
+    deletedAt: envelope.deletedAt ?? null,
+    starred: flags.starred,
+    unread: flags.unread,
+    folder: flags.folder,
+  };
+}
+
+export function countMailbox(envelopes: readonly StoredEnvelope[]): MailboxCounts {
+  const counts = emptyMailboxCounts();
+  for (const envelope of envelopes) {
+    const flags = readMailboxFlags(envelope);
+    if (flags.folder === "trash" || envelope.deletedAt) {
+      counts.trash += 1;
+      continue;
+    }
+    if (INBOX_COUNT_FOLDERS.has(flags.folder)) counts.inbox += 1;
+    if (flags.folder === "requests") counts.requests += 1;
+    if (flags.folder === "sent") counts.sent += 1;
+    if (flags.folder === "drafts") counts.drafts += 1;
+    if (flags.folder === "outbox") counts.outbox += 1;
+    if (flags.folder === "archive") counts.archive += 1;
+    if (flags.folder === "spam") counts.spam += 1;
+    if (flags.unread && flags.folder !== "spam") counts.unread += 1;
+    if (flags.starred) counts.starred += 1;
+  }
+  return counts;
+}
+
+export function mailboxChangedSince(envelope: StoredEnvelope, since: string): boolean {
+  if (envelope.createdAt > since) return true;
+  if (envelope.deletedAt && envelope.deletedAt > since) return true;
+  const updatedAt = readMailboxFlags(envelope).updatedAt;
+  return Boolean(updatedAt && updatedAt > since);
+}
+
+export function maxMailboxTimestamp(
+  envelopes: readonly StoredEnvelope[],
+  fallback: string,
+): string {
+  let max = fallback;
+  for (const envelope of envelopes) {
+    for (const value of [
+      envelope.createdAt,
+      envelope.deletedAt,
+      readMailboxFlags(envelope).updatedAt,
+    ]) {
+      if (value && value > max) max = value;
+    }
+  }
+  return max;
+}
+
+export async function listAllRecipientEnvelopes(
+  repository: Pick<ApiRepository, "listRecipientEnvelopes">,
+  recipient: string,
+  includeTombstones = true,
+): Promise<StoredEnvelope[]> {
+  const items: StoredEnvelope[] = [];
+  let after: string | undefined;
+  for (let page = 0; page < LIST_WALK_MAX_PAGES; page += 1) {
+    const result = await repository.listRecipientEnvelopes(recipient, {
+      status: "all",
+      includeTombstones,
+      limit: LIST_WALK_PAGE_SIZE,
+      after,
+    });
+    items.push(...result.items);
+    if (!result.nextContinuationKey) break;
+    after = result.nextContinuationKey;
+  }
+  return items;
+}
+
+export async function buildMailboxSync(
+  repository: Pick<ApiRepository, "listRecipientEnvelopes">,
+  actor: string,
+  query: { sinceCursor?: string; cursor?: string; limit: number },
+): Promise<MailboxSyncPayload> {
+  const all = await listAllRecipientEnvelopes(repository, actor, true);
+  const counts = countMailbox(all);
+  const syncCursor = encodeCursor(
+    actor,
+    maxMailboxTimestamp(all, new Date().toISOString()),
+    MAILBOX_SYNC_SCOPE,
+  );
+
+  const since = query.sinceCursor
+    ? decodeCursor(query.sinceCursor, actor, MAILBOX_SYNC_SCOPE).continuationKey
+    : null;
+  const filtered = since
+    ? all.filter((envelope) => mailboxChangedSince(envelope, since))
+    : all.filter((envelope) => !envelope.deletedAt);
+
+  const after = query.cursor
+    ? decodeCursor(query.cursor, actor, MAILBOX_SYNC_PAGE_SCOPE).continuationKey
+    : undefined;
+  const page = paginate(filtered, PAGINATED_QUERY_ORDERINGS.listEnvelopes, {
+    limit: query.limit,
+    after,
+  });
+  const items = page.items.map(envelopeToMailboxDescriptor);
+  const deletedIds = query.sinceCursor
+    ? items.filter((item) => item.isTombstone).map((item) => item.messageId)
+    : [];
+
+  return {
+    items,
+    deletedIds,
+    nextCursor: page.nextContinuationKey
+      ? encodeCursor(actor, page.nextContinuationKey, MAILBOX_SYNC_PAGE_SCOPE)
+      : null,
+    hasMore: Boolean(page.nextContinuationKey),
+    syncCursor,
+    counts,
+  };
+}

--- a/src/server/api/mailbox-live.ts
+++ b/src/server/api/mailbox-live.ts
@@ -10,22 +10,14 @@ import type {
   StoredEnvelope,
 } from "./domain";
 import { encodeCursor, decodeCursor } from "./pagination";
-import {
-  paginate,
-  PAGINATED_QUERY_ORDERINGS,
-  type ApiRepository,
-} from "./repository";
+import { paginate, PAGINATED_QUERY_ORDERINGS, type ApiRepository } from "./repository";
 
 export const MAILBOX_SYNC_SCOPE = "mailbox_sync";
 export const MAILBOX_SYNC_PAGE_SCOPE = "mailbox_sync_page";
 const LIST_WALK_PAGE_SIZE = 100;
 const LIST_WALK_MAX_PAGES = 40;
 
-const INBOX_COUNT_FOLDERS = new Set<MailboxLiveFolder>([
-  "inbox",
-  "pending",
-  "requests",
-]);
+const INBOX_COUNT_FOLDERS = new Set<MailboxLiveFolder>(["inbox", "pending", "requests"]);
 
 const LIVE_FOLDERS = new Set<MailboxLiveFolder>([
   "inbox",
@@ -109,8 +101,7 @@ export function applyMailboxFlags(
   const starred = patch.starred ?? current.starred;
   const unread = patch.unread ?? current.unread;
   const folder = patch.folder ?? current.folder;
-  const deletedAt =
-    patch.folder === "trash" ? (envelope.deletedAt ?? now) : envelope.deletedAt;
+  const deletedAt = patch.folder === "trash" ? (envelope.deletedAt ?? now) : envelope.deletedAt;
   let status = envelope.status ?? "pending";
   if (patch.unread === false) status = "delivered";
   if (patch.unread === true) status = "pending";

--- a/src/server/api/mailbox-live.ts
+++ b/src/server/api/mailbox-live.ts
@@ -210,8 +210,9 @@ export async function listAllRecipientEnvelopes(
 export async function buildMailboxSync(
   repository: Pick<ApiRepository, "listRecipientEnvelopes">,
   actor: string,
-  query: { sinceCursor?: string; cursor?: string; limit: number },
+  query: { sinceCursor?: string; cursor?: string; limit?: number },
 ): Promise<MailboxSyncPayload> {
+  const limit = query.limit ?? 50;
   const all = await listAllRecipientEnvelopes(repository, actor, true);
   const counts = countMailbox(all);
   const syncCursor = encodeCursor(
@@ -231,7 +232,7 @@ export async function buildMailboxSync(
     ? decodeCursor(query.cursor, actor, MAILBOX_SYNC_PAGE_SCOPE).continuationKey
     : undefined;
   const page = paginate(filtered, PAGINATED_QUERY_ORDERINGS.listEnvelopes, {
-    limit: query.limit,
+    limit,
     after,
   });
   const items = page.items.map(envelopeToMailboxDescriptor);

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -1114,6 +1114,33 @@ export class MemoryApiRepository implements ApiRepository {
     });
   }
 
+  async patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: import("./domain").MailboxFlagsPatch,
+  ): Promise<StoredEnvelope> {
+    const { applyMailboxFlags } = await import("./mailbox-live");
+    return this.withEnvelopeLock(messageId, async () => {
+      const existing = this.envelopes.get(messageId);
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      if (existing.recipientId.toUpperCase().trim() !== recipient.toUpperCase().trim()) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "Cannot update an envelope belonging to another recipient",
+        );
+      }
+      if (existing.deletedAt && patch.folder && patch.folder !== "trash") {
+        throw new ApiError(409, "conflict", "Cannot move a deleted message");
+      }
+      const updated = applyMailboxFlags(existing, patch, new Date().toISOString());
+      this.envelopes.set(messageId, updated);
+      return structuredClone(updated);
+    });
+  }
+
   async getKeyDirectory(owner: string): Promise<KeyDirectoryRecord | null> {
     const dir = this.keyDirectories.get(owner.toUpperCase());
     return dir ? structuredClone(dir) : null;

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -26,6 +26,7 @@ import type {
   SenderRule,
   Session,
   StoredEnvelope,
+  MailboxFlagsPatch,
   UnknownSenderDecision,
   UnknownSenderRequest,
   User,
@@ -476,6 +477,11 @@ export interface ApiRepository {
   updateEnvelopeStatus(
     messageId: string,
     status: import("./domain").MailboxItemStatus,
+  ): Promise<StoredEnvelope>;
+  patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: MailboxFlagsPatch,
   ): Promise<StoredEnvelope>;
 
   // ---------------------------------------------------------------------------
@@ -1143,6 +1149,15 @@ export class ValidatedApiRepository implements ApiRepository {
     status: import("./domain").MailboxItemStatus,
   ): Promise<StoredEnvelope> {
     const result = await this.inner.updateEnvelopeStatus(messageId, status);
+    return validateRecord<StoredEnvelope>("storedEnvelope", result);
+  }
+
+  async patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: MailboxFlagsPatch,
+  ): Promise<StoredEnvelope> {
+    const result = await this.inner.patchMailboxFlags(messageId, recipient, patch);
     return validateRecord<StoredEnvelope>("storedEnvelope", result);
   }
 
@@ -1857,6 +1872,14 @@ export class RetryableApiRepository implements ApiRepository {
     status: import("./domain").MailboxItemStatus,
   ): Promise<StoredEnvelope> {
     return this.inner.updateEnvelopeStatus(messageId, status);
+  }
+
+  patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: MailboxFlagsPatch,
+  ): Promise<StoredEnvelope> {
+    return this.inner.patchMailboxFlags(messageId, recipient, patch);
   }
 
   getExternalWallets(owner: string): Promise<ExternalWallet[]> {

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1024,6 +1024,35 @@ export class StealthCoordinator extends DurableObjectBase {
     });
   }
 
+  async patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: import("./domain").MailboxFlagsPatch,
+  ): Promise<StoredEnvelope> {
+    const { applyMailboxFlags } = await import("./mailbox-live");
+    return this.runExclusive(`envelope:${messageId}`, async () => {
+      const existing = (await this.ctx.storage.get(`envelope:${messageId}`)) as
+        | StoredEnvelope
+        | undefined;
+      if (!existing) {
+        throw new ApiError(404, "not_found", `No envelope found for message ${messageId}`);
+      }
+      if (existing.recipientId.toUpperCase().trim() !== recipient.toUpperCase().trim()) {
+        throw new ApiError(
+          403,
+          "forbidden",
+          "Cannot update an envelope belonging to another recipient",
+        );
+      }
+      if (existing.deletedAt && patch.folder && patch.folder !== "trash") {
+        throw new ApiError(409, "conflict", "Cannot move a deleted message");
+      }
+      const updated = applyMailboxFlags(existing, patch, new Date().toISOString());
+      await this.ctx.storage.put(`envelope:${messageId}`, updated);
+      return updated;
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Issue #1952 (BETA-045) — Durable jobs, retries, DLQ, and receipt indexing
   // ---------------------------------------------------------------------------

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -484,6 +484,14 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("updateEnvelopeStatus");
     return this.inner.updateEnvelopeStatus(messageId, status);
   }
+  async patchMailboxFlags(
+    messageId: string,
+    recipient: string,
+    patch: import("../../../src/server/api/domain").MailboxFlagsPatch,
+  ) {
+    this.maybeFail("patchMailboxFlags");
+    return this.inner.patchMailboxFlags(messageId, recipient, patch);
+  }
   async listContacts(
     owner: string,
     options?: import("../../../src/server/api/repository").ContactQueryOptions,

--- a/tests/unit/api/web-data-access.contract.test.ts
+++ b/tests/unit/api/web-data-access.contract.test.ts
@@ -165,13 +165,27 @@ describe("client decoding matches OpenAPI schemas", () => {
 describe("query keys and cache invalidation rules", () => {
   it("query keys are stable, scoped tuples", () => {
     expect(queryKeys.mailbox.queue("GABC")).toEqual(["mailbox", "queue", "GABC"]);
+    expect(queryKeys.mailbox.sync("GABC")).toEqual(["mailbox", "sync", "GABC"]);
+    expect(queryKeys.mailbox.counts("GABC")).toEqual(["mailbox", "counts", "GABC"]);
+    expect(queryKeys.mailbox.delta("GABC")).toEqual(["mailbox", "delta", "GABC"]);
     expect(queryKeys.auth.session).toEqual(["auth", "session"]);
     expect(queryKeys.policies.policy("GABC")).toEqual(["policies", "GABC"]);
   });
 
   it("mutations invalidate the documented dependent queries", () => {
     expect(cacheInvalidations.sessionLogout()).toEqual([["auth", "session"]]);
-    expect(cacheInvalidations.tombstoneMessage("GABC")).toEqual([["mailbox", "queue", "GABC"]]);
+    expect(cacheInvalidations.tombstoneMessage("GABC")).toEqual([
+      ["mailbox", "queue", "GABC"],
+      ["mailbox", "sync", "GABC"],
+      ["mailbox", "counts", "GABC"],
+      ["mailbox", "delta", "GABC"],
+    ]);
+    expect(cacheInvalidations.patchMailboxFlags("GABC")).toEqual([
+      ["mailbox", "queue", "GABC"],
+      ["mailbox", "sync", "GABC"],
+      ["mailbox", "counts", "GABC"],
+      ["mailbox", "delta", "GABC"],
+    ]);
     expect(cacheInvalidations.updateMailboxPolicy("GABC")).toEqual([
       ["policies", "GABC"],
       ["policies", "reconciliation", "GABC"],

--- a/tests/unit/mail/live-mailbox.test.ts
+++ b/tests/unit/mail/live-mailbox.test.ts
@@ -79,17 +79,29 @@ describe("mailbox live helpers (BETA-054)", () => {
   it("counts inbox, unread, starred, archive, trash, and deletion", () => {
     const pending = envelope({ messageId: "1".repeat(64), status: "pending" });
     const starred = applyMailboxFlags(
-      envelope({ messageId: "2".repeat(64), status: "delivered", createdAt: "2026-08-17T11:00:00Z" }),
+      envelope({
+        messageId: "2".repeat(64),
+        status: "delivered",
+        createdAt: "2026-08-17T11:00:00Z",
+      }),
       { starred: true, unread: false },
       "2026-08-17T11:01:00Z",
     );
     const archived = applyMailboxFlags(
-      envelope({ messageId: "3".repeat(64), status: "delivered", createdAt: "2026-08-17T12:00:00Z" }),
+      envelope({
+        messageId: "3".repeat(64),
+        status: "delivered",
+        createdAt: "2026-08-17T12:00:00Z",
+      }),
       { folder: "archive", unread: false },
       "2026-08-17T12:01:00Z",
     );
     const trashed = applyMailboxFlags(
-      envelope({ messageId: "4".repeat(64), status: "delivered", createdAt: "2026-08-17T13:00:00Z" }),
+      envelope({
+        messageId: "4".repeat(64),
+        status: "delivered",
+        createdAt: "2026-08-17T13:00:00Z",
+      }),
       { folder: "trash" },
       "2026-08-17T13:01:00Z",
     );

--- a/tests/unit/mail/live-mailbox.test.ts
+++ b/tests/unit/mail/live-mailbox.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import type { Email } from "@/components/mail/data";
+import type { MailboxDescriptor } from "@/lib/api";
+import {
+  applyOverlayToCounts,
+  capMailboxWindow,
+  claimMailboxMutation,
+  emptyMailboxCounts,
+  mailboxMutationKey,
+  mergeMailboxDescriptors,
+} from "@/features/mail/live-mailbox";
+import {
+  applyMailboxFlags,
+  countMailbox,
+  envelopeToMailboxDescriptor,
+  mailboxChangedSince,
+} from "@/server/api/mailbox-live";
+import type { StoredEnvelope } from "@/server/api/domain";
+
+const SENDER = `G${"B".repeat(55)}`;
+const RECIPIENT = `G${"A".repeat(55)}`;
+const MSG = "a".repeat(64);
+
+function envelope(overrides: Partial<StoredEnvelope> = {}): StoredEnvelope {
+  return {
+    messageId: MSG,
+    senderId: SENDER,
+    recipientId: RECIPIENT,
+    ciphertext: "aGVsbG8=",
+    protectedHeaders: { alg: "dir", enc: "A256GCM", version: "v1" },
+    createdAt: "2026-08-17T10:00:00Z",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function descriptor(id: string, overrides: Partial<MailboxDescriptor> = {}): MailboxDescriptor {
+  return {
+    messageId: id,
+    senderId: SENDER,
+    recipientId: RECIPIENT,
+    status: "delivered",
+    createdAt: "2026-08-17T10:00:00Z",
+    protectedHeaders: {},
+    isTombstone: false,
+    deletedAt: null,
+    starred: false,
+    unread: false,
+    folder: "inbox",
+    ...overrides,
+  };
+}
+
+function email(id: string, overrides: Partial<Email> = {}): Email {
+  return {
+    id,
+    from: "Ada",
+    email: `${id}*stealth.mail`,
+    subject: id,
+    preview: "preview",
+    body: "body",
+    time: "Now",
+    unread: true,
+    starred: false,
+    folder: "inbox",
+    labels: [],
+    attachments: [],
+    avatarColor: "#5b6470",
+    ...overrides,
+  };
+}
+
+describe("mailbox live helpers (BETA-054)", () => {
+  it("counts an empty mailbox as zeros", () => {
+    expect(countMailbox([])).toEqual(emptyMailboxCounts());
+  });
+
+  it("counts inbox, unread, starred, archive, trash, and deletion", () => {
+    const pending = envelope({ messageId: "1".repeat(64), status: "pending" });
+    const starred = applyMailboxFlags(
+      envelope({ messageId: "2".repeat(64), status: "delivered", createdAt: "2026-08-17T11:00:00Z" }),
+      { starred: true, unread: false },
+      "2026-08-17T11:01:00Z",
+    );
+    const archived = applyMailboxFlags(
+      envelope({ messageId: "3".repeat(64), status: "delivered", createdAt: "2026-08-17T12:00:00Z" }),
+      { folder: "archive", unread: false },
+      "2026-08-17T12:01:00Z",
+    );
+    const trashed = applyMailboxFlags(
+      envelope({ messageId: "4".repeat(64), status: "delivered", createdAt: "2026-08-17T13:00:00Z" }),
+      { folder: "trash" },
+      "2026-08-17T13:01:00Z",
+    );
+
+    const counts = countMailbox([pending, starred, archived, trashed]);
+    expect(counts.inbox).toBe(2);
+    expect(counts.unread).toBe(1);
+    expect(counts.starred).toBe(1);
+    expect(counts.archive).toBe(1);
+    expect(counts.trash).toBe(1);
+    expect(envelopeToMailboxDescriptor(starred).starred).toBe(true);
+    expect(envelopeToMailboxDescriptor(archived).folder).toBe("archive");
+    expect(envelopeToMailboxDescriptor(trashed).isTombstone).toBe(true);
+  });
+
+  it("treats flag updates as incremental changes after the sync cursor", () => {
+    const updated = applyMailboxFlags(envelope(), { unread: false }, "2026-08-17T12:00:00Z");
+    expect(mailboxChangedSince(updated, "2026-08-17T11:00:00Z")).toBe(true);
+    expect(mailboxChangedSince(updated, "2026-08-17T12:00:00Z")).toBe(false);
+  });
+
+  it("merges cursor deltas, drops deletions, and caps the render window", () => {
+    const existing = [
+      descriptor("1".repeat(64), { createdAt: "2026-08-17T10:00:00Z" }),
+      descriptor("2".repeat(64), { createdAt: "2026-08-17T11:00:00Z" }),
+    ];
+    const merged = mergeMailboxDescriptors(
+      existing,
+      [descriptor("3".repeat(64), { createdAt: "2026-08-17T12:00:00Z", unread: true })],
+      ["1".repeat(64)],
+    );
+    expect(merged.map((item) => item.messageId)).toEqual(["3".repeat(64), "2".repeat(64)]);
+
+    const large = Array.from({ length: 250 }, (_, index) =>
+      descriptor(index.toString(16).padStart(64, "0"), {
+        createdAt: `2026-08-17T10:${String(index % 60).padStart(2, "0")}:00Z`,
+      }),
+    );
+    expect(capMailboxWindow(large, 200)).toHaveLength(200);
+  });
+
+  it("adjusts live counts for optimistic overlay patches and local inserts", () => {
+    const server = [email("a")];
+    const counts = applyOverlayToCounts(
+      { ...emptyMailboxCounts(), inbox: 1, unread: 1 },
+      {
+        patches: { a: { unread: false, starred: true, folder: "archive" } },
+        inserts: [email("local-sent", { folder: "sent", unread: false })],
+      },
+      server,
+    );
+    expect(counts.inbox).toBe(0);
+    expect(counts.archive).toBe(1);
+    expect(counts.unread).toBe(0);
+    expect(counts.starred).toBe(1);
+    expect(counts.sent).toBe(1);
+  });
+
+  it("claims an in-flight mutation once so retries do not duplicate it", () => {
+    const pending = new Set<string>();
+    const key = mailboxMutationKey("a", { starred: true });
+    expect(claimMailboxMutation(pending, key)).toBe(true);
+    expect(claimMailboxMutation(pending, key)).toBe(false);
+  });
+});

--- a/tests/unit/mail/shell-production-path.test.ts
+++ b/tests/unit/mail/shell-production-path.test.ts
@@ -36,7 +36,7 @@ describe("mail shell production path (BETA-053)", () => {
 
     expect(app).not.toContain("getDemoEmails");
     expect(overlays).not.toContain("getDemoEmails");
-    expect(source).toContain("useMailbox");
+    expect(source).toContain("useMailboxSync");
     expect(source).toContain("useTombstoneMessage");
     expect(source).toContain("import.meta.env.DEV");
     expect(source).toContain('import("@/features/mail/demo/demo-data")');

--- a/tests/unit/mailbox/mailbox-descriptor-mapping.test.ts
+++ b/tests/unit/mailbox/mailbox-descriptor-mapping.test.ts
@@ -29,10 +29,18 @@ describe("mailboxDescriptorToEmail (BETA-051)", () => {
     expect(email.subject).toBe("Encrypted message");
   });
 
-  it("maps a delivered descriptor to the inbox as read", () => {
-    const email = mailboxDescriptorToEmail(descriptor({ status: "delivered" }));
-    expect(email.folder).toBe("inbox");
-    expect(email.unread).toBe(false);
+  it("maps server starred, unread, and folder flags when present", () => {
+    const email = mailboxDescriptorToEmail(
+      descriptor({
+        status: "delivered",
+        starred: true,
+        unread: true,
+        folder: "archive",
+      }),
+    );
+    expect(email.folder).toBe("archive");
+    expect(email.starred).toBe(true);
+    expect(email.unread).toBe(true);
   });
 
   it("maps a tombstone to trash with a deleted label", () => {

--- a/tests/unit/mailbox/mailbox-sync.test.ts
+++ b/tests/unit/mailbox/mailbox-sync.test.ts
@@ -147,9 +147,9 @@ describe("Live mailbox sync API (BETA-054)", () => {
       `http://localhost/api/v1/mailbox/sync?sinceCursor=${encodeURIComponent(initial.data.syncCursor)}`,
     );
     const deltaJson = await delta.json();
-    expect(deltaJson.data.items.some((item: { messageId: string }) => item.messageId === MSG1)).toBe(
-      true,
-    );
+    expect(
+      deltaJson.data.items.some((item: { messageId: string }) => item.messageId === MSG1),
+    ).toBe(true);
   });
 
   it("rejects another actor patching a message and conflicts on deleted mail", async () => {

--- a/tests/unit/mailbox/mailbox-sync.test.ts
+++ b/tests/unit/mailbox/mailbox-sync.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { MemoryApiRepository } from "@/server/api/memory-repository";
+import { Route as MailboxSyncRoute } from "@/routes/api/v1/mailbox/sync";
+import { Route as MailboxCountsRoute } from "@/routes/api/v1/mailbox/counts";
+import { Route as MailboxMessageIdRoute } from "@/routes/api/v1/mailbox/$messageId";
+import { type StoredEnvelope } from "@/server/api/domain";
+
+const syncHandlers = MailboxSyncRoute.options.server!.handlers as any as {
+  GET: (ctx: { request: Request }) => Promise<Response>;
+};
+const countsHandlers = MailboxCountsRoute.options.server!.handlers as any as {
+  GET: (ctx: { request: Request }) => Promise<Response>;
+};
+const messageHandlers = MailboxMessageIdRoute.options.server!.handlers as any as {
+  GET: (ctx: { request: Request; params: { messageId: string } }) => Promise<Response>;
+  PATCH: (ctx: { request: Request; params: { messageId: string } }) => Promise<Response>;
+  DELETE: (ctx: { request: Request; params: { messageId: string } }) => Promise<Response>;
+};
+
+const ALICE = `G${"A".repeat(55)}`;
+const BOB = `G${"B".repeat(55)}`;
+const MSG1 = "1111111111111111111111111111111111111111111111111111111111111111";
+const MSG2 = "2222222222222222222222222222222222222222222222222222222222222222";
+const MSG3 = "3333333333333333333333333333333333333333333333333333333333333333";
+
+function makeEnvelope(overrides: Partial<StoredEnvelope>): StoredEnvelope {
+  return {
+    messageId: MSG1,
+    senderId: BOB,
+    recipientId: ALICE,
+    ciphertext: "aGVsbG8=",
+    protectedHeaders: { alg: "dir", enc: "A256GCM", version: "v1" },
+    createdAt: new Date().toISOString(),
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("Live mailbox sync API (BETA-054)", () => {
+  let repository: MemoryApiRepository;
+
+  beforeEach(() => {
+    process.env.STEALTH_CURSOR_SECRET = "test-cursor-secret-12345678901234567890";
+    repository = new MemoryApiRepository();
+    (globalThis as any).__stealthApiRepository = repository;
+  });
+
+  async function sync(url = "http://localhost/api/v1/mailbox/sync") {
+    return syncHandlers.GET({
+      request: new Request(url, { headers: { "x-stealth-address": ALICE } }),
+    });
+  }
+
+  it("rejects unauthenticated sync and counts requests", async () => {
+    const syncResponse = await syncHandlers.GET({
+      request: new Request("http://localhost/api/v1/mailbox/sync"),
+    });
+    const countsResponse = await countsHandlers.GET({
+      request: new Request("http://localhost/api/v1/mailbox/counts"),
+    });
+    expect(syncResponse.status).toBe(401);
+    expect(countsResponse.status).toBe(401);
+  });
+
+  it("returns an empty first page with zero folder counts", async () => {
+    const response = await sync();
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.data.items).toEqual([]);
+    expect(json.data.hasMore).toBe(false);
+    expect(json.data.counts).toEqual({
+      inbox: 0,
+      requests: 0,
+      sent: 0,
+      drafts: 0,
+      outbox: 0,
+      archive: 0,
+      spam: 0,
+      trash: 0,
+      unread: 0,
+      starred: 0,
+    });
+    expect(json.data.syncCursor).toEqual(expect.any(String));
+  });
+
+  it("pages the snapshot and keeps mailbox-wide counts accurate", async () => {
+    await repository.insertEnvelope(
+      makeEnvelope({ messageId: MSG1, createdAt: "2026-08-17T10:00:00Z" }),
+    );
+    await repository.insertEnvelope(
+      makeEnvelope({ messageId: MSG2, createdAt: "2026-08-17T11:00:00Z", status: "delivered" }),
+    );
+    await repository.insertEnvelope(
+      makeEnvelope({ messageId: MSG3, createdAt: "2026-08-17T12:00:00Z" }),
+    );
+
+    const first = await sync("http://localhost/api/v1/mailbox/sync?limit=2");
+    const firstJson = await first.json();
+    expect(first.status).toBe(200);
+    expect(firstJson.data.items).toHaveLength(2);
+    expect(firstJson.data.hasMore).toBe(true);
+    expect(firstJson.data.counts.inbox).toBe(3);
+    expect(firstJson.data.counts.unread).toBe(2);
+
+    const second = await sync(
+      `http://localhost/api/v1/mailbox/sync?limit=2&cursor=${encodeURIComponent(firstJson.data.nextCursor)}`,
+    );
+    const secondJson = await second.json();
+    expect(secondJson.data.items).toHaveLength(1);
+    expect(secondJson.data.hasMore).toBe(false);
+    expect(secondJson.data.counts.inbox).toBe(3);
+  });
+
+  it("patches read/star/archive, then returns those rows on the next delta", async () => {
+    await repository.insertEnvelope(
+      makeEnvelope({ messageId: MSG1, createdAt: "2026-08-17T10:00:00Z" }),
+    );
+    const initial = await (await sync()).json();
+
+    const patch = await messageHandlers.PATCH({
+      request: new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "PATCH",
+        headers: { "x-stealth-address": ALICE, "content-type": "application/json" },
+        body: JSON.stringify({ unread: false, starred: true, folder: "archive" }),
+      }),
+      params: { messageId: MSG1 },
+    });
+    const patched = await patch.json();
+    expect(patch.status).toBe(200);
+    expect(patched.data.starred).toBe(true);
+    expect(patched.data.unread).toBe(false);
+    expect(patched.data.folder).toBe("archive");
+
+    const counts = await countsHandlers.GET({
+      request: new Request("http://localhost/api/v1/mailbox/counts", {
+        headers: { "x-stealth-address": ALICE },
+      }),
+    });
+    const countsJson = await counts.json();
+    expect(countsJson.data.counts.archive).toBe(1);
+    expect(countsJson.data.counts.starred).toBe(1);
+    expect(countsJson.data.counts.unread).toBe(0);
+    expect(countsJson.data.counts.inbox).toBe(0);
+
+    const delta = await sync(
+      `http://localhost/api/v1/mailbox/sync?sinceCursor=${encodeURIComponent(initial.data.syncCursor)}`,
+    );
+    const deltaJson = await delta.json();
+    expect(deltaJson.data.items.some((item: { messageId: string }) => item.messageId === MSG1)).toBe(
+      true,
+    );
+  });
+
+  it("rejects another actor patching a message and conflicts on deleted mail", async () => {
+    await repository.insertEnvelope(makeEnvelope({ messageId: MSG1 }));
+
+    const forbidden = await messageHandlers.PATCH({
+      request: new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "PATCH",
+        headers: { "x-stealth-address": BOB, "content-type": "application/json" },
+        body: JSON.stringify({ starred: true }),
+      }),
+      params: { messageId: MSG1 },
+    });
+    expect(forbidden.status).toBe(403);
+
+    await messageHandlers.DELETE({
+      request: new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "DELETE",
+        headers: { "x-stealth-address": ALICE },
+      }),
+      params: { messageId: MSG1 },
+    });
+
+    const conflict = await messageHandlers.PATCH({
+      request: new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "PATCH",
+        headers: { "x-stealth-address": ALICE, "content-type": "application/json" },
+        body: JSON.stringify({ folder: "inbox" }),
+      }),
+      params: { messageId: MSG1 },
+    });
+    const conflictJson = await conflict.json();
+    expect(conflict.status).toBe(409);
+    expect(conflictJson.error.code).toBe("conflict");
+  });
+
+  it("includes tombstoned ids in the incremental sync payload", async () => {
+    await repository.insertEnvelope(
+      makeEnvelope({ messageId: MSG1, createdAt: "2026-08-17T10:00:00Z" }),
+    );
+    const initial = await (await sync()).json();
+
+    await messageHandlers.DELETE({
+      request: new Request(`http://localhost/api/v1/mailbox/${MSG1}`, {
+        method: "DELETE",
+        headers: { "x-stealth-address": ALICE },
+      }),
+      params: { messageId: MSG1 },
+    });
+
+    const delta = await sync(
+      `http://localhost/api/v1/mailbox/sync?sinceCursor=${encodeURIComponent(initial.data.syncCursor)}`,
+    );
+    const json = await delta.json();
+    expect(json.data.deletedIds).toContain(MSG1);
+    expect(json.data.counts.trash).toBe(1);
+    expect(json.data.counts.inbox).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary

Closes #1961 (BETA-054). Replaces in-memory seeded mail data with live mailbox sync, cursor-based pagination, real-time folder counts, and optimistic mutation handling across tabs.

    Note: This branch (feat/beta-054-live-mailbox) is stacked on top of the unmerged mail-shell branch. Once the shell PR merges, this diff will reflect only the BETA-054 changes.

Key Changes

    Live Sync & Data Layer: Integrated GET /api/v1/mailbox/sync using cursor-based pagination with sinceCursor deltas and GET /api/v1/mailbox/counts for live API data binding.

    Folder & Unread Counts: Added real-time count resolution across all 10 mailbox views: inbox, requests, sent, drafts, outbox, archive, spam, trash, unread, and starred.

    Optimistic Updates & Reconciliation: Built optimistic UI interactions for read, star, and archive actions featuring automatic rollback on failure, in-flight mutation deduplication, and cross-tab state syncing via BroadcastChannel.

    DOM Performance: Applied list pagination paired with a 200-row render cap to prevent unbounded DOM node growth on high-volume mailboxes.

Verification & Testing

    Unit Tests: Executed focused test suite covering sync deltas, optimistic state rollbacks, cross-tab events, and list limits (39 passed).

    CI Verification: Deferred full lint, type-check, and Playwright execution to GitHub Actions for complete CI validation.