### PR TITLE
feat(policies): BETA-037 live versioned sender rules (Closes #1944)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -23,7 +23,9 @@
         "scheme": "bearer",
         "bearerFormat": "SEP-10 JWT",
         "description": "Authenticates a Stellar account through the [SEP-10 Web Authentication](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) challenge flow. Fetch a short-lived challenge transaction from the service's WEB_AUTH_ENDPOINT, verify the server signature and transaction fields, sign the challenge with an authorized Stellar account signer, and exchange the signed transaction for a token. Send that token on protected API calls as `Authorization: Bearer <SEP-10-token>`. Never send a Stellar secret seed. The server derives the actor from the verified token and enforces challenge expiry and replay protection; `x-stealth-address` alone is not proof of identity.",
-        "x-required-headers": ["Authorization"],
+        "x-required-headers": [
+          "Authorization"
+        ],
         "x-signing-specification": "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md",
         "x-challenge-flow": [
           "Request a challenge transaction from the WEB_AUTH_ENDPOINT for the Stellar account.",
@@ -43,7 +45,10 @@
     "schemas": {
       "ApiMeta": {
         "type": "object",
-        "required": ["requestId", "timestamp"],
+        "required": [
+          "requestId",
+          "timestamp"
+        ],
         "properties": {
           "requestId": {
             "type": "string",
@@ -58,7 +63,10 @@
       },
       "RecoveryCodeRedeemRequest": {
         "type": "object",
-        "required": ["identifier", "code"],
+        "required": [
+          "identifier",
+          "code"
+        ],
         "additionalProperties": false,
         "properties": {
           "identifier": {
@@ -73,7 +81,10 @@
       },
       "RecoveryCodeRedeemResponse": {
         "type": "object",
-        "required": ["user", "session"],
+        "required": [
+          "user",
+          "session"
+        ],
         "additionalProperties": false,
         "properties": {
           "user": {
@@ -104,7 +115,12 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["active", "suspended", "pending_verification", "deactivated"]
+                "enum": [
+                  "active",
+                  "suspended",
+                  "pending_verification",
+                  "deactivated"
+                ]
               },
               "createdAt": {
                 "type": "string",
@@ -118,7 +134,13 @@
           },
           "session": {
             "type": "object",
-            "required": ["sessionId", "userId", "createdAt", "expiresAt", "lastActiveAt"],
+            "required": [
+              "sessionId",
+              "userId",
+              "createdAt",
+              "expiresAt",
+              "lastActiveAt"
+            ],
             "additionalProperties": false,
             "properties": {
               "sessionId": {
@@ -149,12 +171,20 @@
       },
       "RecoveryCodeRegenerateResponse": {
         "type": "object",
-        "required": ["status", "totalCodes", "remainingCodes", "generatedAt", "codes"],
+        "required": [
+          "status",
+          "totalCodes",
+          "remainingCodes",
+          "generatedAt",
+          "codes"
+        ],
         "additionalProperties": false,
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["active"]
+            "enum": [
+              "active"
+            ]
           },
           "totalCodes": {
             "type": "integer"
@@ -179,12 +209,21 @@
       },
       "RecoveryCodeStatus": {
         "type": "object",
-        "required": ["status", "totalCodes", "remainingCodes", "generatedAt"],
+        "required": [
+          "status",
+          "totalCodes",
+          "remainingCodes",
+          "generatedAt"
+        ],
         "additionalProperties": false,
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["none", "active", "exhausted"],
+            "enum": [
+              "none",
+              "active",
+              "exhausted"
+            ],
             "description": "Account recovery state. 'none' when no set was ever created; 'exhausted' when every code has been consumed."
           },
           "totalCodes": {
@@ -205,7 +244,10 @@
       },
       "SuccessEnvelope": {
         "type": "object",
-        "required": ["data", "meta"],
+        "required": [
+          "data",
+          "meta"
+        ],
         "properties": {
           "data": {
             "type": "object",
@@ -218,7 +260,10 @@
       },
       "DomainError": {
         "type": "object",
-        "required": ["code", "message"],
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
           "code": {
             "type": "string",
@@ -273,7 +318,11 @@
       },
       "MailboxPolicy": {
         "type": "object",
-        "required": ["allowUnknown", "minimumPostage", "requireVerified"],
+        "required": [
+          "allowUnknown",
+          "minimumPostage",
+          "requireVerified"
+        ],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -288,7 +337,12 @@
       },
       "ChainMailboxPolicy": {
         "type": "object",
-        "required": ["allowUnknown", "minimumPostage", "requireReceipt", "requireVerified"],
+        "required": [
+          "allowUnknown",
+          "minimumPostage",
+          "requireReceipt",
+          "requireVerified"
+        ],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -307,7 +361,11 @@
       },
       "MailboxPolicyWriteRequest": {
         "type": "object",
-        "required": ["allowUnknown", "minimumPostage", "requireVerified"],
+        "required": [
+          "allowUnknown",
+          "minimumPostage",
+          "requireVerified"
+        ],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -326,7 +384,14 @@
       },
       "PolicyWriteIntent": {
         "type": "object",
-        "required": ["owner", "policy", "offchainVersion", "status", "scheduledAt", "updatedAt"],
+        "required": [
+          "owner",
+          "policy",
+          "offchainVersion",
+          "status",
+          "scheduledAt",
+          "updatedAt"
+        ],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/StellarAddress"
@@ -341,7 +406,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "submitted", "confirmed", "failed"]
+            "enum": [
+              "pending",
+              "submitted",
+              "confirmed",
+              "failed"
+            ]
           },
           "scheduledAt": {
             "type": "string",
@@ -364,7 +434,13 @@
       },
       "InitializePolicyDefaultsResult": {
         "type": "object",
-        "required": ["provisioned", "policy", "source", "offchainVersion", "scheduled"],
+        "required": [
+          "provisioned",
+          "policy",
+          "source",
+          "offchainVersion",
+          "scheduled"
+        ],
         "properties": {
           "provisioned": {
             "type": "boolean",
@@ -375,7 +451,10 @@
           },
           "source": {
             "type": "string",
-            "enum": ["default", "configured"]
+            "enum": [
+              "default",
+              "configured"
+            ]
           },
           "offchainVersion": {
             "type": "integer",
@@ -390,11 +469,23 @@
       },
       "PolicyReconciliationState": {
         "type": "string",
-        "enum": ["not_provisioned", "pending_write", "synced", "chain_ahead", "diverged"]
+        "enum": [
+          "not_provisioned",
+          "pending_write",
+          "synced",
+          "chain_ahead",
+          "diverged"
+        ]
       },
       "PolicyReconciliation": {
         "type": "object",
-        "required": ["owner", "state", "offchain", "chain", "writeIntent"],
+        "required": [
+          "owner",
+          "state",
+          "offchain",
+          "chain",
+          "writeIntent"
+        ],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/StellarAddress"
@@ -404,14 +495,21 @@
           },
           "offchain": {
             "type": "object",
-            "required": ["policy", "source", "version"],
+            "required": [
+              "policy",
+              "source",
+              "version"
+            ],
             "properties": {
               "policy": {
                 "$ref": "#/components/schemas/MailboxPolicy"
               },
               "source": {
                 "type": "string",
-                "enum": ["default", "configured"],
+                "enum": [
+                  "default",
+                  "configured"
+                ],
                 "nullable": true
               },
               "version": {
@@ -423,7 +521,10 @@
           },
           "chain": {
             "type": "object",
-            "required": ["policy", "version"],
+            "required": [
+              "policy",
+              "version"
+            ],
             "properties": {
               "policy": {
                 "$ref": "#/components/schemas/MailboxPolicy"
@@ -456,13 +557,21 @@
       },
       "ValidationErrorItem": {
         "type": "object",
-        "required": ["path", "rule", "message"],
+        "required": [
+          "path",
+          "rule",
+          "message"
+        ],
         "additionalProperties": false,
         "properties": {
           "path": {
             "type": "string",
             "description": "Safe request field path using dot and bracket notation; root errors use $.",
-            "examples": ["recipient", "tags[0]", "$"]
+            "examples": [
+              "recipient",
+              "tags[0]",
+              "$"
+            ]
           },
           "rule": {
             "type": "string",
@@ -487,7 +596,9 @@
       },
       "ValidationErrorDetails": {
         "type": "object",
-        "required": ["validationErrors"],
+        "required": [
+          "validationErrors"
+        ],
         "additionalProperties": false,
         "properties": {
           "validationErrors": {
@@ -528,7 +639,11 @@
       },
       "PolicyEvaluationDecision": {
         "type": "object",
-        "required": ["allowed", "reasonCode", "message"],
+        "required": [
+          "allowed",
+          "reasonCode",
+          "message"
+        ],
         "additionalProperties": false,
         "properties": {
           "allowed": {
@@ -554,23 +669,42 @@
           "source": {
             "type": "string",
             "description": "Policy configuration source.",
-            "enum": ["configured", "default"]
+            "enum": [
+              "configured",
+              "default"
+            ]
           },
           "rule": {
             "type": "string",
             "description": "Applied sender override rule.",
-            "enum": ["allow", "block", "default"]
+            "enum": [
+              "allow",
+              "block",
+              "default",
+              "verify",
+              "price"
+            ]
           }
         }
       },
       "RetryClassification": {
         "type": "string",
-        "enum": ["permanent", "transient", "rate_limit", "conflict"],
+        "enum": [
+          "permanent",
+          "transient",
+          "rate_limit",
+          "conflict"
+        ],
         "description": "Stable machine-readable classification of retry eligibility."
       },
       "ProvisioningStatus": {
         "type": "string",
-        "enum": ["pending", "retryable", "active", "failed"],
+        "enum": [
+          "pending",
+          "retryable",
+          "active",
+          "failed"
+        ],
         "description": "State of the transactional account-provisioning state machine."
       },
       "ProvisioningStep": {
@@ -585,7 +719,12 @@
       },
       "ProvisioningFailure": {
         "type": "object",
-        "required": ["step", "code", "message", "failedAt"],
+        "required": [
+          "step",
+          "code",
+          "message",
+          "failedAt"
+        ],
         "properties": {
           "step": {
             "$ref": "#/components/schemas/ProvisioningStep"
@@ -606,7 +745,13 @@
       },
       "ProvisioningProgress": {
         "type": "object",
-        "required": ["status", "requestedUsername", "completedSteps", "currentStep", "attempts"],
+        "required": [
+          "status",
+          "requestedUsername",
+          "completedSteps",
+          "currentStep",
+          "attempts"
+        ],
         "properties": {
           "status": {
             "$ref": "#/components/schemas/ProvisioningStatus"
@@ -659,7 +804,11 @@
       },
       "OnboardingSenderPolicy": {
         "type": "string",
-        "enum": ["request", "verified", "block"]
+        "enum": [
+          "request",
+          "verified",
+          "block"
+        ]
       },
       "OnboardingDraftFields": {
         "type": "object",
@@ -713,7 +862,10 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["in_progress", "completed"]
+            "enum": [
+              "in_progress",
+              "completed"
+            ]
           },
           "step": {
             "$ref": "#/components/schemas/OnboardingStep"
@@ -746,7 +898,10 @@
       },
       "OnboardingDraftSaveRequest": {
         "type": "object",
-        "required": ["step", "draft"],
+        "required": [
+          "step",
+          "draft"
+        ],
         "additionalProperties": false,
         "properties": {
           "step": {
@@ -759,7 +914,9 @@
       },
       "OnboardingCompleteRequest": {
         "type": "object",
-        "required": ["draft"],
+        "required": [
+          "draft"
+        ],
         "additionalProperties": false,
         "properties": {
           "draft": {
@@ -769,7 +926,11 @@
       },
       "OnboardingCompleteResponse": {
         "type": "object",
-        "required": ["alreadyCompleted", "draft", "policy"],
+        "required": [
+          "alreadyCompleted",
+          "draft",
+          "policy"
+        ],
         "additionalProperties": false,
         "properties": {
           "alreadyCompleted": {
@@ -786,12 +947,20 @@
       },
       "ErrorEnvelope": {
         "type": "object",
-        "required": ["error", "meta"],
+        "required": [
+          "error",
+          "meta"
+        ],
         "additionalProperties": false,
         "properties": {
           "error": {
             "type": "object",
-            "required": ["code", "message", "retryable", "retryClassification"],
+            "required": [
+              "code",
+              "message",
+              "retryable",
+              "retryClassification"
+            ],
             "additionalProperties": false,
             "properties": {
               "code": {
@@ -844,7 +1013,10 @@
           },
           "meta": {
             "type": "object",
-            "required": ["requestId", "timestamp"],
+            "required": [
+              "requestId",
+              "timestamp"
+            ],
             "additionalProperties": false,
             "properties": {
               "requestId": {
@@ -998,13 +1170,20 @@
       },
       "RelayHealth": {
         "type": "object",
-        "required": ["status", "service", "version", "time"],
+        "required": [
+          "status",
+          "service",
+          "version",
+          "time"
+        ],
         "additionalProperties": false,
         "description": "Relay liveness payload. Never contains secrets or user data.",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ok"]
+            "enum": [
+              "ok"
+            ]
           },
           "service": {
             "type": "string",
@@ -1022,7 +1201,11 @@
       },
       "RelayReadiness": {
         "type": "object",
-        "required": ["ready", "dependencies", "timeoutMs"],
+        "required": [
+          "ready",
+          "dependencies",
+          "timeoutMs"
+        ],
         "additionalProperties": false,
         "description": "Relay readiness payload. Dependency details never include URLs, keys, or user data.",
         "properties": {
@@ -1031,20 +1214,36 @@
           },
           "dependencies": {
             "type": "object",
-            "required": ["storage", "queue", "network"],
+            "required": [
+              "storage",
+              "queue",
+              "network"
+            ],
             "additionalProperties": false,
             "properties": {
               "storage": {
                 "type": "string",
-                "enum": ["ok", "unavailable", "timeout"]
+                "enum": [
+                  "ok",
+                  "unavailable",
+                  "timeout"
+                ]
               },
               "queue": {
                 "type": "string",
-                "enum": ["ok", "unavailable", "timeout"]
+                "enum": [
+                  "ok",
+                  "unavailable",
+                  "timeout"
+                ]
               },
               "network": {
                 "type": "string",
-                "enum": ["ok", "unavailable", "timeout"]
+                "enum": [
+                  "ok",
+                  "unavailable",
+                  "timeout"
+                ]
               }
             }
           },
@@ -1056,12 +1255,19 @@
       },
       "RelayVersion": {
         "type": "object",
-        "required": ["app", "apiVersion", "protocolVersion", "build"],
+        "required": [
+          "app",
+          "apiVersion",
+          "protocolVersion",
+          "build"
+        ],
         "additionalProperties": false,
         "properties": {
           "app": {
             "type": "string",
-            "enum": ["stealth-relay"]
+            "enum": [
+              "stealth-relay"
+            ]
           },
           "apiVersion": {
             "type": "string",
@@ -1079,7 +1285,13 @@
       },
       "RelaySubmissionRequest": {
         "type": "object",
-        "required": ["messageId", "sender", "recipient", "recipientDomain", "payload"],
+        "required": [
+          "messageId",
+          "sender",
+          "recipient",
+          "recipientDomain",
+          "payload"
+        ],
         "additionalProperties": false,
         "properties": {
           "messageId": {
@@ -1107,12 +1319,19 @@
       },
       "RelaySubmissionResult": {
         "type": "object",
-        "required": ["accepted", "messageId", "queueDepth", "service"],
+        "required": [
+          "accepted",
+          "messageId",
+          "queueDepth",
+          "service"
+        ],
         "additionalProperties": false,
         "properties": {
           "accepted": {
             "type": "boolean",
-            "enum": [true]
+            "enum": [
+              true
+            ]
           },
           "messageId": {
             "$ref": "#/components/schemas/Hash32"
@@ -1164,7 +1383,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "submitted", "confirmed", "failed"]
+            "enum": [
+              "pending",
+              "submitted",
+              "confirmed",
+              "failed"
+            ]
           },
           "scheduledAt": {
             "type": "string",
@@ -1239,12 +1463,21 @@
           },
           "trust": {
             "type": "string",
-            "enum": ["default", "allow", "block"],
+            "enum": [
+              "default",
+              "allow",
+              "block"
+            ],
             "description": "Sender rule. Never applied to policy unless the owner opts in."
           },
           "source": {
             "type": "string",
-            "enum": ["manual", "csv", "vcard", "api"],
+            "enum": [
+              "manual",
+              "csv",
+              "vcard",
+              "api"
+            ],
             "description": "Origin of this contact row."
           },
           "createdAt": {
@@ -1264,7 +1497,10 @@
       },
       "ContactResolution": {
         "type": "object",
-        "required": ["senderRule", "senderRuleConfigured"],
+        "required": [
+          "senderRule",
+          "senderRuleConfigured"
+        ],
         "additionalProperties": false,
         "properties": {
           "identity": {
@@ -1338,14 +1574,22 @@
                   },
                   "freshness": {
                     "type": "string",
-                    "enum": ["fresh", "stale", "unknown"]
+                    "enum": [
+                      "fresh",
+                      "stale",
+                      "unknown"
+                    ]
                   },
                   "memo": {
                     "type": "string"
                   },
                   "memoType": {
                     "type": "string",
-                    "enum": ["text", "id", "hash"]
+                    "enum": [
+                      "text",
+                      "id",
+                      "hash"
+                    ]
                   }
                 }
               },
@@ -1369,7 +1613,11 @@
           },
           "senderRule": {
             "type": "string",
-            "enum": ["default", "allow", "block"]
+            "enum": [
+              "default",
+              "allow",
+              "block"
+            ]
           },
           "senderRuleConfigured": {
             "type": "boolean",
@@ -1379,7 +1627,10 @@
       },
       "ContactWithResolution": {
         "type": "object",
-        "required": ["contact", "resolution"],
+        "required": [
+          "contact",
+          "resolution"
+        ],
         "additionalProperties": false,
         "properties": {
           "contact": {
@@ -1392,7 +1643,10 @@
       },
       "ContactListResult": {
         "type": "object",
-        "required": ["items", "nextContinuationKey"],
+        "required": [
+          "items",
+          "nextContinuationKey"
+        ],
         "additionalProperties": false,
         "properties": {
           "items": {
@@ -1416,7 +1670,10 @@
       },
       "ContactMergeResult": {
         "type": "object",
-        "required": ["contact", "resolution"],
+        "required": [
+          "contact",
+          "resolution"
+        ],
         "additionalProperties": false,
         "description": "The surviving contact after merging, re-resolved against live state.",
         "properties": {
@@ -1444,7 +1701,10 @@
         "properties": {
           "format": {
             "type": "string",
-            "enum": ["csv", "vcard"]
+            "enum": [
+              "csv",
+              "vcard"
+            ]
           },
           "totalRows": {
             "type": "integer",
@@ -1468,7 +1728,9 @@
           },
           "limit": {
             "type": "object",
-            "required": ["maxRows"],
+            "required": [
+              "maxRows"
+            ],
             "properties": {
               "maxRows": {
                 "type": "integer",
@@ -1480,7 +1742,12 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["rowNumber", "name", "address", "status"],
+              "required": [
+                "rowNumber",
+                "name",
+                "address",
+                "status"
+              ],
               "additionalProperties": false,
               "properties": {
                 "rowNumber": {
@@ -1495,7 +1762,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["valid", "duplicate", "error"]
+                  "enum": [
+                    "valid",
+                    "duplicate",
+                    "error"
+                  ]
                 },
                 "error": {
                   "anyOf": [
@@ -1542,14 +1813,21 @@
                   "anyOf": [
                     {
                       "type": "object",
-                      "required": ["contactId", "trust"],
+                      "required": [
+                        "contactId",
+                        "trust"
+                      ],
                       "properties": {
                         "contactId": {
                           "type": "string"
                         },
                         "trust": {
                           "type": "string",
-                          "enum": ["default", "allow", "block"]
+                          "enum": [
+                            "default",
+                            "allow",
+                            "block"
+                          ]
                         }
                       }
                     },
@@ -1606,6 +1884,253 @@
             "items": {
               "$ref": "#/components/schemas/Contact"
             }
+          }
+        }
+      },
+      "DraftAttachmentDescriptor": {
+        "type": "object",
+        "required": [
+          "filename",
+          "contentType",
+          "sizeBytes"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "filename": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "contentHash": {
+            "type": "string",
+            "description": "Optional SHA-256 hash."
+          }
+        }
+      },
+      "Draft": {
+        "type": "object",
+        "required": [
+          "draftId",
+          "owner",
+          "to",
+          "cc",
+          "bcc",
+          "subject",
+          "body",
+          "attachments",
+          "version",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "draftId": {
+            "type": "string",
+            "description": "Unique draft identifier."
+          },
+          "owner": {
+            "$ref": "#/components/schemas/StellarAddress"
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bcc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subject": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DraftAttachmentDescriptor"
+            }
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Monotonic revision version."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "DraftListResult": {
+        "type": "object",
+        "required": [
+          "items",
+          "nextContinuationKey"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Draft"
+            }
+          },
+          "nextContinuationKey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Cursor for the next page, or null at the end."
+          }
+        }
+      },
+      "DraftCreateInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "draftId": {
+            "type": "string"
+          },
+          "to": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "cc": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "bcc": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DraftAttachmentDescriptor"
+            }
+          }
+        }
+      },
+      "DraftUpdateInput": {
+        "type": "object",
+        "required": [
+          "expectedVersion"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "to": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "cc": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "bcc": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DraftAttachmentDescriptor"
+            }
+          },
+          "expectedVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Expected current revision for optimistic concurrency control."
           }
         }
       }
@@ -2879,12 +3404,20 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["operation"],
+                "required": [
+                  "operation"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "operation": {
                     "type": "string",
-                    "enum": ["settle", "refund", "dispute", "expire", "reclaim"]
+                    "enum": [
+                      "settle",
+                      "refund",
+                      "dispute",
+                      "expire",
+                      "reclaim"
+                    ]
                   }
                 }
               },
@@ -3694,7 +4227,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["draft"],
+                  "required": [
+                    "draft"
+                  ],
                   "properties": {
                     "draft": {
                       "allOf": [
@@ -3773,7 +4308,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["draft"],
+                  "required": [
+                    "draft"
+                  ],
                   "properties": {
                     "draft": {
                       "$ref": "#/components/schemas/OnboardingDraft"
@@ -3867,7 +4404,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["data"],
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
                     "data": {
                       "$ref": "#/components/schemas/OnboardingCompleteResponse"
@@ -3951,14 +4490,22 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["provisioning", "accountStatus"],
+                  "required": [
+                    "provisioning",
+                    "accountStatus"
+                  ],
                   "properties": {
                     "provisioning": {
                       "$ref": "#/components/schemas/ProvisioningProgress"
                     },
                     "accountStatus": {
                       "type": "string",
-                      "enum": ["active", "suspended", "pending_verification", "deactivated"]
+                      "enum": [
+                        "active",
+                        "suspended",
+                        "pending_verification",
+                        "deactivated"
+                      ]
                     }
                   }
                 }
@@ -4112,7 +4659,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email", "token"],
+                "required": [
+                  "email",
+                  "token"
+                ],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4186,7 +4736,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email"],
+                "required": [
+                  "email"
+                ],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4277,7 +4829,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email"],
+                "required": [
+                  "email"
+                ],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4368,7 +4922,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["token", "password"],
+                "required": [
+                  "token",
+                  "password"
+                ],
                 "properties": {
                   "token": {
                     "type": "string"
@@ -4559,7 +5116,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "address"],
+                "required": [
+                  "name",
+                  "address"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "name": {
@@ -4572,7 +5132,11 @@
                   },
                   "trust": {
                     "type": "string",
-                    "enum": ["default", "allow", "block"]
+                    "enum": [
+                      "default",
+                      "allow",
+                      "block"
+                    ]
                   }
                 }
               }
@@ -4750,7 +5314,11 @@
                   },
                   "trust": {
                     "type": "string",
-                    "enum": ["default", "allow", "block"]
+                    "enum": [
+                      "default",
+                      "allow",
+                      "block"
+                    ]
                   },
                   "expectedVersion": {
                     "type": "integer",
@@ -4930,7 +5498,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["keepContactId", "mergeContactIds"],
+                "required": [
+                  "keepContactId",
+                  "mergeContactIds"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "keepContactId": {
@@ -5052,12 +5623,18 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["format", "content"],
+                "required": [
+                  "format",
+                  "content"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "format": {
                     "type": "string",
-                    "enum": ["csv", "vcard"]
+                    "enum": [
+                      "csv",
+                      "vcard"
+                    ]
                   },
                   "content": {
                     "type": "string",
@@ -5142,7 +5719,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["rows"],
+                "required": [
+                  "rows"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "rows": {
@@ -5151,7 +5730,10 @@
                     "maxItems": 1000,
                     "items": {
                       "type": "object",
-                      "required": ["name", "address"],
+                      "required": [
+                        "name",
+                        "address"
+                      ],
                       "additionalProperties": false,
                       "properties": {
                         "name": {
@@ -5164,11 +5746,18 @@
                         },
                         "trust": {
                           "type": "string",
-                          "enum": ["default", "allow", "block"]
+                          "enum": [
+                            "default",
+                            "allow",
+                            "block"
+                          ]
                         },
                         "source": {
                           "type": "string",
-                          "enum": ["csv", "vcard"]
+                          "enum": [
+                            "csv",
+                            "vcard"
+                          ]
                         }
                       }
                     }
@@ -5240,6 +5829,408 @@
         }
       }
     },
+    "/drafts": {
+      "get": {
+        "operationId": "listDrafts",
+        "summary": "List encrypted drafts for the authenticated account",
+        "description": "Returns the authenticated actor's drafts ordered by last update time.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination continuation key."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listed drafts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DraftListResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "operationId": "createDraft",
+        "summary": "Create a new encrypted draft",
+        "description": "Stores a new draft sealed at rest with AES-256-GCM authenticated with AAD.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftCreateInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created draft",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — Draft already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/drafts/{draftId}": {
+      "get": {
+        "operationId": "getDraft",
+        "summary": "Get an encrypted draft by identifier",
+        "description": "Fetches and decrypts an existing draft for the authenticated actor.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Draft identifier."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateDraft",
+        "summary": "Update an encrypted draft with optimistic concurrency control",
+        "description": "Updates draft fields when expectedVersion matches the server revision, bumping the monotonic version.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Draft identifier."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DraftUpdateInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Draft updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Draft"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision Conflict — Stale draft version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteDraft",
+        "summary": "Delete an encrypted draft",
+        "description": "Removes an existing draft for the authenticated actor.",
+        "security": [
+          {
+            "ActorHeader": []
+          }
+        ],
+        "x-stability": "beta",
+        "parameters": [
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Draft identifier."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Draft deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/lifecycle/{messageId}": {
       "get": {
         "operationId": "getLifecycleStatus",
@@ -5267,12 +6258,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["status", "updatedAt"],
+                  "required": [
+                    "status",
+                    "updatedAt"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "submitted", "confirmed", "failed"]
+                      "enum": [
+                        "pending",
+                        "submitted",
+                        "confirmed",
+                        "failed"
+                      ]
                     },
                     "updatedAt": {
                       "type": "string",
@@ -5369,7 +6368,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["sender", "recipient"],
+                "required": [
+                  "sender",
+                  "recipient"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "sender": {
@@ -5398,7 +6400,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["messageId", "status"],
+                  "required": [
+                    "messageId",
+                    "status"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "messageId": {
@@ -5406,7 +6411,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "submitted", "confirmed"]
+                      "enum": [
+                        "pending",
+                        "submitted",
+                        "confirmed"
+                      ]
                     },
                     "txHash": {
                       "type": "string",
@@ -5504,7 +6513,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["messageId", "status"],
+                  "required": [
+                    "messageId",
+                    "status"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "messageId": {
@@ -5512,7 +6524,12 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["pending", "submitted", "confirmed", "failed"]
+                      "enum": [
+                        "pending",
+                        "submitted",
+                        "confirmed",
+                        "failed"
+                      ]
                     },
                     "updatedAt": {
                       "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -23,9 +23,7 @@
         "scheme": "bearer",
         "bearerFormat": "SEP-10 JWT",
         "description": "Authenticates a Stellar account through the [SEP-10 Web Authentication](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) challenge flow. Fetch a short-lived challenge transaction from the service's WEB_AUTH_ENDPOINT, verify the server signature and transaction fields, sign the challenge with an authorized Stellar account signer, and exchange the signed transaction for a token. Send that token on protected API calls as `Authorization: Bearer <SEP-10-token>`. Never send a Stellar secret seed. The server derives the actor from the verified token and enforces challenge expiry and replay protection; `x-stealth-address` alone is not proof of identity.",
-        "x-required-headers": [
-          "Authorization"
-        ],
+        "x-required-headers": ["Authorization"],
         "x-signing-specification": "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md",
         "x-challenge-flow": [
           "Request a challenge transaction from the WEB_AUTH_ENDPOINT for the Stellar account.",
@@ -45,10 +43,7 @@
     "schemas": {
       "ApiMeta": {
         "type": "object",
-        "required": [
-          "requestId",
-          "timestamp"
-        ],
+        "required": ["requestId", "timestamp"],
         "properties": {
           "requestId": {
             "type": "string",
@@ -63,10 +58,7 @@
       },
       "RecoveryCodeRedeemRequest": {
         "type": "object",
-        "required": [
-          "identifier",
-          "code"
-        ],
+        "required": ["identifier", "code"],
         "additionalProperties": false,
         "properties": {
           "identifier": {
@@ -81,10 +73,7 @@
       },
       "RecoveryCodeRedeemResponse": {
         "type": "object",
-        "required": [
-          "user",
-          "session"
-        ],
+        "required": ["user", "session"],
         "additionalProperties": false,
         "properties": {
           "user": {
@@ -115,12 +104,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "active",
-                  "suspended",
-                  "pending_verification",
-                  "deactivated"
-                ]
+                "enum": ["active", "suspended", "pending_verification", "deactivated"]
               },
               "createdAt": {
                 "type": "string",
@@ -134,13 +118,7 @@
           },
           "session": {
             "type": "object",
-            "required": [
-              "sessionId",
-              "userId",
-              "createdAt",
-              "expiresAt",
-              "lastActiveAt"
-            ],
+            "required": ["sessionId", "userId", "createdAt", "expiresAt", "lastActiveAt"],
             "additionalProperties": false,
             "properties": {
               "sessionId": {
@@ -171,20 +149,12 @@
       },
       "RecoveryCodeRegenerateResponse": {
         "type": "object",
-        "required": [
-          "status",
-          "totalCodes",
-          "remainingCodes",
-          "generatedAt",
-          "codes"
-        ],
+        "required": ["status", "totalCodes", "remainingCodes", "generatedAt", "codes"],
         "additionalProperties": false,
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "active"
-            ]
+            "enum": ["active"]
           },
           "totalCodes": {
             "type": "integer"
@@ -209,21 +179,12 @@
       },
       "RecoveryCodeStatus": {
         "type": "object",
-        "required": [
-          "status",
-          "totalCodes",
-          "remainingCodes",
-          "generatedAt"
-        ],
+        "required": ["status", "totalCodes", "remainingCodes", "generatedAt"],
         "additionalProperties": false,
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "none",
-              "active",
-              "exhausted"
-            ],
+            "enum": ["none", "active", "exhausted"],
             "description": "Account recovery state. 'none' when no set was ever created; 'exhausted' when every code has been consumed."
           },
           "totalCodes": {
@@ -244,10 +205,7 @@
       },
       "SuccessEnvelope": {
         "type": "object",
-        "required": [
-          "data",
-          "meta"
-        ],
+        "required": ["data", "meta"],
         "properties": {
           "data": {
             "type": "object",
@@ -260,10 +218,7 @@
       },
       "DomainError": {
         "type": "object",
-        "required": [
-          "code",
-          "message"
-        ],
+        "required": ["code", "message"],
         "properties": {
           "code": {
             "type": "string",
@@ -318,11 +273,7 @@
       },
       "MailboxPolicy": {
         "type": "object",
-        "required": [
-          "allowUnknown",
-          "minimumPostage",
-          "requireVerified"
-        ],
+        "required": ["allowUnknown", "minimumPostage", "requireVerified"],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -337,12 +288,7 @@
       },
       "ChainMailboxPolicy": {
         "type": "object",
-        "required": [
-          "allowUnknown",
-          "minimumPostage",
-          "requireReceipt",
-          "requireVerified"
-        ],
+        "required": ["allowUnknown", "minimumPostage", "requireReceipt", "requireVerified"],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -361,11 +307,7 @@
       },
       "MailboxPolicyWriteRequest": {
         "type": "object",
-        "required": [
-          "allowUnknown",
-          "minimumPostage",
-          "requireVerified"
-        ],
+        "required": ["allowUnknown", "minimumPostage", "requireVerified"],
         "properties": {
           "allowUnknown": {
             "type": "boolean"
@@ -384,14 +326,7 @@
       },
       "PolicyWriteIntent": {
         "type": "object",
-        "required": [
-          "owner",
-          "policy",
-          "offchainVersion",
-          "status",
-          "scheduledAt",
-          "updatedAt"
-        ],
+        "required": ["owner", "policy", "offchainVersion", "status", "scheduledAt", "updatedAt"],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/StellarAddress"
@@ -406,12 +341,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "submitted",
-              "confirmed",
-              "failed"
-            ]
+            "enum": ["pending", "submitted", "confirmed", "failed"]
           },
           "scheduledAt": {
             "type": "string",
@@ -434,13 +364,7 @@
       },
       "InitializePolicyDefaultsResult": {
         "type": "object",
-        "required": [
-          "provisioned",
-          "policy",
-          "source",
-          "offchainVersion",
-          "scheduled"
-        ],
+        "required": ["provisioned", "policy", "source", "offchainVersion", "scheduled"],
         "properties": {
           "provisioned": {
             "type": "boolean",
@@ -451,10 +375,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "default",
-              "configured"
-            ]
+            "enum": ["default", "configured"]
           },
           "offchainVersion": {
             "type": "integer",
@@ -469,23 +390,11 @@
       },
       "PolicyReconciliationState": {
         "type": "string",
-        "enum": [
-          "not_provisioned",
-          "pending_write",
-          "synced",
-          "chain_ahead",
-          "diverged"
-        ]
+        "enum": ["not_provisioned", "pending_write", "synced", "chain_ahead", "diverged"]
       },
       "PolicyReconciliation": {
         "type": "object",
-        "required": [
-          "owner",
-          "state",
-          "offchain",
-          "chain",
-          "writeIntent"
-        ],
+        "required": ["owner", "state", "offchain", "chain", "writeIntent"],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/StellarAddress"
@@ -495,21 +404,14 @@
           },
           "offchain": {
             "type": "object",
-            "required": [
-              "policy",
-              "source",
-              "version"
-            ],
+            "required": ["policy", "source", "version"],
             "properties": {
               "policy": {
                 "$ref": "#/components/schemas/MailboxPolicy"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "default",
-                  "configured"
-                ],
+                "enum": ["default", "configured"],
                 "nullable": true
               },
               "version": {
@@ -521,10 +423,7 @@
           },
           "chain": {
             "type": "object",
-            "required": [
-              "policy",
-              "version"
-            ],
+            "required": ["policy", "version"],
             "properties": {
               "policy": {
                 "$ref": "#/components/schemas/MailboxPolicy"
@@ -557,21 +456,13 @@
       },
       "ValidationErrorItem": {
         "type": "object",
-        "required": [
-          "path",
-          "rule",
-          "message"
-        ],
+        "required": ["path", "rule", "message"],
         "additionalProperties": false,
         "properties": {
           "path": {
             "type": "string",
             "description": "Safe request field path using dot and bracket notation; root errors use $.",
-            "examples": [
-              "recipient",
-              "tags[0]",
-              "$"
-            ]
+            "examples": ["recipient", "tags[0]", "$"]
           },
           "rule": {
             "type": "string",
@@ -596,9 +487,7 @@
       },
       "ValidationErrorDetails": {
         "type": "object",
-        "required": [
-          "validationErrors"
-        ],
+        "required": ["validationErrors"],
         "additionalProperties": false,
         "properties": {
           "validationErrors": {
@@ -639,11 +528,7 @@
       },
       "PolicyEvaluationDecision": {
         "type": "object",
-        "required": [
-          "allowed",
-          "reasonCode",
-          "message"
-        ],
+        "required": ["allowed", "reasonCode", "message"],
         "additionalProperties": false,
         "properties": {
           "allowed": {
@@ -669,42 +554,23 @@
           "source": {
             "type": "string",
             "description": "Policy configuration source.",
-            "enum": [
-              "configured",
-              "default"
-            ]
+            "enum": ["configured", "default"]
           },
           "rule": {
             "type": "string",
             "description": "Applied sender override rule.",
-            "enum": [
-              "allow",
-              "block",
-              "default",
-              "verify",
-              "price"
-            ]
+            "enum": ["allow", "block", "default", "verify", "price"]
           }
         }
       },
       "RetryClassification": {
         "type": "string",
-        "enum": [
-          "permanent",
-          "transient",
-          "rate_limit",
-          "conflict"
-        ],
+        "enum": ["permanent", "transient", "rate_limit", "conflict"],
         "description": "Stable machine-readable classification of retry eligibility."
       },
       "ProvisioningStatus": {
         "type": "string",
-        "enum": [
-          "pending",
-          "retryable",
-          "active",
-          "failed"
-        ],
+        "enum": ["pending", "retryable", "active", "failed"],
         "description": "State of the transactional account-provisioning state machine."
       },
       "ProvisioningStep": {
@@ -719,12 +585,7 @@
       },
       "ProvisioningFailure": {
         "type": "object",
-        "required": [
-          "step",
-          "code",
-          "message",
-          "failedAt"
-        ],
+        "required": ["step", "code", "message", "failedAt"],
         "properties": {
           "step": {
             "$ref": "#/components/schemas/ProvisioningStep"
@@ -745,13 +606,7 @@
       },
       "ProvisioningProgress": {
         "type": "object",
-        "required": [
-          "status",
-          "requestedUsername",
-          "completedSteps",
-          "currentStep",
-          "attempts"
-        ],
+        "required": ["status", "requestedUsername", "completedSteps", "currentStep", "attempts"],
         "properties": {
           "status": {
             "$ref": "#/components/schemas/ProvisioningStatus"
@@ -804,11 +659,7 @@
       },
       "OnboardingSenderPolicy": {
         "type": "string",
-        "enum": [
-          "request",
-          "verified",
-          "block"
-        ]
+        "enum": ["request", "verified", "block"]
       },
       "OnboardingDraftFields": {
         "type": "object",
@@ -862,10 +713,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "in_progress",
-              "completed"
-            ]
+            "enum": ["in_progress", "completed"]
           },
           "step": {
             "$ref": "#/components/schemas/OnboardingStep"
@@ -898,10 +746,7 @@
       },
       "OnboardingDraftSaveRequest": {
         "type": "object",
-        "required": [
-          "step",
-          "draft"
-        ],
+        "required": ["step", "draft"],
         "additionalProperties": false,
         "properties": {
           "step": {
@@ -914,9 +759,7 @@
       },
       "OnboardingCompleteRequest": {
         "type": "object",
-        "required": [
-          "draft"
-        ],
+        "required": ["draft"],
         "additionalProperties": false,
         "properties": {
           "draft": {
@@ -926,11 +769,7 @@
       },
       "OnboardingCompleteResponse": {
         "type": "object",
-        "required": [
-          "alreadyCompleted",
-          "draft",
-          "policy"
-        ],
+        "required": ["alreadyCompleted", "draft", "policy"],
         "additionalProperties": false,
         "properties": {
           "alreadyCompleted": {
@@ -947,20 +786,12 @@
       },
       "ErrorEnvelope": {
         "type": "object",
-        "required": [
-          "error",
-          "meta"
-        ],
+        "required": ["error", "meta"],
         "additionalProperties": false,
         "properties": {
           "error": {
             "type": "object",
-            "required": [
-              "code",
-              "message",
-              "retryable",
-              "retryClassification"
-            ],
+            "required": ["code", "message", "retryable", "retryClassification"],
             "additionalProperties": false,
             "properties": {
               "code": {
@@ -1013,10 +844,7 @@
           },
           "meta": {
             "type": "object",
-            "required": [
-              "requestId",
-              "timestamp"
-            ],
+            "required": ["requestId", "timestamp"],
             "additionalProperties": false,
             "properties": {
               "requestId": {
@@ -1170,20 +998,13 @@
       },
       "RelayHealth": {
         "type": "object",
-        "required": [
-          "status",
-          "service",
-          "version",
-          "time"
-        ],
+        "required": ["status", "service", "version", "time"],
         "additionalProperties": false,
         "description": "Relay liveness payload. Never contains secrets or user data.",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ok"
-            ]
+            "enum": ["ok"]
           },
           "service": {
             "type": "string",
@@ -1201,11 +1022,7 @@
       },
       "RelayReadiness": {
         "type": "object",
-        "required": [
-          "ready",
-          "dependencies",
-          "timeoutMs"
-        ],
+        "required": ["ready", "dependencies", "timeoutMs"],
         "additionalProperties": false,
         "description": "Relay readiness payload. Dependency details never include URLs, keys, or user data.",
         "properties": {
@@ -1214,36 +1031,20 @@
           },
           "dependencies": {
             "type": "object",
-            "required": [
-              "storage",
-              "queue",
-              "network"
-            ],
+            "required": ["storage", "queue", "network"],
             "additionalProperties": false,
             "properties": {
               "storage": {
                 "type": "string",
-                "enum": [
-                  "ok",
-                  "unavailable",
-                  "timeout"
-                ]
+                "enum": ["ok", "unavailable", "timeout"]
               },
               "queue": {
                 "type": "string",
-                "enum": [
-                  "ok",
-                  "unavailable",
-                  "timeout"
-                ]
+                "enum": ["ok", "unavailable", "timeout"]
               },
               "network": {
                 "type": "string",
-                "enum": [
-                  "ok",
-                  "unavailable",
-                  "timeout"
-                ]
+                "enum": ["ok", "unavailable", "timeout"]
               }
             }
           },
@@ -1255,19 +1056,12 @@
       },
       "RelayVersion": {
         "type": "object",
-        "required": [
-          "app",
-          "apiVersion",
-          "protocolVersion",
-          "build"
-        ],
+        "required": ["app", "apiVersion", "protocolVersion", "build"],
         "additionalProperties": false,
         "properties": {
           "app": {
             "type": "string",
-            "enum": [
-              "stealth-relay"
-            ]
+            "enum": ["stealth-relay"]
           },
           "apiVersion": {
             "type": "string",
@@ -1285,13 +1079,7 @@
       },
       "RelaySubmissionRequest": {
         "type": "object",
-        "required": [
-          "messageId",
-          "sender",
-          "recipient",
-          "recipientDomain",
-          "payload"
-        ],
+        "required": ["messageId", "sender", "recipient", "recipientDomain", "payload"],
         "additionalProperties": false,
         "properties": {
           "messageId": {
@@ -1319,19 +1107,12 @@
       },
       "RelaySubmissionResult": {
         "type": "object",
-        "required": [
-          "accepted",
-          "messageId",
-          "queueDepth",
-          "service"
-        ],
+        "required": ["accepted", "messageId", "queueDepth", "service"],
         "additionalProperties": false,
         "properties": {
           "accepted": {
             "type": "boolean",
-            "enum": [
-              true
-            ]
+            "enum": [true]
           },
           "messageId": {
             "$ref": "#/components/schemas/Hash32"
@@ -1383,12 +1164,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "submitted",
-              "confirmed",
-              "failed"
-            ]
+            "enum": ["pending", "submitted", "confirmed", "failed"]
           },
           "scheduledAt": {
             "type": "string",
@@ -1463,21 +1239,12 @@
           },
           "trust": {
             "type": "string",
-            "enum": [
-              "default",
-              "allow",
-              "block"
-            ],
+            "enum": ["default", "allow", "block"],
             "description": "Sender rule. Never applied to policy unless the owner opts in."
           },
           "source": {
             "type": "string",
-            "enum": [
-              "manual",
-              "csv",
-              "vcard",
-              "api"
-            ],
+            "enum": ["manual", "csv", "vcard", "api"],
             "description": "Origin of this contact row."
           },
           "createdAt": {
@@ -1497,10 +1264,7 @@
       },
       "ContactResolution": {
         "type": "object",
-        "required": [
-          "senderRule",
-          "senderRuleConfigured"
-        ],
+        "required": ["senderRule", "senderRuleConfigured"],
         "additionalProperties": false,
         "properties": {
           "identity": {
@@ -1574,22 +1338,14 @@
                   },
                   "freshness": {
                     "type": "string",
-                    "enum": [
-                      "fresh",
-                      "stale",
-                      "unknown"
-                    ]
+                    "enum": ["fresh", "stale", "unknown"]
                   },
                   "memo": {
                     "type": "string"
                   },
                   "memoType": {
                     "type": "string",
-                    "enum": [
-                      "text",
-                      "id",
-                      "hash"
-                    ]
+                    "enum": ["text", "id", "hash"]
                   }
                 }
               },
@@ -1613,11 +1369,7 @@
           },
           "senderRule": {
             "type": "string",
-            "enum": [
-              "default",
-              "allow",
-              "block"
-            ]
+            "enum": ["default", "allow", "block"]
           },
           "senderRuleConfigured": {
             "type": "boolean",
@@ -1627,10 +1379,7 @@
       },
       "ContactWithResolution": {
         "type": "object",
-        "required": [
-          "contact",
-          "resolution"
-        ],
+        "required": ["contact", "resolution"],
         "additionalProperties": false,
         "properties": {
           "contact": {
@@ -1643,10 +1392,7 @@
       },
       "ContactListResult": {
         "type": "object",
-        "required": [
-          "items",
-          "nextContinuationKey"
-        ],
+        "required": ["items", "nextContinuationKey"],
         "additionalProperties": false,
         "properties": {
           "items": {
@@ -1670,10 +1416,7 @@
       },
       "ContactMergeResult": {
         "type": "object",
-        "required": [
-          "contact",
-          "resolution"
-        ],
+        "required": ["contact", "resolution"],
         "additionalProperties": false,
         "description": "The surviving contact after merging, re-resolved against live state.",
         "properties": {
@@ -1701,10 +1444,7 @@
         "properties": {
           "format": {
             "type": "string",
-            "enum": [
-              "csv",
-              "vcard"
-            ]
+            "enum": ["csv", "vcard"]
           },
           "totalRows": {
             "type": "integer",
@@ -1728,9 +1468,7 @@
           },
           "limit": {
             "type": "object",
-            "required": [
-              "maxRows"
-            ],
+            "required": ["maxRows"],
             "properties": {
               "maxRows": {
                 "type": "integer",
@@ -1742,12 +1480,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "rowNumber",
-                "name",
-                "address",
-                "status"
-              ],
+              "required": ["rowNumber", "name", "address", "status"],
               "additionalProperties": false,
               "properties": {
                 "rowNumber": {
@@ -1762,11 +1495,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "valid",
-                    "duplicate",
-                    "error"
-                  ]
+                  "enum": ["valid", "duplicate", "error"]
                 },
                 "error": {
                   "anyOf": [
@@ -1813,21 +1542,14 @@
                   "anyOf": [
                     {
                       "type": "object",
-                      "required": [
-                        "contactId",
-                        "trust"
-                      ],
+                      "required": ["contactId", "trust"],
                       "properties": {
                         "contactId": {
                           "type": "string"
                         },
                         "trust": {
                           "type": "string",
-                          "enum": [
-                            "default",
-                            "allow",
-                            "block"
-                          ]
+                          "enum": ["default", "allow", "block"]
                         }
                       }
                     },
@@ -1889,11 +1611,7 @@
       },
       "DraftAttachmentDescriptor": {
         "type": "object",
-        "required": [
-          "filename",
-          "contentType",
-          "sizeBytes"
-        ],
+        "required": ["filename", "contentType", "sizeBytes"],
         "additionalProperties": false,
         "properties": {
           "filename": {
@@ -1984,10 +1702,7 @@
       },
       "DraftListResult": {
         "type": "object",
-        "required": [
-          "items",
-          "nextContinuationKey"
-        ],
+        "required": ["items", "nextContinuationKey"],
         "additionalProperties": false,
         "properties": {
           "items": {
@@ -2071,9 +1786,7 @@
       },
       "DraftUpdateInput": {
         "type": "object",
-        "required": [
-          "expectedVersion"
-        ],
+        "required": ["expectedVersion"],
         "additionalProperties": false,
         "properties": {
           "to": {
@@ -3404,20 +3117,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "operation"
-                ],
+                "required": ["operation"],
                 "additionalProperties": false,
                 "properties": {
                   "operation": {
                     "type": "string",
-                    "enum": [
-                      "settle",
-                      "refund",
-                      "dispute",
-                      "expire",
-                      "reclaim"
-                    ]
+                    "enum": ["settle", "refund", "dispute", "expire", "reclaim"]
                   }
                 }
               },
@@ -4227,9 +3932,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "draft"
-                  ],
+                  "required": ["draft"],
                   "properties": {
                     "draft": {
                       "allOf": [
@@ -4308,9 +4011,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "draft"
-                  ],
+                  "required": ["draft"],
                   "properties": {
                     "draft": {
                       "$ref": "#/components/schemas/OnboardingDraft"
@@ -4404,9 +4105,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "data"
-                  ],
+                  "required": ["data"],
                   "properties": {
                     "data": {
                       "$ref": "#/components/schemas/OnboardingCompleteResponse"
@@ -4490,22 +4189,14 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "provisioning",
-                    "accountStatus"
-                  ],
+                  "required": ["provisioning", "accountStatus"],
                   "properties": {
                     "provisioning": {
                       "$ref": "#/components/schemas/ProvisioningProgress"
                     },
                     "accountStatus": {
                       "type": "string",
-                      "enum": [
-                        "active",
-                        "suspended",
-                        "pending_verification",
-                        "deactivated"
-                      ]
+                      "enum": ["active", "suspended", "pending_verification", "deactivated"]
                     }
                   }
                 }
@@ -4659,10 +4350,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "email",
-                  "token"
-                ],
+                "required": ["email", "token"],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4736,9 +4424,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "email"
-                ],
+                "required": ["email"],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4829,9 +4515,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "email"
-                ],
+                "required": ["email"],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -4922,10 +4606,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "token",
-                  "password"
-                ],
+                "required": ["token", "password"],
                 "properties": {
                   "token": {
                     "type": "string"
@@ -5116,10 +4797,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "address"
-                ],
+                "required": ["name", "address"],
                 "additionalProperties": false,
                 "properties": {
                   "name": {
@@ -5132,11 +4810,7 @@
                   },
                   "trust": {
                     "type": "string",
-                    "enum": [
-                      "default",
-                      "allow",
-                      "block"
-                    ]
+                    "enum": ["default", "allow", "block"]
                   }
                 }
               }
@@ -5314,11 +4988,7 @@
                   },
                   "trust": {
                     "type": "string",
-                    "enum": [
-                      "default",
-                      "allow",
-                      "block"
-                    ]
+                    "enum": ["default", "allow", "block"]
                   },
                   "expectedVersion": {
                     "type": "integer",
@@ -5498,10 +5168,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "keepContactId",
-                  "mergeContactIds"
-                ],
+                "required": ["keepContactId", "mergeContactIds"],
                 "additionalProperties": false,
                 "properties": {
                   "keepContactId": {
@@ -5623,18 +5290,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "format",
-                  "content"
-                ],
+                "required": ["format", "content"],
                 "additionalProperties": false,
                 "properties": {
                   "format": {
                     "type": "string",
-                    "enum": [
-                      "csv",
-                      "vcard"
-                    ]
+                    "enum": ["csv", "vcard"]
                   },
                   "content": {
                     "type": "string",
@@ -5719,9 +5380,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "rows"
-                ],
+                "required": ["rows"],
                 "additionalProperties": false,
                 "properties": {
                   "rows": {
@@ -5730,10 +5389,7 @@
                     "maxItems": 1000,
                     "items": {
                       "type": "object",
-                      "required": [
-                        "name",
-                        "address"
-                      ],
+                      "required": ["name", "address"],
                       "additionalProperties": false,
                       "properties": {
                         "name": {
@@ -5746,18 +5402,11 @@
                         },
                         "trust": {
                           "type": "string",
-                          "enum": [
-                            "default",
-                            "allow",
-                            "block"
-                          ]
+                          "enum": ["default", "allow", "block"]
                         },
                         "source": {
                           "type": "string",
-                          "enum": [
-                            "csv",
-                            "vcard"
-                          ]
+                          "enum": ["csv", "vcard"]
                         }
                       }
                     }
@@ -6258,20 +5907,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "status",
-                    "updatedAt"
-                  ],
+                  "required": ["status", "updatedAt"],
                   "additionalProperties": false,
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "pending",
-                        "submitted",
-                        "confirmed",
-                        "failed"
-                      ]
+                      "enum": ["pending", "submitted", "confirmed", "failed"]
                     },
                     "updatedAt": {
                       "type": "string",
@@ -6368,10 +6009,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "sender",
-                  "recipient"
-                ],
+                "required": ["sender", "recipient"],
                 "additionalProperties": false,
                 "properties": {
                   "sender": {
@@ -6400,10 +6038,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "messageId",
-                    "status"
-                  ],
+                  "required": ["messageId", "status"],
                   "additionalProperties": false,
                   "properties": {
                     "messageId": {
@@ -6411,11 +6046,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "pending",
-                        "submitted",
-                        "confirmed"
-                      ]
+                      "enum": ["pending", "submitted", "confirmed"]
                     },
                     "txHash": {
                       "type": "string",
@@ -6513,10 +6144,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "messageId",
-                    "status"
-                  ],
+                  "required": ["messageId", "status"],
                   "additionalProperties": false,
                   "properties": {
                     "messageId": {
@@ -6524,12 +6152,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "pending",
-                        "submitted",
-                        "confirmed",
-                        "failed"
-                      ]
+                      "enum": ["pending", "submitted", "confirmed", "failed"]
                     },
                     "updatedAt": {
                       "type": "string",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -94,10 +94,13 @@ import { Route as ApiV1AuthPasswordResetCompleteRouteImport } from './routes/api
 import { Route as ApiV1AdminJobsIdRouteImport } from './routes/api/v1/admin/jobs/$id'
 import { Route as ApiV1AdminDlqIdRouteImport } from './routes/api/v1/admin/dlq/$id'
 import { Route as ApiV1AccountsProvisioningRetryRouteImport } from './routes/api/v1/accounts/provisioning/retry'
+import { Route as ApiV1PoliciesOwnerSendersIndexRouteImport } from './routes/api/v1/policies/$owner/senders/index'
 import { Route as ApiV1PoliciesOwnerSendersSenderRouteImport } from './routes/api/v1/policies/$owner/senders/$sender'
 import { Route as ApiV1AdminDlqIdRetryRouteImport } from './routes/api/v1/admin/dlq/$id/retry'
 import { Route as ApiV1AdminDlqIdAbandonRouteImport } from './routes/api/v1/admin/dlq/$id/abandon'
 import { Route as ApiV1AccountsUserIdWalletProvisionRouteImport } from './routes/api/v1/accounts/$userId/wallet/provision'
+import { Route as ApiV1PoliciesOwnerSendersSenderRetryRouteImport } from './routes/api/v1/policies/$owner/senders/$sender/retry'
+import { Route as ApiV1PoliciesOwnerSendersSenderChainStatusRouteImport } from './routes/api/v1/policies/$owner/senders/$sender/chain-status'
 
 const OnboardingRoute = OnboardingRouteImport.update({
   id: '/onboarding',
@@ -543,6 +546,12 @@ const ApiV1AccountsProvisioningRetryRoute =
     path: '/retry',
     getParentRoute: () => ApiV1AccountsProvisioningRoute,
   } as any)
+const ApiV1PoliciesOwnerSendersIndexRoute =
+  ApiV1PoliciesOwnerSendersIndexRouteImport.update({
+    id: '/senders/',
+    path: '/senders/',
+    getParentRoute: () => ApiV1PoliciesOwnerRoute,
+  } as any)
 const ApiV1PoliciesOwnerSendersSenderRoute =
   ApiV1PoliciesOwnerSendersSenderRouteImport.update({
     id: '/senders/$sender',
@@ -564,6 +573,18 @@ const ApiV1AccountsUserIdWalletProvisionRoute =
     id: '/api/v1/accounts/$userId/wallet/provision',
     path: '/api/v1/accounts/$userId/wallet/provision',
     getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiV1PoliciesOwnerSendersSenderRetryRoute =
+  ApiV1PoliciesOwnerSendersSenderRetryRouteImport.update({
+    id: '/retry',
+    path: '/retry',
+    getParentRoute: () => ApiV1PoliciesOwnerSendersSenderRoute,
+  } as any)
+const ApiV1PoliciesOwnerSendersSenderChainStatusRoute =
+  ApiV1PoliciesOwnerSendersSenderChainStatusRouteImport.update({
+    id: '/chain-status',
+    path: '/chain-status',
+    getParentRoute: () => ApiV1PoliciesOwnerSendersSenderRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -655,7 +676,10 @@ export interface FileRoutesByFullPath {
   '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
-  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
+  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRouteWithChildren
+  '/api/v1/policies/$owner/senders/': typeof ApiV1PoliciesOwnerSendersIndexRoute
+  '/api/v1/policies/$owner/senders/$sender/chain-status': typeof ApiV1PoliciesOwnerSendersSenderChainStatusRoute
+  '/api/v1/policies/$owner/senders/$sender/retry': typeof ApiV1PoliciesOwnerSendersSenderRetryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -746,7 +770,10 @@ export interface FileRoutesByTo {
   '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
-  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
+  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRouteWithChildren
+  '/api/v1/policies/$owner/senders': typeof ApiV1PoliciesOwnerSendersIndexRoute
+  '/api/v1/policies/$owner/senders/$sender/chain-status': typeof ApiV1PoliciesOwnerSendersSenderChainStatusRoute
+  '/api/v1/policies/$owner/senders/$sender/retry': typeof ApiV1PoliciesOwnerSendersSenderRetryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -838,7 +865,10 @@ export interface FileRoutesById {
   '/api/v1/accounts/$userId/wallet/provision': typeof ApiV1AccountsUserIdWalletProvisionRoute
   '/api/v1/admin/dlq/$id/abandon': typeof ApiV1AdminDlqIdAbandonRoute
   '/api/v1/admin/dlq/$id/retry': typeof ApiV1AdminDlqIdRetryRoute
-  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRoute
+  '/api/v1/policies/$owner/senders/$sender': typeof ApiV1PoliciesOwnerSendersSenderRouteWithChildren
+  '/api/v1/policies/$owner/senders/': typeof ApiV1PoliciesOwnerSendersIndexRoute
+  '/api/v1/policies/$owner/senders/$sender/chain-status': typeof ApiV1PoliciesOwnerSendersSenderChainStatusRoute
+  '/api/v1/policies/$owner/senders/$sender/retry': typeof ApiV1PoliciesOwnerSendersSenderRetryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -932,6 +962,9 @@ export interface FileRouteTypes {
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
+    | '/api/v1/policies/$owner/senders/'
+    | '/api/v1/policies/$owner/senders/$sender/chain-status'
+    | '/api/v1/policies/$owner/senders/$sender/retry'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1023,6 +1056,9 @@ export interface FileRouteTypes {
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
+    | '/api/v1/policies/$owner/senders'
+    | '/api/v1/policies/$owner/senders/$sender/chain-status'
+    | '/api/v1/policies/$owner/senders/$sender/retry'
   id:
     | '__root__'
     | '/'
@@ -1114,6 +1150,9 @@ export interface FileRouteTypes {
     | '/api/v1/admin/dlq/$id/abandon'
     | '/api/v1/admin/dlq/$id/retry'
     | '/api/v1/policies/$owner/senders/$sender'
+    | '/api/v1/policies/$owner/senders/'
+    | '/api/v1/policies/$owner/senders/$sender/chain-status'
+    | '/api/v1/policies/$owner/senders/$sender/retry'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1794,6 +1833,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1AccountsProvisioningRetryRouteImport
       parentRoute: typeof ApiV1AccountsProvisioningRoute
     }
+    '/api/v1/policies/$owner/senders/': {
+      id: '/api/v1/policies/$owner/senders/'
+      path: '/senders'
+      fullPath: '/api/v1/policies/$owner/senders/'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerSendersIndexRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerRoute
+    }
     '/api/v1/policies/$owner/senders/$sender': {
       id: '/api/v1/policies/$owner/senders/$sender'
       path: '/senders/$sender'
@@ -1821,6 +1867,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/v1/accounts/$userId/wallet/provision'
       preLoaderRoute: typeof ApiV1AccountsUserIdWalletProvisionRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/api/v1/policies/$owner/senders/$sender/retry': {
+      id: '/api/v1/policies/$owner/senders/$sender/retry'
+      path: '/retry'
+      fullPath: '/api/v1/policies/$owner/senders/$sender/retry'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderRetryRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerSendersSenderRoute
+    }
+    '/api/v1/policies/$owner/senders/$sender/chain-status': {
+      id: '/api/v1/policies/$owner/senders/$sender/chain-status'
+      path: '/chain-status'
+      fullPath: '/api/v1/policies/$owner/senders/$sender/chain-status'
+      preLoaderRoute: typeof ApiV1PoliciesOwnerSendersSenderChainStatusRouteImport
+      parentRoute: typeof ApiV1PoliciesOwnerSendersSenderRoute
     }
   }
 }
@@ -1856,16 +1916,37 @@ const ApiV1LifecycleMessageIdRouteWithChildren =
     ApiV1LifecycleMessageIdRouteChildren,
   )
 
+interface ApiV1PoliciesOwnerSendersSenderRouteChildren {
+  ApiV1PoliciesOwnerSendersSenderChainStatusRoute: typeof ApiV1PoliciesOwnerSendersSenderChainStatusRoute
+  ApiV1PoliciesOwnerSendersSenderRetryRoute: typeof ApiV1PoliciesOwnerSendersSenderRetryRoute
+}
+
+const ApiV1PoliciesOwnerSendersSenderRouteChildren: ApiV1PoliciesOwnerSendersSenderRouteChildren =
+  {
+    ApiV1PoliciesOwnerSendersSenderChainStatusRoute:
+      ApiV1PoliciesOwnerSendersSenderChainStatusRoute,
+    ApiV1PoliciesOwnerSendersSenderRetryRoute:
+      ApiV1PoliciesOwnerSendersSenderRetryRoute,
+  }
+
+const ApiV1PoliciesOwnerSendersSenderRouteWithChildren =
+  ApiV1PoliciesOwnerSendersSenderRoute._addFileChildren(
+    ApiV1PoliciesOwnerSendersSenderRouteChildren,
+  )
+
 interface ApiV1PoliciesOwnerRouteChildren {
   ApiV1PoliciesOwnerProvisionRoute: typeof ApiV1PoliciesOwnerProvisionRoute
   ApiV1PoliciesOwnerReconciliationRoute: typeof ApiV1PoliciesOwnerReconciliationRoute
-  ApiV1PoliciesOwnerSendersSenderRoute: typeof ApiV1PoliciesOwnerSendersSenderRoute
+  ApiV1PoliciesOwnerSendersSenderRoute: typeof ApiV1PoliciesOwnerSendersSenderRouteWithChildren
+  ApiV1PoliciesOwnerSendersIndexRoute: typeof ApiV1PoliciesOwnerSendersIndexRoute
 }
 
 const ApiV1PoliciesOwnerRouteChildren: ApiV1PoliciesOwnerRouteChildren = {
   ApiV1PoliciesOwnerProvisionRoute: ApiV1PoliciesOwnerProvisionRoute,
   ApiV1PoliciesOwnerReconciliationRoute: ApiV1PoliciesOwnerReconciliationRoute,
-  ApiV1PoliciesOwnerSendersSenderRoute: ApiV1PoliciesOwnerSendersSenderRoute,
+  ApiV1PoliciesOwnerSendersSenderRoute:
+    ApiV1PoliciesOwnerSendersSenderRouteWithChildren,
+  ApiV1PoliciesOwnerSendersIndexRoute: ApiV1PoliciesOwnerSendersIndexRoute,
 }
 
 const ApiV1PoliciesOwnerRouteWithChildren =

--- a/src/routes/api/v1/policies/$owner/senders/$sender.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender.ts
@@ -1,16 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 
 import { parseDelegationHeader, requireActorMatches } from "@/server/api/actor";
 import { getApiContext } from "@/server/api/context";
-import { senderRuleSchema, stellarAddressSchema } from "@/server/api/domain";
+import { senderRuleWriteSchema, stellarAddressSchema } from "@/server/api/domain";
 import { getSenderRule, setSenderRule } from "@/server/api/policy-service";
+import {
+  createOrUpdateSenderRule,
+  deleteSenderRule,
+  getSenderRuleRecord,
+  transitionSenderRuleChainStatus,
+  retrySenderRuleWrite,
+  evaluateSenderRuleForAdmission,
+} from "@/server/api/sender-rule-service";
 import { parseJsonBody } from "@/server/api/request";
 import { apiSuccess, handleApiRequest } from "@/server/api/response";
-
-const ruleBodySchema = z.object({
-  rule: senderRuleSchema.exclude(["default"]),
-});
 
 export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")({
   server: {
@@ -20,8 +23,27 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
           const context = await getApiContext(request);
           const owner = stellarAddressSchema.parse(params.owner);
           const sender = stellarAddressSchema.parse(params.sender);
+
+          // Return versioned record if available, fall back to legacy
+          const record = await getSenderRuleRecord(context.repository, owner, sender);
+          if (record) {
+            return apiSuccess(request, {
+              owner,
+              sender,
+              rule: record.rule,
+              pricePayload: record.pricePayload,
+              version: record.version,
+              chainStatus: record.chainStatus,
+              scheduledAt: record.scheduledAt,
+              updatedAt: record.updatedAt,
+              confirmedAt: record.confirmedAt,
+              txHash: record.txHash,
+            });
+          }
+
           return apiSuccess(request, await getSenderRule(context.repository, owner, sender));
         }),
+
       PUT: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const context = await getApiContext(request);
@@ -36,11 +58,31 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
               `mailbox:${owner}:senders:${sender}`,
             ),
           );
-          const { rule } = await parseJsonBody(request, ruleBodySchema, {
+
+          const body = await parseJsonBody(request, senderRuleWriteSchema, {
             route: "PUT /policies/{owner}/senders/{sender}",
           });
-          return apiSuccess(request, await setSenderRule(context.repository, owner, sender, rule));
+
+          const result = await createOrUpdateSenderRule(context.repository, owner, sender, {
+            rule: body.rule,
+            pricePayload: body.pricePayload,
+            version: body.version,
+            idempotencyKey: body.idempotencyKey,
+          });
+
+          return apiSuccess(request, {
+            owner: result.owner,
+            sender: result.sender,
+            rule: result.rule.rule,
+            pricePayload: result.rule.pricePayload,
+            version: result.rule.version,
+            chainStatus: result.rule.chainStatus,
+            scheduledAt: result.rule.scheduledAt,
+            updatedAt: result.rule.updatedAt,
+            created: result.created,
+          });
         }),
+
       DELETE: ({ request, params }) =>
         handleApiRequest(request, async () => {
           const context = await getApiContext(request);
@@ -55,10 +97,14 @@ export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender")(
               `mailbox:${owner}:senders:${sender}`,
             ),
           );
-          return apiSuccess(
-            request,
-            await setSenderRule(context.repository, owner, sender, "default"),
-          );
+
+          // Delete versioned record + legacy rule
+          const { deleted } = await deleteSenderRule(context.repository, owner, sender);
+
+          // Also clear the legacy sender rule
+          await setSenderRule(context.repository, owner, sender, "default");
+
+          return apiSuccess(request, { owner, sender, deleted });
         }),
     },
   },

--- a/src/routes/api/v1/policies/$owner/senders/$sender/chain-status.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender/chain-status.ts
@@ -1,0 +1,57 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { senderRuleChainStatusSchema, stellarAddressSchema } from "@/server/api/domain";
+import { transitionSenderRuleChainStatus } from "@/server/api/sender-rule-service";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const transitionBodySchema = z
+  .object({
+    chainStatus: senderRuleChainStatusSchema,
+    txHash: z.string().optional(),
+    lastError: z.string().max(300).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.chainStatus === "confirmed" && !data.txHash) return false;
+      return true;
+    },
+    { message: "txHash is required when transitioning to 'confirmed'" },
+  );
+
+export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender/chain-status")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = stellarAddressSchema.parse(params.owner);
+          const sender = stellarAddressSchema.parse(params.sender);
+
+          const body = await parseJsonBody(request, transitionBodySchema, {
+            route: "POST /policies/{owner}/senders/{sender}/chain-status",
+          });
+
+          const updated = await transitionSenderRuleChainStatus(
+            context.repository,
+            owner,
+            sender,
+            body.chainStatus,
+            { txHash: body.txHash, lastError: body.lastError },
+          );
+
+          return apiSuccess(request, {
+            owner: updated.owner,
+            sender: updated.sender,
+            rule: updated.rule,
+            version: updated.version,
+            chainStatus: updated.chainStatus,
+            txHash: updated.txHash,
+            updatedAt: updated.updatedAt,
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/policies/$owner/senders/$sender/retry.ts
+++ b/src/routes/api/v1/policies/$owner/senders/$sender/retry.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { getApiContext } from "@/server/api/context";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { retrySenderRuleWrite } from "@/server/api/sender-rule-service";
+import { parseJsonBody } from "@/server/api/request";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const retryBodySchema = z.object({});
+
+export const Route = createFileRoute("/api/v1/policies/$owner/senders/$sender/retry")({
+  server: {
+    handlers: {
+      POST: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = stellarAddressSchema.parse(params.owner);
+          const sender = stellarAddressSchema.parse(params.sender);
+
+          await parseJsonBody(request, retryBodySchema, {
+            route: "POST /policies/{owner}/senders/{sender}/retry",
+          });
+
+          const updated = await retrySenderRuleWrite(context.repository, owner, sender);
+
+          return apiSuccess(request, {
+            owner: updated.owner,
+            sender: updated.sender,
+            rule: updated.rule,
+            version: updated.version,
+            chainStatus: updated.chainStatus,
+          });
+        }),
+    },
+  },
+});

--- a/src/routes/api/v1/policies/$owner/senders/index.ts
+++ b/src/routes/api/v1/policies/$owner/senders/index.ts
@@ -1,0 +1,57 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { parseDelegationHeader, requireActorMatches } from "@/server/api/actor";
+import { getApiContext } from "@/server/api/context";
+import { stellarAddressSchema } from "@/server/api/domain";
+import { listSenderRules } from "@/server/api/sender-rule-service";
+import { apiSuccess, handleApiRequest } from "@/server/api/response";
+
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  after: z.string().optional(),
+});
+
+export const Route = createFileRoute("/api/v1/policies/$owner/senders/")({
+  server: {
+    handlers: {
+      GET: ({ request, params }) =>
+        handleApiRequest(request, async () => {
+          const context = await getApiContext(request);
+          const owner = stellarAddressSchema.parse(params.owner);
+          requireActorMatches(
+            context,
+            owner,
+            parseDelegationHeader(request, "policy:senders:read", `mailbox:${owner}:senders`),
+          );
+
+          const url = new URL(request.url);
+          const query = listQuerySchema.parse({
+            limit: url.searchParams.get("limit"),
+            after: url.searchParams.get("after"),
+          });
+
+          const result = await listSenderRules(context.repository, owner, {
+            limit: query.limit,
+            after: query.after,
+          });
+
+          return apiSuccess(request, {
+            records: result.records.map((r) => ({
+              owner: r.owner,
+              sender: r.sender,
+              rule: r.rule,
+              pricePayload: r.pricePayload,
+              version: r.version,
+              chainStatus: r.chainStatus,
+              scheduledAt: r.scheduledAt,
+              updatedAt: r.updatedAt,
+              confirmedAt: r.confirmedAt,
+              txHash: r.txHash,
+            })),
+            nextCursor: result.nextCursor,
+          });
+        }),
+    },
+  },
+});

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -5,6 +5,7 @@ import type { ApiRepository } from "./repository";
 import {
   mailboxPolicySchema,
   senderRuleSchema,
+  senderRuleRecordSchema,
   postageSchema,
   receiptSchema,
   idempotencyRecordSchema,
@@ -206,6 +207,8 @@ globalThis.fetch = function (input: RequestInfo | URL, init?: RequestInit): Prom
 // Register schemas once at module init for Issue #1508 record validation
 registerRecordSchema("mailboxPolicy", 1, mailboxPolicySchema);
 registerRecordSchema("senderRule", 1, senderRuleSchema);
+// BETA-037 (Issue #1944): versioned sender rule records with chain reconciliation
+registerRecordSchema("senderRuleRecord", 1, senderRuleRecordSchema);
 registerRecordSchema("postage", 1, postageSchema);
 registerRecordSchema("receipt", 1, receiptSchema);
 registerRecordSchema("user", 1, userSchema);

--- a/src/server/api/domain.ts
+++ b/src/server/api/domain.ts
@@ -29,7 +29,81 @@ export const stroopAmountSchema = z
     }
   }, "Amount exceeds Soroban i128");
 
-export const senderRuleSchema = z.enum(["default", "allow", "block"]);
+export const senderRuleSchema = z.enum(["default", "allow", "block", "verify", "price"]);
+
+/**
+ * BETA-037 (Issue #1944) — live, versioned sender rules.
+ *
+ * `senderRuleActionSchema` covers the subset of rule types that can be explicitly
+ * set via the API. "default" is the absence of a rule and is set by deleting.
+ */
+export const senderRuleActionSchema = z.enum(["allow", "block", "verify", "price"]);
+export type SenderRuleAction = z.infer<typeof senderRuleActionSchema>;
+
+/**
+ * Chain synchronization status for a sender rule. Each state-changing
+ * operation schedules a testnet contract write; this field tracks where
+ * that write is in its lifecycle and whether local state matches chain state.
+ *
+ * - pending:   local rule recorded, testnet write scheduled but not yet submitted
+ * - submitted: signed transaction submitted to testnet, awaiting confirmation
+ * - confirmed: chain confirmed the rule matches local state
+ * - failed:    testnet write failed after retries; local rule still applies off-chain
+ * - drift:     chain version diverged from local (e.g. external set_sender_rule call)
+ */
+export const senderRuleChainStatusSchema = z.enum([
+  "pending",
+  "submitted",
+  "confirmed",
+  "failed",
+  "drift",
+]);
+
+export type SenderRuleChainStatus = z.infer<typeof senderRuleChainStatusSchema>;
+
+/**
+ * Price rule payload: the minimum postage (in stroops) the sender must attach.
+ * Only valid when rule is "price".
+ */
+export const senderRulePricePayloadSchema = z
+  .object({
+    minimumPostage: stroopAmountSchema,
+  })
+  .optional();
+
+/**
+ * Full versioned sender rule record. Persisted server-side (survives refresh)
+ * and reconciled against testnet.
+ */
+export const senderRuleRecordSchema = z.object({
+  owner: stellarAddressSchema,
+  sender: stellarAddressSchema,
+  rule: senderRuleActionSchema,
+  pricePayload: senderRulePricePayloadSchema,
+  version: z.number().int().nonnegative(),
+  chainStatus: senderRuleChainStatusSchema,
+  scheduledAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  confirmedAt: z.string().datetime().nullable().default(null),
+  failureCount: z.number().int().nonnegative().default(0),
+  lastError: z.string().max(300).nullable().default(null),
+  txHash: z.string().nullable().default(null),
+  idempotencyKey: z.string().min(1).optional(),
+});
+
+export type SenderRuleRecord = z.infer<typeof senderRuleRecordSchema>;
+
+/**
+ * Chain-side representation of a sender rule for reconciliation. Queried
+ * from the Policies contract to compare against local state.
+ */
+export const chainSenderRuleSchema = z.object({
+  rule: senderRuleActionSchema,
+  minimumPostage: stroopAmountSchema.optional(),
+  version: z.number().int().nonnegative(),
+});
+
+export type ChainSenderRule = z.infer<typeof chainSenderRuleSchema>;
 export const postageStatusSchema = z.enum([
   "pending",
   "expired",
@@ -64,9 +138,27 @@ export const mailboxPolicyWriteSchema = z.object({
   version: z.number().int().nonnegative().optional(),
 });
 
-export const senderRuleWriteSchema = z.object({
-  rule: senderRuleSchema,
-});
+/**
+ * Request body for creating or updating a versioned sender rule.
+ * `version` is required for updates (optimistic concurrency check);
+ * omitted for creates.
+ */
+export const senderRuleWriteSchema = z
+  .object({
+    rule: senderRuleActionSchema,
+    pricePayload: senderRulePricePayloadSchema,
+    version: z.number().int().nonnegative().optional(),
+    idempotencyKey: z.string().min(1).max(128).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.rule === "price" && !data.pricePayload?.minimumPostage) {
+        return false;
+      }
+      return true;
+    },
+    { message: "pricePayload.minimumPostage is required when rule is 'price'" },
+  );
 
 // ---------------------------------------------------------------------------
 // BETA-023 (Issue #1930) — privacy-safe mailbox policy provisioning

--- a/src/server/api/kv-repository.ts
+++ b/src/server/api/kv-repository.ts
@@ -39,6 +39,7 @@ import type {
   RecoveryCodeSet,
   RetiredSession,
   SenderRule,
+  SenderRuleRecord,
   Session,
   StoredEnvelope,
   User,
@@ -107,6 +108,35 @@ export class HybridApiRepository implements ApiRepository {
       await this.kv.put(ruleKey, rule);
     }
     return rule;
+  }
+
+  // BETA-037 (Issue #1944): versioned sender rule records
+  async getSenderRuleRecord(owner: string, sender: string): Promise<SenderRuleRecord | null> {
+    const record = await this.kv.get(this.key("sender-rule-record", owner, sender), "json");
+    return (record as SenderRuleRecord) ?? null;
+  }
+
+  async setSenderRuleRecord(record: SenderRuleRecord): Promise<SenderRuleRecord> {
+    await this.kv.put(
+      this.key("sender-rule-record", record.owner, record.sender),
+      JSON.stringify(record),
+    );
+    return record;
+  }
+
+  async deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean> {
+    const existing = await this.getSenderRuleRecord(owner, sender);
+    if (!existing) return false;
+    await this.kv.delete(this.key("sender-rule-record", owner, sender));
+    return true;
+  }
+
+  async listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: SenderRuleRecord[]; nextCursor?: string }> {
+    // BETA-037: Delegate to the DO coordinator for consistent listing.
+    return this.getStub().listSenderRuleRecords(owner, options);
   }
 
   async getPostage(messageId: string): Promise<Postage | null> {

--- a/src/server/api/memory-repository.ts
+++ b/src/server/api/memory-repository.ts
@@ -24,6 +24,7 @@ import type {
   RecoveryCodeSet,
   RetiredSession,
   SenderRule,
+  SenderRuleRecord,
   Session,
   StoredEnvelope,
   UnknownSenderDecision,
@@ -78,6 +79,8 @@ export class MemoryApiRepository implements ApiRepository {
   private readonly deliveryStatuses = new Map<string, MessageDeliveryStatusRecord>();
 
   private readonly senderRules = new Map<string, SenderRule>();
+  // BETA-037 (Issue #1944): versioned sender rule records keyed by `${owner}:${sender}`
+  private readonly senderRuleRecords = new Map<string, SenderRuleRecord>();
   private readonly counters = new Map<string, number[]>();
   private readonly idempotency = new Map<string, IdempotencyRecord>();
   private readonly externalWallets = new Map<string, ExternalWallet[]>();
@@ -292,6 +295,42 @@ export class MemoryApiRepository implements ApiRepository {
     if (rule === "default") this.senderRules.delete(ruleKey);
     else this.senderRules.set(ruleKey, rule);
     return rule;
+  }
+
+  // BETA-037 (Issue #1944): versioned sender rule records
+  async getSenderRuleRecord(owner: string, sender: string): Promise<SenderRuleRecord | null> {
+    return structuredClone(this.senderRuleRecords.get(key(owner, sender)) ?? null);
+  }
+
+  async setSenderRuleRecord(record: SenderRuleRecord): Promise<SenderRuleRecord> {
+    this.senderRuleRecords.set(key(record.owner, record.sender), structuredClone(record));
+    return structuredClone(record);
+  }
+
+  async deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean> {
+    return this.senderRuleRecords.delete(key(owner, sender));
+  }
+
+  async listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: SenderRuleRecord[]; nextCursor?: string }> {
+    const limit = options?.limit ?? 50;
+    const after = options?.after;
+    let records: SenderRuleRecord[] = [];
+    const ownerPrefix = `${owner}:`;
+    for (const [k, v] of this.senderRuleRecords) {
+      if (k.startsWith(ownerPrefix)) {
+        records.push(structuredClone(v));
+      }
+    }
+    records.sort((a, b) => a.sender.localeCompare(b.sender));
+    if (after) {
+      const idx = records.findIndex((r) => r.sender === after);
+      if (idx >= 0) records = records.slice(idx + 1);
+    }
+    const nextCursor = records.length > limit ? records[limit - 1].sender : undefined;
+    return { records: records.slice(0, limit), nextCursor };
   }
 
   async getPostage(messageId: string) {
@@ -1617,6 +1656,7 @@ export class MemoryApiRepository implements ApiRepository {
     this.receipts.clear();
     this.deliveryStatuses.clear();
     this.senderRules.clear();
+    this.senderRuleRecords.clear();
     this.counters.clear();
     this.idempotency.clear();
     this.externalWallets.clear();

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -509,7 +509,7 @@ export const openApiDocument = {
           rule: {
             type: "string",
             description: "Applied sender override rule.",
-            enum: ["allow", "block", "default"],
+            enum: ["allow", "block", "default", "verify", "price"],
           },
         },
       },
@@ -1030,7 +1030,10 @@ export const openApiDocument = {
               { type: "null" },
             ],
           },
-          senderRule: { type: "string", enum: ["default", "allow", "block"] },
+          senderRule: {
+            type: "string",
+            enum: ["default", "allow", "block", "verify", "price"],
+          },
           senderRuleConfigured: {
             type: "boolean",
             description: "True when the owner has an explicit policy rule for this address.",

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -1032,7 +1032,7 @@ export const openApiDocument = {
           },
           senderRule: {
             type: "string",
-            enum: ["default", "allow", "block", "verify", "price"],
+            enum: ["default", "allow", "block"],
           },
           senderRuleConfigured: {
             type: "boolean",

--- a/src/server/api/policy-service.ts
+++ b/src/server/api/policy-service.ts
@@ -130,6 +130,97 @@ export async function evaluateMailboxPolicy(
     verified: boolean;
   },
 ) {
+  // BETA-037: Check versioned sender rule first; fall back to legacy rule
+  const record = await repository.getSenderRuleRecord(input.owner, input.sender);
+  if (record) {
+    switch (record.rule) {
+      case "allow":
+        return {
+          allowed: true,
+          policy: (await getMailboxPolicy(repository, input.owner)).policy,
+          source: (await getMailboxPolicy(repository, input.owner)).source,
+          reason: "sender_allowed" as const,
+          rule: record.rule as SenderRule,
+          versionedRule: record,
+        };
+      case "block":
+        return {
+          allowed: false,
+          policy: (await getMailboxPolicy(repository, input.owner)).policy,
+          source: (await getMailboxPolicy(repository, input.owner)).source,
+          reason: "sender_blocked" as const,
+          rule: record.rule as SenderRule,
+          versionedRule: record,
+        };
+      case "verify": {
+        const { policy, source } = await getMailboxPolicy(repository, input.owner);
+        if (!input.verified) {
+          return {
+            allowed: false,
+            policy,
+            source,
+            reason: "verification_required" as const,
+            rule: record.rule as SenderRule,
+            versionedRule: record,
+          };
+        }
+        // Fall through to check other policy constraints (e.g. postage)
+        if (BigInt(input.postage) < BigInt(policy.minimumPostage)) {
+          return {
+            allowed: false,
+            policy,
+            source,
+            reason: "insufficient_postage" as const,
+            rule: record.rule as SenderRule,
+            versionedRule: record,
+          };
+        }
+        return {
+          allowed: true,
+          policy,
+          source,
+          reason: "policy_satisfied" as const,
+          rule: record.rule as SenderRule,
+          versionedRule: record,
+        };
+      }
+      case "price": {
+        const { policy, source } = await getMailboxPolicy(repository, input.owner);
+        const minPostage = record.pricePayload?.minimumPostage ?? "0";
+        if (BigInt(input.postage) < BigInt(minPostage)) {
+          return {
+            allowed: false,
+            policy,
+            source,
+            reason: "insufficient_postage" as const,
+            rule: record.rule as SenderRule,
+            versionedRule: record,
+          };
+        }
+        // Also check verification if the global policy requires it
+        if (policy.requireVerified && !input.verified) {
+          return {
+            allowed: false,
+            policy,
+            source,
+            reason: "verification_required" as const,
+            rule: record.rule as SenderRule,
+            versionedRule: record,
+          };
+        }
+        return {
+          allowed: true,
+          policy,
+          source,
+          reason: "policy_satisfied" as const,
+          rule: record.rule as SenderRule,
+          versionedRule: record,
+        };
+      }
+    }
+  }
+
+  // Legacy fallback
   const rule = await repository.getSenderRule(input.owner, input.sender);
   const { policy, source } = await getMailboxPolicy(repository, input.owner);
   if (rule === "allow")

--- a/src/server/api/repository.ts
+++ b/src/server/api/repository.ts
@@ -24,6 +24,7 @@ import type {
   RecoveryCodeSet,
   RetiredSession,
   SenderRule,
+  SenderRuleRecord,
   Session,
   StoredEnvelope,
   MailboxFlagsPatch,
@@ -275,6 +276,14 @@ export interface ApiRepository {
   setLifecycleAnchor(anchor: LifecycleAnchor): Promise<LifecycleAnchor>;
   getSenderRule(owner: string, sender: string): Promise<SenderRule>;
   setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule>;
+  // BETA-037 (Issue #1944): versioned sender rule records with chain reconciliation
+  getSenderRuleRecord(owner: string, sender: string): Promise<SenderRuleRecord | null>;
+  setSenderRuleRecord(record: SenderRuleRecord): Promise<SenderRuleRecord>;
+  deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean>;
+  listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: SenderRuleRecord[]; nextCursor?: string }>;
   getPostage(messageId: string): Promise<Postage | null>;
   setPostage(postage: Postage): Promise<Postage>;
   /**
@@ -729,6 +738,32 @@ export class ValidatedApiRepository implements ApiRepository {
 
   setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
     return this.inner.setSenderRule(owner, sender, versionRecord("senderRule", rule));
+  }
+
+  // BETA-037 (Issue #1944): versioned sender rule records with chain reconciliation
+  async getSenderRuleRecord(owner: string, sender: string): Promise<SenderRuleRecord | null> {
+    const raw = await this.inner.getSenderRuleRecord(owner, sender);
+    return raw ? validateRecord<SenderRuleRecord>("senderRuleRecord", raw) : null;
+  }
+
+  async setSenderRuleRecord(record: SenderRuleRecord): Promise<SenderRuleRecord> {
+    const result = await this.inner.setSenderRuleRecord(versionRecord("senderRuleRecord", record));
+    return validateRecord<SenderRuleRecord>("senderRuleRecord", result);
+  }
+
+  async deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean> {
+    return this.inner.deleteSenderRuleRecord(owner, sender);
+  }
+
+  async listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: SenderRuleRecord[]; nextCursor?: string }> {
+    const result = await this.inner.listSenderRuleRecords(owner, options);
+    return {
+      ...result,
+      records: result.records.map((r) => validateRecord<SenderRuleRecord>("senderRuleRecord", r)),
+    };
   }
 
   async getPostage(messageId: string): Promise<Postage | null> {
@@ -1501,6 +1536,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "getPolicyWriteIntent",
   "getLifecycleAnchor",
   "getSenderRule",
+  "getSenderRuleRecord",
+  "listSenderRuleRecords",
   "getPostage",
   "getReceipt",
   "getIdempotencyRecord",
@@ -1514,6 +1551,8 @@ const RETRY_SAFE_OPERATIONS = new Set<string>([
   "setPolicyWriteIntent",
   "setLifecycleAnchor",
   "setSenderRule",
+  "setSenderRuleRecord",
+  "deleteSenderRuleRecord",
   "setPostage",
   "setReceipt",
   "createReceiptIfAbsent",
@@ -1654,6 +1693,32 @@ export class RetryableApiRepository implements ApiRepository {
 
   setSenderRule(owner: string, sender: string, rule: SenderRule): Promise<SenderRule> {
     return this.withRetry("setSenderRule", () => this.inner.setSenderRule(owner, sender, rule));
+  }
+
+  // BETA-037 (Issue #1944): versioned sender rule records
+  getSenderRuleRecord(owner: string, sender: string): Promise<SenderRuleRecord | null> {
+    return this.withRetry("getSenderRuleRecord", () =>
+      this.inner.getSenderRuleRecord(owner, sender),
+    );
+  }
+
+  setSenderRuleRecord(record: SenderRuleRecord): Promise<SenderRuleRecord> {
+    return this.withRetry("setSenderRuleRecord", () => this.inner.setSenderRuleRecord(record));
+  }
+
+  deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean> {
+    return this.withRetry("deleteSenderRuleRecord", () =>
+      this.inner.deleteSenderRuleRecord(owner, sender),
+    );
+  }
+
+  listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: SenderRuleRecord[]; nextCursor?: string }> {
+    return this.withRetry("listSenderRuleRecords", () =>
+      this.inner.listSenderRuleRecords(owner, options),
+    );
   }
 
   getPostage(messageId: string): Promise<Postage | null> {

--- a/src/server/api/request.ts
+++ b/src/server/api/request.ts
@@ -67,6 +67,9 @@ export const ROUTE_BODY_LIMITS = {
   "POST /send/coordinate": "standard",
   "PUT /api/v1/onboarding/draft": "standard",
   "POST /api/v1/onboarding/complete": "standard",
+  // BETA-037: sender rule chain status and retry
+  "POST /policies/{owner}/senders/{sender}/chain-status": "minimal",
+  "POST /policies/{owner}/senders/{sender}/retry": "minimal",
 } as const satisfies Record<string, BodyLimitCategory>;
 
 export type RouteBodyLimitKey = keyof typeof ROUTE_BODY_LIMITS;

--- a/src/server/api/sender-rule-service.ts
+++ b/src/server/api/sender-rule-service.ts
@@ -1,0 +1,441 @@
+import type {
+  SenderRule,
+  SenderRuleAction,
+  SenderRuleRecord,
+  SenderRuleChainStatus,
+  ChainSenderRule,
+} from "./domain";
+import type { ApiRepository } from "./repository";
+import { ApiError } from "./errors";
+import { recordAuditEvent } from "./audit";
+
+// ---------------------------------------------------------------------------
+// BETA-037 (Issue #1944) — Live, versioned sender rules
+//
+// Sender rules (allow / block / verify / price) are persisted server-side,
+// versioned, reconciled against the Policies contract on testnet, and enforced
+// during relay admission. Every state-changing operation is idempotent and
+// emits a structured audit event.
+// ---------------------------------------------------------------------------
+
+export interface SenderRuleServiceResult {
+  owner: string;
+  sender: string;
+  rule: SenderRuleRecord;
+  /** When the operation created a new rule (true) vs updated (false). */
+  created: boolean;
+}
+
+export interface SenderRuleListResult {
+  records: SenderRuleRecord[];
+  nextCursor?: string;
+}
+
+export interface SenderRuleReconciliationResult {
+  owner: string;
+  sender: string;
+  local: SenderRuleRecord | null;
+  chain: ChainSenderRule | null;
+  state: "synced" | "pending" | "drift" | "not_found";
+}
+
+/**
+ * Creates a new versioned sender rule or updates an existing one.
+ *
+ * Idempotency: When `idempotencyKey` matches an existing record with the
+ * same rule type and payload, the operation returns the existing record
+ * without bumping the version (write-once semantic).
+ *
+ * Optimistic concurrency: When `version` is supplied it must match the
+ * current record version; a mismatch returns 409 conflict.
+ *
+ * Owner authorization is NOT enforced here — callers MUST verify the actor
+ * matches the owner before invoking (the route layer handles this).
+ */
+export async function createOrUpdateSenderRule(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+  input: {
+    rule: SenderRuleAction;
+    pricePayload?: { minimumPostage: string };
+    version?: number;
+    idempotencyKey?: string;
+  },
+  now = new Date(),
+): Promise<SenderRuleServiceResult> {
+  const iso = now.toISOString();
+  const existing = await repository.getSenderRuleRecord(owner, sender);
+
+  // --- Validate price rule requires pricePayload ---
+  if (input.rule === "price" && (!input.pricePayload || !input.pricePayload.minimumPostage)) {
+    throw new ApiError(
+      422,
+      "validation_error",
+      "pricePayload.minimumPostage is required when rule is 'price'",
+    );
+  }
+
+  // --- Idempotency: same idempotency key → no-op ---
+  if (existing) {
+    if (input.idempotencyKey && existing.idempotencyKey === input.idempotencyKey) {
+      return { owner, sender, rule: existing, created: false };
+    }
+    // Same rule+payload without version AND without a different idempotency key → no-op
+    if (
+      !input.version &&
+      !input.idempotencyKey &&
+      existing.rule === input.rule &&
+      existing.pricePayload?.minimumPostage === input.pricePayload?.minimumPostage
+    ) {
+      return { owner, sender, rule: existing, created: false };
+    }
+  }
+
+  // --- Optimistic concurrency check ---
+  if (input.version !== undefined) {
+    if (!existing) {
+      throw new ApiError(
+        409,
+        "conflict",
+        "Sender rule does not exist; cannot update with version",
+        { details: { suppliedVersion: input.version } },
+      );
+    }
+    if (existing.version !== input.version) {
+      throw new ApiError(
+        409,
+        "conflict",
+        "Sender rule has been modified since you last loaded it",
+        {
+          details: { currentVersion: existing.version, suppliedVersion: input.version },
+        },
+      );
+    }
+  } else if (existing) {
+    // No version supplied and rule exists — reject to prevent silent overwrite
+    throw new ApiError(409, "conflict", "Sender rule already exists; supply a version to update", {
+      details: { currentVersion: existing.version },
+    });
+  }
+
+  const version = existing ? existing.version + 1 : 1;
+
+  const record: SenderRuleRecord = {
+    owner,
+    sender,
+    rule: input.rule,
+    pricePayload: input.rule === "price" ? input.pricePayload : undefined,
+    version,
+    chainStatus: "pending",
+    scheduledAt: iso,
+    updatedAt: iso,
+    confirmedAt: null,
+    failureCount: 0,
+    lastError: null,
+    txHash: null,
+    idempotencyKey: input.idempotencyKey,
+  };
+
+  const saved = await repository.setSenderRuleRecord(record);
+
+  // Mirror into the legacy sender rule map so evaluateMailboxPolicy sees it
+  await repository.setSenderRule(owner, sender, input.rule as SenderRule);
+
+  recordAuditEvent({
+    actor: owner,
+    action: existing ? "sender_rule.update" : "sender_rule.create",
+    targetType: "sender_rule",
+    safeTargetReference: `sender_rule:${owner}:${sender}:${input.rule}:v${version}`,
+    result: "success",
+    requestId: "",
+  });
+
+  return { owner, sender, rule: saved, created: !existing };
+}
+
+/**
+ * Soft-deletes a sender rule by resetting it to "default". The deletion
+ * is idempotent: deleting a non-existent or already-default rule is a no-op.
+ */
+export async function deleteSenderRule(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+  now = new Date(),
+): Promise<{ owner: string; sender: string; deleted: boolean }> {
+  const existing = await repository.getSenderRuleRecord(owner, sender);
+  if (!existing) {
+    return { owner, sender, deleted: false };
+  }
+
+  const iso = now.toISOString();
+  const deleted = await repository.deleteSenderRuleRecord(owner, sender);
+  await repository.setSenderRule(owner, sender, "default");
+
+  if (deleted) {
+    recordAuditEvent({
+      actor: owner,
+      action: "sender_rule.delete",
+      targetType: "sender_rule",
+      safeTargetReference: `sender_rule:${owner}:${sender}:deleted:v${existing.version}`,
+      result: "success",
+      requestId: "",
+    });
+  }
+
+  return { owner, sender, deleted };
+}
+
+/**
+ * Lists all versioned sender rules for an owner, with cursor-based pagination.
+ */
+export async function listSenderRules(
+  repository: ApiRepository,
+  owner: string,
+  options?: { limit?: number; after?: string },
+): Promise<SenderRuleListResult> {
+  return repository.listSenderRuleRecords(owner, options);
+}
+
+/**
+ * Gets a single versioned sender rule record.
+ */
+export async function getSenderRuleRecord(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+): Promise<SenderRuleRecord | null> {
+  return repository.getSenderRuleRecord(owner, sender);
+}
+
+// ---------------------------------------------------------------------------
+// Chain status transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Transitions a sender rule's chain status. Called by the managed-wallet
+ * signer after signing/submitting a testnet transaction and by the
+ * reconciliation loop after polling for confirmation.
+ *
+ * Allowed transitions:
+ *   pending   → submitted (signed and submitted to testnet)
+ *   pending   → failed    (signing or submission error)
+ *   submitted → confirmed (chain confirmed the write)
+ *   submitted → failed    (chain rejected or timed out)
+ *   failed    → pending   (retry scheduled)
+ *   drift     → pending   (re-sync scheduled)
+ */
+const ALLOWED_CHAIN_TRANSITIONS: Record<SenderRuleChainStatus, Set<SenderRuleChainStatus>> = {
+  pending: new Set(["submitted", "failed"]),
+  submitted: new Set(["confirmed", "failed"]),
+  confirmed: new Set(["drift"]),
+  failed: new Set(["pending"]),
+  drift: new Set(["pending"]),
+};
+
+export async function transitionSenderRuleChainStatus(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+  nextStatus: SenderRuleChainStatus,
+  meta: { txHash?: string; lastError?: string } = {},
+  now = new Date(),
+): Promise<SenderRuleRecord> {
+  const record = await repository.getSenderRuleRecord(owner, sender);
+  if (!record) {
+    throw new ApiError(404, "not_found", "Sender rule record not found");
+  }
+
+  const allowed = ALLOWED_CHAIN_TRANSITIONS[record.chainStatus];
+  if (!allowed?.has(nextStatus)) {
+    throw new ApiError(
+      409,
+      "invalid_state_transition",
+      `Cannot transition sender rule from '${record.chainStatus}' to '${nextStatus}'`,
+      { fromState: record.chainStatus, toState: nextStatus },
+    );
+  }
+
+  const iso = now.toISOString();
+  const updated: SenderRuleRecord = {
+    ...record,
+    chainStatus: nextStatus,
+    updatedAt: iso,
+    txHash: meta.txHash ?? record.txHash,
+    lastError: meta.lastError ? sanitizeFailureReason(meta.lastError) : record.lastError,
+    confirmedAt: nextStatus === "confirmed" ? iso : record.confirmedAt,
+    failureCount: nextStatus === "failed" ? record.failureCount + 1 : record.failureCount,
+  };
+
+  const saved = await repository.setSenderRuleRecord(updated);
+
+  recordAuditEvent({
+    actor: owner,
+    action: `sender_rule.chain.${nextStatus}`,
+    targetType: "sender_rule",
+    safeTargetReference: `sender_rule:${owner}:${sender}:chain:${nextStatus}:v${record.version}`,
+    result: nextStatus === "failed" ? "denied" : "success",
+    requestId: "",
+  });
+
+  return saved;
+}
+
+/**
+ * Retries a failed sender rule write by resetting it to "pending".
+ * Idempotent: if the rule is already pending or confirmed, this is a no-op.
+ */
+export async function retrySenderRuleWrite(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+  now = new Date(),
+): Promise<SenderRuleRecord> {
+  const record = await repository.getSenderRuleRecord(owner, sender);
+  if (!record) {
+    throw new ApiError(404, "not_found", "Sender rule record not found");
+  }
+
+  if (record.chainStatus === "confirmed") {
+    return record; // already confirmed, no-op
+  }
+
+  if (record.chainStatus === "pending" || record.chainStatus === "submitted") {
+    return record; // already in-flight, no-op
+  }
+
+  return transitionSenderRuleChainStatus(repository, owner, sender, "pending", {}, now);
+}
+
+// ---------------------------------------------------------------------------
+// Chain reconciliation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compares the local sender rule against the chain state and updates the
+ * chain status if they diverge. Returns the reconciliation result.
+ */
+export async function reconcileSenderRule(
+  repository: ApiRepository,
+  owner: string,
+  sender: string,
+  chain: ChainSenderRule | null,
+  now = new Date(),
+): Promise<SenderRuleReconciliationResult> {
+  const local = await repository.getSenderRuleRecord(owner, sender);
+
+  if (!local) {
+    return {
+      owner,
+      sender,
+      local: null,
+      chain,
+      state: chain ? "drift" : "not_found",
+    };
+  }
+
+  if (!chain) {
+    return {
+      owner,
+      sender,
+      local,
+      chain: null,
+      state: local.chainStatus === "confirmed" ? "synced" : "pending",
+    };
+  }
+
+  // Compare local vs chain
+  const rulesMatch = local.rule === chain.rule;
+  const priceMatch =
+    local.rule === "price" ? local.pricePayload?.minimumPostage === chain.minimumPostage : true;
+
+  if (rulesMatch && priceMatch && local.version <= chain.version) {
+    // In sync or chain is ahead
+    if (local.chainStatus !== "confirmed") {
+      await transitionSenderRuleChainStatus(repository, owner, sender, "confirmed", {}, now);
+      const refreshed = await repository.getSenderRuleRecord(owner, sender);
+      return { owner, sender, local: refreshed!, chain, state: "synced" };
+    }
+    return { owner, sender, local, chain, state: "synced" };
+  }
+
+  // Divergence detected
+  if (local.chainStatus !== "drift") {
+    await transitionSenderRuleChainStatus(repository, owner, sender, "drift", {}, now);
+    const refreshed = await repository.getSenderRuleRecord(owner, sender);
+    return { owner, sender, local: refreshed!, chain, state: "drift" };
+  }
+
+  return { owner, sender, local, chain, state: "drift" };
+}
+
+// ---------------------------------------------------------------------------
+// Relay admission integration
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates whether a sender is allowed under the current versioned rules
+ * and mailbox policy. This extends the basic `evaluateMailboxPolicy` to
+ * include "verify" and "price" rule types.
+ *
+ * The rule types affect relay admission as follows:
+ *   allow  → always admitted
+ *   block  → never admitted
+ *   verify → admitted only if the sender is verified (same as requireVerified)
+ *   price  → admitted only if postage ≥ pricePayload.minimumPostage
+ *   default → falls through to the global mailbox policy
+ */
+export async function evaluateSenderRuleForAdmission(
+  repository: ApiRepository,
+  input: {
+    owner: string;
+    sender: string;
+    postage: string;
+    verified: boolean;
+  },
+): Promise<{
+  allowed: boolean;
+  reason: string;
+  rule: SenderRuleRecord | null;
+}> {
+  const record = await repository.getSenderRuleRecord(input.owner, input.sender);
+  if (!record) {
+    // Fall through to default
+    return { allowed: true, reason: "no_rule", rule: null };
+  }
+
+  switch (record.rule) {
+    case "allow":
+      return { allowed: true, reason: "sender_allowed", rule: record };
+    case "block":
+      return { allowed: false, reason: "sender_blocked", rule: record };
+    case "verify":
+      if (!input.verified) {
+        return { allowed: false, reason: "verification_required", rule: record };
+      }
+      return { allowed: true, reason: "sender_verified", rule: record };
+    case "price": {
+      const minPostage = record.pricePayload?.minimumPostage ?? "0";
+      if (BigInt(input.postage) < BigInt(minPostage)) {
+        return { allowed: false, reason: "insufficient_postage", rule: record };
+      }
+      return { allowed: true, reason: "postage_sufficient", rule: record };
+    }
+    default:
+      return { allowed: true, reason: "no_rule", rule: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sanitizeFailureReason(message: string): string {
+  let cleaned = "";
+  for (const char of message) {
+    const code = char.charCodeAt(0);
+    cleaned += code > 31 && code !== 127 ? char : " ";
+  }
+  return cleaned.trim().slice(0, 300);
+}

--- a/src/server/api/stealth-coordinator.ts
+++ b/src/server/api/stealth-coordinator.ts
@@ -1080,6 +1080,35 @@ export class StealthCoordinator extends DurableObjectBase {
     return matches.slice(0, limit);
   }
 
+  // ---------------------------------------------------------------------------
+  // BETA-037 (Issue #1944): versioned sender rule records
+  // ---------------------------------------------------------------------------
+
+  async listSenderRuleRecords(
+    owner: string,
+    options?: { limit?: number; after?: string },
+  ): Promise<{ records: import("./domain").SenderRuleRecord[]; nextCursor?: string }> {
+    const limit = options?.limit ?? 50;
+    const records: import("./domain").SenderRuleRecord[] = [];
+    const all = (await this.ctx.storage.list({
+      prefix: `sender-rule-record:${owner}:`,
+    })) as Map<string, import("./domain").SenderRuleRecord>;
+    for (const record of all.values()) {
+      if (record && record.owner === owner) {
+        records.push(record);
+      }
+    }
+    records.sort((a, b) => a.sender.localeCompare(b.sender));
+    let startIndex = 0;
+    if (options?.after) {
+      startIndex = records.findIndex((r) => r.sender === options.after) + 1;
+    }
+    const page = records.slice(startIndex, startIndex + limit);
+    const nextCursor =
+      startIndex + limit < records.length ? page[page.length - 1]?.sender : undefined;
+    return { records: page, nextCursor };
+  }
+
   async listRecipientEnvelopes(
     recipient: string,
     options: import("./repository").MailboxQueryOptions = {},

--- a/tests/unit/api/retryable-repository.test.ts
+++ b/tests/unit/api/retryable-repository.test.ts
@@ -108,6 +108,22 @@ class FailingRepository implements ApiRepository {
     this.maybeFail("setSenderRule");
     return this.inner.setSenderRule(owner, sender, rule);
   }
+  async getSenderRuleRecord(owner: string, sender: string) {
+    this.maybeFail("getSenderRuleRecord");
+    return this.inner.getSenderRuleRecord(owner, sender);
+  }
+  async setSenderRuleRecord(record: import("../../../src/server/api/domain").SenderRuleRecord) {
+    this.maybeFail("setSenderRuleRecord");
+    return this.inner.setSenderRuleRecord(record);
+  }
+  async deleteSenderRuleRecord(owner: string, sender: string): Promise<boolean> {
+    this.maybeFail("deleteSenderRuleRecord");
+    return this.inner.deleteSenderRuleRecord(owner, sender);
+  }
+  async listSenderRuleRecords(owner: string, options?: { limit?: number; after?: string }) {
+    this.maybeFail("listSenderRuleRecords");
+    return this.inner.listSenderRuleRecords(owner, options);
+  }
   async getPostage(messageId: string): Promise<Postage | null> {
     this.maybeFail("getPostage");
     return this.inner.getPostage(messageId);

--- a/tests/unit/api/sender-rule-service.test.ts
+++ b/tests/unit/api/sender-rule-service.test.ts
@@ -1,0 +1,544 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { MemoryApiRepository } from "../../../src/server/api/memory-repository";
+import {
+  createOrUpdateSenderRule,
+  deleteSenderRule,
+  listSenderRules,
+  getSenderRuleRecord,
+  transitionSenderRuleChainStatus,
+  retrySenderRuleWrite,
+  reconcileSenderRule,
+  evaluateSenderRuleForAdmission,
+} from "../../../src/server/api/sender-rule-service";
+import { ApiError } from "../../../src/server/api/errors";
+
+const OWNER = `G${"A".repeat(55)}`;
+const SENDER = `G${"B".repeat(55)}`;
+const OTHER_OWNER = `G${"C".repeat(55)}`;
+
+describe("BETA-037: Sender Rule Service", () => {
+  let repository: MemoryApiRepository;
+
+  beforeEach(() => {
+    repository = new MemoryApiRepository();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Domain rules, malformed input, and boundary cases
+  // ---------------------------------------------------------------------------
+
+  describe("Domain Rules & Validation", () => {
+    it("creates an allow rule", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+      });
+      expect(result.created).toBe(true);
+      expect(result.rule.rule).toBe("allow");
+      expect(result.rule.version).toBe(1);
+      expect(result.rule.chainStatus).toBe("pending");
+    });
+
+    it("creates a block rule", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "block",
+      });
+      expect(result.created).toBe(true);
+      expect(result.rule.rule).toBe("block");
+    });
+
+    it("creates a verify rule", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "verify",
+      });
+      expect(result.created).toBe(true);
+      expect(result.rule.rule).toBe("verify");
+    });
+
+    it("creates a price rule with minimumPostage", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "price",
+        pricePayload: { minimumPostage: "100" },
+      });
+      expect(result.created).toBe(true);
+      expect(result.rule.rule).toBe("price");
+      expect(result.rule.pricePayload?.minimumPostage).toBe("100");
+    });
+
+    it("rejects price rule without pricePayload", async () => {
+      await expect(
+        createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "price" }),
+      ).rejects.toThrow();
+    });
+
+    it("does not store pricePayload for non-price rules", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        pricePayload: { minimumPostage: "50" },
+      });
+      expect(result.rule.pricePayload).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CRUD operations
+  // ---------------------------------------------------------------------------
+
+  describe("CRUD Operations", () => {
+    it("updates an existing rule with version check", async () => {
+      const created = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+      });
+      expect(created.rule.version).toBe(1);
+
+      const updated = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "block",
+        version: 1,
+      });
+      expect(updated.created).toBe(false);
+      expect(updated.rule.rule).toBe("block");
+      expect(updated.rule.version).toBe(2);
+    });
+
+    it("lists all rules for an owner", async () => {
+      const sender2 = `G${"D".repeat(55)}`;
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await createOrUpdateSenderRule(repository, OWNER, sender2, { rule: "block" });
+
+      const result = await listSenderRules(repository, OWNER);
+      expect(result.records.length).toBe(2);
+    });
+
+    it("gets a single rule record", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      const record = await getSenderRuleRecord(repository, OWNER, SENDER);
+      expect(record).not.toBeNull();
+      expect(record!.rule).toBe("allow");
+    });
+
+    it("deletes a rule", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      const deleted = await deleteSenderRule(repository, OWNER, SENDER);
+      expect(deleted.deleted).toBe(true);
+
+      const record = await getSenderRuleRecord(repository, OWNER, SENDER);
+      expect(record).toBeNull();
+    });
+
+    it("deleting a non-existent rule is a no-op", async () => {
+      const deleted = await deleteSenderRule(repository, OWNER, SENDER);
+      expect(deleted.deleted).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Version conflict handling (two concurrent edits)
+  // ---------------------------------------------------------------------------
+
+  describe("Version Conflict Handling", () => {
+    it("rejects stale update with conflict", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+
+      // Simulate concurrent edit
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "block",
+        version: 1,
+      });
+
+      // Stale edit with version 1 should be rejected
+      await expect(
+        createOrUpdateSenderRule(repository, OWNER, SENDER, {
+          rule: "verify",
+          version: 1,
+        }),
+      ).rejects.toThrow(ApiError);
+
+      try {
+        await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+          rule: "verify",
+          version: 1,
+        });
+      } catch (e) {
+        expect((e as ApiError).code).toBe("conflict");
+        expect((e as ApiError).status).toBe(409);
+      }
+    });
+
+    it("allows update with correct version", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      const updated = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "block",
+        version: 1,
+      });
+      expect(updated.rule.version).toBe(2);
+      expect(updated.rule.rule).toBe("block");
+    });
+
+    it("rejects update without version on existing rule", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await expect(
+        createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "block" }),
+      ).rejects.toThrow(ApiError);
+    });
+
+    it("rejects versioned update on non-existent rule", async () => {
+      await expect(
+        createOrUpdateSenderRule(repository, OWNER, SENDER, {
+          rule: "allow",
+          version: 5,
+        }),
+      ).rejects.toThrow(ApiError);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency
+  // ---------------------------------------------------------------------------
+
+  describe("Retry & Idempotency", () => {
+    it("idempotent create with same idempotencyKey", async () => {
+      const first = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        idempotencyKey: "key-1",
+      });
+      const second = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        idempotencyKey: "key-1",
+      });
+      expect(second.rule.version).toBe(1);
+      expect(second.created).toBe(false);
+    });
+
+    it("idempotent create with same rule and no version", async () => {
+      const first = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+      });
+      const second = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+      });
+      expect(second.rule.version).toBe(1);
+      expect(second.created).toBe(false);
+    });
+
+    it("different idempotency key bumps version", async () => {
+      const first = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        idempotencyKey: "key-1",
+      });
+      expect(first.rule.version).toBe(1);
+      // Different idempotency key with version supplied → bumps
+      const second = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        idempotencyKey: "key-2",
+        version: 1,
+      });
+      expect(second.rule.version).toBe(2);
+      expect(second.rule.idempotencyKey).toBe("key-2");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Owner authorization
+  // ---------------------------------------------------------------------------
+
+  describe("Owner Authorization", () => {
+    it("owner can create rule for their own sender", async () => {
+      const result = await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+      });
+      expect(result.rule.owner).toBe(OWNER);
+    });
+
+    it("rules are scoped per owner", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await createOrUpdateSenderRule(repository, OTHER_OWNER, SENDER, { rule: "block" });
+
+      const ownerRule = await getSenderRuleRecord(repository, OWNER, SENDER);
+      const otherRule = await getSenderRuleRecord(repository, OTHER_OWNER, SENDER);
+
+      expect(ownerRule!.rule).toBe("allow");
+      expect(otherRule!.rule).toBe("block");
+    });
+
+    it("listing is scoped per owner", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await createOrUpdateSenderRule(repository, OTHER_OWNER, SENDER, { rule: "block" });
+
+      const ownerList = await listSenderRules(repository, OWNER);
+      const otherList = await listSenderRules(repository, OTHER_OWNER);
+
+      expect(ownerList.records.length).toBe(1);
+      expect(otherList.records.length).toBe(1);
+    });
+
+    it("deleting is scoped per owner", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await createOrUpdateSenderRule(repository, OTHER_OWNER, SENDER, { rule: "block" });
+
+      await deleteSenderRule(repository, OWNER, SENDER);
+
+      const ownerRule = await getSenderRuleRecord(repository, OWNER, SENDER);
+      const otherRule = await getSenderRuleRecord(repository, OTHER_OWNER, SENDER);
+
+      expect(ownerRule).toBeNull();
+      expect(otherRule!.rule).toBe("block");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chain state transitions
+  // ---------------------------------------------------------------------------
+
+  describe("Chain State Transitions", () => {
+    it("pending → submitted → confirmed happy path", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+
+      const submitted = await transitionSenderRuleChainStatus(
+        repository,
+        OWNER,
+        SENDER,
+        "submitted",
+      );
+      expect(submitted.chainStatus).toBe("submitted");
+
+      const confirmed = await transitionSenderRuleChainStatus(
+        repository,
+        OWNER,
+        SENDER,
+        "confirmed",
+        { txHash: "abc123" },
+      );
+      expect(confirmed.chainStatus).toBe("confirmed");
+      expect(confirmed.txHash).toBe("abc123");
+      expect(confirmed.confirmedAt).not.toBeNull();
+    });
+
+    it("pending → failed on error", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+
+      const failed = await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "failed", {
+        lastError: "network timeout",
+      });
+      expect(failed.chainStatus).toBe("failed");
+      expect(failed.failureCount).toBe(1);
+    });
+
+    it("failed → pending on retry", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "failed");
+
+      const retried = await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "pending");
+      expect(retried.chainStatus).toBe("pending");
+    });
+
+    it("rejects invalid transition (confirmed → submitted)", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted");
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "confirmed", {
+        txHash: "abc",
+      });
+
+      await expect(
+        transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted"),
+      ).rejects.toThrow(ApiError);
+    });
+
+    it("retrySenderRuleWrite is idempotent on confirmed", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted");
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "confirmed", {
+        txHash: "abc",
+      });
+
+      const result = await retrySenderRuleWrite(repository, OWNER, SENDER);
+      expect(result.chainStatus).toBe("confirmed");
+    });
+
+    it("retrySenderRuleWrite resets failed to pending", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "failed");
+
+      const result = await retrySenderRuleWrite(repository, OWNER, SENDER);
+      expect(result.chainStatus).toBe("pending");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chain retry: failed write is retryable and reconciles
+  // ---------------------------------------------------------------------------
+
+  describe("Chain Retry & Reconciliation", () => {
+    it("failed write can be retried and eventually confirmed", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "block" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "failed");
+
+      // Retry
+      await retrySenderRuleWrite(repository, OWNER, SENDER);
+      const afterRetry = await getSenderRuleRecord(repository, OWNER, SENDER);
+      expect(afterRetry!.chainStatus).toBe("pending");
+
+      // Submit and confirm
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted");
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "confirmed", {
+        txHash: "retry-hash",
+      });
+
+      const final = await getSenderRuleRecord(repository, OWNER, SENDER);
+      expect(final!.chainStatus).toBe("confirmed");
+      expect(final!.txHash).toBe("retry-hash");
+    });
+
+    it("reconcile detects synced state", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted");
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "confirmed", {
+        txHash: "abc",
+      });
+
+      const result = await reconcileSenderRule(repository, OWNER, SENDER, {
+        rule: "allow",
+        version: 1,
+      });
+      expect(result.state).toBe("synced");
+    });
+
+    it("reconcile detects drift when chain diverges", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "submitted");
+      await transitionSenderRuleChainStatus(repository, OWNER, SENDER, "confirmed", {
+        txHash: "abc",
+      });
+
+      const result = await reconcileSenderRule(repository, OWNER, SENDER, {
+        rule: "block",
+        version: 2,
+      });
+      expect(result.state).toBe("drift");
+    });
+
+    it("reconcile returns pending for unconfirmed local rule", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+
+      const result = await reconcileSenderRule(repository, OWNER, SENDER, null);
+      expect(result.state).toBe("pending");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Relay admission integration (rules affect relay admission)
+  // ---------------------------------------------------------------------------
+
+  describe("Relay Admission Integration", () => {
+    it("allow rule admits sender", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "allow" });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe("sender_allowed");
+    });
+
+    it("block rule rejects sender", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "block" });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("sender_blocked");
+    });
+
+    it("verify rule rejects unverified sender", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "verify" });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("verification_required");
+    });
+
+    it("verify rule admits verified sender", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "verify" });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: true,
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe("sender_verified");
+    });
+
+    it("price rule rejects insufficient postage", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "price",
+        pricePayload: { minimumPostage: "100" },
+      });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "50",
+        verified: true,
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("insufficient_postage");
+    });
+
+    it("price rule admits sufficient postage", async () => {
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, {
+        rule: "price",
+        pricePayload: { minimumPostage: "100" },
+      });
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "200",
+        verified: true,
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe("postage_sufficient");
+    });
+
+    it("no rule returns allowed (falls through to global policy)", async () => {
+      const result = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBe("no_rule");
+    });
+
+    it("rules persist and affect subsequent relay decisions", async () => {
+      // Initially no rule → allowed
+      const before = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(before.allowed).toBe(true);
+
+      // Set block rule
+      await createOrUpdateSenderRule(repository, OWNER, SENDER, { rule: "block" });
+
+      // Now rejected
+      const after = await evaluateSenderRuleForAdmission(repository, {
+        owner: OWNER,
+        sender: SENDER,
+        postage: "0",
+        verified: false,
+      });
+      expect(after.allowed).toBe(false);
+      expect(after.reason).toBe("sender_blocked");
+    });
+  });
+});


### PR DESCRIPTION
Closes #1944

## Summary

Implements live, versioned sender rules (allow/block/verify/price) that persist server-side, reconcile against the Policies contract on testnet, and enforce relay admission decisions.

## Changed Files

| File | Purpose |
|------|---------|
| `src/server/api/domain.ts` | New schemas: senderRuleActionSchema, senderRuleRecordSchema, senderRuleChainStatusSchema, senderRulePricePayloadSchema, chainSenderRuleSchema |
| `src/server/api/sender-rule-service.ts` | Full CRUD, chain state machine, reconciliation, relay admission, idempotency, audit events |
| `src/server/api/repository.ts` | Added getSenderRuleRecord, setSenderRuleRecord, deleteSenderRuleRecord, listSenderRuleRecords to all repository layers |
| `src/server/api/memory-repository.ts` | In-memory implementation of new repository methods |
| `src/server/api/kv-repository.ts` | KV/DO implementation of new repository methods |
| `src/server/api/stealth-coordinator.ts` | listSenderRuleRecords via DO storage prefix scan |
| `src/server/api/policy-service.ts` | Extended evaluateMailboxPolicy to check versioned rules before legacy fallback |
| `src/server/api/context.ts` | Registered senderRuleRecord schema |
| `src/server/api/request.ts` | Added body-limit categories for new routes |
| `src/server/api/openapi.ts` | Extended senderRule enum with verify and price |
| `src/routes/api/v1/policies/$owner/senders/$sender.ts` | Updated PUT/GET/DELETE to use versioned records with CAS |
| `src/routes/api/v1/policies/$owner/senders/index.ts` | New GET list endpoint with cursor pagination |
| `src/routes/api/v1/policies/$owner/senders/$sender/chain-status.ts` | New POST chain status transition endpoint |
| `src/routes/api/v1/policies/$owner/senders/$sender/retry.ts` | New POST retry a failed chain write endpoint |
| `src/routeTree.gen.ts` | Auto-generated by build |
| `tests/unit/api/sender-rule-service.test.ts` | 40 new tests |
| `tests/unit/api/retryable-repository.test.ts` | Added new methods to FailingRepository test double |

## Acceptance Scenario Evidence

### 1. Rules survive refresh and affect relay admission
- Test: "rules persist and affect subsequent relay decisions" - Creates a block rule, verifies the sender is rejected on the next evaluateSenderRuleForAdmission call
- Rule is persisted in MemoryApiRepository and read back correctly

### 2. No silent overwrite on conflict
- Test: "rejects stale update with conflict" - Creates v1, updates to v2, then attempts stale v1 update -> 409 conflict
- Test: "allows update with correct version" - Updates with correct version succeeds

### 3. Authorization - owner-scoped rules
- Test: "rules are scoped per owner" - Owner A creates allow, Owner B creates block for same sender, both coexist
- Test: "listing is scoped per owner" - Listing only returns rules for the requesting owner
- Test: "deleting is scoped per owner" - Deleting Owner A's rule does not affect Owner B's

### 4. Version conflict test
- Test: "rejects stale update with conflict"
- Test: "reject update without version on existing rule"
- Test: "rejects versioned update on non-existent rule"

### 5. Retry/idempotency for each state-changing operation
- Test: "idempotent create with same idempotencyKey"
- Test: "idempotent create with same rule and no version"
- Test: "failed write can be retried and eventually confirmed"

### 6. Chain retry test
- Test: "failed write can be retried and eventually confirmed" - Creates rule -> failed -> retry -> pending -> submitted -> confirmed
- Test: "reconcile detects synced state"
- Test: "reconcile detects drift when chain diverges"

### 7. Audit events
- Every createOrUpdateSenderRule call emits sender_rule.create or sender_rule.update
- Every deleteSenderRule emits sender_rule.delete
- Every chain status transition emits sender_rule.chain.{status}

## Dependency Status

- BETA-017 (#1924, managed-wallet transaction signer with policy controls): Merged on upstream/main. ManagedWalletService exists with set_sender_rule/set_sender_rule_as in the allowed functions list.
- BETA-035 (#1942, off-chain message delivery state machine): Merged on upstream/main. Full transition matrix implemented.

## Test Results

40/40 sender rule service tests pass
277/277 test files pass (3007 tests, 0 failures)
tsc --noEmit: clean
prettier: clean
eslint: clean
vite build (client + SSR): clean

## Secrets Check

No signer keys, testnet credentials, or secrets appear in logs, fixtures, or test data.
