### PR TITLE
feat(mail): offline detection, reconnect recovery, and consistent error states (BETA-071)

### DIFF
--- a/src/components/mail/Compose.tsx
+++ b/src/components/mail/Compose.tsx
@@ -44,6 +44,13 @@ import { SendProgress, type FailureInspectionDetails } from "@/features/compose/
 import { useFreighter } from "@/features/onboarding/useFreighter";
 import { resolveSenderAddress } from "@/services/stellar/wallet";
 import { patchEntry } from "@/services/storage/outbox";
+import {
+  clearUnsentDraft,
+  readUnsentDraft,
+  restoreDraftIfBlank,
+  saveUnsentDraft,
+} from "@/features/mail/unsent-work";
+import { claimOnce, classifyAppFailure, releaseOnce } from "@/lib/api";
 const EMPTY_BLOCKED: string[] = [];
 const EMPTY_RESOLVED: RecipientReadiness[] = [];
 
@@ -85,6 +92,7 @@ export function Compose({
   const [canRetry, setCanRetry] = useState(true);
   const [isCommitted, setIsCommitted] = useState(false);
   const pipelineRef = useRef<SendPipeline | null>(null);
+  const sendLock = useRef(new Set<string>());
   const [encrypted, setEncrypted] = useState(true);
   const [receipt, setReceipt] = useState(true);
   const [postage, setPostage] = useState(initialPostage);
@@ -128,9 +136,13 @@ export function Compose({
   // Hydrate / reset form when opening or closing
   useEffect(() => {
     if (open) {
-      setTo(initialTo);
-      setSubject(initialSubject);
-      setBody(initialBody);
+      const restored = restoreDraftIfBlank(
+        { to: initialTo, subject: initialSubject, body: initialBody },
+        readUnsentDraft(),
+      );
+      setTo(restored.to);
+      setSubject(restored.subject);
+      setBody(restored.body);
       setSendStages([]);
       setSendError(null);
       setFailureDetails(null);
@@ -138,7 +150,7 @@ export function Compose({
       setCanRetry(true);
       setIsCommitted(false);
       pipelineRef.current = null;
-      setPostage(initialPostage);
+      setPostage(restored.restored && restored.postage ? restored.postage : initialPostage);
       postageManuallySet.current = false;
     } else {
       setTo("");
@@ -160,6 +172,14 @@ export function Compose({
       postageManuallySet.current = false;
     }
   }, [open, initialTo, initialSubject, initialBody, initialPostage]);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => {
+      saveUnsentDraft({ to, subject, body, postage });
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [open, to, subject, body, postage]);
 
   // Fetch relay status when compose opens
   useEffect(() => {
@@ -308,6 +328,16 @@ export function Compose({
     });
     if (!isValid) return;
 
+    if (!claimOnce(sendLock.current, "compose-send")) return;
+
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      saveUnsentDraft({ to, subject, body, postage });
+      setSendError("You are offline. The draft is saved on this device.");
+      onShowToast?.("Offline — unsent draft kept");
+      releaseOnce(sendLock.current, "compose-send");
+      return;
+    }
+
     setIsSending(true);
 
     // Run the staged send pipeline (immediate send only).
@@ -340,10 +370,24 @@ export function Compose({
       setSupportId(pipeline.supportId);
       setSendStages(pipeline.getStages());
 
-      const outcome = await pipeline.run();
+      let outcome: Awaited<ReturnType<SendPipeline["run"]>>;
+      try {
+        outcome = await pipeline.run();
+      } catch (error) {
+        setIsSending(false);
+        saveUnsentDraft({ to, subject, body, postage });
+        setSendError(classifyAppFailure(error).message);
+        onShowToast?.("Send failed — unsent draft kept");
+        releaseOnce(sendLock.current, "compose-send");
+        return;
+      }
 
       if (!outcome.ok) {
         setIsSending(false);
+        saveUnsentDraft({ to, subject, body, postage });
+        const failure = classifyAppFailure(new Error(outcome.message), {
+          online: typeof navigator === "undefined" ? true : navigator.onLine,
+        });
         setCanRetry(outcome.canRetry);
         setIsCommitted(outcome.isCommitted);
         setFailureDetails({
@@ -363,9 +407,10 @@ export function Compose({
           setSendError("No Stellar wallet detected. Unlock Freighter, then retry.");
           onShowToast?.("Wallet unavailable");
         } else {
-          setSendError(outcome.message);
-          onShowToast?.("Send failed — you can retry");
+          setSendError(failure.message);
+          onShowToast?.("Send failed — unsent draft kept");
         }
+        releaseOnce(sendLock.current, "compose-send");
         return;
       }
 
@@ -374,6 +419,7 @@ export function Compose({
       setFailureDetails(null);
     }
 
+    clearUnsentDraft();
     onSubmit?.({
       to: to.trim(),
       subject: subject.trim(),
@@ -386,6 +432,7 @@ export function Compose({
       mode: scheduled ? "schedule" : mode,
     });
     setIsSending(false);
+    releaseOnce(sendLock.current, "compose-send");
     onClose();
     onShowToast?.(getSuccessToastMessage(scheduled, isTrustedSender(quoteState), postage));
   };

--- a/src/components/mail/EmailView.tsx
+++ b/src/components/mail/EmailView.tsx
@@ -31,9 +31,12 @@ import { OTPCard, detectOtp } from "@/features/otp";
 import { ConvertSenderButton, SenderBadge } from "@/features/sender-conversion";
 import { SnoozeBanner } from "@/features/snooze";
 import { MailReaderSkeleton } from "@/features/design-system";
+import { DegradedStateBanner } from "@/features/design-system/feedback/DegradedStateBanner";
 import type { MailThread } from "@/features/mail/live-thread";
 import { canRenderBody, isTrustedContent } from "@/features/mail/live-thread";
 import type { ThreadReadView } from "@/features/mail/useThreadRead";
+import type { ClassifiedMailSourceError } from "@/features/mail/source-view";
+import { classifyAppFailure } from "@/lib/api";
 import { parseSafeContent, type BodyBlock as SafeBodyBlock } from "@/features/mail/safe-rendering";
 import { ProvenancePanel } from "./ProvenancePanel";
 import { EmailTrustBadges } from "./EmailTrustBadges";
@@ -897,25 +900,19 @@ function ThreadReadError({
   failure,
   onRetry,
 }: {
-  failure: { kind: string; message: string; retryable: boolean };
+  failure: ClassifiedMailSourceError;
   onRetry?: () => void;
 }) {
+  const classified = classifyAppFailure(failure.error, {
+    online: failure.kind !== "offline",
+  });
   return (
-    <div
-      role="alert"
-      className="mt-5 rounded-lg border border-red-300/20 bg-red-300/[0.04] px-3 py-3"
-    >
-      <p className="text-xs font-medium text-foreground">{failure.message}</p>
-      {failure.retryable && onRetry ? (
-        <button
-          type="button"
-          onClick={onRetry}
-          className="mt-2 rounded-md border border-red-300/15 bg-red-300/[0.06] px-2.5 py-1 text-[10px] font-medium text-red-200 transition hover:bg-red-300/[0.12]"
-        >
-          Retry
-        </button>
-      ) : null}
-    </div>
+    <DegradedStateBanner
+      failure={classified}
+      compact
+      className="mx-0 mb-0 mt-5"
+      onRetry={onRetry}
+    />
   );
 }
 

--- a/src/features/design-system/feedback/DegradedStateBanner.tsx
+++ b/src/features/design-system/feedback/DegradedStateBanner.tsx
@@ -1,0 +1,72 @@
+import { Copy, RefreshCw, ShieldAlert, WifiOff } from "lucide-react";
+
+import { ActionButton } from "../components/action-button";
+import { cn } from "@/lib/utils";
+import type { ClassifiedAppFailure } from "@/lib/api";
+
+export function DegradedStateBanner({
+  failure,
+  onRetry,
+  onReauthenticate,
+  compact = false,
+  className,
+}: {
+  failure: ClassifiedAppFailure;
+  onRetry?: () => void;
+  onReauthenticate?: () => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  const copySupportId = failure.actions.includes("copy_support_id") && failure.supportId;
+  const retry = failure.actions.includes("retry") && onRetry;
+  const signIn = failure.actions.includes("reauthenticate") && onReauthenticate;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={cn(
+        compact
+          ? "mx-3 mb-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-50"
+          : "mx-3 mt-2 flex flex-wrap items-center gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-50",
+        className,
+      )}
+    >
+      {failure.kind === "offline" ? (
+        <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      ) : (
+        <ShieldAlert className="h-4 w-4 shrink-0" aria-hidden="true" />
+      )}
+      <p className="min-w-0 flex-1">{failure.message}</p>
+      {failure.preservedWork ? (
+        <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-amber-100/80">
+          Work kept
+        </span>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {retry ? (
+          <ActionButton size="sm" onClick={onRetry}>
+            <RefreshCw className="h-3 w-3" aria-hidden="true" />
+            Retry
+          </ActionButton>
+        ) : null}
+        {signIn ? (
+          <ActionButton size="sm" onClick={onReauthenticate}>
+            Sign in
+          </ActionButton>
+        ) : null}
+        {copySupportId ? (
+          <ActionButton
+            size="sm"
+            onClick={() => {
+              void navigator.clipboard?.writeText(failure.supportId ?? "");
+            }}
+          >
+            <Copy className="h-3 w-3" aria-hidden="true" />
+            Copy support ID
+          </ActionButton>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/design-system/index.ts
+++ b/src/features/design-system/index.ts
@@ -4,6 +4,7 @@ export { EmptyState } from "./components/empty-state";
 export { Surface } from "./components/surface";
 export { FeedbackViewport } from "./feedback/feedback-viewport";
 export { useFeedback } from "./feedback/use-feedback";
+export { DegradedStateBanner } from "./feedback/DegradedStateBanner";
 
 export type { ActionButtonProps } from "./components/action-button";
 export type { EmptyStateProps } from "./components/empty-state";

--- a/src/features/mail/index.ts
+++ b/src/features/mail/index.ts
@@ -14,6 +14,8 @@ export * from "./useRequests";
 export * from "./useSettings";
 export * from "./workspace";
 export * from "./source-view";
+export * from "./useConnectivity";
+export * from "./unsent-work";
 export * from "./navigation";
 export { MailApp } from "./shell/MailApp";
 export type { MailAppProps } from "./shell/MailApp";

--- a/src/features/mail/shell/MailApp.tsx
+++ b/src/features/mail/shell/MailApp.tsx
@@ -23,6 +23,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { useCalendar } from "@/features/calendar";
 import { FeedbackViewport } from "@/features/design-system/feedback/feedback-viewport";
 import { useFeedback } from "@/features/design-system/feedback/use-feedback";
+import { DegradedStateBanner } from "@/features/design-system/feedback/DegradedStateBanner";
 import { useLayoutPreferences, usePreferences } from "@/features/preferences";
 import { useSenderConversion } from "@/features/sender-conversion";
 import { useSnooze } from "@/features/snooze";
@@ -39,6 +40,7 @@ import { useRequests } from "../useRequests";
 import { useThreadRead } from "../useThreadRead";
 import { MailMailboxStatus } from "./MailMailboxStatus";
 import { MailOverlayStack } from "./MailOverlayStack";
+import { offlineAppFailure } from "@/lib/api";
 
 // BETA-074 (Issue #1981) — the requests triage board and the sender journey are
 // large feature surfaces only shown on demand. Loading them as async chunks
@@ -279,6 +281,15 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
                 onMarkNotificationRead={notificationCenter.markRead}
                 onMarkAllNotificationsRead={notificationCenter.markAllRead}
               />
+              {source.connectivity.paused &&
+              source.sourceView.kind !== "error" &&
+              !blockingSource ? (
+                <DegradedStateBanner
+                  failure={offlineAppFailure()}
+                  compact
+                  onRetry={() => void source.retry()}
+                />
+              ) : null}
               {source.sourceView.kind === "error" && source.sourceView.hasCachedData ? (
                 <MailMailboxStatus
                   view={source.sourceView}

--- a/src/features/mail/shell/MailMailboxStatus.tsx
+++ b/src/features/mail/shell/MailMailboxStatus.tsx
@@ -1,9 +1,6 @@
-import {
-  ActionButton,
-  EmptyState,
-  MailListSkeleton,
-  MailReaderSkeleton,
-} from "@/features/design-system";
+import { EmptyState, MailListSkeleton, MailReaderSkeleton } from "@/features/design-system";
+import { DegradedStateBanner } from "@/features/design-system/feedback/DegradedStateBanner";
+import { classifyAppFailure } from "@/lib/api";
 import type { MailSourceView } from "../source-view";
 
 export function MailMailboxStatus({
@@ -32,43 +29,37 @@ export function MailMailboxStatus({
   }
 
   if (view.kind === "error") {
-    const signIn = view.failure.kind === "unauthorized" || view.failure.kind === "session_expired";
-    return (
-      <div
-        role="alert"
-        className={
+    const failure = classifyAppFailure(view.failure.error, {
+      online: view.failure.kind !== "offline",
+    });
+    const signIn = failure.kind === "unauthorized";
+
+    if (compact) {
+      return (
+        <DegradedStateBanner
+          failure={failure}
           compact
-            ? "mx-3 mb-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-100"
-            : "flex flex-1 items-center justify-center p-6"
-        }
-      >
-        {compact ? (
-          <div className="flex items-center justify-between gap-3">
-            <p>{view.failure.message}</p>
-            {view.failure.retryable ? (
-              <ActionButton size="sm" onClick={onRetry}>
-                Retry
-              </ActionButton>
-            ) : signIn ? (
-              <ActionButton size="sm" onClick={onSignIn}>
-                Sign in
-              </ActionButton>
-            ) : null}
-          </div>
-        ) : (
-          <EmptyState
-            eyebrow="Mailbox"
-            title={signIn ? "Session expired" : "Mailbox unavailable"}
-            description={view.failure.message}
-            action={
-              view.failure.retryable ? (
-                <ActionButton onClick={onRetry}>Retry</ActionButton>
-              ) : signIn ? (
-                <ActionButton onClick={onSignIn}>Sign in</ActionButton>
-              ) : null
-            }
-          />
-        )}
+          onRetry={onRetry}
+          onReauthenticate={onSignIn}
+        />
+      );
+    }
+
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <EmptyState
+          eyebrow="Mailbox"
+          title={signIn ? "Session expired" : "Mailbox unavailable"}
+          description={view.failure.message}
+          action={
+            <DegradedStateBanner
+              failure={failure}
+              className="mx-0 mt-0"
+              onRetry={onRetry}
+              onReauthenticate={onSignIn}
+            />
+          }
+        />
       </div>
     );
   }

--- a/src/features/mail/source-view.ts
+++ b/src/features/mail/source-view.ts
@@ -3,12 +3,7 @@
 // Pure so the shell can render truthful live state without fake delays.
 // ---------------------------------------------------------------------------
 
-import {
-  errorLabel,
-  isApiClientError,
-  normalizeApiClientError,
-  type ApiClientError,
-} from "@/lib/api";
+import { classifyAppFailure, type ApiClientError, type AppFailureAction } from "@/lib/api";
 
 export type MailSourceKind = "loading" | "ready" | "empty" | "error";
 
@@ -19,6 +14,8 @@ export type MailSourceFailureKind =
   | "timeout"
   | "rate_limited"
   | "dependency_failure"
+  | "dependency_down"
+  | "conflict"
   | "unknown";
 
 export interface ClassifiedMailSourceError {
@@ -26,6 +23,8 @@ export interface ClassifiedMailSourceError {
   message: string;
   retryable: boolean;
   error: ApiClientError;
+  supportId?: string;
+  actions?: AppFailureAction[];
 }
 
 export type MailSourceView =
@@ -53,73 +52,21 @@ export interface MailSourceSignals {
 }
 
 export function classifyMailSourceError(error: unknown, online = true): ClassifiedMailSourceError {
-  const normalized = normalizeApiClientError(error);
-  const message = errorLabel(normalized).toLowerCase();
-  const raw = `${normalized.code} ${normalized.message} ${message}`.toLowerCase();
-
-  if (!online || raw.includes("offline") || raw.includes("network")) {
-    return {
-      kind: "offline",
-      message: "You appear to be offline. Check your connection and retry.",
-      retryable: true,
-      error: normalized,
-    };
-  }
-
-  if (normalized.code === "unauthorized") {
-    return {
-      kind: "unauthorized",
-      message: errorLabel(normalized),
-      retryable: false,
-      error: normalized,
-    };
-  }
-
-  if (normalized.code === "session_expired") {
-    return {
-      kind: "session_expired",
-      message: errorLabel(normalized),
-      retryable: false,
-      error: normalized,
-    };
-  }
-
-  if (normalized.code === "rate_limited") {
-    return {
-      kind: "rate_limited",
-      message: errorLabel(normalized),
-      retryable: true,
-      error: normalized,
-    };
-  }
-
-  if (raw.includes("timeout") || raw.includes("timed out")) {
-    return {
-      kind: "timeout",
-      message: "The mailbox request timed out. Retry without sending the action again.",
-      retryable: true,
-      error: normalized,
-    };
-  }
-
-  if (
-    normalized.code === "dependency_failure" ||
-    normalized.retryClassification === "transient" ||
-    normalized.retryable
-  ) {
-    return {
-      kind: "dependency_failure",
-      message: errorLabel(normalized),
-      retryable: true,
-      error: normalized,
-    };
-  }
+  const classified = classifyAppFailure(error, { online });
+  const kind: MailSourceFailureKind =
+    classified.error.code === "session_expired"
+      ? "session_expired"
+      : classified.kind === "dependency_down"
+        ? "dependency_down"
+        : classified.kind;
 
   return {
-    kind: "unknown",
-    message: isApiClientError(error) ? errorLabel(error) : normalized.message,
-    retryable: false,
-    error: normalized,
+    kind,
+    message: classified.message,
+    retryable: classified.retryable,
+    error: classified.error,
+    supportId: classified.supportId,
+    actions: classified.actions,
   };
 }
 

--- a/src/features/mail/unsent-work.ts
+++ b/src/features/mail/unsent-work.ts
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------
+// BETA-071 (Issue #1978) — persist unsent compose work across offline/errors.
+// ---------------------------------------------------------------------------
+
+export const UNSENT_DRAFT_STORAGE_KEY = "stealth.mail.unsentDraft";
+
+export interface UnsentDraft {
+  to: string;
+  subject: string;
+  body: string;
+  postage: string;
+  updatedAt: string;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export function memoryStorage(seed: Record<string, string> = {}): StorageLike {
+  const data = { ...seed };
+  return {
+    getItem: (key) => (key in data ? data[key] : null),
+    setItem: (key, value) => {
+      data[key] = value;
+    },
+    removeItem: (key) => {
+      delete data[key];
+    },
+  };
+}
+
+export function defaultUnsentStorage(): StorageLike | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage;
+}
+
+export function isDraftEmpty(draft: Pick<UnsentDraft, "to" | "subject" | "body">): boolean {
+  return !draft.to.trim() && !draft.subject.trim() && !draft.body.trim();
+}
+
+export function saveUnsentDraft(
+  draft: Omit<UnsentDraft, "updatedAt">,
+  storage: StorageLike | null = defaultUnsentStorage(),
+  now = () => new Date().toISOString(),
+): UnsentDraft | null {
+  if (!storage) return null;
+  if (isDraftEmpty(draft)) {
+    storage.removeItem(UNSENT_DRAFT_STORAGE_KEY);
+    return null;
+  }
+  const record: UnsentDraft = { ...draft, updatedAt: now() };
+  try {
+    storage.setItem(UNSENT_DRAFT_STORAGE_KEY, JSON.stringify(record));
+    return record;
+  } catch {
+    return record;
+  }
+}
+
+export function readUnsentDraft(
+  storage: StorageLike | null = defaultUnsentStorage(),
+): UnsentDraft | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(UNSENT_DRAFT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<UnsentDraft>;
+    if (typeof parsed.to !== "string" || typeof parsed.body !== "string") return null;
+    return {
+      to: parsed.to,
+      subject: typeof parsed.subject === "string" ? parsed.subject : "",
+      body: parsed.body,
+      postage: typeof parsed.postage === "string" ? parsed.postage : "0.0001",
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearUnsentDraft(storage: StorageLike | null = defaultUnsentStorage()): void {
+  storage?.removeItem(UNSENT_DRAFT_STORAGE_KEY);
+}
+
+export function restoreDraftIfBlank(
+  initial: { to?: string; subject?: string; body?: string },
+  stored: UnsentDraft | null,
+): { to: string; subject: string; body: string; postage?: string; restored: boolean } {
+  const hasInitial = Boolean(initial.to?.trim() || initial.subject?.trim() || initial.body?.trim());
+  if (hasInitial || !stored) {
+    return {
+      to: initial.to ?? "",
+      subject: initial.subject ?? "",
+      body: initial.body ?? "",
+      restored: false,
+    };
+  }
+  return {
+    to: stored.to,
+    subject: stored.subject,
+    body: stored.body,
+    postage: stored.postage,
+    restored: true,
+  };
+}

--- a/src/features/mail/useConnectivity.ts
+++ b/src/features/mail/useConnectivity.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import { readDocumentVisible, readNavigatorOnline, shouldPauseSync } from "@/lib/api";
+
+export function useConnectivity() {
+  const [online, setOnline] = useState(() =>
+    typeof navigator === "undefined" ? true : readNavigatorOnline(navigator),
+  );
+  const [visible, setVisible] = useState(() =>
+    typeof document === "undefined" ? true : readDocumentVisible(document),
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onOnline = () => setOnline(true);
+    const onOffline = () => setOnline(false);
+    const onVisibility = () => setVisible(readDocumentVisible(document));
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+    document.addEventListener("visibilitychange", onVisibility);
+    setOnline(readNavigatorOnline(navigator));
+    setVisible(readDocumentVisible(document));
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return {
+    online,
+    visible,
+    paused: shouldPauseSync(online, visible),
+  };
+}

--- a/src/features/mail/useMailSource.ts
+++ b/src/features/mail/useMailSource.ts
@@ -9,6 +9,7 @@ import { errorLabel, normalizeApiClientError, type MailboxFlagsPatch } from "@/l
 import { sessionActor, useSession } from "./useSession";
 import { useTombstoneMessage } from "./useMailbox";
 import { useMailboxSync } from "./useMailboxSync";
+import { useConnectivity } from "./useConnectivity";
 import { resolveMailSourceView, type MailSourceView } from "./source-view";
 import {
   applyEmailPatch,
@@ -37,9 +38,12 @@ export type TrashResult = MailMutationResult;
 export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   const session = useSession({ enabled: !isDemoMode });
   const actor = sessionActor(session.data);
+  const connectivity = useConnectivity();
   const mailbox = useMailboxSync({
     actor: actor ?? "anonymous",
     enabled: Boolean(actor) && !isDemoMode,
+    online: connectivity.online,
+    visible: connectivity.visible,
   });
   const tombstone = useTombstoneMessage(actor ?? "anonymous");
 
@@ -84,7 +88,7 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     async (email: Email, patch: MailboxFlagsPatch): Promise<MailMutationResult> => {
       const key = mailboxMutationKey(email.id, patch);
       if (!claimMailboxMutation(pendingMutations.current, key)) {
-        return { ok: true };
+        return { ok: false, reason: "Action already in progress" };
       }
 
       const displayPatch = emailPatchFromFlags(patch);
@@ -127,7 +131,6 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     if (mailbox.isError) await mailbox.refetch();
   }, [mailbox, session]);
 
-  const online = typeof navigator === "undefined" ? true : navigator.onLine;
   const sourceView: MailSourceView = resolveMailSourceView({
     isDemoMode,
     demoReady,
@@ -138,7 +141,7 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     mailboxError: mailbox.error,
     mailboxFetched: mailbox.isFetched,
     emailCount: emails.length,
-    online,
+    online: connectivity.online,
   });
 
   return {
@@ -151,6 +154,7 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     mutateMailbox,
     retry,
     sourceView,
+    connectivity,
     isDemoMode,
     hasMore: isDemoMode ? false : mailbox.hasMore,
     isLoadingMore: isDemoMode ? false : mailbox.isFetchingNextPage,

--- a/src/features/mail/useMailboxSync.ts
+++ b/src/features/mail/useMailboxSync.ts
@@ -11,7 +11,13 @@ import {
   type InfiniteData,
 } from "@tanstack/react-query";
 
-import { cacheInvalidations, queryKeys, sharedTypedApi as api } from "@/lib/api";
+import {
+  cacheInvalidations,
+  queryKeys,
+  sharedTypedApi as api,
+  shouldPauseSync,
+  shouldResumeSync,
+} from "@/lib/api";
 import type {
   MailboxCounts,
   MailboxDescriptor,
@@ -34,6 +40,8 @@ import {
 export interface UseMailboxSyncOptions {
   actor: string;
   enabled?: boolean;
+  online?: boolean;
+  visible?: boolean;
 }
 
 function mergeSyncPages(
@@ -64,11 +72,19 @@ function mergeSyncPages(
   };
 }
 
-export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions) {
+export function useMailboxSync({
+  actor,
+  enabled = true,
+  online = true,
+  visible = true,
+}: UseMailboxSyncOptions) {
   const queryClient = useQueryClient();
   const tabIdRef = useRef(`tab_${Math.random().toString(36).slice(2, 10)}`);
+  const pausedRef = useRef(false);
   const syncKey = queryKeys.mailbox.sync(actor);
   const countsKey = queryKeys.mailbox.counts(actor);
+  const paused = shouldPauseSync(online, visible);
+  const liveEnabled = enabled && online;
 
   const listQuery = useInfiniteQuery({
     queryKey: syncKey,
@@ -78,6 +94,9 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
     getNextPageParam: (lastPage) =>
       lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
     enabled,
+    refetchOnWindowFocus: !paused,
+    refetchOnReconnect: false,
+    retry: online ? 2 : 0,
   });
 
   const latestPage = listQuery.data?.pages.at(-1);
@@ -98,9 +117,10 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
       if (!since) return null;
       return api.mailbox.sync({ sinceCursor: since, limit: 100 }, signal);
     },
-    enabled: enabled && Boolean(sinceCursor),
-    refetchInterval: MAILBOX_DELTA_INTERVAL_MS,
-    refetchOnWindowFocus: true,
+    enabled: liveEnabled && Boolean(sinceCursor),
+    refetchInterval: paused ? false : MAILBOX_DELTA_INTERVAL_MS,
+    refetchOnWindowFocus: !paused,
+    refetchOnReconnect: false,
   });
 
   const countsQuery = useQuery({
@@ -108,6 +128,9 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
     queryFn: ({ signal }) => api.mailbox.getCounts(signal),
     enabled,
     staleTime: 10_000,
+    refetchOnWindowFocus: !paused,
+    refetchOnReconnect: false,
+    retry: online ? 2 : 0,
   });
 
   // BETA-074 — a stable latest-page snapshot held in a ref so the broadcast
@@ -221,6 +244,13 @@ export function useMailboxSync({ actor, enabled = true }: UseMailboxSyncOptions)
   const refetch = useCallback(async () => {
     await Promise.all([listQuery.refetch(), countsQuery.refetch(), deltaQuery.refetch()]);
   }, [countsQuery, deltaQuery, listQuery]);
+
+  useEffect(() => {
+    const resume = shouldResumeSync(pausedRef.current, paused);
+    pausedRef.current = paused;
+    if (!resume || !enabled) return;
+    void refetch();
+  }, [enabled, paused, refetch]);
 
   return {
     emails,

--- a/src/features/mail/usePolicy.ts
+++ b/src/features/mail/usePolicy.ts
@@ -4,7 +4,13 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { sharedTypedApi as api, queryKeys, cacheInvalidations } from "@/lib/api";
+import {
+  sharedTypedApi as api,
+  queryKeys,
+  cacheInvalidations,
+  claimOnce,
+  releaseOnce,
+} from "@/lib/api";
 import type { MailboxPolicy, MailboxPolicyWrite } from "@/lib/api";
 
 /** Reads the mailbox policy for an owner through the typed policies client. */
@@ -16,12 +22,24 @@ export function useMailboxPolicy(owner: string | null, enabled = true) {
   });
 }
 
+const policyWrites = new Set<string>();
+
 /** Updates the mailbox policy and invalidates policy + settings caches. */
 export function useUpdateMailboxPolicy(owner: string | null) {
   const queryClient = useQueryClient();
 
   return useMutation<MailboxPolicy, Error, MailboxPolicyWrite>({
-    mutationFn: (policy) => api.policies.update(owner ?? "", policy),
+    mutationFn: async (policy) => {
+      const key = `policy:${owner ?? "anonymous"}`;
+      if (!claimOnce(policyWrites, key)) {
+        throw new Error("Policy update already in progress");
+      }
+      try {
+        return await api.policies.update(owner ?? "", policy);
+      } finally {
+        releaseOnce(policyWrites, key);
+      }
+    },
     onSuccess: async () => {
       for (const key of cacheInvalidations.updateMailboxPolicy(owner ?? "anonymous")) {
         await queryClient.invalidateQueries({ queryKey: key });

--- a/src/features/mail/useThreadRead.ts
+++ b/src/features/mail/useThreadRead.ts
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { Email } from "@/components/mail/data";
 import { queryKeys, sharedTypedApi as api } from "@/lib/api";
+import { useConnectivity } from "./useConnectivity";
 import type { MailboxSealedMessage } from "@/lib/api";
 import { applyThreadMessageToEmail, buildMailThread, siblingMessageIds } from "./live-thread";
 import { getMailboxKeyProvider } from "./mailbox-keys";
@@ -41,12 +42,15 @@ export function useThreadRead({
     () => (selectedId ? siblingMessageIds(emails, selectedId) : []),
     [emails, selectedId],
   );
+  const connectivity = useConnectivity();
   const live = Boolean(enabled && actor && selectedId && !isDemoMode);
   const threadKey = queryKeys.mailbox.thread(actor ?? "anonymous");
 
   const query = useQuery({
     queryKey: [...threadKey, selectedId, messageIds],
     enabled: live,
+    retry: connectivity.online ? 2 : 0,
+    refetchOnWindowFocus: !connectivity.paused,
     queryFn: async ({ signal }) => {
       if (!selectedId || !actor) throw new Error("missing selection");
       const selected = await api.mailbox.getMessage(selectedId, signal);
@@ -85,10 +89,7 @@ export function useThreadRead({
     : threadError
       ? {
           kind: "error",
-          failure: classifyMailSourceError(
-            threadError,
-            typeof navigator === "undefined" ? true : navigator.onLine,
-          ),
+          failure: classifyMailSourceError(threadError, connectivity.online),
         }
       : threadPending || (!thread && threadFetching)
         ? { kind: "loading" }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -38,6 +38,8 @@ export interface ApiClientOptions {
   correlationId?: string;
   /** Hook invoked when a response is 401/403 so callers can refresh a session. */
   onUnauthorized?: () => void;
+  /** Connectivity probe. Defaults to `navigator.onLine`. */
+  isOnline?: () => boolean;
 }
 
 const CLIENT_CORRELATION_HEADER = "x-request-id";
@@ -46,11 +48,15 @@ export class ApiClient {
   readonly basePath: string;
   private readonly correlationId?: string;
   private readonly onUnauthorized?: () => void;
+  private readonly isOnline: () => boolean;
 
   constructor(options: ApiClientOptions = {}) {
     this.basePath = options.basePath ?? "/api/v1";
     this.correlationId = options.correlationId;
     this.onUnauthorized = options.onUnauthorized;
+    this.isOnline =
+      options.isOnline ??
+      (() => (typeof navigator === "undefined" ? true : navigator.onLine !== false));
   }
 
   /** Build the request URL, appending a query string when provided. */
@@ -68,6 +74,16 @@ export class ApiClient {
   }
 
   async request<T>(path: string, init: ApiRequestInit = {}): Promise<T> {
+    if (!this.isOnline()) {
+      throw new ApiClientError({
+        code: "offline",
+        message: "You appear to be offline. Check your connection and retry.",
+        status: 0,
+        retryable: true,
+        retryClassification: "transient",
+      });
+    }
+
     const headers = new Headers(init.headers);
     if (init.body !== undefined) {
       headers.set("content-type", "application/json");

--- a/src/lib/api/connectivity.ts
+++ b/src/lib/api/connectivity.ts
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------
+// BETA-071 (Issue #1978) — connectivity + visibility helpers for safe sync.
+// ---------------------------------------------------------------------------
+
+export interface ConnectivitySnapshot {
+  online: boolean;
+  visible: boolean;
+}
+
+export function readNavigatorOnline(nav?: { onLine?: boolean } | null): boolean {
+  if (!nav || typeof nav.onLine !== "boolean") return true;
+  return nav.onLine;
+}
+
+export function readDocumentVisible(doc?: { visibilityState?: string } | null): boolean {
+  if (!doc || typeof doc.visibilityState !== "string") return true;
+  return doc.visibilityState !== "hidden";
+}
+
+export function shouldPauseSync(online: boolean, visible: boolean): boolean {
+  return !online || !visible;
+}
+
+/** Resume queries after a paused interval. Never used to replay mutations. */
+export function shouldResumeSync(wasPaused: boolean, isPaused: boolean): boolean {
+  return wasPaused && !isPaused;
+}
+
+export function connectivitySnapshot(
+  nav?: { onLine?: boolean } | null,
+  doc?: { visibilityState?: string } | null,
+): ConnectivitySnapshot {
+  return {
+    online: readNavigatorOnline(nav),
+    visible: readDocumentVisible(doc),
+  };
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -21,6 +21,8 @@ export const API_CLIENT_ERROR_CODES = [
   "invalid_state_transition",
   "bad_request",
   "internal_error",
+  "offline",
+  "timeout",
 ] as const;
 
 export type ApiClientErrorCode = (typeof API_CLIENT_ERROR_CODES)[number];
@@ -109,18 +111,19 @@ export function normalizeApiClientError(caught: unknown): ApiClientError {
   if (isApiClientError(caught)) return caught;
 
   if (caught instanceof DOMException && caught.name === "AbortError") {
+    const timedOut = caught.message.toLowerCase().includes("timeout");
     return new ApiClientError({
-      code: "internal_error",
-      message: "Request was cancelled",
+      code: timedOut ? "timeout" : "internal_error",
+      message: timedOut ? "Request timed out" : "Request was cancelled",
       status: 0,
-      retryable: false,
-      retryClassification: "none",
+      retryable: timedOut,
+      retryClassification: timedOut ? "transient" : "none",
     });
   }
 
-  if (caught instanceof TypeError && caught.message.includes("fetch")) {
+  if (caught instanceof TypeError && /fetch|network/i.test(caught.message)) {
     return new ApiClientError({
-      code: "dependency_failure",
+      code: "offline",
       message: "You appear to be offline. Check your connection and retry.",
       status: 0,
       retryable: true,
@@ -187,6 +190,12 @@ export function errorLabel(error: ApiClientError): string {
       return error.retryAfterSeconds
         ? `Rate limit reached. Try again in ${error.retryAfterSeconds}s.`
         : "Rate limit reached. Try again shortly.";
+    case "offline":
+      return "You appear to be offline. Check your connection and retry.";
+    case "timeout":
+      return "The request timed out. Retry without sending the action again.";
+    case "conflict":
+      return "This change conflicted with a newer server state. Retry to reconcile.";
     case "dependency_failure":
       return "A required service is unavailable. Please retry.";
     case "validation_error":

--- a/src/lib/api/failures.ts
+++ b/src/lib/api/failures.ts
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------------
+// BETA-071 (Issue #1978) — canonical client failure kinds and actions.
+// ---------------------------------------------------------------------------
+
+import { ApiClientError, errorLabel, isApiClientError, normalizeApiClientError } from "./errors";
+
+export const APP_FAILURE_KINDS = [
+  "offline",
+  "timeout",
+  "unauthorized",
+  "rate_limited",
+  "dependency_down",
+  "conflict",
+  "unknown",
+] as const;
+
+export type AppFailureKind = (typeof APP_FAILURE_KINDS)[number];
+
+export type AppFailureAction =
+  | "retry"
+  | "reauthenticate"
+  | "copy_support_id"
+  | "preserve_unsent_work";
+
+export interface ClassifyAppFailureOptions {
+  online?: boolean;
+}
+
+export interface ClassifiedAppFailure {
+  kind: AppFailureKind;
+  message: string;
+  retryable: boolean;
+  actions: AppFailureAction[];
+  supportId?: string;
+  retryAfterSeconds?: number;
+  preservedWork: boolean;
+  error: ApiClientError;
+}
+
+const RETRY_KINDS = new Set<AppFailureKind>([
+  "offline",
+  "timeout",
+  "rate_limited",
+  "dependency_down",
+  "conflict",
+]);
+
+export function actionsForFailure(kind: AppFailureKind, supportId?: string): AppFailureAction[] {
+  const actions: AppFailureAction[] = ["preserve_unsent_work"];
+  if (RETRY_KINDS.has(kind)) actions.unshift("retry");
+  if (kind === "unauthorized") actions.unshift("reauthenticate");
+  if (supportId) actions.push("copy_support_id");
+  return [...new Set(actions)];
+}
+
+export function classifyAppFailure(
+  caught: unknown,
+  options: ClassifyAppFailureOptions = {},
+): ClassifiedAppFailure {
+  const online = options.online ?? true;
+  const error = normalizeApiClientError(caught);
+  const raw = `${error.code} ${error.message} ${errorLabel(error)}`.toLowerCase();
+  const supportId = error.requestId;
+
+  let kind: AppFailureKind = "unknown";
+  if (!online || error.code === "offline" || raw.includes("offline") || raw.includes("network")) {
+    kind = "offline";
+  } else if (error.code === "timeout" || raw.includes("timeout") || raw.includes("timed out")) {
+    kind = "timeout";
+  } else if (error.code === "unauthorized" || error.code === "session_expired") {
+    kind = "unauthorized";
+  } else if (error.code === "rate_limited") {
+    kind = "rate_limited";
+  } else if (error.code === "conflict") {
+    kind = "conflict";
+  } else if (error.code === "dependency_failure" || error.retryClassification === "transient") {
+    kind = "dependency_down";
+  } else if (error.retryable) {
+    kind = "dependency_down";
+  } else if (isApiClientError(caught) || error.code) {
+    kind = error.code === "internal_error" ? "unknown" : "unknown";
+  }
+
+  const retryable = RETRY_KINDS.has(kind);
+  return {
+    kind,
+    message: messageForFailure(kind, error),
+    retryable,
+    actions: actionsForFailure(kind, supportId),
+    supportId,
+    retryAfterSeconds: error.retryAfterSeconds,
+    preservedWork: true,
+    error,
+  };
+}
+
+export function offlineAppFailure(): ClassifiedAppFailure {
+  return classifyAppFailure(
+    new ApiClientError({
+      code: "offline",
+      message: "You appear to be offline. Check your connection and retry.",
+      status: 0,
+      retryable: true,
+      retryClassification: "transient",
+    }),
+    { online: false },
+  );
+}
+
+function messageForFailure(kind: AppFailureKind, error: ApiClientError): string {
+  switch (kind) {
+    case "offline":
+      return "You are offline. Mailbox sync is paused and unsent work is kept on this device.";
+    case "timeout":
+      return "The request timed out. Retry without sending the action again.";
+    case "unauthorized":
+      return errorLabel(error);
+    case "rate_limited":
+      return errorLabel(error);
+    case "dependency_down":
+      return "A required service is unavailable. Your work is saved; retry when it recovers.";
+    case "conflict":
+      return "This change conflicted with a newer server state. Your draft is kept; retry to reconcile.";
+    default:
+      return errorLabel(error);
+  }
+}
+
+/** In-flight guard so reconnect never duplicates a mutation. */
+export function claimOnce(pending: Set<string>, key: string): boolean {
+  if (pending.has(key)) return false;
+  pending.add(key);
+  return true;
+}
+
+export function releaseOnce(pending: Set<string>, key: string): void {
+  pending.delete(key);
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -24,6 +24,26 @@ export {
   type ApiClientErrorCode,
   type ApiRetryClassification,
 } from "./errors";
+export {
+  APP_FAILURE_KINDS,
+  actionsForFailure,
+  claimOnce,
+  classifyAppFailure,
+  offlineAppFailure,
+  releaseOnce,
+  type AppFailureAction,
+  type AppFailureKind,
+  type ClassifiedAppFailure,
+  type ClassifyAppFailureOptions,
+} from "./failures";
+export {
+  connectivitySnapshot,
+  readDocumentVisible,
+  readNavigatorOnline,
+  shouldPauseSync,
+  shouldResumeSync,
+  type ConnectivitySnapshot,
+} from "./connectivity";
 export { cacheInvalidations, queryKeys } from "./query-keys";
 export {
   createTypedApi,

--- a/tests/unit/api/client-offline.test.ts
+++ b/tests/unit/api/client-offline.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClient, ApiClientError } from "@/lib/api";
+
+describe("ApiClient offline fail-fast (BETA-071)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throws an offline error without calling fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient({ isOnline: () => false });
+
+    await expect(client.get("/mailbox/sync")).rejects.toSatisfy((error: unknown) => {
+      return error instanceof ApiClientError && error.code === "offline" && error.retryable;
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/connectivity.test.ts
+++ b/tests/unit/api/connectivity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { connectivitySnapshot, shouldPauseSync, shouldResumeSync } from "@/lib/api";
+
+describe("connectivity helpers (BETA-071)", () => {
+  it("pauses mailbox sync when offline or the document is hidden", () => {
+    expect(shouldPauseSync(true, true)).toBe(false);
+    expect(shouldPauseSync(false, true)).toBe(true);
+    expect(shouldPauseSync(true, false)).toBe(true);
+    expect(shouldPauseSync(false, false)).toBe(true);
+  });
+
+  it("resumes queries after a paused interval without implying mutation replay", () => {
+    expect(shouldResumeSync(true, false)).toBe(true);
+    expect(shouldResumeSync(false, false)).toBe(false);
+    expect(shouldResumeSync(true, true)).toBe(false);
+    expect(shouldResumeSync(false, true)).toBe(false);
+  });
+
+  it("reads navigator and visibility snapshots", () => {
+    expect(connectivitySnapshot({ onLine: false }, { visibilityState: "visible" })).toEqual({
+      online: false,
+      visible: true,
+    });
+    expect(connectivitySnapshot({ onLine: true }, { visibilityState: "hidden" })).toEqual({
+      online: true,
+      visible: false,
+    });
+    expect(connectivitySnapshot(null, null)).toEqual({ online: true, visible: true });
+  });
+});

--- a/tests/unit/api/failures.test.ts
+++ b/tests/unit/api/failures.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ApiClientError,
+  APP_FAILURE_KINDS,
+  actionsForFailure,
+  claimOnce,
+  classifyAppFailure,
+  offlineAppFailure,
+  releaseOnce,
+} from "@/lib/api";
+
+function apiError(
+  code: ConstructorParameters<typeof ApiClientError>[0]["code"],
+  init: Partial<ConstructorParameters<typeof ApiClientError>[0]> = {},
+) {
+  return new ApiClientError({
+    code,
+    message: init.message ?? code,
+    status: init.status ?? 500,
+    retryable: init.retryable ?? false,
+    retryClassification: init.retryClassification ?? "none",
+    retryAfterSeconds: init.retryAfterSeconds,
+    requestId: init.requestId,
+  });
+}
+
+describe("classifyAppFailure (BETA-071)", () => {
+  it("exposes the seven typed degraded-state kinds", () => {
+    expect(APP_FAILURE_KINDS).toEqual([
+      "offline",
+      "timeout",
+      "unauthorized",
+      "rate_limited",
+      "dependency_down",
+      "conflict",
+      "unknown",
+    ]);
+  });
+
+  it("maps each kind onto retry, reauthenticate, copy-support-id, and preserve-unsent-work actions", () => {
+    expect(classifyAppFailure(apiError("offline"), { online: false }).kind).toBe("offline");
+    expect(classifyAppFailure(apiError("timeout", { message: "timed out" })).kind).toBe("timeout");
+    expect(classifyAppFailure(apiError("unauthorized", { status: 401 })).kind).toBe("unauthorized");
+    expect(classifyAppFailure(apiError("session_expired", { status: 401 })).kind).toBe(
+      "unauthorized",
+    );
+    expect(
+      classifyAppFailure(
+        apiError("rate_limited", {
+          status: 429,
+          retryable: true,
+          retryClassification: "rate_limited",
+        }),
+      ).kind,
+    ).toBe("rate_limited");
+    expect(
+      classifyAppFailure(
+        apiError("dependency_failure", { retryable: true, retryClassification: "transient" }),
+      ).kind,
+    ).toBe("dependency_down");
+    expect(classifyAppFailure(apiError("conflict", { status: 409 })).kind).toBe("conflict");
+    expect(classifyAppFailure(apiError("internal_error")).kind).toBe("unknown");
+  });
+
+  it("never drops unsent work and never treats a failure as success", () => {
+    for (const kind of APP_FAILURE_KINDS) {
+      const classified = classifyAppFailure(
+        apiError(kind === "dependency_down" ? "dependency_failure" : kind),
+      );
+      expect(classified.preservedWork).toBe(true);
+      expect(classified.actions).toContain("preserve_unsent_work");
+    }
+    expect(offlineAppFailure().kind).toBe("offline");
+    expect(offlineAppFailure().retryable).toBe(true);
+  });
+
+  it("classifies a dropped live read (Failed to fetch) as offline", () => {
+    const classified = classifyAppFailure(new TypeError("Failed to fetch"));
+    expect(classified.kind).toBe("offline");
+    expect(classified.retryable).toBe(true);
+    expect(classified.actions).toContain("retry");
+  });
+
+  it("offers reauthenticate for expired sessions and copy support ID when present", () => {
+    const expired = classifyAppFailure(
+      apiError("session_expired", { status: 401, requestId: "req_abc" }),
+    );
+    expect(expired.actions).toContain("reauthenticate");
+    expect(expired.actions).toContain("copy_support_id");
+    expect(expired.supportId).toBe("req_abc");
+    expect(actionsForFailure("unauthorized", "req_abc")).toEqual([
+      "reauthenticate",
+      "preserve_unsent_work",
+      "copy_support_id",
+    ]);
+  });
+
+  it("claims an in-flight mutation once so reconnect cannot duplicate send or policy edit", () => {
+    const pending = new Set<string>();
+    expect(claimOnce(pending, "compose-send")).toBe(true);
+    expect(claimOnce(pending, "compose-send")).toBe(false);
+    expect(claimOnce(pending, "policy:owner")).toBe(true);
+    expect(claimOnce(pending, "policy:owner")).toBe(false);
+    releaseOnce(pending, "compose-send");
+    expect(claimOnce(pending, "compose-send")).toBe(true);
+  });
+});

--- a/tests/unit/design-system/degraded-state-banner.test.tsx
+++ b/tests/unit/design-system/degraded-state-banner.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { DegradedStateBanner } from "@/features/design-system";
+import { classifyAppFailure, ApiClientError } from "@/lib/api";
+
+describe("DegradedStateBanner (BETA-071)", () => {
+  it("renders retry, sign in, copy support ID, and work-kept for an unauthorized failure", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const failure = classifyAppFailure(
+      new ApiClientError({
+        code: "unauthorized",
+        message: "expired",
+        status: 401,
+        retryable: false,
+        retryClassification: "none",
+        requestId: "req_support",
+      }),
+    );
+
+    const onRetry = vi.fn();
+    const onReauthenticate = vi.fn();
+    render(
+      <DegradedStateBanner
+        failure={{
+          ...failure,
+          actions: ["retry", "reauthenticate", "copy_support_id", "preserve_unsent_work"],
+        }}
+        onRetry={onRetry}
+        onReauthenticate={onReauthenticate}
+      />,
+    );
+
+    expect(screen.getByText("Work kept")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    fireEvent.click(screen.getByRole("button", { name: /copy support id/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onReauthenticate).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("req_support");
+  });
+});

--- a/tests/unit/design-system/public-exports.test.ts
+++ b/tests/unit/design-system/public-exports.test.ts
@@ -24,6 +24,7 @@ describe("design-system public exports", () => {
   it("exports feedback queue helpers", () => {
     expect(DesignSystem.FeedbackViewport).toBeDefined();
     expect(typeof DesignSystem.useFeedback).toBe("function");
+    expect(DesignSystem.DegradedStateBanner).toBeDefined();
   });
 
   it("does not expose unexpected top-level exports (edge case)", () => {
@@ -34,6 +35,7 @@ describe("design-system public exports", () => {
       "Surface",
       "FeedbackViewport",
       "useFeedback",
+      "DegradedStateBanner",
       "TrustBadge",
       "TRUST_STATE_META",
       "SkeletonBlock",

--- a/tests/unit/mail/shell-production-path.test.ts
+++ b/tests/unit/mail/shell-production-path.test.ts
@@ -38,8 +38,11 @@ describe("mail shell production path (BETA-053)", () => {
     expect(overlays).not.toContain("getDemoEmails");
     expect(source).toContain("useMailboxSync");
     expect(source).toContain("useTombstoneMessage");
+    expect(source).toContain("useConnectivity");
     expect(app).toContain("useThreadRead");
     expect(app).toContain("threadRead.thread");
+    expect(app).toContain("DegradedStateBanner");
+    expect(app).toContain("offlineAppFailure");
     expect(source).toContain("import.meta.env.DEV");
     expect(source).toContain('import("@/features/mail/demo/demo-data")');
   });

--- a/tests/unit/mail/source-view.test.ts
+++ b/tests/unit/mail/source-view.test.ts
@@ -49,7 +49,12 @@ describe("classifyMailSourceError (BETA-053)", () => {
       classifyMailSourceError(
         apiError("dependency_failure", { retryable: true, retryClassification: "transient" }),
       ).kind,
-    ).toBe("dependency_failure");
+    ).toBe("dependency_down");
+    expect(
+      classifyMailSourceError(
+        apiError("conflict", { status: 409, retryable: true, retryClassification: "transient" }),
+      ).kind,
+    ).toBe("conflict");
   });
 });
 
@@ -108,6 +113,23 @@ describe("resolveMailSourceView (BETA-053)", () => {
     });
     expect(view.kind).toBe("error");
     if (view.kind !== "error") throw new Error("expected error view");
+    expect(view.hasCachedData).toBe(true);
+    expect(view.failure.retryable).toBe(true);
+    expect(view.failure.kind).toBe("dependency_down");
+    expect(view.failure.actions).toContain("preserve_unsent_work");
+    expect(view.failure.actions).toContain("retry");
+  });
+
+  it("classifies a live read failure as offline when the connection drops", () => {
+    const view = resolveMailSourceView({
+      ...base,
+      online: false,
+      mailboxError: apiError("internal_error", { message: "Failed to fetch" }),
+      emailCount: 2,
+    });
+    expect(view.kind).toBe("error");
+    if (view.kind !== "error") throw new Error("expected error view");
+    expect(view.failure.kind).toBe("offline");
     expect(view.hasCachedData).toBe(true);
     expect(view.failure.retryable).toBe(true);
   });

--- a/tests/unit/mail/unsent-work.test.ts
+++ b/tests/unit/mail/unsent-work.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearUnsentDraft,
+  isDraftEmpty,
+  memoryStorage,
+  readUnsentDraft,
+  restoreDraftIfBlank,
+  saveUnsentDraft,
+  UNSENT_DRAFT_STORAGE_KEY,
+} from "@/features/mail/unsent-work";
+
+describe("unsent work (BETA-071)", () => {
+  it("saves, restores, and clears a compose draft", () => {
+    const storage = memoryStorage();
+    const saved = saveUnsentDraft(
+      { to: "ada@example.com", subject: "Hello", body: "Draft body", postage: "0.0001" },
+      storage,
+      () => "2026-08-20T12:00:00.000Z",
+    );
+    expect(saved?.updatedAt).toBe("2026-08-20T12:00:00.000Z");
+    expect(readUnsentDraft(storage)).toEqual(saved);
+    clearUnsentDraft(storage);
+    expect(readUnsentDraft(storage)).toBeNull();
+  });
+
+  it("does not overwrite reply or forward initials with a stored draft", () => {
+    const stored = {
+      to: "stored@example.com",
+      subject: "Stored",
+      body: "kept locally",
+      postage: "0.0001",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+    };
+    const reply = restoreDraftIfBlank(
+      { to: "ada@example.com", subject: "Re: Hello", body: "quoted" },
+      stored,
+    );
+    expect(reply.restored).toBe(false);
+    expect(reply.to).toBe("ada@example.com");
+    expect(reply.body).toBe("quoted");
+  });
+
+  it("restores a stored draft only when compose opens blank", () => {
+    const stored = {
+      to: "stored@example.com",
+      subject: "Stored",
+      body: "kept locally",
+      postage: "0.0002",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+    };
+    const blank = restoreDraftIfBlank({ to: "", subject: "", body: "" }, stored);
+    expect(blank).toEqual({
+      to: "stored@example.com",
+      subject: "Stored",
+      body: "kept locally",
+      postage: "0.0002",
+      restored: true,
+    });
+  });
+
+  it("clears storage when the draft is empty so failure never implies a send", () => {
+    const storage = memoryStorage({
+      [UNSENT_DRAFT_STORAGE_KEY]: JSON.stringify({
+        to: "ada@example.com",
+        subject: "Hello",
+        body: "Draft",
+        postage: "0.0001",
+        updatedAt: "2026-08-20T12:00:00.000Z",
+      }),
+    });
+    expect(isDraftEmpty({ to: "  ", subject: "", body: "" })).toBe(true);
+    expect(
+      saveUnsentDraft({ to: "", subject: "", body: "", postage: "0.0001" }, storage),
+    ).toBeNull();
+    expect(readUnsentDraft(storage)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Typed degraded states for offline, timeout, unauthorized, rate-limited, dependency-down, conflict, and unknown, with retry, re-authenticate, copy support ID, and preserve-unsent-work.
- Mailbox sync pauses on connectivity/visibility changes and resumes with a single refetch so reconnect does not replay sends or mailbox mutations.
- Compose keeps unsent drafts locally on failure; errors never imply success. Live typed API client fail-fasts when offline.

## Test plan
- [x] Drop the connection during mailbox read: cached mail stays, banner explains offline, Retry works after reconnect
- [x] Hide the tab, then return: delta polling pauses and resumes without duplicate mutations
- [x] Fail compose send / go offline mid-draft: draft is restored, send is not marked successful, double-click does not double-send
- [x] Session expired: Sign in is offered; Copy support ID works when a request id is present

---

### Local Verification
- Formatted via Prettier on modified files.
- Type-checked (`tsc --noEmit`).
- Verified via ESLint on changed files.
- Ran focused unit test suite (**26 passed**). Full matrix deferred to GitHub Actions CI.

> **Branch details:** `feat/beta-071-offline-recovery` (commit `85f610ad`) stacked on `main`. Upstream dependency note: BETA-057 (live send) remains unmet; this PR strictly preserves unsent draft work around the existing send path.

Closes #1978