### PR TITLE
feat(mail): implement sent and outbox views from live send state

### DIFF
--- a/src/components/mail/EmailView.tsx
+++ b/src/components/mail/EmailView.tsx
@@ -49,6 +49,8 @@ import {
   type ComposeMode,
   type ComposeSubmission,
 } from "./composeValidation";
+import { getEntry } from "@/services/storage/outbox";
+import { SendProgress } from "@/features/compose/SendProgress";
 
 export type EmailViewActions = {
   onReply?: (email: Email, body?: string) => void;
@@ -70,6 +72,8 @@ export type EmailViewActions = {
   onCalendarResponseChange?: (eventId: string, response: CalendarResponse) => void;
   onCalendarReminderChange?: (eventId: string, reminder: string) => void;
   onPreviewAttachment?: (attachment: { name: string; size: string; type: string }) => void;
+  onRetrySend?: (email: Email) => void;
+  onCancelSend?: (email: Email) => void;
 };
 
 export function EmailView({
@@ -101,6 +105,8 @@ export function EmailView({
     ? canRenderBody(selectedThreadMessage)
     : threadView.kind === "idle";
 
+  const outboxEntry = email ? getEntry(email.id) : null;
+
   return (
     <section className="mail-reader-atmosphere relative m-3 ml-0 flex h-[calc(100vh-3.5rem-1.5rem)] flex-1 flex-col overflow-hidden rounded-[8px]">
       <AnimatePresence mode="wait">
@@ -122,6 +128,116 @@ export function EmailView({
               <p className="mt-1 text-xs text-muted-foreground">
                 Pick a thread from the list to read it here.
               </p>
+            </div>
+          </motion.div>
+        ) : outboxEntry ? (
+          <motion.div
+            key={email.id}
+            initial={false}
+            animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+            exit={{ opacity: 0, y: -8, filter: "blur(8px)" }}
+            transition={{ duration: 0.35, ease: [0.2, 0.8, 0.2, 1] }}
+            className="flex h-full flex-col"
+          >
+            <div className="flex flex-wrap items-center gap-2 border-b border-white/5 px-4 py-2.5">
+              <div className="flex-1">
+                <span className="rounded-full bg-white/5 border border-white/10 px-2.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.16em] text-muted-foreground">
+                  {outboxEntry.status === "failed" ? "Failed Delivery" : "Pending Outbox"}
+                </span>
+              </div>
+
+              <div className="ml-auto flex flex-none items-center justify-end gap-2">
+                {!outboxEntry.isCommitted && (
+                  <motion.button
+                    whileTap={{ scale: 0.96 }}
+                    whileHover={{ y: -1 }}
+                    onClick={() => actions.onCancelSend?.(email)}
+                    className="flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-muted-foreground transition hover:bg-white/10 hover:text-foreground"
+                  >
+                    Cancel Send
+                  </motion.button>
+                )}
+                {outboxEntry.status === "failed" && outboxEntry.canRetry !== false && (
+                  <motion.button
+                    whileTap={{ scale: 0.96 }}
+                    whileHover={{ y: -1 }}
+                    onClick={() => actions.onRetrySend?.(email)}
+                    className="flex items-center gap-1.5 rounded-md border border-blue-400/30 bg-blue-500/20 px-3.5 py-1.5 text-xs font-semibold text-blue-100 transition hover:bg-blue-500/30"
+                  >
+                    Retry Send
+                  </motion.button>
+                )}
+              </div>
+            </div>
+
+            <div className="scrollbar-thin flex-1 overflow-y-auto px-5 py-5 sm:px-7">
+              <article className="mx-auto w-full max-w-[920px]">
+                <div className="border-b border-white/[0.07] pb-5">
+                  <p className="mail-reader-meta mb-2 text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Outbound Message
+                  </p>
+                  <h1 className="mail-reader-title max-w-[720px] text-[26px] font-semibold leading-[1.12] text-foreground sm:text-[30px]">
+                    {email.subject}
+                  </h1>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <span className="mail-reader-meta rounded-md border border-white/[0.1] bg-white/[0.045] px-2 py-1 text-[10px] uppercase text-muted-foreground">
+                      Recipients: {outboxEntry.recipients.join(", ")}
+                    </span>
+                    {outboxEntry.postageAmount && (
+                      <span className="mail-reader-meta rounded-md border border-white/[0.1] bg-white/[0.045] px-2 py-1 text-[10px] uppercase text-muted-foreground">
+                        Postage: {outboxEntry.postageAmount} XLM
+                      </span>
+                    )}
+                    <span className="mail-reader-meta rounded-md border border-white/[0.1] bg-white/[0.045] px-2 py-1 text-[10px] uppercase text-muted-foreground">
+                      Started: {email.time}
+                    </span>
+                  </div>
+                </div>
+
+                {outboxEntry.stages && outboxEntry.stages.length > 0 && (
+                  <div className="mt-6">
+                    <SendProgress
+                      stages={outboxEntry.stages.map((s) => ({
+                        id: s.id as any,
+                        label: s.label,
+                        status: s.status as any,
+                        detail: s.detail,
+                      }))}
+                      error={
+                        outboxEntry.errorMessage ||
+                        (outboxEntry.status === "failed" ? "Relay submission failed" : null)
+                      }
+                      failureDetails={{
+                        stage: outboxEntry.stages.find((s) => s.status === "error")?.id,
+                        code: outboxEntry.errorCode,
+                        message: outboxEntry.errorMessage,
+                        supportId: outboxEntry.supportId,
+                        timestamp: outboxEntry.updatedAt,
+                        isCommitted: outboxEntry.isCommitted,
+                        canRetry: outboxEntry.canRetry,
+                      }}
+                      supportId={outboxEntry.supportId}
+                      canRetry={outboxEntry.canRetry}
+                      isCommitted={outboxEntry.isCommitted}
+                      onRetry={() => actions.onRetrySend?.(email)}
+                      onSaveDraft={() => {
+                        actions.onShowToast?.("Draft already saved.");
+                      }}
+                    />
+                  </div>
+                )}
+
+                <div className="mt-7 max-w-[68ch] space-y-4 text-sm text-muted-foreground">
+                  <p>Plaintext body is not persisted locally for security and privacy reasons.</p>
+                  {outboxEntry.status === "failed" && (
+                    <p className="text-xs text-red-300">
+                      Error Details:{" "}
+                      {outboxEntry.errorMessage ??
+                        "No detailed error message was returned from the relay."}
+                    </p>
+                  )}
+                </div>
+              </article>
             </div>
           </motion.div>
         ) : (

--- a/src/features/compose/sendPipeline.ts
+++ b/src/features/compose/sendPipeline.ts
@@ -300,6 +300,12 @@ export class SendPipeline {
     if (entry.isCommitted) {
       pipeline.isCommitted = true;
     }
+    if (entry.envelope && entry.ciphertext) {
+      pipeline.sealed = {
+        payload: entry.envelope,
+        ciphertext: entry.ciphertext,
+      };
+    }
 
     return pipeline;
   }
@@ -608,6 +614,34 @@ export class SendPipeline {
   }
 
   private async executeSubmitStage(): Promise<SendOutcome | null> {
+    if (!this.requestSigner && this.sealed) {
+      const sign = async (canonical: string) => {
+        const signature = await this.signer(canonical);
+        return signature;
+      };
+      this.requestSigner = {
+        envelopePayload: this.sealed.payload,
+        audience: this.audience,
+        idempotencyKey: this.idempotencyKey,
+        replayWindowSeconds: DEFAULT_REPLAY_WINDOW_SECONDS,
+        sign,
+      };
+    }
+    if (!this.signedRequest && this.requestSigner) {
+      try {
+        this.signedRequest = await buildSignedRelayRequest(this.requestSigner);
+      } catch (error) {
+        this.setStage("submit", "error", error instanceof Error ? error.message : "Signing failed");
+        return this.fail(
+          "submit",
+          "failed",
+          error instanceof Error ? error.message : "Wallet could not sign the request",
+          "ERR_SIGNING_FAILED",
+          true,
+        );
+      }
+    }
+
     if (!this.signedRequest || !this.requestSigner) {
       return this.fail(
         "submit",

--- a/src/features/mail/live-mailbox.ts
+++ b/src/features/mail/live-mailbox.ts
@@ -189,9 +189,9 @@ export function mergeLiveFolderCounts(
     ...local,
     inbox: live.inbox,
     requests: live.requests,
-    sent: live.sent,
+    sent: local.sent, // Use local count since it includes optimistic/outbox entries
     drafts: live.drafts,
-    outbox: live.outbox,
+    outbox: local.outbox, // Use local count since it includes local pending/failed entries
     archive: live.archive,
     spam: live.spam,
     trash: live.trash,

--- a/src/features/mail/shell/MailApp.tsx
+++ b/src/features/mail/shell/MailApp.tsx
@@ -122,6 +122,7 @@ export function MailApp({ isDemoMode = false }: MailAppProps) {
     closeSnooze: snooze.close,
     isDemoMode,
     actor,
+    refreshOutbox: source.refreshOutbox,
   });
 
   const bulk = useMailBulkActions({

--- a/src/features/mail/useMailActions.ts
+++ b/src/features/mail/useMailActions.ts
@@ -22,6 +22,9 @@ import type { TrashResult } from "./useMailSource";
 import type { FeedbackTone } from "@/features/design-system/feedback/use-feedback";
 import type { MailboxFlagsPatch } from "@/lib/api";
 import { flagsPatchFromEmail } from "./live-mailbox";
+import { getEntry, removeEntry, patchEntry } from "@/services/storage/outbox";
+import { SendPipeline } from "@/features/compose/sendPipeline";
+import { authorizeSend } from "@/services/stellar/wallet";
 
 import { sharedTypedApi as api } from "@/lib/api";
 
@@ -51,6 +54,7 @@ export function useMailActions(input: {
   closeSnooze: () => void;
   isDemoMode?: boolean;
   actor?: string | null;
+  refreshOutbox?: () => void;
 }) {
   const {
     emails,
@@ -69,7 +73,62 @@ export function useMailActions(input: {
     closeSnooze,
     isDemoMode = false,
     actor = null,
+    refreshOutbox,
   } = input;
+
+  const handleRetrySend = useCallback(
+    async (email: Email) => {
+      const entry = getEntry(email.id);
+      if (!entry) return;
+
+      patchEntry(email.id, {
+        status: "queued",
+        errorCode: undefined,
+        errorMessage: undefined,
+      });
+      refreshOutbox?.();
+
+      const pipeline = SendPipeline.fromPersisted(
+        entry,
+        {},
+        () => {
+          refreshOutbox?.();
+        },
+        { signer: authorizeSend },
+      );
+
+      try {
+        const outcome = await pipeline.run();
+        if (outcome.ok) {
+          showToast("Message sent successfully");
+        } else {
+          showToast(`Send failed: ${outcome.message}`);
+        }
+        refreshOutbox?.();
+      } catch (error) {
+        showToast("Send failed due to an unexpected error");
+        refreshOutbox?.();
+      }
+    },
+    [refreshOutbox, showToast],
+  );
+
+  const handleCancelSend = useCallback(
+    (email: Email) => {
+      const entry = getEntry(email.id);
+      if (!entry) return;
+
+      if (entry.isCommitted) {
+        showToast("Cannot cancel: message is already committed to the relay");
+        return;
+      }
+
+      removeEntry(email.id);
+      refreshOutbox?.();
+      showToast("Send operation cancelled");
+    },
+    [refreshOutbox, showToast],
+  );
 
   const handleConvertSender = useCallback(
     (target: SenderConversionTarget, choice: SenderPolicyChoice) => {
@@ -321,6 +380,8 @@ export function useMailActions(input: {
       onCalendarResponseChange: input.updateCalendarResponse,
       onCalendarReminderChange: input.updateCalendarReminder,
       onPreviewAttachment: previewAttachment,
+      onRetrySend: handleRetrySend,
+      onCancelSend: handleCancelSend,
     }),
     [
       addMailEvent,
@@ -338,6 +399,8 @@ export function useMailActions(input: {
       previewAttachment,
       showToast,
       updateEmail,
+      handleRetrySend,
+      handleCancelSend,
     ],
   );
 

--- a/src/features/mail/useMailSource.ts
+++ b/src/features/mail/useMailSource.ts
@@ -27,6 +27,7 @@ import {
   mergeLiveFolderCounts,
 } from "./live-mailbox";
 import { buildFolderCounts } from "./navigation";
+import { listOutbox, patchEntry, type OutboxEntry } from "@/services/storage/outbox";
 
 export interface UseMailSourceOptions {
   isDemoMode: boolean;
@@ -34,6 +35,67 @@ export interface UseMailSourceOptions {
 
 export type MailMutationResult = { ok: true } | { ok: false; reason: string };
 export type TrashResult = MailMutationResult;
+
+export function outboxEntryToEmail(entry: OutboxEntry): Email {
+  const folder = entry.status === "delivered" ? "sent" : "outbox";
+  const unread = false;
+
+  let preview = "Outbox: Message ready for delivery";
+  if (entry.status === "failed") {
+    preview = `Failed: ${entry.errorMessage ?? "Relay submission failed"}`;
+  } else if (entry.status === "queued") {
+    preview = "Outbox: Queued for delivery";
+  } else if (entry.status === "encrypting") {
+    preview = "Outbox: Encrypting message...";
+  } else if (entry.status === "awaiting_signature") {
+    preview = "Outbox: Awaiting wallet signature...";
+  } else if (entry.status === "reserving_postage") {
+    preview = "Outbox: Reserving postage...";
+  } else if (entry.status === "submitting") {
+    preview = "Outbox: Submitting to relay...";
+  }
+
+  const labels: string[] = [];
+  if (entry.status === "failed") {
+    labels.push(entry.canRetry !== false ? "Retryable Failure" : "Terminal Failure");
+  } else if (entry.status === "awaiting_signature") {
+    labels.push("Signature Required");
+  } else if (entry.status !== "delivered") {
+    labels.push("Pending Outbox");
+  }
+
+  const from = "Me";
+  const email = entry.sender ?? "me";
+
+  const created = new Date(entry.createdAt);
+  const time = Number.isNaN(created.getTime())
+    ? entry.createdAt
+    : created.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+
+  return {
+    id: entry.id,
+    from,
+    email,
+    subject: entry.subject || "(No Subject)",
+    preview,
+    body: "",
+    time,
+    unread,
+    starred: false,
+    folder,
+    labels,
+    attachments: [],
+    avatarColor: "#5b6470",
+    verifiedSender: false,
+    postageAmount: entry.postageAmount,
+    threadId: `thread-outbox-${entry.id}`,
+  };
+}
 
 export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   const session = useSession({ enabled: !isDemoMode });
@@ -51,6 +113,11 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   const [demoReady, setDemoReady] = useState(!isDemoMode);
   const [overlay, setOverlay] = useState<MailWorkspaceOverlay>(EMPTY_MAIL_WORKSPACE);
   const pendingMutations = useRef(new Set<string>());
+  const [outboxRevision, setOutboxRevision] = useState(0);
+
+  const refreshOutbox = useCallback(() => {
+    setOutboxRevision((prev) => prev + 1);
+  }, []);
 
   useEffect(() => {
     if (!import.meta.env.DEV || !isDemoMode) return;
@@ -66,7 +133,41 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
   }, [isDemoMode]);
 
   const serverEmails = isDemoMode ? demoEmails : mailbox.emails;
-  const emails = useMemo(() => mergeMailWorkspace(serverEmails, overlay), [overlay, serverEmails]);
+
+  useEffect(() => {
+    if (serverEmails.length > 0) {
+      const outbox = listOutbox();
+      const serverIds = new Set(serverEmails.map((email) => email.id));
+      let changed = false;
+      for (const entry of outbox) {
+        if (entry.status !== "delivered" && serverIds.has(entry.id)) {
+          patchEntry(entry.id, {
+            status: "delivered",
+            isCommitted: true,
+            canRetry: false,
+          });
+          changed = true;
+        }
+      }
+      if (changed) {
+        refreshOutbox();
+      }
+    }
+  }, [serverEmails, refreshOutbox]);
+
+  const emails = useMemo(() => {
+    const outboxEntries = listOutbox();
+    const outboxEmails = outboxEntries.map(outboxEntryToEmail);
+    const combined = [...serverEmails];
+    const serverIds = new Set(serverEmails.map((e) => e.id));
+    for (const oEmail of outboxEmails) {
+      if (!serverIds.has(oEmail.id)) {
+        combined.push(oEmail);
+      }
+    }
+    return mergeMailWorkspace(combined, overlay);
+  }, [overlay, serverEmails, outboxRevision]);
+
   const folderCounts = useMemo(() => {
     const local = buildFolderCounts(emails);
     if (isDemoMode) return local;
@@ -159,6 +260,7 @@ export function useMailSource({ isDemoMode }: UseMailSourceOptions) {
     hasMore: isDemoMode ? false : mailbox.hasMore,
     isLoadingMore: isDemoMode ? false : mailbox.isFetchingNextPage,
     loadMore: mailbox.fetchNextPage,
+    refreshOutbox,
   };
 }
 

--- a/src/features/mail/useThreadRead.ts
+++ b/src/features/mail/useThreadRead.ts
@@ -11,6 +11,7 @@ import { useConnectivity } from "./useConnectivity";
 import type { MailboxSealedMessage } from "@/lib/api";
 import { applyThreadMessageToEmail, buildMailThread, siblingMessageIds } from "./live-thread";
 import { getMailboxKeyProvider } from "./mailbox-keys";
+import { getEntry } from "@/services/storage/outbox";
 import {
   classifyMailSourceError,
   type ClassifiedMailSourceError,
@@ -43,7 +44,8 @@ export function useThreadRead({
     [emails, selectedId],
   );
   const connectivity = useConnectivity();
-  const live = Boolean(enabled && actor && selectedId && !isDemoMode);
+  const isOutbox = Boolean(selectedId && getEntry(selectedId));
+  const live = Boolean(enabled && actor && selectedId && !isDemoMode && !isOutbox);
   const threadKey = queryKeys.mailbox.thread(actor ?? "anonymous");
 
   const query = useQuery({

--- a/tests/unit/mail/outbox.test.ts
+++ b/tests/unit/mail/outbox.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { OutboxEntry } from "@/services/storage/outbox";
+import { outboxEntryToEmail } from "@/features/mail/useMailSource";
+import { mergeLiveFolderCounts } from "@/features/mail/live-mailbox";
+import type { MailboxCounts } from "@/lib/api";
+import type { MailFolder } from "@/components/mail/data";
+
+describe("outbox projection and mapping tests", () => {
+  it("correctly maps a delivered outbox entry to sent folder", () => {
+    const entry: OutboxEntry = {
+      id: "msg-1234",
+      createdAt: "2026-08-20T12:00:00.000Z",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+      subject: "Test Sent Message",
+      recipients: ["alice@stealth.xyz"],
+      status: "delivered",
+      attempts: 1,
+      postageAmount: "0.0001",
+    };
+
+    const email = outboxEntryToEmail(entry);
+
+    expect(email.id).toBe("msg-1234");
+    expect(email.folder).toBe("sent");
+    expect(email.subject).toBe("Test Sent Message");
+    expect(email.preview).toBe("Outbox: Message ready for delivery");
+    expect(email.labels).toEqual([]);
+    expect(email.postageAmount).toBe("0.0001");
+  });
+
+  it("correctly maps a pending outbox entry to outbox folder", () => {
+    const entry: OutboxEntry = {
+      id: "msg-5678",
+      createdAt: "2026-08-20T12:00:00.000Z",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+      subject: "Test Pending Message",
+      recipients: ["bob@stealth.xyz"],
+      status: "queued",
+      attempts: 0,
+      postageAmount: "0.0002",
+    };
+
+    const email = outboxEntryToEmail(entry);
+
+    expect(email.id).toBe("msg-5678");
+    expect(email.folder).toBe("outbox");
+    expect(email.subject).toBe("Test Pending Message");
+    expect(email.preview).toBe("Outbox: Queued for delivery");
+    expect(email.labels).toContain("Pending Outbox");
+  });
+
+  it("correctly maps a failed retryable outbox entry", () => {
+    const entry: OutboxEntry = {
+      id: "msg-9999",
+      createdAt: "2026-08-20T12:00:00.000Z",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+      subject: "Test Failed Message",
+      recipients: ["charlic@stealth.xyz"],
+      status: "failed",
+      attempts: 3,
+      errorMessage: "Relay unreachable",
+      canRetry: true,
+    };
+
+    const email = outboxEntryToEmail(entry);
+
+    expect(email.id).toBe("msg-9999");
+    expect(email.folder).toBe("outbox");
+    expect(email.preview).toBe("Failed: Relay unreachable");
+    expect(email.labels).toContain("Retryable Failure");
+  });
+
+  it("correctly maps a failed terminal outbox entry", () => {
+    const entry: OutboxEntry = {
+      id: "msg-0000",
+      createdAt: "2026-08-20T12:00:00.000Z",
+      updatedAt: "2026-08-20T12:00:00.000Z",
+      subject: "Test Terminal Failed Message",
+      recipients: ["dan@stealth.xyz"],
+      status: "failed",
+      attempts: 3,
+      errorMessage: "Recipient rejected postage",
+      canRetry: false,
+    };
+
+    const email = outboxEntryToEmail(entry);
+
+    expect(email.id).toBe("msg-0000");
+    expect(email.folder).toBe("outbox");
+    expect(email.labels).toContain("Terminal Failure");
+  });
+
+  it("preserves local counts for sent and outbox folders in mergeLiveFolderCounts", () => {
+    const local: Record<MailFolder, number> = {
+      all: 10,
+      inbox: 5,
+      priority: 2,
+      snoozed: 0,
+      verified: 3,
+      pending: 0,
+      requests: 0,
+      encrypted: 0,
+      receipts: 0,
+      starred: 1,
+      sent: 4, // local count (optimistic outbox entries included)
+      outbox: 2, // local count (pending outbox entries included)
+      drafts: 1,
+      scheduled: 0,
+      archive: 0,
+      spam: 0,
+      trash: 0,
+    };
+
+    const live: MailboxCounts = {
+      inbox: 6,
+      requests: 1,
+      sent: 2, // live counts on server
+      drafts: 2,
+      outbox: 0, // live counts on server
+      archive: 1,
+      spam: 0,
+      trash: 0,
+      unread: 3,
+      starred: 2,
+    };
+
+    const merged = mergeLiveFolderCounts(local, live);
+
+    // inbox, drafts etc should use live counts
+    expect(merged.inbox).toBe(6);
+    expect(merged.drafts).toBe(2);
+    // sent and outbox should preserve local counts
+    expect(merged.sent).toBe(4);
+    expect(merged.outbox).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #1966

## PR Description

### Background

Issue #1966 identified that the Outbox and Sent folder views in the mail interface were not connected to the live local send state machine. The outbox storage helpers in `src/services/storage/outbox.ts` existed and were being written to by the send pipeline, but nothing in the mail feature was reading from them to project messages into the UI. As a result, users had no way to see the delivery status of their outgoing messages, distinguish submitted mail from mail that never left, identify failures, or safely retry or cancel a stuck send.

The issue also noted that a pending message could appear as sent before the relay confirmed delivery, and that retrying a failed message had to preserve the same logical message ID and idempotency key so the relay could recognise and deduplicate it correctly.

### What I Changed and Why

I built a complete vertical slice connecting the local outbox storage to the mail UI. The work touches the mail feature hooks, the email reader component, the folder count merge, the thread query loader, and the send pipeline itself. I kept all changes strictly within the scope of the issue and did not touch any backend API, contract, or unrelated component.

**Outbox Projection into the Mail UI (`useMailSource.ts`)**

I added a new exported function `outboxEntryToEmail` that takes a raw `OutboxEntry` from local storage and maps it to the `Email` shape used by every mail component. The mapping works as follows:

- If the entry `status` is `"delivered"`, the email is projected into the `"sent"` folder. Otherwise it goes into `"outbox"`.
- The `preview` field is set to a human-readable status string that reflects the current stage, so the message list shows something like "Outbox: Awaiting wallet signature..." instead of a blank or misleading preview.
- The `labels` array is populated based on the entry status. A `"failed"` entry with `canRetry !== false` gets a `"Retryable Failure"` label. A `"failed"` entry with `canRetry === false` gets `"Terminal Failure"`. A pending entry gets `"Pending Outbox"`. An `"awaiting_signature"` entry gets `"Signature Required"` so users know the wallet needs action.
- The body is left empty intentionally. Plaintext bodies are not persisted to the local outbox for security and custody compliance reasons, so there is nothing to display in the reader body.

Inside the `useMailSource` hook itself I added an `outboxRevision` counter in state and a `refreshOutbox` callback. Every time an outbox entry changes state, callers can call `refreshOutbox()` to bump the counter, which invalidates the `useMemo` and causes the email list to rebuild. This avoids polling and ensures the UI is always consistent with the local storage.

I also added a `useEffect` that runs whenever `serverEmails` changes. It reads the full outbox list and checks whether any pending entry now has a matching ID in the server-confirmed mail list. If it does, I mark that entry as `"delivered"` in local storage and trigger a refresh. This is the reconciliation step that moves a message from Outbox to Sent as soon as the relay confirms it.

The final email list is built inside `useMemo` by calling `listOutbox()`, mapping each entry through `outboxEntryToEmail`, then merging the results with `serverEmails` using a `Set` for deduplication in O(N + M) time instead of a nested loop. Only outbox entries whose IDs do not already exist in the server list are included, because once the server confirms delivery the server copy takes priority.

**Folder Count Accuracy (`live-mailbox.ts`)**

The existing `mergeLiveFolderCounts` function was overwriting the local `sent` and `outbox` counts with the server-provided counts. That meant any locally visible pending or failed message was never reflected in the sidebar count badge. I changed those two fields to use `local.sent` and `local.outbox` instead so the counts always match what the user actually sees. All other folders still use the live server counts.

**Thread Query Guard (`useThreadRead.ts`)**

The `useThreadRead` hook fires a server API call to fetch the full message content whenever a message is selected. This should not happen for local outbox entries because they do not exist on the server yet. I imported `getEntry` from the outbox storage module and added a check before computing the `live` flag. If `getEntry(selectedId)` returns an entry, `live` is set to `false` and the query is disabled. This saves unnecessary network requests and avoids errors from querying a message ID that the server does not recognise.

**Envelope Re-hydration and Re-signing on Retry (`sendPipeline.ts`)**

When a send fails before or during the submit stage, the pipeline needs to be able to resume from the persisted outbox entry. The problem is that the relay's replay window is typically 5 to 10 minutes. If the user retries after that window closes, the previously signed relay request is no longer valid.

In `fromPersisted`, I added a block that checks whether the outbox entry has `envelope` and `ciphertext` fields set. If they are present, I assign them to `pipeline.sealed`. This means the pipeline has the already-encrypted payload available without needing to re-encrypt.

In `executeSubmitStage`, I added logic that runs before the existing guard on `signedRequest`. If `requestSigner` is missing but `sealed` is present, I reconstruct a `requestSigner` object using the stored envelope payload and the wallet's `authorizeSend` function as the signing callback. Then if `signedRequest` is still missing after that, I call `buildSignedRelayRequest` to produce a fresh signed request, which prompts the user's Freighter wallet for a new signature. If signing throws, the stage is marked as `"error"` with the error message and a retryable failure is returned. The original guard then catches any remaining missing state.

This ensures that retrying a failed message always produces a fresh, valid signature without duplicating the encryption or postage reservation stages.

**Retry and Cancel Actions (`useMailActions.ts`)**

I added `refreshOutbox` as an optional parameter to the `useMailActions` input. Then I implemented two new callbacks:

`handleRetrySend` reads the outbox entry for the given email ID, resets its status to `"queued"` and clears the `errorCode` and `errorMessage` fields, triggers a refresh so the UI reflects the reset state immediately, then instantiates a `SendPipeline` via `fromPersisted` with the persisted entry and the `authorizeSend` signer. It calls `pipeline.run()` and shows a toast when the result comes back. If the pipeline throws unexpectedly, it also shows a toast and triggers another refresh to display whatever state the pipeline left in storage.

`handleCancelSend` reads the outbox entry and checks `isCommitted`. If the entry is already committed, it means the relay has already accepted the message payload and cancelling is not safe, so the function shows a toast and returns without doing anything. If the entry is not committed, it calls `removeEntry` to delete it from local storage and triggers a refresh so the message disappears from the Outbox folder immediately.

Both callbacks are exposed in the `emailActions` memoized object as `onRetrySend` and `onCancelSend` so that `EmailView` can call them directly.

**Outbox Reader View (`EmailView.tsx`)**

Inside the `EmailView` render function I added a call to `getEntry(email.id)` to check if the selected email is a local outbox entry. If it is, I render a completely different layout instead of the normal message body reader.

The outbox reader layout has a top bar with a status badge that reads either "Failed Delivery" or "Pending Outbox" depending on the entry status. The top bar also contains action buttons. "Cancel Send" is shown when the entry is not yet committed. "Retry Send" is shown when the entry has failed and `canRetry` is not `false`. Both buttons call the corresponding callbacks on the `actions` prop.

Below the top bar, the article section displays the message subject, the recipient list from `outboxEntry.recipients`, the postage amount if set, and the start time. If `outboxEntry.stages` is populated, the `SendProgress` component is rendered and receives the stage list, error string, and a `failureDetails` object containing the stage that failed, the error code, the error message, the support ID, the timestamp, whether the entry is committed, and whether it can be retried. There is also a short note at the bottom explaining that the plaintext body is not stored locally, and a red error details paragraph that appears when the status is `"failed"`.

This layout is inserted as a third conditional branch between the empty state and the normal message reader, so neither of the existing render paths is changed.

**Wiring in MailApp (`shell/MailApp.tsx`)**

I passed `refreshOutbox: source.refreshOutbox` into the `useMailActions` call so the retry and cancel handlers have access to the callback that triggers the outbox list to rebuild.


## Changes Made

- `src/features/mail/useMailSource.ts`: Added `outboxEntryToEmail` function that maps a raw `OutboxEntry` to an `Email` model with accurate folder assignment, label classification, and status preview text. Added `outboxRevision` state counter and `refreshOutbox` callback. Added `useEffect` that reconciles pending outbox entries with the server-confirmed email list and marks them as delivered when a match is found. Rewrote the `emails` `useMemo` to merge outbox-projected emails with server emails using a `Set`-based deduplication pass. Exposed `refreshOutbox` in the return object.

- `src/features/mail/live-mailbox.ts`: Changed `mergeLiveFolderCounts` to use local counts for the `"sent"` and `"outbox"` folders instead of the server-provided counts, so sidebar badges always reflect the number of messages the user actually sees.

- `src/features/mail/useThreadRead.ts`: Imported `getEntry` from the outbox storage module. Added an `isOutbox` boolean computed from `getEntry(selectedId)`. Changed the `live` flag to include `&& !isOutbox` so the server thread query is disabled for messages that exist only in the local outbox.

- `src/features/compose/sendPipeline.ts`: In `fromPersisted`, added a block that re-hydrates `pipeline.sealed` from `entry.envelope` and `entry.ciphertext` when both are present. In `executeSubmitStage`, added logic that reconstructs `requestSigner` from the sealed payload and the wallet signer if `requestSigner` is missing, then calls `buildSignedRelayRequest` to produce a fresh signed request before falling through to the existing submission logic.

- `src/features/mail/useMailActions.ts`: Added `refreshOutbox` to the input parameter type and destructuring. Implemented `handleRetrySend` that resets the outbox entry status, rebuilds the pipeline from persisted state, runs it, and shows a result toast. Implemented `handleCancelSend` that checks `isCommitted` and either blocks cancellation or removes the entry and triggers a refresh. Exposed both as `onRetrySend` and `onCancelSend` in the `emailActions` memoized object.

- `src/features/mail/shell/MailApp.tsx`: Passed `refreshOutbox: source.refreshOutbox` to the `useMailActions` call.

- `src/components/mail/EmailView.tsx`: Imported `getEntry` and `SendProgress`. Added `onRetrySend` and `onCancelSend` to the `EmailViewActions` type. Added `outboxEntry` constant derived from `getEntry(email.id)`. Added a third conditional render branch for outbox entries that shows status badges, Cancel Send and Retry Send buttons, the message metadata header, the `SendProgress` stage checklist with failure details, a privacy note about the missing body, and a red error details line for failed entries.

- `tests/unit/mail/outbox.test.ts`: New test file. Tests that a delivered entry maps to the `"sent"` folder with no labels. Tests that a queued entry maps to `"outbox"` with a `"Pending Outbox"` label. Tests that a retryable failed entry maps to `"outbox"` with a `"Retryable Failure"` label. Tests that a terminal failed entry maps to `"outbox"` with a `"Terminal Failure"` label. Tests that `mergeLiveFolderCounts` preserves local counts for `"sent"` and `"outbox"` while using server counts for all other folders.

## Testing

**New test suite**
```
npx vitest run --pool=forks tests/unit/mail/outbox.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
Duration  1.07s
```

**Related existing suites**
```
npx vitest run --pool=forks tests/unit/compose/sendPipeline.test.ts tests/unit/mail/live-mailbox.test.ts tests/unit/mail/unsent-work.test.ts
Test Files  3 passed (3)
Tests  21 passed (21)
Duration  558ms
```

**Full unit suite**
```
npx vitest run --pool=forks tests/unit/
Test Files  264 passed (264)
Tests  2830 passed | 3 expected fail (2833)
Duration  55.01s
```

**TypeScript compilation**
```
npx tsc --noEmit
Exit code 0, no output
```

**Lint and format**
```
npm run lint
Exit code 0, no output

npm run format
Exit code 0, all files unchanged or reformatted
```

## Scope Notes
- These are frontend-only changes. No backend worker, API route, database schema, or Cloudflare Durable Object was modified.
- No contract logic was touched.
- No new npm dependencies were added.
- No demo fixture or mock data was introduced on any production code path.

## Breaking Changes
None. The changes are strictly additive. Existing email reading, mailbox sync, and compose flows are not affected. The new outbox render branch in `EmailView` only activates when the selected message ID exists in the local outbox storage, so it has zero effect on normal server-backed messages.