### PR TITLE
feat: enforce beta abuse controls across auth, relay, storage, and chain writes

### DIFF
--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -100,6 +100,7 @@ function getService(): RelayService {
       sorobanRpcUrl: runtime.network.sorobanRpcUrl,
     }),
     mailbox: repository,
+    repository,
   });
   void worker.start();
   return service;

--- a/src/routes/api/v1/attachments/chunk.ts
+++ b/src/routes/api/v1/attachments/chunk.ts
@@ -45,6 +45,10 @@ export const Route = createFileRoute("/api/v1/attachments/chunk")({
           }
 
           const input = await parseJsonBody(request, uploadChunkSchema, "relay");
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
 
           const nonceBytes = hexToBytes(input.nonce);
           const ciphertextBytes = Uint8Array.from(atob(input.ciphertext), (c) => c.charCodeAt(0));
@@ -56,6 +60,27 @@ export const Route = createFileRoute("/api/v1/attachments/chunk")({
           chunkBytes.set(nonceBytes, 0);
           chunkBytes.set(ciphertextBytes, nonceBytes.length);
           chunkBytes.set(macBytes, nonceBytes.length + ciphertextBytes.length);
+
+          const { enforceCentralAbuse } = await import("@/server/api/abuse-service");
+          const decision = await enforceCentralAbuse(ctx.repository, {
+            route: "attachment_upload",
+            ip,
+            account: ctx.principal.address,
+            session: input.session_id,
+            storageBytes: chunkBytes.length,
+            headers: request.headers,
+          });
+
+          if (!decision.allowed) {
+            throw new ApiError(
+              429,
+              "too_many_requests",
+              decision.reason === "storage_byte_budget_exceeded"
+                ? "Attachment chunk storage byte budget exceeded"
+                : "Attachment rate limit exceeded",
+              { retryAfterSeconds: decision.retryAfterSeconds ?? 3600 },
+            );
+          }
 
           try {
             const result = await uploadChunk({

--- a/src/routes/api/v1/attachments/initiate.ts
+++ b/src/routes/api/v1/attachments/initiate.ts
@@ -42,6 +42,28 @@ export const Route = createFileRoute("/api/v1/attachments/initiate")({
           }
 
           const input = await parseJsonBody(request, initiateAttachmentSchema, "compact");
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+
+          const { enforceCentralAbuse } = await import("@/server/api/abuse-service");
+          const decision = await enforceCentralAbuse(ctx.repository, {
+            route: "attachment_upload",
+            ip,
+            account: ctx.principal.address,
+            headers: request.headers,
+          });
+
+          if (!decision.allowed) {
+            throw new (await import("@/server/api/errors")).ApiError(
+              429,
+              "too_many_requests",
+              "Attachment rate limit exceeded",
+              { retryAfterSeconds: decision.retryAfterSeconds ?? 3600 },
+            );
+          }
+
           const result = initiateUploadSession({
             ownerAddress: ctx.principal.address,
             messageId: input.message_id,

--- a/src/routes/api/v1/auth/login.ts
+++ b/src/routes/api/v1/auth/login.ts
@@ -46,6 +46,25 @@ export const Route = createFileRoute("/api/v1/auth/login")({
 
           const currentSessionId = parseSessionCookie(request.headers.get("cookie")) ?? undefined;
 
+          const { enforceCentralAbuse } = await import("@/server/api/abuse-service");
+          const abuseDecision = await enforceCentralAbuse(apiContext.repository, {
+            route: "auth_login",
+            ip,
+            account: body.identifier,
+            fingerprint,
+            session: currentSessionId,
+            headers: request.headers,
+          });
+
+          if (!abuseDecision.allowed) {
+            throw new (await import("@/server/api/errors")).ApiError(
+              429,
+              "too_many_requests",
+              "Authentication rate limit exceeded",
+              { retryAfterSeconds: abuseDecision.retryAfterSeconds ?? 900 },
+            );
+          }
+
           const result = await authenticateWithPassword(apiContext, {
             identifier: body.identifier,
             password: body.password,

--- a/src/routes/api/v1/send/coordinate.ts
+++ b/src/routes/api/v1/send/coordinate.ts
@@ -51,6 +51,34 @@ export const Route = createFileRoute("/api/v1/send/coordinate")({
           });
           requireActorMatches(apiContext, input.sender);
 
+          const ip =
+            request.headers.get("cf-connecting-ip") ??
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown";
+          const recipient = "recipient" in input ? (input.recipient as string) : undefined;
+          const { enforceCentralAbuse } = await import("@/server/api/abuse-service");
+          const decision = await enforceCentralAbuse(apiContext.repository, {
+            route: "send_coordinate",
+            ip,
+            account: input.sender,
+            recipient,
+            isChainWrite: input.action === "create" || input.action === "reconcile",
+            headers: request.headers,
+          });
+
+          if (!decision.allowed) {
+            throw new (await import("@/server/api/errors")).ApiError(
+              429,
+              "too_many_requests",
+              decision.reason === "chain_write_budget_exceeded"
+                ? "Chain write budget exceeded"
+                : decision.reason === "recipient_rate_limit_exceeded"
+                  ? "Recipient rate limit exceeded"
+                  : "Send coordinate rate limit exceeded",
+              { retryAfterSeconds: decision.retryAfterSeconds ?? 3600 },
+            );
+          }
+
           const coordinator = new SendCoordinator();
           const rawIdempotencyKey = request.headers.get("x-idempotency-key");
 

--- a/src/server/api/abuse-service.ts
+++ b/src/server/api/abuse-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 import type { ApiRepository } from "./repository";
 import * as metrics from "./metrics";
@@ -9,10 +9,16 @@ function rateLimited(retryAfterSeconds: number) {
 
 export type AbuseRoute =
   | "postage_submit"
+  | "postage_transition"
   | "registration"
   | "verification"
   | "password_reset"
-  | "testnet_funding";
+  | "testnet_funding"
+  | "relay_submit"
+  | "attachment_upload"
+  | "send_coordinate"
+  | "auth_login"
+  | "general_api";
 
 export type AbuseCheck =
   | "account"
@@ -24,7 +30,11 @@ export type AbuseCheck =
   | "email_domain"
   | "username_reservation"
   | "token_guessing"
-  | "invite_code";
+  | "invite_code"
+  | "storage_bytes"
+  | "chain_write"
+  | "session"
+  | "recipient";
 
 export type AbuseOutagePolicy = "fail_closed" | "fail_open";
 
@@ -51,6 +61,8 @@ export const ABUSE_OUTAGE_POLICIES: Record<
     proof_failure: "fail_closed",
     relay: "fail_open",
     sender_recipient: "fail_closed",
+    chain_write: "fail_closed",
+    recipient: "fail_closed",
   },
   registration: {
     account: "fail_closed",
@@ -99,6 +111,49 @@ export const ABUSE_OUTAGE_POLICIES: Record<
     username_reservation: "fail_closed",
     token_guessing: "fail_closed",
     invite_code: "fail_closed",
+    chain_write: "fail_closed",
+  },
+  relay_submit: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_closed",
+    relay: "fail_open",
+    sender_recipient: "fail_closed",
+    storage_bytes: "fail_closed",
+    recipient: "fail_closed",
+  },
+  attachment_upload: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_closed",
+    session: "fail_closed",
+    storage_bytes: "fail_closed",
+  },
+  send_coordinate: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_closed",
+    recipient: "fail_closed",
+    sender_recipient: "fail_closed",
+    chain_write: "fail_closed",
+  },
+  postage_transition: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_closed",
+    chain_write: "fail_closed",
+  },
+  auth_login: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_closed",
+    session: "fail_open",
+  },
+  general_api: {
+    account: "fail_closed",
+    device: "fail_open",
+    ip: "fail_open",
+    session: "fail_open",
   },
 };
 
@@ -208,13 +263,23 @@ export function buildDeviceFingerprint(headers: {
   return createHash("sha256").update(payload).digest("hex").slice(0, 16);
 }
 
+export function canonicalizeSubjectAddress(address?: string): string {
+  if (!address) return "";
+  const trimmed = address.trim();
+  if (trimmed.startsWith("G") || trimmed.startsWith("g")) {
+    return trimmed.toUpperCase();
+  }
+  return trimmed;
+}
+
 export async function checkAccountLimit(
   repository: ApiRepository,
   sender: string,
   route: AbuseRoute = "postage_submit",
 ): Promise<AbuseDecision> {
+  const canonicalSender = canonicalizeSubjectAddress(sender);
   return withOutagePolicy(route, "account", () =>
-    checkIncrementedLimit(repository, `abuse:account:${sender}`, 50, 3600),
+    checkIncrementedLimit(repository, `abuse:account:${canonicalSender}`, 50, 3600),
   );
 }
 
@@ -242,8 +307,15 @@ export async function checkSenderRecipientLimit(
   recipient: string,
   route: AbuseRoute = "postage_submit",
 ): Promise<AbuseDecision> {
+  const canonicalSender = canonicalizeSubjectAddress(sender);
+  const canonicalRecipient = canonicalizeSubjectAddress(recipient);
   return withOutagePolicy(route, "sender_recipient", () =>
-    checkIncrementedLimit(repository, `abuse:pair:${sender}:${recipient}`, 10, 3600),
+    checkIncrementedLimit(
+      repository,
+      `abuse:pair:${canonicalSender}:${canonicalRecipient}`,
+      10,
+      3600,
+    ),
   );
 }
 
@@ -252,13 +324,15 @@ export async function checkProofFailureLimit(
   sender: string,
   route: AbuseRoute = "postage_submit",
 ): Promise<AbuseDecision> {
+  const canonicalSender = canonicalizeSubjectAddress(sender);
   return withOutagePolicy(route, "proof_failure", () =>
-    checkStoredLimit(repository, `abuse:proof:${sender}`, 5, 900),
+    checkStoredLimit(repository, `abuse:proof:${canonicalSender}`, 5, 900),
   );
 }
 
 export async function recordProofFailure(repository: ApiRepository, sender: string): Promise<void> {
-  await repository.incrementCounter(`abuse:proof:${sender}`, 900);
+  const canonicalSender = canonicalizeSubjectAddress(sender);
+  await repository.incrementCounter(`abuse:proof:${canonicalSender}`, 900);
 }
 
 export async function checkRelayLimit(
@@ -421,4 +495,401 @@ export function validateChallengeSolution(
   const hash = createHash("sha256").update(`${challengeId}:${solutionNonce}`).digest("hex");
   const prefix = "0".repeat(difficulty);
   return hash.startsWith(prefix);
+}
+
+// ---------------------------------------------------------------------------
+// BETA-049 (Issue #1956) — Beta Abuse Controls & Budgets
+// ---------------------------------------------------------------------------
+
+export const STORAGE_BYTE_UNIT = 64 * 1024; // 64KB per quota unit
+
+export const STORAGE_BYTE_BUDGETS = {
+  account: {
+    maxBytes: 50 * 1024 * 1024,
+    maxUnits: Math.floor((50 * 1024 * 1024) / STORAGE_BYTE_UNIT),
+    windowSeconds: 3600,
+  },
+  ip: {
+    maxBytes: 100 * 1024 * 1024,
+    maxUnits: Math.floor((100 * 1024 * 1024) / STORAGE_BYTE_UNIT),
+    windowSeconds: 3600,
+  },
+  session: {
+    maxBytes: 25 * 1024 * 1024,
+    maxUnits: Math.floor((25 * 1024 * 1024) / STORAGE_BYTE_UNIT),
+    windowSeconds: 3600,
+  },
+} as const;
+
+export async function checkStorageByteBudget(
+  repository: ApiRepository,
+  subjects: { ip?: string; account?: string; session?: string },
+  bytesToAdd: number,
+  route: AbuseRoute = "attachment_upload",
+): Promise<AbuseDecision> {
+  return withOutagePolicy(route, "storage_bytes", async () => {
+    if (bytesToAdd <= 0) return { allowed: true };
+    const unitsToAdd = Math.max(1, Math.ceil(bytesToAdd / STORAGE_BYTE_UNIT));
+
+    if (subjects.account) {
+      const canonicalAcct = canonicalizeSubjectAddress(subjects.account);
+      if (canonicalAcct) {
+        const count = await repository.incrementCounter(
+          `abuse:storage:account:${canonicalAcct}`,
+          STORAGE_BYTE_BUDGETS.account.windowSeconds,
+          unitsToAdd,
+        );
+        if (count > STORAGE_BYTE_BUDGETS.account.maxUnits) {
+          metrics.incrementCounter("abuse_storage_bytes_exceeded", {
+            route,
+            subject: "account",
+            limit: String(STORAGE_BYTE_BUDGETS.account.maxBytes),
+          });
+          return {
+            allowed: false,
+            reason: "storage_byte_budget_exceeded",
+            retryAfterSeconds: STORAGE_BYTE_BUDGETS.account.windowSeconds,
+          };
+        }
+      }
+    }
+
+    if (subjects.session) {
+      const sess = subjects.session.trim();
+      if (sess && sess !== "unknown") {
+        const count = await repository.incrementCounter(
+          `abuse:storage:session:${sess}`,
+          STORAGE_BYTE_BUDGETS.session.windowSeconds,
+          unitsToAdd,
+        );
+        if (count > STORAGE_BYTE_BUDGETS.session.maxUnits) {
+          metrics.incrementCounter("abuse_storage_bytes_exceeded", {
+            route,
+            subject: "session",
+            limit: String(STORAGE_BYTE_BUDGETS.session.maxBytes),
+          });
+          return {
+            allowed: false,
+            reason: "storage_byte_budget_exceeded",
+            retryAfterSeconds: STORAGE_BYTE_BUDGETS.session.windowSeconds,
+          };
+        }
+      }
+    }
+
+    const ip = subjects.ip?.trim() ?? "unknown";
+    if (ip !== "" && ip !== "unknown") {
+      const count = await repository.incrementCounter(
+        `abuse:storage:ip:${ip}`,
+        STORAGE_BYTE_BUDGETS.ip.windowSeconds,
+        unitsToAdd,
+      );
+      if (count > STORAGE_BYTE_BUDGETS.ip.maxUnits) {
+        metrics.incrementCounter("abuse_storage_bytes_exceeded", {
+          route,
+          subject: "ip",
+          limit: String(STORAGE_BYTE_BUDGETS.ip.maxBytes),
+        });
+        return {
+          allowed: false,
+          reason: "storage_byte_budget_exceeded",
+          retryAfterSeconds: STORAGE_BYTE_BUDGETS.ip.windowSeconds,
+        };
+      }
+    }
+
+    return { allowed: true };
+  });
+}
+
+export const CHAIN_WRITE_BUDGETS = {
+  account: { max: 20, windowSeconds: 3600 },
+  ip: { max: 50, windowSeconds: 3600 },
+} as const;
+
+export async function checkChainWriteBudget(
+  repository: ApiRepository,
+  subjects: { ip?: string; account?: string },
+  route: AbuseRoute = "postage_submit",
+): Promise<AbuseDecision> {
+  return withOutagePolicy(route, "chain_write", async () => {
+    if (subjects.account) {
+      const canonicalAcct = canonicalizeSubjectAddress(subjects.account);
+      if (canonicalAcct) {
+        const count = await repository.incrementCounter(
+          `abuse:chain:account:${canonicalAcct}`,
+          CHAIN_WRITE_BUDGETS.account.windowSeconds,
+        );
+        if (count > CHAIN_WRITE_BUDGETS.account.max) {
+          metrics.incrementCounter("abuse_chain_writes_exceeded", {
+            route,
+            subject: "account",
+            limit: String(CHAIN_WRITE_BUDGETS.account.max),
+          });
+          return {
+            allowed: false,
+            reason: "chain_write_budget_exceeded",
+            retryAfterSeconds: CHAIN_WRITE_BUDGETS.account.windowSeconds,
+          };
+        }
+      }
+    }
+
+    const ip = subjects.ip?.trim() ?? "unknown";
+    if (ip !== "" && ip !== "unknown") {
+      const count = await repository.incrementCounter(
+        `abuse:chain:ip:${ip}`,
+        CHAIN_WRITE_BUDGETS.ip.windowSeconds,
+      );
+      if (count > CHAIN_WRITE_BUDGETS.ip.max) {
+        metrics.incrementCounter("abuse_chain_writes_exceeded", {
+          route,
+          subject: "ip",
+          limit: String(CHAIN_WRITE_BUDGETS.ip.max),
+        });
+        return {
+          allowed: false,
+          reason: "chain_write_budget_exceeded",
+          retryAfterSeconds: CHAIN_WRITE_BUDGETS.ip.windowSeconds,
+        };
+      }
+    }
+
+    return { allowed: true };
+  });
+}
+
+export const SESSION_LIMITS = {
+  max: 100,
+  windowSeconds: 3600,
+} as const;
+
+export async function checkSessionLimit(
+  repository: ApiRepository,
+  sessionId: string,
+  route: AbuseRoute = "general_api",
+  max = SESSION_LIMITS.max,
+  windowSeconds = SESSION_LIMITS.windowSeconds,
+): Promise<AbuseDecision> {
+  const session = sessionId.trim();
+  if (!session || session === "unknown") return { allowed: true };
+
+  return withOutagePolicy(route, "session", () =>
+    checkIncrementedLimit(repository, `abuse:session:${session}`, max, windowSeconds),
+  );
+}
+
+export const RECIPIENT_LIMITS = {
+  max: 50,
+  windowSeconds: 3600,
+} as const;
+
+export async function checkRecipientLimit(
+  repository: ApiRepository,
+  recipient: string,
+  route: AbuseRoute = "postage_submit",
+  max = RECIPIENT_LIMITS.max,
+  windowSeconds = RECIPIENT_LIMITS.windowSeconds,
+): Promise<AbuseDecision> {
+  const canonicalRecipient = canonicalizeSubjectAddress(recipient);
+  if (!canonicalRecipient) return { allowed: true };
+
+  return withOutagePolicy(route, "recipient", () =>
+    checkIncrementedLimit(repository, `abuse:recipient:${canonicalRecipient}`, max, windowSeconds),
+  );
+}
+
+export const OPERATOR_OVERRIDE_HEADER = "x-stealth-operator-override";
+
+export function isOperatorOverride(
+  headers?: Headers | Record<string, string | string[] | undefined> | null,
+): boolean {
+  if (!headers) return false;
+  const configuredSecret = process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN?.trim();
+  if (!configuredSecret) {
+    return false;
+  }
+  let val: string | undefined | null;
+  if (headers instanceof Headers) {
+    val = headers.get(OPERATOR_OVERRIDE_HEADER);
+  } else {
+    const raw =
+      headers[OPERATOR_OVERRIDE_HEADER] ?? headers[OPERATOR_OVERRIDE_HEADER.toLowerCase()];
+    val = Array.isArray(raw) ? raw[0] : raw;
+  }
+  if (!val) return false;
+  const token = val.trim();
+  if (token.length === 0 || token.length !== configuredSecret.length) {
+    return false;
+  }
+  try {
+    return timingSafeEqual(Buffer.from(token, "utf8"), Buffer.from(configuredSecret, "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+export interface CentralAbuseOptions {
+  route: AbuseRoute;
+  ip?: string;
+  session?: string;
+  account?: string;
+  recipient?: string;
+  storageBytes?: number;
+  isChainWrite?: boolean;
+  fingerprint?: string;
+  relayId?: string;
+  headers?: Headers | Record<string, string | string[] | undefined> | null;
+}
+
+export async function enforceCentralAbuse(
+  repository: ApiRepository,
+  opts: CentralAbuseOptions,
+): Promise<AbuseDecision> {
+  if (isOperatorOverride(opts.headers)) {
+    metrics.incrementCounter("abuse_operator_override", {
+      route: opts.route,
+      operatorId: "operator",
+    });
+    return { allowed: true };
+  }
+
+  // Canonicalize addresses
+  const canonicalAccount = opts.account ? canonicalizeSubjectAddress(opts.account) : undefined;
+  const canonicalRecipient = opts.recipient
+    ? canonicalizeSubjectAddress(opts.recipient)
+    : undefined;
+
+  // 1. IP check
+  if (opts.ip) {
+    const ipCheck = await checkIpLimit(repository, opts.ip, opts.route);
+    if (!ipCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "ip",
+        subject: opts.ip,
+      });
+      return ipCheck;
+    }
+  }
+
+  // 2. Session check
+  if (opts.session) {
+    const sessionCheck = await checkSessionLimit(repository, opts.session, opts.route);
+    if (!sessionCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "session",
+        subject: opts.session,
+      });
+      return sessionCheck;
+    }
+  }
+
+  // 3. Account check
+  if (canonicalAccount) {
+    const accountCheck = await checkAccountLimit(repository, canonicalAccount, opts.route);
+    if (!accountCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "account",
+        subject: canonicalAccount,
+      });
+      return accountCheck;
+    }
+  }
+
+  // 4. Recipient check
+  if (canonicalRecipient) {
+    const recipientCheck = await checkRecipientLimit(repository, canonicalRecipient, opts.route);
+    if (!recipientCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "recipient",
+        subject: canonicalRecipient,
+      });
+      return recipientCheck;
+    }
+  }
+
+  // 5. Sender-Recipient pair check
+  if (canonicalAccount && canonicalRecipient) {
+    const pairCheck = await checkSenderRecipientLimit(
+      repository,
+      canonicalAccount,
+      canonicalRecipient,
+      opts.route,
+    );
+    if (!pairCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "sender_recipient",
+        subject: `${canonicalAccount}:${canonicalRecipient}`,
+      });
+      return pairCheck;
+    }
+  }
+
+  // 6. Storage byte budget check
+  if (opts.storageBytes && opts.storageBytes > 0) {
+    const storageCheck = await checkStorageByteBudget(
+      repository,
+      { ip: opts.ip, account: canonicalAccount, session: opts.session },
+      opts.storageBytes,
+      opts.route,
+    );
+    if (!storageCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "storage_bytes",
+        subject: canonicalAccount || opts.ip || "unknown",
+      });
+      return storageCheck;
+    }
+  }
+
+  // 7. Chain write budget check
+  if (opts.isChainWrite) {
+    const chainCheck = await checkChainWriteBudget(
+      repository,
+      { ip: opts.ip, account: canonicalAccount },
+      opts.route,
+    );
+    if (!chainCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "chain_write",
+        subject: canonicalAccount || opts.ip || "unknown",
+      });
+      return chainCheck;
+    }
+  }
+
+  // 8. Device fingerprint check
+  if (opts.fingerprint) {
+    const deviceCheck = await checkDeviceLimit(repository, opts.fingerprint, { route: opts.route });
+    if (!deviceCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "device",
+        subject: opts.fingerprint,
+      });
+      return deviceCheck;
+    }
+  }
+
+  // 9. Relay check
+  if (opts.relayId) {
+    const relayCheck = await checkRelayLimit(repository, opts.relayId, opts.route);
+    if (!relayCheck.allowed) {
+      metrics.incrementCounter("abuse_throttled", {
+        route: opts.route,
+        type: "relay",
+        subject: opts.relayId,
+      });
+      return relayCheck;
+    }
+  }
+
+  return { allowed: true };
 }

--- a/src/server/api/handler.ts
+++ b/src/server/api/handler.ts
@@ -6,6 +6,7 @@ import { apiFailure, apiSuccess } from "./response";
 import * as metrics from "./metrics";
 import { parseJsonBody } from "./request";
 import { consumeRouteQuota, type RateLimitConfig } from "./rate-limit";
+import { isOperatorOverride } from "./abuse-service";
 import { applyCors, corsEarlyResponse, validateCorsPolicy, type CorsPolicy } from "./cors";
 import { planPrivacySafeLog } from "./logging";
 
@@ -107,37 +108,39 @@ export function createRouteHandler<
         }
       }
 
-      // 3. Rate Limiting
+      // 3. Rate Limiting & Abuse Controls
       if (config.rateLimit) {
-        const repo = apiContext.repository;
-        let subject: string;
-        if (config.rateLimit.type === "account") {
-          if (!actorId) {
-            throw new ApiError(401, "unauthorized", "Account rate limit requires authentication");
+        if (!isOperatorOverride(request.headers)) {
+          const repo = apiContext.repository;
+          let subject: string;
+          if (config.rateLimit.type === "account") {
+            if (!actorId) {
+              throw new ApiError(401, "unauthorized", "Account rate limit requires authentication");
+            }
+            subject = actorId;
+          } else {
+            subject =
+              request.headers.get("cf-connecting-ip") ??
+              request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+              "unknown";
           }
-          subject = actorId;
-        } else {
-          subject =
-            request.headers.get("cf-connecting-ip") ??
-            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-            "unknown";
-        }
 
-        const limit = await consumeRouteQuota(
-          repo,
-          config.rateLimit.type,
-          subject,
-          config.rateLimit.operation,
-        );
-        if (!limit.allowed) {
-          throw new ApiError(
-            429,
-            "too_many_requests",
-            `${config.rateLimit.type === "account" ? "Account" : "IP"} limit exceeded`,
-            {
-              retryAfterSeconds: limit.retryAfterSeconds,
-            },
+          const limit = await consumeRouteQuota(
+            repo,
+            config.rateLimit.type,
+            subject,
+            config.rateLimit.operation,
           );
+          if (!limit.allowed) {
+            throw new ApiError(
+              429,
+              "too_many_requests",
+              `${config.rateLimit.type === "account" ? "Account" : "IP"} limit exceeded`,
+              {
+                retryAfterSeconds: limit.retryAfterSeconds,
+              },
+            );
+          }
         }
       }
 

--- a/src/server/api/metrics.ts
+++ b/src/server/api/metrics.ts
@@ -85,6 +85,12 @@ export const METRIC_DESCRIPTORS = {
   abuse_disposable_email_blocked: ["domain"],
   abuse_invite_code_invalid: ["code"],
   abuse_verification_token_locked: ["tokenId"],
+  abuse_throttled: ["route", "type", "subject"],
+  abuse_storage_bytes_exceeded: ["route", "subject", "limit"],
+  abuse_chain_writes_exceeded: ["route", "subject", "limit"],
+  abuse_operator_override: ["route", "operatorId"],
+  abuse_recipient_exceeded: ["route", "recipient", "limit"],
+  abuse_session_exceeded: ["route", "sessionId", "limit"],
 
   // 1. Auth & Session Management (RED / USE)
   auth_requests_total: ["operation", "status", "outcome"],

--- a/src/server/api/postage-service.ts
+++ b/src/server/api/postage-service.ts
@@ -7,6 +7,8 @@ import {
   checkIpLimit,
   checkRelayLimit,
   checkSenderRecipientLimit,
+  checkRecipientLimit,
+  checkChainWriteBudget,
   type AbuseDecision,
 } from "./abuse-service";
 import { getMailboxPolicy } from "./policy-service";
@@ -656,6 +658,34 @@ export async function submitPostage(
       );
     }
 
+    const recipientLimit = await checkRecipientLimit(context.repository, input.recipient);
+    if (!recipientLimit.allowed) {
+      rejectLimitedPostage(
+        recipientLimit,
+        {
+          limit: "recipient",
+          recipient: input.recipient,
+        },
+        "Recipient limit exceeded",
+      );
+    }
+
+    const chainLimit = await checkChainWriteBudget(
+      context.repository,
+      { ip, account: input.sender },
+      "postage_submit",
+    );
+    if (!chainLimit.allowed) {
+      rejectLimitedPostage(
+        chainLimit,
+        {
+          limit: "chain_write",
+          actorId,
+        },
+        "Chain write budget exceeded",
+      );
+    }
+
     if (await context.repository.getPostage(input.messageId)) {
       throw new ApiError(409, "conflict", "Postage already exists for this message");
     }
@@ -853,6 +883,17 @@ async function transitionEscrow(
     validatePostageTransition(postage.status, nextStatus);
   } catch {
     throw terminalConflictError(postage.status, nextStatus, messageId);
+  }
+
+  const chainLimit = await checkChainWriteBudget(
+    context.repository,
+    { account: actor },
+    "postage_transition",
+  );
+  if (!chainLimit.allowed) {
+    throw new ApiError(429, "too_many_requests", "Chain write budget exceeded", {
+      retryAfterSeconds: chainLimit.retryAfterSeconds ?? 3600,
+    });
   }
 
   if (!context.escrow || !context.escrow.isLive()) {

--- a/src/server/api/rate-limit.ts
+++ b/src/server/api/rate-limit.ts
@@ -22,6 +22,14 @@ const RATE_LIMITS: Record<RateLimitType, { max: number; windowSeconds: number }>
   ip: { max: 100, windowSeconds: 3600 },
 };
 
+export function canonicalizeSubject(subject: string): string {
+  const trimmed = subject.trim();
+  if (trimmed.startsWith("G") || trimmed.startsWith("g")) {
+    return trimmed.toUpperCase();
+  }
+  return trimmed;
+}
+
 export async function consumeRouteQuota(
   repository: ApiRepository,
   type: RateLimitType,
@@ -34,9 +42,14 @@ export async function consumeRouteQuota(
     return { allowed: true };
   }
 
+  const normalizedSubject = type === "account" ? canonicalizeSubject(subject) : subject;
   const { max, windowSeconds } = RATE_LIMITS[type];
   const cost = RATE_LIMIT_OPERATION_COSTS[operation];
-  const count = await repository.incrementCounter(`abuse:${type}:${subject}`, windowSeconds, cost);
+  const count = await repository.incrementCounter(
+    `abuse:${type}:${normalizedSubject}`,
+    windowSeconds,
+    cost,
+  );
 
   if (count > max) {
     return { allowed: false, retryAfterSeconds: windowSeconds };
@@ -108,7 +121,8 @@ export async function checkAuthFailureThrottle(
 ): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
   const ipVal = ip || "unknown";
   const ipHash = hashValue(ipVal);
-  const ipAcctHash = hashValue(`${ipVal}:${attemptedAddress}`);
+  const canonicalAcct = canonicalizeSubject(attemptedAddress);
+  const ipAcctHash = hashValue(`${ipVal}:${canonicalAcct}`);
 
   const ipAcctKey = `abuse:auth_fail:ip_acct:${ipAcctHash}`;
   const ipWideKey = `abuse:auth_fail:ip:${ipHash}`;
@@ -141,7 +155,8 @@ export async function recordAuthFailure(
 ): Promise<{ delaySeconds: number }> {
   const ipVal = ip || "unknown";
   const ipHash = hashValue(ipVal);
-  const ipAcctHash = hashValue(`${ipVal}:${attemptedAddress}`);
+  const canonicalAcct = canonicalizeSubject(attemptedAddress);
+  const ipAcctHash = hashValue(`${ipVal}:${canonicalAcct}`);
 
   const ipAcctKey = `abuse:auth_fail:ip_acct:${ipAcctHash}`;
   const ipWideKey = `abuse:auth_fail:ip:${ipHash}`;

--- a/src/services/relay/relay-service.ts
+++ b/src/services/relay/relay-service.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Relay receiving service (Issue #1935 BETA-028).
  *
  * This is the domain service behind the relay health contract and message
@@ -146,6 +146,7 @@ export interface RelayServiceDependencies {
   evaluator: RelayAdmissionEvaluator;
   objectStore?: RelayObjectStore;
   mailbox?: RelayMailboxStore;
+  repository?: any;
   now?: () => Date;
 }
 
@@ -206,6 +207,10 @@ export class RelayService {
 
   getConfig(): RelayServiceConfig {
     return this.config;
+  }
+
+  getRepository(): any {
+    return this.deps.repository ?? (this.deps.mailbox as any);
   }
 
   isNonceSeen(nonce: string): boolean {

--- a/src/services/relay/transport.ts
+++ b/src/services/relay/transport.ts
@@ -17,6 +17,7 @@ import {
   type RelayRequest,
 } from "@/services/crypto/relayAuth";
 
+import { enforceCentralAbuse } from "@/server/api/abuse-service";
 import {
   relaySubmissionSchema,
   RELAY_MAX_PAYLOAD_BYTES,
@@ -139,6 +140,38 @@ export function handleRelaySubmit(request: Request, service: RelayService) {
       throw new ApiError(422, "validation_error", "Request validation failed");
     }
     const input = parsedInput.data;
+
+    // 1. Pre-auth Central Abuse Enforcement: check IP, storage bytes, and relay ID before expensive crypto
+    const ip =
+      request.headers.get("cf-connecting-ip") ??
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      "unknown";
+    const payloadBytes = Buffer.byteLength(rawBodyText, "utf8");
+    const relayId = request.headers.get("x-stealth-relay-id") ?? undefined;
+    const repo = service.getRepository();
+
+    if (repo && typeof repo.incrementCounter === "function") {
+      const preAuthDecision = await enforceCentralAbuse(repo, {
+        route: "relay_submit",
+        ip,
+        storageBytes: payloadBytes,
+        relayId,
+        headers: request.headers,
+      });
+
+      if (!preAuthDecision.allowed) {
+        throw new ApiError(
+          429,
+          "too_many_requests",
+          preAuthDecision.reason === "storage_byte_budget_exceeded"
+            ? "Relay storage byte budget exceeded"
+            : "Relay rate limit exceeded",
+          {
+            retryAfterSeconds: preAuthDecision.retryAfterSeconds ?? 3600,
+          },
+        );
+      }
+    }
 
     const nowSeconds = service.getConfig().nowSeconds
       ? service.getConfig().nowSeconds!()
@@ -275,6 +308,29 @@ export function handleRelaySubmit(request: Request, service: RelayService) {
           throw new ApiError(409, "conflict", "REPLAY_DETECTED: request_nonce already recorded");
         }
         service.markNonceSeen(nonceHeader);
+      }
+    }
+
+    // 2. Post-auth Central Abuse Enforcement: charge authenticated sender account and recipient quotas
+    if (repo && typeof repo.incrementCounter === "function") {
+      const postAuthDecision = await enforceCentralAbuse(repo, {
+        route: "relay_submit",
+        account: input.sender,
+        recipient: input.recipient,
+        headers: request.headers,
+      });
+
+      if (!postAuthDecision.allowed) {
+        throw new ApiError(
+          429,
+          "too_many_requests",
+          postAuthDecision.reason === "recipient_rate_limit_exceeded"
+            ? "Relay recipient rate limit exceeded"
+            : "Relay account rate limit exceeded",
+          {
+            retryAfterSeconds: postAuthDecision.retryAfterSeconds ?? 3600,
+          },
+        );
       }
     }
 

--- a/tests/unit/api/abuse-service.test.ts
+++ b/tests/unit/api/abuse-service.test.ts
@@ -12,6 +12,15 @@ import {
   checkRelayLimit,
   checkSenderRecipientLimit,
   recordProofFailure,
+  checkStorageByteBudget,
+  checkChainWriteBudget,
+  checkSessionLimit,
+  checkRecipientLimit,
+  isOperatorOverride,
+  enforceCentralAbuse,
+  STORAGE_BYTE_BUDGETS,
+  CHAIN_WRITE_BUDGETS,
+  canonicalizeSubjectAddress,
 } from "../../../src/server/api/abuse-service";
 
 const sender = `G${"B".repeat(55)}`;
@@ -47,6 +56,8 @@ describe("abuse service", () => {
       proof_failure: "fail_closed",
       relay: "fail_open",
       sender_recipient: "fail_closed",
+      chain_write: "fail_closed",
+      recipient: "fail_closed",
     });
   });
 
@@ -296,6 +307,235 @@ describe("abuse service", () => {
         check: "proof_failure",
         policy: "fail_closed",
       },
+    });
+  });
+
+  describe("BETA-049: address canonicalization (anti-evasion)", () => {
+    it("canonicalizes lowercase and padded addresses so limits cannot be evaded", async () => {
+      const repository = new MemoryApiRepository();
+      const lowerSender = sender.toLowerCase();
+      const paddedSender = `   ${sender}   `;
+
+      // Fill account limit using the canonical address
+      for (let i = 0; i < 50; i++) {
+        await checkAccountLimit(repository, sender);
+      }
+
+      // Attacker attempts to evade using lowercase or whitespace padding
+      const lowerResult = await checkAccountLimit(repository, lowerSender);
+      expect(lowerResult.allowed).toBe(false);
+
+      const paddedResult = await checkAccountLimit(repository, paddedSender);
+      expect(paddedResult.allowed).toBe(false);
+    });
+
+    it("canonicalizes sender-recipient pair addresses", async () => {
+      const repository = new MemoryApiRepository();
+      const lowerSender = sender.toLowerCase();
+      const paddedRecipient = `  ${recipient}  `;
+
+      for (let i = 0; i < 10; i++) {
+        await checkSenderRecipientLimit(repository, sender, recipient);
+      }
+
+      const evasionResult = await checkSenderRecipientLimit(
+        repository,
+        lowerSender,
+        paddedRecipient,
+      );
+      expect(evasionResult.allowed).toBe(false);
+    });
+  });
+
+  describe("BETA-049: storage byte budgets", () => {
+    it("allows attachment bytes under account and IP budgets", async () => {
+      const repository = new MemoryApiRepository();
+      const result = await checkStorageByteBudget(
+        repository,
+        { ip: "192.0.2.1", account: sender, session: "sess_123" },
+        1024 * 1024, // 1MB
+      );
+      expect(result).toMatchObject({ allowed: true });
+    });
+
+    it("blocks when storage byte budget is exceeded per account", async () => {
+      const repository = new MemoryApiRepository();
+      const limit = STORAGE_BYTE_BUDGETS.account.maxBytes;
+
+      // Consume up to limit
+      const first = await checkStorageByteBudget(repository, { account: sender }, limit);
+      expect(first.allowed).toBe(true);
+
+      // Exceed limit
+      const second = await checkStorageByteBudget(repository, { account: sender }, 1);
+      expect(second.allowed).toBe(false);
+      expect(second.reason).toBe("storage_byte_budget_exceeded");
+      expect(second.retryAfterSeconds).toBe(STORAGE_BYTE_BUDGETS.account.windowSeconds);
+    });
+
+    it("blocks when storage byte budget is exceeded per IP", async () => {
+      const repository = new MemoryApiRepository();
+      const limit = STORAGE_BYTE_BUDGETS.ip.maxBytes;
+
+      const first = await checkStorageByteBudget(repository, { ip: "198.51.100.2" }, limit);
+      expect(first.allowed).toBe(true);
+
+      const second = await checkStorageByteBudget(repository, { ip: "198.51.100.2" }, 1);
+      expect(second.allowed).toBe(false);
+      expect(second.reason).toBe("storage_byte_budget_exceeded");
+    });
+  });
+
+  describe("BETA-049: chain-write budgets", () => {
+    it("allows chain writes within account budget and blocks when exceeded", async () => {
+      const repository = new MemoryApiRepository();
+      const max = CHAIN_WRITE_BUDGETS.account.max;
+
+      for (let i = 0; i < max; i++) {
+        const check = await checkChainWriteBudget(repository, { account: sender });
+        expect(check.allowed).toBe(true);
+      }
+
+      const blocked = await checkChainWriteBudget(repository, { account: sender });
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.reason).toBe("chain_write_budget_exceeded");
+      expect(blocked.retryAfterSeconds).toBe(CHAIN_WRITE_BUDGETS.account.windowSeconds);
+    });
+  });
+
+  describe("BETA-049: session & recipient rate limits", () => {
+    it("throttles excessive requests per session", async () => {
+      const repository = new MemoryApiRepository();
+      const sessionId = "sess_test_abc123";
+
+      for (let i = 0; i < 100; i++) {
+        const check = await checkSessionLimit(repository, sessionId);
+        expect(check.allowed).toBe(true);
+      }
+
+      const blocked = await checkSessionLimit(repository, sessionId);
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.retryAfterSeconds).toBe(3600);
+    });
+
+    it("throttles excessive traffic targeting a single recipient", async () => {
+      const repository = new MemoryApiRepository();
+
+      for (let i = 0; i < 50; i++) {
+        const check = await checkRecipientLimit(repository, recipient);
+        expect(check.allowed).toBe(true);
+      }
+
+      const blocked = await checkRecipientLimit(repository, recipient);
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.retryAfterSeconds).toBe(3600);
+    });
+  });
+
+  describe("BETA-049: operator overrides", () => {
+    it("requires configured secret and rejects public literals", () => {
+      const originalEnv = process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+      try {
+        delete process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+
+        // When unconfigured, no override is permitted
+        expect(
+          isOperatorOverride(new Headers({ "x-stealth-operator-override": "stealth-token" })),
+        ).toBe(false);
+        expect(isOperatorOverride({ "x-stealth-operator-override": "true" })).toBe(false);
+        expect(isOperatorOverride({ "x-stealth-operator-override": "operator-bypass" })).toBe(
+          false,
+        );
+
+        // Configure secret
+        process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = "super-secret-token-1234";
+
+        const validHeaders = new Headers({
+          "x-stealth-operator-override": "super-secret-token-1234",
+        });
+        expect(isOperatorOverride(validHeaders)).toBe(true);
+
+        const plainHeaders = { "x-stealth-operator-override": "super-secret-token-1234" };
+        expect(isOperatorOverride(plainHeaders)).toBe(true);
+
+        // Public literals and incorrect tokens are rejected
+        expect(isOperatorOverride({ "x-stealth-operator-override": "true" })).toBe(false);
+        expect(isOperatorOverride({ "x-stealth-operator-override": "operator-bypass" })).toBe(
+          false,
+        );
+        expect(
+          isOperatorOverride(new Headers({ "x-stealth-operator-override": "wrong-token" })),
+        ).toBe(false);
+        expect(isOperatorOverride(null)).toBe(false);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = originalEnv;
+        } else {
+          delete process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+        }
+      }
+    });
+
+    it("bypasses all abuse checks when operator override is active with valid configured secret", async () => {
+      const originalEnv = process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+      process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = "test-override-secret";
+      try {
+        const repository = new MemoryApiRepository();
+        // Exhaust account limit
+        for (let i = 0; i < 50; i++) {
+          await checkAccountLimit(repository, sender);
+        }
+
+        const overrideHeaders = new Headers({
+          "x-stealth-operator-override": "test-override-secret",
+        });
+
+        const decision = await enforceCentralAbuse(repository, {
+          route: "relay_submit",
+          ip: "203.0.113.1",
+          account: sender,
+          recipient,
+          storageBytes: 1000,
+          headers: overrideHeaders,
+        });
+
+        expect(decision.allowed).toBe(true);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = originalEnv;
+        } else {
+          delete process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+        }
+      }
+    });
+  });
+
+  describe("BETA-049: central abuse policy enforcer & false-positive resistance", () => {
+    it("allows legitimate requests with all parameters within limits", async () => {
+      const repository = new MemoryApiRepository();
+      const decision = await enforceCentralAbuse(repository, {
+        route: "postage_submit",
+        ip: "192.0.2.55",
+        account: sender,
+        recipient,
+        storageBytes: 1024,
+        isChainWrite: true,
+      });
+
+      expect(decision.allowed).toBe(true);
+    });
+
+    it("enforces storage byte limit centrally before expensive operations", async () => {
+      const repository = new MemoryApiRepository();
+      const decision = await enforceCentralAbuse(repository, {
+        route: "attachment_upload",
+        ip: "192.0.2.55",
+        account: sender,
+        storageBytes: 60 * 1024 * 1024, // 60MB exceeds 50MB limit
+      });
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe("storage_byte_budget_exceeded");
     });
   });
 });

--- a/tests/unit/security/beta-controls.test.ts
+++ b/tests/unit/security/beta-controls.test.ts
@@ -24,6 +24,13 @@ import {
   recordAuthFailure,
 } from "../../../src/server/api/rate-limit";
 import {
+  enforceCentralAbuse,
+  checkStorageByteBudget,
+  checkChainWriteBudget,
+  checkSessionLimit,
+  checkRecipientLimit,
+} from "../../../src/server/api/abuse-service";
+import {
   corsEarlyResponse,
   validateCorsPolicy,
   type CorsPolicy,
@@ -188,6 +195,41 @@ describe("BETA-076 SC-05/SC-06: abuse throttles deny at their documented limits"
       allowed: false,
       retryAfterSeconds: AUTH_FAILURE_LIMITS.ipAndAccount.windowSeconds,
     });
+  });
+
+  it("BETA-049: enforces storage-byte and chain-write budgets centrally with address canonicalization", async () => {
+    const repository = new MemoryApiRepository();
+    const acct = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    const lowerAcct = acct.toLowerCase();
+
+    // Storage byte budget enforcement (50MB cap)
+    const storageRes = await enforceCentralAbuse(repository, {
+      route: "attachment_upload",
+      account: lowerAcct, // Lowercase evasion attempt
+      storageBytes: 60 * 1024 * 1024,
+    });
+    expect(storageRes.allowed).toBe(false);
+    expect(storageRes.reason).toBe("storage_byte_budget_exceeded");
+    expect(storageRes.retryAfterSeconds).toBe(3600);
+
+    // Operator override bypass with configured secret
+    const prev = process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+    process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = "beta-override-token";
+    try {
+      const overrideRes = await enforceCentralAbuse(repository, {
+        route: "attachment_upload",
+        account: lowerAcct,
+        storageBytes: 60 * 1024 * 1024,
+        headers: new Headers({ "x-stealth-operator-override": "beta-override-token" }),
+      });
+      expect(overrideRes.allowed).toBe(true);
+    } finally {
+      if (prev !== undefined) {
+        process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN = prev;
+      } else {
+        delete process.env.STEALTH_OPERATOR_OVERRIDE_TOKEN;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Enforces centralized beta abuse controls, quotas, and budgets across authentication, relay message submission, attachment storage, and on-chain Soroban write routes. This protects beta infrastructure from unthrottled storage and compute abuse while providing safe retry-after responses, anti-evasion address canonicalization, and operator override capabilities.

## Linked Issue

Closes #1956 

## Changes

- **Abuse Service Hardening & Budgets (`src/server/api/abuse-service.ts`)**:
  - Implemented storage byte budgets (50MB/hr per account, 100MB/hr per IP, 25MB/hr per session) tracked in bounded 64KB counter units.
  - Implemented chain-write budgets (20 writes/hr per account, 50 writes/hr per IP) for on-chain/postage submissions.
  - Implemented session rate limits (100 req/hr) and recipient rate limits (50 req/hr).
  - Added address canonicalization (`canonicalizeSubjectAddress`) to ensure whitespace and casing variations resolve to identical quota keys.
  - Added operator override header support (`x-stealth-operator-override`) with token validation and metric tracking (`abuse_operator_override`).
  - Added central gate `enforceCentralAbuse()` to evaluate IP, account, recipient, session, storage, and chain-write limits before expensive operations.
- **Relay & Storage Route Integration**:
  - **Relay Transport (`src/services/relay/transport.ts`)**: Invokes `enforceCentralAbuse` with `relay_submit` before signature verification.
  - **Attachment Storage (`src/routes/api/v1/attachments/initiate.ts`, `chunk.ts`)**: Checks storage budgets prior to chunk upload and object store writes.
  - **Send Coordinator (`src/routes/api/v1/send/coordinate.ts`)**: Enforces recipient and chain-write limits.
  - **Postage Service (`src/server/api/postage-service.ts`)**: Enforces recipient rate limits and chain-write budgets.
  - **API Handler (`src/server/api/handler.ts`)**: Added operator override bypass support to central route handlers.
- **Metrics (`src/server/api/metrics.ts`)**:
  - Registered metric descriptors for `abuse_throttled`, `abuse_storage_bytes_exceeded`, `abuse_chain_writes_exceeded`, `abuse_operator_override`, `abuse_recipient_exceeded`, and `abuse_session_exceeded`.
- **Dependencies Confirmed**:
  - #1913 (BETA-006)
  - #1935 (BETA-028)
  - #1951 (BETA-044)

## Validation

- [x] Formatting and linting
  - `npx prettier --check .` (0 formatting errors)
  - `npx eslint src/server/api/abuse-service.ts src/server/api/rate-limit.ts src/server/api/handler.ts src/services/relay/transport.ts src/services/relay/relay-service.ts src/relay/index.ts src/routes/api/v1/attachments/initiate.ts src/routes/api/v1/attachments/chunk.ts src/routes/api/v1/send/coordinate.ts src/server/api/postage-service.ts src/server/api/metrics.ts tests/unit/api/abuse-service.test.ts tests/unit/security/beta-controls.test.ts` (0 errors, 0 warnings)
- [x] Type checking and unit tests
  - `npx tsc --noEmit` (0 type errors)
  - `npx vitest run tests/unit` (313 test files passed, 3,445 tests passed)
- [x] Relevant integration/E2E/contract tests
  - `npx vitest run tests/unit/api/abuse-service.test.ts tests/unit/api/rate-limit.test.ts tests/unit/security/beta-controls.test.ts tests/unit/relay/relay-service.test.ts tests/unit/api/postage-service.test.ts tests/unit/api/handler.test.ts` (100/100 passed)
  - `node scripts/security/run-regression.mjs` (passed with status: pass)
- [x] Manual or deployed-path verification, when required
  - Verified address canonicalization anti-evasion and operator override bypass across relay submission, attachment upload, and send coordination.
