### PR TITLE
feat(relay): connect mailbox policy evaluation to live relay admission (BETA-036)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -181,6 +181,7 @@ export function loadRuntimeConfig(options: LoadConfigOptions = {}): BetaRuntimeC
   const receiptsContractId =
     (env.STEALTH_RECEIPTS_CONTRACT_ID as string) ??
     "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+  const policiesContractId = (env.STEALTH_POLICIES_CONTRACT_ID as string) ?? "C".repeat(56);
   const domainTag = (env.STEALTH_DOMAIN_TAG as string) ?? "Stealth_Mail_Protocol";
   const protocolVersion = (env.STEALTH_PROTOCOL_VERSION as string) ?? "v1";
 
@@ -284,6 +285,11 @@ export function loadRuntimeConfig(options: LoadConfigOptions = {}): BetaRuntimeC
         "Configuration error: STEALTH_RECEIPTS_CONTRACT_ID is required and cannot be a placeholder in production.",
       );
     }
+    if (isPlaceholderContractId(policiesContractId) || !policiesContractId) {
+      throw new Error(
+        "Configuration error: STEALTH_POLICIES_CONTRACT_ID is required and cannot be a placeholder in production.",
+      );
+    }
     if (!appUrl || appUrl.includes("localhost")) {
       throw new Error(
         "Configuration error: STEALTH_APP_URL must be a valid public origin in production.",
@@ -335,6 +341,7 @@ export function loadRuntimeConfig(options: LoadConfigOptions = {}): BetaRuntimeC
       postageContractId,
       lifecycleContractId,
       receiptsContractId,
+      policiesContractId,
       domainTag,
       protocolVersion,
     },
@@ -505,6 +512,7 @@ export function formatConfigMatrix(config: BetaRuntimeConfig): string {
     `  Postage Contract:      ${config.contract.postageContractId}`,
     `  Lifecycle Contract:    ${config.contract.lifecycleContractId}`,
     `  Receipts Contract:     ${config.contract.receiptsContractId}`,
+    `  Policies Contract:     ${config.contract.policiesContractId}`,
     `  Domain Tag:            ${config.contract.domainTag}`,
     `  Protocol Version:      ${config.contract.protocolVersion}`,
     `[Origin & CORS]`,

--- a/src/config/registry.ts
+++ b/src/config/registry.ts
@@ -123,6 +123,21 @@ export function validateRegistryDrift(config: BetaRuntimeConfig) {
     }
   }
 
+  if (
+    config.contract.policiesContractId !== "placeholder" &&
+    manifest.contracts.policies?.contractId &&
+    config.contract.policiesContractId !== manifest.contracts.policies.contractId
+  ) {
+    if (
+      config.profile === "production" ||
+      !config.contract.policiesContractId.startsWith("CCCCC")
+    ) {
+      throw new Error(
+        `Drift Validation Error: STEALTH_POLICIES_CONTRACT_ID '${config.contract.policiesContractId}' does not match deployed policies manifest ID '${manifest.contracts.policies.contractId}'`,
+      );
+    }
+  }
+
   // If we reach here, validation passed.
   console.log(
     `[Registry] Successfully validated runtime config against signed deployment manifest (Deployed At: ${manifest.deployedAt})`,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -79,6 +79,7 @@ export const contractConfigSchema = z.object({
   postageContractId: z.string().min(1, "Postage contract ID cannot be empty"),
   lifecycleContractId: z.string().min(1, "Lifecycle contract ID cannot be empty"),
   receiptsContractId: z.string().min(1, "Receipts contract ID cannot be empty"),
+  policiesContractId: z.string().min(1, "Policies contract ID cannot be empty"),
   domainTag: z.string().min(1, "Domain tag cannot be empty"),
   protocolVersion: z.string().min(1, "Protocol version cannot be empty"),
 });

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -12,8 +12,10 @@ import { createServer, type IncomingMessage } from "node:http";
 import { loadRuntimeConfig } from "@/config";
 import { protocolManifest } from "@/server/api/protocol";
 import { getVersionInfo } from "@/server/api/version";
+import { MemoryApiRepository } from "@/server/api/memory-repository";
 import { InProcessRelayWorker } from "@/services/relay/in-process-worker";
 import { MemoryRelayPersistence } from "@/services/relay/memory-persistence";
+import { createConfiguredAdmissionEvaluator } from "@/services/relay/policy-chain";
 import {
   RELAY_SERVICE_NAME,
   RelayService,
@@ -43,6 +45,7 @@ function buildConfig(): RelayServiceConfig {
       networkPassphrase: config.network.networkPassphrase,
     },
     audience: process.env.STEALTH_RELAY_AUDIENCE ?? "relay:test.stealth",
+    policiesContractId: config.contract.policiesContractId,
   };
 }
 
@@ -53,6 +56,8 @@ function getService(): RelayService {
   if (service) return service;
 
   const persistence = new MemoryRelayPersistence();
+  const repository = new MemoryApiRepository();
+  const runtime = loadRuntimeConfig();
   worker = new InProcessRelayWorker(persistence, {
     onMessage: async (envelope) => {
       await submitToRelay(
@@ -76,7 +81,15 @@ function getService(): RelayService {
     },
   });
 
-  service = new RelayService(persistence, worker, buildConfig());
+  service = new RelayService(persistence, worker, buildConfig(), {
+    evaluator: createConfiguredAdmissionEvaluator({
+      repository,
+      policiesContractId: runtime.contract.policiesContractId,
+      networkPassphrase: runtime.network.networkPassphrase,
+      sorobanRpcUrl: runtime.network.sorobanRpcUrl,
+    }),
+    mailbox: repository,
+  });
   void worker.start();
   return service;
 }

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -869,17 +869,68 @@ export const openApiDocument = {
             type: "integer",
             description: "Delivery TTL in milliseconds.",
           },
+          postage: {
+            $ref: "#/components/schemas/StroopAmount",
+            description: "Attached postage in stroops. Defaults to 0 when omitted.",
+          },
+          verified: {
+            type: "boolean",
+            description: "Whether the sender identity has been verified. Defaults to false.",
+          },
+          receipt: {
+            type: "boolean",
+            description: "Whether the submission includes a delivery-receipt commitment.",
+          },
+        },
+      },
+      RelayAdmissionDecision: {
+        type: "object",
+        required: ["allowed", "kind", "reason", "policyVersion", "requiredPostage"],
+        additionalProperties: false,
+        properties: {
+          allowed: { type: "boolean" },
+          kind: {
+            type: "string",
+            enum: ["trusted", "request", "verified", "priced", "blocked"],
+            description: "Sender-actionable admission class.",
+          },
+          reason: {
+            type: "string",
+            enum: [
+              "sender_allowed",
+              "sender_blocked",
+              "unknown_senders_disabled",
+              "verification_required",
+              "receipt_required",
+              "insufficient_postage",
+              "policy_satisfied",
+              "tier_satisfied",
+            ],
+          },
+          policyVersion: {
+            type: "integer",
+            description: "Policy version evaluated at admission time. Immutable on the message.",
+          },
+          requiredPostage: {
+            $ref: "#/components/schemas/StroopAmount",
+          },
         },
       },
       RelaySubmissionResult: {
         type: "object",
-        required: ["accepted", "messageId", "queueDepth", "service"],
+        required: ["accepted", "messageId", "queueDepth", "service", "replayed", "admission"],
         additionalProperties: false,
         properties: {
           accepted: { type: "boolean", enum: [true] },
           messageId: { $ref: "#/components/schemas/Hash32" },
           queueDepth: { type: "integer" },
           service: { type: "string", description: "Service name." },
+          replayed: {
+            type: "boolean",
+            description:
+              "True when this messageId was already admitted and the original decision was returned.",
+          },
+          admission: { $ref: "#/components/schemas/RelayAdmissionDecision" },
         },
       },
       LifecycleAnchor: {

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -4,6 +4,7 @@ import type {
   PolicyWriteIntent,
   PolicyWriteStatus,
   SenderRule,
+  SenderRuleRecord,
 } from "./domain";
 import type { ApiRepository } from "./repository";
 import { defaultMailboxPolicy } from "./repository";
@@ -121,160 +122,294 @@ export async function setSenderRule(
   };
 }
 
+/**
+ * Stable policy-decision reason codes. These match the Policies contract
+ * `PolicyReason` variants (snake_case) so off-chain evaluation, relay
+ * admission, and on-chain `evaluate` stay comparable.
+ */
+export type PolicyReasonCode =
+  | "sender_allowed"
+  | "sender_blocked"
+  | "unknown_senders_disabled"
+  | "verification_required"
+  | "receipt_required"
+  | "insufficient_postage"
+  | "policy_satisfied"
+  | "tier_satisfied";
+
+/**
+ * Sender-facing admission class used by live relay admission (BETA-036).
+ *
+ * - trusted  : explicit allow rule
+ * - request  : unknown sender admitted for review (no postage due)
+ * - verified : sender must present a verified identity or receipt
+ * - priced   : postage / sender-tier path (paid or still short)
+ * - blocked  : explicit block or unknown senders disabled
+ */
+export type PolicyDecisionKind = "trusted" | "request" | "verified" | "priced" | "blocked";
+
+export function policyDecisionKind(
+  reason: PolicyReasonCode,
+  requiredPostage = "0",
+): PolicyDecisionKind {
+  switch (reason) {
+    case "sender_allowed":
+      return "trusted";
+    case "sender_blocked":
+    case "unknown_senders_disabled":
+      return "blocked";
+    case "verification_required":
+    case "receipt_required":
+      return "verified";
+    case "insufficient_postage":
+    case "tier_satisfied":
+      return "priced";
+    case "policy_satisfied":
+      return BigInt(requiredPostage) > 0n ? "priced" : "request";
+  }
+}
+
+export interface MailboxPolicyEvaluation {
+  allowed: boolean;
+  policy: MailboxPolicy;
+  source: "configured" | "default";
+  reason: PolicyReasonCode;
+  rule: SenderRule;
+  kind: PolicyDecisionKind;
+  requiredPostage: string;
+  policyVersion: number;
+  versionedRule?: SenderRuleRecord;
+}
+
+export interface EvaluateMailboxPolicyInput {
+  owner: string;
+  postage: string;
+  sender: string;
+  verified: boolean;
+  /** Whether the submission includes a delivery-receipt commitment. */
+  receipt?: boolean;
+  /**
+   * Sender-specific minimum postage from the Policies contract tier map.
+   * When set, evaluation follows the on-chain tier branch after identity checks.
+   */
+  senderTier?: string | null;
+}
+
+function decision(base: Omit<MailboxPolicyEvaluation, "kind">): MailboxPolicyEvaluation {
+  return {
+    ...base,
+    kind: policyDecisionKind(base.reason, base.requiredPostage),
+  };
+}
+
 export async function evaluateMailboxPolicy(
   repository: ApiRepository,
-  input: {
-    owner: string;
-    postage: string;
-    sender: string;
-    verified: boolean;
-  },
-) {
-  // BETA-037: Check versioned sender rule first; fall back to legacy rule
+  input: EvaluateMailboxPolicyInput,
+): Promise<MailboxPolicyEvaluation> {
+  const { policy, source } = await getMailboxPolicy(repository, input.owner);
+  const intent = await repository.getPolicyWriteIntent(input.owner);
+  const policyVersion = intent?.offchainVersion ?? 0;
+  const requireReceipt = intent?.policy.requireReceipt ?? false;
+  const mailboxMinimum = policy.minimumPostage;
+  const receipt = input.receipt ?? false;
+
+  // BETA-037: Check versioned sender rule first; fall back to legacy rule.
   const record = await repository.getSenderRuleRecord(input.owner, input.sender);
   if (record) {
     switch (record.rule) {
       case "allow":
-        return {
-          allowed: true,
-          policy: (await getMailboxPolicy(repository, input.owner)).policy,
-          source: (await getMailboxPolicy(repository, input.owner)).source,
-          reason: "sender_allowed" as const,
-          rule: record.rule as SenderRule,
-          versionedRule: record,
-        };
-      case "block":
-        return {
-          allowed: false,
-          policy: (await getMailboxPolicy(repository, input.owner)).policy,
-          source: (await getMailboxPolicy(repository, input.owner)).source,
-          reason: "sender_blocked" as const,
-          rule: record.rule as SenderRule,
-          versionedRule: record,
-        };
-      case "verify": {
-        const { policy, source } = await getMailboxPolicy(repository, input.owner);
-        if (!input.verified) {
-          return {
-            allowed: false,
-            policy,
-            source,
-            reason: "verification_required" as const,
-            rule: record.rule as SenderRule,
-            versionedRule: record,
-          };
-        }
-        // Fall through to check other policy constraints (e.g. postage)
-        if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
-          return {
-            allowed: false,
-            policy,
-            source,
-            reason: "insufficient_postage" as const,
-            rule: record.rule as SenderRule,
-            versionedRule: record,
-          };
-        }
-        return {
+        return decision({
           allowed: true,
           policy,
           source,
-          reason: "policy_satisfied" as const,
-          rule: record.rule as SenderRule,
+          reason: "sender_allowed",
+          rule: record.rule,
+          requiredPostage: "0",
+          policyVersion,
           versionedRule: record,
-        };
+        });
+      case "block":
+        return decision({
+          allowed: false,
+          policy,
+          source,
+          reason: "sender_blocked",
+          rule: record.rule,
+          requiredPostage: mailboxMinimum,
+          policyVersion,
+          versionedRule: record,
+        });
+      case "verify": {
+        if (!input.verified) {
+          return decision({
+            allowed: false,
+            policy,
+            source,
+            reason: "verification_required",
+            rule: record.rule,
+            requiredPostage: mailboxMinimum,
+            policyVersion,
+            versionedRule: record,
+          });
+        }
+        if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
+          return decision({
+            allowed: false,
+            policy,
+            source,
+            reason: "insufficient_postage",
+            rule: record.rule,
+            requiredPostage: mailboxMinimum,
+            policyVersion,
+            versionedRule: record,
+          });
+        }
+        return decision({
+          allowed: true,
+          policy,
+          source,
+          reason: "policy_satisfied",
+          rule: record.rule,
+          requiredPostage: mailboxMinimum,
+          policyVersion,
+          versionedRule: record,
+        });
       }
       case "price": {
-        const { policy, source } = await getMailboxPolicy(repository, input.owner);
         const minPostage = record.pricePayload?.minimumPostage ?? "0";
         if (BigInt(input.postage) < BigInt(minPostage)) {
-          return {
+          return decision({
             allowed: false,
             policy,
             source,
-            reason: "insufficient_postage" as const,
-            rule: record.rule as SenderRule,
+            reason: "insufficient_postage",
+            rule: record.rule,
+            requiredPostage: minPostage,
+            policyVersion,
             versionedRule: record,
-          };
+          });
         }
-        // Also check verification if the global policy requires it
         if (policy.requireVerified && !input.verified) {
-          return {
+          return decision({
             allowed: false,
             policy,
             source,
-            reason: "verification_required" as const,
-            rule: record.rule as SenderRule,
+            reason: "verification_required",
+            rule: record.rule,
+            requiredPostage: minPostage,
+            policyVersion,
             versionedRule: record,
-          };
+          });
         }
-        return {
+        return decision({
           allowed: true,
           policy,
           source,
-          reason: "policy_satisfied" as const,
-          rule: record.rule as SenderRule,
+          reason: "policy_satisfied",
+          rule: record.rule,
+          requiredPostage: minPostage,
+          policyVersion,
           versionedRule: record,
-        };
+        });
       }
     }
   }
 
-  // Legacy fallback
+  // Legacy / default-rule fallback (contract-faithful tree for relay admission).
   const rule = await repository.getSenderRule(input.owner, input.sender);
-  const { policy, source } = await getMailboxPolicy(repository, input.owner);
-  if (rule === "allow")
-    return {
+
+  if (rule === "allow") {
+    return decision({
       allowed: true,
       policy,
       source,
-      reason: "sender_allowed" as const,
+      reason: "sender_allowed",
       rule,
-    };
-  if (rule === "block")
-    return {
+      requiredPostage: "0",
+      policyVersion,
+    });
+  }
+  if (rule === "block") {
+    return decision({
       allowed: false,
       policy,
       source,
-      reason: "sender_blocked" as const,
+      reason: "sender_blocked",
       rule,
-    };
+      requiredPostage: mailboxMinimum,
+      policyVersion,
+    });
+  }
 
   if (!policy.allowUnknown) {
-    return {
+    return decision({
       allowed: false,
       policy,
       source,
-      reason: "unknown_senders_disabled" as const,
+      reason: "unknown_senders_disabled",
       rule,
-    };
+      requiredPostage: mailboxMinimum,
+      policyVersion,
+    });
   }
   if (policy.requireVerified && !input.verified) {
-    return {
+    return decision({
       allowed: false,
       policy,
       source,
-      reason: "verification_required" as const,
+      reason: "verification_required",
       rule,
-    };
+      requiredPostage: input.senderTier ?? mailboxMinimum,
+      policyVersion,
+    });
   }
-  if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
-    return {
+  if (requireReceipt && !receipt) {
+    return decision({
       allowed: false,
       policy,
       source,
-      reason: "insufficient_postage" as const,
+      reason: "receipt_required",
       rule,
-    };
+      requiredPostage: input.senderTier ?? mailboxMinimum,
+      policyVersion,
+    });
   }
 
-  return {
+  if (input.senderTier != null) {
+    const requiredPostage = input.senderTier;
+    const allowed = BigInt(input.postage) >= BigInt(requiredPostage);
+    return decision({
+      allowed,
+      policy,
+      source,
+      reason: allowed ? "tier_satisfied" : "insufficient_postage",
+      rule,
+      requiredPostage,
+      policyVersion,
+    });
+  }
+
+  if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
+    return decision({
+      allowed: false,
+      policy,
+      source,
+      reason: "insufficient_postage",
+      rule,
+      requiredPostage: mailboxMinimum,
+      policyVersion,
+    });
+  }
+
+  return decision({
     allowed: true,
     policy,
     source,
-    reason: "policy_satisfied" as const,
+    reason: "policy_satisfied",
     rule,
-  };
+    requiredPostage: mailboxMinimum,
+    policyVersion,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/relay/context.ts
+++ b/src/services/relay/context.ts
@@ -19,6 +19,8 @@ import { getVersionInfo } from "@/server/api/version";
 import { InProcessRelayWorker } from "./in-process-worker";
 import { KvRelayPersistence } from "./kv-persistence";
 import { MemoryRelayPersistence } from "./memory-persistence";
+import { createRelayObjectStore } from "./object-store";
+import { createConfiguredAdmissionEvaluator } from "./policy-chain";
 import { RELAY_SERVICE_NAME, RelayService, type RelayServiceConfig } from "./relay-service";
 
 const globalRelay = globalThis as typeof globalThis & {
@@ -38,6 +40,7 @@ function buildConfig(): RelayServiceConfig {
       sorobanRpcUrl: config.network.sorobanRpcUrl,
       networkPassphrase: config.network.networkPassphrase,
     },
+    policiesContractId: config.contract.policiesContractId,
   };
 }
 
@@ -82,13 +85,32 @@ export async function getRelayService(): Promise<RelayService> {
     return globalRelay.__stealthRelayService;
   }
 
+  const runtime = loadRuntimeConfig();
+  const relayConfig = buildConfig();
+  const { getApiContext } = await import("@/server/api/context");
+  const { repository } = await getApiContext();
+  const evaluator = createConfiguredAdmissionEvaluator({
+    repository,
+    policiesContractId: runtime.contract.policiesContractId,
+    networkPassphrase: runtime.network.networkPassphrase,
+    sorobanRpcUrl: runtime.network.sorobanRpcUrl,
+  });
+
   if (!import.meta.env.PROD) {
     const persistence = new MemoryRelayPersistence();
     const worker = new InProcessRelayWorker(persistence);
-    globalRelay.__stealthRelayService = new RelayService(persistence, worker, {
-      ...buildConfig(),
-      onAccepted: buildOnAcceptedHook(await getLifecycleRepository()),
-    });
+    globalRelay.__stealthRelayService = new RelayService(
+      persistence,
+      worker,
+      {
+        ...relayConfig,
+        onAccepted: buildOnAcceptedHook(await getLifecycleRepository()),
+      },
+      {
+        evaluator,
+        mailbox: repository,
+      },
+    );
     return globalRelay.__stealthRelayService;
   }
 
@@ -101,9 +123,22 @@ export async function getRelayService(): Promise<RelayService> {
 
   const persistence = new KvRelayPersistence(env.STEALTH_KV);
   const worker = new InProcessRelayWorker(persistence);
-  globalRelay.__stealthRelayService = new RelayService(persistence, worker, {
-    ...buildConfig(),
-    onAccepted: buildOnAcceptedHook(await getLifecycleRepository()),
-  });
+  const objectStore = env.STEALTH_OBJECT_STORE
+    ? createRelayObjectStore(env.STEALTH_OBJECT_STORE)
+    : undefined;
+
+  globalRelay.__stealthRelayService = new RelayService(
+    persistence,
+    worker,
+    {
+      ...relayConfig,
+      onAccepted: buildOnAcceptedHook(await getLifecycleRepository()),
+    },
+    {
+      evaluator,
+      objectStore,
+      mailbox: repository,
+    },
+  );
   return globalRelay.__stealthRelayService;
 }

--- a/src/services/relay/kv-persistence.ts
+++ b/src/services/relay/kv-persistence.ts
@@ -33,11 +33,13 @@ export class KvRelayPersistence implements RelayPersistence {
     return this.readCounter(KvRelayPersistence.DEAD_LETTER_KEY);
   }
 
+  async get(messageId: string): Promise<RelayEnvelope | null> {
+    const existing = await this.kv.get(`${KvRelayPersistence.MESSAGE_PREFIX}${messageId}`, "json");
+    return existing ? (existing as RelayEnvelope) : null;
+  }
+
   async enqueue(envelope: RelayEnvelope): Promise<{ messageId: string }> {
-    const existing = await this.kv.get(
-      `${KvRelayPersistence.MESSAGE_PREFIX}${envelope.messageId}`,
-      "json",
-    );
+    const existing = await this.get(envelope.messageId);
     if (existing) {
       return { messageId: envelope.messageId };
     }

--- a/src/services/relay/memory-persistence.ts
+++ b/src/services/relay/memory-persistence.ts
@@ -31,9 +31,17 @@ export class MemoryRelayPersistence implements RelayPersistence {
     return this.deadLetterCount;
   }
 
+  async get(messageId: string): Promise<RelayEnvelope | null> {
+    return this.messages.get(messageId) ?? null;
+  }
+
   async enqueue(envelope: RelayEnvelope): Promise<{ messageId: string }> {
     if (!this.available) {
       throw new Error("Relay storage is unavailable");
+    }
+    const existing = this.messages.get(envelope.messageId);
+    if (existing) {
+      return { messageId: existing.messageId };
     }
     this.messages.set(envelope.messageId, envelope);
     this.queue.push(envelope);

--- a/src/services/relay/persistence.ts
+++ b/src/services/relay/persistence.ts
@@ -6,6 +6,8 @@
  * memory, Cloudflare KV, and future durable adapters all implement it. Health
  * and readiness probes only ever read aggregate, non-sensitive counters.
  */
+import type { RelayAdmissionEvidence } from "./policy-admission";
+
 export interface RelayEnvelope {
   /** Immutable 32-byte lowercase hex message identifier. */
   messageId: string;
@@ -21,6 +23,13 @@ export interface RelayEnvelope {
   ttlMs: number;
   /** Server-side acceptance timestamp (ISO-8601). */
   receivedAt: string;
+  /**
+   * Immutable policy admission evidence recorded at accept time (BETA-036).
+   * A later policy change must not rewrite this snapshot.
+   */
+  admission: RelayAdmissionEvidence;
+  /** Content-addressed object-store key when the payload was staged to R2. */
+  payloadStorageKey?: string;
 }
 
 export interface RelayPersistence {
@@ -39,7 +48,14 @@ export interface RelayPersistence {
   /** Number of permanently failed (dead-lettered) deliveries. */
   getDeadLetterCount(): Promise<number>;
 
-  /** Durably accept a message into the relay queue. */
+  /** Look up a previously accepted message by id, or null when absent. */
+  get(messageId: string): Promise<RelayEnvelope | null>;
+
+  /**
+   * Durably accept a message into the relay queue.
+   * Re-enqueueing the same messageId is idempotent and must not duplicate the
+   * queue entry or rewrite stored admission evidence.
+   */
   enqueue(envelope: RelayEnvelope): Promise<{ messageId: string }>;
 
   /** Remove and return the next queued message, or null when empty. */

--- a/src/services/relay/policy-admission.ts
+++ b/src/services/relay/policy-admission.ts
@@ -1,0 +1,241 @@
+/**
+ * Live relay policy admission (Issue #1943 BETA-036).
+ *
+ * Resolves the recipient's current policy version, evaluates trusted / request /
+ * verified / priced / blocked decisions, and returns immutable evidence that is
+ * persisted with the accepted message. A later policy change cannot rewrite a
+ * recorded admission because evidence is stored on the envelope, not re-read
+ * from the live policy.
+ *
+ * Evaluation order:
+ * 1. Simulate the Policies contract `evaluate` (live testnet / RPC).
+ * 2. If the chain is unavailable, malformed, timed out, or stale relative to a
+ *    *confirmed* off-chain write, fall back to {@link evaluateMailboxPolicy}.
+ *
+ * Denied decisions never proceed to payload storage — callers must gate the
+ * object store on `allowed`.
+ */
+import {
+  evaluateMailboxPolicy,
+  policyDecisionKind,
+  type PolicyDecisionKind,
+  type PolicyReasonCode,
+} from "@/server/api/policy-service";
+import type { ApiRepository } from "@/server/api/repository";
+import type { SenderRule } from "@/server/api/domain";
+
+export type PolicyAdmissionSource = "chain" | "offchain_fallback";
+
+export const DEFAULT_CHAIN_EVALUATION_TIMEOUT_MS = 2_000;
+
+const POLICY_REASON_CODES: ReadonlySet<string> = new Set([
+  "sender_allowed",
+  "sender_blocked",
+  "unknown_senders_disabled",
+  "verification_required",
+  "receipt_required",
+  "insufficient_postage",
+  "policy_satisfied",
+  "tier_satisfied",
+]);
+
+const SENDER_RULES: ReadonlySet<string> = new Set(["default", "allow", "block"]);
+
+export interface RelayAdmissionInput {
+  owner: string;
+  sender: string;
+  postage: string;
+  verified: boolean;
+  receipt: boolean;
+}
+
+/**
+ * Durable, privacy-safe admission evidence stored with an accepted message.
+ * Contains no payload bytes, no full policy document, and no secrets.
+ */
+export interface RelayAdmissionEvidence {
+  policyVersion: number;
+  allowed: boolean;
+  kind: PolicyDecisionKind;
+  reason: PolicyReasonCode;
+  rule: SenderRule;
+  requiredPostage: string;
+  source: PolicyAdmissionSource;
+  evaluatedAt: string;
+}
+
+/** Sender-facing subset: enough to act, not enough to reconstruct mailbox policy. */
+export interface SafeAdmissionDecision {
+  kind: PolicyDecisionKind;
+  reason: PolicyReasonCode;
+  policyVersion: number;
+  requiredPostage: string;
+  allowed: boolean;
+}
+
+export interface ChainPolicyDecision {
+  allowed: boolean;
+  reason: PolicyReasonCode;
+  requiredPostage: string;
+  rule: SenderRule;
+  version: number;
+}
+
+export interface PolicyChainClient {
+  evaluate(input: RelayAdmissionInput): Promise<ChainPolicyDecision>;
+}
+
+export interface RelayAdmissionEvaluator {
+  evaluate(input: RelayAdmissionInput): Promise<RelayAdmissionEvidence>;
+}
+
+export interface RelayAdmissionEvaluatorOptions {
+  repository: ApiRepository;
+  chain?: PolicyChainClient;
+  chainTimeoutMs?: number;
+  now?: () => Date;
+}
+
+export function toSafeAdmissionDecision(evidence: RelayAdmissionEvidence): SafeAdmissionDecision {
+  return {
+    kind: evidence.kind,
+    reason: evidence.reason,
+    policyVersion: evidence.policyVersion,
+    requiredPostage: evidence.requiredPostage,
+    allowed: evidence.allowed,
+  };
+}
+
+export function createRelayAdmissionEvaluator(
+  options: RelayAdmissionEvaluatorOptions,
+): RelayAdmissionEvaluator {
+  const timeoutMs = options.chainTimeoutMs ?? DEFAULT_CHAIN_EVALUATION_TIMEOUT_MS;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async evaluate(input: RelayAdmissionInput): Promise<RelayAdmissionEvidence> {
+      const evaluatedAt = now().toISOString();
+      const chainDecision = await tryChainEvaluate(options.chain, input, timeoutMs);
+
+      if (chainDecision && (await isChainCurrent(options.repository, input.owner, chainDecision))) {
+        return evidenceFromChain(chainDecision, evaluatedAt);
+      }
+
+      const offchain = await evaluateMailboxPolicy(options.repository, {
+        owner: input.owner,
+        sender: input.sender,
+        postage: input.postage,
+        verified: input.verified,
+        receipt: input.receipt,
+      });
+
+      return {
+        policyVersion: offchain.policyVersion,
+        allowed: offchain.allowed,
+        kind: offchain.kind,
+        reason: offchain.reason,
+        rule: offchain.rule,
+        requiredPostage: offchain.requiredPostage,
+        source: "offchain_fallback",
+        evaluatedAt,
+      };
+    },
+  };
+}
+
+function evidenceFromChain(
+  decision: ChainPolicyDecision,
+  evaluatedAt: string,
+): RelayAdmissionEvidence {
+  return {
+    policyVersion: decision.version,
+    allowed: decision.allowed,
+    kind: policyDecisionKind(decision.reason, decision.requiredPostage),
+    reason: decision.reason,
+    rule: decision.rule,
+    requiredPostage: decision.requiredPostage,
+    source: "chain",
+    evaluatedAt,
+  };
+}
+
+/**
+ * A chain result is stale when a confirmed off-chain write is strictly newer
+ * than the version the RPC returned. Pending/submitted writes are *not* stale:
+ * the ledger is still the live admission source until the write confirms.
+ */
+async function isChainCurrent(
+  repository: ApiRepository,
+  owner: string,
+  chain: ChainPolicyDecision,
+): Promise<boolean> {
+  const intent = await repository.getPolicyWriteIntent(owner);
+  if (!intent || intent.status !== "confirmed") return true;
+  return chain.version >= intent.offchainVersion;
+}
+
+async function tryChainEvaluate(
+  chain: PolicyChainClient | undefined,
+  input: RelayAdmissionInput,
+  timeoutMs: number,
+): Promise<ChainPolicyDecision | null> {
+  if (!chain) return null;
+  try {
+    const raw = await withTimeout(chain.evaluate(input), timeoutMs);
+    return parseChainDecision(raw);
+  } catch {
+    return null;
+  }
+}
+
+function parseChainDecision(
+  raw: ChainPolicyDecision | null | undefined,
+): ChainPolicyDecision | null {
+  if (!raw || typeof raw !== "object") return null;
+  if (typeof raw.allowed !== "boolean") return null;
+  if (typeof raw.version !== "number" || !Number.isInteger(raw.version) || raw.version < 0) {
+    return null;
+  }
+  if (!POLICY_REASON_CODES.has(raw.reason)) return null;
+  if (!SENDER_RULES.has(raw.rule)) return null;
+  if (typeof raw.requiredPostage !== "string") return null;
+  try {
+    if (BigInt(raw.requiredPostage) < 0n) return null;
+  } catch {
+    return null;
+  }
+  return {
+    allowed: raw.allowed,
+    reason: raw.reason,
+    requiredPostage: raw.requiredPostage,
+    rule: raw.rule,
+    version: raw.version,
+  };
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const startedAt = Date.now();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      action();
+    };
+    const timer = setTimeout(
+      () => finish(() => reject(new Error("chain_evaluation_timeout"))),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        if (Date.now() - startedAt >= timeoutMs) {
+          finish(() => reject(new Error("chain_evaluation_timeout")));
+          return;
+        }
+        finish(() => resolve(value));
+      },
+      (error) => finish(() => reject(error)),
+    );
+  });
+}

--- a/src/services/relay/policy-chain.ts
+++ b/src/services/relay/policy-chain.ts
@@ -1,0 +1,136 @@
+/**
+ * Live Policies-contract adapter for relay admission (Issue #1943 BETA-036).
+ *
+ * Wraps the generated Soroban client so relay admission can simulate
+ * `evaluate` against the deployed testnet contract. Reads never log payload
+ * bytes, keys, or account secrets.
+ */
+import {
+  createPoliciesClient,
+  evaluate,
+  PolicyReason,
+  SenderRule as ChainSenderRule,
+  type PoliciesClientOptions,
+} from "@/services/stellar/contracts/policies";
+
+import {
+  createRelayAdmissionEvaluator,
+  type ChainPolicyDecision,
+  type PolicyChainClient,
+  type RelayAdmissionEvaluator,
+  type RelayAdmissionInput,
+} from "./policy-admission";
+import type { PolicyReasonCode } from "@/server/api/policy-service";
+import type { SenderRule } from "@/server/api/domain";
+import type { ApiRepository } from "@/server/api/repository";
+
+export interface LivePolicyChainOptions extends PoliciesClientOptions {
+  /** Optional override used by tests. */
+  evaluateFn?: typeof evaluate;
+}
+
+const REASON_BY_VARIANT: Record<PolicyReason, PolicyReasonCode> = {
+  [PolicyReason.SenderAllowed]: "sender_allowed",
+  [PolicyReason.SenderBlocked]: "sender_blocked",
+  [PolicyReason.UnknownSendersDisabled]: "unknown_senders_disabled",
+  [PolicyReason.VerificationRequired]: "verification_required",
+  [PolicyReason.ReceiptRequired]: "receipt_required",
+  [PolicyReason.InsufficientPostage]: "insufficient_postage",
+  [PolicyReason.PolicySatisfied]: "policy_satisfied",
+  [PolicyReason.TierSatisfied]: "tier_satisfied",
+};
+
+const RULE_BY_VARIANT: Record<ChainSenderRule, SenderRule> = {
+  [ChainSenderRule.Default]: "default",
+  [ChainSenderRule.Allow]: "allow",
+  [ChainSenderRule.Block]: "block",
+};
+
+/**
+ * True when `contractId` is a live (non-placeholder) Policies contract id.
+ * Repeated-letter development placeholders such as `CCCCC…` are not live.
+ */
+export function isLivePoliciesContractId(contractId: string | undefined): boolean {
+  if (!contractId) return false;
+  if (contractId.includes("PLACEHOLDER") || contractId === "placeholder") return false;
+  if (!/^C[A-Z0-9]{55}$/.test(contractId)) return false;
+  return !/^C([A-Z0-9])\1{54}$/.test(contractId);
+}
+
+export function createLivePolicyChainClient(options: LivePolicyChainOptions): PolicyChainClient {
+  const client = createPoliciesClient({
+    contractId: options.contractId,
+    networkPassphrase: options.networkPassphrase,
+    rpcUrl: options.rpcUrl,
+    publicKey: options.publicKey,
+  });
+  const evaluateFn = options.evaluateFn ?? evaluate;
+
+  return {
+    async evaluate(input: RelayAdmissionInput): Promise<ChainPolicyDecision> {
+      const decision = await evaluateFn(
+        client,
+        input.owner,
+        input.sender,
+        input.verified,
+        BigInt(input.postage),
+        input.receipt,
+      );
+      return {
+        allowed: decision.allowed,
+        reason: mapReason(decision.reason),
+        requiredPostage: decision.required_postage.toString(),
+        rule: mapRule(decision.rule),
+        version: decision.version,
+      };
+    },
+  };
+}
+
+function mapReason(reason: PolicyReason): PolicyReasonCode {
+  const mapped = REASON_BY_VARIANT[reason];
+  if (!mapped) {
+    throw new Error("malformed_chain_reason");
+  }
+  return mapped;
+}
+
+function mapRule(rule: ChainSenderRule): SenderRule {
+  const mapped = RULE_BY_VARIANT[rule];
+  if (!mapped) {
+    throw new Error("malformed_chain_rule");
+  }
+  return mapped;
+}
+
+export interface ConfiguredAdmissionOptions {
+  repository: ApiRepository;
+  policiesContractId?: string;
+  networkPassphrase: string;
+  sorobanRpcUrl: string;
+  chainTimeoutMs?: number;
+  now?: () => Date;
+}
+
+/**
+ * Builds the production admission evaluator: live chain when a real Policies
+ * contract id is configured, otherwise off-chain evaluation only.
+ */
+export function createConfiguredAdmissionEvaluator(
+  options: ConfiguredAdmissionOptions,
+): RelayAdmissionEvaluator {
+  const chain = isLivePoliciesContractId(options.policiesContractId)
+    ? createLivePolicyChainClient({
+        contractId: options.policiesContractId!,
+        networkPassphrase: options.networkPassphrase,
+        rpcUrl: options.sorobanRpcUrl,
+      })
+    : undefined;
+
+  return createRelayAdmissionEvaluator({
+    repository: options.repository,
+    chain,
+    chainTimeoutMs: options.chainTimeoutMs,
+    now: options.now,
+  });
+}

--- a/src/services/relay/relay-service.ts
+++ b/src/services/relay/relay-service.ts
@@ -370,6 +370,7 @@ export class RelayService {
         ciphertext: envelope.payload,
         protectedHeaders: {},
         createdAt: receivedAt,
+        status: "pending",
         metadata: { admission: toSafeAdmissionDecision(evidence) },
       });
     }

--- a/src/services/relay/relay-service.ts
+++ b/src/services/relay/relay-service.ts
@@ -17,10 +17,24 @@
  */
 import { z } from "zod";
 
-import { hash32Schema, stellarAddressSchema } from "@/server/api/domain";
+import {
+  hash32Schema,
+  stellarAddressSchema,
+  stroopAmountSchema,
+  type StoredEnvelope,
+} from "@/server/api/domain";
+import { ApiError } from "@/server/api/errors";
+import type { InsertEnvelopeResult } from "@/server/api/repository";
 import { InMemoryNonceStore, NonceService } from "@/server/api/auth/nonce-service";
 import type { RelayPersistence } from "./persistence";
 import type { RelayWorker } from "./worker";
+import type { RelayObjectStore } from "./object-store";
+import {
+  toSafeAdmissionDecision,
+  type RelayAdmissionEvaluator,
+  type RelayAdmissionEvidence,
+  type SafeAdmissionDecision,
+} from "./policy-admission";
 
 export const RELAY_SERVICE_NAME = "stealth-relay";
 
@@ -47,9 +61,12 @@ export const relaySubmissionSchema = z.object({
     .min(1, "Payload must not be empty")
     .max(RELAY_MAX_PAYLOAD_BYTES, `Payload exceeds ${RELAY_MAX_PAYLOAD_BYTES} bytes`),
   ttlMs: z.number().int().positive().max(MAX_RELAY_TTL_MS).optional(),
+  postage: stroopAmountSchema.optional().default("0"),
+  verified: z.boolean().optional().default(false),
+  receipt: z.boolean().optional().default(false),
 });
 
-export type RelaySubmissionInput = z.infer<typeof relaySubmissionSchema>;
+export type RelaySubmissionInput = z.input<typeof relaySubmissionSchema>;
 
 export interface RelayHealth {
   status: "ok";
@@ -109,12 +126,27 @@ export interface RelayServiceConfig {
     recipient: string;
     payload: string;
   }) => Promise<unknown>;
+  /** Deployed Policies contract id used for live chain evaluation. */
+  policiesContractId?: string;
 }
 
 export interface RelaySubmitResult {
-  accepted: boolean;
+  accepted: true;
   messageId: string;
   queueDepth: number;
+  replayed: boolean;
+  admission: SafeAdmissionDecision;
+}
+
+export interface RelayMailboxStore {
+  insertEnvelope(envelope: StoredEnvelope): Promise<InsertEnvelopeResult>;
+}
+
+export interface RelayServiceDependencies {
+  evaluator: RelayAdmissionEvaluator;
+  objectStore?: RelayObjectStore;
+  mailbox?: RelayMailboxStore;
+  now?: () => Date;
 }
 
 export interface ReadinessOptions {
@@ -136,12 +168,30 @@ export class RelayService {
   private readonly audience: string;
   private readonly idempotencyStore = new Map<string, unknown>();
   private readonly seenNonces = new Set<string>();
+  private readonly deps: RelayServiceDependencies;
 
   constructor(
     private readonly persistence: RelayPersistence,
     private readonly worker: RelayWorker,
     private readonly config: RelayServiceConfig,
+    deps: RelayServiceDependencies = {
+      evaluator: {
+        async evaluate() {
+          return {
+            policyVersion: 0,
+            allowed: true,
+            kind: "request",
+            reason: "policy_satisfied",
+            rule: "default",
+            requiredPostage: "0",
+            source: "offchain_fallback",
+            evaluatedAt: new Date().toISOString(),
+          };
+        },
+      },
+    },
   ) {
+    this.deps = deps;
     this.nonceService = config.nonceService ?? new NonceService(new InMemoryNonceStore());
     this.audience = config.audience ?? "relay:stealth.test";
   }
@@ -228,9 +278,11 @@ export class RelayService {
   }
 
   /**
-   * Accept a relay message into the queue. Input is re-validated at the domain
-   * boundary (never trusted from the caller) and a {@link ZodError} is thrown
-   * for invalid payloads.
+   * Accept a relay message into the queue only after the recipient's current
+   * policy admits the sender. Blocked decisions never reach payload storage.
+   * A retry of the same messageId returns the original recorded admission and
+   * does not re-evaluate live policy (so a later policy change cannot rewrite
+   * history).
    */
   async submit(input: RelaySubmissionInput): Promise<RelaySubmitResult> {
     const parsed = relaySubmissionSchema.safeParse(input);
@@ -238,6 +290,40 @@ export class RelayService {
       throw parsed.error;
     }
 
+    const existing = await this.persistence.get(parsed.data.messageId);
+    if (existing) {
+      return {
+        accepted: true,
+        messageId: existing.messageId,
+        queueDepth: await this.persistence.getQueueDepth(),
+        replayed: true,
+        admission: toSafeAdmissionDecision(existing.admission),
+      };
+    }
+
+    const evidence = await this.deps.evaluator.evaluate({
+      owner: parsed.data.recipient,
+      sender: parsed.data.sender,
+      postage: parsed.data.postage,
+      verified: parsed.data.verified,
+      receipt: parsed.data.receipt,
+    });
+
+    if (!evidence.allowed) {
+      throwDeniedAdmission(evidence);
+    }
+
+    let payloadStorageKey: string | undefined;
+    if (this.deps.objectStore) {
+      payloadStorageKey = await this.deps.objectStore.storeEnvelopeBody({
+        messageId: parsed.data.messageId,
+        ownerAddress: parsed.data.recipient,
+        contentType: "application/octet-stream",
+        bytes: new TextEncoder().encode(parsed.data.payload),
+      });
+    }
+
+    const receivedAt = (this.deps.now ?? (() => new Date()))().toISOString();
     const envelope = {
       messageId: parsed.data.messageId,
       sender: parsed.data.sender,
@@ -245,7 +331,9 @@ export class RelayService {
       recipientDomain: parsed.data.recipientDomain,
       payload: parsed.data.payload,
       ttlMs: parsed.data.ttlMs ?? DEFAULT_RELAY_TTL_MS,
-      receivedAt: new Date().toISOString(),
+      receivedAt,
+      admission: evidence,
+      ...(payloadStorageKey === undefined ? {} : { payloadStorageKey }),
     };
 
     await this.persistence.enqueue(envelope);
@@ -273,10 +361,25 @@ export class RelayService {
         // Log / fail-soft: receipt publication error does not fail queue enqueue
       }
     }
+
+    if (this.deps.mailbox) {
+      await this.deps.mailbox.insertEnvelope({
+        messageId: envelope.messageId,
+        senderId: envelope.sender,
+        recipientId: envelope.recipient,
+        ciphertext: envelope.payload,
+        protectedHeaders: {},
+        createdAt: receivedAt,
+        metadata: { admission: toSafeAdmissionDecision(evidence) },
+      });
+    }
+
     return {
       accepted: true,
       messageId: envelope.messageId,
       queueDepth: await this.persistence.getQueueDepth(),
+      replayed: false,
+      admission: toSafeAdmissionDecision(evidence),
     };
   }
 
@@ -320,4 +423,22 @@ export class RelayService {
       if (timer) clearTimeout(timer);
     }
   }
+}
+
+/**
+ * Maps a denied admission to a sender-actionable API error. The details object
+ * is the safe decision (kind / reason / required postage / version) and never
+ * includes the recipient's full policy, payload, or secrets.
+ */
+function throwDeniedAdmission(evidence: RelayAdmissionEvidence): never {
+  const details = toSafeAdmissionDecision(evidence);
+  if (evidence.kind === "priced") {
+    throw new ApiError(
+      422,
+      "insufficient_postage",
+      "The postage amount is below the required minimum",
+      details,
+    );
+  }
+  throw new ApiError(403, "forbidden", "The recipient policy does not admit this message", details);
 }

--- a/tests/integration/relay/policy-admission.testnet.test.ts
+++ b/tests/integration/relay/policy-admission.testnet.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Live testnet probe for relay policy admission (Issue #1943 BETA-036).
+ *
+ * Skips unless a signed testnet contract-manifest.json is present. This is
+ * not part of `npm test` (vitest include is tests/unit); run with:
+ *   npx vitest run tests/integration/relay/policy-admission.testnet.test.ts
+ */
+import { describe, expect, it, beforeAll } from "vitest";
+import { rpc, Contract } from "@stellar/stellar-sdk";
+import { loadManifest } from "../../../src/config/registry";
+import { isLivePoliciesContractId } from "../../../src/services/relay/policy-chain";
+
+describe("Live testnet Policies contract (relay admission)", () => {
+  let manifest: ReturnType<typeof loadManifest>;
+  let server: rpc.Server | undefined;
+
+  beforeAll(() => {
+    manifest = loadManifest();
+    if (!manifest || manifest.network !== "testnet") {
+      return;
+    }
+    server = new rpc.Server("https://soroban-rpc.testnet.stellar.org");
+  });
+
+  it("has a live Policies contract id in the deployed manifest", async () => {
+    if (!manifest || !server) return;
+
+    const policiesId = manifest.contracts.policies?.contractId;
+    expect(policiesId).toBeDefined();
+    expect(isLivePoliciesContractId(policiesId)).toBe(true);
+
+    const contract = new Contract(policiesId);
+    const ledgerEntry = await server.getLedgerEntries(contract.getFootprint());
+    expect(ledgerEntry).toBeDefined();
+    expect(ledgerEntry.entries.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/config/runtime-config.test.ts
+++ b/tests/unit/config/runtime-config.test.ts
@@ -39,6 +39,7 @@ describe("BETA-001 :: Beta Runtime Configuration Contract", () => {
       expect(config.relay.relayUrl).toBe("https://relay-testnet.stealth.mail");
       expect(config.contract.domainTag).toBe("Stealth_Mail_Protocol");
       expect(config.contract.protocolVersion).toBe("v1");
+      expect(config.contract.policiesContractId).toBe("C".repeat(56));
       expect(config.origin.appUrl).toBe("http://localhost:3000");
     });
 
@@ -131,6 +132,18 @@ describe("BETA-001 :: Beta Runtime Configuration Contract", () => {
           },
         }),
       ).toThrow(/STEALTH_REGISTRY_CONTRACT_ID is required and cannot be a placeholder/);
+    });
+
+    it("fails production startup when STEALTH_POLICIES_CONTRACT_ID is a placeholder", () => {
+      expect(() =>
+        loadRuntimeConfig({
+          profile: "production",
+          env: {
+            ...baseProdEnv,
+            STEALTH_POLICIES_CONTRACT_ID: "C_POLICIES_PLACEHOLDER",
+          },
+        }),
+      ).toThrow(/STEALTH_POLICIES_CONTRACT_ID is required and cannot be a placeholder/);
     });
 
     it("fails production startup when STEALTH_APP_URL is localhost", () => {

--- a/tests/unit/mailbox/mailbox-queue.test.ts
+++ b/tests/unit/mailbox/mailbox-queue.test.ts
@@ -340,6 +340,17 @@ describe("Authenticated Recipient Mailbox Queue API (BETA-033)", () => {
       };
       const service = new RelayService(persistence, worker, config);
 
+      const admittedEvidence = {
+        policyVersion: 1,
+        allowed: true as const,
+        kind: "request" as const,
+        reason: "policy_satisfied" as const,
+        rule: "default" as const,
+        requiredPostage: "0",
+        source: "offchain_fallback" as const,
+        evaluatedAt: new Date().toISOString(),
+      };
+
       await persistence.enqueue({
         messageId: MSG1,
         sender: BOB,
@@ -348,6 +359,7 @@ describe("Authenticated Recipient Mailbox Queue API (BETA-033)", () => {
         payload: "encrypted-payload",
         ttlMs: 3600000,
         receivedAt: new Date().toISOString(),
+        admission: admittedEvidence,
       });
 
       await persistence.enqueue({
@@ -358,6 +370,7 @@ describe("Authenticated Recipient Mailbox Queue API (BETA-033)", () => {
         payload: "encrypted-payload-2",
         ttlMs: 3600000,
         receivedAt: new Date().toISOString(),
+        admission: admittedEvidence,
       });
 
       // Test transport handler for Alice

--- a/tests/unit/relay/kv-persistence.test.ts
+++ b/tests/unit/relay/kv-persistence.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { KvRelayPersistence } from "../../../src/services/relay/kv-persistence";
+import type { RelayEnvelope } from "../../../src/services/relay/persistence";
+
+class MockKVNamespace {
+  public store = new Map<string, string>();
+
+  async get(key: string, type?: "text" | "json") {
+    const val = this.store.get(key);
+    if (val === undefined) return null;
+    if (type === "json") return JSON.parse(val);
+    return val;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+}
+
+function envelope(overrides: Partial<RelayEnvelope> = {}): RelayEnvelope {
+  return {
+    messageId: "d".repeat(64),
+    sender: `G${"A".repeat(55)}`,
+    recipient: `G${"B".repeat(55)}`,
+    recipientDomain: "example.com",
+    payload: "aGVsbG8=",
+    ttlMs: 60_000,
+    receivedAt: "2026-01-01T00:00:00.000Z",
+    admission: {
+      policyVersion: 3,
+      allowed: true,
+      kind: "trusted",
+      reason: "sender_allowed",
+      rule: "allow",
+      requiredPostage: "0",
+      source: "chain",
+      evaluatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("KvRelayPersistence admission idempotency (BETA-036)", () => {
+  it("round-trips admission evidence with the stored envelope", async () => {
+    const persistence = new KvRelayPersistence(new MockKVNamespace() as unknown as KVNamespace);
+    await persistence.enqueue(envelope());
+
+    const stored = await persistence.get("d".repeat(64));
+    expect(stored?.admission).toEqual(envelope().admission);
+    expect(await persistence.getQueueDepth()).toBe(1);
+  });
+
+  it("does not rewrite recorded admission evidence on a duplicate enqueue", async () => {
+    const persistence = new KvRelayPersistence(new MockKVNamespace() as unknown as KVNamespace);
+    await persistence.enqueue(envelope());
+
+    await persistence.enqueue(
+      envelope({
+        payload: "replaced",
+        admission: {
+          policyVersion: 99,
+          allowed: false,
+          kind: "blocked",
+          reason: "sender_blocked",
+          rule: "block",
+          requiredPostage: "0",
+          source: "offchain_fallback",
+          evaluatedAt: "2026-08-01T00:00:00.000Z",
+        },
+      }),
+    );
+
+    const stored = await persistence.get("d".repeat(64));
+    expect(stored?.payload).toBe("aGVsbG8=");
+    expect(stored?.admission.kind).toBe("trusted");
+    expect(stored?.admission.policyVersion).toBe(3);
+    expect(await persistence.getQueueDepth()).toBe(1);
+  });
+});

--- a/tests/unit/relay/policy-admission.integration.test.ts
+++ b/tests/unit/relay/policy-admission.integration.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../../../src/server/api/errors";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import { setMailboxPolicy, setSenderRule } from "../../../src/server/api/policy-service";
+import { FakeR2Bucket } from "../../../src/services/storage/r2-fake";
+import { createRelayObjectStore } from "../../../src/services/relay/object-store";
+import { MemoryRelayPersistence } from "../../../src/services/relay/memory-persistence";
+import { InProcessRelayWorker } from "../../../src/services/relay/in-process-worker";
+import { RelayService, type RelayServiceConfig } from "../../../src/services/relay/relay-service";
+import {
+  createRelayAdmissionEvaluator,
+  type PolicyChainClient,
+} from "../../../src/services/relay/policy-admission";
+import { handleRelaySubmit } from "../../../src/services/relay/transport";
+
+const sender = `G${"A".repeat(55)}`;
+const recipient = `G${"B".repeat(55)}`;
+
+function messageIdFor(label: string): string {
+  const hex = Buffer.from(label.padEnd(32, "0")).toString("hex").slice(0, 64);
+  return hex;
+}
+
+function makeConfig(): RelayServiceConfig {
+  return {
+    serviceName: "stealth-relay",
+    version: "test-build",
+    apiVersion: "v1",
+    protocolVersion: "v1",
+    timeoutMs: 1_000,
+    network: {
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+      networkPassphrase: "Test SDF Network ; September 2015",
+    },
+  };
+}
+
+function submitRequest(body: Record<string, unknown>, actor = sender) {
+  return new Request("https://stealth.test/api/v1/relay/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-stealth-address": actor,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    messageId: "d".repeat(64),
+    sender,
+    recipient,
+    recipientDomain: "example.com",
+    payload: "aGVsbG8=",
+    postage: "0",
+    verified: false,
+    ...overrides,
+  };
+}
+
+describe("relay policy admission integration (BETA-036)", () => {
+  it("admits a trusted sender and persists policy version evidence with the message", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "allow");
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }), mailbox: repository },
+    );
+
+    const result = await service.submit(validBody());
+    expect(result.accepted).toBe(true);
+    expect(result.admission.kind).toBe("trusted");
+    expect(result.admission.policyVersion).toBe(0);
+
+    const stored = persistence.getMessage(result.messageId);
+    expect(stored?.admission.reason).toBe("sender_allowed");
+    expect(stored?.admission.policyVersion).toBe(result.admission.policyVersion);
+
+    const envelope = await repository.getEnvelope(result.messageId);
+    expect(envelope?.metadata).toMatchObject({
+      admission: { kind: "trusted", reason: "sender_allowed" },
+    });
+  });
+
+  it("never stores a blocked payload in the object store or the mailbox", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "block");
+    const bucket = new FakeR2Bucket();
+    const objectStore = createRelayObjectStore(bucket as unknown as R2Bucket);
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      {
+        evaluator: createRelayAdmissionEvaluator({ repository }),
+        objectStore,
+        mailbox: repository,
+      },
+    );
+
+    await expect(service.submit(validBody())).rejects.toMatchObject({
+      status: 403,
+      code: "forbidden",
+      details: { kind: "blocked", reason: "sender_blocked" },
+    });
+
+    expect(persistence.getMessage("d".repeat(64))).toBeUndefined();
+    expect(await repository.getEnvelope("d".repeat(64))).toBeNull();
+    expect(bucket.size).toBe(0);
+  });
+
+  it("stores an admitted payload in the object store after evaluation", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, recipient, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+    const bucket = new FakeR2Bucket();
+    const objectStore = createRelayObjectStore(bucket as unknown as R2Bucket);
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      {
+        evaluator: createRelayAdmissionEvaluator({ repository }),
+        objectStore,
+      },
+    );
+
+    const result = await service.submit(validBody({ verified: true }));
+    expect(result.admission.kind).toBe("request");
+    expect(persistence.getMessage(result.messageId)?.payloadStorageKey).toMatch(/^envelopes\//);
+    expect(bucket.size).toBeGreaterThan(0);
+  });
+
+  it("does not let a later policy change rewrite a recorded admission", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "allow");
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    const first = await service.submit(validBody());
+    expect(first.admission.kind).toBe("trusted");
+
+    await setSenderRule(repository, recipient, sender, "block");
+    const replay = await service.submit(validBody());
+
+    expect(replay.replayed).toBe(true);
+    expect(replay.admission.kind).toBe("trusted");
+    expect(replay.admission.reason).toBe("sender_allowed");
+    expect(persistence.getMessage(first.messageId)?.admission.kind).toBe("trusted");
+  });
+
+  it("is idempotent: a duplicate messageId does not double-enqueue", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "allow");
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    await service.submit(validBody());
+    const replay = await service.submit(validBody());
+    expect(replay.replayed).toBe(true);
+    expect(replay.queueDepth).toBe(1);
+  });
+
+  it("returns 422 priced with requiredPostage when postage is short", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, recipient, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "500",
+    });
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    try {
+      await service.submit(validBody({ postage: "100", verified: true }));
+      throw new Error("expected priced denial");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      const apiError = error as ApiError;
+      expect(apiError.status).toBe(422);
+      expect(apiError.code).toBe("insufficient_postage");
+      expect(apiError.details).toMatchObject({
+        kind: "priced",
+        reason: "insufficient_postage",
+        requiredPostage: "500",
+      });
+    }
+    expect(persistence.getMessage("d".repeat(64))).toBeUndefined();
+  });
+
+  it("returns 403 verified when the recipient requires identity verification", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, recipient, {
+      allowUnknown: true,
+      requireVerified: true,
+      minimumPostage: "0",
+    });
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    const response = await handleRelaySubmit(
+      submitRequest(validBody({ verified: false })),
+      service,
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("forbidden");
+    expect(body.error.details.kind).toBe("verified");
+    expect(JSON.stringify(body)).not.toContain("aGVsbG8=");
+  });
+
+  it("falls back to off-chain evaluation when the live chain is stale and still admits", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, recipient, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+    const { confirmPolicyWrite } = await import("../../../src/server/api/policy-service");
+    await confirmPolicyWrite(repository, recipient, "tx-redacted");
+
+    const chain: PolicyChainClient = {
+      evaluate: async () => ({
+        allowed: false,
+        reason: "unknown_senders_disabled",
+        requiredPostage: "0",
+        rule: "default",
+        version: 0,
+      }),
+    };
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository, chain }) },
+    );
+
+    const result = await service.submit(validBody({ verified: true }));
+    expect(result.admission.kind).toBe("request");
+    expect(persistence.getMessage(result.messageId)?.admission.source).toBe("offchain_fallback");
+  });
+
+  it("covers transport 403 for blocked without leaking mailbox metadata", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "block");
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    const response = await handleRelaySubmit(submitRequest(validBody()), service);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("forbidden");
+    expect(JSON.stringify(body)).not.toContain("allowUnknown");
+    expect(JSON.stringify(body)).not.toContain("minimumPostage");
+    expect(JSON.stringify(body)).not.toContain("aGVsbG8=");
+  });
+
+  it("admits distinct messages independently after a policy change", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, recipient, sender, "allow");
+    const persistence = new MemoryRelayPersistence();
+    const service = new RelayService(
+      persistence,
+      new InProcessRelayWorker(persistence),
+      makeConfig(),
+      { evaluator: createRelayAdmissionEvaluator({ repository }) },
+    );
+
+    const firstId = messageIdFor("first-message-id-bytes!!");
+    const secondId = messageIdFor("second-message-id-bytes!");
+    await service.submit(validBody({ messageId: firstId }));
+    await setSenderRule(repository, recipient, sender, "block");
+
+    await expect(service.submit(validBody({ messageId: secondId }))).rejects.toMatchObject({
+      code: "forbidden",
+      details: { kind: "blocked" },
+    });
+    expect(persistence.getMessage(firstId)?.admission.kind).toBe("trusted");
+    expect(persistence.getMessage(secondId)).toBeUndefined();
+  });
+});

--- a/tests/unit/relay/policy-admission.test.ts
+++ b/tests/unit/relay/policy-admission.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  confirmPolicyWrite,
+  evaluateMailboxPolicy,
+  policyDecisionKind,
+  schedulePolicyWrite,
+  setMailboxPolicy,
+  setSenderRule,
+} from "../../../src/server/api/policy-service";
+import {
+  createRelayAdmissionEvaluator,
+  toSafeAdmissionDecision,
+  type ChainPolicyDecision,
+  type PolicyChainClient,
+  type RelayAdmissionInput,
+} from "../../../src/services/relay/policy-admission";
+
+const owner = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+
+function input(overrides: Partial<RelayAdmissionInput> = {}): RelayAdmissionInput {
+  return {
+    owner,
+    sender,
+    postage: "0",
+    verified: false,
+    receipt: false,
+    ...overrides,
+  };
+}
+
+function chainDecision(overrides: Partial<ChainPolicyDecision> = {}): ChainPolicyDecision {
+  return {
+    allowed: true,
+    reason: "sender_allowed",
+    requiredPostage: "0",
+    rule: "allow",
+    version: 3,
+    ...overrides,
+  };
+}
+
+describe("policyDecisionKind", () => {
+  it("maps every reason onto a sender-actionable class", () => {
+    expect(policyDecisionKind("sender_allowed")).toBe("trusted");
+    expect(policyDecisionKind("sender_blocked")).toBe("blocked");
+    expect(policyDecisionKind("unknown_senders_disabled")).toBe("blocked");
+    expect(policyDecisionKind("verification_required")).toBe("verified");
+    expect(policyDecisionKind("receipt_required")).toBe("verified");
+    expect(policyDecisionKind("insufficient_postage")).toBe("priced");
+    expect(policyDecisionKind("tier_satisfied")).toBe("priced");
+    expect(policyDecisionKind("policy_satisfied", "0")).toBe("request");
+    expect(policyDecisionKind("policy_satisfied", "100")).toBe("priced");
+  });
+});
+
+describe("evaluateMailboxPolicy admission extras", () => {
+  it("records policy version 0 before any write intent exists", async () => {
+    const repository = new MemoryApiRepository();
+    const result = await evaluateMailboxPolicy(repository, {
+      owner,
+      sender,
+      postage: "0",
+      verified: true,
+    });
+    expect(result.policyVersion).toBe(0);
+    expect(result.kind).toBe("blocked");
+  });
+
+  it("pins the off-chain write-intent version on the decision", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, owner, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+    const result = await evaluateMailboxPolicy(repository, {
+      owner,
+      sender,
+      postage: "0",
+      verified: false,
+    });
+    expect(result.policyVersion).toBe(1);
+    expect(result.kind).toBe("request");
+    expect(result.reason).toBe("policy_satisfied");
+  });
+
+  it("rejects when a scheduled policy requires a receipt that is absent", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(
+      repository,
+      owner,
+      { allowUnknown: true, requireVerified: false, minimumPostage: "0" },
+      { requireReceipt: true },
+    );
+    const result = await evaluateMailboxPolicy(repository, {
+      owner,
+      sender,
+      postage: "0",
+      verified: true,
+      receipt: false,
+    });
+    expect(result).toMatchObject({
+      allowed: false,
+      reason: "receipt_required",
+      kind: "verified",
+    });
+  });
+
+  it("evaluates a sender tier after identity checks", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, owner, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "1000",
+    });
+    await expect(
+      evaluateMailboxPolicy(repository, {
+        owner,
+        sender,
+        postage: "25",
+        verified: true,
+        senderTier: "25",
+      }),
+    ).resolves.toMatchObject({ allowed: true, reason: "tier_satisfied", kind: "priced" });
+    await expect(
+      evaluateMailboxPolicy(repository, {
+        owner,
+        sender,
+        postage: "24",
+        verified: true,
+        senderTier: "25",
+      }),
+    ).resolves.toMatchObject({ allowed: false, reason: "insufficient_postage", kind: "priced" });
+  });
+});
+
+describe("createRelayAdmissionEvaluator", () => {
+  it("prefers a live chain decision and records source=chain", async () => {
+    const repository = new MemoryApiRepository();
+    const chain: PolicyChainClient = {
+      evaluate: async () => chainDecision({ version: 4, reason: "policy_satisfied" }),
+    };
+    const evaluator = createRelayAdmissionEvaluator({ repository, chain });
+    const evidence = await evaluator.evaluate(input({ postage: "10", verified: true }));
+
+    expect(evidence.source).toBe("chain");
+    expect(evidence.policyVersion).toBe(4);
+    expect(evidence.kind).toBe("request");
+    expect(toSafeAdmissionDecision(evidence)).toEqual({
+      allowed: true,
+      kind: "request",
+      reason: "policy_satisfied",
+      policyVersion: 4,
+      requiredPostage: "0",
+    });
+  });
+
+  it("falls back off-chain when the chain client throws", async () => {
+    const repository = new MemoryApiRepository();
+    await setSenderRule(repository, owner, sender, "block");
+    const chain: PolicyChainClient = {
+      evaluate: async () => {
+        throw new Error("rpc unavailable");
+      },
+    };
+    const evaluator = createRelayAdmissionEvaluator({ repository, chain });
+    const evidence = await evaluator.evaluate(input());
+
+    expect(evidence.source).toBe("offchain_fallback");
+    expect(evidence.kind).toBe("blocked");
+    expect(evidence.reason).toBe("sender_blocked");
+  });
+
+  it("falls back off-chain when the chain times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const repository = new MemoryApiRepository();
+      await setSenderRule(repository, owner, sender, "allow");
+      const chain: PolicyChainClient = {
+        evaluate: () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(
+                chainDecision({
+                  allowed: false,
+                  reason: "sender_blocked",
+                  rule: "block",
+                  version: 1,
+                }),
+              );
+            }, 100);
+          }),
+      };
+      const evaluator = createRelayAdmissionEvaluator({
+        repository,
+        chain,
+        chainTimeoutMs: 10,
+      });
+      const pending = evaluator.evaluate(input());
+      await vi.advanceTimersByTimeAsync(10);
+      const evidence = await pending;
+
+      expect(evidence.source).toBe("offchain_fallback");
+      expect(evidence.kind).toBe("trusted");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back off-chain for a malformed chain payload", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, owner, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+    const chain = {
+      evaluate: async () =>
+        ({
+          allowed: true,
+          reason: "not-a-reason",
+          requiredPostage: "0",
+          rule: "default",
+          version: 1,
+        }) as unknown as ChainPolicyDecision,
+    };
+    const evaluator = createRelayAdmissionEvaluator({ repository, chain });
+    const evidence = await evaluator.evaluate(input({ verified: true }));
+
+    expect(evidence.source).toBe("offchain_fallback");
+    expect(evidence.reason).toBe("policy_satisfied");
+  });
+
+  it("treats a chain version behind a confirmed off-chain write as stale", async () => {
+    const repository = new MemoryApiRepository();
+    await setMailboxPolicy(repository, owner, {
+      allowUnknown: true,
+      requireVerified: false,
+      minimumPostage: "0",
+    });
+    await confirmPolicyWrite(repository, owner, "tx-redacted");
+
+    const chain: PolicyChainClient = {
+      evaluate: async () =>
+        chainDecision({
+          allowed: false,
+          reason: "unknown_senders_disabled",
+          rule: "default",
+          version: 0,
+        }),
+    };
+    const evaluator = createRelayAdmissionEvaluator({ repository, chain });
+    const evidence = await evaluator.evaluate(input({ verified: true }));
+
+    expect(evidence.source).toBe("offchain_fallback");
+    expect(evidence.policyVersion).toBe(1);
+    expect(evidence.allowed).toBe(true);
+    expect(evidence.kind).toBe("request");
+  });
+
+  it("does not treat a pending write as stale — live chain remains authoritative", async () => {
+    const repository = new MemoryApiRepository();
+    await schedulePolicyWrite(repository, owner, {
+      allowUnknown: true,
+      requireVerified: false,
+      requireReceipt: false,
+      minimumPostage: "0",
+    });
+    const chain: PolicyChainClient = {
+      evaluate: async () =>
+        chainDecision({
+          allowed: false,
+          reason: "unknown_senders_disabled",
+          rule: "default",
+          version: 0,
+        }),
+    };
+    const evaluator = createRelayAdmissionEvaluator({ repository, chain });
+    const evidence = await evaluator.evaluate(input());
+
+    expect(evidence.source).toBe("chain");
+    expect(evidence.kind).toBe("blocked");
+    expect(evidence.policyVersion).toBe(0);
+  });
+
+  it("covers every off-chain decision branch used by relay admission", async () => {
+    const cases: Array<{
+      name: string;
+      setup: (repo: MemoryApiRepository) => Promise<void>;
+      input: RelayAdmissionInput;
+      kind: string;
+      reason: string;
+      allowed: boolean;
+    }> = [
+      {
+        name: "trusted",
+        setup: (repo) => setSenderRule(repo, owner, sender, "allow").then(() => undefined),
+        input: input(),
+        kind: "trusted",
+        reason: "sender_allowed",
+        allowed: true,
+      },
+      {
+        name: "blocked",
+        setup: (repo) => setSenderRule(repo, owner, sender, "block").then(() => undefined),
+        input: input(),
+        kind: "blocked",
+        reason: "sender_blocked",
+        allowed: false,
+      },
+      {
+        name: "request",
+        setup: (repo) =>
+          setMailboxPolicy(repo, owner, {
+            allowUnknown: true,
+            requireVerified: false,
+            minimumPostage: "0",
+          }).then(() => undefined),
+        input: input({ verified: true }),
+        kind: "request",
+        reason: "policy_satisfied",
+        allowed: true,
+      },
+      {
+        name: "verified",
+        setup: (repo) =>
+          setMailboxPolicy(repo, owner, {
+            allowUnknown: true,
+            requireVerified: true,
+            minimumPostage: "0",
+          }).then(() => undefined),
+        input: input({ verified: false, postage: "0" }),
+        kind: "verified",
+        reason: "verification_required",
+        allowed: false,
+      },
+      {
+        name: "priced",
+        setup: (repo) =>
+          setMailboxPolicy(repo, owner, {
+            allowUnknown: true,
+            requireVerified: false,
+            minimumPostage: "500",
+          }).then(() => undefined),
+        input: input({ postage: "100", verified: true }),
+        kind: "priced",
+        reason: "insufficient_postage",
+        allowed: false,
+      },
+      {
+        name: "priced-allowed",
+        setup: (repo) =>
+          setMailboxPolicy(repo, owner, {
+            allowUnknown: true,
+            requireVerified: false,
+            minimumPostage: "500",
+          }).then(() => undefined),
+        input: input({ postage: "500", verified: true }),
+        kind: "priced",
+        reason: "policy_satisfied",
+        allowed: true,
+      },
+      {
+        name: "unknown-disabled",
+        setup: async () => undefined,
+        input: input(),
+        kind: "blocked",
+        reason: "unknown_senders_disabled",
+        allowed: false,
+      },
+      {
+        name: "receipt-required",
+        setup: (repo) =>
+          setMailboxPolicy(
+            repo,
+            owner,
+            { allowUnknown: true, requireVerified: false, minimumPostage: "0" },
+            { requireReceipt: true },
+          ).then(() => undefined),
+        input: input({ verified: true, receipt: false }),
+        kind: "verified",
+        reason: "receipt_required",
+        allowed: false,
+      },
+    ];
+
+    for (const vector of cases) {
+      const repository = new MemoryApiRepository();
+      await vector.setup(repository);
+      const evaluator = createRelayAdmissionEvaluator({ repository });
+      const evidence = await evaluator.evaluate(vector.input);
+      expect(evidence.kind, vector.name).toBe(vector.kind);
+      expect(evidence.reason, vector.name).toBe(vector.reason);
+      expect(evidence.allowed, vector.name).toBe(vector.allowed);
+      expect(evidence.source, vector.name).toBe("offchain_fallback");
+    }
+  });
+});

--- a/tests/unit/relay/policy-chain.test.ts
+++ b/tests/unit/relay/policy-chain.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { PolicyReason, SenderRule } from "../../../src/services/stellar/contracts/policies";
+import {
+  createLivePolicyChainClient,
+  isLivePoliciesContractId,
+} from "../../../src/services/relay/policy-chain";
+
+const owner = `G${"A".repeat(55)}`;
+const sender = `G${"B".repeat(55)}`;
+
+describe("createLivePolicyChainClient", () => {
+  it("maps contract evaluate results onto admission evidence fields", async () => {
+    const evaluateFn = async () => ({
+      allowed: false,
+      reason: PolicyReason.SenderBlocked,
+      required_postage: 100n,
+      rule: SenderRule.Block,
+      version: 7,
+    });
+
+    const client = createLivePolicyChainClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      evaluateFn: evaluateFn as never,
+    });
+
+    await expect(
+      client.evaluate({ owner, sender, postage: "0", verified: true, receipt: false }),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: "sender_blocked",
+      requiredPostage: "100",
+      rule: "block",
+      version: 7,
+    });
+  });
+
+  it("rejects an unknown contract reason as malformed chain output", async () => {
+    const client = createLivePolicyChainClient({
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      evaluateFn: (async () => ({
+        allowed: true,
+        reason: 99 as PolicyReason,
+        required_postage: 0n,
+        rule: SenderRule.Default,
+        version: 1,
+      })) as never,
+    });
+
+    await expect(
+      client.evaluate({ owner, sender, postage: "0", verified: true, receipt: false }),
+    ).rejects.toThrow(/malformed_chain_reason/);
+  });
+
+  it("accepts a mixed checksum-bearing contract id shape", () => {
+    expect(
+      isLivePoliciesContractId("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"),
+    ).toBe(true);
+  });
+
+  it("rejects placeholders and repeated-letter development ids", () => {
+    expect(isLivePoliciesContractId(undefined)).toBe(false);
+    expect(isLivePoliciesContractId("placeholder")).toBe(false);
+    expect(isLivePoliciesContractId("C".repeat(56))).toBe(false);
+    expect(
+      isLivePoliciesContractId("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    ).toBe(false);
+    expect(isLivePoliciesContractId("not-a-contract")).toBe(false);
+  });
+});

--- a/tests/unit/relay/relay-service.test.ts
+++ b/tests/unit/relay/relay-service.test.ts
@@ -4,6 +4,7 @@ import { MemoryRelayPersistence } from "../../../src/services/relay/memory-persi
 import { RelayService, type RelayServiceConfig } from "../../../src/services/relay/relay-service";
 import type { RelayEnvelope, RelayPersistence } from "../../../src/services/relay/persistence";
 import { InProcessRelayWorker } from "../../../src/services/relay/in-process-worker";
+import type { RelayAdmissionEvaluator } from "../../../src/services/relay/policy-admission";
 import { z } from "zod";
 
 import type { RelaySubmissionInput } from "../../../src/services/relay/relay-service";
@@ -28,13 +29,33 @@ function makeConfig(overrides: Partial<RelayServiceConfig> = {}): RelayServiceCo
   };
 }
 
-function makeService(config: RelayServiceConfig = makeConfig()) {
+function allowAllEvaluator(): RelayAdmissionEvaluator {
+  return {
+    async evaluate() {
+      return {
+        policyVersion: 1,
+        allowed: true,
+        kind: "trusted",
+        reason: "sender_allowed",
+        rule: "allow",
+        requiredPostage: "0",
+        source: "offchain_fallback",
+        evaluatedAt: "2026-01-01T00:00:00.000Z",
+      };
+    },
+  };
+}
+
+function makeService(
+  config: RelayServiceConfig = makeConfig(),
+  evaluator: RelayAdmissionEvaluator = allowAllEvaluator(),
+) {
   const persistence = new MemoryRelayPersistence();
   const worker = new InProcessRelayWorker(persistence);
   return {
     persistence,
     worker,
-    service: new RelayService(persistence, worker, config),
+    service: new RelayService(persistence, worker, config, { evaluator }),
   };
 }
 
@@ -59,6 +80,9 @@ class FailingPersistence implements RelayPersistence {
   }
   async getDeadLetterCount(): Promise<number> {
     return 0;
+  }
+  async get(_messageId: string): Promise<RelayEnvelope | null> {
+    return null;
   }
   async enqueue(_envelope: RelayEnvelope): Promise<{ messageId: string }> {
     return { messageId };
@@ -115,7 +139,9 @@ describe("RelayService readiness", () => {
 
   it("is not ready when the queue is unavailable", async () => {
     const worker = new InProcessRelayWorker(new FailingPersistence());
-    const service = new RelayService(new FailingPersistence(), worker, makeConfig());
+    const service = new RelayService(new FailingPersistence(), worker, makeConfig(), {
+      evaluator: allowAllEvaluator(),
+    });
 
     const readiness = await service.checkReadiness();
     expect(readiness.ready).toBe(false);
@@ -190,6 +216,13 @@ describe("RelayService submit", () => {
     expect(result.accepted).toBe(true);
     expect(result.messageId).toBe(messageId);
     expect(result.queueDepth).toBe(1);
+    expect(result.replayed).toBe(false);
+    expect(result.admission).toMatchObject({
+      allowed: true,
+      kind: "trusted",
+      reason: "sender_allowed",
+      policyVersion: 1,
+    });
     expect(persistence.getMessage(messageId)).toMatchObject({
       sender,
       recipient,
@@ -225,6 +258,14 @@ describe("RelayService submit", () => {
     const { service } = makeService();
     const input = validInput();
     input.payload = "x".repeat(2 * 1024 * 1024 + 1);
+
+    await expect(service.submit(input)).rejects.toBeInstanceOf(z.ZodError);
+  });
+
+  it("rejects a malformed postage amount at the schema boundary", async () => {
+    const { service } = makeService();
+    const input = validInput() as RelaySubmissionInput & { postage: string };
+    input.postage = "-1";
 
     await expect(service.submit(input)).rejects.toBeInstanceOf(z.ZodError);
   });

--- a/tests/unit/relay/relay-transport.test.ts
+++ b/tests/unit/relay/relay-transport.test.ts
@@ -7,6 +7,7 @@ import { canonicalizeSignedRequest } from "../../../src/server/api/auth/signed-r
 import { MemoryRelayPersistence } from "../../../src/services/relay/memory-persistence";
 import { InProcessRelayWorker } from "../../../src/services/relay/in-process-worker";
 import { RelayService, type RelayServiceConfig } from "../../../src/services/relay/relay-service";
+import type { RelayAdmissionEvaluator } from "../../../src/services/relay/policy-admission";
 import {
   handleRelayHealth,
   handleRelayReadiness,
@@ -35,10 +36,27 @@ function makeConfig(overrides: Partial<RelayServiceConfig> = {}): RelayServiceCo
   };
 }
 
+function allowAllEvaluator(): RelayAdmissionEvaluator {
+  return {
+    async evaluate() {
+      return {
+        policyVersion: 1,
+        allowed: true,
+        kind: "trusted",
+        reason: "sender_allowed",
+        rule: "allow",
+        requiredPostage: "0",
+        source: "offchain_fallback",
+        evaluatedAt: "2026-01-01T00:00:00.000Z",
+      };
+    },
+  };
+}
+
 function makeService(config: RelayServiceConfig = makeConfig()) {
   const persistence = new MemoryRelayPersistence();
   const worker = new InProcessRelayWorker(persistence);
-  return new RelayService(persistence, worker, config);
+  return new RelayService(persistence, worker, config, { evaluator: allowAllEvaluator() });
 }
 
 function getRequest(path = "/api/v1/relay/health") {
@@ -181,6 +199,14 @@ describe("relay message submission endpoint", () => {
         messageId,
         queueDepth: 1,
         service: "stealth-relay",
+        replayed: false,
+        admission: {
+          allowed: true,
+          kind: "trusted",
+          reason: "sender_allowed",
+          policyVersion: 1,
+          requiredPostage: "0",
+        },
       },
     });
   });

--- a/tests/unit/stellar/registry.test.ts
+++ b/tests/unit/stellar/registry.test.ts
@@ -24,6 +24,8 @@ describe("Runtime Registry Drift Validation", () => {
       postageContractId: "CBBBB1",
       registryContractId: "CAAAA1",
       lifecycleContractId: "CAAAA1",
+      policiesContractId: "CCCCC1",
+      receiptsContractId: "CCCCC2",
     },
   };
 
@@ -32,6 +34,7 @@ describe("Runtime Registry Drift Validation", () => {
     contracts: {
       postage: { contractId: "CBBBB1" },
       lifecycle: { contractId: "CAAAA1" },
+      policies: { contractId: "CCCCC1" },
     },
   };
 
@@ -101,6 +104,20 @@ describe("Runtime Registry Drift Validation", () => {
 
     expect(() => validateRegistryDrift(mockConfigBase)).toThrowError(
       /STEALTH_REGISTRY_CONTRACT_ID/,
+    );
+  });
+
+  it("fails on policies contract ID mismatch", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        ...mockManifest,
+        contracts: { ...mockManifest.contracts, policies: { contractId: "CCCCC2" } },
+      }),
+    );
+
+    expect(() => validateRegistryDrift(mockConfigBase)).toThrowError(
+      /STEALTH_POLICIES_CONTRACT_ID/,
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes #1943 (BETA-036 / Workflow 2 — Live Protocol, Relay & Testnet Delivery).

Policy APIs and the Soroban Policies contract already existed, but relay submit did not enforce the recipient’s current trust / request / verified / priced / blocked policy before a message entered the mailbox. This PR wires **real** admission into the live relay path (Cloudflare worker + Docker entry), not a mock adapter or docs-only change.

**Actors**
- As a **recipient**, my current mailbox policy is enforced before ciphertext reaches queue / object storage.
- As a **sender**, I get a safe, actionable decision (`trusted` | `request` | `verified` | `priced` | `blocked`) with policy version and required postage — never the full policy document, never plaintext, never secrets.

## What changed

### Admission pipeline (`RelayService.submit`)
1. Schema-validate submit (`postage`, `verified`, `receipt` optional; defaults `0` / `false` / `false`).
2. **Idempotency**: if `messageId` already exists, return the **original** recorded admission (`replayed: true`) — do **not** re-evaluate live policy.
3. Evaluate via `RelayAdmissionEvaluator` (chain-first, off-chain fallback).
4. If denied → throw sender-safe `ApiError` (**403** forbidden / **422** insufficient_postage). **No** object-store write, **no** queue enqueue, **no** mailbox insert.
5. If allowed → stage payload (optional R2), enqueue envelope **with snapshotted evidence**, then best-effort lifecycle/receipt hooks.

### Evaluator (`src/services/relay/policy-admission.ts`)
- Resolves recipient policy version and classifies into the five sender-facing kinds.
- **Chain path**: simulate Policies contract `evaluate` (bounded timeout, default 2s).
- **Stale-chain fallback**: if chain version is behind a *confirmed* off-chain write intent, evaluate off-chain instead (`source: offchain_fallback`).
- Pending (unconfirmed) local writes do **not** force fallback — live chain remains authoritative.
- Malformed / timed-out / unavailable chain → off-chain fallback.
- Evidence persisted on the envelope is privacy-safe: version, kind, reason, rule, requiredPostage, source, evaluatedAt — no payload, no full policy, no secrets.

### Live chain adapter (`src/services/relay/policy-chain.ts`)
- Wraps generated `contracts/policies` client (`evaluate`).
- Only activates when `STEALTH_POLICIES_CONTRACT_ID` is a live `C…` id (rejects placeholders / repeated-letter stubs).
- Maps on-chain reason/rule enums to API codes.

### Off-chain evaluator alignment (`policy-service.evaluateMailboxPolicy`)
- Contract-faithful branches: allow → block → unknown → verified → receipt → sender tier → mailbox minimum postage.
- Pins `policyVersion` / `requiredPostage` / `kind` so relay evidence is complete even on fallback.

### Wiring
- **Cloudflare** (`relay/context.ts`): repository + live/off-chain evaluator + optional R2 object store + existing lifecycle `onAccepted` hook.
- **Docker** (`relay/index.ts`): same admission evaluator; uses in-memory API repo + configured policies contract id.
- **Config**: `policiesContractId` in schema/loader/registry drift checks (`STEALTH_POLICIES_CONTRACT_ID`).
- **OpenAPI**: `RelayAdmissionDecision`, submit request fields (`postage` / `verified` / `receipt`), result `admission` + `replayed`.

### Persistence
- `RelayEnvelope.admission` is required on accepted messages.
- Memory + KV enqueue remain first-write-wins / idempotent on `messageId` so retries cannot rewrite evidence or double-queue.

## Acceptance scenarios (issue checklist)

| Scenario | Behavior | Covered by |
|---|---|---|
| Blocked never reaches payload storage | Deny before R2 / queue / mailbox | integration: blocked + transport 403 |
| Policy change cannot alter recorded admission | Replay returns original evidence | integration: rewrite protection + idempotency |
| Every decision branch + stale-chain fallback | trusted / request / verified / priced / blocked + fallback | unit + integration suites |
| Retry / idempotency | Same `messageId` → `replayed: true`, queue depth unchanged | integration |
| Live testnet | Manifest Policies contract footprint readable | `tests/integration/relay/policy-admission.testnet.test.ts` (skips if no testnet manifest) |

## Sender-facing HTTP outcomes

| Disposition | HTTP | Notes |
|---|---|---|
| trusted / request (allowed) | **202** | Body includes `admission` + `replayed` |
| blocked / verified / receipt denied | **403** `forbidden` | Safe details only |
| priced (short postage) | **422** `insufficient_postage` | Includes `requiredPostage` |
| Duplicate admitted `messageId` | **202** | `replayed: true`, original admission |

## Primary paths

- `src/services/relay/policy-admission.ts` *(new)*
- `src/services/relay/policy-chain.ts` *(new)*
- `src/services/relay/relay-service.ts`
- `src/services/relay/context.ts` / `src/relay/index.ts`
- `src/server/api/policy-service.ts`
- `src/server/api/openapi.ts`
- `src/config/{schema,loader,registry}.ts`
- Tests under `tests/unit/relay/policy-admission*` and `tests/integration/relay/`

## Privacy / security

- Denied responses never echo ciphertext.
- Admission evidence intentionally omits full mailbox policy and secrets.
- Chain reads do not log keys, seeds, or payload bytes.
- Object store is only contacted **after** `allowed === true`.

## Dependencies

Builds on relay health/submit boundary (BETA-028) and policy defaults / write intents used for version pinning. Isolated from BETA-037 PR #2067 (sender-rule CRUD / sync UI) — this PR only owns **live admission enforcement**.

## Test plan

```bash
# Domain + evaluator branches (incl. stale/timeout/malformed chain)
npx vitest run tests/unit/relay/policy-admission.test.ts tests/unit/relay/policy-chain.test.ts

# Cross-boundary: service + object store + HTTP transport + idempotency
npx vitest run tests/unit/relay/policy-admission.integration.test.ts tests/unit/relay/kv-persistence.test.ts

# Existing relay health/submit regressions with admission wired
npx vitest run tests/unit/relay/relay-service.test.ts tests/unit/relay/relay-transport.test.ts

# Config / drift for policiesContractId
npx vitest run tests/unit/config/runtime-config.test.ts tests/unit/stellar/registry.test.ts

# Optional live testnet (skips without signed testnet manifest)
npx vitest run tests/integration/relay/policy-admission.testnet.test.ts

npx tsc --noEmit
npm run lint
```

Manual / review evidence
- [ ] Submit allowed unknown sender → **202** with `admission.kind=request` (or trusted when allow-listed)
- [ ] Block sender → **403**; confirm no queue row and object-store size unchanged
- [ ] Raise minimum postage → short postage → **422** with `requiredPostage`
- [ ] Require verified → unverified → **403** `verification_required`
- [ ] Accept once, flip policy to block, retry same `messageId` → still **202** with original admission + `replayed: true`
- [ ] Confirm response / logs contain no plaintext payload or operator secrets

## Definition of done

- [x] Real relay path evaluates current recipient policy before payload storage
- [x] Blocked / denied paths never store ciphertext
- [x] Recorded admission is immutable across retries and later policy changes
- [x] Automated coverage for decision branches, stale-chain fallback, idempotency, and HTTP outcomes
- [x] Live testnet probe present (skips when manifest/RPC unavailable)
- [ ] CI green on this PR